### PR TITLE
fix: replace hardcoded app name strings with dynamic lookup

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -167,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Final fallback: SF Symbol
         let fallback = NSImage(
             systemSymbolName: "mic",
-            accessibilityDescription: "EnviousWispr Local"
+            accessibilityDescription: AppConstants.appName
         )
         fallback?.isTemplate = isTemplate
         fallback?.size = NSSize(width: 18, height: 18)
@@ -231,7 +231,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(.separator())
 
         // Quit
-        let quitItem = NSMenuItem(title: "Quit EnviousWispr Local", action: #selector(quitApp), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "Quit \(AppConstants.appName)", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")
         quitItem.target = self
         menu.addItem(quitItem)
@@ -268,7 +268,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             action()
         } else {
             // Fallback: find and show an existing window
-            for window in NSApp.windows where window.title == "EnviousWispr Local" {
+            for window in NSApp.windows where window.title == AppConstants.appName {
                 window.makeKeyAndOrderFront(nil)
                 break
             }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -5,7 +5,7 @@ struct EnviousWisprApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        Window("EnviousWispr Local", id: "main") {
+        Window(AppConstants.appName, id: "main") {
             UnifiedWindowView()
                 .frame(minWidth: 560, minHeight: 400)
                 .environment(appDelegate.appState)

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingView.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingView.swift
@@ -96,7 +96,7 @@ struct OnboardingView: View {
         VStack(spacing: 16) {
             IconCircle(systemName: "mic.circle.fill", tint: .blue)
 
-            Text("Welcome to EnviousWispr Local")
+            Text("Welcome to \(AppConstants.appName)")
                 .font(.title)
                 .bold()
 
@@ -119,7 +119,7 @@ struct OnboardingView: View {
                 .font(.title2)
                 .bold()
 
-            Text("EnviousWispr Local needs microphone access to capture your speech for transcription.")
+            Text("\(AppConstants.appName) needs microphone access to capture your speech for transcription.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 


### PR DESCRIPTION
## Summary
- Replace all 6 hardcoded `"EnviousWispr Local"` strings with `AppConstants.appName`
- `AppConstants.appName` reads from `Info.plist` `CFBundleName` — production shows "EnviousWispr", dev shows "EnviousWispr Local"
- Fixes menu bar showing "Quit EnviousWispr Local" on production v1.0.1

## Files changed
- `AppDelegate.swift` — quit menu item, fallback icon description, window finder
- `EnviousWisprApp.swift` — SwiftUI window title
- `OnboardingView.swift` — welcome text, microphone access text

## Test plan
- [ ] Production build shows "Quit EnviousWispr" in menu bar
- [ ] Local dev build shows "Quit EnviousWispr Local" in menu bar
- [ ] Onboarding text matches app name
