### PR TITLE
fix: switch Sparkle feed URL to GitHub Pages

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -52,7 +52,7 @@
 
     <!-- Sparkle auto-updater -->
     <key>SUFeedURL</key>
-    <string>https://raw.githubusercontent.com/saurabhav88/EnviousWispr/main/appcast.xml</string>
+    <string>https://saurabhav88.github.io/EnviousWispr/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
     <key>CFBundleIconFile</key>


### PR DESCRIPTION
## Summary
- Changes `SUFeedURL` in Info.plist from `raw.githubusercontent.com` to `saurabhav88.github.io`
- Fixes stale appcast fetches caused by aggressive CDN caching on raw.githubusercontent.com (5-min max-age with unpredictable edge propagation)

## Changes
- `Sources/EnviousWispr/Resources/Info.plist`: Update `SUFeedURL` value

## Test plan
- [ ] Verify `https://saurabhav88.github.io/EnviousWispr/appcast.xml` serves the current appcast
- [ ] Next release: confirm Sparkle picks up the new URL and finds updates correctly
