### PR TITLE
docs: add TCC reset procedure for dev+prod coexistence

### DIFF
--- a/.claude/knowledge/gotchas.md
+++ b/.claude/knowledge/gotchas.md
@@ -138,6 +138,32 @@ Toggling Apple Voice Processing I/O at runtime can break the AVAudioEngine — t
 
 The binary hash changes on every `swift build`, which invalidates the existing Accessibility TCC grant. macOS `tccutil` only supports `reset`, NOT `grant` — there is no command-line way to auto-grant Accessibility. Workarounds: (1) sign local builds with a stable Developer ID cert (TCC persists across rebuilds), or (2) re-grant manually in System Settings > Privacy & Security > Accessibility after each rebuild. See also "NEVER Use Blanket TCC Resets" above.
 
+## Running Dev + Production Builds Simultaneously (TCC Permissions)
+
+**Problem**: macOS TCC database can get confused when granting Accessibility/Microphone permissions to two builds of the same app with different bundle IDs. Granting to one may invalidate the other.
+
+**Our setup**:
+- Production: `com.enviouswispr.app` ("EnviousWispr") — installed in /Applications
+- Development: `com.enviouswispr.app.dev` ("EnviousWispr Local") — runs from .build/
+
+**Fix when permissions break**:
+```bash
+# 1. Quit both apps
+# 2. Reset TCC for both bundle IDs
+tccutil reset Accessibility com.enviouswispr.app
+tccutil reset Accessibility com.enviouswispr.app.dev
+# 3. Reboot
+# 4. Re-grant permissions one at a time:
+#    - Launch production app first, grant Accessibility
+#    - Then launch dev app, grant Accessibility
+#    - For dev builds, manually drag .app into System Settings > Accessibility
+#      (don't rely on the automatic prompt — it's less reliable for unsigned builds)
+```
+
+**Best practice**: The two-app workflow (separate bundle IDs for dev vs prod) is industry standard. Apps like Raycast, Alfred, and Bartender all use this approach. Never develop against the production bundle ID — it risks data corruption, TCC chaos, and accidental debug releases.
+
+**Also**: UserDefaults are already separated by bundle ID (`UserDefaults.standard` uses `CFBundleIdentifier` as the domain), so dev and prod settings don't interfere.
+
 ## installTap Before engine.start() Leaves Orphaned Tap on Failure
 
 If `engine.start()` throws after a tap has been installed on the input node, the tap remains attached even though recording never started. A subsequent `startCapture()` call will then fail with "format mismatch" or "tap already installed". **Always remove the tap in the error path** before rethrowing. Pattern:


### PR DESCRIPTION
## Summary
- Documents the procedure for running dev and production builds simultaneously
- Adds TCC reset commands and re-grant sequence to gotchas.md
- Notes that the two-app workflow (separate bundle IDs) is industry standard

## Changes
- `.claude/knowledge/gotchas.md`: New section "Running Dev + Production Builds Simultaneously"
