### PR TITLE
fix(release): remove self-copy bug in appcast push step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,8 +172,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
           git checkout main
-          cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
-          git add appcast.xml
+          git add -f appcast.xml
           if git diff --staged --quiet; then
             echo "==> appcast.xml unchanged, skipping."
           else

--- a/docs/email-feedback-gap-analysis.md
+++ b/docs/email-feedback-gap-analysis.md
@@ -1,0 +1,230 @@
+# Gap Analysis: Email Feedback vs Current Codebase
+
+## Status Summary
+
+| # | Finding | Severity | Status | Notes |
+|---|---------|----------|--------|-------|
+| 1 | Self-copy aborts release step | P0 | OPEN | `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` still present on line 175 of release.yml after `git checkout main` |
+| 2 | Missing CodeQL permissions | P1 | FIXED (N/A) | CodeQL workflow does not exist — only `pr-check.yml` and `release.yml` in `.github/workflows/` |
+| 3 | Sparkle feed URL mismatch | P1 | FIXED | `SPARKLE_FEED_URL` in release.yml is already the GitHub Pages URL; `build-dmg.sh` overrides Info.plist from env var |
+| 4 | AppConstants.appName vs window title | P1 | PARTIALLY FIXED | `AppConstants.appName` reads `CFBundleName` dynamically; window title uses `AppConstants.appName`; but Info.plist still has `CFBundleName = "EnviousWispr Local"` and `build-dmg.sh` patches it only at bundle time |
+| 5 | Same as Finding 4 | P1 | PARTIALLY FIXED | Duplicate of Finding 4 |
+| 6 | Onboarding close doesn't restore accessory | P2 | PARTIALLY FIXED | `closeOnboardingWindow()` restores `.accessory`; but `onboardingCloseObserver` (red-button path) calls only `updateIcon()`, never `NSApp.setActivationPolicy(.accessory)` |
+| 7 | TCC docs reference non-existent .dev bundle ID | P2 | MOOT | `com.enviouswispr.app.dev` IS the actual bundle ID in Info.plist; the finding's premise is incorrect |
+| 8 | Incorrect UserDefaults isolation claim | P2 | MOOT | Follows from Finding 7 — `.dev` bundle ID does exist; isolation claim is correct |
+| 9 | Non-retryable appcast branch names | P2 | FIXED (N/A) | The PR branch approach was replaced entirely — workflow now pushes directly to main without creating a branch |
+| 10 | Sparkle 2.8.1 → 2.9.0 available | DEP | OPEN | Package.resolved pins Sparkle at 2.8.1; Package.swift has `from: "2.6.0"` (will not auto-update past resolved pin) |
+
+---
+
+## Detailed Analysis
+
+### Finding 1: Self-copy aborts release step
+
+- **Status**: OPEN
+- **Evidence**: `.github/workflows/release.yml` line 174–175:
+  ```yaml
+  git checkout main
+  cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+  ```
+  After `git checkout main`, the working directory IS `$GITHUB_WORKSPACE`. The `cp` source and destination resolve to the same inode. On macOS (BSD `cp`), this exits non-zero with "are the same file". Under `set -euo pipefail` (the step runs in bash's `-e` mode by default in GitHub Actions), this kills the step before `git add`, `git commit`, or `git push` execute. The GitHub Release creation step at line 185 runs after this, so releases may be created without the appcast being updated.
+- **Current code**: `.github/workflows/release.yml` lines 166–183:
+  ```yaml
+  - name: Push appcast update to main
+    env:
+      APPCAST_BOT_TOKEN: ${{ secrets.APPCAST_BOT_TOKEN }}
+      VERSION: ${{ steps.version.outputs.version }}
+    run: |
+      git config user.name "github-actions[bot]"
+      git config user.email "github-actions[bot]@users.noreply.github.com"
+      git fetch origin main
+      git checkout main
+      cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml   # <-- BUG: same file
+      git add appcast.xml
+      ...
+  ```
+  Note: The step does NOT use `set -euo pipefail` explicitly in its `run:` block, but GitHub Actions implicitly runs shell with `-e`. The `cp` failure may or may not abort depending on exact runner behavior — but the self-copy is definitely a no-op at minimum, meaning the updated appcast.xml generated in the "Update appcast.xml" step is never committed.
+- **Action needed**: Remove the `cp` line. After `git checkout main`, the `appcast.xml` generated in the prior step is already at `$GITHUB_WORKSPACE/appcast.xml` which IS the working directory. The `git add appcast.xml` on the next line will pick it up directly. Alternatively, use `git add -f appcast.xml` (already mentioned in gotchas.md) in case it's gitignored.
+
+---
+
+### Finding 2: Missing CodeQL permissions
+
+- **Status**: FIXED (N/A) — CodeQL workflow was never merged or was removed
+- **Evidence**: `ls .github/workflows/` shows only two files: `pr-check.yml` and `release.yml`. No `codeql.yml` or equivalent exists in the repository. The PR (#13) that introduced the CodeQL workflow either was not merged or was subsequently reverted.
+- **Current code**: N/A — file does not exist
+- **Action needed**: None. If CodeQL scanning is desired in the future, create the workflow with proper permissions (`contents: read`, `actions: read`, `security-events: write`).
+
+---
+
+### Finding 3: Sparkle feed URL mismatch
+
+- **Status**: FIXED
+- **Evidence**: Two independent checks confirm alignment:
+  1. `release.yml` line 67: `SPARKLE_FEED_URL: "https://saurabhav88.github.io/EnviousWispr/appcast.xml"` — already the GitHub Pages URL.
+  2. `scripts/build-dmg.sh` lines 103–106: when `SPARKLE_FEED_URL` is set, it overrides Info.plist's `SUFeedURL` via `plutil -replace`. This means the release build will always have the correct GitHub Pages URL even if Info.plist has the wrong value at rest.
+  3. `Sources/EnviousWispr/Resources/Info.plist` line 55: `SUFeedURL` is already `https://saurabhav88.github.io/EnviousWispr/appcast.xml`.
+- **Current code**: All three sources agree on the GitHub Pages URL. No raw.githubusercontent.com reference remains.
+- **Action needed**: None.
+
+---
+
+### Finding 4: AppConstants.appName vs window title mismatch
+
+- **Status**: PARTIALLY FIXED
+- **Evidence**: The finding identified that `AppConstants.appName` reading `CFBundleName` dynamically would diverge from a hardcoded SwiftUI window title. The current code has improved this, but a subtle issue remains:
+  - `Constants.swift` line 4: `static let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "EnviousWispr"` — dynamic, good.
+  - `EnviousWisprApp.swift` line 10: `Window(AppConstants.appName, id: "main")` — uses the constant, good.
+  - `Info.plist` line 10: `CFBundleName = "EnviousWispr Local"` — the committed value is the dev name.
+  - `build-dmg.sh` line 100: `plutil -replace CFBundleName -string "${APP_NAME}" "${CONTENTS}/Info.plist"` — patches it to `"EnviousWispr"` at bundle time.
+  - `AppDelegate.swift` line 55: `window.title == AppConstants.appName` — matches windows by title at runtime.
+
+  **The remaining risk**: In local development (running the bare binary, not a bundled .app), `CFBundleName` is `"EnviousWispr Local"` and `AppConstants.appName` resolves to `"EnviousWispr Local"`. The SwiftUI `Window` title is therefore `"EnviousWispr Local"`, and the `AppDelegate` title-match also uses `"EnviousWispr Local"`, so they DO match in dev. In production (bundled .app), `build-dmg.sh` patches `CFBundleName` to `"EnviousWispr"` and both sides agree.
+
+  **The actual remaining bug** (from the original finding's perspective): The original finding claimed a hardcoded `"EnviousWispr Local"` in the SwiftUI title vs dynamic `AppConstants.appName` — that mismatch no longer exists since both sides now use `AppConstants.appName`. However, `AppDelegate`'s `windowCloseObserver` block captures `mainWindow` lazily on first `willClose` event (line 53–56), not on open. If the main window closes before it is ever captured, `mainWindow` remains `nil` and the `guard window === self.mainWindow` on line 59 will never match, so `.accessory` policy is never restored on settings close. This is a latent bug but not the exact one described in Finding 4.
+
+- **Current code**: `AppDelegate.swift` lines 53–61:
+  ```swift
+  if self.mainWindow == nil, window.styleMask.contains(.titled),
+     window.title == AppConstants.appName {
+      self.mainWindow = window
+  }
+  guard window === self.mainWindow else { return }
+  NSApp.setActivationPolicy(.accessory)
+  ```
+- **Action needed**: The title-match approach captures `mainWindow` only when the window closes for the first time — if the window is opened and closed repeatedly, it works. But the first time the main window closes, it both captures and matches in the same event. This logic is correct for the normal flow. The real fix needed is for the latent case where `mainWindow` is nil on first close: the `if` block on lines 53–56 both assigns `self.mainWindow = window` AND then the `guard` on line 59 will fail because the assignment happened in the `if` block but the `guard` checks `window === self.mainWindow` — which IS now equal. Wait: the assignment runs, then the guard runs — `window === self.mainWindow` is true. So this path does work. The finding is effectively resolved.
+
+---
+
+### Finding 5: Same as Finding 4
+
+- **Status**: PARTIALLY FIXED (same as Finding 4)
+- **Evidence**: Duplicate finding, same analysis applies.
+- **Action needed**: Same as Finding 4.
+
+---
+
+### Finding 6: Onboarding close doesn't restore accessory mode
+
+- **Status**: PARTIALLY FIXED — the normal completion path is fixed; the abort (red X button) path is still broken
+- **Evidence**:
+  - **Normal path** (Done button): `closeOnboardingWindow()` at `AppDelegate.swift` lines 162–166 calls `NSApp.setActivationPolicy(.accessory)` — FIXED.
+  - **Abort path** (red X button): `onboardingCloseObserver` at `AppDelegate.swift` lines 136–157 — when the onboarding window is closed before completion, the observer calls only `self.updateIcon()` (line 153) but never `NSApp.setActivationPolicy(.accessory)`. App stays in Dock.
+  - Additionally, `ActionWirer`'s `onChange(of: isOnboardingPresented)` at `EnviousWisprApp.swift` lines 63–70 does call `NSApp.setActivationPolicy(.accessory)` when `isOnboardingPresented` flips to false — but this binding is only flipped programmatically via `closeOnboardingWindow()` → `dismissOnboardingAction?()`. When the user clicks the red X, SwiftUI dismisses the window via its own mechanism without flipping the binding, so this path is also not triggered.
+- **Current code**: `AppDelegate.swift` lines 149–154:
+  ```swift
+  if self.appState.settings.onboardingState != .completed {
+      self.updateIcon()
+      // Missing: NSApp.setActivationPolicy(.accessory)
+  }
+  ```
+- **Action needed**: Add `NSApp.setActivationPolicy(.accessory)` immediately after `self.updateIcon()` in the `onboardingCloseObserver` abort path (AppDelegate.swift line 153).
+
+---
+
+### Finding 7: TCC docs reference non-existent .dev bundle ID
+
+- **Status**: MOOT — the `.dev` bundle ID DOES exist
+- **Evidence**: `Sources/EnviousWispr/Resources/Info.plist` line 8:
+  ```xml
+  <key>CFBundleIdentifier</key>
+  <string>com.enviouswispr.app.dev</string>
+  ```
+  The committed Info.plist uses `com.enviouswispr.app.dev` as the bundle identifier for local/dev builds. The production bundle ID `com.enviouswispr.app` is written by `build-dmg.sh` at bundle time (`BUNDLE_ID="com.enviouswispr.app"` on line 21, applied via `plutil -replace CFBundleIdentifier`).
+
+  The finding's premise — that `.dev` bundle ID "doesn't exist in the codebase" — was incorrect at the time or has since been corrected by adding this Info.plist. The gotchas.md TCC documentation (lines 141–165) correctly documents both bundle IDs and their TCC reset commands.
+- **Current code**: gotchas.md lines 143–163 correctly reference both `com.enviouswispr.app` and `com.enviouswispr.app.dev`.
+- **Action needed**: None. Documentation is accurate.
+
+---
+
+### Finding 8: Incorrect UserDefaults isolation claim
+
+- **Status**: MOOT — follows from Finding 7
+- **Evidence**: Since `com.enviouswispr.app.dev` IS the actual dev bundle ID (confirmed in Info.plist), the UserDefaults isolation claim in gotchas.md is accurate: `UserDefaults.standard` uses `CFBundleIdentifier` as its domain, so dev (`com.enviouswispr.app.dev`) and prod (`com.enviouswispr.app`) do not share UserDefaults.
+- **Current code**: gotchas.md line 165: "UserDefaults are already separated by bundle ID..." — correct.
+- **Action needed**: None.
+
+---
+
+### Finding 9: Non-retryable appcast branch names
+
+- **Status**: FIXED (N/A) — the branch-based PR approach was replaced
+- **Evidence**: The current `release.yml` "Push appcast update to main" step (lines 166–183) pushes directly to `main` using `APPCAST_BOT_TOKEN`. There is no `ci/appcast-v${VERSION}` branch creation or PR merge step anywhere in the workflow. The entire branch-based approach described in the finding was removed in the fix that introduced direct-push.
+- **Current code**: Direct push to main — no branch naming involved.
+- **Action needed**: None for the branch naming issue. The self-copy bug (Finding 1) means the direct-push approach itself is broken, but that's a separate issue.
+
+---
+
+### Finding 10: Sparkle 2.8.1 → 2.9.0 update available
+
+- **Status**: OPEN
+- **Evidence**: `Package.resolved` pins Sparkle at version `2.8.1` (revision `5581748cef2bae787496fe6d61139aebe0a451f6`). `Package.swift` declares `from: "2.6.0"` which permits 2.9.0 by semver, but the resolved pin takes precedence until explicitly updated via `swift package update`.
+- **Current code**: `Package.swift` line 13: `.package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0")`; `Package.resolved` state: `"version": "2.8.1"`.
+- **Action needed**: Run `swift package update sparkle` or update `Package.resolved` manually to pull in 2.9.0. Key benefits for this project: Swift concurrency API annotations (relevant to Swift 6 mode), in-memory temp file downloads (security improvement), signed/verified appcast feeds.
+
+---
+
+## Unaddressed Fixes — Phased Plan
+
+### Phase 1: Critical (P0, blocks release)
+
+#### Finding 1: Self-copy in release.yml (P0)
+
+**File**: `.github/workflows/release.yml`
+
+**Problem**: Line 175 `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` is a no-op self-copy that may exit non-zero under GitHub Actions' implicit `-e` shell mode, aborting the step before `git add`/`git commit`/`git push`. Even if `cp` exits 0 (some versions tolerate same-file), the `git add` that follows will find no changes because the file was already at that path — making the appcast push silently skip every release.
+
+**Fix**: Delete line 175. After `git checkout main` (which does `git fetch origin main && git checkout main`), `$GITHUB_WORKSPACE` IS the working directory. The `appcast.xml` written by the prior "Update appcast.xml" step is already present at `$GITHUB_WORKSPACE/appcast.xml`. The `git add appcast.xml` on the next line handles it directly.
+
+```yaml
+# BEFORE (broken):
+git fetch origin main
+git checkout main
+cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+git add appcast.xml
+
+# AFTER (fixed):
+git fetch origin main
+git checkout main
+git add -f appcast.xml
+```
+
+Using `git add -f` (force) ensures the file is staged even if it appears in `.gitignore` (gotchas.md line 85 documents this).
+
+---
+
+### Phase 2: Medium Priority (P2)
+
+#### Finding 6: Onboarding abort path doesn't restore accessory mode (P2)
+
+**File**: `Sources/EnviousWispr/App/AppDelegate.swift`
+
+**Problem**: When a user closes the onboarding window via the red X button before completing setup, the `onboardingCloseObserver` fires and calls `self.updateIcon()` but never calls `NSApp.setActivationPolicy(.accessory)`. The app remains in `.regular` mode (visible in Dock) after aborting onboarding.
+
+**Fix**: Add `NSApp.setActivationPolicy(.accessory)` in the abort path of `onboardingCloseObserver`. Location: AppDelegate.swift around line 152–153, inside the guard block where `onboardingState != .completed`:
+
+```swift
+// BEFORE:
+if self.appState.settings.onboardingState != .completed {
+    self.updateIcon()
+}
+
+// AFTER:
+if self.appState.settings.onboardingState != .completed {
+    NSApp.setActivationPolicy(.accessory)
+    self.updateIcon()
+}
+```
+
+---
+
+### Phase 3: Dependency Updates
+
+#### Finding 10: Sparkle 2.8.1 → 2.9.0
+
+**File**: `Package.resolved` (and optionally `Package.swift`)
+
+**Command**: `swift package update sparkle` from the project root.
+
+**Verification**: After updating, run `swift build` to confirm no breaking API changes. Sparkle 2.9.0 includes Swift concurrency annotations relevant to the project's Swift 6 mode — if there are new `Sendable` conformances or `async` APIs that conflict with the `@preconcurrency import Sparkle` usage in `AppDelegate.swift`, the build will surface them. The gotchas.md already documents that Sparkle requires `@preconcurrency import`.

--- a/docs/email-feedback-implementation-plan.md
+++ b/docs/email-feedback-implementation-plan.md
@@ -1,0 +1,164 @@
+# Email Feedback Implementation Plan
+
+> Generated 2026-03-02 from audit of 34 GitHub bot emails.
+> Reviewed by: Claude (gap analysis) + Gemini (plan polish via buddies)
+
+---
+
+## Audit Summary
+
+| Metric | Value |
+|--------|-------|
+| Emails scanned | 34 |
+| Actionable findings | 10 |
+| Already fixed | 5 |
+| Moot (bot was wrong) | 2 |
+| **Still open** | **3** |
+
+---
+
+## Phase 1: Unblock the Release Pipeline
+
+**Finding**: [P0] Self-copy bug in `release.yml` — blocks every release
+**Complexity**: Low (trivial code change, validation is key)
+**File**: `.github/workflows/release.yml`
+
+### Problem
+
+Line 175: `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` runs after `git checkout main`. Since `$GITHUB_WORKSPACE` IS the working directory, source and destination are the same file. Under GitHub Actions' implicit `-e` mode, `cp` either errors or silently no-ops — the updated appcast never gets committed to main.
+
+### Fix
+
+```yaml
+# BEFORE (broken):
+git fetch origin main
+git checkout main
+cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+git add appcast.xml
+
+# AFTER (fixed):
+git fetch origin main
+git checkout main
+git add -f appcast.xml
+```
+
+The `-f` flag ensures staging even if `appcast.xml` is in `.gitignore`.
+
+### Validation
+
+1. Apply fix, merge to `main`
+2. Next release workflow should complete successfully
+3. Verify the commit on `main` contains the updated `appcast.xml`
+
+---
+
+## Phase 2: Correct Onboarding UX Flaw
+
+**Finding**: [P2] Onboarding abort (red X) doesn't restore `.accessory` mode
+**Complexity**: Low
+**File**: `Sources/EnviousWispr/App/AppDelegate.swift` ~line 152
+
+### Problem
+
+When a user closes the onboarding window via the red X button, `onboardingCloseObserver` calls `self.updateIcon()` but never restores `.accessory` activation policy. The Done button path (`closeOnboardingWindow()`) correctly calls `NSApp.setActivationPolicy(.accessory)`. Result: app stays visible in Dock after aborting onboarding — bad UX for a menu-bar utility.
+
+### Fix
+
+```swift
+// BEFORE:
+if self.appState.settings.onboardingState != .completed {
+    self.updateIcon()
+}
+
+// AFTER:
+if self.appState.settings.onboardingState != .completed {
+    NSApp.setActivationPolicy(.accessory)
+    self.updateIcon()
+}
+```
+
+### Recommended Improvement (optional)
+
+Refactor into a shared function to prevent future divergence between exit paths:
+
+```swift
+private func finalizeOnboarding() {
+    NSApp.setActivationPolicy(.accessory)
+    self.updateIcon()
+}
+```
+
+Both `closeOnboardingWindow()` and `onboardingCloseObserver` would call this.
+
+### Validation
+
+1. Launch app to trigger onboarding (clear settings or first-run)
+2. Confirm app icon appears in Dock
+3. Click the red X to close onboarding window
+4. **Expected**: App icon disappears from Dock immediately
+5. Relaunch, complete onboarding via Done button — verify that path still works
+
+---
+
+## Phase 3: Update Sparkle Dependency
+
+**Finding**: [DEP] Sparkle 2.8.1 → 2.9.0 available (Dependabot PR #2)
+**Complexity**: Low (code) / Medium (testing)
+**File**: `Package.resolved`
+
+### Problem
+
+Sparkle 2.8.1 is pinned in `Package.resolved`. Version 2.9.0 is available with significant benefits:
+
+- **Swift concurrency annotations** — critical for our Swift 6 strict mode
+- **Markdown release notes** — macOS 12+ (we target 14+)
+- **Signed/verified appcast feeds** — security improvement
+- **In-memory temp file downloads** — reduces disk I/O
+- **Impatient update check interval** — better auto-update UX
+
+### Fix
+
+```bash
+swift package update sparkle
+swift build  # verify no breaking changes
+```
+
+Alternatively, merge Dependabot PR #2.
+
+### Risks
+
+Sparkle is fundamental to app delivery. A regression here blocks all future updates for shipped users.
+
+### Validation
+
+1. Build compiles cleanly with 2.9.0
+2. Check `@preconcurrency import Sparkle` still compiles (may become unnecessary with new concurrency annotations)
+3. Full end-to-end auto-update test:
+   - Build v1 with old Sparkle, v2 with new Sparkle
+   - Point v1 at local appcast serving v2
+   - Trigger "Check for Updates" — verify download, install, relaunch
+   - In v2, verify "Check for Updates" reports up-to-date
+
+---
+
+## Items Already Resolved (No Action Needed)
+
+| # | Finding | Status | Why |
+|---|---------|--------|-----|
+| 2 | Missing CodeQL permissions | N/A | CodeQL workflow was never merged |
+| 3 | Sparkle feed URL mismatch | FIXED | All 3 sources (release.yml, build-dmg.sh, Info.plist) now agree on GitHub Pages URL |
+| 4/5 | AppConstants.appName mismatch | FIXED | Both SwiftUI window and AppDelegate now use `AppConstants.appName` dynamically |
+| 7/8 | TCC docs .dev bundle ID | MOOT | `.dev` bundle ID exists in Info.plist — bot's premise was wrong |
+| 9 | Non-retryable branch names | FIXED | Branch-based PR approach replaced with direct push to main |
+
+---
+
+## Execution Order
+
+```
+Phase 1 (P0) → Phase 2 (P2) → Phase 3 (DEP)
+```
+
+Phase 1 is a release blocker and should be done first. Phase 2 is a quick UX fix. Phase 3 requires the most testing but carries the most long-term value.
+
+**Estimated total effort**: ~2-3 hours including testing.

--- a/docs/email-feedback-pr-cross-reference.md
+++ b/docs/email-feedback-pr-cross-reference.md
@@ -1,0 +1,140 @@
+# PR Cross-Reference: Open Findings vs Open PRs
+
+## Summary
+
+| Finding | Severity | Open PR | Addressed in PR? | Evidence |
+|---------|----------|---------|-------------------|----------|
+| 1 - release.yml self-copy | P0 | PR #13 | NO | PR only removes `pull-requests: write`; the `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` line at line 175 is untouched |
+| 6 - onboarding abort | P2 | PR #7 | PARTIAL | `willCloseNotification` handler calls `updateIcon()` in abort path but does NOT call `NSApp.setActivationPolicy(.accessory)` |
+| 10 - Sparkle bump | DEP | PR #2 | YES | Package.resolved updated: `2.8.1` → `2.9.0`, revision `5581748c` → `21d8df80` |
+
+---
+
+## Detailed Analysis
+
+### Finding 1 vs PR #13
+
+**Finding:** Line 175 of `.github/workflows/release.yml` contains:
+```yaml
+cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+```
+This runs after `git checkout main` inside the appcast-update step, meaning the file is being copied onto itself (same path in workspace). The copy is a no-op at best and a silent data-loss risk if the paths diverge under a different runner working directory.
+
+**What PR #13 actually changes in `release.yml`:**
+
+The diff for `release.yml` in PR #13 is exactly one line:
+```diff
+ permissions:
+   contents: write
+-  pull-requests: write
+```
+
+That is the entirety of the `release.yml` change. The `pull-requests: write` permission was a leftover from when the appcast update was done via PR (the old flow); PR #13 correctly removes it now that appcast pushes go direct to `main` via `APPCAST_BOT_TOKEN`. However, the self-copy bug at line 175 is **not touched**.
+
+Confirmed by checking the current file on the local `feature/022-onboarding` branch (which shares the main-branch state for this file):
+```
+line 175: cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+```
+
+**Verdict: Finding 1 is NOT addressed by PR #13. It remains fully open.**
+
+---
+
+### Finding 6 vs PR #7
+
+**Finding:** In `AppDelegate.swift`, the `onboardingCloseObserver` (fires when the user clicks the red X to close the onboarding window mid-flow) calls `updateIcon()` but omits `NSApp.setActivationPolicy(.accessory)`. This leaves the app in `.regular` policy after abort — meaning the Dock icon remains visible and the app behaves as a regular app rather than a menu-bar utility.
+
+**What PR #7 introduces:**
+
+The branch adds a `willCloseNotification` observer inside `openOnboardingWindow()`. The abort path (when `onboardingState != .completed` at close time) is:
+
+```swift
+// Only treat as abort if onboarding not yet completed.
+if self.appState.settings.onboardingState != .completed {
+    self.updateIcon()
+}
+```
+
+`updateIcon()` is called — but `NSApp.setActivationPolicy(.accessory)` is **not** called in this abort branch.
+
+For comparison, the success path (`closeOnboardingWindow()`, called by the Done button) correctly does both:
+```swift
+func closeOnboardingWindow() {
+    dismissOnboardingAction?()
+    NSApp.setActivationPolicy(.accessory)  // present
+    updateIcon()
+}
+```
+
+There is also a state-driven dismissal path in `EnviousWisprApp.swift` (the `.onChange(of: isOnboardingPresented)` handler), which does call `NSApp.setActivationPolicy(.accessory)` — but that path fires only when `isOnboardingPresented` is flipped to `false` programmatically. When the user force-closes the window via the red X, the `willCloseNotification` handler fires, not the state-driven path.
+
+**Verdict: Finding 6 is PARTIALLY addressed. The close observer infrastructure is new and correct. However, the abort branch inside `willCloseNotification` still calls only `updateIcon()` and omits `NSApp.setActivationPolicy(.accessory)`. Merging PR #7 will not fully fix Finding 6.**
+
+---
+
+### Finding 10 vs PR #2
+
+**Finding:** Sparkle is pinned to 2.8.1 in `Package.resolved`; 2.9.0 is available.
+
+**What PR #2 changes:**
+
+The diff is exactly the expected dependency bump in `Package.resolved`:
+```diff
+-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
+-        "version" : "2.8.1"
++        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
++        "version" : "2.9.0"
+```
+
+The `originHash` is also updated, confirming this is a legitimate `swift package update` output, not a manual edit. `Package.swift` itself is not changed (the version constraint already accommodates 2.9.0).
+
+**Verdict: Finding 10 is FULLY addressed by PR #2. Merging it closes the finding.**
+
+---
+
+## Revised Status
+
+| Finding | True Status after PR analysis |
+|---------|-------------------------------|
+| 1 - release.yml self-copy (P0) | **OPEN** — No existing PR fixes it. Must be addressed manually. |
+| 6 - onboarding abort (P2) | **OPEN** — PR #7 is the right PR to fix it in, but the fix is incomplete. The abort branch in `willCloseNotification` needs `NSApp.setActivationPolicy(.accessory)` added before `updateIcon()`. |
+| 10 - Sparkle bump (DEP) | **WILL CLOSE on PR #2 merge** — Complete and correct. |
+
+---
+
+## Updated Recommendation
+
+### What merging the existing PRs resolves
+
+- **PR #2 merge**: Closes Finding 10 entirely. No further action needed on Sparkle.
+- **PR #13 merge**: Does not close any of the three findings. Its `release.yml` change (removing `pull-requests: write`) is correct cleanup but is unrelated to Finding 1.
+- **PR #7 merge**: Does not close Finding 6. The onboarding infrastructure is substantially improved, but the one-line omission in the abort path persists.
+
+### What still needs manual work after all PRs are merged
+
+**Finding 1 (P0) — release.yml self-copy: requires a dedicated fix.**
+
+In `.github/workflows/release.yml`, the step that runs after `git checkout main` (around line 175) contains:
+```yaml
+cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml
+```
+After `git checkout main` into a temp directory, `appcast.xml` has already been written to the workspace root by the preceding Python step. The `cp` of the workspace file back onto itself is redundant. The correct fix depends on intent:
+- If the intent is to copy the just-generated appcast into the checked-out `main` working tree, verify the destination path is the `main`-checkout directory, not `$GITHUB_WORKSPACE` itself.
+- Simplest safe fix: remove the `cp` line if the file is already in the correct location from the Python write step.
+
+**Finding 6 (P2) — onboarding abort missing activation policy: requires a one-line fix inside PR #7.**
+
+In `Sources/EnviousWispr/App/AppDelegate.swift`, inside the `openOnboardingWindow()` method's `willCloseNotification` handler, the abort block:
+```swift
+if self.appState.settings.onboardingState != .completed {
+    self.updateIcon()
+}
+```
+needs to become:
+```swift
+if self.appState.settings.onboardingState != .completed {
+    NSApp.setActivationPolicy(.accessory)
+    self.updateIcon()
+}
+```
+This one-line addition aligns the abort path with the success path in `closeOnboardingWindow()`. The fix should be applied to the `feature/022-onboarding` branch before PR #7 is merged.

--- a/docs/email-feedback-raw-findings.md
+++ b/docs/email-feedback-raw-findings.md
@@ -1,0 +1,97 @@
+# Raw Email Findings — 2026-03-01/02
+
+## Source: chatgpt-codex-connector[bot] (OpenAI Codex PR Reviews)
+
+### Finding 1: [P0] PR #10 — Self-copy aborts release step
+- **PR**: fix(release): push appcast directly to main instead of via PR
+- **Commit**: 2728467ca8
+- **Issue**: After `git checkout main`, `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` resolves to same file. `cp` exits non-zero (`same file`), step stops under `bash -e`. Release workflow fails before committing/pushing appcast or creating GitHub release.
+- **File**: `.github/workflows/release.yml`
+- **Impact**: Release pipeline broken on every run
+
+### Finding 2: [P1] PR #13 — Missing read scopes in CodeQL permissions
+- **PR**: chore: audit cleanup + add CodeQL security scanning
+- **Commit**: 085aca7fa3
+- **Issue**: Workflow sets `permissions: security-events: write` only, implicitly sets all other scopes to `none`. `actions/checkout` and CodeQL need `contents: read` and `actions: read`. Fails in private repos and Dependabot PRs.
+- **File**: `.github/workflows/codeql.yml` (or wherever CodeQL workflow lives)
+- **Impact**: CodeQL workflow fails consistently
+
+### Finding 3: [P1] PR #11 — Sparkle feed URL not aligned in release builds
+- **PR**: fix: switch Sparkle feed URL to GitHub Pages
+- **Commit**: ca5cada9a1
+- **Issue**: Info.plist changed to `https://saurabhav88.github.io/EnviousWispr/appcast.xml` but `release.yml` still exports `SPARKLE_FEED_URL` as `https://raw.githubusercontent.com/...`, and `scripts/build-dmg.sh` rewrites SUFeedURL from that env var. Release builds still use old raw URL.
+- **File**: `.github/workflows/release.yml` (line 67), `scripts/build-dmg.sh` (lines 104-105)
+- **Impact**: Production users still polling old cached URL
+
+### Finding 4: [P1] PR #4 — Dynamic app name breaks window-title matching
+- **PR**: fix: CG-rendered idle icon + dynamic app name
+- **Commit**: 6a550ef6ed
+- **Issue**: `AppConstants.appName` now reads `CFBundleName` (resolves to `"EnviousWispr"` in release), but SwiftUI window title hardcoded as `"EnviousWispr Local"`. `AppDelegate` matches `window.title == AppConstants.appName` — never captures `mainWindow` in release. Closing settings doesn't restore `.accessory` mode.
+- **File**: `Sources/EnviousWispr/App/AppConstants.swift`, `Sources/EnviousWispr/App/EnviousWisprApp.swift`
+- **Impact**: App stuck in Dock in production builds
+
+### Finding 5: [P1] PR #3 — Same issue as Finding 4
+- **PR**: fix: CG-rendered idle icon + dynamic app name from Info.plist
+- **Commit**: 6a550ef6ed
+- **Issue**: Identical to Finding 4 — `CFBundleName` vs window title mismatch in release builds breaks `mainWindow` detection.
+- **Duplicate of**: Finding 4
+
+### Finding 6: [P2] PR #7 — Onboarding close doesn't restore accessory mode
+- **PR**: feat: first-run onboarding (#022)
+- **Commit**: 8c13106586
+- **Issue**: When user closes setup window via red close button, close observer calls `updateIcon()` but never restores `NSApp` to `.accessory`. `openOnboardingWindow()` switched to `.regular`, so app stays in Dock after dismissal.
+- **File**: Onboarding window management code
+- **Impact**: Menu-bar app visible in Dock after aborting onboarding
+
+### Finding 7: [P2] PR #12 — TCC docs reference non-existent .dev bundle ID
+- **PR**: docs: add TCC reset procedure for dev+prod coexistence
+- **Commit**: 22a52cbd38
+- **Issue**: Reset procedure uses `com.enviouswispr.app.dev` but codebase only defines `com.enviouswispr.app`. The `tccutil reset` command won't clear dev build permissions, leaving broken Accessibility state.
+- **File**: `.claude/knowledge/gotchas.md` (or wherever TCC docs live)
+- **Impact**: Misleading documentation, broken dev workflow instructions
+
+### Finding 8: [P2] PR #12 — Incorrect UserDefaults isolation claim
+- **PR**: docs: add TCC reset procedure for dev+prod coexistence
+- **Commit**: 22a52cbd38
+- **Issue**: Claims dev/prod UserDefaults "don't interfere" because of separate bundle IDs, but `.dev` bundle ID doesn't exist. Engineers may assume data isolation they don't have.
+- **Duplicate/related**: Finding 7
+
+### Finding 9: [P2] PR #5 — Non-retryable appcast branch names
+- **PR**: fix: repair malformed Sparkle appcast EdDSA signatures
+- **Commit**: 73d9d81210
+- **Issue**: Fixed branch name `ci/appcast-v${VERSION}` causes `git push` to fail as non-fast-forward on re-runs. Makes release pipeline non-retryable if a run fails after push but before merge.
+- **File**: `.github/workflows/release.yml`
+- **Impact**: Release pipeline not idempotent
+
+## Source: dependabot[bot]
+
+### Finding 10: Sparkle 2.8.1 → 2.9.0 update available
+- **PR**: #2 — chore(deps): bump sparkle from 2.8.1 to 2.9.0
+- **Key changes in 2.9.0**:
+  - Markdown support for release notes (macOS 12+)
+  - Signed/verified appcast feeds
+  - `sparkle:hardwareRequirements` for arm64 enforcement
+  - `sparkle:minimumUpdateVersion` for staged upgrades
+  - Swift concurrency API annotations
+  - In-memory temp file downloads
+  - Impatient update check interval for auto-updates
+- **Note**: Dependabot couldn't add `dependencies` label (doesn't exist in repo)
+- **Impact**: Using outdated Sparkle; new version has Swift concurrency fixes relevant to our Swift 6 mode
+
+## Source: GitHub Actions CI
+
+### CI Failures (noise — not actionable code fixes)
+- v1.0.0 Release: 5 failures/cancellations (3df6ffd, b7a0d1f, 12ef124, 3c55c34, 8c60447, ab3a190)
+- v1.0.1 Release: 1 failure (eb058fd)
+- v1.0.2 Release: 2 failures (50795ce x2)
+- PR Check cancelled: feature/022-onboarding (26b025f)
+- Pages build cancelled: main (47b4cd1, cdf0916)
+- CodeQL failed: chore/audit-cleanup-and-codeql (7806894)
+- PR Check + CodeQL cancelled: chore/audit-cleanup-and-codeql (085aca7)
+
+## Source: GitHub (Account notifications)
+- Fine-grained PAT "EnviousWispr Appcast Bot" added — expected, part of release infra
+- 2x sudo verification codes — expected, from PAT creation
+
+## Source: Google (Security)
+- New sign-in on Mac alert — expected, saurabhav@gmail.com

--- a/docs/email-feedback-report.md
+++ b/docs/email-feedback-report.md
@@ -1,0 +1,164 @@
+# Email Bot Feedback Report — 2026-03-02
+
+## Executive Summary
+
+34 emails were scanned across four sources: OpenAI Codex PR reviews, Dependabot, GitHub Actions CI notifications, and account/security alerts. Nine actionable code or documentation findings were identified — one P0 (release pipeline broken on every run), four P1s (production-impacting defects in the release workflow and app behavior), and four P2s (moderate issues including misleading documentation and a non-idempotent CI pipeline). One dependency update (Sparkle 2.9.0) is available and contains Swift concurrency API annotations directly relevant to this project's Swift 6 strict concurrency mode.
+
+---
+
+## Critical Findings (P0-P1)
+
+### [P0] Self-copy aborts release step on every run
+- **Source**: chatgpt-codex-connector[bot] — PR #10
+- **Commit**: 2728467ca8
+- **What's wrong**: After `git checkout main`, the step `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` resolves to the same file. `cp` exits non-zero with a "same file" error, and `bash -e` halts the job immediately — before the appcast is committed, pushed, or the GitHub Release is created.
+- **File**: `.github/workflows/release.yml`
+- **Impact**: Release pipeline fails on every run — no appcast update and no GitHub Release are ever produced.
+- **Recommended fix**: Copy to a temporary path first, or guard the copy with a source/destination equality check before invoking `cp`.
+
+---
+
+### [P1] Missing `contents: read` and `actions: read` in CodeQL workflow permissions
+- **Source**: chatgpt-codex-connector[bot] — PR #13
+- **Commit**: 085aca7fa3
+- **What's wrong**: The workflow declares only `permissions: security-events: write`, which implicitly sets all other scopes to `none`. `actions/checkout` requires `contents: read` and CodeQL requires `actions: read`; both fail in private repos and on Dependabot PRs.
+- **File**: `.github/workflows/codeql.yml`
+- **Impact**: CodeQL security scanning fails consistently, leaving the repository without automated vulnerability detection.
+- **Recommended fix**: Add `contents: read` and `actions: read` to the workflow-level permissions block alongside `security-events: write`.
+
+---
+
+### [P1] Release builds still poll the old raw.githubusercontent.com Sparkle feed URL
+- **Source**: chatgpt-codex-connector[bot] — PR #11
+- **Commit**: ca5cada9a1
+- **What's wrong**: `Info.plist` was updated to the GitHub Pages URL (`https://saurabhav88.github.io/EnviousWispr/appcast.xml`), but `release.yml` still exports `SPARKLE_FEED_URL` pointing to `raw.githubusercontent.com`, and `scripts/build-dmg.sh` rewrites `SUFeedURL` from that environment variable at build time, overriding the plist value.
+- **Files**: `.github/workflows/release.yml` (line 67), `scripts/build-dmg.sh` (lines 104-105)
+- **Impact**: All production users running release builds continue to poll the old CDN-cached URL, making the GitHub Pages migration ineffective.
+- **Recommended fix**: Update the `SPARKLE_FEED_URL` export in `release.yml` to the GitHub Pages URL, or remove the `build-dmg.sh` rewrite step so the corrected `Info.plist` value is used unmodified.
+
+---
+
+### [P1] Window-title mismatch causes app to get stuck in the Dock in production builds
+- **Source**: chatgpt-codex-connector[bot] — PRs #4 and #3 (duplicate finding)
+- **Commit**: 6a550ef6ed
+- **What's wrong**: `AppConstants.appName` now reads `CFBundleName` from the bundle (resolves to `"EnviousWispr"` in release), but the SwiftUI window title is hardcoded as `"EnviousWispr Local"`. `AppDelegate` matches `window.title == AppConstants.appName` to identify the main window; the strings never match in a release build, so `mainWindow` is never captured and closing Settings does not restore `NSApp` to `.accessory` mode.
+- **Files**: `Sources/EnviousWispr/App/AppConstants.swift`, `Sources/EnviousWispr/App/EnviousWisprApp.swift`
+- **Impact**: In every production build the app remains visible in the Dock after the Settings window closes — a fundamental regression for a menu-bar-only app.
+- **Recommended fix**: Align the SwiftUI window title with `AppConstants.appName` (or switch to a window identifier rather than title matching) so `mainWindow` detection works regardless of build configuration.
+
+---
+
+## Medium Findings (P2)
+
+### [P2] Onboarding close via red button does not restore `.accessory` activation policy
+- **Source**: chatgpt-codex-connector[bot] — PR #7
+- **Commit**: 8c13106586
+- **What's wrong**: `openOnboardingWindow()` switches `NSApp.activationPolicy` to `.regular`. When the user dismisses the onboarding window via the red close button, the close observer calls `updateIcon()` but never resets the policy back to `.accessory`.
+- **File**: Onboarding window management code
+- **Impact**: After aborting onboarding, the app remains visible in the Dock — defeating the menu-bar-only UX contract.
+- **Recommended fix**: In the window-close observer, call `NSApp.setActivationPolicy(.accessory)` alongside `updateIcon()` whenever the onboarding window is dismissed without completing setup.
+
+---
+
+### [P2] TCC reset docs reference a `.dev` bundle ID that does not exist
+- **Source**: chatgpt-codex-connector[bot] — PR #12
+- **Commit**: 22a52cbd38
+- **What's wrong**: The documented `tccutil reset` procedure uses `com.enviouswispr.app.dev`, but the codebase only defines `com.enviouswispr.app`. The reset command targets a non-existent bundle ID and leaves any broken Accessibility state untouched.
+- **File**: `.claude/knowledge/gotchas.md` (TCC reset procedure section)
+- **Impact**: Misleading documentation causes silent dev-workflow failures; engineers will believe Accessibility has been reset when it has not.
+- **Recommended fix**: Correct the bundle ID in the docs to `com.enviouswispr.app`, or implement the `.dev` suffix in the build system and propagate it consistently everywhere it is referenced.
+
+---
+
+### [P2] UserDefaults isolation claim is false without a real `.dev` bundle ID
+- **Source**: chatgpt-codex-connector[bot] — PR #12 (related to finding above)
+- **Commit**: 22a52cbd38
+- **What's wrong**: The same documentation claims dev and production UserDefaults "don't interfere" due to separate bundle IDs. Since `com.enviouswispr.app.dev` does not exist, both dev and prod builds share the same UserDefaults domain.
+- **File**: `.claude/knowledge/gotchas.md`
+- **Impact**: Engineers may rely on assumed data isolation that does not exist, risking test contamination or accidental corruption of production defaults during development.
+- **Recommended fix**: Address together with the bundle ID fix above; update the documentation to accurately reflect the actual isolation state of the current setup.
+
+---
+
+### [P2] Fixed appcast branch name makes the release pipeline non-retryable
+- **Source**: chatgpt-codex-connector[bot] — PR #5
+- **Commit**: 73d9d81210
+- **What's wrong**: The release workflow creates a branch named `ci/appcast-v${VERSION}`. If a run fails after the branch is pushed but before it is merged, retrying the workflow produces a non-fast-forward `git push` failure on the same fixed branch name.
+- **File**: `.github/workflows/release.yml`
+- **Impact**: Any partial release failure requires manual branch cleanup before the pipeline can be retried — a significant operational burden on a solo-dev project.
+- **Recommended fix**: Use a unique branch name per attempt (e.g., append `$GITHUB_RUN_ID`), or use `--force-with-lease` with idempotency guards, or adopt the direct-push pattern already used for the appcast commit step.
+
+---
+
+## Dependency Updates
+
+### Sparkle 2.8.1 → 2.9.0 (Dependabot PR #2)
+
+Dependabot opened a version bump to Sparkle 2.9.0. Key additions relevant to this project:
+
+- **Swift concurrency API annotations** — directly addresses compatibility concerns under Swift 6 strict concurrency mode; the most important change for this codebase.
+- **Signed/verified appcast feeds** — aligns with the existing EdDSA signing infrastructure already in place.
+- **Markdown release notes** (macOS 12+) — enables richer in-app update changelogs.
+- **`sparkle:hardwareRequirements`** — allows arm64-only enforcement in the appcast for future Apple Silicon-only builds.
+- **`sparkle:minimumUpdateVersion`** — supports staged upgrade paths, useful for future breaking migrations.
+- **In-memory temp file downloads** — reduces disk I/O during update downloads.
+- **Impatient update check interval** — faster auto-update detection after fresh install.
+
+Note: Dependabot could not apply the `dependencies` label because it does not exist in the repository. The PR is otherwise ready to review and merge.
+
+---
+
+## CI/CD Health
+
+13 CI run failures or cancellations were recorded across the notification window:
+
+- **v1.0.0 Release** — 6 failures/cancellations: indicative of the self-copy P0 bug (Finding 1) hitting the pipeline repeatedly before any workaround was in place.
+- **v1.0.1 Release** — 1 failure: same root cause likely still present.
+- **v1.0.2 Release** — 2 failures (same commit `50795ce` run twice): pipeline non-idempotency (Finding 9, P2) is likely a contributing factor.
+- **PR Check cancelled** (feature/022-onboarding, `26b025f`): routine cancel from a superseding push; expected and harmless.
+- **Pages build cancelled** (main, 2 runs): routine GitHub Pages rebuild cancellations; expected and harmless.
+- **CodeQL failed** (chore/audit-cleanup-and-codeql, `7806894`): directly explained by the missing permissions P1 (Finding 2).
+- **PR Check + CodeQL cancelled** (same branch, `085aca7`): superseded by a subsequent push; expected.
+
+Emerging pattern: the majority of substantive CI failures trace back to two root causes — the self-copy release bug (P0) and missing CodeQL permissions (P1). Fixing those two issues should restore CI health substantially. The non-idempotent branch naming (P2) is a secondary contributor to retry failures.
+
+---
+
+## Raw Email Index
+
+| # | Subject | From | Date | Category |
+|---|---------|------|------|----------|
+| 1 | PR #10: fix(release): push appcast directly to main — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 2 | PR #13: chore: audit cleanup + add CodeQL security scanning — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 3 | PR #11: fix: switch Sparkle feed URL to GitHub Pages — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 4 | PR #4: fix: CG-rendered idle icon + dynamic app name — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 5 | PR #3: fix: CG-rendered idle icon + dynamic app name from Info.plist — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 6 | PR #7: feat: first-run onboarding (#022) — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 7 | PR #12: docs: add TCC reset procedure — Code Review (finding 1 of 2) | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 8 | PR #12: docs: add TCC reset procedure — Code Review (finding 2 of 2) | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 9 | PR #5: fix: repair malformed Sparkle appcast EdDSA signatures — Code Review | chatgpt-codex-connector[bot] | 2026-03-01 | Codex Review |
+| 10 | chore(deps): bump sparkle from 2.8.1 to 2.9.0 | dependabot[bot] | 2026-03-01 | Dependabot |
+| 11 | Dependabot unable to apply "dependencies" label (label not found) | dependabot[bot] | 2026-03-01 | Dependabot |
+| 12 | Run failed: release.yml — v1.0.0 (3df6ffd) | GitHub Actions | 2026-03-01 | CI Notification |
+| 13 | Run cancelled: release.yml — v1.0.0 (b7a0d1f) | GitHub Actions | 2026-03-01 | CI Notification |
+| 14 | Run cancelled: release.yml — v1.0.0 (12ef124) | GitHub Actions | 2026-03-01 | CI Notification |
+| 15 | Run cancelled: release.yml — v1.0.0 (3c55c34) | GitHub Actions | 2026-03-01 | CI Notification |
+| 16 | Run cancelled: release.yml — v1.0.0 (8c60447) | GitHub Actions | 2026-03-01 | CI Notification |
+| 17 | Run cancelled: release.yml — v1.0.0 (ab3a190) | GitHub Actions | 2026-03-01 | CI Notification |
+| 18 | Run failed: release.yml — v1.0.1 (eb058fd) | GitHub Actions | 2026-03-01 | CI Notification |
+| 19 | Run failed: release.yml — v1.0.2 (50795ce) | GitHub Actions | 2026-03-02 | CI Notification |
+| 20 | Run failed: release.yml — v1.0.2 (50795ce, retry) | GitHub Actions | 2026-03-02 | CI Notification |
+| 21 | Run cancelled: pr-check.yml — feature/022-onboarding (26b025f) | GitHub Actions | 2026-03-01 | CI Notification |
+| 22 | Run cancelled: pages-build — main (47b4cd1) | GitHub Actions | 2026-03-01 | CI Notification |
+| 23 | Run cancelled: pages-build — main (cdf0916) | GitHub Actions | 2026-03-01 | CI Notification |
+| 24 | Run failed: codeql.yml — chore/audit-cleanup-and-codeql (7806894) | GitHub Actions | 2026-03-01 | CI Notification |
+| 25 | Run cancelled: pr-check.yml — chore/audit-cleanup-and-codeql (085aca7) | GitHub Actions | 2026-03-01 | CI Notification |
+| 26 | Run cancelled: codeql.yml — chore/audit-cleanup-and-codeql (085aca7) | GitHub Actions | 2026-03-01 | CI Notification |
+| 27 | Fine-grained PAT "EnviousWispr Appcast Bot" added to account | GitHub | 2026-03-01 | Account |
+| 28 | Sudo verification code (1 of 2) | GitHub | 2026-03-01 | Account |
+| 29 | Sudo verification code (2 of 2) | GitHub | 2026-03-01 | Account |
+| 30 | New sign-in on Mac — saurabhav@gmail.com | Google | 2026-03-01 | Security |
+| 31 | PR #10 merged | GitHub | 2026-03-01 | CI Notification |
+| 32 | PR #11 merged | GitHub | 2026-03-01 | CI Notification |
+| 33 | PR #13 opened | GitHub | 2026-03-01 | CI Notification |
+| 34 | PR #5 merged | GitHub | 2026-03-01 | CI Notification |


### PR DESCRIPTION
## Summary
- Removes the `cp "$GITHUB_WORKSPACE/appcast.xml" appcast.xml` self-copy that was silently aborting the appcast push step in every release
- After `git checkout main`, `$GITHUB_WORKSPACE` IS the working directory — the `cp` was a same-file no-op (or error under `-e`)
- Switched to `git add -f appcast.xml` to ensure staging even if gitignored

## Context
Identified via email feedback audit — ChatGPT Codex bot flagged this as P0 on PR #10. Gap analysis confirmed the bug is still present on `main`.

## Audit docs included
- `docs/email-feedback-raw-findings.md` — 10 findings from 34 bot emails
- `docs/email-feedback-report.md` — executive summary
- `docs/email-feedback-gap-analysis.md` — codebase comparison
- `docs/email-feedback-pr-cross-reference.md` — cross-ref against open PRs
- `docs/email-feedback-implementation-plan.md` — phased fix plan

## Test plan
- [ ] Next release workflow run should complete the appcast push step successfully
- [ ] Verify `appcast.xml` is committed to `main` after release
