### PR TITLE
docs(ci): mark main-protection ruleset as active

### DIFF
--- a/.github/CI-GOVERNANCE.md
+++ b/.github/CI-GOVERNANCE.md
@@ -26,10 +26,12 @@ Actions updates are grouped into a single PR per week to reduce noise.
 
 ## Required checks
 
-`main` is protected with required status checks:
+`main` is protected via the `main-protection` ruleset (active) with required status checks:
 
 - `build-check` (from `pr-check.yml`) — debug build, release build, test compilation
 - `drift-check` (from `ci-drift-check.yml`) — SHA pinning, script existence, YAML validity
+- Branches must be up to date before merging
+- Restrict deletions and block force pushes enabled
 
 Direct pushes to `main` are allowed for the release bot (appcast updates) but
 human changes should go through PRs.


### PR DESCRIPTION
## Summary
- Updates CI-GOVERNANCE.md to reflect that the `main-protection` ruleset is now active
- Required checks: `build-check`, `drift-check`
- Branches must be up to date before merging

## Test plan
- [x] CI drift check passes
- [x] Build check passes