### PR TITLE
chore(legal): update licensor and copyright to Envious Labs LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,9 @@ Business Source License 1.1
 
 Parameters
 
-Licensor:             Envious Labs
+Licensor:             Envious Labs LLC
 Licensed Work:        EnviousWispr
-                      The Licensed Work is (c) 2024-2026 Envious Labs
+                      The Licensed Work is (c) 2024-2026 Envious Labs LLC
 Additional Use Grant: You may make personal, non-commercial use of the
                       Licensed Work. "Non-commercial" means you may not
                       use the Licensed Work or any derivative work for

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -37,7 +37,7 @@
 	<key>SUFeedURL</key>
 	<string>https://enviouswispr.com/appcast.xml</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025–2026 EnviousWispr. All rights reserved.</string>
+	<string>Copyright © 2025–2026 Envious Labs LLC. All rights reserved.</string>
 	<key>SUPublicEDKey</key>
 	<string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
 </dict>


### PR DESCRIPTION
## Summary
- Updates LICENSE licensor from "Envious Labs" to "Envious Labs LLC"
- Updates Info.plist copyright from "EnviousWispr" to "Envious Labs LLC"
- Reflects formation of Envious Labs LLC (NY, filed 2026-03-23)

## Test plan
- [ ] Build succeeds (CI)
- [ ] No functional changes — legal text only
