### PR TITLE
fix(website): point download links to GitHub latest release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,9 @@ Business Source License 1.1
 
 Parameters
 
-Licensor:             Envious Labs
+Licensor:             Envious Labs LLC
 Licensed Work:        EnviousWispr
-                      The Licensed Work is (c) 2024-2026 Envious Labs
+                      The Licensed Work is (c) 2024-2026 Envious Labs LLC
 Additional Use Grant: You may make personal, non-commercial use of the
                       Licensed Work. "Non-commercial" means you may not
                       use the Licensed Work or any derivative work for

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -37,7 +37,7 @@
 	<key>SUFeedURL</key>
 	<string>https://enviouswispr.com/appcast.xml</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025–2026 EnviousWispr. All rights reserved.</string>
+	<string>Copyright © 2025–2026 Envious Labs LLC. All rights reserved.</string>
 	<key>SUPublicEDKey</key>
 	<string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
 </dict>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -30,8 +30,7 @@ const year = new Date().getFullYear();
         <a href="/how-it-works/">How It Works</a>
         <a href="/#privacy">Privacy</a>
         <a href="/blog/">Blog</a>
-        <a href="/downloads/EnviousWispr-1.3.0.dmg">Download</a>
-        <!-- GitHub link hidden while account is flagged (ew-dx73) -->
+        <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
         <a href="https://x.com/EnviousLabs" target="_blank" rel="noopener">X / Twitter</a>
       </nav>
     </div>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -43,8 +43,7 @@ const { activePage = 'home' } = Astro.props;
       <li><a href="/blog/">Blog</a></li>
     </ul>
     <div class="nav-cta-group">
-      <!-- GitHub link hidden while account is flagged (ew-dx73) -->
-      <a href="/downloads/EnviousWispr-1.3.0.dmg" class="nav-cta">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="nav-cta">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Download Free
       </a>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -64,7 +64,7 @@ const jsonLd = JSON.stringify({
       <p class="hero-sub reveal" style="--i:2">The fastest way to turn your voice into polished text on Mac. Private by design — your voice never leaves your device.</p>
 
       <div class="hero-ctas reveal" style="--i:3">
-        <a href="/downloads/EnviousWispr-1.3.0.dmg" class="btn-primary">
+        <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Download Free
         </a>
@@ -624,7 +624,7 @@ const jsonLd = JSON.stringify({
         <p>Free download. No account required. No credit card.</p>
 
         <div class="cta-btns">
-          <a href="/downloads/EnviousWispr-1.3.0.dmg" class="btn-cta-primary">
+          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-cta-primary">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             Download EnviousWispr
           </a>


### PR DESCRIPTION
## Summary
- Replace hardcoded `/downloads/EnviousWispr-1.3.0.dmg` with GitHub's latest-release redirect URL (`/releases/latest/download/EnviousWispr.dmg`)
- Download links now always serve the current version — no manual website updates needed after releases
- Removed stale "GitHub hidden while flagged" comments (account unflagged since 2026-03-20)

Closes ew-lhq1

## Test plan
- [ ] Click Download button on homepage hero — should download v1.5.4 DMG from GitHub
- [ ] Click Download in nav bar — same
- [ ] Click Download in footer — same
- [ ] Click Download in bottom CTA section — same
