### PR TITLE
fix(ci): macOS 26 runner + FoundationModels compile gate

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,20 +10,50 @@ concurrency:
 
 jobs:
   build-check:
-    runs-on: macos-15
+    runs-on: macos-26-large
     timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify Swift version
+      - name: Verify Xcode/SDK supports FoundationModels
         run: |
+          set -euo pipefail
+
           swift --version
-          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
-            echo "::error::Swift 6.0+ required"
+          XCODE_VER="$(xcodebuild -version | head -n1)"
+          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
+          SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+          echo "$XCODE_VER — SDK $SDK_VER"
+
+          XCODE_MAJOR=$(echo "$XCODE_VER" | grep -oE '[0-9]+' | head -1)
+          if [ "${XCODE_MAJOR:-0}" -lt 26 ]; then
+            echo "::error::Xcode 26+ required for FoundationModels (found: $XCODE_VER)"
             exit 1
           fi
+
+          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
+            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
+            exit 1
+          fi
+
+          cat > foundation_models_probe.swift <<'PROBE'
+          import Foundation
+          import FoundationModels
+
+          func _probe() {
+            _ = SystemLanguageModel.default
+          }
+          PROBE
+
+          xcrun swiftc \
+            -sdk "$SDK_PATH" \
+            -target arm64-apple-macos26.0 \
+            foundation_models_probe.swift \
+            -o /tmp/foundation_models_probe
+
+          echo "==> FoundationModels compile probe PASSED"
 
       - name: Cache SPM dependencies
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -59,9 +59,9 @@ jobs:
           SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
           echo "macOS SDK: $SDK_VER ($SDK_PATH)"
 
-          # Xcode check — optional (CLT-only machines don't have xcodebuild)
-          if command -v xcodebuild &>/dev/null; then
-            XCODE_VER="$(xcodebuild -version | head -n1)"
+          # Xcode check — optional (CLT shim exists but fails without full Xcode)
+          XCODE_VER="$(xcodebuild -version 2>/dev/null | head -n1 || true)"
+          if [ -n "$XCODE_VER" ]; then
             echo "Xcode: $XCODE_VER"
           else
             echo "Xcode: not installed (Command Line Tools only)"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,20 +50,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify Xcode/SDK supports FoundationModels
+      - name: Verify SDK supports FoundationModels
         run: |
           set -euo pipefail
 
           swift --version
-          XCODE_VER="$(xcodebuild -version | head -n1)"
           SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
           SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-          echo "$XCODE_VER — SDK $SDK_VER"
+          echo "macOS SDK: $SDK_VER ($SDK_PATH)"
 
-          XCODE_MAJOR=$(echo "$XCODE_VER" | grep -oE '[0-9]+' | head -1)
-          if [ "${XCODE_MAJOR:-0}" -lt 26 ]; then
-            echo "::error::Xcode 26+ required for FoundationModels (found: $XCODE_VER)"
-            exit 1
+          # Xcode check — optional (CLT-only machines don't have xcodebuild)
+          if command -v xcodebuild &>/dev/null; then
+            XCODE_VER="$(xcodebuild -version | head -n1)"
+            echo "Xcode: $XCODE_VER"
+          else
+            echo "Xcode: not installed (Command Line Tools only)"
           fi
 
           if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,8 +10,41 @@ concurrency:
 
 jobs:
   build-check:
-    runs-on: macos-26-large
+    runs-on: macos-15
     timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify Swift version
+        run: |
+          swift --version
+          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
+            echo "::error::Swift 6.0+ required"
+            exit 1
+          fi
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Build (debug)
+        run: swift build
+
+      - name: Build (release)
+        run: swift build -c release --arch arm64
+
+      - name: Verify test target compiles
+        run: swift build --build-tests
+
+  ai-compile-gate:
+    runs-on: [self-hosted, enviouswispr-release]
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -42,6 +75,7 @@ jobs:
           import Foundation
           import FoundationModels
 
+          // Minimal type reference so this is a real compile gate, not just syntax.
           func _probe() {
             _ = SystemLanguageModel.default
           }
@@ -54,20 +88,3 @@ jobs:
             -o /tmp/foundation_models_probe
 
           echo "==> FoundationModels compile probe PASSED"
-
-      - name: Cache SPM dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
-      - name: Build (debug)
-        run: swift build
-
-      - name: Build (release)
-        run: swift build -c release --arch arm64
-
-      - name: Verify test target compiles
-        run: swift build --build-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-26-large
+    runs-on: [self-hosted, enviouswispr-release]
     timeout-minutes: 330
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-15
+    runs-on: macos-26-large
     timeout-minutes: 330
     permissions:
       contents: write
@@ -19,13 +19,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify Swift version
+      - name: Verify Xcode/SDK supports FoundationModels
         run: |
+          set -euo pipefail
+
+          echo "==> Environment diagnostics"
           swift --version
-          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
-            echo "::error::Swift 6.0+ required but not found"
+          XCODE_VER="$(xcodebuild -version | head -n1)"
+          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
+          SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+          echo "$XCODE_VER"
+          echo "macOS SDK: $SDK_VER"
+          echo "SDK path: $SDK_PATH"
+
+          XCODE_MAJOR=$(echo "$XCODE_VER" | grep -oE '[0-9]+' | head -1)
+          if [ "${XCODE_MAJOR:-0}" -lt 26 ]; then
+            echo "::error::Xcode 26+ required for FoundationModels (found: $XCODE_VER)"
             exit 1
           fi
+
+          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
+            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
+            exit 1
+          fi
+
+          cat > foundation_models_probe.swift <<'PROBE'
+          import Foundation
+          import FoundationModels
+
+          // Minimal type reference so this is a real compile gate, not just syntax.
+          func _probe() {
+            _ = SystemLanguageModel.default
+          }
+          PROBE
+
+          xcrun swiftc \
+            -sdk "$SDK_PATH" \
+            -target arm64-apple-macos26.0 \
+            foundation_models_probe.swift \
+            -o /tmp/foundation_models_probe
+
+          echo "==> FoundationModels compile probe PASSED"
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,23 +19,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify Xcode/SDK supports FoundationModels
+      - name: Verify SDK supports FoundationModels
         run: |
           set -euo pipefail
 
           echo "==> Environment diagnostics"
           swift --version
-          XCODE_VER="$(xcodebuild -version | head -n1)"
           SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
           SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-          echo "$XCODE_VER"
           echo "macOS SDK: $SDK_VER"
           echo "SDK path: $SDK_PATH"
 
-          XCODE_MAJOR=$(echo "$XCODE_VER" | grep -oE '[0-9]+' | head -1)
-          if [ "${XCODE_MAJOR:-0}" -lt 26 ]; then
-            echo "::error::Xcode 26+ required for FoundationModels (found: $XCODE_VER)"
-            exit 1
+          # Xcode check — optional (CLT-only machines don't have xcodebuild)
+          if command -v xcodebuild &>/dev/null; then
+            echo "Xcode: $(xcodebuild -version | head -n1)"
+          else
+            echo "Xcode: not installed (Command Line Tools only)"
           fi
 
           if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,10 @@ jobs:
           echo "macOS SDK: $SDK_VER"
           echo "SDK path: $SDK_PATH"
 
-          # Xcode check — optional (CLT-only machines don't have xcodebuild)
-          if command -v xcodebuild &>/dev/null; then
-            echo "Xcode: $(xcodebuild -version | head -n1)"
+          # Xcode check — optional (CLT shim exists but fails without full Xcode)
+          XCODE_VER="$(xcodebuild -version 2>/dev/null | head -n1 || true)"
+          if [ -n "$XCODE_VER" ]; then
+            echo "Xcode: $XCODE_VER"
           else
             echo "Xcode: not installed (Command Line Tools only)"
           fi

--- a/docs/apple-intelligence-diagnostics-spec.md
+++ b/docs/apple-intelligence-diagnostics-spec.md
@@ -1,0 +1,410 @@
+# Apple Intelligence Availability Hardening Plan
+
+Bead: ew-5gzo | Depends on: ew-eel4 (CI/SDK fix)
+
+## Goal
+
+Upgrade the current Apple Intelligence availability checker from a simple UI status into a full diagnostic subsystem that:
+
+- performs layered gate checks
+- returns explicit failure reasons
+- logs every decision point
+- emits telemetry/debug breadcrumbs for later investigation
+- supports fast support triage on fresh installs
+
+This should help us answer:
+- Why is Apple Intelligence unavailable on this machine?
+- Was it compiled in correctly?
+- Is the runtime environment eligible?
+- Did the model/session initialization fail later?
+- What exact state did the user/device have when the issue happened?
+
+---
+
+## Desired Architecture
+
+Create a dedicated diagnostic component, not ad hoc checks in the settings view.
+
+Suggested types:
+
+- `AppleIntelligenceDiagnosticsService`
+- `AppleIntelligenceAvailabilityReport`
+- `AppleIntelligenceFailureReason`
+- `AppleIntelligenceTelemetrySnapshot`
+
+The settings UI should consume a structured report, not compute availability inline.
+
+---
+
+## Layered Gate Checks
+
+Implement availability as a multi-stage pipeline.
+
+### Stage 1: Build / Binary Gate
+Purpose: verify this app binary was actually built with Apple Intelligence support.
+
+Checks:
+- compile-time path for `FoundationModels` present
+- runtime marker confirming AI-capable binary path exists
+- optional build metadata flag embedded at build time:
+  - `appleIntelligenceCompiled = true`
+  - build SDK version
+  - app version / build number
+
+Why:
+This distinguishes:
+- "feature absent from binary"
+from
+- "feature present but unavailable on device"
+
+### Stage 2: OS / Runtime Environment Gate
+Checks:
+- macOS version meets minimum required floor for the API path you use
+- process is running on supported hardware class
+- any required framework/class/symbol can be loaded at runtime
+- sandbox / entitlement assumptions if relevant
+
+### Stage 3: Device Eligibility Gate
+Checks:
+- device is eligible for Apple Intelligence
+- Apple Intelligence support is actually active/usable for this user/device
+- language/locale/region prerequisites if your runtime path exposes this indirectly
+- model availability state if exposed by the runtime API
+
+Important:
+Do not reduce this to one boolean. Capture:
+- eligible
+- not eligible
+- unknown
+- temporarily unavailable
+- disabled / not configured
+
+### Stage 4: Model Access Gate
+Checks:
+- can create or access the system language model
+- can create a session / request object
+- lightweight probe call succeeds
+- timeout handling for slow first-load conditions
+
+This distinguishes:
+- "framework exists"
+from
+- "actual model usage is working"
+
+### Stage 5: Functional Probe Gate
+Run a tiny safe probe in debug / controlled contexts:
+- instantiate model/session
+- perform minimal no-op or tiny generation path if safe and cheap
+- record latency and result category
+
+Do not run expensive generation every time the settings page opens.
+Use caching and throttling.
+
+---
+
+## Report Object Design
+
+Create a structured report:
+
+```swift
+struct AppleIntelligenceAvailabilityReport {
+    let overallStatus: OverallStatus
+    let buildCompiledIn: Bool
+    let osVersion: String
+    let hardwareClass: String
+    let runtimeFrameworkPresent: Bool
+    let deviceEligibility: TriState
+    let modelAccessible: TriState
+    let probeSucceeded: TriState
+    let failureReasons: [AppleIntelligenceFailureReason]
+    let userVisibleMessage: String
+    let debugSummary: String
+    let generatedAt: Date
+}
+```
+
+Use enums, not strings:
+
+```swift
+enum OverallStatus {
+    case available
+    case unavailable
+    case degraded
+    case unknown
+    case checking
+}
+
+enum TriState {
+    case yes
+    case no
+    case unknown
+}
+```
+
+Failure reasons should be explicit and stable:
+
+```swift
+enum AppleIntelligenceFailureReason: String {
+    case notCompiledIn
+    case unsupportedOS
+    case unsupportedHardware
+    case frameworkMissingAtRuntime
+    case deviceNotEligible
+    case appleIntelligenceDisabledOrUnavailable
+    case localeOrRegionUnsupported
+    case modelAccessFailed
+    case probeTimedOut
+    case probeFailed
+    case unknownError
+}
+```
+
+---
+
+## UI Improvements
+
+Replace the single Available badge with richer status states.
+
+### Recommended UI states
+- Available
+- Checking...
+- Unavailable
+- Partially available
+- Error initializing
+- Unsupported on this Mac
+
+### Add "Why?" detail text
+
+Show a concise explanation under status:
+- "This build includes Apple Intelligence support and this Mac can use it."
+- "This build includes Apple Intelligence support, but this Mac does not meet runtime requirements."
+- "Apple Intelligence appears supported, but model initialization failed."
+- "Apple Intelligence support is missing from this app build."
+
+### Add a developer disclosure / debug section
+
+For dev builds or hidden advanced mode:
+- build compiled in: yes/no
+- OS version
+- hardware identifier / Apple silicon class if available
+- framework detected: yes/no
+- model access: yes/no/unknown
+- last probe time
+- last failure reason
+- last initialization error string
+
+### Add manual re-check action
+
+Keep the refresh button, but make it:
+- debounced
+- cancellable
+- stateful
+- logged
+
+---
+
+## Logging Requirements
+
+Structured logs, not generic print statements.
+
+### Log every stage
+
+For each stage emit:
+- stage name
+- pass/fail/unknown
+- reason code
+- duration
+- relevant environment metadata
+
+Example event names:
+- `ai_check_started`
+- `ai_build_gate_passed`
+- `ai_runtime_gate_failed`
+- `ai_model_probe_started`
+- `ai_model_probe_failed`
+- `ai_check_completed`
+
+### Include stable fields
+
+Every log/telemetry event should include:
+- app version
+- build number
+- macOS version
+- machine architecture
+- fresh install indicator if available
+- first launch indicator
+- selected provider = Apple Intelligence
+- check trigger source: app launch / settings open / manual refresh / first use / dictation attempt
+
+### Record durations
+
+Capture timing for:
+- full check duration
+- model initialization duration
+- probe duration
+
+This matters because some failures are really slow-init / timeout issues.
+
+---
+
+## Crash / Telemetry Integration
+
+### Before risky calls
+
+Add breadcrumbs before:
+- entering AI availability check
+- creating model/session objects
+- making first probe request
+- switching to Apple Intelligence as active provider
+- using Apple Intelligence during dictation cleanup
+
+### After risky calls
+
+Add breadcrumbs for:
+- success
+- error category
+- timeout
+- fallback triggered
+
+### Attach latest snapshot to errors
+
+Persist the most recent `AppleIntelligenceAvailabilityReport` in memory and optionally on disk.
+When a crash or tracked error occurs, include:
+- latest report summary
+- latest failure reason
+- provider selection
+- whether fallback occurred
+- recent timestamps
+
+---
+
+## Persistence / Debug History
+
+Keep a rolling history of recent checks.
+
+Suggested:
+- last 20 reports in memory
+- optionally last 5 persisted to disk for dev/support builds
+
+Store:
+- timestamp
+- trigger
+- status
+- failure reasons
+- durations
+
+Why: Fresh install bugs are often intermittent. A single current-state view is not enough.
+
+---
+
+## Fallback Behavior
+
+If Apple Intelligence fails:
+- do not silently present it as healthy
+- mark provider unavailable/degraded
+- fall back to another provider if your UX permits
+- log fallback reason
+- surface a clear message in settings
+
+Need explicit distinction between:
+- unavailable at startup
+- available at startup but failed at first use
+- available at startup but degraded later
+
+---
+
+## Fresh Install Hardening
+
+On first app launch:
+- run a full diagnostic once
+- log `fresh_install = true`
+- persist first-run report
+- run a second delayed re-check after a short interval if needed
+- compare first-check vs second-check state
+
+Reason: Some first-install bugs are timing/setup related, not true incompatibility.
+
+---
+
+## Testing Matrix
+
+### Unit tests
+- report building logic
+- failure reason mapping
+- UI message generation
+- fallback decision logic
+
+### Integration tests
+- compiled-in / not-compiled-in scenarios if possible via mocks
+- probe success / failure / timeout / unknown
+- refresh path
+- first-launch path
+
+### Manual QA scenarios
+- fresh install on supported Apple silicon machine
+- unsupported / simulated unsupported machine state
+- Apple Intelligence disabled/unavailable state
+- first launch offline
+- upgrade install vs fresh install
+- provider switched repeatedly
+- probe timeout / slow init simulation
+
+---
+
+## Implementation Notes
+
+### Avoid
+- a single boolean `isAvailable`
+- one-shot checks with no reason codes
+- unstructured console prints
+- expensive probe on every UI render
+- silently swallowing model init failures
+
+### Prefer
+- structured diagnostic reports
+- stable enums for failure reasons
+- cached availability state with manual refresh
+- background-safe logging
+- telemetry breadcrumbs before and after risky calls
+- explicit support snapshots
+
+---
+
+## Nice-to-Have
+
+Hidden "Copy diagnostics" button in dev builds that copies a compact support blob:
+- app version, build number, macOS version
+- provider selected, overall status
+- failure reasons
+- last probe duration, last error summary
+
+---
+
+## Suggested Priority Order
+
+### Phase 1
+- introduce report model
+- split checks into stages
+- add explicit reason codes
+- improve UI messaging
+
+### Phase 2
+- add structured logging + telemetry breadcrumbs
+- persist latest snapshot
+- add first-launch instrumentation
+
+### Phase 3
+- add probe timing, history, and support export
+- tighten tests and edge-case coverage
+
+---
+
+## Success Criteria
+
+This is successful when:
+- a fresh install issue can be classified from logs alone
+- support can distinguish build issue vs device issue vs runtime failure
+- crash tooling contains the last known AI availability state
+- the settings page explains why availability is failing
+- provider fallback behavior is deterministic and logged
+- telemetry fields are stable and enum-based, not freeform strings

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,0 +1,87 @@
+# Self-Hosted GitHub Actions Runner
+
+## Why
+
+Release builds require the macOS 26 SDK for FoundationModels (Apple Intelligence).
+GitHub's hosted runners (`macos-15`) don't have it. Larger runners (`macos-26-large`)
+require a Team/Enterprise org plan. A self-hosted runner on our macOS 26 machine is
+free, fast, and fully controlled.
+
+## Current Setup
+
+- **Machine:** M4 Pro MacBook (m4pro_sv)
+- **Runner name:** `enviouswispr-release`
+- **Labels:** `self-hosted`, `macOS`, `ARM64`, `apple-silicon`, `enviouswispr-release`
+- **Install path:** `~/actions-runner/`
+- **Service plist:** `~/Library/LaunchAgents/actions.runner.saurabhav88-EnviousWispr.enviouswispr-release.plist`
+- **Logs:** `~/Library/Logs/actions.runner.saurabhav88-EnviousWispr.enviouswispr-release/`
+
+## Workflow Split
+
+| Workflow | Runner | Purpose |
+|----------|--------|---------|
+| `pr-check.yml` → `build-check` | `macos-15` (hosted) | Fast compile gate — debug + release + test target |
+| `pr-check.yml` → `ai-compile-gate` | `self-hosted, enviouswispr-release` | FoundationModels compile probe |
+| `release.yml` → `build-and-release` | `self-hosted, enviouswispr-release` | Full release: build + sign + notarize + DMG |
+
+## Managing the Runner
+
+```bash
+# Check status
+cd ~/actions-runner && ./svc.sh status
+
+# Stop
+cd ~/actions-runner && ./svc.sh stop
+
+# Start
+cd ~/actions-runner && ./svc.sh start
+
+# Uninstall service (keeps runner files)
+cd ~/actions-runner && ./svc.sh uninstall
+
+# View logs
+tail -f ~/Library/Logs/actions.runner.saurabhav88-EnviousWispr.enviouswispr-release/*.log
+```
+
+## Recovery: Re-register Runner
+
+If the runner token expires or the runner needs re-registration:
+
+```bash
+cd ~/actions-runner
+
+# Get new token
+TOKEN=$(gh api repos/saurabhav88/EnviousWispr/actions/runners/registration-token --method POST --jq '.token')
+
+# Remove old config
+./config.sh remove --token "$TOKEN"
+
+# Re-register
+./config.sh --url https://github.com/saurabhav88/EnviousWispr \
+  --token "$TOKEN" \
+  --name enviouswispr-release \
+  --labels self-hosted,macOS,apple-silicon,enviouswispr-release \
+  --unattended --replace
+
+# Restart service
+./svc.sh install && ./svc.sh start
+```
+
+## Updating the Runner
+
+GitHub releases new runner versions regularly. To update:
+
+```bash
+cd ~/actions-runner && ./svc.sh stop
+# Download latest from https://github.com/actions/runner/releases
+curl -o actions-runner-osx-arm64-VERSION.tar.gz -L https://github.com/actions/runner/releases/download/vVERSION/actions-runner-osx-arm64-VERSION.tar.gz
+tar xzf actions-runner-osx-arm64-VERSION.tar.gz
+./svc.sh start
+```
+
+## Security Notes
+
+- The runner executes code from PRs. Since this is a private repo with controlled access, this is acceptable.
+- If the repo becomes public, restrict the runner to only run on `push` events (not `pull_request` from forks) to prevent arbitrary code execution.
+- Runner credentials are stored in `~/actions-runner/.credentials` and `~/actions-runner/.runner`.
+- The runner runs as the current user (`m4pro_sv`) with full access to the machine's toolchain and keychain.


### PR DESCRIPTION
## Summary
- Switch `release.yml` and `pr-check.yml` from `macos-15` to `macos-26-large` runner
- Add 3-layer fail-fast verification before any build step:
  1. Xcode major version >= 26
  2. macOS SDK version >= 26.0
  3. Real `swiftc` compile probe that `import FoundationModels` and references `SystemLanguageModel.default`
- No release DMG can ship without Apple Intelligence compiled in

## Why
`#if canImport(FoundationModels)` is compile-time. The `macos-15` runner has macOS 15 SDK which lacks FoundationModels — all Apple Intelligence code was silently stripped from every shipped binary. Users on macOS 26 got "AI polish failed" because the feature was never in the binary.

Confirmed by user: recompiling locally on a macOS 26 machine fixed AI polish immediately.

## Test plan
- [ ] PR check runs on `macos-26-large` — FoundationModels probe passes
- [ ] Build succeeds with macOS 26 SDK
- [ ] After merge, next tagged release should include Apple Intelligence in the binary

Closes ew-eel4
