### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.4</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.4</string>
+	<string>1.6.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
Version bump to 1.6.0. First release with Apple Intelligence compiled in via self-hosted macOS 26 runner.