### PR TITLE
feat: PostHog + Sentry observability stack (Phase 1)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6254dbf0ea7db11520451a2c2cbfa2fd8df8b0a49df6da2b6622fad6e804643c",
+  "originHash" : "6e305dba3639bb0c074ca6202541c9d6cbf04f06f1481800048c2e3217a9ee52",
   "pins" : [
     {
       "identity" : "fluidaudio",
@@ -8,6 +8,33 @@
       "state" : {
         "revision" : "9830ce835881c0d0d40f90aabfaae3a6da5bebfb",
         "version" : "0.12.4"
+      }
+    },
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
+        "version" : "1.12.2"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "573b68562fb03438b1f535d3326b00a731233f4f",
+        "version" : "3.48.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "05d3ce8332097ff0b2347231ac66476fd7d2f4d8",
+        "version" : "9.8.0"
       }
     },
     {
@@ -71,15 +98,6 @@
       "state" : {
         "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
         "version" : "1.1.9"
-      }
-    },
-    {
-      "identity" : "swiftsdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/TelemetryDeck/SwiftSDK.git",
-      "state" : {
-        "revision" : "d41d6e86265dc182ba4474f9ef53ecddbbe052b8",
-        "version" : "2.12.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
-        .package(url: "https://github.com/TelemetryDeck/SwiftSDK.git", from: "2.0.0"),
+        .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),
     ],
     targets: [
         .target(
@@ -40,7 +41,8 @@ let package = Package(
             name: "EnviousWisprServices",
             dependencies: [
                 "EnviousWisprCore",
-                .product(name: "TelemetryDeck", package: "SwiftSDK"),
+                .product(name: "PostHog", package: "posthog-ios"),
+                .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: "Sources/EnviousWisprServices"
         ),
@@ -108,7 +110,6 @@ let package = Package(
                 "WhisperKit",
                 "FluidAudio",
                 "Sparkle",
-                .product(name: "TelemetryDeck", package: "SwiftSDK"),
             ],
             path: "Sources/EnviousWispr",
             exclude: ["Resources"]

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import EnviousWisprCore
-import TelemetryDeck
+import EnviousWisprServices
 
 @main
 struct EnviousWisprApp: App {
@@ -9,12 +9,10 @@ struct EnviousWisprApp: App {
         !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
 
     init() {
-        // Only initialize TelemetryDeck if the user has completed onboarding.
-        // Onboarding says "No account, no tracking" — honour that promise.
-        if UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-            let config = TelemetryDeck.Config(appID: "30801A60-9339-4313-8ACE-CC294B2A3EEA")
-            TelemetryDeck.initialize(config: config)
-        }
+        // Initialize observability (PostHog + Sentry) unconditionally at launch —
+        // captures install/open/update lifecycle events, startup crashes, and the
+        // full onboarding funnel. Anonymous from first launch.
+        ObservabilityBootstrap.initialize()
     }
 
     var body: some Scene {

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -3,7 +3,6 @@ import EnviousWisprCore
 import EnviousWisprServices
 import EnviousWisprASR
 import EnviousWisprLLM
-import TelemetryDeck
 
 // MARK: - ViewModel
 
@@ -96,10 +95,6 @@ final class OnboardingV2ViewModel {
 
     func finishOnboarding(settings: SettingsManager) {
         settings.onboardingState = .completed
-        // Initialize TelemetryDeck now — the app init() skipped it because
-        // onboarding wasn't complete at launch time.
-        let config = TelemetryDeck.Config(appID: "30801A60-9339-4313-8ACE-CC294B2A3EEA")
-        TelemetryDeck.initialize(config: config)
         TelemetryService.shared.onboardingCompleted(asrBackend: settings.selectedBackend.rawValue, recordingMode: settings.recordingMode.rawValue)
     }
 }
@@ -184,7 +179,7 @@ private struct WelcomeScreenV2: View {
         ("shield.fill",  "On-Device",     "Your voice never leaves your Mac."),
         ("wifi.slash",   "Offline-Ready",  "Works without internet."),
         ("bolt.fill",    "Native Speed",   "Built for Apple Silicon."),
-        ("person.fill",  "Free & Private", "No account, no tracking."),
+        ("person.fill",  "Free & Private", "No account required. Anonymous analytics only."),
     ]
 
     @State private var appeared = false

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -1,0 +1,84 @@
+import Foundation
+import PostHog
+import Sentry
+
+/// Initializes PostHog and Sentry at app launch.
+/// Call UNCONDITIONALLY before onboarding — captures install/open/update/startup crashes.
+/// Limb: missing keys log a warning and skip initialization — never crashes the app.
+public enum ObservabilityBootstrap {
+
+    public static func initialize() {
+        initializePostHog()
+        initializeSentry()
+    }
+
+    // MARK: - Private
+
+    private static func initializePostHog() {
+        guard let apiKey = resolveKey(plistKey: "PostHogAPIKey", fileName: "posthog-api-key") else {
+            print("[ObservabilityBootstrap] Warning: PostHog API key not found — skipping PostHog initialization")
+            return
+        }
+
+        let config = PostHogConfig(apiKey: apiKey)
+        config.captureApplicationLifecycleEvents = true
+        config.enableSwizzling = false
+        config.captureScreenViews = false
+        config.sendFeatureFlagEvent = false
+        config.flushAt = 20
+        config.flushIntervalSeconds = 30
+        config.maxQueueSize = 1000
+        config.setBeforeSend { event in
+            // Placeholder for future PII redaction — drop or modify events here
+            return event
+        }
+
+        PostHogSDK.shared.setup(config)
+    }
+
+    private static func initializeSentry() {
+        guard let dsn = resolveKey(plistKey: "SentryDSN", fileName: "sentry-dsn") else {
+            print("[ObservabilityBootstrap] Warning: Sentry DSN not found — skipping Sentry initialization")
+            return
+        }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.sendDefaultPii = false
+            #if os(macOS)
+            options.enableUncaughtNSExceptionReporting = true
+            #endif
+            options.enableAutoSessionTracking = true
+            options.enableAutoBreadcrumbTracking = true
+            options.enableNetworkBreadcrumbs = false
+            options.enableFileIOTracing = false
+            options.enableCoreDataTracing = false
+            options.tracesSampleRate = NSNumber(value: 0)
+            options.beforeSend = { event in
+                print("[ObservabilityBootstrap] Sentry beforeSend")
+                return event
+            }
+        }
+    }
+
+    /// Resolves a key by checking Info.plist first, then falling back to the file system.
+    /// File system path: `~/.enviouswispr-keys/<fileName>`
+    private static func resolveKey(plistKey: String, fileName: String) -> String? {
+        // Try Info.plist first (stamped at build time for release builds)
+        if let plistValue = Bundle.main.object(forInfoDictionaryKey: plistKey) as? String,
+           !plistValue.isEmpty {
+            return plistValue
+        }
+
+        // Fall back to file system (dev builds)
+        let keysDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".enviouswispr-keys")
+        let keyFile = keysDir.appendingPathComponent(fileName)
+        if let value = try? String(contentsOf: keyFile, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+           !value.isEmpty {
+            return value
+        }
+
+        return nil
+    }
+}

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1,9 +1,9 @@
 import Foundation
-import TelemetryDeck
+import PostHog
 import EnviousWisprCore
 
-/// Thin wrapper — type-safe signal names, no business logic.
-/// Limb: observes facts from domain objects, publishes to TelemetryDeck.
+/// Thin wrapper — type-safe event names, no business logic.
+/// Limb: observes facts from domain objects, publishes to PostHog.
 @MainActor
 public final class TelemetryService {
     public static let shared = TelemetryService()
@@ -41,29 +41,52 @@ public final class TelemetryService {
         }
     }
 
+    // MARK: - App Lifecycle
+
+    public func appLaunched(version: String, build: String, osVersion: String, hardware: String, isFreshInstall: Bool, aiAvailable: Bool) {
+        PostHogSDK.shared.capture("app.launched", properties: [
+            "version": version,
+            "build": build,
+            "os_version": osVersion,
+            "hardware": hardware,
+            "is_fresh_install": isFreshInstall,
+            "ai_available": aiAvailable,
+        ])
+    }
+
+    public func providerChanged(from: String, to: String) {
+        PostHogSDK.shared.capture("provider.changed", properties: [
+            "from": from,
+            "to": to,
+        ])
+    }
+
     // MARK: - Onboarding
 
     public func onboardingStarted() {
-        TelemetryDeck.signal("Onboarding.started")
+        PostHogSDK.shared.capture("onboarding.started")
     }
 
     public func onboardingStepCompleted(step: String, result: String, durationSeconds: Double? = nil) {
-        var params: [String: String] = ["step": step, "result": result]
-        if let d = durationSeconds { params["durationSeconds"] = String(format: "%.3f", d) }
-        TelemetryDeck.signal("Onboarding.stepCompleted", parameters: params, floatValue: durationSeconds ?? 0)
+        var props: [String: Any] = ["step": step, "result": result]
+        if let d = durationSeconds {
+            props["duration_seconds"] = String(format: "%.3f", d)
+            props["$value"] = d
+        }
+        PostHogSDK.shared.capture("onboarding.step_completed", properties: props)
     }
 
     public func onboardingCompleted(asrBackend: String, recordingMode: String) {
-        TelemetryDeck.signal("Onboarding.completed", parameters: [
-            "asrBackend": asrBackend,
-            "recordingMode": recordingMode,
+        PostHogSDK.shared.capture("onboarding.completed", properties: [
+            "asr_backend": asrBackend,
+            "recording_mode": recordingMode,
         ])
     }
 
     // MARK: - Permissions
 
     public func permissionStatus(permission: String, status: String, context: String) {
-        TelemetryDeck.signal("Permission.status", parameters: [
+        PostHogSDK.shared.capture("permission.status", properties: [
             "permission": permission,
             "status": status,
             "context": context,
@@ -73,83 +96,90 @@ public final class TelemetryService {
     // MARK: - Dictation Lifecycle
 
     public func dictationInvoked(triggerSource: String, inputMode: String, targetApp: String?) {
-        var params: [String: String] = ["triggerSource": triggerSource, "inputMode": inputMode]
-        if let app = targetApp { params["targetApp"] = app }
-        TelemetryDeck.signal("Dictation.invoked", parameters: params)
+        var props: [String: Any] = ["trigger_source": triggerSource, "input_mode": inputMode]
+        if let app = targetApp { props["target_app"] = app }
+        PostHogSDK.shared.capture("dictation.invoked", properties: props)
     }
 
     public func dictationCompleted(result: String, inputMode: String, asrBackend: String,
                                     llmProvider: String?, stylePreset: String?, fillerRemoval: Bool,
                                     targetApp: String?, pasteResult: String?,
                                     e2eSeconds: Double, asrSeconds: Double?, llmSeconds: Double?) {
-        var params: [String: String] = [
+        var props: [String: Any] = [
             "result": result,
-            "inputMode": inputMode,
-            "asrBackend": asrBackend,
-            "fillerRemoval": String(fillerRemoval),
-            "e2eSeconds": String(format: "%.3f", e2eSeconds),
+            "input_mode": inputMode,
+            "asr_backend": asrBackend,
+            "filler_removal": fillerRemoval,
+            "e2e_seconds": String(format: "%.3f", e2eSeconds),
+            "$value": e2eSeconds,
         ]
-        if let p = llmProvider { params["llmProvider"] = p }
-        if let s = stylePreset { params["stylePreset"] = s }
-        if let a = targetApp { params["targetApp"] = a }
-        if let pr = pasteResult { params["pasteResult"] = pr }
-        if let asr = asrSeconds { params["asrSeconds"] = String(format: "%.3f", asr) }
-        if let llm = llmSeconds { params["llmSeconds"] = String(format: "%.3f", llm) }
-        TelemetryDeck.signal("Dictation.completed", parameters: params, floatValue: e2eSeconds)
+        if let p = llmProvider { props["llm_provider"] = p }
+        if let s = stylePreset { props["style_preset"] = s }
+        if let a = targetApp { props["target_app"] = a }
+        if let pr = pasteResult { props["paste_result"] = pr }
+        if let asr = asrSeconds { props["asr_seconds"] = String(format: "%.3f", asr) }
+        if let llm = llmSeconds { props["llm_seconds"] = String(format: "%.3f", llm) }
+        PostHogSDK.shared.capture("dictation.completed", properties: props)
     }
 
     public func dictationCanceled(stage: String, reason: String, durationSeconds: Double?) {
-        var params: [String: String] = ["stage": stage, "reason": reason]
-        if let d = durationSeconds { params["durationSeconds"] = String(format: "%.3f", d) }
-        TelemetryDeck.signal("Dictation.canceled", parameters: params, floatValue: durationSeconds ?? 0)
+        var props: [String: Any] = ["stage": stage, "reason": reason]
+        if let d = durationSeconds {
+            props["duration_seconds"] = String(format: "%.3f", d)
+            props["$value"] = d
+        }
+        PostHogSDK.shared.capture("dictation.canceled", properties: props)
     }
 
     // MARK: - Pipeline Steps
 
     public func asrCompleted(backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int) {
-        TelemetryDeck.signal("ASR.completed", parameters: [
+        PostHogSDK.shared.capture("asr.completed", properties: [
             "backend": backend,
             "result": result,
-            "coldStart": String(coldStart),
-            "latencySeconds": String(format: "%.3f", latencySeconds),
-            "charCount": String(charCount),
-        ], floatValue: latencySeconds)
+            "cold_start": coldStart,
+            "latency_seconds": String(format: "%.3f", latencySeconds),
+            "char_count": charCount,
+            "$value": latencySeconds,
+        ])
     }
 
     public func llmPolishCompleted(provider: String, model: String?, stylePreset: String?,
                                     result: String, latencySeconds: Double) {
-        var params: [String: String] = [
+        var props: [String: Any] = [
             "provider": provider,
             "result": result,
-            "latencySeconds": String(format: "%.3f", latencySeconds),
+            "latency_seconds": String(format: "%.3f", latencySeconds),
+            "$value": latencySeconds,
         ]
-        if let m = model { params["model"] = m }
-        if let s = stylePreset { params["stylePreset"] = s }
-        TelemetryDeck.signal("LLM.polishCompleted", parameters: params, floatValue: latencySeconds)
+        if let m = model { props["model"] = m }
+        if let s = stylePreset { props["style_preset"] = s }
+        PostHogSDK.shared.capture("llm.polish_completed", properties: props)
     }
 
     public func pasteCompleted(tier: String, targetApp: String?, result: String, latencyMs: Int) {
-        var params: [String: String] = [
+        var props: [String: Any] = [
             "tier": tier,
             "result": result,
-            "latencyMs": String(latencyMs),
+            "latency_ms": latencyMs,
+            "$value": Double(latencyMs),
         ]
-        if let a = targetApp { params["targetApp"] = a }
-        TelemetryDeck.signal("Paste.completed", parameters: params, floatValue: Double(latencyMs))
+        if let a = targetApp { props["target_app"] = a }
+        PostHogSDK.shared.capture("paste.completed", properties: props)
     }
 
     // MARK: - Errors
 
     public func pipelineFailed(stage: String, errorCategory: String, errorCode: String,
                                 recoverable: Bool, backend: String?) {
-        var params: [String: String] = [
+        var props: [String: Any] = [
             "stage": stage,
-            "errorCategory": errorCategory,
-            "errorCode": errorCode,
-            "recoverable": String(recoverable),
+            "error_category": errorCategory,
+            "error_code": errorCode,
+            "recoverable": recoverable,
         ]
-        if let b = backend { params["backend"] = b }
-        TelemetryDeck.signal("Pipeline.failed", parameters: params)
+        if let b = backend { props["backend"] = b }
+        PostHogSDK.shared.capture("pipeline.failed", properties: props)
     }
 
     // MARK: - Settings Snapshot
@@ -157,15 +187,15 @@ public final class TelemetryService {
     public func settingsSnapshot(asrBackend: String, llmProvider: String, recordingMode: String,
                                   writingStyle: String, fillerRemoval: Bool, customWordsCount: Int,
                                   hasApiKeys: Bool, noiseSuppression: Bool) {
-        TelemetryDeck.signal("Settings.snapshot", parameters: [
-            "asrBackend": asrBackend,
-            "llmProvider": llmProvider,
-            "recordingMode": recordingMode,
-            "writingStyle": writingStyle,
-            "fillerRemoval": String(fillerRemoval),
-            "customWordsCount": String(customWordsCount),
-            "hasApiKeys": String(hasApiKeys),
-            "noiseSuppression": String(noiseSuppression),
+        PostHogSDK.shared.capture("settings.snapshot", properties: [
+            "asr_backend": asrBackend,
+            "llm_provider": llmProvider,
+            "recording_mode": recordingMode,
+            "writing_style": writingStyle,
+            "filler_removal": fillerRemoval,
+            "custom_words_count": customWordsCount,
+            "has_api_keys": hasApiKeys,
+            "noise_suppression": noiseSuppression,
         ])
     }
 
@@ -173,12 +203,13 @@ public final class TelemetryService {
 
     public func metricPipelineE2E(seconds: Double, inputMode: String, asrBackend: String,
                                    llmProvider: String?, result: String) {
-        var params: [String: String] = [
-            "inputMode": inputMode,
-            "asrBackend": asrBackend,
+        var props: [String: Any] = [
+            "input_mode": inputMode,
+            "asr_backend": asrBackend,
             "result": result,
+            "$value": seconds,
         ]
-        if let p = llmProvider { params["llmProvider"] = p }
-        TelemetryDeck.signal("Metric.pipeline.e2eSeconds", parameters: params, floatValue: seconds)
+        if let p = llmProvider { props["llm_provider"] = p }
+        PostHogSDK.shared.capture("metric.pipeline.e2e_seconds", properties: props)
     }
 }


### PR DESCRIPTION
## Summary
- Replace TelemetryDeck with PostHog for product analytics (1M events/month free)
- Add Sentry for crash reporting + error tracking (5K errors/month free)
- Both SDKs initialize at app launch (before onboarding) — captures install/open/update lifecycle events and startup crashes
- TelemetryService rewritten to emit to PostHog instead of TelemetryDeck
- Onboarding copy updated from "No tracking" to "Anonymous analytics only"

## Phase 1 Exit Checklist (all passed)
- [x] PostHog lifecycle events visible (Application Installed)
- [x] Manual PostHog custom event visible (observability_test_event, settings.snapshot)
- [x] Sentry init verified (session started, project registered)
- [x] Sentry handled error captured (ENVIOUSWISPR-1)
- [x] Sentry real crash captured (ENVIOUSWISPR-2, SIGABRT Fatal)
- [x] Privacy/redaction confirmed (sendDefaultPii=false, beforeSend hooks)
- [x] Config sanity checked (autocapture trimmed)
- [x] Cold relaunch verified (events arrive after quit+relaunch)

## Test plan
- [x] All 8 exit checklist items verified on live dashboards
- [ ] CI build passes on both hosted + self-hosted runners
