### PR TITLE
feat: Sentry pipeline breadcrumbs + error capture (Phase 2)

### DIFF
--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -1,6 +1,7 @@
 import Foundation
 import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprServices
 
 /// Polishes transcribed text using an LLM provider.
 @MainActor
@@ -39,6 +40,10 @@ public final class LLMPolishStep: TextProcessingStep {
 
     public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
         onWillProcess?()
+        SentryBreadcrumb.add(stage: "polish", message: "LLM polish started", data: [
+            "provider": llmProvider.rawValue,
+            "model": llmModel,
+        ])
 
         // Short-circuit: ultra-short transcripts get passed through verbatim.
         // LLMs treat 1-3 word inputs as prompts to respond to, not text to clean.
@@ -63,7 +68,9 @@ public final class LLMPolishStep: TextProcessingStep {
         case .gemini: GeminiConnector(keychainManager: keychainManager)
         case .ollama: OllamaConnector()
         case .appleIntelligence: AppleIntelligenceConnector()
-        case .none: throw LLMError.providerUnavailable
+        case .none:
+            SentryBreadcrumb.captureError(LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
+            throw LLMError.providerUnavailable
         }
 
         let keychainId: String? = switch llmProvider {
@@ -122,6 +129,12 @@ public final class LLMPolishStep: TextProcessingStep {
         )
         let llmEnd = CFAbsoluteTimeGetCurrent()
 
+        SentryBreadcrumb.add(stage: "polish", message: "LLM polish completed", data: [
+            "provider": llmProvider.rawValue,
+            "model": llmModel,
+            "duration_s": String(format: "%.3f", llmEnd - llmStart),
+            "char_count": result.polishedText.count,
+        ])
         Task { await AppLogger.shared.log(
             "LLM polish complete: \(result.polishedText.count) chars in \(String(format: "%.3f", llmEnd - llmStart))s " +
             "(provider=\(llmProvider.rawValue), model=\(llmModel))",

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -135,9 +135,11 @@ public final class TranscriptionPipeline: DictationPipeline {
         // Ensure model is loaded (model should already be cached by WhisperKitSetupService)
         if !asrManager.isModelLoaded {
             state = .loadingModel
+            SentryBreadcrumb.add(stage: "asr", message: "Model loading", data: ["backend": asrManager.activeBackendType.rawValue])
             do {
                 try await asrManager.loadModel()
             } catch {
+                SentryBreadcrumb.captureError(error, category: .modelLoadFailed, stage: "asr", extra: ["backend": asrManager.activeBackendType.rawValue])
                 stopRequested = false
                 state = .error("Model load failed: \(error.localizedDescription)")
                 return
@@ -163,6 +165,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 streamingASRActive = true
                 streamingBuffersDispatched = 0
                 streamingBuffersFed = 0
+                SentryBreadcrumb.add(stage: "asr", message: "Streaming ASR started", data: ["backend": asrManager.activeBackendType.rawValue])
 
                 // Wire audio buffer forwarding: each converted buffer goes to streaming ASR.
                 // The streamingASRActive flag gates delivery — deactivateStreamingForwarding()
@@ -191,6 +194,7 @@ public final class TranscriptionPipeline: DictationPipeline {
             } catch {
                 // Streaming init failed — fall back to batch after recording
                 deactivateStreamingForwarding()
+                SentryBreadcrumb.add(stage: "asr", message: "Streaming start failed, will use batch", level: .warning)
                 Task { await AppLogger.shared.log(
                     "Streaming ASR failed to start, will use batch: \(error.localizedDescription)",
                     level: .info, category: "Pipeline"
@@ -224,6 +228,10 @@ public final class TranscriptionPipeline: DictationPipeline {
             state = .recording
             recordingStartTime = Date()
             currentTranscript = nil
+            SentryBreadcrumb.add(stage: "recording", message: "Recording started", data: [
+                "backend": asrManager.activeBackendType.rawValue,
+                "streaming": streamingASRActive,
+            ])
 
             if stopRequested {
                 stopRequested = false
@@ -244,6 +252,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 await asrManager.cancelStreaming()
             }
             deactivateStreamingForwarding()
+            SentryBreadcrumb.captureError(error, category: .audioCaptureFailed, stage: "recording")
             stopRequested = false
             state = .error("Recording failed: \(error.localizedDescription)")
         }
@@ -313,6 +322,7 @@ public final class TranscriptionPipeline: DictationPipeline {
         // Without this reorder, deactivateStreamingForwarding() sets the flag to false
         // and all queued tasks drop their buffers — losing ~250-500ms of trailing audio.
         let rawSamples = await audioCapture.stopCapture()
+        SentryBreadcrumb.add(stage: "recording", message: "Recording stopped", data: ["sample_count": rawSamples.count])
 
         if wasStreaming {
             // Deterministic drain: freeze the dispatch count after stopCapture (no new buffers
@@ -354,6 +364,7 @@ public final class TranscriptionPipeline: DictationPipeline {
             if wasStreaming {
                 await asrManager.cancelStreaming()
             }
+            SentryBreadcrumb.add(stage: "recording", message: "No audio captured", level: .warning)
             state = .error("No audio captured")
             return
         }
@@ -399,6 +410,10 @@ public final class TranscriptionPipeline: DictationPipeline {
         }
 
         state = .transcribing
+        SentryBreadcrumb.add(stage: "asr", message: "Transcription started", data: [
+            "mode": wasStreaming ? "streaming" : "batch",
+            "backend": asrManager.activeBackendType.rawValue,
+        ])
 
         do {
             let asrStart = CFAbsoluteTimeGetCurrent()
@@ -431,6 +446,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 } catch {
                     // Streaming finalization failed or timed out — cancel and fall back to batch
                     await asrManager.cancelStreaming()
+                    SentryBreadcrumb.add(stage: "asr", message: "Streaming finalize failed, falling back to batch", level: .warning)
                     Task { await AppLogger.shared.log(
                         "Streaming ASR finalize failed, falling back to batch: \(error.localizedDescription)",
                         level: .info, category: "Pipeline"
@@ -445,6 +461,11 @@ public final class TranscriptionPipeline: DictationPipeline {
 
             let asrText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !asrText.isEmpty else {
+                SentryBreadcrumb.captureError(
+                    NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "ASR returned empty text"]),
+                    category: .asrEmptyResult, stage: "asr",
+                    extra: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"]
+                )
                 state = .error("No speech detected — try speaking closer to the microphone")
                 Task { await AppLogger.shared.log(
                     "ASR returned empty text, showing error to user",
@@ -453,6 +474,12 @@ public final class TranscriptionPipeline: DictationPipeline {
                 return
             }
 
+            SentryBreadcrumb.add(stage: "asr", message: "ASR completed", data: [
+                "mode": wasStreaming ? "streaming" : "batch",
+                "backend": asrManager.activeBackendType.rawValue,
+                "duration_s": String(format: "%.3f", asrEnd - asrStart),
+                "char_count": asrText.count,
+            ])
             Task { await AppLogger.shared.log(
                 "Pipeline timing: ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s " +
                 "(mode=\(wasStreaming ? "streaming" : "batch"), \(asrText.count) chars, lang=\(result.language ?? "?"))",
@@ -465,6 +492,10 @@ public final class TranscriptionPipeline: DictationPipeline {
             do {
                 context = try await runTextProcessing(asrText: asrText, language: result.language)
             } catch {
+                SentryBreadcrumb.captureError(error, category: .generationFailed, stage: "polish", extra: [
+                    "provider": llmPolishStep.llmProvider.rawValue,
+                    "model": llmPolishStep.llmModel,
+                ])
                 Task { await AppLogger.shared.log(
                     "Text processing failed: \(error.localizedDescription)",
                     level: .info, category: "Pipeline"
@@ -614,8 +645,18 @@ public final class TranscriptionPipeline: DictationPipeline {
                 e2eSeconds: pipelineEnd - pipelineStart
             )
             currentTranscript = transcript
+            SentryBreadcrumb.add(stage: "pipeline", message: "Pipeline complete", data: [
+                "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
+                "asr_s": String(format: "%.3f", asrEnd - asrStart),
+                "polish_s": String(format: "%.3f", polishEnd - polishStart),
+                "paste_tier": pasteTier?.rawValue ?? "none",
+                "backend": asrManager.activeBackendType.rawValue,
+            ])
             state = .complete
         } catch {
+            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: [
+                "backend": asrManager.activeBackendType.rawValue,
+            ])
             state = .error("Transcription failed: \(error.localizedDescription)")
         }
     }
@@ -626,6 +667,10 @@ public final class TranscriptionPipeline: DictationPipeline {
         guard !state.isActive || state == .complete else { return nil }
 
         state = .polishing
+        SentryBreadcrumb.add(stage: "polish", message: "Re-polish requested", data: [
+            "provider": llmPolishStep.llmProvider.rawValue,
+            "model": llmPolishStep.llmModel,
+        ])
         let polishedText: String
         do {
             var context = TextProcessingContext(
@@ -701,6 +746,11 @@ public final class TranscriptionPipeline: DictationPipeline {
     /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
     /// Called by AppState's unified interruption handler, not set directly on audioCapture.
     public func handleEngineInterruption() {
+        SentryBreadcrumb.captureError(
+            NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted"]),
+            category: .xpcServiceError, stage: "audio",
+            extra: ["was_recording": state == .recording]
+        )
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -720,6 +770,11 @@ public final class TranscriptionPipeline: DictationPipeline {
     /// Called by AppState's unified ASR interruption handler when this pipeline is active.
     /// Must stop audio capture (still running — only ASR died) and clean up fully.
     public func handleASRServiceInterruption() {
+        SentryBreadcrumb.captureError(
+            NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed"]),
+            category: .xpcServiceError, stage: "asr",
+            extra: ["was_recording": state == .recording]
+        )
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -201,6 +201,7 @@ public final class WhisperKitPipeline: DictationPipeline {
 
         state = .startingUp
         lastPolishError = nil
+        SentryBreadcrumb.add(stage: "whisperkit", message: "Pipeline starting up")
 
         // Load model if not ready
         let isBackendReady = await backend.isReady
@@ -208,9 +209,11 @@ public final class WhisperKitPipeline: DictationPipeline {
 
         if !isBackendReady {
             state = .loadingModel
+            SentryBreadcrumb.add(stage: "asr", message: "WhisperKit model loading")
             do {
                 try await backend.prepare()
             } catch {
+                SentryBreadcrumb.captureError(error, category: .modelLoadFailed, stage: "asr", extra: ["backend": "whisperKit"])
                 state = .error("Model load failed: \(error.localizedDescription)")
                 return
             }
@@ -244,6 +247,7 @@ public final class WhisperKitPipeline: DictationPipeline {
             state = .recording
             recordingStartTime = Date()
             currentTranscript = nil
+            SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording started", data: ["backend": "whisperKit"])
             startVADMonitoring()
             await startIncrementalWorker()
 
@@ -252,6 +256,7 @@ public final class WhisperKitPipeline: DictationPipeline {
                 level: .info, category: "WhisperKitPipeline"
             ) }
         } catch {
+            SentryBreadcrumb.captureError(error, category: .audioCaptureFailed, stage: "recording", extra: ["backend": "whisperKit"])
             state = .error("Recording failed: \(error.localizedDescription)")
         }
     }
@@ -305,6 +310,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         vadMonitorTask = nil
 
         let rawSamples = await audioCapture.stopCapture()
+        SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording stopped", data: ["sample_count": rawSamples.count])
 
         // Pre-warm LLM connection while ASR runs
         LLMNetworkSession.shared.preWarmIfConfigured(
@@ -313,6 +319,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         )
 
         guard !rawSamples.isEmpty else {
+            SentryBreadcrumb.add(stage: "recording", message: "No audio captured (WhisperKit)", level: .warning)
             state = .error("No audio captured")
             return
         }
@@ -357,6 +364,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         }
 
         state = .transcribing
+        SentryBreadcrumb.add(stage: "asr", message: "WhisperKit transcription started", data: ["backend": "whisperKit"])
 
         do {
             let asrStart = CFAbsoluteTimeGetCurrent()
@@ -416,10 +424,20 @@ public final class WhisperKitPipeline: DictationPipeline {
             let asrEnd = CFAbsoluteTimeGetCurrent()
 
             guard !asrText.isEmpty else {
+                SentryBreadcrumb.captureError(
+                    NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "WhisperKit ASR returned empty text"]),
+                    category: .asrEmptyResult, stage: "asr",
+                    extra: ["backend": "whisperKit", "incremental": usedIncremental]
+                )
                 state = .error("No speech detected — try speaking closer to the microphone")
                 return
             }
 
+            SentryBreadcrumb.add(stage: "asr", message: "WhisperKit ASR completed", data: [
+                "duration_s": String(format: "%.3f", asrEnd - asrStart),
+                "char_count": asrText.count,
+                "incremental": usedIncremental,
+            ])
             Task { await AppLogger.shared.log(
                 "WhisperKit ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s " +
                 "(\(asrText.count) chars, lang=\(asrLanguage ?? "?"), incremental=\(usedIncremental))",
@@ -432,6 +450,10 @@ public final class WhisperKitPipeline: DictationPipeline {
             do {
                 context = try await runTextProcessing(asrText: asrText, language: asrLanguage)
             } catch {
+                SentryBreadcrumb.captureError(error, category: .generationFailed, stage: "polish", extra: [
+                    "provider": llmPolishStep.llmProvider.rawValue,
+                    "model": llmPolishStep.llmModel,
+                ])
                 lastPolishError = error.localizedDescription
                 context = TextProcessingContext(text: asrText, originalASRText: asrText, language: asrLanguage)
             }
@@ -492,9 +514,16 @@ public final class WhisperKitPipeline: DictationPipeline {
                 e2eSeconds: pipelineEnd - pipelineStart
             )
             currentTranscript = transcript
+            SentryBreadcrumb.add(stage: "pipeline", message: "WhisperKit pipeline complete", data: [
+                "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
+                "asr_s": String(format: "%.3f", asrEnd - asrStart),
+                "polish_s": String(format: "%.3f", polishEnd - polishStart),
+                "paste_tier": pasteTier?.rawValue ?? "none",
+            ])
             state = .complete
             scheduleModelUnloadIfNeeded()
         } catch {
+            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"])
             state = .error("Transcription failed: \(error.localizedDescription)")
         }
     }
@@ -502,6 +531,11 @@ public final class WhisperKitPipeline: DictationPipeline {
     /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
     /// Called by AppState's unified interruption handler, not set directly on audioCapture.
     public func handleEngineInterruption() {
+        SentryBreadcrumb.captureError(
+            NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted (WhisperKit)"]),
+            category: .xpcServiceError, stage: "audio",
+            extra: ["was_recording": state == .recording, "backend": "whisperKit"]
+        )
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -517,6 +551,11 @@ public final class WhisperKitPipeline: DictationPipeline {
     /// Called by AppState's unified ASR interruption handler when this pipeline is active.
     /// Must stop audio capture (still running — only ASR died) and clean up fully.
     public func handleASRServiceInterruption() {
+        SentryBreadcrumb.captureError(
+            NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed (WhisperKit)"]),
+            category: .xpcServiceError, stage: "asr",
+            extra: ["was_recording": state == .recording, "backend": "whisperKit"]
+        )
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -44,18 +44,28 @@ public enum ObservabilityBootstrap {
 
         SentrySDK.start { options in
             options.dsn = dsn
+
+            // Privacy: no PII, no default data collection
             options.sendDefaultPii = false
+
+            // Crash reporting: the core reason Sentry exists here
             #if os(macOS)
             options.enableUncaughtNSExceptionReporting = true
             #endif
             options.enableAutoSessionTracking = true
-            options.enableAutoBreadcrumbTracking = true
+
+            // Manual-only instrumentation: we add our own breadcrumbs via SentryBreadcrumb.
+            // Disable all auto-collection to avoid surprise data, noise, and hidden swizzling.
+            options.enableAutoBreadcrumbTracking = false
             options.enableNetworkBreadcrumbs = false
+            options.enableCaptureFailedRequests = false
+            options.enableSwizzling = false
             options.enableFileIOTracing = false
             options.enableCoreDataTracing = false
+            options.enableAppHangTracking = false
             options.tracesSampleRate = NSNumber(value: 0)
+
             options.beforeSend = { event in
-                print("[ObservabilityBootstrap] Sentry beforeSend")
                 return event
             }
         }

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Sentry
+
+/// Thin, type-safe Sentry breadcrumb + error helper for pipeline instrumentation.
+/// Limb: all methods are fire-and-forget — a Sentry call failure never blocks the pipeline.
+@MainActor
+public enum SentryBreadcrumb {
+
+    // MARK: - Breadcrumbs
+
+    /// Add a structured breadcrumb at a pipeline stage boundary.
+    /// - Parameters:
+    ///   - stage: Pipeline stage (e.g. "recording", "asr", "polish", "paste")
+    ///   - message: Human-readable description (no PII — no transcript text)
+    ///   - level: Sentry level (default .info)
+    ///   - data: Structured key-value pairs (provider, duration, outcome, etc.)
+    public static func add(
+        stage: String,
+        message: String,
+        level: SentryLevel = .info,
+        data: [String: Any]? = nil
+    ) {
+        let crumb = Breadcrumb(level: level, category: "pipeline.\(stage)")
+        crumb.message = message
+        crumb.type = "default"
+        if let data {
+            crumb.data = data
+        }
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    // MARK: - Handled Errors
+
+    /// Capture a handled error with pipeline context tags.
+    /// Use for failures that don't crash the app but should be diagnosable in Sentry.
+    public static func captureError(
+        _ error: any Error,
+        category: ErrorCategory,
+        stage: String,
+        extra: [String: Any]? = nil
+    ) {
+        let event = Event(level: .error)
+        event.message = SentryMessage(formatted: "\(category.rawValue): \(error.localizedDescription)")
+        event.tags = [
+            "pipeline.stage": stage,
+            "error.category": category.rawValue,
+        ]
+        if let extra {
+            event.extra = extra
+        }
+
+        // Also add a breadcrumb so the error appears in the trail
+        add(
+            stage: stage,
+            message: "ERROR: \(category.rawValue)",
+            level: .error,
+            data: extra
+        )
+
+        SentrySDK.capture(event: event)
+    }
+
+    // MARK: - Error Taxonomy
+
+    /// Structured error categories for pipeline failures.
+    /// Maps to Sentry tags for filtering and alerting.
+    public enum ErrorCategory: String, Sendable {
+        case availabilityCheckFailed = "availability_check_failed"
+        case providerInitFailed = "provider_init_failed"
+        case generationFailed = "generation_failed"
+        case fallbackFailed = "fallback_failed"
+        case pasteFailed = "paste_failed"
+        case stateMismatch = "state_mismatch"
+        case xpcServiceError = "xpc_service_error"
+        case modelLoadFailed = "model_load_failed"
+        case audioCaptureFailed = "audio_capture_failed"
+        case asrFailed = "asr_failed"
+        case asrEmptyResult = "asr_empty_result"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SentryBreadcrumb` helper in EnviousWisprServices — thin, type-safe API for adding breadcrumbs and capturing handled errors with pipeline context tags
- Instruments both TranscriptionPipeline and WhisperKitPipeline with structured breadcrumbs at every stage boundary (recording start/stop, ASR start/success/fail, polish start/success/fail, pipeline complete)
- Adds manual error capture with typed `ErrorCategory` enum at failure points: model load, audio capture, ASR empty result, polish/generation failure, XPC service crash, engine interruption
- Instruments LLMPolishStep with provider/model breadcrumbs for polish start, completion, and provider unavailable errors

## Privacy
- No transcript text, prompts, API keys, or secrets in any Sentry event or breadcrumb
- Only sends: stage names, backend type, provider/model names, duration values, character counts, boolean flags, paste tier, sample counts, system error descriptions

## Error taxonomy
`availability_check_failed`, `provider_init_failed`, `generation_failed`, `fallback_failed`, `paste_failed`, `state_mismatch`, `xpc_service_error`, `model_load_failed`, `audio_capture_failed`, `asr_failed`, `asr_empty_result`

## Test plan
- [ ] Release build passes (`swift build -c release`)
- [ ] Test target compiles (`swift build --build-tests`)
- [ ] Normal dictation flow produces breadcrumb trail in Sentry
- [ ] Provider failure with fallback produces error event + breadcrumb
- [ ] No PII in Sentry dashboard events
