### PR TITLE
feat: Apple Intelligence diagnostics subsystem (Phase 3)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -100,6 +100,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
 
+        // Run Apple Intelligence diagnostics and attach report to Sentry context.
+        // Fire-and-forget — report is logged as breadcrumb and persisted in Sentry scope
+        // so any future crash includes the AI availability state.
+        let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
+        SentryBreadcrumb.reportAIDiagnostics(aiReport)
+        Task { await AppLogger.shared.log(
+            "AI diagnostics: status=\(aiReport.overallStatus.rawValue), " +
+            "reasons=\(aiReport.failureReasons.map(\.rawValue)), " +
+            "duration=\(aiReport.checkDurationMs)ms",
+            level: .info, category: "Diagnostics"
+        ) }
+
         // Check Accessibility permission on launch (query only — never auto-prompt).
         appState.permissions.refreshOnLaunch()
         updateIcon() // Reflect accessibility warning state in menu bar icon

--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -104,7 +104,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Fire-and-forget — report is logged as breadcrumb and persisted in Sentry scope
         // so any future crash includes the AI availability state.
         let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
-        SentryBreadcrumb.reportAIDiagnostics(aiReport)
+        SentryBreadcrumb.attachAIDiagnostics(aiReport)
         Task { await AppLogger.shared.log(
             "AI diagnostics: status=\(aiReport.overallStatus.rawValue), " +
             "reasons=\(aiReport.failureReasons.map(\.rawValue)), " +

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// MARK: - Apple Intelligence Availability Report
+
+/// Structured diagnostic report for Apple Intelligence availability.
+/// Produced by the diagnostics service, consumed by UI and observability.
+public struct AppleIntelligenceAvailabilityReport: Sendable {
+    public let overallStatus: AIAvailabilityStatus
+    public let buildCompiledIn: Bool
+    public let osVersion: String
+    public let hardwareClass: String
+    public let runtimeFrameworkPresent: Bool
+    public let deviceEligibility: AITriState
+    public let modelAccessible: AITriState
+    public let failureReasons: [AIFailureReason]
+    public let userVisibleMessage: String
+    public let debugSummary: String
+    public let generatedAt: Date
+    public let checkDurationMs: Int
+
+    public init(
+        overallStatus: AIAvailabilityStatus,
+        buildCompiledIn: Bool,
+        osVersion: String,
+        hardwareClass: String,
+        runtimeFrameworkPresent: Bool,
+        deviceEligibility: AITriState,
+        modelAccessible: AITriState,
+        failureReasons: [AIFailureReason],
+        userVisibleMessage: String,
+        debugSummary: String,
+        generatedAt: Date = Date(),
+        checkDurationMs: Int = 0
+    ) {
+        self.overallStatus = overallStatus
+        self.buildCompiledIn = buildCompiledIn
+        self.osVersion = osVersion
+        self.hardwareClass = hardwareClass
+        self.runtimeFrameworkPresent = runtimeFrameworkPresent
+        self.deviceEligibility = deviceEligibility
+        self.modelAccessible = modelAccessible
+        self.failureReasons = failureReasons
+        self.userVisibleMessage = userVisibleMessage
+        self.debugSummary = debugSummary
+        self.generatedAt = generatedAt
+        self.checkDurationMs = checkDurationMs
+    }
+
+    /// Compact dictionary for Sentry context attachment — no PII, no user content.
+    public var sentryContext: [String: Any] {
+        [
+            "overall_status": overallStatus.rawValue,
+            "build_compiled_in": buildCompiledIn,
+            "os_version": osVersion,
+            "hardware_class": hardwareClass,
+            "runtime_framework_present": runtimeFrameworkPresent,
+            "device_eligibility": deviceEligibility.rawValue,
+            "model_accessible": modelAccessible.rawValue,
+            "failure_reasons": failureReasons.map(\.rawValue),
+            "check_duration_ms": checkDurationMs,
+        ]
+    }
+}
+
+// MARK: - Enums
+
+/// Overall availability status for Apple Intelligence.
+public enum AIAvailabilityStatus: String, Sendable {
+    case available
+    case unavailable
+    case degraded
+    case unknown
+}
+
+/// Three-state value for gate checks that may not be deterministic.
+public enum AITriState: String, Sendable {
+    case yes
+    case no
+    case unknown
+}
+
+/// Explicit, stable failure reasons for Apple Intelligence availability.
+/// Each maps to a specific diagnostic condition — not freeform strings.
+public enum AIFailureReason: String, Sendable, CaseIterable {
+    case notCompiledIn
+    case unsupportedOS
+    case unsupportedHardware
+    case frameworkMissingAtRuntime
+    case deviceNotEligible
+    case appleIntelligenceDisabled
+    case modelNotReady
+    case modelAccessFailed
+    case sessionInitFailed
+    case generationFailed
+    case unknownError
+}

--- a/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
@@ -1,0 +1,190 @@
+import Foundation
+import EnviousWisprCore
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Runs layered gate checks to produce a structured Apple Intelligence availability report.
+/// Each gate returns pass/fail/unknown with explicit failure reasons.
+///
+/// Gate stages:
+/// 1. Build/Binary — was FoundationModels compiled in?
+/// 2. OS/Runtime — is macOS version sufficient? Is the framework loadable?
+/// 3. Device Eligibility — is this device eligible for Apple Intelligence?
+/// 4. Model Access — can the system language model be accessed?
+///
+/// Limb: never throws, never blocks. Returns a report regardless of outcome.
+public enum AppleIntelligenceDiagnosticsService {
+
+    /// Run all gate checks and produce a structured report.
+    @MainActor
+    public static func runDiagnostics() -> AppleIntelligenceAvailabilityReport {
+        let start = CFAbsoluteTimeGetCurrent()
+        let osVersion = Self.currentOSVersion()
+        let hardwareClass = Self.currentHardwareClass()
+
+        var failureReasons: [AIFailureReason] = []
+        var debugLines: [String] = []
+
+        // Stage 1: Build / Binary Gate
+        let buildCompiledIn = Self.checkBuildGate()
+        debugLines.append("Stage 1 (Build): compiled_in=\(buildCompiledIn)")
+        if !buildCompiledIn {
+            failureReasons.append(.notCompiledIn)
+        }
+
+        // Stage 2: OS / Runtime Environment Gate
+        let (runtimePresent, osGateReasons) = Self.checkOSRuntimeGate(osVersion: osVersion)
+        debugLines.append("Stage 2 (OS/Runtime): framework_present=\(runtimePresent)")
+        failureReasons.append(contentsOf: osGateReasons)
+
+        // Stage 3 + 4: Device Eligibility + Model Access Gates
+        // These require FoundationModels to be compiled in and macOS 26+
+        var deviceEligibility: AITriState = .unknown
+        var modelAccessible: AITriState = .unknown
+
+        if buildCompiledIn && runtimePresent {
+            let (eligibility, modelAccess, deviceReasons) = Self.checkDeviceAndModelGates()
+            deviceEligibility = eligibility
+            modelAccessible = modelAccess
+            debugLines.append("Stage 3 (Device): eligibility=\(eligibility.rawValue)")
+            debugLines.append("Stage 4 (Model): accessible=\(modelAccess.rawValue)")
+            failureReasons.append(contentsOf: deviceReasons)
+        } else {
+            debugLines.append("Stage 3 (Device): skipped (build/runtime gate failed)")
+            debugLines.append("Stage 4 (Model): skipped (build/runtime gate failed)")
+        }
+
+        // Determine overall status
+        let overallStatus: AIAvailabilityStatus
+        let userMessage: String
+
+        if failureReasons.isEmpty {
+            overallStatus = .available
+            userMessage = "Apple Intelligence is available and ready to use."
+        } else if failureReasons.contains(.notCompiledIn) {
+            overallStatus = .unavailable
+            userMessage = "This build was compiled without Apple Intelligence support."
+        } else if failureReasons.contains(.unsupportedOS) {
+            overallStatus = .unavailable
+            userMessage = "Apple Intelligence requires macOS 26 or later."
+        } else if failureReasons.contains(.unsupportedHardware) || failureReasons.contains(.deviceNotEligible) {
+            overallStatus = .unavailable
+            userMessage = "This Mac does not support Apple Intelligence. Requires Apple Silicon (M1 or later)."
+        } else if failureReasons.contains(.appleIntelligenceDisabled) {
+            overallStatus = .unavailable
+            userMessage = "Apple Intelligence is not enabled. Turn it on in System Settings > Apple Intelligence & Siri."
+        } else if failureReasons.contains(.modelNotReady) {
+            overallStatus = .degraded
+            userMessage = "The on-device model is not ready — it may still be downloading. Try again later."
+        } else if failureReasons.contains(.modelAccessFailed) || failureReasons.contains(.sessionInitFailed) {
+            overallStatus = .degraded
+            userMessage = "Apple Intelligence is available but model initialization failed."
+        } else {
+            overallStatus = .unknown
+            userMessage = "Apple Intelligence availability could not be determined."
+        }
+
+        let durationMs = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+        let debugSummary = debugLines.joined(separator: " | ")
+
+        return AppleIntelligenceAvailabilityReport(
+            overallStatus: overallStatus,
+            buildCompiledIn: buildCompiledIn,
+            osVersion: osVersion,
+            hardwareClass: hardwareClass,
+            runtimeFrameworkPresent: runtimePresent,
+            deviceEligibility: deviceEligibility,
+            modelAccessible: modelAccessible,
+            failureReasons: failureReasons,
+            userVisibleMessage: userMessage,
+            debugSummary: debugSummary,
+            checkDurationMs: durationMs
+        )
+    }
+
+    // MARK: - Stage 1: Build / Binary Gate
+
+    private static func checkBuildGate() -> Bool {
+#if canImport(FoundationModels)
+        return true
+#else
+        return false
+#endif
+    }
+
+    // MARK: - Stage 2: OS / Runtime Environment Gate
+
+    private static func checkOSRuntimeGate(osVersion: String) -> (frameworkPresent: Bool, reasons: [AIFailureReason]) {
+        var reasons: [AIFailureReason] = []
+
+#if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return (true, [])
+        } else {
+            reasons.append(.unsupportedOS)
+            return (false, reasons)
+        }
+#else
+        reasons.append(.frameworkMissingAtRuntime)
+        return (false, reasons)
+#endif
+    }
+
+    // MARK: - Stage 3 + 4: Device Eligibility + Model Access
+
+    private static func checkDeviceAndModelGates() -> (eligibility: AITriState, modelAccess: AITriState, reasons: [AIFailureReason]) {
+#if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return checkDeviceAndModelGatesImpl()
+        }
+#endif
+        return (.unknown, .unknown, [.unknownError])
+    }
+
+#if canImport(FoundationModels)
+    @available(macOS 26.0, *)
+    private static func checkDeviceAndModelGatesImpl() -> (eligibility: AITriState, modelAccess: AITriState, reasons: [AIFailureReason]) {
+        let model = SystemLanguageModel.default
+
+        switch model.availability {
+        case .available:
+            return (.yes, .yes, [])
+
+        case .unavailable(let reason):
+            var reasons: [AIFailureReason] = []
+
+            switch reason {
+            case .deviceNotEligible:
+                reasons.append(.deviceNotEligible)
+                return (.no, .no, reasons)
+            case .appleIntelligenceNotEnabled:
+                reasons.append(.appleIntelligenceDisabled)
+                return (.yes, .no, reasons)
+            case .modelNotReady:
+                reasons.append(.modelNotReady)
+                return (.yes, .no, reasons)
+            @unknown default:
+                reasons.append(.unknownError)
+                return (.unknown, .unknown, reasons)
+            }
+        }
+    }
+#endif
+
+    // MARK: - Environment Helpers
+
+    private static func currentOSVersion() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }
+
+    private static func currentHardwareClass() -> String {
+        var size: size_t = 0
+        sysctlbyname("hw.machine", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.machine", &machine, &size, nil, 0)
+        return String(cString: machine)
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -499,7 +499,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 // If Apple Intelligence failed, run a fresh diagnostics check and attach it
                 if llmPolishStep.llmProvider == .appleIntelligence {
                     let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
-                    SentryBreadcrumb.reportAIDiagnostics(aiReport)
+                    SentryBreadcrumb.reportAIFailure(aiReport)
                 }
                 Task { await AppLogger.shared.log(
                     "Text processing failed: \(error.localizedDescription)",

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -496,6 +496,11 @@ public final class TranscriptionPipeline: DictationPipeline {
                     "provider": llmPolishStep.llmProvider.rawValue,
                     "model": llmPolishStep.llmModel,
                 ])
+                // If Apple Intelligence failed, run a fresh diagnostics check and attach it
+                if llmPolishStep.llmProvider == .appleIntelligence {
+                    let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
+                    SentryBreadcrumb.reportAIDiagnostics(aiReport)
+                }
                 Task { await AppLogger.shared.log(
                     "Text processing failed: \(error.localizedDescription)",
                     level: .info, category: "Pipeline"

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -454,6 +454,11 @@ public final class WhisperKitPipeline: DictationPipeline {
                     "provider": llmPolishStep.llmProvider.rawValue,
                     "model": llmPolishStep.llmModel,
                 ])
+                // If Apple Intelligence failed, run a fresh diagnostics check and attach it
+                if llmPolishStep.llmProvider == .appleIntelligence {
+                    let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
+                    SentryBreadcrumb.reportAIDiagnostics(aiReport)
+                }
                 lastPolishError = error.localizedDescription
                 context = TextProcessingContext(text: asrText, originalASRText: asrText, language: asrLanguage)
             }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -457,7 +457,7 @@ public final class WhisperKitPipeline: DictationPipeline {
                 // If Apple Intelligence failed, run a fresh diagnostics check and attach it
                 if llmPolishStep.llmProvider == .appleIntelligence {
                     let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
-                    SentryBreadcrumb.reportAIDiagnostics(aiReport)
+                    SentryBreadcrumb.reportAIFailure(aiReport)
                 }
                 lastPolishError = error.localizedDescription
                 context = TextProcessingContext(text: asrText, originalASRText: asrText, language: asrLanguage)

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Sentry
+import EnviousWisprCore
 
 /// Thin, type-safe Sentry breadcrumb + error helper for pipeline instrumentation.
 /// Limb: all methods are fire-and-forget — a Sentry call failure never blocks the pipeline.
@@ -58,6 +59,42 @@ public enum SentryBreadcrumb {
         )
 
         SentrySDK.capture(event: event)
+    }
+
+    // MARK: - Apple Intelligence Diagnostics
+
+    /// Report a full AI diagnostics check with breadcrumbs for each gate stage.
+    /// Also attaches the report as Sentry context so any future crash includes AI state.
+    public static func reportAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
+        // Breadcrumb for each gate result
+        add(stage: "ai_diagnostics", message: "AI availability check completed", data: [
+            "overall_status": report.overallStatus.rawValue,
+            "build_compiled_in": report.buildCompiledIn,
+            "os_version": report.osVersion,
+            "hardware_class": report.hardwareClass,
+            "runtime_framework_present": report.runtimeFrameworkPresent,
+            "device_eligibility": report.deviceEligibility.rawValue,
+            "model_accessible": report.modelAccessible.rawValue,
+            "failure_reasons": report.failureReasons.map(\.rawValue),
+            "check_duration_ms": report.checkDurationMs,
+        ])
+
+        // Attach as persistent Sentry context — included in every future event/crash
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: report.sentryContext, key: "apple_intelligence")
+        }
+
+        // If unavailable or degraded, capture a handled error for Sentry alerting
+        if report.overallStatus == .unavailable || report.overallStatus == .degraded {
+            let event = Event(level: .warning)
+            event.message = SentryMessage(formatted: "Apple Intelligence \(report.overallStatus.rawValue): \(report.failureReasons.map(\.rawValue).joined(separator: ", "))")
+            event.tags = [
+                "ai.overall_status": report.overallStatus.rawValue,
+                "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
+            ]
+            event.extra = report.sentryContext
+            SentrySDK.capture(event: event)
+        }
     }
 
     // MARK: - Error Taxonomy

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -63,15 +63,13 @@ public enum SentryBreadcrumb {
 
     // MARK: - Apple Intelligence Diagnostics
 
-    /// Report a full AI diagnostics check with breadcrumbs for each gate stage.
-    /// Also attaches the report as Sentry context so any future crash includes AI state.
-    public static func reportAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
-        // Breadcrumb for each gate result
+    /// Attach an AI diagnostics report as persistent Sentry context + breadcrumb.
+    /// Use at app launch — logs the state but does NOT fire a warning event.
+    /// The report is included in every future crash/error event automatically.
+    public static func attachAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
         add(stage: "ai_diagnostics", message: "AI availability check completed", data: [
             "overall_status": report.overallStatus.rawValue,
             "build_compiled_in": report.buildCompiledIn,
-            "os_version": report.osVersion,
-            "hardware_class": report.hardwareClass,
             "runtime_framework_present": report.runtimeFrameworkPresent,
             "device_eligibility": report.deviceEligibility.rawValue,
             "model_accessible": report.modelAccessible.rawValue,
@@ -79,22 +77,27 @@ public enum SentryBreadcrumb {
             "check_duration_ms": report.checkDurationMs,
         ])
 
-        // Attach as persistent Sentry context — included in every future event/crash
         SentrySDK.configureScope { scope in
             scope.setContext(value: report.sentryContext, key: "apple_intelligence")
         }
+    }
 
-        // If unavailable or degraded, capture a handled error for Sentry alerting
-        if report.overallStatus == .unavailable || report.overallStatus == .degraded {
-            let event = Event(level: .warning)
-            event.message = SentryMessage(formatted: "Apple Intelligence \(report.overallStatus.rawValue): \(report.failureReasons.map(\.rawValue).joined(separator: ", "))")
-            event.tags = [
-                "ai.overall_status": report.overallStatus.rawValue,
-                "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
-            ]
-            event.extra = report.sentryContext
-            SentrySDK.capture(event: event)
-        }
+    /// Report an AI failure that the user actually hit during dictation.
+    /// Attaches a fresh diagnostics report AND fires a Sentry warning event
+    /// so we can alert on real user-facing Apple Intelligence failures.
+    public static func reportAIFailure(_ report: AppleIntelligenceAvailabilityReport) {
+        // Update the persistent context with the fresh report
+        attachAIDiagnostics(report)
+
+        // Fire a warning event — this is a real user-facing failure, not just launch state
+        let event = Event(level: .warning)
+        event.message = SentryMessage(formatted: "Apple Intelligence failed during dictation: \(report.failureReasons.map(\.rawValue).joined(separator: ", "))")
+        event.tags = [
+            "ai.overall_status": report.overallStatus.rawValue,
+            "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
+        ]
+        event.extra = report.sentryContext
+        SentrySDK.capture(event: event)
     }
 
     // MARK: - Error Taxonomy


### PR DESCRIPTION
## Summary
- Adds `AppleIntelligenceAvailabilityReport` and `AIFailureReason` enum (11 cases) to Core — structured value types for diagnostic results
- Adds `AppleIntelligenceDiagnosticsService` in LLM module with 4-stage gate checks: build gate, OS/runtime gate, device eligibility gate, model access gate
- Each gate returns pass/fail/unknown with explicit failure reasons — no booleans, no freeform strings
- Report attached as persistent Sentry context (`apple_intelligence` key) so every future crash includes AI availability state
- Diagnostics run at app launch (via AppDelegate) and on-demand when Apple Intelligence fails during dictation (both pipelines)
- Adds `reportAIDiagnostics()` to SentryBreadcrumb helper — emits structured breadcrumb + attaches report to Sentry scope + captures warning event for unavailable/degraded status

## Architecture
- Report types in Core (value types only, no business logic)
- Diagnostics service in LLM module (needs FoundationModels, returns Core types)
- Sentry wiring in Services (SentryBreadcrumb helper)
- App-level orchestration in AppDelegate (launch) and Pipeline (on-failure)
- Dependency direction: Core ← LLM ← Pipeline/App → Services ✓

## Privacy
Zero PII — report contains only: status enums, OS version, hardware class, boolean flags, failure reason codes, check duration in ms.

## Test plan
- [x] Release build passes (`swift build -c release`)
- [x] Test target compiles (`swift build --build-tests`)
- [ ] Launch app — verify AI diagnostics breadcrumb appears in Sentry
- [ ] With AI provider selected, force failure — verify fresh report captured

Addresses bead ew-5gzo (Phase 1 of Apple Intelligence diagnostics spec).
