### PR TITLE
fix: observability V1 closeout — wire app.launched event

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -112,6 +112,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             level: .info, category: "Diagnostics"
         ) }
 
+        // Fire structured app.launched event — unconditional, before onboarding guard.
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        let osVer = ProcessInfo.processInfo.operatingSystemVersion
+        TelemetryService.shared.appLaunched(
+            version: version,
+            build: build,
+            osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
+            hardware: aiReport.hardwareClass,
+            isFreshInstall: appState.settings.onboardingState != .completed,
+            aiAvailable: aiReport.overallStatus == .available
+        )
+
         // Check Accessibility permission on launch (query only — never auto-prompt).
         appState.permissions.refreshOnLaunch()
         updateIcon() // Reflect accessibility warning state in menu bar icon


### PR DESCRIPTION
## Summary
- Wires `TelemetryService.appLaunched()` which was defined but never called (dead code since Phase 1)
- Fires unconditionally from `applicationDidFinishLaunching` with structured properties: version, build, OS version, hardware class, fresh install flag, AI availability

## Observability V1 Status (complete)

### Shipped (PRs #28, #29, #30 + this PR)
- PostHog + Sentry SDK init with all auto-collection explicitly disabled
- Manual breadcrumbs at every pipeline stage boundary
- Handled error capture with 11-category typed taxonomy
- Apple Intelligence 4-stage diagnostics with structured AvailabilityReport
- Vendor containment: `import Sentry`/`import PostHog` only in EnviousWisprServices

### Dashboards (live)
- [Product Health](https://us.posthog.com/project/354235/dashboard/1391797) — dictation volume, app launches, ASR/LLM provider splits
- [Pipeline Performance](https://us.posthog.com/project/354235/dashboard/1391798) — E2E/ASR/LLM latency p50/p95, paste tier distribution

### Alerts (live)
- Dictation Volume Drop (daily, PostHog)
- E2E Latency Spike p95 (daily, PostHog)

### Operator Stack (installed)
- PostHog MCP — analytics queries + dashboard ops
- Sentry MCP — issue triage + debugging

### Remaining follow-ups
- [ ] Sentry alerts (4 rules) — need Sentry web UI (MCP is read-only for alerts)
- [ ] Sentry CLI + dSYM upload — wire into release workflow (ew-e2v2 adjacent)
- [ ] PII redaction rules in beforeSend hooks (ew-e2v2)
- [ ] Onboarding funnel events (code exists, not yet flowing)
