### PR TITLE
feat: observability closeout — PII redaction, dSYM upload, onboarding funnel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,34 @@ jobs:
             exit 1
           fi
 
+      - name: Upload dSYMs to Sentry
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Install sentry-cli (pinned version, explicit install dir for self-hosted runner)
+          export INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.39.1 bash
+          export PATH="$INSTALL_DIR:$PATH"
+
+          # Create release and associate commits
+          sentry-cli releases new "v${VERSION}"
+          sentry-cli releases set-commits "v${VERSION}" --auto
+
+          # Upload debug symbols — --arch arm64 puts artifacts in arch-specific dir
+          echo "==> Uploading dSYMs ..."
+          sentry-cli debug-files upload --include-sources .build/arm64-apple-macosx/release/
+
+          # Finalize release
+          sentry-cli releases finalize "v${VERSION}"
+          echo "==> Sentry release v${VERSION} finalized with dSYMs."
+
       - name: Generate Sparkle appcast entry
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -518,10 +518,12 @@ private struct PermissionsPhaseView: View {
             if appState.permissions.accessibilityGranted && !viewModel.accessibilityGranted {
                 viewModel.accessibilityGranted = true
                 appState.settings.autoCopyToClipboard = true
+                TelemetryService.shared.onboardingStepCompleted(step: "accessibility_permission", result: "granted")
             }
 
             if appState.permissions.hasMicrophonePermission && !viewModel.micGranted {
                 viewModel.micGranted = true
+                TelemetryService.shared.onboardingStepCompleted(step: "mic_permission", result: "granted")
             }
 
             if elapsed >= 10 && !viewModel.showSkipLink {

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -29,7 +29,17 @@ public enum ObservabilityBootstrap {
         config.flushIntervalSeconds = 30
         config.maxQueueSize = 1000
         config.setBeforeSend { event in
-            // Placeholder for future PII redaction — drop or modify events here
+            // PII redaction: strip transcript content, API keys, and emails from event properties.
+            // This is a limb — must never throw or crash. Heart is unaffected if this fails.
+            var redactedProperties: [String: Any] = [:]
+            for (key, value) in event.properties {
+                if let str = value as? String {
+                    redactedProperties[key] = ObservabilityBootstrap.redactString(str)
+                } else {
+                    redactedProperties[key] = value
+                }
+            }
+            event.properties = redactedProperties
             return event
         }
 
@@ -66,9 +76,91 @@ public enum ObservabilityBootstrap {
             options.tracesSampleRate = NSNumber(value: 0)
 
             options.beforeSend = { event in
+                // PII redaction: strip transcript content, API keys, and emails.
+                // This is a limb — must never throw or crash. Heart is unaffected if this fails.
+
+                // Redact event message (SentryMessage wraps formatted + raw strings)
+                if let sentryMsg = event.message {
+                    let redacted = ObservabilityBootstrap.redactString(sentryMsg.formatted)
+                    if redacted != sentryMsg.formatted {
+                        event.message = SentryMessage(formatted: redacted)
+                    }
+                }
+
+                // Redact extra context values
+                if let extra = event.extra {
+                    var redactedExtra: [String: Any] = [:]
+                    for (key, value) in extra {
+                        if let str = value as? String {
+                            redactedExtra[key] = ObservabilityBootstrap.redactString(str)
+                        } else {
+                            redactedExtra[key] = value
+                        }
+                    }
+                    event.extra = redactedExtra
+                }
+
+                // Redact breadcrumb messages
+                if let crumbs = event.breadcrumbs {
+                    for crumb in crumbs {
+                        if let msg = crumb.message {
+                            crumb.message = ObservabilityBootstrap.redactString(msg)
+                        }
+                        if let data = crumb.data {
+                            var redactedData: [String: Any] = [:]
+                            for (key, value) in data {
+                                if let str = value as? String {
+                                    redactedData[key] = ObservabilityBootstrap.redactString(str)
+                                } else {
+                                    redactedData[key] = value
+                                }
+                            }
+                            crumb.data = redactedData
+                        }
+                    }
+                }
+
                 return event
             }
         }
+    }
+
+    /// Redacts a string if it matches known PII patterns:
+    /// - Long strings (> 100 chars) that are not URLs (likely transcript content)
+    /// - API key patterns: sk-*, phc_*, sntrys_*, key_*, or >= 32 contiguous hex chars
+    /// - Email-like patterns
+    /// Returns the original string if it matches no pattern, or `[REDACTED]` if it does.
+    /// Never throws — any regex failure is silently ignored and the original value returned.
+    static func redactString(_ input: String) -> String {
+        // Long non-URL strings (transcript content heuristic)
+        if input.count > 100 {
+            let lower = input.lowercased()
+            if !lower.hasPrefix("http://") && !lower.hasPrefix("https://") {
+                return "[REDACTED]"
+            }
+        }
+
+        // API key patterns
+        let apiKeyPrefixes = ["sk-", "phc_", "sntrys_", "key_"]
+        for prefix in apiKeyPrefixes {
+            if input.lowercased().hasPrefix(prefix) && input.count >= 20 {
+                return "[REDACTED]"
+            }
+        }
+
+        // 32+ contiguous hex characters (generic secret/token heuristic)
+        if let hexRange = input.range(of: "[0-9a-fA-F]{32,}", options: .regularExpression),
+           hexRange == input.startIndex..<input.endIndex || input.count <= input[hexRange].count + 8 {
+            return "[REDACTED]"
+        }
+
+        // Email pattern: something@something.something
+        if let _ = input.range(of: #"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"#,
+                                options: .regularExpression) {
+            return "[REDACTED]"
+        }
+
+        return input
     }
 
     /// Resolves a key by checking Info.plist first, then falling back to the file system.


### PR DESCRIPTION
## Summary
- PII redaction in PostHog/Sentry beforeSend hooks (transcript content, API keys, hex tokens, emails)
- sentry-cli dSYM upload + release creation wired into release.yml (continue-on-error, pinned CLI)
- Onboarding funnel: mic/accessibility permission step tracking for conversion analysis
- 4 Sentry alert rules configured (New Issue, Error Spike, XPC Crash, AI Failure)
- GitHub secrets: SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
- Gmail filter: "Sentry Alerts" label with skip-inbox

## Beads closed
ew-e2v2, ew-bgei, ew-jxl2, ew-o6a1

## Test plan
- [x] `swift build -c release` passes
- [x] Code reviewed by 3 specialized agents (PII redaction APIs verified against SDK source, release.yml path bug caught and fixed, onboarding double-fire protection confirmed)
- [x] UAT: normal dictation generates pipeline breadcrumbs in Sentry
- [x] UAT: XPC service kill -9 during recording → Sentry captures `xpc_service_error` events (ENVIOUSWISPR-4, ENVIOUSWISPR-5)
- [x] App survives XPC crash and recovers
