### PR TITLE
fix: move PR build-check to self-hosted macOS 26 runner

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,18 +10,27 @@ concurrency:
 
 jobs:
   build-check:
-    runs-on: macos-15
+    runs-on: [self-hosted, enviouswispr-release]
     timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify Swift version
+      - name: Verify environment
         run: |
+          set -euo pipefail
           swift --version
+          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
+          echo "macOS SDK: $SDK_VER"
+
           if ! swift --version 2>&1 | grep -q "Swift version 6"; then
             echo "::error::Swift 6.0+ required"
+            exit 1
+          fi
+
+          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
+            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
             exit 1
           fi
 
@@ -42,41 +51,15 @@ jobs:
       - name: Verify test target compiles
         run: swift build --build-tests
 
-  ai-compile-gate:
-    runs-on: [self-hosted, enviouswispr-release]
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Verify SDK supports FoundationModels
+      - name: Verify FoundationModels compile probe
         run: |
           set -euo pipefail
-
-          swift --version
-          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
           SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-          echo "macOS SDK: $SDK_VER ($SDK_PATH)"
 
-          # Xcode check — optional (CLT shim exists but fails without full Xcode)
-          XCODE_VER="$(xcodebuild -version 2>/dev/null | head -n1 || true)"
-          if [ -n "$XCODE_VER" ]; then
-            echo "Xcode: $XCODE_VER"
-          else
-            echo "Xcode: not installed (Command Line Tools only)"
-          fi
-
-          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
-            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
-            exit 1
-          fi
-
-          cat > foundation_models_probe.swift <<'PROBE'
+          cat > /tmp/foundation_models_probe.swift <<'PROBE'
           import Foundation
           import FoundationModels
 
-          // Minimal type reference so this is a real compile gate, not just syntax.
           func _probe() {
             _ = SystemLanguageModel.default
           }
@@ -85,7 +68,7 @@ jobs:
           xcrun swiftc \
             -sdk "$SDK_PATH" \
             -target arm64-apple-macos26.0 \
-            foundation_models_probe.swift \
+            /tmp/foundation_models_probe.swift \
             -o /tmp/foundation_models_probe
 
           echo "==> FoundationModels compile probe PASSED"


### PR DESCRIPTION
## Summary
- Move `build-check` from hosted `macos-15` to self-hosted `enviouswispr-release` (macOS 26 SDK)
- Merge `ai-compile-gate` into `build-check` (now redundant as separate job)
- Add SDK version check and FoundationModels compile probe as build-check steps

## Why
Hosted macos-15 compiled with macOS 15 SDK. `canImport(FoundationModels)` was false, so all Apple Intelligence code was silently stripped during PR validation. We were validating a different binary than what ships.

## Test plan
- [x] Self-hosted runner has macOS 26 SDK (verified: release.yml already uses it)
- [x] `build-check` is the only required status check in branch protection
