### PR TITLE
chore(release): bump version to 1.6.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
Version bump for v1.6.1 release.

## Changes since v1.6.0
- PII redaction in PostHog/Sentry beforeSend hooks
- sentry-cli dSYM upload in release workflow
- Onboarding funnel events (mic/accessibility permission tracking)
- 4 Sentry alert rules + Gmail filter
- PR build-check moved to self-hosted macOS 26 runner
- Apple Intelligence diagnostics subsystem
- PostHog + Sentry observability stack
