### PR TITLE
fix: add pull-requests: write to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 330
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Add `pull-requests: write` permission to release workflow job. The appcast PR step failed on v1.6.1 because explicit `permissions:` block overrides repo defaults — only listed permissions are granted.

## Test plan
- [x] v1.6.1 release succeeded (build, sign, notarize, dSYM upload, GitHub Release)
- [x] Only the appcast PR step failed — manually created PR #35 as workaround
- [x] Next release will auto-create the appcast PR
