### PR TITLE
fix: stamp observability keys into release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,25 @@ jobs:
             -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
 
+      - name: Stamp observability keys into Info.plist
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          PLIST="Sources/EnviousWispr/Resources/Info.plist"
+          if [[ -n "${POSTHOG_API_KEY}" ]]; then
+            plutil -replace PostHogAPIKey -string "${POSTHOG_API_KEY}" "$PLIST"
+            echo "==> PostHog API key stamped into Info.plist"
+          else
+            echo "::warning::POSTHOG_API_KEY secret not set — PostHog will be disabled in this release"
+          fi
+          if [[ -n "${SENTRY_DSN}" ]]; then
+            plutil -replace SentryDSN -string "${SENTRY_DSN}" "$PLIST"
+            echo "==> Sentry DSN stamped into Info.plist"
+          else
+            echo "::warning::SENTRY_DSN secret not set — Sentry will be disabled in this release"
+          fi
+
       - name: Package and sign DMG
         env:
           CODESIGN_IDENTITY: "Developer ID Application: ${{ secrets.APPLE_TEAM_NAME }} (${{ secrets.APPLE_TEAM_ID }})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 330
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Release builds had **zero observability** — PostHog and Sentry were silently disabled on every installed copy since v1.6.0. The API keys were never stamped into Info.plist by CI; the fallback path (`~/.enviouswispr-keys/`) only exists on dev machines.

## Fix
- Add CI step to stamp `PostHogAPIKey` and `SentryDSN` into Info.plist via `plutil -replace` before bundle assembly
- New GitHub secrets: `POSTHOG_API_KEY`, `SENTRY_DSN` (both set)
- Warns but doesn't fail if secrets are missing

## Test plan
- [x] Secrets set via `gh secret set`
- [ ] v1.6.2 release → install on work laptop → verify events appear in PostHog + Sentry
