### PR TITLE
fix: add cache-control headers for appcast.xml

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,0 +1,3 @@
+/appcast.xml
+  Cache-Control: public, max-age=300
+  X-Robots-Tag: noindex


### PR DESCRIPTION
## Summary
- Adds `website/public/_headers` with `Cache-Control: public, max-age=300` for `/appcast.xml`
- Prevents aggressive CDN caching that caused stale Sparkle update feeds after v1.6.2
- Adds `X-Robots-Tag: noindex` to prevent search engine indexing of XML

## Context
After v1.6.2 release, users got stale appcast showing v1.6.1 — required manual Cloudflare cache purge. Council (GPT + Gemini) reviewed and recommended short TTL without explicit purge to avoid race condition of purging before CF Pages finishes deploying.

## Test plan
- [ ] After merge + CF deploy: `curl -I https://enviouswispr.com/appcast.xml` confirms `Cache-Control: public, max-age=300`
- [ ] Confirm `ETag` header present (automatic from CF Pages)
- [ ] Confirm `X-Robots-Tag: noindex` present
