### PR TITLE
feat: real download progress in onboarding + version label fix

### DIFF
--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -45,8 +45,23 @@ final class OnboardingV2ViewModel {
         }
     }
 
+    /// Minimum free disk space required for model download + compilation (1 GB).
+    private static let requiredDiskSpaceBytes: Int64 = 1_073_741_824
+
     func startSetup(asrManager: any ASRManagerInterface, settings: SettingsManager) async {
         settings.onboardingState = .settingUp
+
+        // Disk space preflight — fail early with a friendly message instead of failing at 80%.
+        if let attrs = try? FileManager.default.attributesOfFileSystem(
+            forPath: NSHomeDirectory()
+        ), let freeSpace = attrs[.systemFreeSize] as? Int64,
+           freeSpace < Self.requiredDiskSpaceBytes {
+            let freeMB = freeSpace / 1_048_576
+            downloadError = "Not enough disk space (\(freeMB) MB free). EnviousWispr needs about 1 GB to download and install the speech model."
+            checklistStatuses[0] = .error(downloadError!)
+            return
+        }
+
         checklistStatuses[0] = .inProgress
         do {
             try await asrManager.loadModel()
@@ -269,9 +284,10 @@ private struct SettingUpScreenV2: View {
 
 private struct ChecklistPhaseView: View {
     var viewModel: OnboardingV2ViewModel
+    @Environment(AppState.self) private var appState
 
     private static let items: [(title: String, subtitle: String)] = [
-        ("Downloading speech model", "~100 MB, one-time setup"),
+        ("Downloading speech model", "~460 MB, one-time setup"),
         ("Configuring on-device AI", "Apple Intelligence"),
         ("Setting your hotkey",      "Default: ⌥ Option"),
     ]
@@ -287,7 +303,7 @@ private struct ChecklistPhaseView: View {
                 .kerning(-0.4)
                 .padding(.bottom, 6)
 
-            Text("Setting up your private, on-device transcription.")
+            Text("Downloading the local speech model so EnviousWispr can run privately on your Mac.")
                 .font(.obBody)
                 .foregroundStyle(Color.obTextSecondary)
                 .multilineTextAlignment(.center)
@@ -299,8 +315,9 @@ private struct ChecklistPhaseView: View {
                         index: index,
                         status: viewModel.checklistStatuses[index],
                         title: item.title,
-                        subtitle: item.subtitle,
-                        showProgressBar: index == 0 && viewModel.checklistStatuses[0].isInProgress
+                        subtitle: downloadSubtitle(for: index, fallback: item.subtitle),
+                        showProgressBar: index == 0 && viewModel.checklistStatuses[0].isInProgress,
+                        progress: index == 0 ? appState.asrManager.downloadProgress : nil
                     )
                     if index < Self.items.count - 1 {
                         Divider().padding(.horizontal, 14)
@@ -331,6 +348,16 @@ private struct ChecklistPhaseView: View {
             Spacer()
         }
     }
+
+    /// Returns live download status text for the model download row, or the static subtitle otherwise.
+    private func downloadSubtitle(for index: Int, fallback: String) -> String {
+        guard index == 0, viewModel.checklistStatuses[0].isInProgress else { return fallback }
+        let phase = appState.asrManager.downloadPhase
+        let detail = appState.asrManager.downloadDetail
+        if phase.isEmpty { return fallback }
+        if detail.isEmpty { return phase }
+        return "\(phase) \(detail)"
+    }
 }
 
 private struct ChecklistItemRow: View {
@@ -339,8 +366,16 @@ private struct ChecklistItemRow: View {
     let title: String
     let subtitle: String
     let showProgressBar: Bool
+    /// Live download progress (0.0–1.0). Nil means indeterminate/not applicable.
+    var progress: Double?
 
     @State private var spinAngle: Double = 0
+
+    /// Clamped progress value for the bar width. Shows a minimum sliver (2%) so the bar is never invisible.
+    private var barFraction: CGFloat {
+        guard let progress else { return 0.02 }
+        return max(CGFloat(progress), 0.02)
+    }
 
     var body: some View {
         VStack(spacing: 6) {
@@ -370,7 +405,8 @@ private struct ChecklistItemRow: View {
                             .frame(height: 3)
                         RoundedRectangle(cornerRadius: 2)
                             .fill(Color.obRainbow)
-                            .frame(width: geo.size.width * 0.65, height: 3)
+                            .frame(width: geo.size.width * barFraction, height: 3)
+                            .animation(.easeInOut(duration: 0.3), value: barFraction)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: 3)

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -3,6 +3,7 @@ import EnviousWisprCore
 import EnviousWisprServices
 import EnviousWisprASR
 import EnviousWisprLLM
+import IOKit.pwr_mgt
 
 // MARK: - ViewModel
 
@@ -31,6 +32,18 @@ final class OnboardingV2ViewModel {
 
     var downloadError: String?
     var retryCount = 0
+
+    /// Coarse ETA text, shown only when download rate is stable. Empty = hidden.
+    var downloadETA: String = ""
+
+    // ETA computation state — rolling window of (timestamp, fraction) samples.
+    private var etaSamples: [(time: CFAbsoluteTime, fraction: Double)] = []
+    private static let etaWindowSeconds: CFAbsoluteTime = 10
+    private static let etaMinSamples = 3
+
+    // Sleep prevention — holds a power assertion during download to prevent macOS sleep.
+    private var sleepAssertionID: IOPMAssertionID = 0
+    private var isSleepPrevented = false
 
     var lipsState: LipsAnimationState {
         switch currentScreen {
@@ -63,11 +76,14 @@ final class OnboardingV2ViewModel {
         }
 
         checklistStatuses[0] = .inProgress
+        preventSleep()
         do {
             try await asrManager.loadModel()
+            allowSleep()
             // Check cancellation before advancing — window may have closed during download.
             try Task.checkCancellation()
             checklistStatuses[0] = .completed
+            downloadETA = ""
             TelemetryService.shared.onboardingStepCompleted(step: "model_download", result: "completed")
 
             checklistStatuses[1] = .inProgress
@@ -85,18 +101,137 @@ final class OnboardingV2ViewModel {
             settings.onboardingState = .needsPermissions
             setupPhase = .permissions
         } catch is CancellationError {
+            allowSleep()
             // Task was cancelled (window closed mid-setup). Leave onboardingState as .settingUp
             // so the next launch re-runs the checklist from scratch.
         } catch {
-            downloadError = error.localizedDescription
-            checklistStatuses[0] = .error(error.localizedDescription)
+            allowSleep()
+            let friendly = Self.friendlyError(error)
+            downloadError = friendly
+            checklistStatuses[0] = .error(friendly)
         }
     }
 
     func retryDownload() {
         downloadError = nil
+        downloadETA = ""
+        etaSamples = []
         checklistStatuses = [.pending, .pending, .pending]
         retryCount += 1
+    }
+
+    /// Update ETA from current download progress. Called by the view's onChange handler.
+    /// Only shows ETA during the download phase (fraction < 0.5) when the rate is stable.
+    func updateETA(fraction: Double) {
+        // Only compute ETA during download phase (0.0–0.5 in FluidAudio's range)
+        guard fraction > 0 && fraction < 0.5 else {
+            downloadETA = ""
+            return
+        }
+
+        let now = CFAbsoluteTimeGetCurrent()
+        etaSamples.append((time: now, fraction: fraction))
+
+        // Trim samples outside the rolling window
+        let cutoff = now - Self.etaWindowSeconds
+        etaSamples.removeAll { $0.time < cutoff }
+
+        guard etaSamples.count >= Self.etaMinSamples,
+              let first = etaSamples.first, let last = etaSamples.last else {
+            downloadETA = ""
+            return
+        }
+
+        let dt = last.time - first.time
+        let df = last.fraction - first.fraction
+        guard dt > 1.0, df > 0.001 else {
+            downloadETA = ""
+            return
+        }
+
+        // Rate = fraction-per-second. Remaining fraction to 0.5 (end of download).
+        let rate = df / dt
+        let remaining = (0.5 - fraction) / rate
+
+        // Stability check: coefficient of variation of inter-sample rates.
+        // If too noisy, hide ETA rather than show a jumpy number.
+        if etaSamples.count >= 4 {
+            var rates: [Double] = []
+            for i in 1..<etaSamples.count {
+                let sdt = etaSamples[i].time - etaSamples[i-1].time
+                let sdf = etaSamples[i].fraction - etaSamples[i-1].fraction
+                if sdt > 0.1 && sdf > 0 { rates.append(sdf / sdt) }
+            }
+            if rates.count >= 3 {
+                let mean = rates.reduce(0, +) / Double(rates.count)
+                let variance = rates.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(rates.count)
+                let cv = mean > 0 ? sqrt(variance) / mean : 1.0
+                if cv > 0.5 {
+                    downloadETA = ""
+                    return
+                }
+            }
+        }
+
+        // Bucket into coarse text
+        switch remaining {
+        case ..<30:
+            downloadETA = "Almost done"
+        case 30..<90:
+            downloadETA = "About a minute remaining"
+        case 90..<180:
+            downloadETA = "About 2 minutes remaining"
+        case 180..<300:
+            downloadETA = "A few minutes remaining"
+        default:
+            downloadETA = "This may take several minutes"
+        }
+    }
+
+    // MARK: - Sleep Prevention
+
+    private func preventSleep() {
+        guard !isSleepPrevented else { return }
+        let reason = "EnviousWispr is downloading the speech model" as CFString
+        let success = IOPMAssertionCreateWithName(
+            kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            reason,
+            &sleepAssertionID
+        )
+        isSleepPrevented = (success == kIOReturnSuccess)
+    }
+
+    private func allowSleep() {
+        guard isSleepPrevented else { return }
+        IOPMAssertionRelease(sleepAssertionID)
+        isSleepPrevented = false
+    }
+
+    // MARK: - Friendly Error Messages
+
+    /// Maps raw error descriptions to user-friendly messages.
+    private static func friendlyError(_ error: any Error) -> String {
+        let desc = error.localizedDescription.lowercased()
+
+        if desc.contains("timed out") || desc.contains("timeout") {
+            return "The download timed out. Please check your internet connection and try again."
+        }
+        if desc.contains("not connected") || desc.contains("network") || desc.contains("offline") {
+            return "No internet connection. Please connect to the internet and try again."
+        }
+        if desc.contains("could not connect") || desc.contains("cannot connect") {
+            return "Couldn't reach the download server. Please check your internet connection and try again."
+        }
+        if desc.contains("rate limit") {
+            return "The download server is busy. Please wait a moment and try again."
+        }
+        if desc.contains("disk") || desc.contains("space") || desc.contains("no space") {
+            return "Not enough disk space. Please free up space and try again."
+        }
+
+        // Fallback: use the original description but trim technical prefixes
+        return "Download failed: \(error.localizedDescription)"
     }
 
     func requestMicPermission(permissions: PermissionsService) async {
@@ -347,6 +482,9 @@ private struct ChecklistPhaseView: View {
 
             Spacer()
         }
+        .onChange(of: appState.asrManager.downloadProgress) { _, newValue in
+            viewModel.updateETA(fraction: newValue)
+        }
     }
 
     /// Returns live download status text for the model download row, or the static subtitle otherwise.
@@ -355,8 +493,12 @@ private struct ChecklistPhaseView: View {
         let phase = appState.asrManager.downloadPhase
         let detail = appState.asrManager.downloadDetail
         if phase.isEmpty { return fallback }
-        if detail.isEmpty { return phase }
-        return "\(phase) \(detail)"
+        // Build subtitle: phase + detail + optional ETA
+        var text = detail.isEmpty ? phase : "\(phase) \(detail)"
+        if !viewModel.downloadETA.isEmpty {
+            text += " · \(viewModel.downloadETA)"
+        }
+        return text
     }
 }
 

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -31,6 +31,8 @@ final class OnboardingV2ViewModel {
     var showSkipLink = false
 
     var downloadError: String?
+    /// Raw error details for support diagnostics (hidden behind "Copy error details" button).
+    var rawErrorDetails: String?
     var retryCount = 0
 
     /// Coarse ETA text, shown only when download rate is stable. Empty = hidden.
@@ -108,12 +110,14 @@ final class OnboardingV2ViewModel {
             allowSleep()
             let friendly = Self.friendlyError(error)
             downloadError = friendly
+            rawErrorDetails = "\(error)"
             checklistStatuses[0] = .error(friendly)
         }
     }
 
     func retryDownload() {
         downloadError = nil
+        rawErrorDetails = nil
         downloadETA = ""
         etaSamples = []
         checklistStatuses = [.pending, .pending, .pending]
@@ -474,8 +478,22 @@ private struct ChecklistPhaseView: View {
                         .foregroundStyle(Color.obError)
                         .multilineTextAlignment(.center)
 
-                    Button("Retry") { viewModel.retryDownload() }
-                        .buttonStyle(OnboardingButtonStyle(color: .obError))
+                    HStack(spacing: 12) {
+                        Button("Retry") { viewModel.retryDownload() }
+                            .buttonStyle(OnboardingButtonStyle(color: .obError))
+
+                        if viewModel.rawErrorDetails != nil {
+                            Button("Copy error details") {
+                                if let details = viewModel.rawErrorDetails {
+                                    NSPasteboard.general.clearContents()
+                                    NSPasteboard.general.setString(details, forType: .string)
+                                }
+                            }
+                            .font(.obCaption)
+                            .foregroundStyle(Color.obTextTertiary)
+                            .buttonStyle(.plain)
+                        }
+                    }
                 }
                 .padding(.top, 4)
             }

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -35,9 +35,6 @@ final class OnboardingV2ViewModel {
     var rawErrorDetails: String?
     var retryCount = 0
 
-    /// Coarse ETA text, shown only when download rate is stable. Empty = hidden.
-    var downloadETA: String = ""
-
     /// ViewModel-owned progress state, polled from ASR manager.
     /// SwiftUI can't observe @Observable properties through protocol existentials
     /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
@@ -46,10 +43,26 @@ final class OnboardingV2ViewModel {
     var downloadDetail: String = ""
     private var progressPollTimer: Timer?
 
-    // ETA computation state — rolling window of (timestamp, fraction) samples.
-    private var etaSamples: [(time: CFAbsoluteTime, fraction: Double)] = []
-    private static let etaWindowSeconds: CFAbsoluteTime = 10
-    private static let etaMinSamples = 3
+    /// Quirky installation message, cycled during the compilation phase.
+    var installQuip: String = ""
+    private var quipTimer: Timer?
+    private var quipIndex: Int = 0
+
+    /// Fun status messages shown during model compilation (~20-30s wait).
+    private static let installQuips = [
+        "Tuning the neural ears...",
+        "Teaching AI to listen politely...",
+        "Loading all 50,000 words...",
+        "Installing 'um' and 'uh' filters...",
+        "Calibrating whisper detection...",
+        "Warming up Apple Silicon...",
+        "Polishing the speech engine...",
+        "Training patience module...",
+        "Preparing to ignore background noise...",
+        "Sharpening neural networks...",
+        "Convincing AI that you said 'duck'...",
+        "Almost there... pinky promise",
+    ]
 
     // Sleep prevention — holds a power assertion during download to prevent macOS sleep.
     private var sleepAssertionID: IOPMAssertionID = 0
@@ -95,7 +108,8 @@ final class OnboardingV2ViewModel {
             // Check cancellation before advancing — window may have closed during download.
             try Task.checkCancellation()
             checklistStatuses[0] = .completed
-            downloadETA = ""
+            installQuip = ""
+            stopQuipTimer()
             TelemetryService.shared.onboardingStepCompleted(step: "model_download", result: "completed")
 
             checklistStatuses[1] = .inProgress
@@ -130,100 +144,31 @@ final class OnboardingV2ViewModel {
     func retryDownload() {
         downloadError = nil
         rawErrorDetails = nil
-        downloadETA = ""
-        etaSamples = []
+        installQuip = ""
+        stopQuipTimer()
         checklistStatuses = [.pending, .pending, .pending]
         retryCount += 1
     }
 
-    /// Update ETA from current download progress. Called by the view's onChange handler.
-    /// Only shows ETA during the download phase (fraction < 0.5) when the rate is stable.
-    func updateETA(fraction: Double) {
-        // Only compute ETA during download phase (0.0–0.5 in FluidAudio's range).
-        // Require at least 5% progress (fraction > 0.025) to avoid misleading ETAs
-        // from the initial burst of small model files downloading instantly.
-        guard fraction > 0.025 && fraction < 0.5 else {
-            downloadETA = ""
-            return
-        }
-
-        let now = CFAbsoluteTimeGetCurrent()
-        etaSamples.append((time: now, fraction: fraction))
-
-        // Trim samples outside the rolling window
-        let cutoff = now - Self.etaWindowSeconds
-        etaSamples.removeAll { $0.time < cutoff }
-
-        guard etaSamples.count >= Self.etaMinSamples,
-              let first = etaSamples.first, let last = etaSamples.last else {
-            downloadETA = ""
-            return
-        }
-
-        let dt = last.time - first.time
-        let df = last.fraction - first.fraction
-        guard dt > 1.0, df > 0.001 else {
-            downloadETA = ""
-            return
-        }
-
-        // Rate = fraction-per-second. Remaining fraction to 0.5 (end of download).
-        let rate = df / dt
-        let remaining = (0.5 - fraction) / rate
-
-        // Stability check: coefficient of variation of inter-sample rates.
-        // If too noisy, hide ETA rather than show a jumpy number.
-        if etaSamples.count >= 4 {
-            var rates: [Double] = []
-            for i in 1..<etaSamples.count {
-                let sdt = etaSamples[i].time - etaSamples[i-1].time
-                let sdf = etaSamples[i].fraction - etaSamples[i-1].fraction
-                if sdt > 0.1 && sdf > 0 { rates.append(sdf / sdt) }
-            }
-            if rates.count >= 3 {
-                let mean = rates.reduce(0, +) / Double(rates.count)
-                let variance = rates.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(rates.count)
-                let cv = mean > 0 ? sqrt(variance) / mean : 1.0
-                if cv > 0.5 {
-                    downloadETA = ""
-                    return
-                }
-            }
-        }
-
-        // Bucket into coarse text
-        switch remaining {
-        case ..<30:
-            downloadETA = "Almost done"
-        case 30..<90:
-            downloadETA = "About a minute remaining"
-        case 90..<180:
-            downloadETA = "About 2 minutes remaining"
-        case 180..<300:
-            downloadETA = "A few minutes remaining"
-        default:
-            downloadETA = "This may take several minutes"
-        }
-    }
-
     // MARK: - Progress Polling
 
-    /// Start polling the ASR manager for download progress at ~8 Hz.
-    /// Copies values into ViewModel-owned properties that SwiftUI can observe.
-    /// Uses .common run loop mode so polling continues during UI tracking interactions.
+    /// Start polling the shared progress file at ~8 Hz.
+    /// The XPC ASR service writes progress to a temp file; we read it here.
+    /// This bypasses all XPC serialization issues.
     func startProgressPolling(asrManager: any ASRManagerInterface) {
         stopProgressPolling()
+        let progressFile = ProgressFile.shared
         let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
-            // Timer fires on main run loop — ViewModel is @MainActor, safe to access.
             guard let self else { return }
-            let newProgress = asrManager.downloadProgress
-            let newPhase = asrManager.downloadPhase
-            let newDetail = asrManager.downloadDetail
-            if newProgress != self.downloadProgress || newPhase != self.downloadPhase || newDetail != self.downloadDetail {
-                self.downloadProgress = newProgress
-                self.downloadPhase = newPhase
-                self.downloadDetail = newDetail
-                self.updateETA(fraction: newProgress)
+            if let state = progressFile.read() {
+                self.downloadProgress = state.fraction
+                self.downloadPhase = state.phase
+                self.downloadDetail = state.detail
+
+                // Start quip timer when compilation begins (fraction >= 0.5)
+                if state.fraction >= 0.5 && self.quipTimer == nil {
+                    self.startQuipTimer()
+                }
             }
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -233,6 +178,27 @@ final class OnboardingV2ViewModel {
     func stopProgressPolling() {
         progressPollTimer?.invalidate()
         progressPollTimer = nil
+        stopQuipTimer()
+    }
+
+    // MARK: - Installation Quips
+
+    private func startQuipTimer() {
+        quipIndex = 0
+        installQuip = Self.installQuips[0]
+        let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+            self.installQuip = Self.installQuips[self.quipIndex]
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        quipTimer = timer
+    }
+
+    private func stopQuipTimer() {
+        quipTimer?.invalidate()
+        quipTimer = nil
+        installQuip = ""
     }
 
     // MARK: - Sleep Prevention
@@ -468,7 +434,7 @@ private struct ChecklistPhaseView: View {
     var viewModel: OnboardingV2ViewModel
 
     private static let items: [(title: String, subtitle: String)] = [
-        ("Downloading speech model", "~460 MB, one-time setup"),
+        ("Setting up speech model", "One-time setup"),
         ("Configuring on-device AI", "Apple Intelligence"),
         ("Setting your hotkey",      "Default: ⌥ Option"),
     ]
@@ -544,18 +510,21 @@ private struct ChecklistPhaseView: View {
         }
     }
 
-    /// Returns live download status text for the model download row, or the static subtitle otherwise.
+    /// Returns live status text for the model setup row.
+    /// During download: "Downloading... X MB of 23 MB"
+    /// During compilation: cycles through quirky installation quips
     private func downloadSubtitle(for index: Int, fallback: String) -> String {
         guard index == 0, viewModel.checklistStatuses[0].isInProgress else { return fallback }
+
+        // During compilation phase — show quips
+        if viewModel.downloadProgress >= 0.5 && !viewModel.installQuip.isEmpty {
+            return viewModel.installQuip
+        }
+
         let phase = viewModel.downloadPhase
         let detail = viewModel.downloadDetail
         if phase.isEmpty { return fallback }
-        // Build subtitle: phase + detail + optional ETA
-        var text = detail.isEmpty ? phase : "\(phase) \(detail)"
-        if !viewModel.downloadETA.isEmpty {
-            text += " · \(viewModel.downloadETA)"
-        }
-        return text
+        return detail.isEmpty ? phase : "\(phase) \(detail)"
     }
 }
 

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -127,8 +127,10 @@ final class OnboardingV2ViewModel {
     /// Update ETA from current download progress. Called by the view's onChange handler.
     /// Only shows ETA during the download phase (fraction < 0.5) when the rate is stable.
     func updateETA(fraction: Double) {
-        // Only compute ETA during download phase (0.0–0.5 in FluidAudio's range)
-        guard fraction > 0 && fraction < 0.5 else {
+        // Only compute ETA during download phase (0.0–0.5 in FluidAudio's range).
+        // Require at least 5% progress (fraction > 0.025) to avoid misleading ETAs
+        // from the initial burst of small model files downloading instantly.
+        guard fraction > 0.025 && fraction < 0.5 else {
             downloadETA = ""
             return
         }
@@ -531,10 +533,16 @@ private struct ChecklistItemRow: View {
 
     @State private var spinAngle: Double = 0
 
-    /// Clamped progress value for the bar width. Shows a minimum sliver (2%) so the bar is never invisible.
+    /// Maps FluidAudio's raw progress to a bar that fills 0–100% during download,
+    /// then stays full during installation. FluidAudio uses [0.0, 0.5] for download
+    /// and [0.5, 1.0] for CoreML compilation.
     private var barFraction: CGFloat {
         guard let progress else { return 0.02 }
-        return max(CGFloat(progress), 0.02)
+        if progress >= 0.5 {
+            return 1.0 // Installation phase — bar stays full
+        }
+        // Download phase: map [0.0, 0.5] → [0.0, 1.0]
+        return max(CGFloat(progress * 2.0), 0.02)
     }
 
     var body: some View {

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -38,6 +38,14 @@ final class OnboardingV2ViewModel {
     /// Coarse ETA text, shown only when download rate is stable. Empty = hidden.
     var downloadETA: String = ""
 
+    /// ViewModel-owned progress state, polled from ASR manager.
+    /// SwiftUI can't observe @Observable properties through protocol existentials
+    /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+    var downloadProgress: Double = 0
+    var downloadPhase: String = ""
+    var downloadDetail: String = ""
+    private var progressPollTimer: Timer?
+
     // ETA computation state — rolling window of (timestamp, fraction) samples.
     private var etaSamples: [(time: CFAbsoluteTime, fraction: Double)] = []
     private static let etaWindowSeconds: CFAbsoluteTime = 10
@@ -79,8 +87,10 @@ final class OnboardingV2ViewModel {
 
         checklistStatuses[0] = .inProgress
         preventSleep()
+        startProgressPolling(asrManager: asrManager)
         do {
             try await asrManager.loadModel()
+            stopProgressPolling()
             allowSleep()
             // Check cancellation before advancing — window may have closed during download.
             try Task.checkCancellation()
@@ -103,10 +113,12 @@ final class OnboardingV2ViewModel {
             settings.onboardingState = .needsPermissions
             setupPhase = .permissions
         } catch is CancellationError {
+            stopProgressPolling()
             allowSleep()
             // Task was cancelled (window closed mid-setup). Leave onboardingState as .settingUp
             // so the next launch re-runs the checklist from scratch.
         } catch {
+            stopProgressPolling()
             allowSleep()
             let friendly = Self.friendlyError(error)
             downloadError = friendly
@@ -192,6 +204,35 @@ final class OnboardingV2ViewModel {
         default:
             downloadETA = "This may take several minutes"
         }
+    }
+
+    // MARK: - Progress Polling
+
+    /// Start polling the ASR manager for download progress at ~8 Hz.
+    /// Copies values into ViewModel-owned properties that SwiftUI can observe.
+    /// Uses .common run loop mode so polling continues during UI tracking interactions.
+    func startProgressPolling(asrManager: any ASRManagerInterface) {
+        stopProgressPolling()
+        let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
+            // Timer fires on main run loop — ViewModel is @MainActor, safe to access.
+            guard let self else { return }
+            let newProgress = asrManager.downloadProgress
+            let newPhase = asrManager.downloadPhase
+            let newDetail = asrManager.downloadDetail
+            if newProgress != self.downloadProgress || newPhase != self.downloadPhase || newDetail != self.downloadDetail {
+                self.downloadProgress = newProgress
+                self.downloadPhase = newPhase
+                self.downloadDetail = newDetail
+                self.updateETA(fraction: newProgress)
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        progressPollTimer = timer
+    }
+
+    func stopProgressPolling() {
+        progressPollTimer?.invalidate()
+        progressPollTimer = nil
     }
 
     // MARK: - Sleep Prevention
@@ -425,7 +466,6 @@ private struct SettingUpScreenV2: View {
 
 private struct ChecklistPhaseView: View {
     var viewModel: OnboardingV2ViewModel
-    @Environment(AppState.self) private var appState
 
     private static let items: [(title: String, subtitle: String)] = [
         ("Downloading speech model", "~460 MB, one-time setup"),
@@ -458,7 +498,7 @@ private struct ChecklistPhaseView: View {
                         title: item.title,
                         subtitle: downloadSubtitle(for: index, fallback: item.subtitle),
                         showProgressBar: index == 0 && viewModel.checklistStatuses[0].isInProgress,
-                        progress: index == 0 ? appState.asrManager.downloadProgress : nil
+                        progress: index == 0 ? viewModel.downloadProgress : nil
                     )
                     if index < Self.items.count - 1 {
                         Divider().padding(.horizontal, 14)
@@ -502,16 +542,13 @@ private struct ChecklistPhaseView: View {
 
             Spacer()
         }
-        .onChange(of: appState.asrManager.downloadProgress) { _, newValue in
-            viewModel.updateETA(fraction: newValue)
-        }
     }
 
     /// Returns live download status text for the model download row, or the static subtitle otherwise.
     private func downloadSubtitle(for index: Int, fallback: String) -> String {
         guard index == 0, viewModel.checklistStatuses[0].isInProgress else { return fallback }
-        let phase = appState.asrManager.downloadPhase
-        let detail = appState.asrManager.downloadDetail
+        let phase = viewModel.downloadPhase
+        let detail = viewModel.downloadDetail
         if phase.isEmpty { return fallback }
         // Build subtitle: phase + detail + optional ETA
         var text = detail.isEmpty ? phase : "\(phase) \(detail)"

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -22,19 +22,12 @@ struct UnifiedWindowView: View {
             .scrollContentBackground(.hidden)
             .background(Color.stSidebarBg)
             .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 200)
-            .safeAreaInset(edge: .bottom) {
-                Text("v\(AppConstants.appVersion)")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.bottom, 8)
-            }
         } detail: {
             detailContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .accentColor(.stAccent)
-        .navigationTitle(AppConstants.appName)
+        .navigationTitle("\(AppConstants.appName) v\(AppConstants.appVersion)")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 RecordButton()

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -9,6 +9,11 @@ public final class ASRManager: ASRManagerInterface {
     public private(set) var activeBackendType: ASRBackendType = .parakeet
     public private(set) var isModelLoaded = false
     public private(set) var isStreaming = false
+
+    // Download progress — updated in-process during loadModel().
+    public private(set) var downloadProgress: Double = 0
+    public private(set) var downloadPhase: String = ""
+    public private(set) var downloadDetail: String = ""
     public var onServiceInterrupted: (() -> Void)?  // No-op for in-process — no XPC crash path
     private var idleTimer: Timer?
     private var lastTranscriptionTime: Date?
@@ -54,7 +59,26 @@ public final class ASRManager: ASRManagerInterface {
 
     /// Load the active backend's model.
     public func loadModel() async throws {
-        try await activeBackend.prepare()
+        downloadProgress = 0
+        downloadPhase = "Preparing download..."
+        downloadDetail = ""
+
+        // For Parakeet, use the progress-reporting variant so in-process path also reports progress.
+        if activeBackendType == .parakeet {
+            try await parakeetBackend.prepare { [weak self] fraction, phase, detail in
+                Task { @MainActor [weak self] in
+                    guard let self, !self.isModelLoaded else { return }
+                    self.downloadProgress = fraction
+                    self.downloadPhase = phase
+                    self.downloadDetail = detail
+                }
+            }
+        } else {
+            try await activeBackend.prepare()
+        }
+        downloadProgress = 1.0
+        downloadPhase = ""
+        downloadDetail = ""
         isModelLoaded = await activeBackend.isReady
     }
 

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -12,6 +12,12 @@ public protocol ASRManagerInterface: AnyObject {
     var isModelLoaded: Bool { get }
     var isStreaming: Bool { get }
 
+    // Download progress (0.0–1.0), phase description, and detail string.
+    // Updated during loadModel() when model download is in progress.
+    var downloadProgress: Double { get }
+    var downloadPhase: String { get }
+    var downloadDetail: String { get }
+
     // Model lifecycle
     func loadModel() async throws
     func unloadModel() async

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -39,6 +39,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
     // MARK: - Idle timer (stays in proxy — same as ASRManager)
 
     private var idleTimer: Timer?
+    private var progressPollTimer: Timer?
 
     public init() {}
 
@@ -52,6 +53,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
         ensureConnection()
         resendConfigIfNeeded()
+
+        // Start polling the XPC service for progress at 4 Hz.
+        // This is the reliable path — request/response, no Mach port backpressure,
+        // no bidirectional callback issues. The XPC push callback is kept as a
+        // supplementary fast path but polling is the primary progress source.
+        startProgressPolling()
+
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
             let guard_ = OneShotContinuationASR(cont)
             serviceProxy { proxy in
@@ -66,11 +74,36 @@ public final class ASRManagerProxy: ASRManagerInterface {
                 guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
             }
         }
-        // Clear progress on completion
+        // Stop polling and clear progress on completion
+        stopProgressPolling()
         downloadProgress = 1.0
         downloadPhase = ""
         downloadDetail = ""
         isModelLoaded = true
+    }
+
+    private func startProgressPolling() {
+        stopProgressPolling()
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.serviceProxy { proxy in
+                proxy.getDownloadProgress { fraction, phase, detail in
+                    Task { @MainActor [weak self] in
+                        guard let self, !self.isModelLoaded else { return }
+                        self.downloadProgress = fraction
+                        self.downloadPhase = phase
+                        self.downloadDetail = detail
+                    }
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        progressPollTimer = timer
+    }
+
+    private func stopProgressPolling() {
+        progressPollTimer?.invalidate()
+        progressPollTimer = nil
     }
 
     public func unloadModel() async {

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -18,6 +18,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
     public private(set) var isModelLoaded = false
     public private(set) var isStreaming = false
 
+    // Download progress — updated via XPC callback from ASR service.
+    public private(set) var downloadProgress: Double = 0
+    public private(set) var downloadPhase: String = ""
+    public private(set) var downloadDetail: String = ""
+
     // MARK: - XPC connection
 
     private var connection: NSXPCConnection?
@@ -40,6 +45,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
     // MARK: - ASRManagerInterface: Model lifecycle
 
     public func loadModel() async throws {
+        // Reset progress state before starting
+        downloadProgress = 0
+        downloadPhase = "Preparing download..."
+        downloadDetail = ""
+
         ensureConnection()
         resendConfigIfNeeded()
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
@@ -56,6 +66,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
                 guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
             }
         }
+        // Clear progress on completion
+        downloadProgress = 1.0
+        downloadPhase = ""
+        downloadDetail = ""
         isModelLoaded = true
     }
 
@@ -225,6 +239,8 @@ public final class ASRManagerProxy: ASRManagerInterface {
         conn.remoteObjectInterface = NSXPCInterface(with: ASRServiceProtocol.self)
         conn.exportedInterface = NSXPCInterface(with: ASRServiceClientProtocol.self)
 
+        conn.exportedObject = self
+
         conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
         conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
 
@@ -304,6 +320,21 @@ public final class ASRManagerProxy: ASRManagerInterface {
                     proxy.onServiceInterrupted?()
                 }
             }
+        }
+    }
+}
+
+// MARK: - ASRServiceClientProtocol (XPC callbacks from service → app)
+
+extension ASRManagerProxy: ASRServiceClientProtocol {
+    /// Receives download progress from the ASR XPC service.
+    /// Called on an XPC dispatch queue — must marshal to MainActor for UI state updates.
+    nonisolated public func reportDownloadProgress(_ fractionCompleted: Double, phase: String, detail: String) {
+        Task { @MainActor [weak self] in
+            guard let self, !self.isModelLoaded else { return }
+            self.downloadProgress = fractionCompleted
+            self.downloadPhase = phase
+            self.downloadDetail = detail
         }
     }
 }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -84,17 +84,15 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
     private func startProgressPolling() {
         stopProgressPolling()
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            self.serviceProxy { proxy in
-                proxy.getDownloadProgress { fraction, phase, detail in
-                    Task { @MainActor [weak self] in
-                        guard let self, !self.isModelLoaded else { return }
-                        self.downloadProgress = fraction
-                        self.downloadPhase = phase
-                        self.downloadDetail = detail
-                    }
-                }
+        // Read progress from shared file — bypasses XPC entirely.
+        // XPC serializes replies, so polling via XPC is blocked behind loadModel's pending reply.
+        let progressFile = ProgressFile.shared
+        let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
+            guard let self, !self.isModelLoaded else { return }
+            if let state = progressFile.read() {
+                self.downloadProgress = state.fraction
+                self.downloadPhase = state.phase
+                self.downloadDetail = state.detail
             }
         }
         RunLoop.main.add(timer, forMode: .common)

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -60,7 +60,7 @@ public actor ModelDownloadManager {
             )
 
             // Verify checksum if configured
-            verifyChecksum()
+            Self.verifyChecksum()
 
             return models
         } catch {
@@ -71,7 +71,7 @@ public actor ModelDownloadManager {
                 do {
                     try await downloadViaR2(progressCallback: progressCallback)
                     let models = try await loadOnly(progressCallback: progressCallback)
-                    verifyChecksum()
+                    Self.verifyChecksum()
                     return models
                 } catch {
                     throw ModelDownloadError.fallbackFailed(underlying: error)
@@ -200,7 +200,8 @@ public actor ModelDownloadManager {
     /// Verify the SHA-256 checksum of the encoder model file.
     /// Logs a warning if verification fails but does NOT block — the model may still work.
     /// This is a defense-in-depth measure, not a hard gate.
-    private func verifyChecksum() {
+    /// Static because it only reads from disk — no actor state needed.
+    public static func verifyChecksum() {
         guard !Self.encoderChecksum.isEmpty else { return }
 
         let encoderModel = Self.modelCacheDir

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -43,13 +43,6 @@ public actor ModelDownloadManager {
         return appSupport.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
     }()
 
-    // MARK: - Stall Detection State
-
-    private var lastProgressTime: CFAbsoluteTime = 0
-    private var lastFraction: Double = 0
-    private var isStalled = false
-    private var stallCheckTask: Task<Void, Never>?
-
     public init() {}
 
     // MARK: - Public API
@@ -57,20 +50,14 @@ public actor ModelDownloadManager {
     /// Download and load Parakeet v3 models with stall detection and optional R2 fallback.
     /// Returns loaded AsrModels ready for transcription.
     public func downloadAndLoad(progressCallback: ProgressCallback?) async throws -> AsrModels {
-        lastProgressTime = CFAbsoluteTimeGetCurrent()
-        lastFraction = 0
-        isStalled = false
-
-        // Start stall monitor
-        stallCheckTask = Task.detached { [weak self] in
-            await self?.monitorForStalls()
-        }
-
-        defer { stallCheckTask?.cancel() }
+        let stallTracker = StallTracker(timeout: Self.stallTimeout)
 
         do {
             // Primary path: FluidAudio's HuggingFace download
-            let models = try await downloadViaFluidAudio(progressCallback: progressCallback)
+            let models = try await downloadViaFluidAudio(
+                progressCallback: progressCallback,
+                stallTracker: stallTracker
+            )
 
             // Verify checksum if configured
             verifyChecksum()
@@ -78,7 +65,7 @@ public actor ModelDownloadManager {
             return models
         } catch {
             // If we stalled and R2 is configured, try the fallback
-            if isStalled && !Self.r2BaseURL.isEmpty {
+            if stallTracker.isStalled && !Self.r2BaseURL.isEmpty {
                 progressCallback?(0.01, "Trying alternate download source...", "")
 
                 do {
@@ -96,11 +83,14 @@ public actor ModelDownloadManager {
 
     // MARK: - Primary Download (FluidAudio / HuggingFace)
 
-    private func downloadViaFluidAudio(progressCallback: ProgressCallback?) async throws -> AsrModels {
+    private func downloadViaFluidAudio(
+        progressCallback: ProgressCallback?,
+        stallTracker: StallTracker
+    ) async throws -> AsrModels {
         let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
-            { [weak self] progress in
-                // Update stall detection timestamp
-                Task { await self?.recordProgress(fraction: progress.fractionCompleted) }
+            { progress in
+                // Update stall tracker — lock-based, no actor hop, zero overhead on download thread
+                stallTracker.recordProgress(fraction: progress.fractionCompleted)
 
                 let phase: String
                 let detail: String
@@ -205,29 +195,6 @@ public actor ModelDownloadManager {
         )
     }
 
-    // MARK: - Stall Detection
-
-    private func recordProgress(fraction: Double) {
-        if fraction > lastFraction + 0.001 {
-            lastProgressTime = CFAbsoluteTimeGetCurrent()
-            lastFraction = fraction
-        }
-    }
-
-    private func monitorForStalls() async {
-        while !Task.isCancelled {
-            try? await Task.sleep(nanoseconds: 5_000_000_000) // Check every 5 seconds
-            guard !Task.isCancelled else { return }
-
-            let elapsed = CFAbsoluteTimeGetCurrent() - lastProgressTime
-            // Only stall-detect during download phase (fraction < 0.5)
-            if elapsed >= Self.stallTimeout && lastFraction < 0.5 && lastFraction > 0 {
-                isStalled = true
-                return
-            }
-        }
-    }
-
     // MARK: - Checksum Verification
 
     /// Verify the SHA-256 checksum of the encoder model file.
@@ -277,5 +244,44 @@ public enum ModelDownloadError: LocalizedError {
         case .fallbackFailed(let error):
             return "Both download sources failed: \(error.localizedDescription)"
         }
+    }
+}
+
+// MARK: - Stall Tracker
+
+/// Thread-safe stall detector. Uses NSLock — zero actor overhead on the download thread.
+/// Called from FluidAudio's URLSession delegate thread; must not block or create Tasks.
+final class StallTracker: @unchecked Sendable {
+    private let timeout: TimeInterval
+    private let lock = NSLock()
+    private var lastProgressTime: CFAbsoluteTime
+    private var lastFraction: Double = 0
+    private var _isStalled = false
+
+    init(timeout: TimeInterval) {
+        self.timeout = timeout
+        self.lastProgressTime = CFAbsoluteTimeGetCurrent()
+    }
+
+    /// Record a progress update. Called from the download delegate thread — must be fast.
+    func recordProgress(fraction: Double) {
+        lock.lock()
+        if fraction > lastFraction + 0.001 {
+            lastProgressTime = CFAbsoluteTimeGetCurrent()
+            lastFraction = fraction
+        }
+        // Check for stall inline — no separate monitor task needed
+        let elapsed = CFAbsoluteTimeGetCurrent() - lastProgressTime
+        if elapsed >= timeout && lastFraction < 0.5 && lastFraction > 0 {
+            _isStalled = true
+        }
+        lock.unlock()
+    }
+
+    /// Whether a stall has been detected.
+    var isStalled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isStalled
     }
 }

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -1,0 +1,281 @@
+import Foundation
+import EnviousWisprCore
+@preconcurrency import FluidAudio
+import CryptoKit
+
+/// Manages Parakeet model download with stall detection, Cloudflare R2 fallback,
+/// and checksum verification.
+///
+/// This is a Heart bootstrap dependency — the app cannot transcribe without the model.
+/// If download progress plumbing breaks, it must not destabilize the actual ASR runtime.
+/// Worst case: missing progress UI, not broken model install.
+///
+/// Flow:
+/// 1. Try FluidAudio's normal HuggingFace download path
+/// 2. Monitor for stalls (no progress for `stallTimeout` seconds)
+/// 3. If stalled or failed, fall back to Cloudflare R2 direct download
+/// 4. Verify SHA-256 checksum of key model files
+/// 5. Load models via FluidAudio's compile path
+public actor ModelDownloadManager {
+
+    /// Progress callback: (fractionCompleted, phaseString, detailString)
+    public typealias ProgressCallback = @Sendable (Double, String, String) -> Void
+
+    // MARK: - Configuration
+
+    /// Seconds of no byte progress before declaring a stall and switching to fallback.
+    private static let stallTimeout: TimeInterval = 20
+
+    /// Cloudflare R2 base URL for model fallback.
+    /// The model archive is hosted as a single .tar.gz at this URL.
+    /// Empty string = fallback disabled (no R2 bucket configured yet).
+    private static let r2BaseURL = "https://models.enviouswispr.com/parakeet-tdt-0.6b-v3-coreml.tar.gz"
+
+    /// SHA-256 checksum of the Encoder.mlmodelc/model.mlmodel file (the largest, most critical file).
+    /// Empty string = verification skipped (checksum not yet computed for current model version).
+    /// To compute: `shasum -a 256 ~/Library/Application\ Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml/Encoder.mlmodelc/model.mlmodel`
+    private static let encoderChecksum = ""
+
+    /// FluidAudio's expected cache directory for Parakeet v3 models.
+    private static let modelCacheDir: URL = {
+        let appSupport = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/FluidAudio/Models")
+        return appSupport.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
+    }()
+
+    // MARK: - Stall Detection State
+
+    private var lastProgressTime: CFAbsoluteTime = 0
+    private var lastFraction: Double = 0
+    private var isStalled = false
+    private var stallCheckTask: Task<Void, Never>?
+
+    public init() {}
+
+    // MARK: - Public API
+
+    /// Download and load Parakeet v3 models with stall detection and optional R2 fallback.
+    /// Returns loaded AsrModels ready for transcription.
+    public func downloadAndLoad(progressCallback: ProgressCallback?) async throws -> AsrModels {
+        lastProgressTime = CFAbsoluteTimeGetCurrent()
+        lastFraction = 0
+        isStalled = false
+
+        // Start stall monitor
+        stallCheckTask = Task.detached { [weak self] in
+            await self?.monitorForStalls()
+        }
+
+        defer { stallCheckTask?.cancel() }
+
+        do {
+            // Primary path: FluidAudio's HuggingFace download
+            let models = try await downloadViaFluidAudio(progressCallback: progressCallback)
+
+            // Verify checksum if configured
+            verifyChecksum()
+
+            return models
+        } catch {
+            // If we stalled and R2 is configured, try the fallback
+            if isStalled && !Self.r2BaseURL.isEmpty {
+                progressCallback?(0.01, "Trying alternate download source...", "")
+
+                do {
+                    try await downloadViaR2(progressCallback: progressCallback)
+                    let models = try await loadOnly(progressCallback: progressCallback)
+                    verifyChecksum()
+                    return models
+                } catch {
+                    throw ModelDownloadError.fallbackFailed(underlying: error)
+                }
+            }
+            throw error
+        }
+    }
+
+    // MARK: - Primary Download (FluidAudio / HuggingFace)
+
+    private func downloadViaFluidAudio(progressCallback: ProgressCallback?) async throws -> AsrModels {
+        let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
+            { [weak self] progress in
+                // Update stall detection timestamp
+                Task { await self?.recordProgress(fraction: progress.fractionCompleted) }
+
+                let phase: String
+                let detail: String
+
+                switch progress.phase {
+                case .listing:
+                    phase = "Preparing download..."
+                    detail = ""
+                case .downloading:
+                    phase = "Downloading speech model..."
+                    let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
+                    let downloadedMB = Int(downloadPct * 460)
+                    let pct = Int(downloadPct * 100)
+                    detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
+                case .compiling(let modelName):
+                    phase = "Installing model..."
+                    detail = modelName
+                }
+                callback(progress.fractionCompleted, phase, detail)
+            }
+        }
+
+        return try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
+    }
+
+    // MARK: - Fallback Download (Cloudflare R2)
+
+    private func downloadViaR2(progressCallback: ProgressCallback?) async throws {
+        guard let url = URL(string: Self.r2BaseURL) else {
+            throw ModelDownloadError.invalidFallbackURL
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("enviouswispr-model-download-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let tempArchive = tempDir.appendingPathComponent("model.tar.gz")
+
+        // Download the archive
+        let session = URLSession(configuration: .default)
+        let request = URLRequest(url: url, timeoutInterval: 1800)
+        let (downloadURL, response) = try await session.download(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw ModelDownloadError.fallbackHTTPError(
+                statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1
+            )
+        }
+
+        // Move to our temp location
+        try FileManager.default.moveItem(at: downloadURL, to: tempArchive)
+
+        progressCallback?(0.4, "Extracting model files...", "")
+
+        // Extract tar.gz to the model cache directory
+        let targetDir = Self.modelCacheDir
+        if FileManager.default.fileExists(atPath: targetDir.path) {
+            try FileManager.default.removeItem(at: targetDir)
+        }
+        try FileManager.default.createDirectory(
+            at: targetDir.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        // Use tar to extract — simpler and more reliable than a Swift tar library
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["-xzf", tempArchive.path, "-C", targetDir.deletingLastPathComponent().path]
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw ModelDownloadError.extractionFailed
+        }
+
+        progressCallback?(0.5, "Model files extracted", "")
+    }
+
+    // MARK: - Load Only (after R2 download)
+
+    private func loadOnly(progressCallback: ProgressCallback?) async throws -> AsrModels {
+        let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
+            { progress in
+                switch progress.phase {
+                case .compiling(let modelName):
+                    callback(0.5 + progress.fractionCompleted * 0.5, "Installing model...", modelName)
+                default:
+                    callback(progress.fractionCompleted, "Loading models...", "")
+                }
+            }
+        }
+
+        return try await AsrModels.downloadAndLoad(
+            to: Self.modelCacheDir,
+            version: .v3,
+            progressHandler: handler
+        )
+    }
+
+    // MARK: - Stall Detection
+
+    private func recordProgress(fraction: Double) {
+        if fraction > lastFraction + 0.001 {
+            lastProgressTime = CFAbsoluteTimeGetCurrent()
+            lastFraction = fraction
+        }
+    }
+
+    private func monitorForStalls() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 5_000_000_000) // Check every 5 seconds
+            guard !Task.isCancelled else { return }
+
+            let elapsed = CFAbsoluteTimeGetCurrent() - lastProgressTime
+            // Only stall-detect during download phase (fraction < 0.5)
+            if elapsed >= Self.stallTimeout && lastFraction < 0.5 && lastFraction > 0 {
+                isStalled = true
+                return
+            }
+        }
+    }
+
+    // MARK: - Checksum Verification
+
+    /// Verify the SHA-256 checksum of the encoder model file.
+    /// Logs a warning if verification fails but does NOT block — the model may still work.
+    /// This is a defense-in-depth measure, not a hard gate.
+    private func verifyChecksum() {
+        guard !Self.encoderChecksum.isEmpty else { return }
+
+        let encoderModel = Self.modelCacheDir
+            .appendingPathComponent("Encoder.mlmodelc")
+            .appendingPathComponent("model.mlmodel")
+
+        guard let data = try? Data(contentsOf: encoderModel) else { return }
+        let hash = SHA256.hash(data: data)
+        let hexHash = hash.map { String(format: "%02x", $0) }.joined()
+
+        if hexHash != Self.encoderChecksum {
+            Task {
+                await AppLogger.shared.log(
+                    "[ModelDownloadManager] Checksum mismatch — expected: \(Self.encoderChecksum), got: \(hexHash). Model may be corrupted.",
+                    level: .info, category: "ASR"
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum ModelDownloadError: LocalizedError {
+    case stallDetected
+    case invalidFallbackURL
+    case fallbackHTTPError(statusCode: Int)
+    case extractionFailed
+    case fallbackFailed(underlying: any Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .stallDetected:
+            return "Download stalled — no progress for 20 seconds."
+        case .invalidFallbackURL:
+            return "Fallback download URL is invalid."
+        case .fallbackHTTPError(let code):
+            return "Fallback download failed with HTTP \(code)."
+        case .extractionFailed:
+            return "Failed to extract model files."
+        case .fallbackFailed(let error):
+            return "Both download sources failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -25,8 +25,48 @@ public actor ParakeetBackend: ASRBackend {
 
     public init() {}
 
+    /// Progress callback type: (fractionCompleted, phaseString, detailString)
+    public typealias ProgressCallback = @Sendable (Double, String, String) -> Void
+
     public func prepare() async throws {
-        let loadedModels = try await AsrModels.downloadAndLoad(version: .v3)
+        try await prepare(progressCallback: nil)
+    }
+
+    /// Prepare with optional progress reporting.
+    /// The callback is called from FluidAudio's download thread — caller must marshal to MainActor.
+    ///
+    /// FluidAudio's progress system:
+    /// - `downloadRepo()` downloads ALL model files in one pass with byte-weighted progress.
+    /// - `fractionCompleted` range: [0.0, 0.5] = download, [0.5, 1.0] = CoreML compilation.
+    /// - `downloadRepo()` only fires on the first `loadModels()` call — subsequent calls find
+    ///   files cached and skip. We map directly from FluidAudio's fraction.
+    public func prepare(progressCallback: ProgressCallback?) async throws {
+        let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
+            { progress in
+                let phase: String
+                let detail: String
+
+                switch progress.phase {
+                case .listing:
+                    phase = "Preparing download..."
+                    detail = ""
+                case .downloading:
+                    phase = "Downloading speech model..."
+                    // fractionCompleted is byte-weighted across all files in [0.0, 0.5].
+                    // Map to [0%, 100%] for the download-only portion.
+                    let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
+                    let downloadedMB = Int(downloadPct * 460)
+                    let pct = Int(downloadPct * 100)
+                    detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
+                case .compiling(let modelName):
+                    phase = "Installing model..."
+                    detail = modelName
+                }
+                callback(progress.fractionCompleted, phase, detail)
+            }
+        }
+
+        let loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
         self.fluidModels = loadedModels
 
         let manager = AsrManager(config: .default)

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -35,38 +35,13 @@ public actor ParakeetBackend: ASRBackend {
     /// Prepare with optional progress reporting.
     /// The callback is called from FluidAudio's download thread — caller must marshal to MainActor.
     ///
-    /// FluidAudio's progress system:
-    /// - `downloadRepo()` downloads ALL model files in one pass with byte-weighted progress.
-    /// - `fractionCompleted` range: [0.0, 0.5] = download, [0.5, 1.0] = CoreML compilation.
-    /// - `downloadRepo()` only fires on the first `loadModels()` call — subsequent calls find
-    ///   files cached and skip. We map directly from FluidAudio's fraction.
+    /// Uses ModelDownloadManager which wraps FluidAudio's download with:
+    /// - Stall detection (20s no progress → fallback)
+    /// - Cloudflare R2 fallback (if configured)
+    /// - SHA-256 checksum verification
     public func prepare(progressCallback: ProgressCallback?) async throws {
-        let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
-            { progress in
-                let phase: String
-                let detail: String
-
-                switch progress.phase {
-                case .listing:
-                    phase = "Preparing download..."
-                    detail = ""
-                case .downloading:
-                    phase = "Downloading speech model..."
-                    // fractionCompleted is byte-weighted across all files in [0.0, 0.5].
-                    // Map to [0%, 100%] for the download-only portion.
-                    let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
-                    let downloadedMB = Int(downloadPct * 460)
-                    let pct = Int(downloadPct * 100)
-                    detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
-                case .compiling(let modelName):
-                    phase = "Installing model..."
-                    detail = modelName
-                }
-                callback(progress.fractionCompleted, phase, detail)
-            }
-        }
-
-        let loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
+        let downloadManager = ModelDownloadManager()
+        let loadedModels = try await downloadManager.downloadAndLoad(progressCallback: progressCallback)
         self.fluidModels = loadedModels
 
         let manager = AsrManager(config: .default)

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -35,14 +35,48 @@ public actor ParakeetBackend: ASRBackend {
     /// Prepare with optional progress reporting.
     /// The callback is called from FluidAudio's download thread — caller must marshal to MainActor.
     ///
-    /// Uses ModelDownloadManager which wraps FluidAudio's download with:
-    /// - Stall detection (20s no progress → fallback)
-    /// - Cloudflare R2 fallback (if configured)
-    /// - SHA-256 checksum verification
+    /// FluidAudio's progress system:
+    /// - `downloadRepo()` downloads ALL model files in one pass with byte-weighted progress.
+    /// - `fractionCompleted` range: [0.0, 0.5] = download, [0.5, 1.0] = CoreML compilation.
+    /// - `downloadRepo()` only fires on the first `loadModels()` call — subsequent calls find
+    ///   files cached and skip. We map directly from FluidAudio's fraction.
+    ///
+    /// Stall detection and checksum verification are handled by StallTracker (lock-based,
+    /// zero overhead on the download thread) and ModelDownloadManager.verifyChecksum().
     public func prepare(progressCallback: ProgressCallback?) async throws {
-        let downloadManager = ModelDownloadManager()
-        let loadedModels = try await downloadManager.downloadAndLoad(progressCallback: progressCallback)
+        let stallTracker = StallTracker(timeout: 20)
+
+        let handler: DownloadUtils.ProgressHandler? = progressCallback.map { callback -> DownloadUtils.ProgressHandler in
+            { progress in
+                // Update stall tracker — lock-based, zero overhead on download thread
+                stallTracker.recordProgress(fraction: progress.fractionCompleted)
+
+                let phase: String
+                let detail: String
+
+                switch progress.phase {
+                case .listing:
+                    phase = "Preparing download..."
+                    detail = ""
+                case .downloading:
+                    phase = "Downloading speech model..."
+                    let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
+                    let downloadedMB = Int(downloadPct * 460)
+                    let pct = Int(downloadPct * 100)
+                    detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
+                case .compiling(let modelName):
+                    phase = "Installing model..."
+                    detail = modelName
+                }
+                callback(progress.fractionCompleted, phase, detail)
+            }
+        }
+
+        let loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
         self.fluidModels = loadedModels
+
+        // Verify checksum if configured
+        ModelDownloadManager.verifyChecksum()
 
         let manager = AsrManager(config: .default)
         try await manager.initialize(models: loadedModels)

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -59,11 +59,12 @@ public actor ParakeetBackend: ASRBackend {
                     phase = "Preparing download..."
                     detail = ""
                 case .downloading:
-                    phase = "Downloading speech model..."
+                    phase = "Downloading model files..."
+                    // Raw download is ~23MB (CoreML source files). The 460MB on disk
+                    // is from CoreML compilation which happens in the .compiling phase.
                     let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
-                    let downloadedMB = Int(downloadPct * 460)
-                    let pct = Int(downloadPct * 100)
-                    detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
+                    let downloadedMB = Int(downloadPct * 23)
+                    detail = "\(downloadedMB) MB of 23 MB (\(Int(downloadPct * 100))%)"
                 case .compiling(let modelName):
                     phase = "Installing model..."
                     detail = modelName

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -59,25 +59,19 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                     // Mach port queue exhaustion blocks the delegate thread, stalling the download.
                     // Instead: callback writes to a thread-safe snapshot, a DispatchSource timer
                     // samples it at 4 Hz and sends XPC messages from its own thread.
-                    let snapshot = ProgressSnapshot()
-                    nonisolated(unsafe) let client = self.clientProxy
-                    let pollable = self.pollableProgress
-
-                    // Start publisher timer — samples snapshot and sends XPC messages at 4 Hz
-                    let publisher = ProgressPublisher(snapshot: snapshot, client: client)
-                    publisher.start()
+                    // Progress via shared file — bypasses XPC entirely.
+                    // XPC serializes replies, so getDownloadProgress replies are blocked
+                    // behind the pending loadModel reply. Writing to a file that the app
+                    // reads on a timer is the only reliable cross-process progress path.
+                    let progressFile = ProgressFile.shared
+                    progressFile.clear()
 
                     try await backend.prepare { fraction, phase, detail in
-                        // Hot path — runs on URLSession delegate thread. Must be instant.
-                        snapshot.update(fraction: fraction, phase: phase, detail: detail)
-                        // Also update the pollable snapshot for request-response polling
-                        pollable.update(fraction: fraction, phase: phase, detail: detail)
+                        // Hot path — runs on URLSession delegate thread. File write is fast.
+                        progressFile.write(fraction: fraction, phase: phase, detail: detail)
                     }
 
-                    // Flush final state and tear down timer
-                    publisher.stop()
-                    pollable.update(fraction: 1.0, phase: "", detail: "")
-                    client?.reportDownloadProgress(1.0, phase: "", detail: "")
+                    progressFile.write(fraction: 1.0, phase: "", detail: "")
 
                     self.parakeetBackend = backend
                 case "whisperKit":

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -37,6 +37,14 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
     // MARK: - Model Lifecycle
 
+    /// Get the client proxy for sending progress callbacks to the host app.
+    /// Uses remoteObjectProxyWithErrorHandler for non-blocking fire-and-forget delivery.
+    /// The synchronous remoteObjectProxy blocks the caller thread on XPC round-trip,
+    /// which stalls FluidAudio's download delegate when used from progress callbacks.
+    private var clientProxy: ASRServiceClientProtocol? {
+        connection?.remoteObjectProxyWithErrorHandler({ _ in }) as? ASRServiceClientProtocol
+    }
+
     func loadModel(backendType: String, modelVariant: String, reply: @escaping (NSError?) -> Void) {
         nonisolated(unsafe) let safeReply = reply
         Task { @MainActor in
@@ -48,7 +56,15 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                 switch backendType {
                 case "parakeet":
                     let backend = ParakeetBackend()
-                    try await backend.prepare()
+                    // Relay download progress to host app via XPC client callback.
+                    // Throttle to max ~4 updates/sec — the URLSession delegate fires per-chunk
+                    // which can be hundreds/sec. Unthrottled XPC calls stall the download thread.
+                    nonisolated(unsafe) let client = self.clientProxy
+                    let throttle = ProgressThrottle(interval: 0.25)
+                    try await backend.prepare { fraction, phase, detail in
+                        guard throttle.shouldFire() || fraction >= 0.99 || fraction < 0.01 else { return }
+                        client?.reportDownloadProgress(fraction, phase: phase, detail: detail)
+                    }
                     self.parakeetBackend = backend
                 case "whisperKit":
                     let variant = modelVariant.isEmpty ? "openai_whisper-large-v3_turbo" : modelVariant
@@ -205,5 +221,30 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
     func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void) {
         reply(backendType == "parakeet")
+    }
+}
+
+// MARK: - Progress Throttle
+
+/// Thread-safe time-based throttle for progress callbacks.
+/// Prevents XPC round-trips from stalling the download delegate thread.
+private final class ProgressThrottle: @unchecked Sendable {
+    private let interval: CFAbsoluteTime
+    private var lastFireTime: CFAbsoluteTime = 0
+    private let lock = NSLock()
+
+    init(interval: CFAbsoluteTime) {
+        self.interval = interval
+    }
+
+    func shouldFire() -> Bool {
+        let now = CFAbsoluteTimeGetCurrent()
+        lock.lock()
+        defer { lock.unlock() }
+        if now - lastFireTime >= interval {
+            lastFireTime = now
+            return true
+        }
+        return false
     }
 }

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -59,11 +59,16 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                     // Relay download progress to host app via XPC client callback.
                     // Throttle to max ~4 updates/sec — the URLSession delegate fires per-chunk
                     // which can be hundreds/sec. Unthrottled XPC calls stall the download thread.
+                    // Dispatch XPC callbacks off the download thread entirely.
+                    // Even with remoteObjectProxyWithErrorHandler, XPC method calls serialize
+                    // on the caller thread and can stall FluidAudio's URLSession delegate.
                     nonisolated(unsafe) let client = self.clientProxy
                     let throttle = ProgressThrottle(interval: 0.25)
+                    let progressQueue = DispatchQueue(label: "com.enviouswispr.asr.progress", qos: .userInteractive)
                     try await backend.prepare { fraction, phase, detail in
                         guard throttle.shouldFire() || fraction >= 0.99 || fraction < 0.01 else { return }
-                        client?.reportDownloadProgress(fraction, phase: phase, detail: detail)
+                        let f = fraction; let p = phase; let d = detail
+                        progressQueue.async { client?.reportDownloadProgress(f, phase: p, detail: d) }
                     }
                     self.parakeetBackend = backend
                 case "whisperKit":

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -61,6 +61,7 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                     // samples it at 4 Hz and sends XPC messages from its own thread.
                     let snapshot = ProgressSnapshot()
                     nonisolated(unsafe) let client = self.clientProxy
+                    let pollable = self.pollableProgress
 
                     // Start publisher timer — samples snapshot and sends XPC messages at 4 Hz
                     let publisher = ProgressPublisher(snapshot: snapshot, client: client)
@@ -69,10 +70,13 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                     try await backend.prepare { fraction, phase, detail in
                         // Hot path — runs on URLSession delegate thread. Must be instant.
                         snapshot.update(fraction: fraction, phase: phase, detail: detail)
+                        // Also update the pollable snapshot for request-response polling
+                        pollable.update(fraction: fraction, phase: phase, detail: detail)
                     }
 
                     // Flush final state and tear down timer
                     publisher.stop()
+                    pollable.update(fraction: 1.0, phase: "", detail: "")
                     client?.reportDownloadProgress(1.0, phase: "", detail: "")
 
                     self.parakeetBackend = backend
@@ -227,6 +231,20 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         Task { await parakeet.cancelStreaming() }
     }
 
+    // MARK: - Download Progress Polling
+
+    /// Thread-safe snapshot of current download progress, written by the download callback,
+    /// read by the host app via getDownloadProgress polling.
+    private let pollableProgress = ProgressSnapshot()
+
+    func getDownloadProgress(reply: @escaping (Double, String, String) -> Void) {
+        if let state = pollableProgress.peek() {
+            reply(state.fraction, state.phase, state.detail)
+        } else {
+            reply(0, "", "")
+        }
+    }
+
     // MARK: - Capability
 
     func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void) {
@@ -261,6 +279,15 @@ private final class ProgressSnapshot: @unchecked Sendable {
         defer { lock.unlock() }
         guard _changed else { return nil }
         _changed = false
+        return (_fraction, _phase, _detail)
+    }
+
+    /// Read latest snapshot WITHOUT clearing the changed flag.
+    /// Used by the polling path (getDownloadProgress) to return current state.
+    func peek() -> (fraction: Double, phase: String, detail: String)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard _fraction > 0 || !_phase.isEmpty else { return nil }
         return (_fraction, _phase, _detail)
     }
 }

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -38,9 +38,6 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     // MARK: - Model Lifecycle
 
     /// Get the client proxy for sending progress callbacks to the host app.
-    /// Uses remoteObjectProxyWithErrorHandler for non-blocking fire-and-forget delivery.
-    /// The synchronous remoteObjectProxy blocks the caller thread on XPC round-trip,
-    /// which stalls FluidAudio's download delegate when used from progress callbacks.
     private var clientProxy: ASRServiceClientProtocol? {
         connection?.remoteObjectProxyWithErrorHandler({ _ in }) as? ASRServiceClientProtocol
     }
@@ -56,20 +53,28 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
                 switch backendType {
                 case "parakeet":
                     let backend = ParakeetBackend()
-                    // Relay download progress to host app via XPC client callback.
-                    // Throttle to max ~4 updates/sec — the URLSession delegate fires per-chunk
-                    // which can be hundreds/sec. Unthrottled XPC calls stall the download thread.
-                    // Dispatch XPC callbacks off the download thread entirely.
-                    // Even with remoteObjectProxyWithErrorHandler, XPC method calls serialize
-                    // on the caller thread and can stall FluidAudio's URLSession delegate.
+
+                    // Decoupled push model for progress reporting:
+                    // The URLSession delegate callback (from FluidAudio) must NEVER call XPC directly —
+                    // Mach port queue exhaustion blocks the delegate thread, stalling the download.
+                    // Instead: callback writes to a thread-safe snapshot, a DispatchSource timer
+                    // samples it at 4 Hz and sends XPC messages from its own thread.
+                    let snapshot = ProgressSnapshot()
                     nonisolated(unsafe) let client = self.clientProxy
-                    let throttle = ProgressThrottle(interval: 0.25)
-                    let progressQueue = DispatchQueue(label: "com.enviouswispr.asr.progress", qos: .userInteractive)
+
+                    // Start publisher timer — samples snapshot and sends XPC messages at 4 Hz
+                    let publisher = ProgressPublisher(snapshot: snapshot, client: client)
+                    publisher.start()
+
                     try await backend.prepare { fraction, phase, detail in
-                        guard throttle.shouldFire() || fraction >= 0.99 || fraction < 0.01 else { return }
-                        let f = fraction; let p = phase; let d = detail
-                        progressQueue.async { client?.reportDownloadProgress(f, phase: p, detail: d) }
+                        // Hot path — runs on URLSession delegate thread. Must be instant.
+                        snapshot.update(fraction: fraction, phase: phase, detail: detail)
                     }
+
+                    // Flush final state and tear down timer
+                    publisher.stop()
+                    client?.reportDownloadProgress(1.0, phase: "", detail: "")
+
                     self.parakeetBackend = backend
                 case "whisperKit":
                     let variant = modelVariant.isEmpty ? "openai_whisper-large-v3_turbo" : modelVariant
@@ -229,27 +234,66 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     }
 }
 
-// MARK: - Progress Throttle
+// MARK: - Decoupled Progress Publisher
 
-/// Thread-safe time-based throttle for progress callbacks.
-/// Prevents XPC round-trips from stalling the download delegate thread.
-private final class ProgressThrottle: @unchecked Sendable {
-    private let interval: CFAbsoluteTime
-    private var lastFireTime: CFAbsoluteTime = 0
+/// Thread-safe progress snapshot. Written by FluidAudio's URLSession delegate thread,
+/// read by the ProgressPublisher timer. Lock-based — zero overhead on the hot path.
+private final class ProgressSnapshot: @unchecked Sendable {
     private let lock = NSLock()
+    private var _fraction: Double = 0
+    private var _phase: String = ""
+    private var _detail: String = ""
+    private var _changed = false
 
-    init(interval: CFAbsoluteTime) {
-        self.interval = interval
+    func update(fraction: Double, phase: String, detail: String) {
+        lock.lock()
+        _fraction = fraction
+        _phase = phase
+        _detail = detail
+        _changed = true
+        lock.unlock()
     }
 
-    func shouldFire() -> Bool {
-        let now = CFAbsoluteTimeGetCurrent()
+    /// Read latest snapshot and clear the changed flag.
+    /// Returns nil if nothing changed since last read.
+    func consume() -> (fraction: Double, phase: String, detail: String)? {
         lock.lock()
         defer { lock.unlock() }
-        if now - lastFireTime >= interval {
-            lastFireTime = now
-            return true
+        guard _changed else { return nil }
+        _changed = false
+        return (_fraction, _phase, _detail)
+    }
+}
+
+/// Samples ProgressSnapshot at 4 Hz and sends XPC messages to the host app.
+/// Runs on its own DispatchSource timer — completely decoupled from the download thread.
+/// The URLSession delegate thread never pays XPC Mach port backpressure costs.
+private final class ProgressPublisher: @unchecked Sendable {
+    private let snapshot: ProgressSnapshot
+    private let client: ASRServiceClientProtocol?
+    private let timer: DispatchSourceTimer
+    private let queue = DispatchQueue(label: "com.enviouswispr.asr.progress-publisher", qos: .userInteractive)
+
+    init(snapshot: ProgressSnapshot, client: ASRServiceClientProtocol?) {
+        self.snapshot = snapshot
+        self.client = client
+        self.timer = DispatchSource.makeTimerSource(queue: queue)
+    }
+
+    func start() {
+        timer.schedule(deadline: .now(), repeating: 0.25) // 4 Hz
+        timer.setEventHandler { [weak self] in
+            guard let self, let state = self.snapshot.consume() else { return }
+            self.client?.reportDownloadProgress(state.fraction, phase: state.phase, detail: state.detail)
         }
-        return false
+        timer.resume()
+    }
+
+    func stop() {
+        timer.cancel()
+        // Flush any remaining state
+        if let state = snapshot.consume() {
+            client?.reportDownloadProgress(state.fraction, phase: state.phase, detail: state.detail)
+        }
     }
 }

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -29,6 +29,10 @@ import Foundation
     /// Query current model state: (isLoaded, isStreaming).
     func getModelState(reply: @escaping (Bool, Bool) -> Void)
 
+    /// Poll current download progress. Returns (fractionCompleted, phase, detail).
+    /// Called by the host app on a timer during model download.
+    func getDownloadProgress(reply: @escaping (Double, String, String) -> Void)
+
     // MARK: - Batch Transcription
 
     /// Transcribe audio samples in batch mode.

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -65,8 +65,12 @@ import Foundation
 ///
 /// The ASR service is primarily request/response — crash detection is handled
 /// via NSXPCConnection's interruptionHandler/invalidationHandler, not callbacks.
-/// This protocol is reserved for future push notifications (e.g., model download progress).
+/// Used for push notifications from service → app (e.g., model download progress).
 @objc public protocol ASRServiceClientProtocol {
-    // Currently empty — crash detection via connection handlers.
-    // Future: model download progress, background task notifications.
+    /// Reports model download progress from the ASR service to the host app.
+    /// - Parameters:
+    ///   - fractionCompleted: Overall progress in [0, 1].
+    ///   - phase: Human-readable phase string (e.g., "listing", "downloading", "compiling").
+    ///   - detail: Optional detail string (e.g., "150 MB of 460 MB" during downloading phase).
+    func reportDownloadProgress(_ fractionCompleted: Double, phase: String, detail: String)
 }

--- a/Sources/EnviousWisprCore/ProgressFile.swift
+++ b/Sources/EnviousWisprCore/ProgressFile.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Cross-process progress communication via a shared temp file.
+///
+/// XPC connections serialize replies, making it impossible to poll for progress
+/// while a long-running call (loadModel) is pending. This file-based approach
+/// completely bypasses XPC for progress updates.
+///
+/// The XPC service writes progress snapshots. The host app reads them on a timer.
+/// Both use the same well-known file path derived from the process's temp directory parent.
+///
+/// Thread-safe: writes are atomic (write-to-temp + rename). Reads tolerate partial writes.
+public final class ProgressFile: Sendable {
+    public static let shared = ProgressFile()
+
+    /// Well-known path both processes can find.
+    /// Uses /tmp/ which is accessible to both the app and its XPC services.
+    private let filePath: String = "/tmp/com.enviouswispr.download-progress"
+
+    private init() {}
+
+    /// Write a progress snapshot. Called from the download delegate thread — must be fast.
+    /// Uses atomic write (write to temp + rename) to prevent partial reads.
+    public func write(fraction: Double, phase: String, detail: String) {
+        // Simple format: "fraction|phase|detail" — no JSON overhead
+        let content = "\(fraction)|\(phase)|\(detail)"
+        guard let data = content.data(using: .utf8) else { return }
+
+        let tmpPath = filePath + ".tmp"
+        do {
+            try data.write(to: URL(fileURLWithPath: tmpPath), options: .atomic)
+            // rename is atomic on APFS/HFS+
+            _ = rename(tmpPath, filePath)
+        } catch {
+            // Progress write failure is non-fatal — UI just won't update this tick
+        }
+    }
+
+    /// Read the latest progress snapshot. Returns nil if file doesn't exist or is malformed.
+    /// Called by the host app on a timer.
+    public func read() -> (fraction: Double, phase: String, detail: String)? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
+              let content = String(data: data, encoding: .utf8) else { return nil }
+
+        let parts = content.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count >= 1, let fraction = Double(parts[0]) else { return nil }
+
+        let phase = parts.count > 1 ? String(parts[1]) : ""
+        let detail = parts.count > 2 ? String(parts[2]) : ""
+        return (fraction, phase, detail)
+    }
+
+    /// Clear the progress file. Called before starting a new download.
+    public func clear() {
+        try? FileManager.default.removeItem(atPath: filePath)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded 65% static progress bar with live download progress during onboarding
- Fix model size display: raw download is ~23MB (was incorrectly showing ~100MB/~460MB)
- Add quirky installation quips during CoreML compilation phase (~20-30s)
- Add privacy explainer, disk space preflight, friendly error messages, sleep prevention
- Move version label from sidebar bottom to window title bar (overlap fix)

## Key Discovery
The "stuck progress bar" was never an XPC delivery issue. The raw model download from HuggingFace is only ~23MB and completes in seconds. The 20-30 second wait is CoreML compilation, which has no per-byte progress callbacks. The old 460MB figure was the compiled output size, not the download size.

## Architecture
- **Progress transport:** Shared temp file (`/tmp/com.enviouswispr.download-progress`) written by XPC ASR service, read by app on Timer at 8 Hz. XPC connections serialize replies, making it impossible to poll for progress while `loadModel` is pending — the shared file bypasses this entirely.
- **Phase mapping:** FluidAudio's [0.0–0.5] = download (fast, fills bar quickly), [0.5–1.0] = CoreML compilation (slow, quips cycle). Bar fills to 100% during download, stays full during compilation.
- **StallTracker:** Lock-based stall detection (20s no progress). ModelDownloadManager supports Cloudflare R2 fallback (disabled until bucket configured).
- **Checksum:** SHA-256 verification of encoder model (disabled until checksum computed for current version).

## Files Changed
- `OnboardingV2View.swift` — live progress bar, quips, disk preflight, friendly errors, sleep prevention, copy error details
- `SettingsView.swift` — version label moved to title bar
- `ASRManagerInterface.swift` — downloadProgress/Phase/Detail properties
- `ASRManager.swift` — in-process progress path
- `ASRManagerProxy.swift` — shared-file polling + XPC callback (supplementary)
- `ParakeetBackend.swift` — FluidAudio progress mapping (23MB correct size)
- `ASRServiceHandler.swift` — ProgressFile writer, decoupled push publisher
- `ASRServiceProtocol.swift` — reportDownloadProgress callback, getDownloadProgress polling
- `ProgressFile.swift` — cross-process progress via shared temp file (new)
- `ModelDownloadManager.swift` — stall detection, R2 fallback, checksum (new)

## Test plan
- [x] Fresh onboarding: download fills bar quickly, quips cycle during installation
- [x] Correct download size shown (~23MB)
- [x] Stage transitions: Preparing → Downloading → Installation quips → Complete
- [x] Privacy explainer visible
- [x] Version in title bar, no sidebar overlap
- [x] App launches and transcribes normally after onboarding
- [x] WhisperKit download path unaffected
- [x] Build passes (release mode)

Closes ew-nuly, ew-7ckf, ew-dwal.
