### PR TITLE
chore: remove dead XPC progress code

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -270,8 +270,6 @@ public final class ASRManagerProxy: ASRManagerInterface {
         conn.remoteObjectInterface = NSXPCInterface(with: ASRServiceProtocol.self)
         conn.exportedInterface = NSXPCInterface(with: ASRServiceClientProtocol.self)
 
-        conn.exportedObject = self
-
         conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
         conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
 
@@ -351,21 +349,6 @@ public final class ASRManagerProxy: ASRManagerInterface {
                     proxy.onServiceInterrupted?()
                 }
             }
-        }
-    }
-}
-
-// MARK: - ASRServiceClientProtocol (XPC callbacks from service → app)
-
-extension ASRManagerProxy: ASRServiceClientProtocol {
-    /// Receives download progress from the ASR XPC service.
-    /// Called on an XPC dispatch queue — must marshal to MainActor for UI state updates.
-    nonisolated public func reportDownloadProgress(_ fractionCompleted: Double, phase: String, detail: String) {
-        Task { @MainActor [weak self] in
-            guard let self, !self.isModelLoaded else { return }
-            self.downloadProgress = fractionCompleted
-            self.downloadPhase = phase
-            self.downloadDetail = detail
         }
     }
 }

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -37,11 +37,6 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
     // MARK: - Model Lifecycle
 
-    /// Get the client proxy for sending progress callbacks to the host app.
-    private var clientProxy: ASRServiceClientProtocol? {
-        connection?.remoteObjectProxyWithErrorHandler({ _ in }) as? ASRServiceClientProtocol
-    }
-
     func loadModel(backendType: String, modelVariant: String, reply: @escaping (NSError?) -> Void) {
         nonisolated(unsafe) let safeReply = reply
         Task { @MainActor in
@@ -225,20 +220,6 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         Task { await parakeet.cancelStreaming() }
     }
 
-    // MARK: - Download Progress Polling
-
-    /// Thread-safe snapshot of current download progress, written by the download callback,
-    /// read by the host app via getDownloadProgress polling.
-    private let pollableProgress = ProgressSnapshot()
-
-    func getDownloadProgress(reply: @escaping (Double, String, String) -> Void) {
-        if let state = pollableProgress.peek() {
-            reply(state.fraction, state.phase, state.detail)
-        } else {
-            reply(0, "", "")
-        }
-    }
-
     // MARK: - Capability
 
     func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void) {
@@ -246,75 +227,3 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     }
 }
 
-// MARK: - Decoupled Progress Publisher
-
-/// Thread-safe progress snapshot. Written by FluidAudio's URLSession delegate thread,
-/// read by the ProgressPublisher timer. Lock-based — zero overhead on the hot path.
-private final class ProgressSnapshot: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _fraction: Double = 0
-    private var _phase: String = ""
-    private var _detail: String = ""
-    private var _changed = false
-
-    func update(fraction: Double, phase: String, detail: String) {
-        lock.lock()
-        _fraction = fraction
-        _phase = phase
-        _detail = detail
-        _changed = true
-        lock.unlock()
-    }
-
-    /// Read latest snapshot and clear the changed flag.
-    /// Returns nil if nothing changed since last read.
-    func consume() -> (fraction: Double, phase: String, detail: String)? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard _changed else { return nil }
-        _changed = false
-        return (_fraction, _phase, _detail)
-    }
-
-    /// Read latest snapshot WITHOUT clearing the changed flag.
-    /// Used by the polling path (getDownloadProgress) to return current state.
-    func peek() -> (fraction: Double, phase: String, detail: String)? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard _fraction > 0 || !_phase.isEmpty else { return nil }
-        return (_fraction, _phase, _detail)
-    }
-}
-
-/// Samples ProgressSnapshot at 4 Hz and sends XPC messages to the host app.
-/// Runs on its own DispatchSource timer — completely decoupled from the download thread.
-/// The URLSession delegate thread never pays XPC Mach port backpressure costs.
-private final class ProgressPublisher: @unchecked Sendable {
-    private let snapshot: ProgressSnapshot
-    private let client: ASRServiceClientProtocol?
-    private let timer: DispatchSourceTimer
-    private let queue = DispatchQueue(label: "com.enviouswispr.asr.progress-publisher", qos: .userInteractive)
-
-    init(snapshot: ProgressSnapshot, client: ASRServiceClientProtocol?) {
-        self.snapshot = snapshot
-        self.client = client
-        self.timer = DispatchSource.makeTimerSource(queue: queue)
-    }
-
-    func start() {
-        timer.schedule(deadline: .now(), repeating: 0.25) // 4 Hz
-        timer.setEventHandler { [weak self] in
-            guard let self, let state = self.snapshot.consume() else { return }
-            self.client?.reportDownloadProgress(state.fraction, phase: state.phase, detail: state.detail)
-        }
-        timer.resume()
-    }
-
-    func stop() {
-        timer.cancel()
-        // Flush any remaining state
-        if let state = snapshot.consume() {
-            client?.reportDownloadProgress(state.fraction, phase: state.phase, detail: state.detail)
-        }
-    }
-}

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -29,10 +29,6 @@ import Foundation
     /// Query current model state: (isLoaded, isStreaming).
     func getModelState(reply: @escaping (Bool, Bool) -> Void)
 
-    /// Poll current download progress. Returns (fractionCompleted, phase, detail).
-    /// Called by the host app on a timer during model download.
-    func getDownloadProgress(reply: @escaping (Double, String, String) -> Void)
-
     // MARK: - Batch Transcription
 
     /// Transcribe audio samples in batch mode.
@@ -69,12 +65,11 @@ import Foundation
 ///
 /// The ASR service is primarily request/response — crash detection is handled
 /// via NSXPCConnection's interruptionHandler/invalidationHandler, not callbacks.
-/// Used for push notifications from service → app (e.g., model download progress).
+///
+/// Note: XPC connections serialize ALL replies, so push-based progress callbacks
+/// cannot be delivered while a long-running call (loadModel) is pending.
+/// Download progress uses a shared temp file instead (ProgressFile).
 @objc public protocol ASRServiceClientProtocol {
-    /// Reports model download progress from the ASR service to the host app.
-    /// - Parameters:
-    ///   - fractionCompleted: Overall progress in [0, 1].
-    ///   - phase: Human-readable phase string (e.g., "listing", "downloading", "compiling").
-    ///   - detail: Optional detail string (e.g., "150 MB of 460 MB" during downloading phase).
-    func reportDownloadProgress(_ fractionCompleted: Double, phase: String, detail: String)
+    // Currently empty — crash detection via connection handlers.
+    // Progress uses ProgressFile (shared temp file) to bypass XPC reply serialization.
 }


### PR DESCRIPTION
## Summary
- Remove 119 lines of dead code from the onboarding progress iteration
- ProgressPublisher, ProgressSnapshot, pollableProgress, getDownloadProgress, reportDownloadProgress callback — all unused after switching to shared file approach

## Context
Progress delivery iterated through XPC push callbacks → XPC polling → shared temp file. The shared file won. The intermediate XPC infrastructure was left behind.
