### PR TITLE
fix: enrich Sentry error context with audio route, frozen snapshot, XPC logging

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -113,9 +113,19 @@ final class AppState {
         // that happened to set onEngineInterrupted last.
         audioCapture.onEngineInterrupted = { [weak self] in
             guard let self else { return }
-            if self.pipeline.state == .recording {
+            let pState = self.pipeline.state
+            let wkState = self.whisperKitPipeline.state
+            Task { await AppLogger.shared.log(
+                "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+                level: .info, category: "XPC"
+            ) }
+            SentryBreadcrumb.add(stage: "audio", message: "Audio XPC interrupted", level: .error, data: [
+                "parakeet_state": "\(pState)",
+                "whisperkit_state": "\(wkState)",
+            ])
+            if pState == .recording {
                 self.pipeline.handleEngineInterruption()
-            } else if self.whisperKitPipeline.state == .recording {
+            } else if wkState == .recording {
                 self.whisperKitPipeline.handleEngineInterruption()
             }
             // Dismiss recording overlay if showing
@@ -126,9 +136,13 @@ final class AppState {
         // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
         // recovery, but breadcrumbs live in EnviousWisprServices (unavailable in the audio module).
         // AppState observes here to stay within module boundary rules.
-        NotificationCenter.default.addObserver(forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil) { _ in
+        NotificationCenter.default.addObserver(forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil) { [weak self] _ in
             Task { @MainActor in
-                SentryBreadcrumb.add(stage: "audio", message: "Audio route changed", level: .warning)
+                let route = self?.audioCapture.currentAudioRoute ?? "unknown"
+                SentryBreadcrumb.add(stage: "audio", message: "Audio route changed", level: .warning, data: [
+                    "audio_route": route,
+                ])
+                SentryBreadcrumb.updateAudioRoute(route)
             }
         }
 

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -8,6 +8,8 @@ public protocol AudioCaptureInterface: AnyObject {
     var isCapturing: Bool { get }
     var audioLevel: Float { get }
     var capturedSamples: [Float] { get }
+    /// Low-cardinality audio route label for Sentry. Set after route resolution.
+    var currentAudioRoute: String { get }
 
     // Callback properties (read-write)
     var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -66,6 +66,24 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// The last route decision — for telemetry and debugging.
     private var lastRouteDecision: CaptureRouteDecision?
 
+    /// Low-cardinality audio route label derived from the last route decision.
+    public var currentAudioRoute: String {
+        guard let decision = lastRouteDecision else { return "unknown" }
+        switch decision.reason {
+        case .noBTAutoInput, .noBTUserSelectedDevice:
+            return "built_in_mic"
+        case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
+             .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
+            return "capture_session_bt"
+        case .forcedEngine, .fallbackToEngine:
+            return "audio_engine"
+        case .forcedCaptureSession:
+            return "capture_session"
+        case .failedNoFallback:
+            return "failed"
+        }
+    }
+
     public init() {}
 
     // MARK: - AudioCaptureInterface

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -63,11 +63,22 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         interleaved: false
     )!
 
+    /// Derived at startEnginePhase time from the same BT detection logic as CaptureRouteResolver.
+    public private(set) var currentAudioRoute: String = "unknown"
+
     public init() {}
 
     // MARK: - Core lifecycle
 
     public func startEnginePhase() async throws {
+        // Derive route label app-side (same BT check as CaptureRouteResolver).
+        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
+           AudioDeviceEnumerator.isBluetoothDevice(outID) {
+            currentAudioRoute = "capture_session_bt"
+        } else {
+            currentAudioRoute = "built_in_mic"
+        }
+
         ensureConnection()
         resendConfigIfNeeded()
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
@@ -309,14 +320,18 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
             Task { @MainActor [weak proxy] in
                 guard let proxy else { return }
-                if proxy.isCapturing {
+                let wasCapturing = proxy.isCapturing
+                await AppLogger.shared.log(
+                    "[AudioCaptureProxy] XPC interruptionHandler fired — wasCapturing=\(wasCapturing)",
+                    level: .info, category: "XPC"
+                )
+                if wasCapturing {
                     proxy.isCapturing = false
                     proxy.audioLevel = 0
                     proxy.captureGeneration &+= 1
                     proxy.bufferContinuation?.finish()
                     proxy.bufferContinuation = nil
                     proxy.onEngineInterrupted?()
-
                 }
                 proxy.needsReinit = true
             }

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -69,6 +69,8 @@ public final class TranscriptionPipeline: DictationPipeline {
     private var stopRequested = false
     /// Whether audio input has been pre-warmed (engine started) by PTT key-down.
     private var isPreWarmed = false
+    /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
+    private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
 
     public init(
         audioCapture: any AudioCaptureInterface,
@@ -233,6 +235,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 "streaming": streamingASRActive,
             ])
             SentryBreadcrumb.updateRecordingState(active: true, backend: "parakeet", isStreaming: streamingASRActive)
+            SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
 
             if stopRequested {
                 stopRequested = false
@@ -308,6 +311,18 @@ public final class TranscriptionPipeline: DictationPipeline {
                 return
             }
         }
+        // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
+        let snapshotStartTime = recordingStartTime ?? Date()
+        let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
+        frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
+            backend: "parakeet",
+            audioRoute: audioCapture.currentAudioRoute,
+            wasStreaming: streamingASRActive,
+            startTime: snapshotStartTime,
+            durationMs: durationMs,
+            targetAppBundleID: targetApp?.bundleIdentifier
+        )
+
         recordingStartTime = nil
 
         // Cancel VAD monitoring
@@ -466,8 +481,10 @@ public final class TranscriptionPipeline: DictationPipeline {
                 SentryBreadcrumb.captureError(
                     NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "ASR returned empty text"]),
                     category: .asrEmptyResult, stage: "asr",
-                    extra: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"]
+                    extra: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"],
+                    snapshot: frozenSnapshot
                 )
+                frozenSnapshot = nil
                 state = .error("No speech detected — try speaking closer to the microphone")
                 Task { await AppLogger.shared.log(
                     "ASR returned empty text, showing error to user",
@@ -659,11 +676,13 @@ public final class TranscriptionPipeline: DictationPipeline {
                 "paste_tier": pasteTier?.rawValue ?? "none",
                 "backend": asrManager.activeBackendType.rawValue,
             ])
+            frozenSnapshot = nil
             state = .complete
         } catch {
             SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: [
                 "backend": asrManager.activeBackendType.rawValue,
-            ])
+            ], snapshot: frozenSnapshot)
+            frozenSnapshot = nil
             state = .error("Transcription failed: \(error.localizedDescription)")
         }
     }
@@ -753,11 +772,16 @@ public final class TranscriptionPipeline: DictationPipeline {
     /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
     /// Called by AppState's unified interruption handler, not set directly on audioCapture.
     public func handleEngineInterruption() {
+        // Build snapshot at interruption time — recording_state may be cleared before captureError runs.
+        let snapshot = buildInterruptionSnapshot()
         SentryBreadcrumb.captureError(
             NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted"]),
             category: .xpcServiceError, stage: "audio",
-            extra: ["was_recording": state == .recording]
+            extra: ["was_recording": state == .recording],
+            snapshot: snapshot
         )
+        SentryBreadcrumb.updateRecordingState(active: false)
+        frozenSnapshot = nil
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -777,11 +801,15 @@ public final class TranscriptionPipeline: DictationPipeline {
     /// Called by AppState's unified ASR interruption handler when this pipeline is active.
     /// Must stop audio capture (still running — only ASR died) and clean up fully.
     public func handleASRServiceInterruption() {
+        let snapshot = buildInterruptionSnapshot()
         SentryBreadcrumb.captureError(
             NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed"]),
             category: .xpcServiceError, stage: "asr",
-            extra: ["was_recording": state == .recording]
+            extra: ["was_recording": state == .recording],
+            snapshot: snapshot
         )
+        SentryBreadcrumb.updateRecordingState(active: false)
+        frozenSnapshot = nil
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -796,6 +824,21 @@ public final class TranscriptionPipeline: DictationPipeline {
         targetElement = nil
         recordingStartTime = nil
         state = .error("Transcription service crashed — please try again")
+    }
+
+    /// Build a snapshot at interruption time when no frozen snapshot exists yet
+    /// (e.g., XPC crash during recording before stopAndTranscribe is reached).
+    private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
+        if let existing = frozenSnapshot { return existing }
+        let start = recordingStartTime ?? Date()
+        return SentryBreadcrumb.RecordingSnapshot(
+            backend: "parakeet",
+            audioRoute: audioCapture.currentAudioRoute,
+            wasStreaming: streamingASRActive,
+            startTime: start,
+            durationMs: Int(Date().timeIntervalSince(start) * 1000),
+            targetAppBundleID: targetApp?.bundleIdentifier
+        )
     }
 
     /// Cancel an active recording immediately without transcribing.

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -86,6 +86,8 @@ public final class WhisperKitPipeline: DictationPipeline {
 
     private var silenceDetector: SilenceDetector?
     private var vadMonitorTask: Task<Void, Never>?
+    /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
+    private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
     private var incrementalWorker: WhisperKitIncrementalWorker?
     private var modelUnloadTask: Task<Void, Never>?
 
@@ -249,6 +251,7 @@ public final class WhisperKitPipeline: DictationPipeline {
             currentTranscript = nil
             SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording started", data: ["backend": "whisperKit"])
             SentryBreadcrumb.updateRecordingState(active: true, backend: "whisperkit")
+            SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
             startVADMonitoring()
             await startIncrementalWorker()
 
@@ -306,6 +309,18 @@ public final class WhisperKitPipeline: DictationPipeline {
                 return
             }
         }
+        // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
+        let snapshotStartTime = recordingStartTime ?? Date()
+        let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
+        frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
+            backend: "whisperkit",
+            audioRoute: audioCapture.currentAudioRoute,
+            wasStreaming: false,
+            startTime: snapshotStartTime,
+            durationMs: durationMs,
+            targetAppBundleID: targetApp?.bundleIdentifier
+        )
+
         recordingStartTime = nil
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
@@ -429,8 +444,10 @@ public final class WhisperKitPipeline: DictationPipeline {
                 SentryBreadcrumb.captureError(
                     NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "WhisperKit ASR returned empty text"]),
                     category: .asrEmptyResult, stage: "asr",
-                    extra: ["backend": "whisperKit", "incremental": usedIncremental]
+                    extra: ["backend": "whisperKit", "incremental": usedIncremental],
+                    snapshot: frozenSnapshot
                 )
+                frozenSnapshot = nil
                 state = .error("No speech detected — try speaking closer to the microphone")
                 return
             }
@@ -527,10 +544,12 @@ public final class WhisperKitPipeline: DictationPipeline {
                 "polish_s": String(format: "%.3f", polishEnd - polishStart),
                 "paste_tier": pasteTier?.rawValue ?? "none",
             ])
+            frozenSnapshot = nil
             state = .complete
             scheduleModelUnloadIfNeeded()
         } catch {
-            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"])
+            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"], snapshot: frozenSnapshot)
+            frozenSnapshot = nil
             state = .error("Transcription failed: \(error.localizedDescription)")
         }
     }
@@ -538,11 +557,15 @@ public final class WhisperKitPipeline: DictationPipeline {
     /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
     /// Called by AppState's unified interruption handler, not set directly on audioCapture.
     public func handleEngineInterruption() {
+        let snapshot = buildInterruptionSnapshot()
         SentryBreadcrumb.captureError(
             NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted (WhisperKit)"]),
             category: .xpcServiceError, stage: "audio",
-            extra: ["was_recording": state == .recording, "backend": "whisperKit"]
+            extra: ["was_recording": state == .recording, "backend": "whisperKit"],
+            snapshot: snapshot
         )
+        SentryBreadcrumb.updateRecordingState(active: false)
+        frozenSnapshot = nil
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -558,11 +581,15 @@ public final class WhisperKitPipeline: DictationPipeline {
     /// Called by AppState's unified ASR interruption handler when this pipeline is active.
     /// Must stop audio capture (still running — only ASR died) and clean up fully.
     public func handleASRServiceInterruption() {
+        let snapshot = buildInterruptionSnapshot()
         SentryBreadcrumb.captureError(
             NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed (WhisperKit)"]),
             category: .xpcServiceError, stage: "asr",
-            extra: ["was_recording": state == .recording, "backend": "whisperKit"]
+            extra: ["was_recording": state == .recording, "backend": "whisperKit"],
+            snapshot: snapshot
         )
+        SentryBreadcrumb.updateRecordingState(active: false)
+        frozenSnapshot = nil
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
@@ -575,6 +602,19 @@ public final class WhisperKitPipeline: DictationPipeline {
         isStopping = false
         isPreWarmed = false
         state = .error("Transcription service crashed — please try again")
+    }
+
+    private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
+        if let existing = frozenSnapshot { return existing }
+        let start = recordingStartTime ?? Date()
+        return SentryBreadcrumb.RecordingSnapshot(
+            backend: "whisperkit",
+            audioRoute: audioCapture.currentAudioRoute,
+            wasStreaming: false,
+            startTime: start,
+            durationMs: Int(Date().timeIntervalSince(start) * 1000),
+            targetAppBundleID: targetApp?.bundleIdentifier
+        )
     }
 
     public func cancelRecording() async {

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -9,39 +9,48 @@ public enum SentryBreadcrumb {
 
     // MARK: - Recording Snapshot (for handled errors)
 
-    /// Point-in-time snapshot of recording state, attached to handled errors via scope clone.
-    /// For fatal crashes, use the persistent global scope instead (always pre-populated).
+    /// Immutable point-in-time snapshot frozen before recording teardown.
+    /// Attached directly to handled errors so post-recording events carry full context
+    /// even after the global scope's recording_state is cleared.
     public struct RecordingSnapshot: Sendable {
-        public let durationMs: Int
-        public let chunksProcessed: Int
+        public let backend: String
+        public let audioRoute: String
         public let wasStreaming: Bool
+        public let startTime: Date
+        public let durationMs: Int
         public let targetAppBundleID: String?
-        public let sessionDictationCount: Int
-        public let appUptimeSeconds: Int
+        public let transcriptCharCount: Int
+        public let transcriptWordCount: Int
 
         public init(
-            durationMs: Int,
-            chunksProcessed: Int,
+            backend: String,
+            audioRoute: String,
             wasStreaming: Bool,
+            startTime: Date,
+            durationMs: Int,
             targetAppBundleID: String?,
-            sessionDictationCount: Int,
-            appUptimeSeconds: Int
+            transcriptCharCount: Int = 0,
+            transcriptWordCount: Int = 0
         ) {
-            self.durationMs = durationMs
-            self.chunksProcessed = chunksProcessed
+            self.backend = backend
+            self.audioRoute = audioRoute
             self.wasStreaming = wasStreaming
+            self.startTime = startTime
+            self.durationMs = durationMs
             self.targetAppBundleID = targetAppBundleID
-            self.sessionDictationCount = sessionDictationCount
-            self.appUptimeSeconds = appUptimeSeconds
+            self.transcriptCharCount = transcriptCharCount
+            self.transcriptWordCount = transcriptWordCount
         }
 
         var sentryContext: [String: Any] {
             var ctx: [String: Any] = [
-                "duration_ms": durationMs,
-                "chunks_processed": chunksProcessed,
+                "backend": backend,
+                "audio_route": audioRoute,
                 "was_streaming": wasStreaming,
-                "session_dictation_count": sessionDictationCount,
-                "app_uptime_seconds": appUptimeSeconds,
+                "start_time": ISO8601DateFormatter().string(from: startTime),
+                "duration_ms": durationMs,
+                "transcript_char_count": transcriptCharCount,
+                "transcript_word_count": transcriptWordCount,
             ]
             if let targetAppBundleID {
                 ctx["target_app_bundle_id"] = targetAppBundleID
@@ -56,6 +65,14 @@ public enum SentryBreadcrumb {
     public static func updateASRBackend(_ backend: String) {
         SentrySDK.configureScope { scope in
             scope.setTag(value: backend, key: "asr.backend")
+        }
+    }
+
+    /// Update the audio route tag. Called when capture route is resolved or changes.
+    /// Values are low-cardinality: built_in_mic, bt_headset, capture_session, audio_engine, unknown.
+    public static func updateAudioRoute(_ route: String) {
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: route, key: "audio.route")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `audio.route` as searchable Sentry tag (low-cardinality: `built_in_mic`, `capture_session_bt`, etc.)
- Freeze `RecordingSnapshot` before recording teardown — post-recording errors carry full context even after global scope is cleared
- Add logging + Sentry breadcrumbs to audio XPC interruption path (was completely silent — zero log lines)
- Clear `recording_state` context on crash paths to prevent stale scope
- Pass frozen snapshot to all `captureError` call sites in both pipelines

## Validated (ew-4ydq Tests A-C)
- **Test A (XPC crash during recording):** `audio.route=built_in_mic` tag + `recording_snapshot` context (backend, duration, target_app, streaming) + new log lines confirmed in Sentry
- **Test B (empty recording):** `audio.route` tag + `recording_snapshot` survives past teardown (key fix — was missing before)
- **Test C (BT route change):** Skipped — requires physical Bluetooth hardware

## Test plan
- [x] Release build compiles clean (no new errors)
- [x] Test A: kill -9 audio XPC during recording → Sentry event has `audio.route`, `recording_snapshot`, breadcrumbs
- [x] Test B: empty recording → Sentry event has `recording_snapshot` despite `recording_state` being cleared
- [ ] Test C: BT route change (manual, requires hardware)
- [ ] CI build-check passes
