### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.2</string>
+	<string>1.7.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary

Version bump for v1.7.0 release.

### What's in v1.7.0
- **Smart Polish v2** — ASR-aware context enrichment for API providers (#50)
- Real download progress in onboarding + version label fix (#46)
- Enriched Sentry error context (#44, #48)
- Removed dead XPC progress code (#47)
- Fixed Cloudflare adapter for static Astro site (#45)
- Automated appcast pipeline with GitHub App token (#43)
- Cache-control headers for appcast.xml (#42)
