### PR TITLE
fix(website): add noindex to 404 page

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ interface Props {
   ogImageAlt?: string;
   ogType?: 'website' | 'article';
   canonicalPath?: string;
+  noindex?: boolean;
 }
 
 const {
@@ -22,6 +23,7 @@ const {
   ogImageAlt = 'EnviousWispr — Private AI dictation for macOS',
   ogType = 'website',
   canonicalPath,
+  noindex = false,
 } = Astro.props;
 
 const siteUrl = 'https://enviouswispr.com';
@@ -36,7 +38,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{title}</title>
   <meta name="description" content={description} />
-  <meta name="robots" content="index, follow" />
+  <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
   <meta name="author" content="Envious Labs" />
   <link rel="canonical" href={canonical} />
   <meta property="og:title" content={title} />

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -6,6 +6,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   title="Page Not Found — EnviousWispr"
   description="This page doesn't exist. Head back to EnviousWispr to download the app or read the blog."
   canonicalPath="/404/"
+  noindex
 >
 
 <style>


### PR DESCRIPTION
## Summary
- GSC flagged "Page with redirect" indexing issues (benign — trailing slash redirects)
- 404 page was incorrectly set to `index, follow` — now `noindex, nofollow`
- Added `noindex` prop to `BaseLayout.astro` for reuse on any future page that shouldn't be indexed

## Test plan
- [x] `npm run build` passes
- [x] Verified `dist/404.html` contains `noindex, nofollow`
- [x] Other pages unchanged (`index, follow`)
