### PR TITLE
feat: Apple Intelligence diagnostics v2 — 5-stage gate pipeline

### DIFF
--- a/Sources/EnviousWispr/App/AIAvailabilityCoordinator.swift
+++ b/Sources/EnviousWispr/App/AIAvailabilityCoordinator.swift
@@ -1,0 +1,202 @@
+import Foundation
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import AppKit
+
+/// Coordinates Apple Intelligence availability checks for the Settings UI.
+/// Owns: UI state, stale-result protection, persistence, telemetry emission,
+/// first-launch re-check, rolling history, and support export.
+/// The diagnostics service is pure computation — this coordinator owns the side effects.
+@MainActor @Observable
+final class AIAvailabilityCoordinator {
+
+    /// Latest completed diagnostics report, or nil if never checked.
+    private(set) var latestReport: AppleIntelligenceAvailabilityReport?
+
+    /// Rolling history of recent checks (in-memory, last 20).
+    private(set) var history: [AppleIntelligenceAvailabilityReport.HistoryEntry] = []
+
+    /// Whether a check is currently in progress.
+    private(set) var isChecking = false
+
+    /// Request token incremented on each check — stale results are discarded.
+    private var currentRequestToken: UInt = 0
+
+    /// Debounce work item for re-check requests.
+    private var debounceTask: Task<Void, Never>?
+
+    /// Configurable delayed re-check interval for first launch (seconds).
+    private static let delayedRecheckSeconds: TimeInterval = 30
+
+    /// UserDefaults keys.
+    private static let snapshotKey = "aiDiagnosticsLatestReport"
+    private static let historyKey = "aiDiagnosticsHistory"
+
+    /// Caps.
+    private static let maxHistoryInMemory = 20
+    private static let maxHistoryPersisted = 5
+
+    // MARK: - Initialization
+
+    init() {
+        loadCachedReport()
+        loadCachedHistory()
+    }
+
+    // MARK: - Public API
+
+    /// Run a full diagnostics check. Emits telemetry and persists result.
+    /// - Parameter trigger: What caused this check (for telemetry).
+    func checkAvailability(trigger: String = "manual_refresh") async {
+        currentRequestToken &+= 1
+        let myToken = currentRequestToken
+        isChecking = true
+
+        let report = await AppleIntelligenceDiagnosticsService.runDiagnostics()
+
+        // Discard if a newer check was started while we were running
+        guard myToken == currentRequestToken else { return }
+
+        latestReport = report
+        isChecking = false
+
+        // Side effects: persist, history, Sentry, PostHog
+        persistReport(report)
+        appendHistory(report: report, trigger: trigger)
+        SentryBreadcrumb.attachAIDiagnostics(report)
+        emitPerGateBreadcrumbs(report: report, trigger: trigger)
+        TelemetryService.shared.aiDiagnosticsRunCompleted(report: report, trigger: trigger)
+    }
+
+    /// Debounced re-check — waits 500ms before starting. Cancels any pending debounce.
+    func debouncedCheck() {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            await checkAvailability(trigger: "manual_refresh")
+        }
+    }
+
+    /// First-launch sequence: immediate check + delayed re-check after 30s.
+    /// Call from AppDelegate on first launch only.
+    func firstLaunchCheck() {
+        Task {
+            await checkAvailability(trigger: "app_launch")
+            let firstReport = latestReport
+
+            try? await Task.sleep(for: .seconds(Self.delayedRecheckSeconds))
+            guard !Task.isCancelled else { return }
+
+            await checkAvailability(trigger: "delayed_recheck")
+
+            if let first = firstReport, let second = latestReport,
+               first.hasMeaningfulDifference(from: second) {
+                SentryBreadcrumb.add(
+                    stage: "ai_diagnostics",
+                    message: "First-launch re-check: availability changed",
+                    data: [
+                        "first_status": first.overallStatus.rawValue,
+                        "second_status": second.overallStatus.rawValue,
+                        "first_reasons": first.failureReasons.map(\.rawValue),
+                        "second_reasons": second.failureReasons.map(\.rawValue),
+                    ]
+                )
+            }
+        }
+    }
+
+    /// Copy a compact diagnostics JSON blob to the clipboard for support.
+    func copyDiagnosticsToClipboard() {
+        guard let report = latestReport else { return }
+
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+
+        var blob: [String: Any] = [
+            "export_version": 1,
+            "report_version": report.reportVersion,
+            "app_version": version,
+            "app_build": build,
+            "os_version": report.osVersion,
+            "hardware_class": report.hardwareClass,
+            "overall_status": report.overallStatus.rawValue,
+            "failure_reasons": report.failureReasons.map(\.rawValue),
+            "check_duration_ms": report.checkDurationMs,
+            "generated_at": ISO8601DateFormatter().string(from: report.generatedAt),
+        ]
+
+        for (name, result) in report.gates.allGates {
+            let key = name.lowercased().replacingOccurrences(of: " ", with: "_")
+            var gateData: [String: Any] = [
+                "status": result.status.rawValue,
+                "summary": result.summary,
+            ]
+            if let ms = result.durationMs { gateData["duration_ms"] = ms }
+            if !result.reasons.isEmpty { gateData["reasons"] = result.reasons.map(\.rawValue) }
+            blob["gate_\(key)"] = gateData
+        }
+
+        if let jsonData = try? JSONSerialization.data(withJSONObject: blob, options: [.prettyPrinted, .sortedKeys]),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(jsonString, forType: .string)
+        }
+    }
+
+    // MARK: - History
+
+    private func appendHistory(report: AppleIntelligenceAvailabilityReport, trigger: String) {
+        let entry = AppleIntelligenceAvailabilityReport.HistoryEntry(from: report, trigger: trigger)
+        history.append(entry)
+        if history.count > Self.maxHistoryInMemory {
+            history.removeFirst(history.count - Self.maxHistoryInMemory)
+        }
+        persistHistory()
+    }
+
+    // MARK: - Persistence
+
+    private func persistReport(_ report: AppleIntelligenceAvailabilityReport) {
+        guard let data = try? JSONEncoder().encode(report) else { return }
+        UserDefaults.standard.set(data, forKey: Self.snapshotKey)
+    }
+
+    private func loadCachedReport() {
+        guard let data = UserDefaults.standard.data(forKey: Self.snapshotKey) else { return }
+        latestReport = try? JSONDecoder().decode(AppleIntelligenceAvailabilityReport.self, from: data)
+    }
+
+    private func persistHistory() {
+        // Persist the last 5 entries — payload is tiny (~1KB) so persisted for all builds.
+        // UI display of history is gated to debug mode in Settings.
+        let toPersist = Array(history.suffix(Self.maxHistoryPersisted))
+        guard let data = try? JSONEncoder().encode(toPersist) else { return }
+        UserDefaults.standard.set(data, forKey: Self.historyKey)
+    }
+
+    private func loadCachedHistory() {
+        guard let data = UserDefaults.standard.data(forKey: Self.historyKey) else { return }
+        history = (try? JSONDecoder().decode([AppleIntelligenceAvailabilityReport.HistoryEntry].self, from: data)) ?? []
+    }
+
+    // MARK: - Telemetry
+
+    private func emitPerGateBreadcrumbs(report: AppleIntelligenceAvailabilityReport, trigger: String) {
+        for (name, result) in report.gates.allGates {
+            var data: [String: Any] = [
+                "status": result.status.rawValue,
+                "summary": result.summary,
+                "trigger": trigger,
+            ]
+            if let ms = result.durationMs { data["duration_ms"] = ms }
+            if !result.reasons.isEmpty { data["reasons"] = result.reasons.map(\.rawValue) }
+            SentryBreadcrumb.add(
+                stage: "ai_gate_\(name.lowercased().replacingOccurrences(of: " ", with: "_"))",
+                message: "\(name): \(result.status.rawValue)",
+                data: data
+            )
+        }
+    }
+}

--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -100,29 +100,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
 
-        // Run Apple Intelligence diagnostics and attach report to Sentry context.
-        // Fire-and-forget — report is logged as breadcrumb and persisted in Sentry scope
-        // so any future crash includes the AI availability state.
-        let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
-        SentryBreadcrumb.attachAIDiagnostics(aiReport)
-        Task { await AppLogger.shared.log(
-            "AI diagnostics: status=\(aiReport.overallStatus.rawValue), " +
-            "reasons=\(aiReport.failureReasons.map(\.rawValue)), " +
-            "duration=\(aiReport.checkDurationMs)ms",
-            level: .info, category: "Diagnostics"
-        ) }
+        // Run Apple Intelligence diagnostics via coordinator.
+        // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
+        let isFreshInstall = appState.settings.onboardingState != .completed
+        if isFreshInstall {
+            appState.aiAvailability.firstLaunchCheck()
+        } else {
+            Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
+        }
 
-        // Fire structured app.launched event — unconditional, before onboarding guard.
+        // Fire structured app.launched event — uses cached report (loaded from UserDefaults in coordinator init).
+        // No async wait needed — cached snapshot is available synchronously.
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
         let osVer = ProcessInfo.processInfo.operatingSystemVersion
+        let cachedReport = appState.aiAvailability.latestReport
         TelemetryService.shared.appLaunched(
             version: version,
             build: build,
             osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
-            hardware: aiReport.hardwareClass,
-            isFreshInstall: appState.settings.onboardingState != .completed,
-            aiAvailable: aiReport.overallStatus == .available
+            hardware: cachedReport?.hardwareClass ?? "unknown",
+            isFreshInstall: isFreshInstall,
+            aiAvailable: cachedReport?.overallStatus == .available
         )
 
         // Check Accessibility permission on launch (query only — never auto-prompt).

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -55,6 +55,9 @@ final class AppState {
     // Model discovery — delegated to coordinator
     let llmDiscovery: LLMModelDiscoveryCoordinator
 
+    // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
+    let aiAvailability = AIAvailabilityCoordinator()
+
     init() {
         // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
         // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -195,7 +195,7 @@ struct AIPolishSettingsView: View {
                     }
                 }
             } else if appState.settings.llmProvider == .appleIntelligence {
-                Task { await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: appState.settings.llmProvider, settings: appState.settings) }
+                Task { await appState.aiAvailability.checkAvailability(trigger: "settings_open") }
             } else if appState.settings.llmProvider != .none {
                 appState.llmDiscovery.loadCachedModels(for: appState.settings.llmProvider)
             }
@@ -216,7 +216,7 @@ struct AIPolishSettingsView: View {
                 }
             case .appleIntelligence:
                 appState.ollamaSetup.cancelPull()
-                Task { await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: newProvider, settings: appState.settings) }
+                Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
             default:
                 appState.ollamaSetup.cancelPull()
                 appState.llmDiscovery.loadCachedModels(for: newProvider)
@@ -635,36 +635,126 @@ struct AIPolishSettingsView: View {
             .font(.stHelper)
             .foregroundStyle(Color.stTextTertiary)
 
-        if #available(macOS 26.0, *) {
-            HStack {
-                Text("Status:")
-                Spacer()
-                switch appState.llmDiscovery.keyValidationState {
-                case .valid:
-                    Label("Available", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.stSuccess)
-                case .invalid(let msg):
-                    Label(msg, systemImage: "xmark.circle.fill")
-                        .foregroundStyle(.stError)
-                        .font(.caption)
-                case .validating:
-                    ProgressView().controlSize(.small)
-                case .idle:
-                    Text("Not checked").foregroundStyle(Color.stTextTertiary)
-                }
+        // Status row
+        HStack {
+            Text("Status:")
+            Spacer()
+            aiStatusLabel
+            Button {
+                appState.aiAvailability.debouncedCheck()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .disabled(appState.aiAvailability.isChecking)
+            .help("Check Apple Intelligence availability")
+        }
 
-                Button {
-                    Task { await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: .appleIntelligence, settings: appState.settings) }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.borderless)
-                .help("Check Apple Intelligence availability")
+        // "Why?" detail text
+        if let report = appState.aiAvailability.latestReport,
+           report.overallStatus != .available {
+            Text(report.userVisibleMessage)
+                .font(.stHelper)
+                .foregroundStyle(Color.stTextTertiary)
+        }
+
+        // Debug section — dev builds only
+        if appState.settings.isDebugModeEnabled, let report = appState.aiAvailability.latestReport {
+            aiDebugSection(report: report)
+        }
+    }
+
+    @ViewBuilder
+    private var aiStatusLabel: some View {
+        if appState.aiAvailability.isChecking {
+            ProgressView().controlSize(.small)
+        } else if let report = appState.aiAvailability.latestReport {
+            switch report.overallStatus {
+            case .available:
+                Label("Available", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.stSuccess)
+            case .degraded:
+                Label("Degraded", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.stWarning)
+            case .unavailable:
+                Label("Unavailable", systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.stError)
+            case .unknown:
+                Label("Unknown", systemImage: "questionmark.circle")
+                    .foregroundStyle(Color.stTextTertiary)
             }
         } else {
-            Label("Requires macOS 26 or later.", systemImage: "exclamationmark.triangle.fill")
+            Text("Not checked")
+                .foregroundStyle(Color.stTextTertiary)
+        }
+    }
+
+    @ViewBuilder
+    private func aiDebugSection(report: AppleIntelligenceAvailabilityReport) -> some View {
+        DisclosureGroup("Diagnostics") {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(report.gates.allGates, id: \.name) { gate in
+                    HStack(spacing: 6) {
+                        gateStatusIcon(gate.result.status)
+                        Text(gate.name)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Text(gate.result.summary)
+                            .font(.caption2)
+                            .foregroundStyle(Color.stTextTertiary)
+                            .lineLimit(1)
+                        if let ms = gate.result.durationMs {
+                            Text("\(ms)ms")
+                                .font(.caption2)
+                                .foregroundStyle(Color.stTextTertiary)
+                        }
+                    }
+                }
+                HStack {
+                    Text("OS: \(report.osVersion)")
+                    Spacer()
+                    Text("HW: \(report.hardwareClass)")
+                    Spacer()
+                    Text("Total: \(report.checkDurationMs)ms")
+                }
+                .font(.caption2)
+                .foregroundStyle(Color.stTextTertiary)
+
+                Button("Copy Diagnostics") {
+                    appState.aiAvailability.copyDiagnosticsToClipboard()
+                }
+                .font(.caption)
+                .buttonStyle(.borderless)
+            }
+            .padding(.vertical, 4)
+        }
+        .font(.caption)
+    }
+
+    @ViewBuilder
+    private func gateStatusIcon(_ status: AIGateStatus) -> some View {
+        switch status {
+        case .passed:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.stSuccess)
+                .font(.caption2)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.stError)
+                .font(.caption2)
+        case .skipped:
+            Image(systemName: "minus.circle")
+                .foregroundStyle(Color.stTextTertiary)
+                .font(.caption2)
+        case .timedOut:
+            Image(systemName: "clock.badge.exclamationmark")
                 .foregroundStyle(.stWarning)
-                .font(.stHelper)
+                .font(.caption2)
+        case .unknown:
+            Image(systemName: "questionmark.circle")
+                .foregroundStyle(Color.stTextTertiary)
+                .font(.caption2)
         }
     }
 

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -1,78 +1,25 @@
 import Foundation
 
-// MARK: - Apple Intelligence Availability Report
-
-/// Structured diagnostic report for Apple Intelligence availability.
-/// Produced by the diagnostics service, consumed by UI and observability.
-public struct AppleIntelligenceAvailabilityReport: Sendable {
-    public let overallStatus: AIAvailabilityStatus
-    public let buildCompiledIn: Bool
-    public let osVersion: String
-    public let hardwareClass: String
-    public let runtimeFrameworkPresent: Bool
-    public let deviceEligibility: AITriState
-    public let modelAccessible: AITriState
-    public let failureReasons: [AIFailureReason]
-    public let userVisibleMessage: String
-    public let debugSummary: String
-    public let generatedAt: Date
-    public let checkDurationMs: Int
-
-    public init(
-        overallStatus: AIAvailabilityStatus,
-        buildCompiledIn: Bool,
-        osVersion: String,
-        hardwareClass: String,
-        runtimeFrameworkPresent: Bool,
-        deviceEligibility: AITriState,
-        modelAccessible: AITriState,
-        failureReasons: [AIFailureReason],
-        userVisibleMessage: String,
-        debugSummary: String,
-        generatedAt: Date = Date(),
-        checkDurationMs: Int = 0
-    ) {
-        self.overallStatus = overallStatus
-        self.buildCompiledIn = buildCompiledIn
-        self.osVersion = osVersion
-        self.hardwareClass = hardwareClass
-        self.runtimeFrameworkPresent = runtimeFrameworkPresent
-        self.deviceEligibility = deviceEligibility
-        self.modelAccessible = modelAccessible
-        self.failureReasons = failureReasons
-        self.userVisibleMessage = userVisibleMessage
-        self.debugSummary = debugSummary
-        self.generatedAt = generatedAt
-        self.checkDurationMs = checkDurationMs
-    }
-
-    /// Compact dictionary for Sentry context attachment — no PII, no user content.
-    public var sentryContext: [String: Any] {
-        [
-            "overall_status": overallStatus.rawValue,
-            "build_compiled_in": buildCompiledIn,
-            "os_version": osVersion,
-            "hardware_class": hardwareClass,
-            "runtime_framework_present": runtimeFrameworkPresent,
-            "device_eligibility": deviceEligibility.rawValue,
-            "model_accessible": modelAccessible.rawValue,
-            "failure_reasons": failureReasons.map(\.rawValue),
-            "check_duration_ms": checkDurationMs,
-        ]
-    }
-}
-
 // MARK: - Enums
 
 /// Overall availability status for Apple Intelligence.
-public enum AIAvailabilityStatus: String, Sendable {
+public enum AIAvailabilityStatus: String, Sendable, Codable {
     case available
     case unavailable
     case degraded
     case unknown
 }
 
-/// Three-state value for gate checks that may not be deterministic.
+/// Per-gate result status.
+public enum AIGateStatus: String, Sendable, Codable {
+    case passed
+    case failed
+    case skipped      // upstream gate failed, this gate was not run
+    case timedOut
+    case unknown
+}
+
+/// Three-state value for leaf observations that may not be deterministic.
 public enum AITriState: String, Sendable {
     case yes
     case no
@@ -81,16 +28,253 @@ public enum AITriState: String, Sendable {
 
 /// Explicit, stable failure reasons for Apple Intelligence availability.
 /// Each maps to a specific diagnostic condition — not freeform strings.
-public enum AIFailureReason: String, Sendable, CaseIterable {
+public enum AIFailureReason: String, Sendable, CaseIterable, Codable {
     case notCompiledIn
     case unsupportedOS
-    case unsupportedHardware
-    case frameworkMissingAtRuntime
+    case unsupportedHardware           // Reserved: deviceNotEligible covers this via Apple's API
+    case frameworkMissingAtRuntime      // Reserved: compile-time gate only (no runtime dynamic load check)
     case deviceNotEligible
     case appleIntelligenceDisabled
     case modelNotReady
     case modelAccessFailed
-    case sessionInitFailed
+    case sessionInitFailed             // Reserved: LanguageModelSession init is non-throwing
     case generationFailed
     case unknownError
+}
+
+// MARK: - Gate Result
+
+/// Result of a single diagnostic gate check.
+public struct AIGateResult: Sendable, Codable {
+    public let status: AIGateStatus
+    public let reasons: [AIFailureReason]
+    public let durationMs: Int?
+    public let summary: String
+
+    public init(status: AIGateStatus, reasons: [AIFailureReason] = [], durationMs: Int? = nil, summary: String) {
+        self.status = status
+        self.reasons = reasons
+        self.durationMs = durationMs
+        self.summary = summary
+    }
+
+    /// Convenience for a passed gate.
+    public static func passed(summary: String, durationMs: Int? = nil) -> AIGateResult {
+        AIGateResult(status: .passed, durationMs: durationMs, summary: summary)
+    }
+
+    /// Convenience for a failed gate.
+    public static func failed(reasons: [AIFailureReason], summary: String, durationMs: Int? = nil) -> AIGateResult {
+        AIGateResult(status: .failed, reasons: reasons, durationMs: durationMs, summary: summary)
+    }
+
+    /// Convenience for a skipped gate.
+    public static func skipped(summary: String) -> AIGateResult {
+        AIGateResult(status: .skipped, summary: summary)
+    }
+
+    /// Convenience for a timed-out gate.
+    public static func timedOut(summary: String, durationMs: Int? = nil) -> AIGateResult {
+        AIGateResult(status: .timedOut, durationMs: durationMs, summary: summary)
+    }
+}
+
+// MARK: - Gate Set
+
+/// The full ordered set of diagnostic gates for one availability check run.
+public struct AIGateSet: Sendable, Codable {
+    public let build: AIGateResult
+    public let runtime: AIGateResult
+    public let eligibility: AIGateResult
+    public let modelAccess: AIGateResult
+    public let functionalProbe: AIGateResult
+
+    public init(build: AIGateResult, runtime: AIGateResult, eligibility: AIGateResult, modelAccess: AIGateResult, functionalProbe: AIGateResult) {
+        self.build = build
+        self.runtime = runtime
+        self.eligibility = eligibility
+        self.modelAccess = modelAccess
+        self.functionalProbe = functionalProbe
+    }
+
+    /// All gate results as an ordered array for iteration.
+    public var allGates: [(name: String, result: AIGateResult)] {
+        [
+            ("Build", build),
+            ("Runtime", runtime),
+            ("Eligibility", eligibility),
+            ("Model Access", modelAccess),
+            ("Functional Probe", functionalProbe)
+        ]
+    }
+}
+
+// MARK: - Availability Report
+
+/// Structured diagnostic report for Apple Intelligence availability.
+/// Produced by the diagnostics service, consumed by UI and observability.
+public struct AppleIntelligenceAvailabilityReport: Sendable, Codable {
+    public static let currentReportVersion = 2
+
+    public let reportVersion: Int
+    public let overallStatus: AIAvailabilityStatus
+    public let gates: AIGateSet
+    public let failureReasons: [AIFailureReason]
+    public let osVersion: String
+    public let hardwareClass: String
+    public let generatedAt: Date
+    public let checkDurationMs: Int
+
+    public init(
+        overallStatus: AIAvailabilityStatus,
+        gates: AIGateSet,
+        failureReasons: [AIFailureReason],
+        osVersion: String,
+        hardwareClass: String,
+        generatedAt: Date = Date(),
+        checkDurationMs: Int = 0
+    ) {
+        self.reportVersion = Self.currentReportVersion
+        self.overallStatus = overallStatus
+        self.gates = gates
+        self.failureReasons = failureReasons
+        self.osVersion = osVersion
+        self.hardwareClass = hardwareClass
+        self.generatedAt = generatedAt
+        self.checkDurationMs = checkDurationMs
+    }
+
+    // MARK: - Derived Presentation Fields
+
+    /// User-facing message derived from failure reasons. NOT stored, always computed.
+    public var userVisibleMessage: String {
+        if failureReasons.isEmpty {
+            return "Apple Intelligence is available and ready to use."
+        }
+        if failureReasons.contains(.notCompiledIn) {
+            return "This build was compiled without Apple Intelligence support."
+        }
+        if failureReasons.contains(.unsupportedOS) {
+            return "Apple Intelligence requires macOS 26 or later."
+        }
+        if failureReasons.contains(.unsupportedHardware) || failureReasons.contains(.deviceNotEligible) {
+            return "This Mac does not support Apple Intelligence. Requires Apple Silicon (M1 or later)."
+        }
+        if failureReasons.contains(.appleIntelligenceDisabled) {
+            return "Apple Intelligence is not enabled. Turn it on in System Settings > Apple Intelligence & Siri."
+        }
+        if failureReasons.contains(.modelNotReady) {
+            return "The on-device model is not ready — it may still be downloading. Try again later."
+        }
+        if failureReasons.contains(.modelAccessFailed) || failureReasons.contains(.sessionInitFailed) {
+            return "Apple Intelligence is available but model initialization failed."
+        }
+        if failureReasons.contains(.generationFailed) {
+            return "Apple Intelligence model access works but generation failed. Try again later."
+        }
+        return "Apple Intelligence availability could not be determined."
+    }
+
+    /// Debug summary derived from gate results. For dev builds and support.
+    public var debugSummary: String {
+        gates.allGates.map { "\($0.name): \($0.result.status.rawValue) — \($0.result.summary)" }.joined(separator: " | ")
+    }
+
+    /// Compact dictionary for Sentry context attachment — no PII, no user content.
+    public var sentryContext: [String: Any] {
+        var ctx: [String: Any] = [
+            "report_version": reportVersion,
+            "overall_status": overallStatus.rawValue,
+            "os_version": osVersion,
+            "hardware_class": hardwareClass,
+            "failure_reasons": failureReasons.map(\.rawValue),
+            "check_duration_ms": checkDurationMs,
+        ]
+        for (name, result) in gates.allGates {
+            ctx["gate_\(name.lowercased().replacingOccurrences(of: " ", with: "_"))"] = result.status.rawValue
+        }
+        return ctx
+    }
+
+    // MARK: - History Entry
+
+    /// Lightweight snapshot for rolling history. Stores only what matters for trendability.
+    public struct HistoryEntry: Sendable, Codable {
+        public let timestamp: Date
+        public let trigger: String
+        public let overallStatus: AIAvailabilityStatus
+        public let failureReasons: [AIFailureReason]
+        public let gateStatuses: [String: AIGateStatus]
+        public let totalDurationMs: Int
+        public let probeDurationMs: Int?
+
+        public init(from report: AppleIntelligenceAvailabilityReport, trigger: String) {
+            self.timestamp = report.generatedAt
+            self.trigger = trigger
+            self.overallStatus = report.overallStatus
+            self.failureReasons = report.failureReasons
+            var statuses: [String: AIGateStatus] = [:]
+            for (name, result) in report.gates.allGates {
+                statuses[name] = result.status
+            }
+            self.gateStatuses = statuses
+            self.totalDurationMs = report.checkDurationMs
+            self.probeDurationMs = report.gates.functionalProbe.durationMs
+        }
+    }
+
+    /// Convenience accessor for Stage 5 probe latency.
+    public var probeLatencyMs: Int? {
+        gates.functionalProbe.durationMs
+    }
+
+    // MARK: - Meaningful Comparison
+
+    /// Compare two reports by meaningful fields only (ignores generatedAt, durations, summaries).
+    /// Used for first-launch re-check to detect if availability state actually changed.
+    /// Checks: overallStatus, failureReasons, and per-gate statuses.
+    public func hasMeaningfulDifference(from other: AppleIntelligenceAvailabilityReport) -> Bool {
+        if overallStatus != other.overallStatus { return true }
+        if failureReasons != other.failureReasons { return true }
+        let myStatuses = gates.allGates.map { $0.result.status }
+        let otherStatuses = other.gates.allGates.map { $0.result.status }
+        return myStatuses != otherStatuses
+    }
+
+    // MARK: - Overall Status Derivation
+
+    /// Derive overallStatus from gate results.
+    /// Rules:
+    /// - Build, Runtime, or Eligibility fail → unavailable
+    /// - Model Access fails → unavailable (can't use AI at all)
+    /// - Model Access times out or unknown → degraded
+    /// - Functional Probe fails or times out (all else passing) → degraded
+    /// - All pass (or probe skipped with everything else passing) → available
+    /// - Otherwise → unknown
+    public static func deriveOverallStatus(from gates: AIGateSet) -> AIAvailabilityStatus {
+        // Any critical gate failure = unavailable
+        if gates.build.status == .failed || gates.runtime.status == .failed || gates.eligibility.status == .failed {
+            return .unavailable
+        }
+        // Model access failure = unavailable (can't use AI at all)
+        if gates.modelAccess.status == .failed {
+            return .unavailable
+        }
+        // Model access degraded states
+        if gates.modelAccess.status == .timedOut || gates.modelAccess.status == .unknown {
+            return .degraded
+        }
+        // Probe failure/timeout with everything else passing = degraded
+        if gates.functionalProbe.status == .failed || gates.functionalProbe.status == .timedOut {
+            return .degraded
+        }
+        // All passed — probe .skipped branch is currently unreachable (probe only skips
+        // when model access fails), but kept for forward compatibility if probe becomes optional.
+        if gates.build.status == .passed && gates.runtime.status == .passed && gates.eligibility.status == .passed && gates.modelAccess.status == .passed {
+            if gates.functionalProbe.status == .passed || gates.functionalProbe.status == .skipped {
+                return .available
+            }
+        }
+        return .unknown
+    }
 }

--- a/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
@@ -6,169 +6,291 @@ import FoundationModels
 #endif
 
 /// Runs layered gate checks to produce a structured Apple Intelligence availability report.
-/// Each gate returns pass/fail/unknown with explicit failure reasons.
+/// Each gate returns an AIGateResult with explicit status and failure reasons.
 ///
 /// Gate stages:
 /// 1. Build/Binary — was FoundationModels compiled in?
-/// 2. OS/Runtime — is macOS version sufficient? Is the framework loadable?
-/// 3. Device Eligibility — is this device eligible for Apple Intelligence?
-/// 4. Model Access — can the system language model be accessed?
+/// 2. OS/Runtime Preconditions — is macOS version sufficient? (compile-time framework gate)
+/// 3. Device Eligibility — is this device eligible for Apple Intelligence? (locale deferred)
+/// 4. Model Access — can a LanguageModelSession be created?
+/// 5. Functional Probe — can a minimal generation succeed? (timeout-bounded)
 ///
-/// Limb: never throws, never blocks. Returns a report regardless of outcome.
+/// Limb: never throws, never blocks indefinitely. Returns a report regardless of outcome.
+/// Telemetry/breadcrumbs are NOT emitted here — the coordinator owns that responsibility.
 public enum AppleIntelligenceDiagnosticsService {
 
-    /// Run all gate checks and produce a structured report.
-    @MainActor
-    public static func runDiagnostics() -> AppleIntelligenceAvailabilityReport {
-        let start = CFAbsoluteTimeGetCurrent()
-        let osVersion = Self.currentOSVersion()
-        let hardwareClass = Self.currentHardwareClass()
+    /// Timeout budget for the functional probe (Stage 5).
+    private static let probeTimeoutSeconds: TimeInterval = 3.0
 
-        var failureReasons: [AIFailureReason] = []
-        var debugLines: [String] = []
+    /// Overall timeout budget for the entire diagnostics run (default 10s).
+    /// If elapsed time exceeds this, remaining gates get .timedOut status.
+    private static let totalTimeoutSeconds: TimeInterval = 10.0
+
+    /// Stage 4 timeout budget (session creation).
+    private static let sessionTimeoutSeconds: TimeInterval = 2.0
+
+    /// Run all gate checks and produce a structured report.
+    /// Async because stages 4-5 may need to create sessions / run generation.
+    public static func runDiagnostics() async -> AppleIntelligenceAvailabilityReport {
+        let start = CFAbsoluteTimeGetCurrent()
+        let osVersion = currentOSVersion()
+        let hardwareClass = currentHardwareClass()
 
         // Stage 1: Build / Binary Gate
-        let buildCompiledIn = Self.checkBuildGate()
-        debugLines.append("Stage 1 (Build): compiled_in=\(buildCompiledIn)")
-        if !buildCompiledIn {
-            failureReasons.append(.notCompiledIn)
-        }
+        let buildResult = checkBuildGate()
 
-        // Stage 2: OS / Runtime Environment Gate
-        let (runtimePresent, osGateReasons) = Self.checkOSRuntimeGate(osVersion: osVersion)
-        debugLines.append("Stage 2 (OS/Runtime): framework_present=\(runtimePresent)")
-        failureReasons.append(contentsOf: osGateReasons)
-
-        // Stage 3 + 4: Device Eligibility + Model Access Gates
-        // These require FoundationModels to be compiled in and macOS 26+
-        var deviceEligibility: AITriState = .unknown
-        var modelAccessible: AITriState = .unknown
-
-        if buildCompiledIn && runtimePresent {
-            let (eligibility, modelAccess, deviceReasons) = Self.checkDeviceAndModelGates()
-            deviceEligibility = eligibility
-            modelAccessible = modelAccess
-            debugLines.append("Stage 3 (Device): eligibility=\(eligibility.rawValue)")
-            debugLines.append("Stage 4 (Model): accessible=\(modelAccess.rawValue)")
-            failureReasons.append(contentsOf: deviceReasons)
+        // Stage 2: OS / Runtime Preconditions Gate
+        let runtimeResult: AIGateResult
+        if elapsedMs(since: start) < totalTimeoutMs() {
+            runtimeResult = checkOSRuntimeGate()
         } else {
-            debugLines.append("Stage 3 (Device): skipped (build/runtime gate failed)")
-            debugLines.append("Stage 4 (Model): skipped (build/runtime gate failed)")
+            runtimeResult = .timedOut(summary: "Not run — total budget expired")
         }
 
-        // Determine overall status
-        let overallStatus: AIAvailabilityStatus
-        let userMessage: String
-
-        if failureReasons.isEmpty {
-            overallStatus = .available
-            userMessage = "Apple Intelligence is available and ready to use."
-        } else if failureReasons.contains(.notCompiledIn) {
-            overallStatus = .unavailable
-            userMessage = "This build was compiled without Apple Intelligence support."
-        } else if failureReasons.contains(.unsupportedOS) {
-            overallStatus = .unavailable
-            userMessage = "Apple Intelligence requires macOS 26 or later."
-        } else if failureReasons.contains(.unsupportedHardware) || failureReasons.contains(.deviceNotEligible) {
-            overallStatus = .unavailable
-            userMessage = "This Mac does not support Apple Intelligence. Requires Apple Silicon (M1 or later)."
-        } else if failureReasons.contains(.appleIntelligenceDisabled) {
-            overallStatus = .unavailable
-            userMessage = "Apple Intelligence is not enabled. Turn it on in System Settings > Apple Intelligence & Siri."
-        } else if failureReasons.contains(.modelNotReady) {
-            overallStatus = .degraded
-            userMessage = "The on-device model is not ready — it may still be downloading. Try again later."
-        } else if failureReasons.contains(.modelAccessFailed) || failureReasons.contains(.sessionInitFailed) {
-            overallStatus = .degraded
-            userMessage = "Apple Intelligence is available but model initialization failed."
+        // Stage 3: Device Eligibility Gate
+        let eligibilityResult: AIGateResult
+        if buildResult.status == .passed && runtimeResult.status == .passed {
+            if elapsedMs(since: start) < totalTimeoutMs() {
+                eligibilityResult = checkEligibilityGate()
+            } else {
+                eligibilityResult = .timedOut(summary: "Not run — total budget expired")
+            }
         } else {
-            overallStatus = .unknown
-            userMessage = "Apple Intelligence availability could not be determined."
+            eligibilityResult = .skipped(summary: "Skipped — build or runtime gate failed")
         }
 
+        // Stage 4: Model Access Gate (with per-stage timeout)
+        let modelAccessResult: AIGateResult
+        if eligibilityResult.status == .passed {
+            if elapsedMs(since: start) < totalTimeoutMs() {
+                modelAccessResult = await checkModelAccessGateWithTimeout()
+            } else {
+                modelAccessResult = .timedOut(summary: "Not run — total budget expired")
+            }
+        } else {
+            modelAccessResult = .skipped(summary: "Skipped — eligibility gate did not pass")
+        }
+
+        // Stage 5: Functional Probe Gate (async, timeout-bounded)
+        let probeResult: AIGateResult
+        if modelAccessResult.status == .passed {
+            if elapsedMs(since: start) < totalTimeoutMs() {
+                probeResult = await checkFunctionalProbeGate()
+            } else {
+                probeResult = .timedOut(summary: "Not run — total budget expired")
+            }
+        } else {
+            probeResult = .skipped(summary: "Skipped — model access gate did not pass")
+        }
+
+        let gates = AIGateSet(
+            build: buildResult,
+            runtime: runtimeResult,
+            eligibility: eligibilityResult,
+            modelAccess: modelAccessResult,
+            functionalProbe: probeResult
+        )
+
+        // Dedupe while preserving order — prevents noisy telemetry from duplicate reasons
+        var seen = Set<AIFailureReason>()
+        let failureReasons = gates.allGates.flatMap { $0.result.reasons }.filter { seen.insert($0).inserted }
+
+        let overallStatus = AppleIntelligenceAvailabilityReport.deriveOverallStatus(from: gates)
         let durationMs = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
-        let debugSummary = debugLines.joined(separator: " | ")
 
         return AppleIntelligenceAvailabilityReport(
             overallStatus: overallStatus,
-            buildCompiledIn: buildCompiledIn,
+            gates: gates,
+            failureReasons: failureReasons,
             osVersion: osVersion,
             hardwareClass: hardwareClass,
-            runtimeFrameworkPresent: runtimePresent,
-            deviceEligibility: deviceEligibility,
-            modelAccessible: modelAccessible,
-            failureReasons: failureReasons,
-            userVisibleMessage: userMessage,
-            debugSummary: debugSummary,
             checkDurationMs: durationMs
         )
     }
 
+    // MARK: - Timeout Helpers
+
+    private static func totalTimeoutMs() -> Int {
+        Int(totalTimeoutSeconds * 1000)
+    }
+
+    private static func elapsedMs(since start: CFAbsoluteTime) -> Int {
+        Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+    }
+
     // MARK: - Stage 1: Build / Binary Gate
 
-    private static func checkBuildGate() -> Bool {
+    private static func checkBuildGate() -> AIGateResult {
+        let start = CFAbsoluteTimeGetCurrent()
 #if canImport(FoundationModels)
-        return true
+        let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+        return .passed(summary: "FoundationModels compiled in", durationMs: ms)
 #else
-        return false
+        let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+        return .failed(reasons: [.notCompiledIn], summary: "FoundationModels not compiled in", durationMs: ms)
 #endif
     }
 
-    // MARK: - Stage 2: OS / Runtime Environment Gate
+    // MARK: - Stage 2: OS / Runtime Preconditions Gate
 
-    private static func checkOSRuntimeGate(osVersion: String) -> (frameworkPresent: Bool, reasons: [AIFailureReason]) {
-        var reasons: [AIFailureReason] = []
-
+    private static func checkOSRuntimeGate() -> AIGateResult {
+        let start = CFAbsoluteTimeGetCurrent()
 #if canImport(FoundationModels)
         if #available(macOS 26.0, *) {
-            return (true, [])
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            return .passed(summary: "macOS 26+ runtime available", durationMs: ms)
         } else {
-            reasons.append(.unsupportedOS)
-            return (false, reasons)
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            return .failed(reasons: [.unsupportedOS], summary: "macOS 26+ required", durationMs: ms)
         }
 #else
-        reasons.append(.frameworkMissingAtRuntime)
-        return (false, reasons)
+        let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+        return .failed(reasons: [.frameworkMissingAtRuntime], summary: "FoundationModels framework missing at runtime", durationMs: ms)
 #endif
     }
 
-    // MARK: - Stage 3 + 4: Device Eligibility + Model Access
+    // MARK: - Stage 3: Device Eligibility Gate
 
-    private static func checkDeviceAndModelGates() -> (eligibility: AITriState, modelAccess: AITriState, reasons: [AIFailureReason]) {
+    private static func checkEligibilityGate() -> AIGateResult {
 #if canImport(FoundationModels)
         if #available(macOS 26.0, *) {
-            return checkDeviceAndModelGatesImpl()
+            return checkEligibilityGateImpl()
         }
 #endif
-        return (.unknown, .unknown, [.unknownError])
+        return .failed(reasons: [.unknownError], summary: "Unexpected: eligibility check reached without framework")
     }
 
 #if canImport(FoundationModels)
     @available(macOS 26.0, *)
-    private static func checkDeviceAndModelGatesImpl() -> (eligibility: AITriState, modelAccess: AITriState, reasons: [AIFailureReason]) {
+    private static func checkEligibilityGateImpl() -> AIGateResult {
+        let start = CFAbsoluteTimeGetCurrent()
         let model = SystemLanguageModel.default
 
         switch model.availability {
         case .available:
-            return (.yes, .yes, [])
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            return .passed(summary: "Device eligible, Apple Intelligence enabled", durationMs: ms)
 
         case .unavailable(let reason):
-            var reasons: [AIFailureReason] = []
-
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
             switch reason {
             case .deviceNotEligible:
-                reasons.append(.deviceNotEligible)
-                return (.no, .no, reasons)
+                return .failed(reasons: [.deviceNotEligible], summary: "Device not eligible for Apple Intelligence", durationMs: ms)
             case .appleIntelligenceNotEnabled:
-                reasons.append(.appleIntelligenceDisabled)
-                return (.yes, .no, reasons)
+                return .failed(reasons: [.appleIntelligenceDisabled], summary: "Apple Intelligence not enabled in System Settings", durationMs: ms)
             case .modelNotReady:
-                reasons.append(.modelNotReady)
-                return (.yes, .no, reasons)
+                return .failed(reasons: [.modelNotReady], summary: "Model not ready (may still be downloading)", durationMs: ms)
             @unknown default:
-                reasons.append(.unknownError)
-                return (.unknown, .unknown, reasons)
+                return .failed(reasons: [.unknownError], summary: "Unknown unavailability reason from system", durationMs: ms)
             }
+        }
+    }
+#endif
+
+    // MARK: - Stage 4: Model Access Gate
+
+    private static func checkModelAccessGateWithTimeout() async -> AIGateResult {
+#if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return await checkModelAccessGateWithTimeoutImpl()
+        }
+#endif
+        return .failed(reasons: [.modelAccessFailed], summary: "Unexpected: model access check reached without framework")
+    }
+
+#if canImport(FoundationModels)
+    @available(macOS 26.0, *)
+    private static func checkModelAccessGateWithTimeoutImpl() async -> AIGateResult {
+        let start = CFAbsoluteTimeGetCurrent()
+
+        // Race session creation against a timeout
+        do {
+            let result = try await withThrowingTaskGroup(of: AIGateResult.self) { group in
+                group.addTask { @Sendable in
+                    _ = LanguageModelSession(
+                        model: .default,
+                        instructions: "You are a diagnostic probe."
+                    )
+                    let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                    return .passed(summary: "Session created successfully", durationMs: ms)
+                }
+
+                group.addTask { @Sendable in
+                    try await Task.sleep(for: .seconds(sessionTimeoutSeconds))
+                    let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                    return .timedOut(summary: "Session creation timed out after \(Int(sessionTimeoutSeconds))s", durationMs: ms)
+                }
+
+                let first = try await group.next()!
+                group.cancelAll()
+                return first
+            }
+            return result
+        } catch {
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            return .failed(reasons: [.sessionInitFailed], summary: "Session creation error: \(error.localizedDescription)", durationMs: ms)
+        }
+    }
+#endif
+
+    // MARK: - Stage 5: Functional Probe Gate
+
+    private static func checkFunctionalProbeGate() async -> AIGateResult {
+#if canImport(FoundationModels)
+        if #available(macOS 26.0, *) {
+            return await checkFunctionalProbeGateImpl()
+        }
+#endif
+        return .skipped(summary: "Functional probe not available without framework")
+    }
+
+#if canImport(FoundationModels)
+    @available(macOS 26.0, *)
+    private static func checkFunctionalProbeGateImpl() async -> AIGateResult {
+        let start = CFAbsoluteTimeGetCurrent()
+
+        // Race the probe against a timeout
+        do {
+            let result = try await withThrowingTaskGroup(of: AIGateResult.self) { group in
+                group.addTask { @Sendable in
+                    do {
+                        let session = LanguageModelSession(
+                            model: .default,
+                            instructions: "Respond with exactly the word OK."
+                        )
+                        let response = try await session.respond(to: "Probe")
+                        let text = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                        if text.isEmpty {
+                            return .failed(reasons: [.generationFailed], summary: "Probe returned empty response", durationMs: ms)
+                        }
+                        let normalized = text.lowercased()
+                        let isValidProbe = normalized == "ok" || normalized == "ok." || normalized.hasPrefix("ok")
+                        if isValidProbe {
+                            return .passed(summary: "Probe succeeded", durationMs: ms)
+                        } else {
+                            return .passed(summary: "Probe returned unexpected content: \(text.prefix(30))", durationMs: ms)
+                        }
+                    } catch {
+                        let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                        return .failed(reasons: [.generationFailed], summary: "Probe generation failed: \(error.localizedDescription)", durationMs: ms)
+                    }
+                }
+
+                group.addTask { @Sendable in
+                    try await Task.sleep(for: .seconds(probeTimeoutSeconds))
+                    let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+                    return .timedOut(summary: "Probe timed out after \(Int(probeTimeoutSeconds))s", durationMs: ms)
+                }
+
+                let first = try await group.next()!
+                group.cancelAll()
+                return first
+            }
+            return result
+        } catch {
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            return .failed(reasons: [.generationFailed], summary: "Probe task error: \(error.localizedDescription)", durationMs: ms)
         }
     }
 #endif
@@ -185,6 +307,6 @@ public enum AppleIntelligenceDiagnosticsService {
         sysctlbyname("hw.machine", nil, &size, nil, 0)
         var machine = [CChar](repeating: 0, count: size)
         sysctlbyname("hw.machine", &machine, &size, nil, 0)
-        return String(cString: machine)
+        return String(decoding: machine.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
     }
 }

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -517,7 +517,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                 ])
                 // If Apple Intelligence failed, run a fresh diagnostics check and attach it
                 if llmPolishStep.llmProvider == .appleIntelligence {
-                    let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
+                    let aiReport = await AppleIntelligenceDiagnosticsService.runDiagnostics()
                     SentryBreadcrumb.reportAIFailure(aiReport)
                 }
                 Task { await AppLogger.shared.log(

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -475,7 +475,7 @@ public final class WhisperKitPipeline: DictationPipeline {
                 ])
                 // If Apple Intelligence failed, run a fresh diagnostics check and attach it
                 if llmPolishStep.llmProvider == .appleIntelligence {
-                    let aiReport = AppleIntelligenceDiagnosticsService.runDiagnostics()
+                    let aiReport = await AppleIntelligenceDiagnosticsService.runDiagnostics()
                     SentryBreadcrumb.reportAIFailure(aiReport)
                 }
                 lastPolishError = error.localizedDescription

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -173,15 +173,7 @@ public enum SentryBreadcrumb {
     /// Use at app launch — logs the state but does NOT fire a warning event.
     /// The report is included in every future crash/error event automatically.
     public static func attachAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
-        add(stage: "ai_diagnostics", message: "AI availability check completed", data: [
-            "overall_status": report.overallStatus.rawValue,
-            "build_compiled_in": report.buildCompiledIn,
-            "runtime_framework_present": report.runtimeFrameworkPresent,
-            "device_eligibility": report.deviceEligibility.rawValue,
-            "model_accessible": report.modelAccessible.rawValue,
-            "failure_reasons": report.failureReasons.map(\.rawValue),
-            "check_duration_ms": report.checkDurationMs,
-        ])
+        add(stage: "ai_diagnostics", message: "AI availability check completed", data: report.sentryContext)
 
         SentrySDK.configureScope { scope in
             scope.setContext(value: report.sentryContext, key: "apple_intelligence")

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -199,6 +199,27 @@ public final class TelemetryService {
         ])
     }
 
+    // MARK: - AI Diagnostics
+
+    /// One summary event per diagnostics check run.
+    /// Trigger: "app_launch", "delayed_recheck", "manual_refresh", "provider_switch"
+    public func aiDiagnosticsRunCompleted(report: AppleIntelligenceAvailabilityReport, trigger: String) {
+        var props: [String: Any] = [
+            "overall_status": report.overallStatus.rawValue,
+            "failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
+            "check_duration_ms": report.checkDurationMs,
+            "os_version": report.osVersion,
+            "hardware_class": report.hardwareClass,
+            "trigger": trigger,
+        ]
+        for (name, result) in report.gates.allGates {
+            let key = name.lowercased().replacingOccurrences(of: " ", with: "_")
+            props["gate_\(key)_status"] = result.status.rawValue
+            if let ms = result.durationMs { props["gate_\(key)_ms"] = ms }
+        }
+        PostHogSDK.shared.capture("ai_diagnostics.run_completed", properties: props)
+    }
+
     // MARK: - Metrics
 
     public func metricPipelineE2E(seconds: Double, inputMode: String, asrBackend: String,


### PR DESCRIPTION
## Summary

- Replace simple boolean AI availability check with a 5-stage diagnostic gate pipeline (Build → Runtime → Eligibility → Model Access → Functional Probe)
- New `AIAvailabilityCoordinator` owns UI state, stale-result protection, persistence, and telemetry — replacing the `KeyValidationState` proxy
- Rich Settings UI: status badge with 4 states, "Why?" detail text, collapsible debug section with per-gate results, Copy Diagnostics button
- Per-stage Sentry breadcrumbs + one PostHog `ai_diagnostics.run_completed` summary event per run
- UserDefaults persistence for latest snapshot + rolling history (last 5 entries)
- First-launch delayed re-check (30s) with meaningful-change detection
- Overall 10s timeout budget with per-stage timeouts (Stage 4: 2s, Stage 5: 3s)
- Stage 5 performs real `LanguageModelSession.respond()` probe with strict validation

## Architecture

- **Core types** (`EnviousWisprCore`): `AIGateStatus`, `AIGateResult`, `AIGateSet`, upgraded `AppleIntelligenceAvailabilityReport` with derived fields, `HistoryEntry`
- **Service** (`EnviousWisprLLM`): Pure computation, no side effects, no telemetry imports
- **Coordinator** (`EnviousWispr` app): Owns all side effects — persistence, Sentry, PostHog, first-launch logic
- **Settings UI**: Consumes structured report, never computes availability inline

## Test plan

- [ ] Build passes (`swift build`)
- [ ] Select Apple Intelligence as provider → status shows Available/Unavailable with reason
- [ ] Click refresh button → debounced re-check fires
- [ ] Enable debug mode → diagnostics disclosure group visible with per-gate results
- [ ] Click "Copy Diagnostics" → JSON blob in clipboard with export_version=1
- [ ] Fresh install → first-launch check + 30s delayed re-check fires
- [ ] Kill app during check → stale result discarded on next launch (cached report loads)
