### PR TITLE
fix: stale model name when switching to Apple Intelligence

### DIFF
--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -42,10 +42,11 @@ final class PipelineSettingsSync {
         // Parakeet pipeline
         pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
         pipeline.llmPolish.llmProvider = settings.llmProvider
-        pipeline.llmPolish.llmModel = settings.llmModel
-        if settings.llmProvider == .ollama {
-            pipeline.llmPolish.llmModel = settings.ollamaModel
-        }
+        // Defensive normalization: ensure model matches provider before syncing
+        let resolvedModel = settings.llmProvider == .appleIntelligence ? "apple-intelligence"
+            : settings.llmProvider == .ollama ? settings.ollamaModel
+            : settings.llmModel
+        pipeline.llmPolish.llmModel = resolvedModel
         pipeline.vadAutoStop = settings.vadAutoStop
         pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
         pipeline.vadSensitivity = settings.vadSensitivity
@@ -119,9 +120,19 @@ final class PipelineSettingsSync {
         case .llmProvider:
             pipeline.llmPolish.llmProvider = settings.llmProvider
             whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
+            // Also sync model — provider change may canonicalize the model
+            let provSyncModel = settings.llmProvider == .appleIntelligence ? "apple-intelligence"
+                : settings.llmProvider == .ollama ? settings.ollamaModel
+                : settings.llmModel
+            pipeline.llmPolish.llmModel = provSyncModel
+            whisperKitPipeline.llmPolish.llmModel = provSyncModel
         case .llmModel:
-            pipeline.llmPolish.llmModel = settings.llmModel
-            whisperKitPipeline.llmPolish.llmModel = settings.llmModel
+            // Defensive: resolve model based on provider at the sync boundary
+            let syncModel = settings.llmProvider == .appleIntelligence ? "apple-intelligence"
+                : settings.llmProvider == .ollama ? settings.ollamaModel
+                : settings.llmModel
+            pipeline.llmPolish.llmModel = syncModel
+            whisperKitPipeline.llmPolish.llmModel = syncModel
             if settings.llmProvider == .ollama {
                 settings.ollamaModel = settings.llmModel
             }
@@ -256,10 +267,10 @@ final class PipelineSettingsSync {
         whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
         whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
         whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
-        whisperKitPipeline.llmPolish.llmModel = settings.llmModel
-        if settings.llmProvider == .ollama {
-            whisperKitPipeline.llmPolish.llmModel = settings.ollamaModel
-        }
+        let wkResolvedModel = settings.llmProvider == .appleIntelligence ? "apple-intelligence"
+            : settings.llmProvider == .ollama ? settings.ollamaModel
+            : settings.llmModel
+        whisperKitPipeline.llmPolish.llmModel = wkResolvedModel
         whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
         whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
         whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -202,7 +202,11 @@ struct AIPolishSettingsView: View {
         }
         .onChange(of: appState.settings.llmProvider) { _, newProvider in
             appState.llmDiscovery.reset()
-            appState.settings.llmModel = ""
+            // Don't blank the model for Apple Intelligence — SettingsManager canonicalizes it.
+            // For other providers, clear it so discovery can auto-select.
+            if newProvider != .appleIntelligence {
+                appState.settings.llmModel = ""
+            }
 
             switch newProvider {
             case .none:
@@ -216,6 +220,7 @@ struct AIPolishSettingsView: View {
                 }
             case .appleIntelligence:
                 appState.ollamaSetup.cancelPull()
+                // Model canonicalization handled by SettingsManager.llmProvider didSet
                 Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
             default:
                 appState.ollamaSetup.cancelPull()

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -68,6 +68,10 @@ public final class SettingsManager {
     public var llmProvider: LLMProvider {
         didSet {
             UserDefaults.standard.set(llmProvider.rawValue, forKey: "llmProvider")
+            // Canonicalize: Apple Intelligence has a fixed model name
+            if llmProvider == .appleIntelligence && llmModel != "apple-intelligence" {
+                llmModel = "apple-intelligence"
+            }
             onChange?(.llmProvider)
         }
     }
@@ -391,5 +395,11 @@ public final class SettingsManager {
         environmentPreset = EnvironmentPreset(rawValue: defaults.string(forKey: "environmentPreset") ?? "") ?? .normal
         writingStylePreset = WritingStylePreset(rawValue: defaults.string(forKey: "writingStylePreset") ?? "") ?? .standard
         useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
+
+        // Canonicalize provider-coupled model names after all properties are loaded.
+        // Apple Intelligence has a fixed model — persisted values from other providers are stale.
+        if llmProvider == .appleIntelligence && llmModel != "apple-intelligence" {
+            llmModel = "apple-intelligence"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Regression from #56 (diagnostics v2) — replacing `validateKeyAndDiscoverModels` with `checkAvailability()` removed model auto-correction on provider switch
- Model name stayed stale (e.g. `gemini-2.5-flash`) in pipeline logs when switching back to Apple Intelligence
- Fix enforces invariant at SettingsManager (source of truth) + PipelineSettingsSync (defensive backstop)

## Test plan

- [x] Automated 4-way provider switch test (AI→OpenAI→AI→Gemini→AI) — all PASS
- [x] E2E dictation test on Apple Intelligence — `model=apple-intelligence` in log
- [x] App launch with stale persisted model — canonicalized on init
- [ ] Manual: switch providers and dictate with each, verify log model names
