### PR TITLE
fix: stale model and hidden reasoning toggle on provider switch

### DIFF
--- a/Sources/EnviousWispr/App/LLMModelDiscoveryCoordinator.swift
+++ b/Sources/EnviousWispr/App/LLMModelDiscoveryCoordinator.swift
@@ -57,12 +57,7 @@ final class LLMModelDiscoveryCoordinator {
             }
             keyValidationState = .valid
 
-            if !models.contains(where: { $0.id == settings.llmModel && $0.isAvailable }) {
-                if let firstAvailable = models.first(where: { $0.isAvailable }) {
-                    settings.llmModel = firstAvailable.id
-                    if provider == .ollama { settings.ollamaModel = firstAvailable.id }
-                }
-            }
+            settings.applyDiscoveredModels(models, for: provider)
         } catch LLMError.providerUnavailable {
             keyValidationState = .invalid(
                 provider == .ollama

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -16,6 +16,10 @@ struct AIPolishSettingsView: View {
         appState.settings.llmProvider == .openAI || appState.settings.llmProvider == .gemini
     }
 
+    private var isReasoningModel: Bool {
+        appState.settings.llmProvider.supportsReasoning(model: appState.settings.llmModel)
+    }
+
     private var showModelSection: Bool {
         appState.settings.llmProvider != .none && appState.settings.llmProvider != .appleIntelligence
     }
@@ -168,7 +172,7 @@ struct AIPolishSettingsView: View {
             }
 
             // ── Section 4: Advanced ───────────────────────────────────
-            if isCloudProvider {
+            if isReasoningModel {
                 BrandedSection(header: "Advanced") {
                     BrandedRow(showDivider: false) {
                         @Bindable var state2 = appState
@@ -202,11 +206,8 @@ struct AIPolishSettingsView: View {
         }
         .onChange(of: appState.settings.llmProvider) { _, newProvider in
             appState.llmDiscovery.reset()
-            // Don't blank the model for Apple Intelligence — SettingsManager canonicalizes it.
-            // For other providers, clear it so discovery can auto-select.
-            if newProvider != .appleIntelligence {
-                appState.settings.llmModel = ""
-            }
+            // Model canonicalization handled by SettingsManager.llmProvider didSet.
+            // Discovery will refine the model async if needed.
 
             switch newProvider {
             case .none:

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -19,6 +19,29 @@ extension LLMProvider {
         case .none:              return "None"
         }
     }
+
+    /// Default model for a provider. Used to restore a sensible model when switching providers.
+    public static func defaultModel(for provider: LLMProvider, ollamaModel: String = "llama3.2") -> String {
+        switch provider {
+        case .openAI:            return "gpt-4o-mini"
+        case .gemini:            return "gemini-2.0-flash"
+        case .ollama:            return ollamaModel
+        case .appleIntelligence: return "apple-intelligence"
+        case .none:              return ""
+        }
+    }
+
+    /// Whether this provider + model combination supports reasoning/thinking controls.
+    public func supportsReasoning(model: String) -> Bool {
+        switch self {
+        case .gemini:
+            return model.hasPrefix("gemini-2.5") || model.hasPrefix("gemini-3")
+        case .openAI:
+            return model.hasPrefix("o1") || model.hasPrefix("o3") || model.hasPrefix("o4")
+        case .ollama, .appleIntelligence, .none:
+            return false
+        }
+    }
 }
 
 /// Result from LLM transcript polishing.

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -9,7 +9,7 @@ public final class LLMPolishStep: TextProcessingStep {
     public let name = "LLM Polish"
 
     public var llmProvider: LLMProvider = .none
-    public var llmModel: String = "gpt-4o-mini"
+    public var llmModel: String = LLMProvider.defaultModel(for: .openAI)
     public var polishInstructions: PolishInstructions = .default
     public var useExtendedThinking: Bool = false
     public var customWords: [CustomWord] = []
@@ -293,14 +293,11 @@ public final class LLMPolishStep: TextProcessingStep {
 
     /// Resolve thinking/reasoning config based on provider, model, and user toggle.
     private func resolveThinkingConfig() -> (thinkingBudget: Int?, reasoningEffort: String?) {
+        guard llmProvider.supportsReasoning(model: llmModel) else { return (nil, nil) }
         switch llmProvider {
         case .gemini:
-            let isThinkingModel = llmModel.hasPrefix("gemini-2.5") || llmModel.hasPrefix("gemini-3")
-            guard isThinkingModel else { return (nil, nil) }
             return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)
         case .openAI:
-            let isReasoningModel = llmModel.hasPrefix("o1") || llmModel.hasPrefix("o3") || llmModel.hasPrefix("o4")
-            guard isReasoningModel else { return (nil, nil) }
             return (nil, useExtendedThinking ? "medium" : "low")
         case .ollama, .appleIntelligence, .none:
             return (nil, nil)

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -68,9 +68,11 @@ public final class SettingsManager {
     public var llmProvider: LLMProvider {
         didSet {
             UserDefaults.standard.set(llmProvider.rawValue, forKey: "llmProvider")
-            // Canonicalize: Apple Intelligence has a fixed model name
-            if llmProvider == .appleIntelligence && llmModel != "apple-intelligence" {
+            // Canonicalize model for the new provider
+            if llmProvider == .appleIntelligence {
                 llmModel = "apple-intelligence"
+            } else if llmModel == "apple-intelligence" || llmModel.isEmpty {
+                llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
             }
             onChange?(.llmProvider)
         }
@@ -327,7 +329,7 @@ public final class SettingsManager {
         whisperKitModel = defaults.string(forKey: "whisperKitModel") ?? "openai_whisper-large-v3_turbo"
         recordingMode = RecordingMode(rawValue: defaults.string(forKey: "recordingMode") ?? "") ?? .pushToTalk
         llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .none
-        llmModel = defaults.string(forKey: "llmModel") ?? "gpt-4o-mini"
+        llmModel = defaults.string(forKey: "llmModel") ?? LLMProvider.defaultModel(for: .openAI)
         ollamaModel = defaults.string(forKey: "ollamaModel") ?? "llama3.2"
         autoCopyToClipboard = defaults.object(forKey: "autoCopyToClipboard") as? Bool ?? true
         hotkeyEnabled = true  // toggle removed; always enabled
@@ -397,9 +399,28 @@ public final class SettingsManager {
         useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
 
         // Canonicalize provider-coupled model names after all properties are loaded.
-        // Apple Intelligence has a fixed model — persisted values from other providers are stale.
-        if llmProvider == .appleIntelligence && llmModel != "apple-intelligence" {
+        if llmProvider == .appleIntelligence {
             llmModel = "apple-intelligence"
+        } else if llmModel == "apple-intelligence" || llmModel.isEmpty {
+            llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
+        }
+    }
+
+    /// Apply discovered models from async discovery. SettingsManager decides whether to update.
+    /// - Parameters:
+    ///   - models: Models returned by the provider's API.
+    ///   - provider: The provider these models belong to. Stale results (user already switched) are dropped.
+    public func applyDiscoveredModels(_ models: [LLMModelInfo], for provider: LLMProvider) {
+        guard provider == llmProvider else { return }
+        if models.isEmpty {
+            llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
+            return
+        }
+        if !models.contains(where: { $0.id == llmModel && $0.isAvailable }) {
+            if let first = models.first(where: { $0.isAvailable }) {
+                llmModel = first.id
+                if provider == .ollama { ollamaModel = first.id }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Hide Deep Reasoning toggle** for non-reasoning models — toggle only appears for OpenAI o1/o3/o4 and Gemini 2.5+/3.x (ew-m7ba)
- **Fix stale model on provider switch** — switching away from Apple Intelligence no longer leaves an empty or stale model (ew-bpzz)
- **Single-writer rule for llmModel** — SettingsManager is now the sole authority. View no longer blanks model to `""`. Discovery routes through `applyDiscoveredModels()` with async race guard.

## Test plan
- [ ] Switch Gemini → Apple Intelligence → Gemini: model shows valid default, not empty
- [ ] Switch Apple Intelligence → OpenAI: model shows valid OpenAI model
- [ ] Deep Reasoning toggle visible for Gemini 2.5 Flash, hidden for Gemini 2.0 Flash
- [ ] Full settings scan: 10/10 tabs pass
- [ ] Rapid provider switching: no crash, no stale cross-provider model persists after discovery
