### PR TITLE
fix(blog): constrain images to container width

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -351,6 +351,13 @@ const breadcrumbJsonLd = JSON.stringify({
     font-size: 14px;
   }
 
+  .blog-body :global(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: 12px;
+    margin: 1.8em 0;
+  }
+
   .blog-body :global(hr) {
     border: none;
     height: 1px;


### PR DESCRIPTION
## Summary
- Blog post images were overflowing the 720px content column
- Added `max-width: 100%; height: auto` to `.blog-body :global(img)` in BlogPost.astro

## Test plan
- [ ] Verify images in the Claude Code blog post stay within container
- [ ] Verify images have rounded corners (12px)
