### PR TITLE
feat(website): add PostHog web analytics

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -58,6 +58,17 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="theme-color" content="#f8f5ff" />
   <slot name="head" />
+  <!-- PostHog Analytics -->
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageviewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_W1N51z2mqKZGo8UxBYQ5avkpjpJ3npT8retNQUaRSKk', {
+      api_host: 'https://us.i.posthog.com',
+      person_profiles: 'identified_only',
+      capture_pageview: true,
+      capture_pageleave: true,
+      autocapture: true,
+    });
+  </script>
 </head>
 <body>
   <div class="dot-grid" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- Add PostHog JS snippet to BaseLayout.astro — every page gets analytics
- Autocapture tracks all clicks including both download button CTAs
- Pageview + pageleave tracking for session flow analysis
- Uses same PostHog project (354235) as the native app
- `person_profiles: 'identified_only'` — anonymous by default, privacy-first

## What this enables in PostHog
- Landing page analysis (which pages do visitors arrive on?)
- Download funnel (blog → homepage → download click)
- Click heatmaps on any page
- Session recordings (if enabled later)
- Page view counts per URL
- Referrer tracking (where traffic comes from)

## Test plan
- [ ] Build passes (verified: 26 pages, 910ms)
- [ ] PostHog snippet present in homepage, blog index, and blog post HTML
- [ ] Visit site after deploy → verify events appear in PostHog
