### PR TITLE
chore(release): bump version to 1.7.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
- Version bump to 1.7.1 for release

## What's in v1.7.1
- fix: unblock paste path, fix Sparkle window focus
- fix: stale model and hidden reasoning toggle on provider switch
- fix: stale model name when switching to Apple Intelligence
- feat: Apple Intelligence diagnostics v2 — 5-stage gate pipeline

## Test plan
- [ ] CI passes build-check
- [ ] Tag and release after merge
