### PR TITLE
fix(ci): handle sentry-cli already installed on self-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,8 +492,10 @@ jobs:
 
           export INSTALL_DIR="$HOME/.local/bin"
           mkdir -p "$INSTALL_DIR"
-          curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.39.1 bash
+          curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.39.1 bash || true
+          # Install script returns 1 if already installed on self-hosted runner
           export PATH="$INSTALL_DIR:$PATH"
+          sentry-cli --version
 
           sentry-cli releases new "v${VERSION}"
           sentry-cli releases set-commits "v${VERSION}" --auto


### PR DESCRIPTION
## Summary
- sentry-cli install script exits 1 when already installed, killing the release pipeline
- Add `|| true` to tolerate pre-installed sentry-cli on self-hosted runner
- Add version check to confirm sentry-cli is available

## Test plan
- [ ] CI passes build-check
- [ ] Re-run release after merge
