### PR TITLE
fix(custom-words): ambiguity guard tracks cross-canonical competition only

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -132,11 +132,11 @@ public struct WordCorrector: Sendable {
                             for (alias, canonical) in candidates {
                                 let s = score(phrase, against: alias)
                                 if s > bestScore {
-                                    secondBest = bestScore
+                                    if bestCanonical != canonical { secondBest = bestScore }
                                     bestScore = s
                                     bestCanonical = canonical
                                     bestAlias = alias
-                                } else if s > secondBest {
+                                } else if s > secondBest && canonical != bestCanonical {
                                     secondBest = s
                                 }
                             }
@@ -197,10 +197,10 @@ public struct WordCorrector: Sendable {
 
                 let s = score(coreLower, against: surface)
                 if s > bestScore {
-                    secondBest = bestScore
+                    if bestMatch != canonical { secondBest = bestScore }
                     bestScore = s
                     bestMatch = canonical
-                } else if s > secondBest {
+                } else if s > secondBest && canonical != bestMatch {
                     secondBest = s
                 }
             }

--- a/benchmark-results/wordcorrector-benchmark.swift
+++ b/benchmark-results/wordcorrector-benchmark.swift
@@ -475,10 +475,10 @@ func correctV2(_ text: String, against words: [CustomWord]) -> String {
                         for (alias, canonical) in candidates {
                             let s = compositeScore(phrase, against: alias)
                             if s > bestScore {
-                                secondBest = bestScore
+                                if bestCanonical != canonical { secondBest = bestScore }
                                 bestScore = s
                                 bestCanonical = canonical
-                            } else if s > secondBest {
+                            } else if s > secondBest && canonical != bestCanonical {
                                 secondBest = s
                             }
                         }
@@ -531,10 +531,10 @@ func correctV2(_ text: String, against words: [CustomWord]) -> String {
 
             let s = compositeScore(coreLower, against: surface)
             if s > bestScore {
-                secondBest = bestScore
+                if bestMatch != canonical { secondBest = bestScore }
                 bestScore = s
                 bestMatch = canonical
-            } else if s > secondBest {
+            } else if s > secondBest && canonical != bestMatch {
                 secondBest = s
             }
         }
@@ -576,4 +576,4 @@ func correctV2(_ text: String, against words: [CustomWord]) -> String {
     return corrected.joined(separator: " ")
 }
 
-runBenchmark(name: "V2 (new code)", corrector: correctV2)
+runBenchmark(name: "V2 + AMBIGUITY FIX", corrector: correctV2)


### PR DESCRIPTION
## Summary
- Fixed bug where same-canonical aliases competed with each other in the ambiguity margin check, falsely rejecting valid fuzzy corrections
- Affects passes 2 (fuzzy multi-word) and 4 (fuzzy single-word aliases)
- Council-validated: GPT-5.4 + Gemini 3.1 Pro confirmed correctness

## Metrics
- Recall: 81.4% -> 83.7%
- FP rate: unchanged at 10%
- No regressions

## Test plan
- [x] Build passes (`swift build`)
- [x] Benchmark suite run with before/after comparison
- [x] Council review (GPT + Gemini)
