### PR TITLE
feat: streaming-final via FluidAudio fork + n-gram WordCorrector

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "3fae69b255be3402363db93b422d0bca256ef2ac17afe6f12a89d8daf40fab80",
+  "originHash" : "94d3683633a7d46753f342e9f3a88aa4b34f5ee59ddd23f33784d978e46073e5",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
-        "version" : "0.13.4"
+        "revision" : "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
+        .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
         .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -435,15 +435,16 @@ public final class TranscriptionPipeline: DictationPipeline {
         do {
             let asrStart = CFAbsoluteTimeGetCurrent()
 
-            // Always use batch transcription for the authoritative final result.
-            // Streaming is kept active during recording for live partial preview only.
-            // Batch produces complete text even for 2-5 minute dictation, while streaming
-            // window assembly silently drops ~30% of content at longer durations.
+            // Use streaming finalize when available for lowest latency.
+            // FluidAudio fork uses fresh decoder state per chunk + chunk-aware text assembly
+            // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
+            // Falls back to batch transcription when streaming was not active.
             let result: ASRResult
             if wasStreaming {
-                await asrManager.cancelStreaming()
+                result = try await asrManager.finalizeStreaming()
+            } else {
+                result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
             }
-            result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
 
             let asrEnd = CFAbsoluteTimeGetCurrent()
 
@@ -998,6 +999,12 @@ public final class TranscriptionPipeline: DictationPipeline {
         )
         context.targetAppBundleID = targetApp?.bundleIdentifier
         context.targetAppName = targetApp?.localizedName
+        Task {
+            await AppLogger.shared.log(
+                "CORRECTION_DEBUG [RAW ASR] \(asrText)",
+                level: .info, category: "CorrectionDebug"
+            )
+        }
         for step in textProcessingSteps where step.isEnabled {
             let stepName = step.name
             let input = context
@@ -1012,11 +1019,30 @@ public final class TranscriptionPipeline: DictationPipeline {
                     try await unsafeStep.process(input)
                 }
                 let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
+                let inputText = input.polishedText ?? input.text
+                let outputText = context.polishedText ?? context.text
+                let changed = inputText != outputText
                 Task {
                     await AppLogger.shared.log(
                         "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
                         level: .info, category: "PipelineTiming"
                     )
+                    // Debug: log text at each correction layer
+                    if changed {
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] IN:  \(inputText)",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] OUT: \(outputText)",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                    } else {
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] no change",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                    }
                 }
             } catch is CancellationError {
                 throw CancellationError()

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -4,7 +4,9 @@ import EnviousWisprCore
 
 /// Pure, Sendable word correction engine.
 ///
-/// Five-pass replacement:
+/// Six-pass replacement:
+/// 0. **N-gram compound match** -- concatenate 1-3 adjacent words, match against canonicals
+///    with spaces removed. Catches "Chat G P T" -> "ChatGPT", "Open A I" -> "OpenAI".
 /// 1. **Exact multi-word alias** -- O(1) lookup for multi-word aliases (longest match first).
 /// 2. **Fuzzy multi-word alias** -- score phrase against same-token-count aliases when exact misses.
 /// 3. **Exact single-word alias** -- O(1) lookup including canonical self-entries for casing fixes.
@@ -91,6 +93,61 @@ public struct WordCorrector: Sendable {
 
         var replacements = 0
         var tokens = text.components(separatedBy: .whitespaces)
+
+        // Build nospace lookup for Pass 0 (n-gram compound matching)
+        // Maps lowercase-nospace canonical -> original canonical
+        // e.g., "chatgpt" -> "ChatGPT", "openai" -> "OpenAI", "vscode" -> "VS Code"
+        var nospaceCanonicalMap: [String: String] = [:]
+        for word in words {
+            let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
+            nospaceCanonicalMap[nospace] = word.canonical
+            // Also index aliases without spaces
+            for alias in word.aliases {
+                let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
+                if nospaceCanonicalMap[aliasNospace] == nil {
+                    nospaceCanonicalMap[aliasNospace] = word.canonical
+                }
+            }
+        }
+
+        // Pass 0: N-gram compound matching
+        // Concatenate 1-3 adjacent words (stripped of punctuation, lowercased, spaces removed)
+        // and check against nospace canonical/alias map.
+        // "Chat G P T" -> "chatgpt" matches "ChatGPT"
+        if !nospaceCanonicalMap.isEmpty {
+            var i = 0
+            while i < tokens.count {
+                var matched = false
+
+                for n in (1...min(3, tokens.count - i)).reversed() {
+                    let slice = tokens[i..<(i + n)]
+                    let ngram = slice
+                        .map { stripPunctuation($0).lowercased() }
+                        .joined()  // No separator: concatenate directly
+
+                    guard ngram.count >= 3 else { continue }
+
+                    // Length ratio check: ngram must be within 25% of candidate length
+                    if let canonical = nospaceCanonicalMap[ngram] {
+                        let canonicalNospace = canonical.replacingOccurrences(of: " ", with: "")
+                        // Check it's not already correct
+                        let rawConcat = slice.map { stripPunctuation($0) }.joined()
+                        if rawConcat == canonicalNospace { break }
+
+                        let (firstPrefix, _, _) = splitPunctuation(tokens[i])
+                        let (_, _, lastSuffix) = splitPunctuation(tokens[i + n - 1])
+                        tokens.replaceSubrange(i..<(i + n), with: [firstPrefix + canonical + lastSuffix])
+                        replacements += 1
+                        matched = true
+                        Self.logger.debug("WordCorrector: type=ngram-compound source='\(rawConcat)' target='\(canonical)' n=\(n)")
+                        break
+                    }
+                }
+
+                i += 1
+                if matched { continue }
+            }
+        }
 
         // Pass 1 + 2: multi-word (exact then fuzzy)
         if !multiAliasMap.isEmpty {

--- a/docs/feature-requests/ctc-vocabulary-boosting.md
+++ b/docs/feature-requests/ctc-vocabulary-boosting.md
@@ -64,8 +64,9 @@ Wire FluidAudio's CTC-based vocabulary boosting into the Parakeet pipeline so cu
 - `ASRManagerInterface` (@MainActor): app-side abstraction. Both ASRManager (in-process) and ASRManagerProxy (XPC) conform.
 
 ### Streaming CTC limitation
-- StreamingAsrManager has 10s minContextForConfirmation. Short dictation never confirms.
-- Correct pattern: stream for speed, batch post-rescore with CTC on accumulated audio.
+- SlidingWindowAsrManager has 10s minContextForConfirmation. Short dictation never confirms.
+- Per-chunk streaming CTC (configureVocabularyBoosting) has limited context and contributed to original 35% precision failure.
+- Correct pattern: streaming-final for base text, batch CTC rescore on full buffered audio as post-processing step.
 
 ## Key Design Patterns
 
@@ -423,7 +424,7 @@ Set at recording start. Used to validate rescore results are for current utteran
 // Heart path: always runs first, both streaming and batch
 let result: ASRResult
 if wasStreaming {
-    result = try await finalizeStreamingWithTimeout(samples: samples)
+    result = try await asrManager.finalizeStreaming()
 } else {
     result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
 }


### PR DESCRIPTION
## Summary
- FluidAudio switched to private fork (saurabhav88/FluidAudio) with streaming text loss fix
- TranscriptionPipeline uses streaming-final instead of batch-final (PR #81 workaround removed)
- WordCorrector v2 gains Pass 0: n-gram compound matching for "chat GPT" -> "ChatGPT" etc.
- Per-step CORRECTION_DEBUG logging for debugging correction layers

## Context
- Streaming fix: fresh decoder state per chunk eliminates ~12% text loss at 60s+
- N-gram pass: catches multi-word compounds without CTC acoustic models
- Debug logging: traces RAW ASR -> WordCorrector -> Filler -> LLM Polish per utterance

## Test plan
- [ ] 137s TTS stress test: streaming produces complete transcript (331 words)
- [ ] Short utterance: "open chat gpt" -> "Open ChatGPT" (n-gram pass)
- [ ] Confuser: "the clouds moved in quickly" stays unchanged
- [ ] Build passes in release mode
