### PR TITLE
feat: pre-roll audio buffer with warm engine for first-word capture

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.5</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.1</string>
+	<string>1.7.5</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>
@@ -30,14 +30,14 @@
 	<string>EnviousWispr uses Accessibility APIs to paste transcribed text into the active application.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025–2026 Envious Labs LLC. All rights reserved.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>EnviousWispr needs microphone access for speech-to-text dictation.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
 	<string>https://enviouswispr.com/appcast.xml</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025–2026 Envious Labs LLC. All rights reserved.</string>
 	<key>SUPublicEDKey</key>
 	<string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
 </dict>

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -94,6 +94,7 @@ final class AVAudioEngineSource: AudioInputSource {
     private var activeTasks: [Task<Void, Never>] = []
     private var tapStoppedFlag: TapStoppedFlag?
     private var isRecovering = false
+    private var forwarder: PreRollForwarder?
 
     /// Called when an audio device operation fails.
     var onDeviceError: ((String) -> Void)?
@@ -201,9 +202,11 @@ final class AVAudioEngineSource: AudioInputSource {
         btCrashLogger.info("Engine starting — stop token created, observer registered (queue: nil)")
         try engine.start()
         btCrashLogger.info("Engine started successfully")
-    }
 
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+        // Install pre-roll tap immediately after engine start.
+        // Format is stable for built-in mic (BT uses AVCaptureSessionSource).
+        // The tap routes through a PreRollForwarder that buffers audio until
+        // startCapture() activates live forwarding.
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
 
@@ -213,71 +216,67 @@ final class AVAudioEngineSource: AudioInputSource {
             channels: Self.targetChannels,
             interleaved: false
         ) else {
-            throw AudioError.formatCreationFailed
+            btCrashLogger.error("Pre-roll: failed to create target format — tap not installed")
+            return
         }
 
         guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            throw AudioError.formatCreationFailed
+            btCrashLogger.error("Pre-roll: failed to create converter from \(inputFormat) — tap not installed")
+            return
         }
         self.converter = audioConverter
+
+        let fwd = PreRollForwarder()
+        self.forwarder = fwd
+
+        let tapHandler = Self.makeTapHandler(
+            audioConverter: audioConverter,
+            targetFormat: targetFormat,
+            inputFormat: inputFormat,
+            forwarder: fwd,
+            stoppedFlag: stopToken
+        )
+        inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
+        AudioCaptureManager.btRouteLog("Pre-roll tap installed — capturing audio during setup latency")
+    }
+
+    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+        guard let fwd = forwarder else {
+            throw AudioError.formatCreationFailed
+        }
+
+        // Reset stoppedFlag in case a config change happened during pre-roll
+        tapStoppedFlag?.reset()
 
         let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
             self.bufferContinuation = continuation
         }
 
-        guard let stoppedFlag = self.tapStoppedFlag else {
-            throw AudioError.formatCreationFailed
-        }
-        stoppedFlag.reset()
-        btCrashLogger.info("startCapture: stop token reset, installing tap")
-
-        // Forward samples to the manager via callback. The manager owns capturedSamples accumulation.
-        // The source does NOT accumulate samples — avoids double-storage.
-        let onSamplesCallback = self.onSamples
-        let onSamples: @Sendable (Float, [Float]) -> Void = { level, samples in
-            onSamplesCallback?(samples, level)
-        }
-
-        let tapContinuation = self.bufferContinuation
-        let bufferCallback = self.onBufferCaptured
-
-        let bufferSize: AVAudioFrameCount = 4096
-        let tapHandler = Self.makeTapHandler(
-            audioConverter: audioConverter,
-            targetFormat: targetFormat,
-            inputFormat: inputFormat,
-            continuation: tapContinuation,
-            onSamples: onSamples,
-            onBuffer: bufferCallback,
-            stoppedFlag: stoppedFlag
+        // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
+        _ = fwd.activate(
+            onSamples: self.onSamples,
+            onBuffer: self.onBufferCaptured,
+            continuation: self.bufferContinuation,
+            logPrefix: "Pre-roll"
         )
-        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat, block: tapHandler)
-
-        if !engine.isRunning {
-            do {
-                try engine.start()
-            } catch {
-                stoppedFlag.set()
-                tapStoppedFlag = nil
-                inputNode.removeTap(onBus: 0)
-                bufferContinuation?.finish()
-                bufferContinuation = nil
-                converter = nil
-                if let observer = configChangeObserver {
-                    NotificationCenter.default.removeObserver(observer)
-                    configChangeObserver = nil
-                }
-                throw error
-            }
-        }
 
         isCapturing = true
         return stream
     }
 
+    func deactivateCapture() {
+        forwarder?.returnToPreRoll()
+        isCapturing = false
+        bufferContinuation = nil
+        AudioCaptureManager.btRouteLog("Engine deactivated — tap stays warm, pre-roll capturing")
+    }
+
     func stop() async -> [Float] {
         for task in activeTasks { task.cancel() }
         activeTasks.removeAll()
+
+        forwarder?.stop()
+        forwarder = nil
 
         tapStoppedFlag?.set()
         tapStoppedFlag = nil
@@ -288,7 +287,6 @@ final class AVAudioEngineSource: AudioInputSource {
         isCapturing = false
         currentInputDeviceID = nil
         isRecovering = false
-        bufferContinuation?.finish()
         bufferContinuation = nil
         converter = nil
         if let observer = configChangeObserver {
@@ -320,34 +318,20 @@ final class AVAudioEngineSource: AudioInputSource {
 
     func abortPrepare() {
         guard engine.isRunning, !isCapturing else { return }
-        engine.stop()
+        teardownEngine()
         try? engine.inputNode.setVoiceProcessingEnabled(false)
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
     }
 
     func rebuild() {
-        if engine.isRunning { engine.stop() }
-        engine.inputNode.removeTap(onBus: 0)
+        teardownEngine()
         engine.reset()
         engine = AVAudioEngine()
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
     }
 
     /// Build (or rebuild) the AVAudioEngine with voice-processing configuration.
     func buildEngine(noiseSuppression: Bool) {
-        if engine.isRunning { engine.stop() }
-        engine.inputNode.removeTap(onBus: 0)
+        teardownEngine()
         engine = AVAudioEngine()
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
 
         if noiseSuppression {
             do {
@@ -372,6 +356,21 @@ final class AVAudioEngineSource: AudioInputSource {
     /// Track a spawned Task so it can be cancelled during teardown.
     func trackTask(_ task: Task<Void, Never>) {
         activeTasks.append(task)
+    }
+
+    // MARK: - Private: Engine Teardown
+
+    /// Shared teardown: stop forwarder, stop engine, remove tap, remove config observer.
+    /// Does NOT reset or replace the engine (caller decides whether to do that).
+    private func teardownEngine() {
+        forwarder?.stop()
+        forwarder = nil
+        if engine.isRunning { engine.stop() }
+        engine.inputNode.removeTap(onBus: 0)
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
     }
 
     // MARK: - Private: Input Device
@@ -494,22 +493,27 @@ final class AVAudioEngineSource: AudioInputSource {
             stoppedFlag.reset()
             btCrashLogger.info("Recovery: stop token reset for new tap")
 
-            let onSamplesCallback = self.onSamples
-            let onSamples: @Sendable (Float, [Float]) -> Void = { level, samples in
-                onSamplesCallback?(samples, level)
+            guard let fwd = forwarder else {
+                throw AudioError.formatCreationFailed
             }
 
-            let tapContinuation = self.bufferContinuation
-            let bufferCallback = self.onBufferCaptured
+            // Validate format before reinstalling tap.
+            // After codec switch, format may be zero/invalid.
+            guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+                btCrashLogger.error("Recovery: invalid input format \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch — emergency teardown")
+                throw AudioError.formatCreationFailed
+            }
 
-            let bufferSize: AVAudioFrameCount = 4096
+            // Safety: remove tap again before reinstalling.
+            // AVAudioEngine may not fully clear tap state after engine.stop().
+            inputNode.removeTap(onBus: 0)
+
+            let bufferSize: AVAudioFrameCount = 2048
             let tapHandler = Self.makeTapHandler(
                 audioConverter: audioConverter,
                 targetFormat: targetFormat,
                 inputFormat: inputFormat,
-                continuation: tapContinuation,
-                onSamples: onSamples,
-                onBuffer: bufferCallback,
+                forwarder: fwd,
                 stoppedFlag: stoppedFlag
             )
             inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat, block: tapHandler)
@@ -538,6 +542,9 @@ final class AVAudioEngineSource: AudioInputSource {
         for task in activeTasks { task.cancel() }
         activeTasks.removeAll()
 
+        forwarder?.stop()
+        forwarder = nil
+
         tapStoppedFlag?.set()
         tapStoppedFlag = nil
 
@@ -548,7 +555,6 @@ final class AVAudioEngineSource: AudioInputSource {
         isCapturing = false
         currentInputDeviceID = nil
         isRecovering = false
-        bufferContinuation?.finish()
         bufferContinuation = nil
         converter = nil
 
@@ -566,9 +572,7 @@ final class AVAudioEngineSource: AudioInputSource {
         audioConverter: AVAudioConverter,
         targetFormat: AVAudioFormat,
         inputFormat: AVAudioFormat,
-        continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?,
-        onSamples: @escaping @Sendable (Float, [Float]) -> Void,
-        onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?,
+        forwarder: PreRollForwarder,
         stoppedFlag: TapStoppedFlag
     ) -> (AVAudioPCMBuffer, AVAudioTime) -> Void {
         return { buffer, _ in
@@ -619,11 +623,8 @@ final class AVAudioEngineSource: AudioInputSource {
                     start: channelData[0],
                     count: frameCount
                 ))
-                onSamples(level, samples)
+                forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
             }
-
-            onBuffer?(convertedBuffer)
-            continuation?.yield(convertedBuffer)
         }
     }
 }

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -31,6 +31,7 @@ final class AVCaptureSessionSource: AudioInputSource {
     private var audioOutput: AVCaptureAudioDataOutput?
     private var delegate: CaptureDelegate?
     private var interruptionObservers: [NSObjectProtocol] = []
+    private var forwarder: PreRollForwarder?
 
     /// Dedicated serial queue for AVCaptureSession start/stop operations.
     /// Apple recommends session lifecycle on a serial queue to avoid race conditions.
@@ -91,6 +92,18 @@ final class AVCaptureSessionSource: AudioInputSource {
         self.session = captureSession
         self.audioOutput = output
 
+        // Install pre-roll delegate to capture audio during setup latency.
+        // CaptureDelegate routes through PreRollForwarder, which buffers until
+        // startCapture() activates live forwarding.
+        let fwd = PreRollForwarder()
+        self.forwarder = fwd
+        let preRollDelegate = CaptureDelegate(
+            targetFormat: Self.targetFormat,
+            forwarder: fwd
+        )
+        self.delegate = preRollDelegate
+        output.setSampleBufferDelegate(preRollDelegate, queue: callbackQueue)
+
         // Register interruption observers
         registerInterruptionObservers(for: captureSession)
 
@@ -116,32 +129,37 @@ final class AVCaptureSessionSource: AudioInputSource {
         guard !isCapturing else {
             throw AudioError.alreadyCapturing
         }
-        guard let output = audioOutput else {
+        guard let fwd = forwarder else {
             throw AudioError.formatCreationFailed
         }
 
-        // Capture callbacks on @MainActor before entering AsyncStream closure (which may not be isolated)
-        let samplesCallback = onSamples
-        let bufferCallback = onBufferCaptured
-
-        let captureDelegate = CaptureDelegate(
-            onSamples: samplesCallback,
-            onBufferCaptured: bufferCallback,
-            targetFormat: Self.targetFormat
-        )
-        self.delegate = captureDelegate
-
-        output.setSampleBufferDelegate(captureDelegate, queue: callbackQueue)
-
         let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
-            captureDelegate.continuation = continuation
+            self.delegate?.continuation = continuation
         }
+
+        // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
+        _ = fwd.activate(
+            onSamples: self.onSamples,
+            onBuffer: self.onBufferCaptured,
+            continuation: self.delegate?.continuation,
+            logPrefix: "AVCaptureSessionSource"
+        )
 
         isCapturing = true
         return stream
     }
 
+    func deactivateCapture() {
+        forwarder?.returnToPreRoll()
+        isCapturing = false
+        delegate?.continuation = nil
+        AudioCaptureManager.btRouteLog("AVCaptureSession deactivated — session stays warm, pre-roll capturing")
+    }
+
     func stop() async -> [Float] {
+        forwarder?.stop()
+        forwarder = nil
+
         // Stop session FIRST — stopRunning() is synchronous per Apple docs, blocks until
         // the session stops and no new frames are delivered to callbackQueue.
         // RULE: Do NOT touch delegate, callback queue, or continuation state until
@@ -162,8 +180,6 @@ final class AVCaptureSessionSource: AudioInputSource {
         isCapturing = false
         removeInterruptionObservers()
 
-        // Finish the continuation so stream consumers see termination.
-        delegate?.continuation?.finish()
         delegate?.continuation = nil
         delegate = nil
 
@@ -178,27 +194,32 @@ final class AVCaptureSessionSource: AudioInputSource {
 
     func abortPrepare() {
         guard session?.isRunning == true, !isCapturing else { return }
-        // Fire-and-forget stop on session queue. abortPrepare is synchronous (protocol requirement)
-        // so we can't await. Using async avoids serial-queue self-deadlock risk.
-        let captureSession = session
-        sessionQueue.async {
-            captureSession?.stopRunning()
-        }
-        removeInterruptionObservers()
+        teardownSession(clearDelegate: false)
     }
 
     func rebuild() {
-        audioOutput?.setSampleBufferDelegate(nil, queue: nil)
-        delegate?.continuation?.finish()
-        delegate = nil
-        // Fire-and-forget stop — rebuild() is synchronous (protocol requirement).
+        teardownSession(clearDelegate: true)
+        session = nil
+        audioOutput = nil
+    }
+
+    /// Shared teardown: stop forwarder, fire-and-forget session stop, remove observers.
+    /// `clearDelegate` controls whether delegate/continuation are nil'd (rebuild needs it,
+    /// abortPrepare does not because session stop handles it).
+    private func teardownSession(clearDelegate: Bool) {
+        forwarder?.stop()
+        forwarder = nil
+        if clearDelegate {
+            audioOutput?.setSampleBufferDelegate(nil, queue: nil)
+            delegate?.continuation?.finish()
+            delegate = nil
+        }
+        // Fire-and-forget stop — synchronous protocol methods can't await.
         // Using async avoids serial-queue self-deadlock risk.
         let captureSession = session
         sessionQueue.async {
             captureSession?.stopRunning()
         }
-        session = nil
-        audioOutput = nil
         removeInterruptionObservers()
     }
 
@@ -276,25 +297,19 @@ final class AVCaptureSessionSource: AudioInputSource {
 /// Extracts Float32 samples from CMSampleBuffer and forwards via callbacks.
 private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate, @unchecked Sendable {
 
-    private let onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
-    private let onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
     /// Set after init by the AsyncStream closure.
     var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
     private let targetFormat: AVAudioFormat
+    private let forwarder: PreRollForwarder
 
     /// Track whether first buffer format has been validated.
     private var formatValidated = false
     /// If true, format was wrong — drop all subsequent buffers.
     private var formatMismatch = false
 
-    init(
-        onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?,
-        onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?,
-        targetFormat: AVAudioFormat
-    ) {
-        self.onSamples = onSamples
-        self.onBufferCaptured = onBufferCaptured
+    init(targetFormat: AVAudioFormat, forwarder: PreRollForwarder) {
         self.targetFormat = targetFormat
+        self.forwarder = forwarder
     }
 
     func captureOutput(
@@ -350,19 +365,13 @@ private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuf
         // Calculate audio level (RMS)
         let level = AudioBufferProcessor.calculateRMS(pcmBuffer)
 
-        // Extract [Float] samples
+        // Route through forwarder (pre-roll ring or live callbacks)
         if let channelData = pcmBuffer.floatChannelData {
             let samples = Array(UnsafeBufferPointer(
                 start: channelData[0],
                 count: frameCount
             ))
-            onSamples?(samples, level)
+            forwarder.route(samples: samples, level: level, buffer: pcmBuffer)
         }
-
-        // Forward buffer to streaming ASR
-        onBufferCaptured?(pcmBuffer)
-
-        // Yield to stream consumers
-        continuation?.yield(pcmBuffer)
     }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -7,8 +7,7 @@ import os
 ///
 /// Owns app-facing state (capturedSamples, audioLevel, isCapturing) and the
 /// `AudioCaptureInterface` contract. Delegates all hardware interaction to the
-/// active `AudioInputSource` (currently `AVAudioEngineSource`; `AVCaptureSessionSource`
-/// will be added in Step 6b.3).
+/// active `AudioInputSource` (`AVAudioEngineSource` or `AVCaptureSessionSource`).
 ///
 /// **Ownership boundaries:**
 /// - Sources own hardware/session/engine lifecycle, conversion, tap logic, recovery
@@ -63,6 +62,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// Route resolver — decides which source to use based on BT state + user preference.
     private var routeResolver = CaptureRouteResolver()
 
+    /// Idle teardown timer: shuts down the warm engine after inactivity.
+    private var warmEngineTeardownTask: Task<Void, Never>?
+
+    /// How long to keep the engine warm after recording stops (seconds).
+    private static let warmEngineIdleTimeout: TimeInterval = 30
+
     /// The last route decision — for telemetry and debugging.
     private var lastRouteDecision: CaptureRouteDecision?
 
@@ -95,7 +100,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     }
 
     public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard var source = activeSource else {
+        guard let source = activeSource else {
             throw AudioError.formatCreationFailed
         }
 
@@ -157,10 +162,20 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
         isCapturing = false
         audioLevel = 0.0
-        _ = await source.stop()
 
-        // Clear source so next recording re-evaluates BT state via resolver.
-        activeSource = nil
+        // Deactivate capture but keep engine warm. The tap stays installed and the
+        // pre-roll ring buffer continues capturing audio. On the next recording,
+        // prepare() sees the engine is already running and skips startup.
+        // This eliminates first-word clipping by ensuring the ring buffer has
+        // audio from before the user pressed the key.
+        source.deactivateCapture()
+
+        // Keep activeSource alive — resolveSource() will reuse it if still running.
+        // BT state changes are handled by resolveSource() re-evaluating the route.
+
+        // Schedule full teardown after idle period. Engine stays warm for rapid-fire
+        // dictation but doesn't run indefinitely.
+        scheduleWarmEngineTeardown()
 
         // Samples accumulated via onSamples callback → manager.capturedSamples
         let samples = capturedSamples
@@ -223,13 +238,52 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         (activeSource as? AVAudioEngineSource)?.trackTask(task)
     }
 
+    // MARK: - Warm Engine Management
+
+    /// Schedule full engine teardown after idle timeout.
+    /// Cancelled if a new recording starts before timeout fires.
+    private func scheduleWarmEngineTeardown() {
+        warmEngineTeardownTask?.cancel()
+        warmEngineTeardownTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.warmEngineIdleTimeout))
+            guard !Task.isCancelled, let self, !self.isCapturing else { return }
+            if let source = self.activeSource {
+                Self.btRouteLog("Warm engine idle timeout — full teardown")
+                _ = await source.stop()
+                self.activeSource = nil
+            }
+        }
+    }
+
     // MARK: - Source Management
 
     /// Resolve and create the appropriate capture source based on BT state and user preference.
     /// Re-evaluates on every call — BT state may change between recordings.
     private func resolveSource() -> any AudioInputSource {
-        // If a source is already running (e.g., pre-warmed), keep it.
-        if let existing = activeSource, existing.isRunning { return existing }
+        // Cancel idle teardown — we're about to record
+        warmEngineTeardownTask?.cancel()
+        warmEngineTeardownTask = nil
+
+        // If a source is already running (warm engine), check route compatibility
+        if let existing = activeSource, existing.isRunning {
+            let decision = routeResolver.resolve(
+                preferredInputDeviceUID: preferredInputDeviceIDOverride,
+                noiseSuppression: noiseSuppressionEnabled
+            )
+            let existingIsEngine = existing is AVAudioEngineSource
+            let wantsEngine = decision.sourceType == .audioEngine
+            if existingIsEngine == wantsEngine {
+                // Route unchanged — reuse warm source
+                lastRouteDecision = decision
+                Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
+                return existing
+            }
+            // Route changed (e.g., BT connected/disconnected) — synchronous teardown.
+            // Must be synchronous to avoid racing with new source's prepare() on same hardware.
+            Self.btRouteLog("Route changed while warm — tearing down old source")
+            existing.rebuild()
+            activeSource = nil
+        }
 
         let decision = routeResolver.resolve(
             preferredInputDeviceUID: preferredInputDeviceIDOverride,
@@ -261,12 +315,6 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
         activeSource = source
         return source
-    }
-
-    /// Get the active source, creating via resolver if needed.
-    private func ensureSource() -> any AudioInputSource {
-        if let source = activeSource { return source }
-        return resolveSource()
     }
 
     // MARK: - BT Route Logging (Step 6 instrumentation)

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -21,6 +21,12 @@ protocol AudioInputSource: AnyObject {
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>
     func stop() async -> [Float]
 
+    /// Deactivate live capture but keep engine/session and tap warm.
+    /// The forwarder returns to preRolling mode so the ring buffer continues
+    /// capturing audio for instant first-word capture on next recording.
+    /// Call stop() for full teardown.
+    func deactivateCapture()
+
     // State
     var isCapturing: Bool { get }
     var isRunning: Bool { get }

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -1,0 +1,268 @@
+@preconcurrency import AVFoundation
+import os
+
+/// Thread-safe state machine with preallocated ring buffer for pre-roll audio capture.
+///
+/// Eliminates first-word clipping by capturing audio between prepare() and startCapture().
+/// The tap handler routes converted audio through this forwarder, which buffers during
+/// pre-roll and forwards to live callbacks during capture.
+///
+/// Four modes:
+/// - `.preRolling` -- stores converted samples in ring buffer
+/// - `.activating` -- callbacks installed, still buffering (ordering transition)
+/// - `.capturing` -- forwards to live callbacks
+/// - `.stopped` -- drops all samples
+///
+/// Two-step activation ensures strict sample ordering (no live audio before pre-roll):
+/// 1. `beginActivation()` -- snapshots ring, installs callbacks, enters `.activating`
+/// 2. Caller feeds pre-roll through callbacks
+/// 3. `commitCapture()` -- drains delta, enters `.capturing`
+final class PreRollForwarder: @unchecked Sendable {
+
+    // MARK: - Types
+
+    enum Mode: Sendable {
+        case preRolling
+        case activating
+        case capturing
+        case stopped
+    }
+
+    private struct State: Sendable {
+        var mode: Mode = .preRolling
+        var ring: [Float]
+        var writeIdx: Int = 0
+        var count: Int = 0
+        var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
+        var onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?
+        var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+    }
+
+    // MARK: - State
+
+    /// Ring buffer capacity in samples. 500ms at 16kHz.
+    private let capacity: Int
+    private let lock: OSAllocatedUnfairLock<State>
+
+    // MARK: - Init
+
+    /// Create a forwarder with a preallocated ring buffer.
+    /// Default capacity: 8000 samples = 500ms at 16kHz = 32KB.
+    init(capacity: Int = 8000) {
+        self.capacity = capacity
+        lock = OSAllocatedUnfairLock(initialState: State(
+            ring: [Float](repeating: 0, count: capacity)
+        ))
+    }
+
+    // MARK: - Audio Thread
+
+    /// Route converted audio samples. Called from the audio thread on every tap callback.
+    ///
+    /// Lock hold time is minimal: mode check + memcpy (preRolling/activating) or pointer
+    /// copy (capturing). Callbacks are invoked OUTSIDE the lock.
+    func route(samples: [Float], level: Float, buffer: AVAudioPCMBuffer) {
+        enum Action {
+            case store
+            case forward(
+                onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?,
+                onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?,
+                continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+            )
+            case drop
+        }
+
+        let action: Action = lock.withLock { state in
+            switch state.mode {
+            case .preRolling, .activating:
+                appendToRing(samples, state: &state)
+                return .store
+            case .capturing:
+                return .forward(
+                    onSamples: state.onSamples,
+                    onBuffer: state.onBuffer,
+                    continuation: state.continuation
+                )
+            case .stopped:
+                return .drop
+            }
+        }
+
+        switch action {
+        case .store, .drop:
+            break
+        case .forward(let onSamples, let onBuffer, let continuation):
+            onSamples?(samples, level)
+            onBuffer?(buffer)
+            continuation?.yield(buffer)
+        }
+    }
+
+    // MARK: - MainActor (Two-Step Activation)
+
+    /// Step 1: Install callbacks, snapshot ring contents, enter `.activating` mode.
+    /// During `.activating`, `route()` still writes to ring (preserving ordering).
+    /// Returns the pre-roll samples captured since prepare().
+    func beginActivation(
+        onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?,
+        onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?,
+        continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+    ) -> [Float] {
+        lock.withLock { state in
+            state.onSamples = onSamples
+            state.onBuffer = onBuffer
+            state.continuation = continuation
+
+            let result = drainRing(&state)
+            state.mode = .activating
+            return result
+        }
+    }
+
+    /// Step 2: Drain any delta samples accumulated during activation, flip to `.capturing`.
+    /// After this call, `route()` forwards directly through callbacks.
+    func commitCapture() -> [Float] {
+        lock.withLock { state in
+            let delta = drainRing(&state)
+            state.mode = .capturing
+            return delta
+        }
+    }
+
+    /// Return to pre-rolling mode. Called when recording stops but engine stays warm.
+    /// Clears callbacks, finishes continuation, resets ring, but keeps forwarder alive
+    /// so the tap continues capturing audio for the next recording.
+    func returnToPreRoll() {
+        resetTo(mode: .preRolling)
+    }
+
+    /// Stop forwarding. Idempotent. Finishes the stream continuation.
+    func stop() {
+        resetTo(mode: .stopped)
+    }
+
+    /// Shared teardown: clear callbacks, finish continuation, reset ring, set target mode.
+    /// Idempotent for `.stopped` (skips if already stopped).
+    private func resetTo(mode targetMode: Mode) {
+        let cont: AsyncStream<AVAudioPCMBuffer>.Continuation? = lock.withLock { state in
+            if targetMode == .stopped, state.mode == .stopped { return nil }
+            let c = state.continuation
+            state.continuation = nil
+            state.onSamples = nil
+            state.onBuffer = nil
+            state.count = 0
+            state.writeIdx = 0
+            state.mode = targetMode
+            return c
+        }
+        cont?.finish()
+    }
+
+    // MARK: - Two-Step Activation (Convenience)
+
+    /// Full two-step activation: beginActivation, feed pre-roll, commitCapture, feed delta.
+    /// Consolidates the repeated pattern from both AVAudioEngineSource and AVCaptureSessionSource.
+    func activate(
+        onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?,
+        onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?,
+        continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?,
+        logPrefix: String
+    ) -> Int {
+        let preRollSamples = beginActivation(
+            onSamples: onSamples,
+            onBuffer: onBuffer,
+            continuation: continuation
+        )
+
+        if !preRollSamples.isEmpty {
+            Self.feedPreRoll(preRollSamples, onSamples: onSamples, onBuffer: onBuffer, continuation: continuation)
+            AudioCaptureManager.btRouteLog("\(logPrefix) pre-roll drained: \(preRollSamples.count) samples (\(Int(Double(preRollSamples.count) / 16000.0 * 1000))ms)")
+        } else {
+            AudioCaptureManager.btRouteLog("\(logPrefix) pre-roll empty: no samples buffered during setup")
+        }
+
+        let delta = commitCapture()
+        if !delta.isEmpty {
+            Self.feedPreRoll(delta, onSamples: onSamples, onBuffer: onBuffer, continuation: continuation)
+            AudioCaptureManager.btRouteLog("\(logPrefix) pre-roll delta: \(delta.count) samples")
+        }
+
+        return preRollSamples.count + delta.count
+    }
+
+    // MARK: - Pre-Roll Drain Helper
+
+    /// Feed drained pre-roll samples through callbacks and reconstructed AVAudioPCMBuffers.
+    /// Called from MainActor after beginActivation()/commitCapture() returns samples.
+    /// Chunks samples into ~40ms segments to match streaming ASR cadence.
+    static func feedPreRoll(
+        _ samples: [Float],
+        onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?,
+        onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?,
+        continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+    ) {
+        guard !samples.isEmpty else { return }
+
+        let rms = sqrt(samples.reduce(Float(0)) { $0 + $1 * $1 } / Float(samples.count))
+        onSamples?(samples, rms)
+
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ) else { return }
+
+        // ~40ms chunks at 16kHz
+        let chunkSize = 640
+        var offset = 0
+        while offset < samples.count {
+            let thisChunk = min(samples.count - offset, chunkSize)
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(thisChunk)
+            ) else {
+                offset += thisChunk
+                continue
+            }
+            buffer.frameLength = AVAudioFrameCount(thisChunk)
+            if let channelData = buffer.floatChannelData {
+                samples.withUnsafeBufferPointer { src in
+                    channelData[0].update(from: src.baseAddress! + offset, count: thisChunk)
+                }
+            }
+            onBuffer?(buffer)
+            continuation?.yield(buffer)
+            offset += thisChunk
+        }
+    }
+
+    // MARK: - Private
+
+    /// Append samples to the circular ring buffer. MUST be called under lock.
+    private func appendToRing(_ samples: [Float], state: inout State) {
+        for sample in samples {
+            state.ring[state.writeIdx] = sample
+            state.writeIdx = (state.writeIdx + 1) % capacity
+        }
+        state.count = min(state.count + samples.count, capacity)
+    }
+
+    /// Drain ring buffer contents in chronological order. Resets ring state.
+    /// MUST be called under lock.
+    private func drainRing(_ state: inout State) -> [Float] {
+        let count = state.count
+        guard count > 0 else { return [] }
+
+        var result = [Float]()
+        result.reserveCapacity(count)
+        let startIdx = (state.writeIdx - count + capacity) % capacity
+        for i in 0..<count {
+            result.append(state.ring[(startIdx + i) % capacity])
+        }
+
+        state.count = 0
+        state.writeIdx = 0
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Eliminates first-word clipping by keeping the audio engine warm between recordings with a 500ms ring buffer
- New `PreRollForwarder` type: thread-safe state machine with preallocated ring buffer, four modes, two-step activation for strict sample ordering
- Tap installed in `prepare()` instead of `startCapture()`, buffer size 4096->2048
- Warm engine with 30s idle timeout; route re-evaluation on reuse
- Crash hardening: redundant removeTap + format validation in codec switch recovery
- Version bump to 1.7.5

## Validation
- 10/10 first words captured on rapid PTT testing
- 500ms pre-roll drained on every warm recording
- Debug + release builds pass (Swift 6 strict concurrency)
- Council reviewed: GPT + Gemini (3 rounds, design iterated from two-tap to single-tap to warm engine)
- Code review + simplifier agents run, all findings addressed

## Test plan
- [ ] Rapid-fire PTT recordings (2-3s apart): verify first word captured on all
- [ ] Cold start recording: verify no regression (first word still captured, ~55ms gap vs old ~115ms)
- [ ] 30s+ idle between recordings: verify engine tears down and re-warms on next use
- [ ] BT headphone connect/disconnect between recordings: verify route re-evaluation
- [ ] Check bt-route.log for "Pre-roll drained" / "Reusing warm" telemetry
