### PR TITLE
feat(website): AEO improvements for AI engine visibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "94d3683633a7d46753f342e9f3a88aa4b34f5ee59ddd23f33784d978e46073e5",
+  "originHash" : "dd5b4dbe9936745d5301fc8796844af5b53b406b252774be1ab58576358da707",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"
+        "branch" : "35a1df1",
+        "revision" : "35a1df1efde4ad4e9aa7e8fdb94e385da2cb37b7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
-        .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"),
+        .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "35a1df1"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
         .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.5</string>
+	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.5</string>
+	<string>1.8.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -162,6 +162,27 @@ public final class ASRManager: ASRManagerInterface {
         idleTimer = nil
     }
 
+    // MARK: - CTC Vocabulary Boosting
+
+    public var isVocabularyBoostingReady: Bool {
+        // In-process: not currently tracked. Conservative: always attempt.
+        true
+    }
+
+    public func prepareVocabularyBoosting(_ config: VocabularyBoostingConfig) async {
+        guard activeBackendType == .parakeet else { return }
+        await parakeetBackend.prepareVocabularyBoosting(config)
+    }
+
+    public func clearVocabularyBoosting() async {
+        await parakeetBackend.clearVocabularyBoosting()
+    }
+
+    public func rescoreWithVocabulary(audioSamples: [Float], language: String) async -> ASRResult? {
+        guard activeBackendType == .parakeet else { return nil }
+        return await parakeetBackend.rescoreWithVocabulary(audioSamples: audioSamples, language: language)
+    }
+
     /// Schedule (or reset) the idle timer for timed policies.
     private func scheduleIdleTimer(policy: ModelUnloadPolicy) {
         guard let interval = policy.interval else { return }

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -43,4 +43,10 @@ public protocol ASRManagerInterface: AnyObject {
     // Crash notification — fires when XPC ASR service dies during an active session.
     // Wired by AppState to route to the active pipeline (same pattern as AudioCaptureProxy.onEngineInterrupted).
     var onServiceInterrupted: (() -> Void)? { get set }
+
+    // CTC vocabulary boosting (Parakeet limb)
+    var isVocabularyBoostingReady: Bool { get }
+    func prepareVocabularyBoosting(_ config: VocabularyBoostingConfig) async
+    func clearVocabularyBoosting() async
+    func rescoreWithVocabulary(audioSamples: [Float], language: String) async -> ASRResult?
 }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -261,6 +261,85 @@ public final class ASRManagerProxy: ASRManagerInterface {
         }
     }
 
+    // MARK: - CTC Vocabulary Boosting
+
+    /// Tracks whether vocabulary boosting has been prepared (app-side best-effort).
+    /// True after a successful prep call, false after clear or XPC crash.
+    private var vocabularyBoostingPrepared = false
+
+    public var isVocabularyBoostingReady: Bool { vocabularyBoostingPrepared }
+
+    public func prepareVocabularyBoosting(_ config: VocabularyBoostingConfig) async {
+        guard let configData = try? PropertyListEncoder().encode(config) else {
+            Task { await AppLogger.shared.log(
+                "[CTC] Failed to encode VocabularyBoostingConfig", level: .info, category: "CTC"
+            ) }
+            return
+        }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            serviceProxy { proxy in
+                proxy.prepareVocabularyBoosting(configData) { [weak self] error in
+                    if let error {
+                        Task { await AppLogger.shared.log(
+                            "[CTC] prepareVocabularyBoosting failed: \(error.localizedDescription)",
+                            level: .info, category: "CTC"
+                        ) }
+                    } else {
+                        self?.vocabularyBoostingPrepared = true
+                    }
+                    cont.resume()
+                }
+            } onProxyError: {
+                Task { await AppLogger.shared.log(
+                    "[CTC] prepareVocabularyBoosting: XPC service unreachable", level: .info, category: "CTC"
+                ) }
+                cont.resume()
+            }
+        }
+    }
+
+    public func clearVocabularyBoosting() async {
+        vocabularyBoostingPrepared = false
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            serviceProxy { proxy in
+                proxy.clearVocabularyBoosting {
+                    cont.resume()
+                }
+            } onProxyError: {
+                cont.resume()
+            }
+        }
+    }
+
+    public func rescoreWithVocabulary(audioSamples: [Float], language: String) async -> ASRResult? {
+        let data = audioSamples.withUnsafeBytes { Data($0) }
+
+        let result: (Data?, NSError?) = await withCheckedContinuation { (cont: CheckedContinuation<(Data?, NSError?), Never>) in
+            serviceProxy { proxy in
+                proxy.rescoreWithVocabulary(data, sampleCount: audioSamples.count, language: language) { resultData, error in
+                    cont.resume(returning: (resultData, error))
+                }
+            } onProxyError: {
+                Task { await AppLogger.shared.log(
+                    "[CTC] rescoreWithVocabulary: XPC service unreachable", level: .info, category: "CTC"
+                ) }
+                cont.resume(returning: (nil, nil))
+            }
+        }
+
+        if let error = result.1 {
+            Task { await AppLogger.shared.log(
+                "[CTC] rescoreWithVocabulary failed: \(error.localizedDescription)", level: .info, category: "CTC"
+            ) }
+            return nil
+        }
+        guard let resultData = result.0,
+              let decoded = try? PropertyListDecoder().decode(ASRResult.self, from: resultData) else {
+            return nil
+        }
+        return decoded
+    }
+
     // MARK: - XPC Connection
 
     private func ensureConnection() {
@@ -320,6 +399,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
                 if proxy.isModelLoaded {
                     proxy.isModelLoaded = false
                     proxy.isStreaming = false
+                    proxy.vocabularyBoostingPrepared = false
                 }
                 proxy.needsReinit = true
                 await AppLogger.shared.log(

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -21,6 +21,9 @@ public actor ParakeetBackend: ASRBackend {
     private var streamingManager: SlidingWindowAsrManager?
     private var streamingStartTime: CFAbsoluteTime = 0
 
+    // CTC vocabulary boosting limb (lazy, created on first prep request)
+    private var vocabularyBoostingLimb: ParakeetVocabularyBoostingLimb?
+
     public var supportsStreaming: Bool { true }
 
     public init() {}
@@ -177,9 +180,51 @@ public actor ParakeetBackend: ASRBackend {
             await streaming.cancel()
             streamingManager = nil
         }
+        if let limb = vocabularyBoostingLimb {
+            await limb.clear()
+            vocabularyBoostingLimb = nil
+        }
         await fluidAsrManager?.cleanup()
         fluidAsrManager = nil
         fluidModels = nil
         isReady = false
+    }
+
+    // MARK: - CTC Vocabulary Boosting (Limb)
+
+    /// Fire-and-forget: prepare CTC vocabulary boosting with the given config.
+    /// Creates the limb lazily on first call. No-ops if already ready with same config.
+    public func prepareVocabularyBoosting(_ config: VocabularyBoostingConfig) async {
+        guard isReady, let models = fluidModels else { return }
+
+        if vocabularyBoostingLimb == nil {
+            vocabularyBoostingLimb = ParakeetVocabularyBoostingLimb()
+        }
+        await vocabularyBoostingLimb!.requestPreparation(config: config, primaryModels: models)
+    }
+
+    /// Clear CTC vocabulary configuration and free CTC resources.
+    public func clearVocabularyBoosting() async {
+        await vocabularyBoostingLimb?.clear()
+    }
+
+    /// Re-transcribe audio through the CTC-boosted manager.
+    /// Returns nil if CTC is not ready or on any failure.
+    public func rescoreWithVocabulary(audioSamples: [Float], language: String) async -> ASRResult? {
+        guard let limb = vocabularyBoostingLimb else { return nil }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        guard let text = await limb.rescore(audioSamples: audioSamples, language: language) else {
+            return nil
+        }
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+
+        return ASRResult(
+            text: text,
+            language: language,
+            duration: 0,
+            processingTime: elapsed,
+            backendType: .parakeet
+        )
     }
 }

--- a/Sources/EnviousWisprASR/ParakeetVocabularyBoostingLimb.swift
+++ b/Sources/EnviousWisprASR/ParakeetVocabularyBoostingLimb.swift
@@ -1,0 +1,211 @@
+@preconcurrency import AVFoundation
+@preconcurrency import FluidAudio
+import EnviousWisprCore
+import Foundation
+
+/// CTC vocabulary boosting limb for the Parakeet backend.
+///
+/// Downloads the CTC model once, stores the vocabulary config, and creates a fresh
+/// boosted SlidingWindowAsrManager per rescore to avoid state contamination.
+/// Shares primary AsrModels with the heart manager (reference copy, not recompilation).
+///
+/// This is a LIMB: it may fail, time out, or be unavailable without affecting
+/// the heart path. Callers should always have the heart result ready as fallback.
+public actor ParakeetVocabularyBoostingLimb {
+
+    // MARK: - State
+
+    public enum State: Sendable {
+        case idle
+        case preparing(contentHash: String)
+        case ready(contentHash: String)
+        case failed(message: String)
+    }
+
+    public private(set) var state: State = .idle
+
+    // MARK: - Resources
+
+    private var loadedCtcModels: CtcModels?
+    private var storedVocabulary: CustomVocabularyContext?
+    private var storedPrimaryModels: AsrModels?
+    private var preparationTask: Task<Void, any Error>?
+    private var preparationGeneration: Int = 0
+
+    public init() {}
+
+    // MARK: - Preparation
+
+    /// Fire-and-forget: spawns background preparation task.
+    /// Downloads CTC model if needed, tokenizes vocabulary, validates config.
+    /// Safe to call multiple times; no-ops if already ready with same config.
+    public func requestPreparation(
+        config: VocabularyBoostingConfig,
+        primaryModels: AsrModels
+    ) {
+        guard !config.terms.isEmpty else {
+            clear()
+            return
+        }
+
+        let newHash = config.contentHash
+
+        // Already ready with same config
+        if case .ready(let hash) = state, hash == newHash {
+            self.storedPrimaryModels = primaryModels
+            return
+        }
+
+        // Already preparing for same config (don't cancel and restart)
+        if case .preparing(let hash) = state, hash == newHash {
+            self.storedPrimaryModels = primaryModels
+            return
+        }
+
+        // Cancel any in-flight preparation for a different config
+        preparationTask?.cancel()
+        preparationGeneration += 1
+        let generation = preparationGeneration
+
+        self.storedPrimaryModels = primaryModels
+        state = .preparing(contentHash: newHash)
+
+        preparationTask = Task {
+            do {
+                try Task.checkCancellation()
+
+                // Download CTC models if not cached (~64MB, one-time)
+                let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+
+                try Task.checkCancellation()
+
+                // Build vocabulary context with FluidVoice-derived thresholds
+                let terms = config.terms.map { term in
+                    CustomVocabularyTerm(
+                        text: term.canonical,
+                        aliases: term.aliases.isEmpty ? nil : term.aliases
+                    )
+                }
+                let vocabulary = CustomVocabularyContext(
+                    terms: terms,
+                    alpha: 2.8,
+                    minCtcScore: -2.2,
+                    minSimilarity: 0.72,
+                    minCombinedConfidence: 0.64
+                )
+
+                try Task.checkCancellation()
+
+                // Generation check: only commit if we're still the current preparation
+                guard self.isCurrentGeneration(generation) else { return }
+
+                self.loadedCtcModels = models
+                self.storedVocabulary = vocabulary
+                self.state = .ready(contentHash: newHash)
+
+                Task { await AppLogger.shared.log(
+                    "CTC vocabulary boosting ready (\(config.terms.count) terms, hash: \(newHash))",
+                    level: .info, category: "CTC"
+                ) }
+            } catch is CancellationError {
+                // Superseded by newer preparation; silently discard
+            } catch {
+                guard self.isCurrentGeneration(generation) else { return }
+                self.state = .failed(message: error.localizedDescription)
+                Task { await AppLogger.shared.log(
+                    "CTC vocabulary boosting preparation failed: \(error.localizedDescription)",
+                    level: .info, category: "CTC"
+                ) }
+            }
+        }
+    }
+
+    /// Clear vocabulary configuration and free CTC resources.
+    public func clear() {
+        preparationTask?.cancel()
+        preparationTask = nil
+        preparationGeneration += 1  // Invalidate any in-flight task past its last checkCancellation
+        loadedCtcModels = nil
+        storedVocabulary = nil
+        state = .idle
+    }
+
+    // MARK: - Rescore
+
+    /// Re-transcribe audio through a CTC-boosted SlidingWindowAsrManager.
+    /// Creates a fresh manager per call to avoid decoder state contamination.
+    /// Returns nil if not ready or on any failure (limb pattern: silent fallback).
+    public func rescore(audioSamples: [Float], language: String) async -> String? {
+        guard case .ready = state else { return nil }
+        guard let models = storedPrimaryModels,
+              let ctcModels = loadedCtcModels,
+              let vocabulary = storedVocabulary else { return nil }
+
+        let rescoreStart = CFAbsoluteTimeGetCurrent()
+
+        do {
+            // Fresh manager per rescore: no state contamination between utterances.
+            // Configure vocabulary BEFORE start to match FluidAudio's documented lifecycle.
+            let config = SlidingWindowAsrConfig.streaming
+            let manager = SlidingWindowAsrManager(config: config)
+            try await manager.configureVocabularyBoosting(
+                vocabulary: vocabulary,
+                ctcModels: ctcModels
+            )
+            try await manager.start(models: models, source: .microphone)
+
+            // Feed all audio as a single buffer for batch-final transcription
+            guard let buffer = Self.samplesToBuffer(audioSamples) else { return nil }
+            nonisolated(unsafe) let unsafeBuffer = buffer
+            await manager.streamAudio(unsafeBuffer)
+
+            let text = try await manager.finish()
+            let elapsed = CFAbsoluteTimeGetCurrent() - rescoreStart
+
+            Task { await AppLogger.shared.log(
+                "CTC rescore completed in \(String(format: "%.3f", elapsed))s: \(text.prefix(80))...",
+                level: .info, category: "CTC"
+            ) }
+
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            Task { await AppLogger.shared.log(
+                "CTC rescore failed (limb, non-fatal): \(error.localizedDescription)",
+                level: .info, category: "CTC"
+            ) }
+            return nil
+        }
+    }
+
+    public var isReady: Bool {
+        if case .ready = state { return true }
+        return false
+    }
+
+    // MARK: - Private
+
+    private func isCurrentGeneration(_ gen: Int) -> Bool {
+        gen == preparationGeneration
+    }
+
+    /// Convert Float32 samples to AVAudioPCMBuffer for SlidingWindowAsrManager.
+    private static func samplesToBuffer(_ samples: [Float]) -> AVAudioPCMBuffer? {
+        guard !samples.isEmpty else { return nil }
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        ) else { return nil }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ) else { return nil }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        samples.withUnsafeBufferPointer { src in
+            buffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
+        }
+        return buffer
+    }
+}

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -225,5 +225,68 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void) {
         reply(backendType == "parakeet")
     }
+
+    // MARK: - CTC Vocabulary Boosting
+
+    func prepareVocabularyBoosting(_ configData: Data, reply: @escaping (NSError?) -> Void) {
+        nonisolated(unsafe) let safeReply = reply
+
+        guard let parakeet = parakeetBackend else {
+            safeReply(VocabularyBoostingError.unsupportedBackend.toNSError())
+            return
+        }
+
+        guard let config = try? PropertyListDecoder().decode(VocabularyBoostingConfig.self, from: configData) else {
+            safeReply(VocabularyBoostingError.preparationFailed.toNSError(message: "Invalid config data"))
+            return
+        }
+
+        Task { @MainActor in
+            await parakeet.prepareVocabularyBoosting(config)
+            safeReply(nil)
+        }
+    }
+
+    func clearVocabularyBoosting(reply: @escaping () -> Void) {
+        nonisolated(unsafe) let safeReply = reply
+        guard let parakeet = parakeetBackend else { safeReply(); return }
+        Task { @MainActor in
+            await parakeet.clearVocabularyBoosting()
+            safeReply()
+        }
+    }
+
+    func rescoreWithVocabulary(_ audioData: Data, sampleCount: Int, language: String, reply: @escaping (Data?, NSError?) -> Void) {
+        nonisolated(unsafe) let safeReply = reply
+
+        guard let parakeet = parakeetBackend else {
+            safeReply(nil, VocabularyBoostingError.unsupportedBackend.toNSError())
+            return
+        }
+
+        guard audioData.count == sampleCount * MemoryLayout<Float>.size else {
+            safeReply(nil, VocabularyBoostingError.preparationFailed.toNSError(message: "Audio data size mismatch"))
+            return
+        }
+
+        Task { @MainActor in
+            let samples = audioData.withUnsafeBytes { raw -> [Float] in
+                guard raw.count > 0 else { return [] }
+                return Array(raw.bindMemory(to: Float.self))
+            }
+
+            guard let result = await parakeet.rescoreWithVocabulary(audioSamples: samples, language: language) else {
+                safeReply(nil, VocabularyBoostingError.notReady.toNSError())
+                return
+            }
+
+            do {
+                let encoded = try PropertyListEncoder().encode(result)
+                safeReply(encoded, nil)
+            } catch {
+                safeReply(nil, error as NSError)
+            }
+        }
+    }
 }
 

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -322,7 +322,7 @@ final class AVAudioEngineSource: AudioInputSource {
         try? engine.inputNode.setVoiceProcessingEnabled(false)
     }
 
-    func rebuild() {
+    func rebuild() async {
         teardownEngine()
         engine.reset()
         engine = AVAudioEngine()

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -197,15 +197,31 @@ final class AVCaptureSessionSource: AudioInputSource {
         teardownSession(clearDelegate: false)
     }
 
-    func rebuild() {
-        teardownSession(clearDelegate: true)
+    func rebuild() async {
+        forwarder?.stop()
+        forwarder = nil
+        audioOutput?.setSampleBufferDelegate(nil, queue: nil)
+        delegate?.continuation?.finish()
+        delegate = nil
+        // Await session stop completion to prevent overlap with new source on same hardware.
+        // Previous version was fire-and-forget which raced BT route changes.
+        if let captureSession = session {
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                sessionQueue.async {
+                    captureSession.stopRunning()
+                    cont.resume()
+                }
+            }
+        }
         session = nil
         audioOutput = nil
+        removeInterruptionObservers()
     }
 
     /// Shared teardown: stop forwarder, fire-and-forget session stop, remove observers.
     /// `clearDelegate` controls whether delegate/continuation are nil'd (rebuild needs it,
     /// abortPrepare does not because session stop handles it).
+    /// Note: this is fire-and-forget (used by abortPrepare). For awaitable teardown, use rebuild().
     private func teardownSession(clearDelegate: Bool) {
         forwarder?.stop()
         forwarder = nil
@@ -214,8 +230,6 @@ final class AVCaptureSessionSource: AudioInputSource {
             delegate?.continuation?.finish()
             delegate = nil
         }
-        // Fire-and-forget stop — synchronous protocol methods can't await.
-        // Using async avoids serial-queue self-deadlock risk.
         let captureSession = session
         sessionQueue.async {
             captureSession?.stopRunning()

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -95,7 +95,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
     public func startEnginePhase() async throws {
         // Re-evaluate route on every recording start — BT state may have changed.
-        let source = resolveSource()
+        let source = await resolveSource()
         try await source.prepare()
     }
 
@@ -184,7 +184,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     }
 
     public func rebuildEngine() {
-        activeSource?.rebuild()
+        Task { await activeSource?.rebuild() }
     }
 
     public func buildEngine(noiseSuppression: Bool) {
@@ -196,8 +196,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         if let engineSource = activeSource as? AVAudioEngineSource {
             engineSource.buildEngine(noiseSuppression: noiseSuppression)
         } else {
-            // Tear down any existing non-engine source before replacing
-            activeSource?.rebuild()
+            // Tear down any existing non-engine source before replacing.
+            // Fire-and-forget: buildEngine is called at startup, teardown can complete async.
+            let oldSource = activeSource
+            Task { await oldSource?.rebuild() }
             let engineSource = AVAudioEngineSource()
             engineSource.buildEngine(noiseSuppression: noiseSuppression)
             activeSource = engineSource
@@ -205,7 +207,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     }
 
     public func preWarm() async {
-        let source = resolveSource()
+        let source = await resolveSource()
         guard !source.isRunning else { return }
         do {
             try await source.prepare()
@@ -259,12 +261,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
     /// Resolve and create the appropriate capture source based on BT state and user preference.
     /// Re-evaluates on every call — BT state may change between recordings.
-    private func resolveSource() -> any AudioInputSource {
+    private func resolveSource() async -> any AudioInputSource {
         // Cancel idle teardown — we're about to record
         warmEngineTeardownTask?.cancel()
         warmEngineTeardownTask = nil
 
-        // If a source is already running (warm engine), check route compatibility
+        // If a source is already running (warm engine), check route + config compatibility
         if let existing = activeSource, existing.isRunning {
             let decision = routeResolver.resolve(
                 preferredInputDeviceUID: preferredInputDeviceIDOverride,
@@ -272,16 +274,26 @@ public final class AudioCaptureManager: AudioCaptureInterface {
             )
             let existingIsEngine = existing is AVAudioEngineSource
             let wantsEngine = decision.sourceType == .audioEngine
-            if existingIsEngine == wantsEngine {
-                // Route unchanged — reuse warm source
+
+            // Check full config signature, not just source type.
+            // Device/VP changes between recordings must trigger rebuild.
+            var configMatch = existingIsEngine == wantsEngine
+            if configMatch, let engineSource = existing as? AVAudioEngineSource {
+                let deviceMatch = engineSource.preferredInputDeviceIDOverride == preferredInputDeviceIDOverride
+                let vpMatch = engineSource.noiseSuppressionEnabled == noiseSuppressionEnabled
+                configMatch = deviceMatch && vpMatch
+            }
+
+            if configMatch {
+                // Route and config unchanged, reuse warm source
                 lastRouteDecision = decision
-                Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
+                Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source (config match)")
                 return existing
             }
             // Route changed (e.g., BT connected/disconnected) — synchronous teardown.
             // Must be synchronous to avoid racing with new source's prepare() on same hardware.
             Self.btRouteLog("Route changed while warm — tearing down old source")
-            existing.rebuild()
+            await existing.rebuild()
             activeSource = nil
         }
 

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -34,5 +34,5 @@ protocol AudioInputSource: AnyObject {
     // Engine-specific (no-op for AVCaptureSessionSource)
     func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
     func abortPrepare()
-    func rebuild()
+    func rebuild() async
 }

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -239,13 +239,31 @@ final class PreRollForwarder: @unchecked Sendable {
 
     // MARK: - Private
 
-    /// Append samples to the circular ring buffer. MUST be called under lock.
+    /// Append samples to the circular ring buffer via bulk memcpy. MUST be called under lock.
+    /// Handles wrap-around (at most 2 copies) and overflow (keeps last `capacity` samples).
     private func appendToRing(_ samples: [Float], state: inout State) {
-        for sample in samples {
-            state.ring[state.writeIdx] = sample
-            state.writeIdx = (state.writeIdx + 1) % capacity
+        guard !samples.isEmpty, capacity > 0 else { return }
+
+        let n = samples.count
+        let retainedCount = min(n, capacity)
+        let srcStart = n - retainedCount
+        let dstStart = (n >= capacity) ? (state.writeIdx + n) % capacity : state.writeIdx
+        let finalWriteIdx = (state.writeIdx + n) % capacity
+
+        state.ring.withUnsafeMutableBufferPointer { dst in
+            samples.withUnsafeBufferPointer { src in
+                guard let dstBase = dst.baseAddress, let srcBase = src.baseAddress else { return }
+                let srcPtr = srcBase.advanced(by: srcStart)
+                let firstChunk = min(retainedCount, capacity - dstStart)
+                memcpy(dstBase.advanced(by: dstStart), srcPtr, firstChunk * MemoryLayout<Float>.size)
+                if retainedCount > firstChunk {
+                    memcpy(dstBase, srcPtr.advanced(by: firstChunk), (retainedCount - firstChunk) * MemoryLayout<Float>.size)
+                }
+            }
         }
-        state.count = min(state.count + samples.count, capacity)
+
+        state.writeIdx = finalWriteIdx
+        state.count = min(state.count + n, capacity)
     }
 
     /// Drain ring buffer contents in chronological order. Resets ring state.

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -59,6 +59,25 @@ import Foundation
 
     /// Check whether the specified backend supports streaming transcription.
     func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void)
+
+    // MARK: - CTC Vocabulary Boosting
+
+    /// Fire-and-forget: enqueue CTC vocabulary preparation in the ASR service.
+    /// - Parameter configData: PropertyList-encoded VocabularyBoostingConfig.
+    /// - Parameter reply: nil on success (prep enqueued), NSError on validation failure.
+    func prepareVocabularyBoosting(_ configData: Data, reply: @escaping (NSError?) -> Void)
+
+    /// Clear CTC vocabulary configuration and free CTC resources.
+    func clearVocabularyBoosting(reply: @escaping () -> Void)
+
+    /// Re-transcribe audio with CTC-boosted vocabulary and return the improved result.
+    /// Fails fast with VocabularyBoostingError if preparation is not complete.
+    /// - Parameters:
+    ///   - audioData: Raw Float32 PCM bytes (16kHz mono).
+    ///   - sampleCount: Number of Float32 samples.
+    ///   - language: ISO 639-1 language code.
+    ///   - reply: (Codable-encoded ASRResult as Data, or nil) + (NSError or nil).
+    func rescoreWithVocabulary(_ audioData: Data, sampleCount: Int, language: String, reply: @escaping (Data?, NSError?) -> Void)
 }
 
 /// XPC protocol: callbacks from ASR service to host app.

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -36,8 +36,8 @@ public enum AudioConstants {
     /// Audio channels for recording (mono).
     public static let channels: Int = 1
 
-    /// Audio buffer size for capture tap (256ms at 16kHz).
-    public static let captureBufferSize: Int = 4096
+    /// Audio buffer size for capture tap (128ms at 16kHz).
+    public static let captureBufferSize: Int = 2048
 
     /// Minimum samples required for valid transcription (1 second).
     public static let minimumTranscriptionSamples: Int = 16000

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -32,6 +32,27 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     }
 }
 
+extension CustomWord {
+    /// Whether this word is safe for CTC vocabulary boosting.
+    /// CTC-safe terms are rare proper nouns with low acoustic confuser risk.
+    /// Short common English words with acoustic collisions (cloud/Claude, counsel/Council)
+    /// are excluded to prevent false positives. These stay on the WordCorrector path.
+    ///
+    /// Known unsafe terms are blocklisted. All others pass through.
+    /// This is conservative: we only block known confusers.
+    public var isCTCSafe: Bool {
+        let lower = canonical.lowercased()
+        // Blocklist: terms with known acoustic confusers against common English words.
+        // These were identified during CTC eval (21+ runs, benchmark-results/ctc-eval/).
+        let unsafeTerms: Set<String> = [
+            "claude",       // cloud, cloudy, clawed
+            "council",      // counsel, counselor
+            "beads",        // beady, beats
+        ]
+        return !unsafeTerms.contains(lower)
+    }
+}
+
 extension Array where Element == CustomWord {
     public var canonicals: [String] { map(\.canonical) }
 }

--- a/Sources/EnviousWisprCore/VocabularyBoostingTypes.swift
+++ b/Sources/EnviousWisprCore/VocabularyBoostingTypes.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Configuration for CTC vocabulary boosting, transported across XPC as Codable Data.
+///
+/// Serialized via PropertyListEncoder for XPC transport. The ASR service process
+/// receives this, tokenizes terms with the CTC tokenizer, and configures the
+/// boosted AsrManager.
+public struct VocabularyBoostingConfig: Codable, Sendable {
+    public let terms: [Term]
+    public let revision: Int
+
+    public struct Term: Codable, Sendable {
+        public let canonical: String
+        public let aliases: [String]
+
+        public init(canonical: String, aliases: [String] = []) {
+            self.canonical = canonical
+            self.aliases = aliases
+        }
+    }
+
+    public init(terms: [Term], revision: Int) {
+        self.terms = terms
+        self.revision = revision
+    }
+
+    /// Content-based identity for detecting config changes.
+    /// Hashes canonicals AND aliases so alias-only edits trigger re-preparation.
+    public var contentHash: String {
+        let payload = terms
+            .sorted { $0.canonical < $1.canonical }
+            .map { term in
+                let aliases = term.aliases.sorted().joined(separator: "|")
+                return "\(term.canonical):\(aliases)"
+            }
+            .joined(separator: "\n")
+        // Simple deterministic hash; not cryptographic, just change-detection.
+        var hasher = Hasher()
+        hasher.combine(payload)
+        return String(hasher.finalize(), radix: 16)
+    }
+}
+
+/// Errors from CTC vocabulary boosting, carried across XPC as NSError.
+public enum VocabularyBoostingError: Int, Sendable {
+    case notReady = 1
+    case notConfigured = 2
+    case unsupportedBackend = 3
+    case preparationFailed = 4
+
+    public static let domain = "com.enviouswispr.vocabulary-boosting"
+
+    public func toNSError(message: String? = nil) -> NSError {
+        let description: String
+        switch self {
+        case .notReady: description = message ?? "CTC vocabulary boosting is not ready yet"
+        case .notConfigured: description = message ?? "No vocabulary configured"
+        case .unsupportedBackend: description = message ?? "CTC vocabulary boosting requires Parakeet backend"
+        case .preparationFailed: description = message ?? "CTC preparation failed"
+        }
+        return NSError(
+            domain: Self.domain,
+            code: rawValue,
+            userInfo: [NSLocalizedDescriptionKey: description]
+        )
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -149,6 +149,11 @@ public final class TranscriptionPipeline: DictationPipeline {
             guard !Task.isCancelled else { return }
         }
 
+        // Fire-and-forget: sync CTC vocabulary config to ASR service.
+        // Runs in background; CTC prep may still be in progress when recording starts.
+        // If not ready by rescore time, limb returns nil and heart result is used.
+        syncVocabularyBoostingIfNeeded()
+
         // Remember the frontmost app and focused text field so we can paste back
         // (LLM polishing can take seconds, during which focus may shift)
         targetApp = NSWorkspace.shared.frontmostApplication
@@ -421,6 +426,9 @@ public final class TranscriptionPipeline: DictationPipeline {
             samples = rawSamples
         }
 
+        // Capture real speech length before padding (used for streaming fallback decision).
+        let prePaddingSampleCount = samples.count
+
         // Pad short recordings with silence so single-word inputs ("hey", "hi") work.
         if samples.count > 0 && samples.count < minimumSamples {
             samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
@@ -438,11 +446,19 @@ public final class TranscriptionPipeline: DictationPipeline {
             // Use streaming finalize when available for lowest latency.
             // FluidAudio fork uses fresh decoder state per chunk + chunk-aware text assembly
             // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
-            // Falls back to batch transcription when streaming was not active.
+            // Falls back to batch transcription when streaming was not active or audio is too short.
+            //
+            // Short-audio fallback: streaming mode has no minimum-duration safeguard
+            // (the padding at line 430 only applies to the batch samples variable).
+            // Sub-1s streaming produces hallucinations ("testing four" -> "testing for the U.S.").
+            // Cancel streaming and use the padded batch path instead.
             let result: ASRResult
-            if wasStreaming {
+            if wasStreaming, prePaddingSampleCount >= minimumSamples {
                 result = try await asrManager.finalizeStreaming()
             } else {
+                if wasStreaming {
+                    await asrManager.cancelStreaming()
+                }
                 result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
             }
 
@@ -477,11 +493,32 @@ public final class TranscriptionPipeline: DictationPipeline {
                 level: .info, category: "PipelineTiming"
             ) }
 
+            // CTC vocabulary boosting limb: re-transcribe with CTC-boosted manager.
+            // Only attempt if vocabulary boosting is prepared (avoids sending the full
+            // audio buffer over XPC when there's nothing to rescore).
+            // Limb: returns nil on any failure, heart result is always the fallback.
+            var effectiveAsrText = asrText
+            if asrManager.isVocabularyBoostingReady,
+               let ctcResult = await asrManager.rescoreWithVocabulary(
+                audioSamples: samples,
+                language: result.language ?? "en"
+            ) {
+                let ctcText = ctcResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !ctcText.isEmpty {
+                    Task { await AppLogger.shared.log(
+                        "CTC rescore changed text (\(String(format: "%.3f", ctcResult.processingTime))s): " +
+                        "[\(asrText.prefix(60))] -> [\(ctcText.prefix(60))]",
+                        level: .info, category: "CTC"
+                    ) }
+                    effectiveAsrText = ctcText
+                }
+            }
+
             // Run pluggable text processing steps (word correction, LLM polish, etc.)
             let polishStart = CFAbsoluteTimeGetCurrent()
             var context: TextProcessingContext
             do {
-                context = try await runTextProcessing(asrText: asrText, language: result.language)
+                context = try await runTextProcessing(asrText: effectiveAsrText, language: result.language)
             } catch {
                 SentryBreadcrumb.captureError(error, category: .generationFailed, stage: "polish", extra: [
                     "provider": llmPolishStep.llmProvider.rawValue,
@@ -501,7 +538,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                     level: .info, category: "Pipeline"
                 ) }
                 lastPolishError = error.localizedDescription
-                context = TextProcessingContext(text: asrText, originalASRText: asrText, language: result.language)
+                context = TextProcessingContext(text: effectiveAsrText, originalASRText: effectiveAsrText, language: result.language)
                 context.targetAppBundleID = targetApp?.bundleIdentifier
                 context.targetAppName = targetApp?.localizedName
             }
@@ -991,6 +1028,39 @@ public final class TranscriptionPipeline: DictationPipeline {
 
     // MARK: - Text Processing
 
+    /// Sync current custom words to CTC vocabulary boosting in the ASR service.
+    /// Fire-and-forget: CTC prep runs in background. If not ready by rescore time,
+    /// the limb returns nil and heart result is used unchanged.
+    private func syncVocabularyBoostingIfNeeded() {
+        guard asrManager.activeBackendType == .parakeet else { return }
+
+        let words = wordCorrectionStep.customWords
+
+        // Filter to CTC-safe terms only: rare proper nouns with low confuser risk.
+        // Common English words with acoustic collisions (cloud/Claude, counsel/Council)
+        // stay on the WordCorrector + LLM hints path.
+        let safeTerms = words.compactMap { word -> VocabularyBoostingConfig.Term? in
+            guard word.isCTCSafe else { return nil }
+            return VocabularyBoostingConfig.Term(
+                canonical: word.canonical,
+                aliases: word.aliases
+            )
+        }
+
+        // Clear stale boosting when no safe terms remain (covers both
+        // "all words deleted" and "only CTC-unsafe words left" paths).
+        guard !safeTerms.isEmpty else {
+            Task { await asrManager.clearVocabularyBoosting() }
+            return
+        }
+
+        let config = VocabularyBoostingConfig(
+            terms: safeTerms,
+            revision: safeTerms.count // Simple revision; content hash handles change detection
+        )
+        Task { await asrManager.prepareVocabularyBoosting(config) }
+    }
+
     private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
         var context = TextProcessingContext(
             text: asrText,
@@ -1002,7 +1072,7 @@ public final class TranscriptionPipeline: DictationPipeline {
         Task {
             await AppLogger.shared.log(
                 "CORRECTION_DEBUG [RAW ASR] \(asrText)",
-                level: .info, category: "CorrectionDebug"
+                level: .verbose, category: "CorrectionDebug"
             )
         }
         for step in textProcessingSteps where step.isEnabled {
@@ -1027,20 +1097,20 @@ public final class TranscriptionPipeline: DictationPipeline {
                         "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
                         level: .info, category: "PipelineTiming"
                     )
-                    // Debug: log text at each correction layer
+                    // Debug: log text at each correction layer (verbose: contains user content)
                     if changed {
                         await AppLogger.shared.log(
                             "CORRECTION_DEBUG [\(stepName)] IN:  \(inputText)",
-                            level: .info, category: "CorrectionDebug"
+                            level: .verbose, category: "CorrectionDebug"
                         )
                         await AppLogger.shared.log(
                             "CORRECTION_DEBUG [\(stepName)] OUT: \(outputText)",
-                            level: .info, category: "CorrectionDebug"
+                            level: .verbose, category: "CorrectionDebug"
                         )
                     } else {
                         await AppLogger.shared.log(
                             "CORRECTION_DEBUG [\(stepName)] no change",
-                            level: .info, category: "CorrectionDebug"
+                            level: .verbose, category: "CorrectionDebug"
                         )
                     }
                 }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -111,15 +111,15 @@ public struct WordCorrector: Sendable {
         }
 
         // Pass 0: N-gram compound matching
-        // Concatenate 1-3 adjacent words (stripped of punctuation, lowercased, spaces removed)
+        // Concatenate 1-4 adjacent words (stripped of punctuation, lowercased, spaces removed)
         // and check against nospace canonical/alias map.
-        // "Chat G P T" -> "chatgpt" matches "ChatGPT"
+        // "Chat G P T" (4 tokens) -> "chatgpt" matches "ChatGPT"
         if !nospaceCanonicalMap.isEmpty {
             var i = 0
             while i < tokens.count {
                 var matched = false
 
-                for n in (1...min(3, tokens.count - i)).reversed() {
+                for n in (1...min(4, tokens.count - i)).reversed() {
                     let slice = tokens[i..<(i + n)]
                     let ngram = slice
                         .map { stripPunctuation($0).lowercased() }

--- a/website/src/content/blog/async-communication-better-when-you-speak.md
+++ b/website/src/content/blog/async-communication-better-when-you-speak.md
@@ -4,6 +4,7 @@ description: "Why dictating Slack messages, emails, and async updates beats typi
 pubDate: 2026-03-17
 tags: ["remote-work", "async-communication", "dictation", "productivity", "slack"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Most people type at 40 words per minute but speak at 150. In async-heavy remote work, that gap costs you hours every week -- and worse, it degrades the quality of what you write. By 3 PM, your hands are tired and your messages have gotten shorter, vaguer, and harder for your teammates to act on.

--- a/website/src/content/blog/building-commercial-software-solo-with-claude-code.md
+++ b/website/src/content/blog/building-commercial-software-solo-with-claude-code.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-26
 tags: ["claude-code", "vibe-coding", "solo-dev", "ai-tools", "productivity"]
 image: "/images/blog/claude-code-structure/three-pillars.jpg"
 draft: false
+author: "Saurabh Vaish"
 ---
 
 I've been building EnviousWispr, a commercial macOS voice-to-text app, entirely by myself using Claude Code. Along the way I made a lot of mistakes, rewrote things I didn't need to, and lost context between sessions more times than I'd like to admit.

--- a/website/src/content/blog/dictate-emails-speed-of-thought.md
+++ b/website/src/content/blog/dictate-emails-speed-of-thought.md
@@ -4,6 +4,7 @@ description: "Stop typing emails between meetings. Dictate on-device with speech
 pubDate: 2026-03-13
 tags: ["dictation", "email", "productivity", "executive", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 The average executive types around 40 words per minute. They speak 130 to 150. That's roughly 3-4x throughput on the single activity that dominates their day: writing emails — and that's a rough estimate, not a measured fact, but the gap is real and it compounds across dozens of messages a day.

--- a/website/src/content/blog/dictate-first-drafts-sound-like-you.md
+++ b/website/src/content/blog/dictate-first-drafts-sound-like-you.md
@@ -4,6 +4,7 @@ description: "Most dictation tools strip your voice. Here's how to dictate first
 pubDate: 2026-03-14
 tags: ["writing", "dictation", "workflow", "writing-style"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Every dictation tool on the market is lying to you about the same thing. They promise "natural-sounding text" and then hand you output that reads like it was written by a corporate chatbot. The filler words are gone, sure -- but so is your voice, your rhythm, every stylistic choice that makes your writing yours.

--- a/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+++ b/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
@@ -3,6 +3,7 @@ title: "Dictating Podcast Scripts on macOS Without Losing Flow"
 description: "Stop wrestling with blank pages. Dictate podcast scripts in your natural speaking voice using on-device post-processing and hands-free mode on macOS."
 pubDate: 2026-03-21
 tags: ["podcasting", "dictation", "workflow", "post-processing", "hands-free"]
+author: "Saurabh Vaish"
 ---
 
 You will never write a better podcast script than the one you speak out loud. That's not motivational fluff -- it's the fundamental mismatch that makes typed scripts sound wrong on mic. You type in "writing voice." You record in "speaking voice." They're different registers, and the gap between them is where your show's energy goes to die.

--- a/website/src/content/blog/dictation-for-developers-code-reviews.md
+++ b/website/src/content/blog/dictation-for-developers-code-reviews.md
@@ -4,6 +4,7 @@ description: "How developers use macOS voice dictation to write PR descriptions,
 pubDate: 2026-03-12
 tags: ["developers", "dictation", "productivity", "code-review"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 The biggest time sink in software development isn't writing code — it's everything around the code. PR descriptions, review comments, Slack threads, postmortems, design docs, README updates. Developers often spend a surprising share of their workday writing prose, not code — and most of that prose gets typed in the cracks between implementation work, breaking flow state every time.

--- a/website/src/content/blog/dictation-for-writers-skip-blank-page.md
+++ b/website/src/content/blog/dictation-for-writers-skip-blank-page.md
@@ -4,6 +4,7 @@ description: "Voice writing bypasses the blank page entirely. Learn how dictatio
 pubDate: 2026-03-14
 tags: ["writing", "dictation", "workflow", "creativity"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What if the blank page wasn't the starting point? What if, instead of sitting down to type your first sentence, you could skip straight to having 800 words of rough prose on the screen -- words that sound like you, organized roughly the way you think, ready to edit?

--- a/website/src/content/blog/dictation-parents-type-one-handed.md
+++ b/website/src/content/blog/dictation-parents-type-one-handed.md
@@ -4,6 +4,7 @@ description: "Voice typing for parents who can't sit at a keyboard. EnviousWispr
 pubDate: 2026-03-15
 tags: ["parents", "dictation", "hands-free", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 7:15 AM. Your baby is asleep on your left arm. Your right thumb is pecking out a reply to a daycare email on your phone. You misspell three words, autocorrect turns "pickup at 3" into something unrecognizable, and you give up. The email sits in drafts until bedtime -- if you remember it at all.

--- a/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
+++ b/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
@@ -4,6 +4,7 @@ description: "Remote work means typing all day — Slack, email, docs, tickets. 
 pubDate: 2026-03-17
 tags: ["dictation", "remote-work", "productivity", "voice-typing", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 2:30 PM on a Wednesday. You've been in three video calls since 9 AM. Now you're staring at four Slack threads, two emails, a project brief, and a standup summary -- all due before end of day. All requiring typing. Your wrists ache from the morning's messages, and you haven't even started the real writing yet.

--- a/website/src/content/blog/essay-outline-by-talking-it-out.md
+++ b/website/src/content/blog/essay-outline-by-talking-it-out.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-17
 tags: ["students", "essays", "dictation", "writing-style", "study-hack"]
 keywords: ["essay outline voice dictation", "dictate essay outline mac", "voice to outline", "speech to text essay", "writing outline by speaking", "mac dictation students", "free dictation app essays"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What if your essay outline was already in your head -- and all you had to do was say it out loud?

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -4,6 +4,7 @@ description: "Install EnviousWispr, grant two permissions, and start dictating i
 pubDate: 2026-03-11
 tags: ["getting-started", "tutorial", "setup", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 You'll be dictating polished text into your apps before you finish your coffee. No account to create, no API key to find, no subscription to debate. Download, grant two permissions, talk. That's the entire setup, and it takes under two minutes.

--- a/website/src/content/blog/hands-free-typing-toddler-climbs-you.md
+++ b/website/src/content/blog/hands-free-typing-toddler-climbs-you.md
@@ -4,6 +4,7 @@ description: "Hands-free typing for parents who never have both hands available.
 pubDate: 2026-03-15
 tags: ["parenting", "hands-free", "dictation", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 2 PM. Your toddler just woke up from a nap that was supposed to last another hour. You're three sentences into an email to your kid's teacher when a small human decides your lap is a climbing wall. One hand goes to the keyboard, the other goes to preventing a head injury. The email sits there, half-finished, for the next three hours.

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -4,6 +4,7 @@ description: "Fully private, on-device dictation for macOS that never sends your
 pubDate: 2026-03-11
 tags: ["accessibility", "privacy", "dictation", "offline"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What happens to your primary input method when the Wi-Fi goes down? If voice input is how you write -- because typing hurts, or because it's simply not an option -- that's not a hypothetical question. It's the difference between a tool you can depend on and one that fails when you need it most.

--- a/website/src/content/blog/meeting-notes-polished-summaries.md
+++ b/website/src/content/blog/meeting-notes-polished-summaries.md
@@ -4,6 +4,7 @@ description: "Turn post-meeting chaos into structured summaries with action item
 pubDate: 2026-03-13
 tags: ["meetings", "dictation", "productivity", "writing-styles"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 You'll never need to type meeting notes again. Not because some AI will attend your meetings for you -- but because a thirty-second voice dump into your Mac, right after the meeting ends, produces a better summary than ten minutes of careful typing ever did.

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -3,6 +3,7 @@ title: "On-Device vs Cloud Dictation on macOS: What's Private"
 description: "A fair comparison of on-device and cloud dictation — how each handles your voice data, where recordings go, and what that means for your privacy on macOS."
 pubDate: 2026-03-23
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]
+author: "Saurabh Vaish"
 ---
 
 "Your data is processed securely." Every cloud dictation service says some version of this. Almost none of them tell you what it actually means -- where your audio goes, who can access it, how long it persists, or what happens to it after transcription. The assumption is that you won't ask.

--- a/website/src/content/blog/podcast-show-notes-to-blog-posts.md
+++ b/website/src/content/blog/podcast-show-notes-to-blog-posts.md
@@ -3,6 +3,7 @@ title: "Turn Podcast Show Notes Into Blog Posts with Dictation"
 description: "Repurpose podcast episodes into show notes and blog posts using on-device dictation. Speak your recap — polished text lands in your CMS in seconds on macOS."
 pubDate: 2026-03-22
 tags: ["podcasting", "workflow", "dictation", "content-creation"]
+author: "Saurabh Vaish"
 ---
 
 Imagine spending forty-five minutes writing show notes for a forty-five minute episode. Same amount of time producing the write-up as recording the conversation. After three months of that, a podcaster might have a backlog of twenty episodes with no written counterpart — no blog posts, no detailed descriptions, no newsletter recaps. The content exists, locked in audio form, because the writing step feels like doing the same job twice.

--- a/website/src/content/blog/switched-typing-to-dictating-git-commits.md
+++ b/website/src/content/blog/switched-typing-to-dictating-git-commits.md
@@ -4,6 +4,7 @@ description: "Dictating git commits produces better messages than typing. Here's
 pubDate: 2026-03-16
 tags: ["developer", "git", "workflow", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Imagine going back through six months of git history. The first three months are the usual graveyard: "fix bug," "update stuff," "misc changes." The last three months? Every commit has a subject line, a body, and actual reasoning. The code didn't change between those two periods. What changed was the input method — the developer switched from typing commit messages to speaking them.

--- a/website/src/content/blog/take-lecture-notes-by-speaking.md
+++ b/website/src/content/blog/take-lecture-notes-by-speaking.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-17
 tags: ["students", "lecture-notes", "dictation", "how-to"]
 keywords: ["lecture notes by speaking", "voice notes for students", "dictate lecture notes mac", "speech to text lecture", "take notes without typing", "mac dictation students free", "hands-free note taking"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's a 9 AM organic chemistry lecture. The professor is three slides ahead, rattling off the difference between SN1 and SN2 mechanisms while you're still trying to spell "nucleophilic." Your fingers are moving as fast as they can, but by the time you finish one sentence, you've missed the next two. You look at your notes after class and half of them are gibberish.

--- a/website/src/content/blog/voice-coding-macos-without-cloud.md
+++ b/website/src/content/blog/voice-coding-macos-without-cloud.md
@@ -4,6 +4,7 @@ description: "How to use on-device voice dictation for developer coding workflow
 pubDate: 2026-03-16
 tags: ["voice-coding", "privacy", "developer", "macos", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Most voice-to-text tools are solving the wrong problem for developers. They optimize for casual messages and emails while ignoring the actual pain point: you spend half your day writing prose -- PR descriptions, code reviews, docs, Slack threads, incident reports -- and every word of it breaks your flow state. Meanwhile, those same tools happily stream recordings of your terminal, your architecture discussions, and your credentials to someone else's infrastructure.

--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -4,6 +4,7 @@ description: "RSI makes every keystroke a trade-off. Voice input offers a practi
 pubDate: 2026-03-12
 tags: ["accessibility", "rsi", "voice-input", "workflow", "hands-free"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 By some estimates, knowledge workers produce somewhere between 5,000 and 10,000 words per day across emails, messages, documents, and tickets. That's roughly 125,000 to 250,000 keystrokes -- every single workday, five days a week, for years. The human wrist was not designed for this.

--- a/website/src/content/blog/voice-to-prose-writing-workflow.md
+++ b/website/src/content/blog/voice-to-prose-writing-workflow.md
@@ -3,6 +3,7 @@ title: "Voice to Prose on macOS: A Realistic Writing Workflow"
 description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, writing style presets, and first-draft setup tips."
 pubDate: 2026-03-24
 tags: ["writing", "workflow", "dictation", "writing-style"]
+author: "Saurabh Vaish"
 ---
 
 A typical EnviousWispr session: dictate a first draft in about fifteen minutes while pacing the room, then spend another twenty minutes editing the typed version. Roughly thirty-five minutes for a finished article. The equivalent piece typed start to finish often takes an hour and forty minutes.

--- a/website/src/content/blog/welcome-to-enviouswispr.md
+++ b/website/src/content/blog/welcome-to-enviouswispr.md
@@ -3,6 +3,7 @@ title: "EnviousWispr: Free Private AI Dictation for macOS"
 description: "EnviousWispr is free on-device AI dictation for macOS. No cloud, no account — hold a hotkey, speak, and polished text lands on your clipboard in ~2 seconds."
 pubDate: 2026-03-25
 tags: ["announcement", "privacy", "dictation"]
+author: "Saurabh Vaish"
 ---
 
 What if you didn't have to choose between fast dictation and private dictation? What if a single tool could give you both -- cloud-quality transcription speed with the guarantee that your recordings never leave your Mac?

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -15,11 +15,12 @@ interface Props {
   updatedDate?: Date;
   tags?: string[];
   author?: string;
+  authorUrl?: string;
   image?: string;
   relatedPosts?: RelatedPost[];
 }
 
-const { title, description, pubDate, updatedDate, tags = [], author = 'Envious Labs', image, relatedPosts = [] } = Astro.props;
+const { title, description, pubDate, updatedDate, tags = [], author = 'Saurabh Vaish', authorUrl = 'https://enviouswispr.com/authors/saurabh-vaish/', image, relatedPosts = [] } = Astro.props;
 
 const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
@@ -38,9 +39,30 @@ const articleJsonLd = JSON.stringify({
   "datePublished": pubDate.toISOString(),
   ...(updatedDate && { "dateModified": updatedDate.toISOString() }),
   "author": {
-    "@type": "Organization",
+    "@type": "Person",
     "name": author,
-    "url": siteUrl,
+    "url": authorUrl,
+    "jobTitle": "Founder",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "Envious Labs",
+      "url": "https://enviouslabs.com",
+    },
+    "sameAs": [
+      "https://github.com/saurabhav88",
+      "https://www.linkedin.com/in/saurabh-a-vaish-568253a6/",
+      "https://x.com/saborav",
+    ],
+    "knowsAbout": [
+      "AI dictation",
+      "speech-to-text",
+      "on-device AI",
+      "macOS development",
+      "Apple Silicon",
+      "accessibility",
+      "privacy-first software",
+      "open source software",
+    ],
   },
   "publisher": {
     "@type": "Organization",
@@ -133,6 +155,18 @@ const breadcrumbJsonLd = JSON.stringify({
           <slot />
         </div>
       </article>
+
+      <aside class="author-bio" aria-label="About the author">
+        <div class="author-bio-inner">
+          <div class="author-bio-text">
+            <p class="author-bio-label">Written by</p>
+            <p class="author-bio-name">
+              {authorUrl ? <a href={authorUrl} rel="author">{author}</a> : author}
+            </p>
+            <p class="author-bio-desc">Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility.</p>
+          </div>
+        </div>
+      </aside>
 
       {relatedPosts.length > 0 && (
         <section class="related-posts" aria-label="Related posts">
@@ -419,6 +453,54 @@ const breadcrumbJsonLd = JSON.stringify({
     height: 1px;
     background: var(--border-hover);
     margin: 2.5em 0;
+  }
+
+  /* Author bio */
+  .author-bio {
+    margin-top: 48px;
+    padding: 24px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+  }
+
+  .author-bio-inner {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .author-bio-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-3);
+    margin-bottom: 6px;
+  }
+
+  .author-bio-name {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 8px;
+  }
+
+  .author-bio-name a {
+    color: var(--text);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .author-bio-name a:hover {
+    color: var(--accent);
+  }
+
+  .author-bio-desc {
+    font-size: 14px;
+    color: var(--text-2);
+    line-height: 1.6;
+    margin: 0;
   }
 
   /* Related posts */

--- a/website/src/pages/authors/saurabh-vaish.astro
+++ b/website/src/pages/authors/saurabh-vaish.astro
@@ -1,0 +1,219 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getPublishedPosts } from '../../utils/posts';
+
+const siteUrl = 'https://enviouswispr.com';
+const authorName = 'Saurabh Vaish';
+const authorUrl = `${siteUrl}/authors/saurabh-vaish/`;
+
+const posts = await getPublishedPosts();
+const authorPosts = posts.filter(p => !p.data.author || p.data.author === authorName);
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+const personJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": authorName,
+  "url": authorUrl,
+  "jobTitle": "Founder",
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": "https://enviouslabs.com",
+  },
+  "sameAs": [
+    "https://github.com/saurabhav88",
+    "https://www.linkedin.com/in/saurabh-a-vaish-568253a6/",
+    "https://x.com/saborav",
+  ],
+  "knowsAbout": [
+    "AI dictation",
+    "speech-to-text",
+    "on-device AI",
+    "macOS development",
+    "Apple Silicon",
+    "accessibility",
+    "privacy-first software",
+    "open source software",
+  ],
+  "description": "Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS.",
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": authorName, "item": authorUrl },
+  ],
+});
+---
+
+<BaseLayout
+  title={`${authorName} — EnviousWispr`}
+  description="Saurabh Vaish is the founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility."
+  canonicalPath="/authors/saurabh-vaish/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={personJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+  <div class="author-page">
+    <div class="author-container">
+      <a href="/blog/" class="back-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+        Blog
+      </a>
+
+      <header class="author-header">
+        <h1 class="author-name">{authorName}</h1>
+        <p class="author-bio">Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility.</p>
+        <div class="author-links">
+          <a href="https://github.com/saurabhav88" rel="me noopener" target="_blank">GitHub</a>
+          <a href="https://www.linkedin.com/in/saurabh-a-vaish-568253a6/" rel="me noopener" target="_blank">LinkedIn</a>
+          <a href="https://x.com/saborav" rel="me noopener" target="_blank">X</a>
+        </div>
+      </header>
+
+      <section class="author-posts" aria-label="Posts by this author">
+        <h2 class="author-posts-heading">Posts</h2>
+        <div class="author-posts-list">
+          {authorPosts.map(post => (
+            <a href={`/blog/${post.id}/`} class="author-post-card">
+              <p class="author-post-title">{post.data.title}</p>
+              <p class="author-post-desc">{post.data.description.length > 140 ? post.data.description.slice(0, 140).trimEnd() + '...' : post.data.description}</p>
+              <time class="author-post-date" datetime={post.data.pubDate.toISOString()}>
+                {formatDate(post.data.pubDate)}
+              </time>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .author-page {
+    padding: 120px 0 96px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .author-container {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 32px;
+  }
+
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-3);
+    text-decoration: none;
+    margin-bottom: 40px;
+    transition: color 0.2s;
+  }
+  .back-link:hover { color: var(--accent); }
+
+  .author-header {
+    margin-bottom: 48px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .author-name {
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -1.5px;
+    color: var(--text);
+    margin-bottom: 16px;
+  }
+
+  .author-bio {
+    font-size: 17px;
+    line-height: 1.7;
+    color: var(--text-2);
+    margin-bottom: 20px;
+  }
+
+  .author-links {
+    display: flex;
+    gap: 16px;
+  }
+
+  .author-links a {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--accent);
+    text-decoration: none;
+    transition: opacity 0.2s;
+  }
+  .author-links a:hover { opacity: 0.7; }
+
+  .author-posts-heading {
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-3);
+    margin-bottom: 20px;
+  }
+
+  .author-posts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .author-post-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 20px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+    text-decoration: none;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  .author-post-card:hover {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .author-post-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.35;
+    margin: 0;
+  }
+  .author-post-card:hover .author-post-title { color: var(--accent); }
+
+  .author-post-desc {
+    font-size: 14px;
+    color: var(--text-2);
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .author-post-date {
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-3);
+    margin-top: 4px;
+  }
+
+  @media (max-width: 600px) {
+    .author-page { padding: 100px 0 64px; }
+    .author-container { padding: 0 20px; }
+    .author-name { font-size: 28px; }
+  }
+</style>

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
-const { title, description, pubDate, updatedDate, tags, author, image } = post.data;
+const { title, description, pubDate, updatedDate, tags, author, authorUrl, image } = post.data;
 
 const allPosts = await getPublishedPosts();
 const currentTags = tags ?? [];
@@ -42,6 +42,7 @@ const relatedPosts = allPosts
   updatedDate={updatedDate}
   tags={tags}
   author={author}
+  authorUrl={authorUrl}
   image={image}
   relatedPosts={relatedPosts}
 >

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -34,6 +34,52 @@ const breadcrumbJsonLd = JSON.stringify({
     },
   ],
 });
+
+const howToJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Dictate Text on macOS with EnviousWispr",
+  "description": "Use EnviousWispr to turn speech into polished, paste-ready text on your Mac. Everything runs on-device using Apple Silicon.",
+  "totalTime": "PT5M",
+  "tool": [
+    { "@type": "HowToTool", "name": "EnviousWispr for macOS" },
+    { "@type": "HowToTool", "name": "Microphone (built-in or external)" },
+  ],
+  "supply": [
+    { "@type": "HowToSupply", "name": "Mac with Apple Silicon (M1 or later)" },
+    { "@type": "HowToSupply", "name": "macOS 14 Sonoma or later" },
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Download and install EnviousWispr",
+      "text": "Download the free .dmg from the EnviousWispr website or GitHub releases page. Drag the app to Applications and launch it. Grant microphone access when macOS prompts you.",
+      "url": `${siteUrl}/how-it-works/#step-install`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Hold the hotkey and speak",
+      "text": "Press and hold your designated hotkey, then talk naturally. No need to slow down or speak formally. Just say what you mean.",
+      "url": `${siteUrl}/how-it-works/#step-record`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Release to transcribe",
+      "text": "When you release the hotkey, EnviousWispr transcribes your speech on-device using Apple Silicon. Your audio never leaves your Mac. AI polish cleans up grammar and filler words automatically.",
+      "url": `${siteUrl}/how-it-works/#step-transcribe`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Paste polished text",
+      "text": "Clean, polished text is pasted directly into whatever app you are using. Works in any text field, any app, without switching windows.",
+      "url": `${siteUrl}/how-it-works/#step-paste`,
+    },
+  ],
+});
 ---
 
 <BaseLayout
@@ -45,6 +91,7 @@ const breadcrumbJsonLd = JSON.stringify({
   <Fragment slot="head">
     <script type="application/ld+json" set:html={webPageJsonLd}></script>
     <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={howToJsonLd}></script>
   </Fragment>
 
 <style>
@@ -200,25 +247,25 @@ const breadcrumbJsonLd = JSON.stringify({
 <section class="section" aria-label="Pipeline Steps">
   <div class="container">
     <div class="steps-grid">
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-install">
         <div class="step-number">Step 01</div>
         <div class="step-icon">🎙</div>
         <div class="step-title">Record</div>
         <p class="step-desc">Press your hotkey and talk naturally. No need to slow down or speak formally — just say what you mean.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-record">
         <div class="step-number">Step 02</div>
         <div class="step-icon">⚡</div>
         <div class="step-title">Transcribe</div>
         <p class="step-desc">AI on your Mac converts speech to text instantly. Everything runs locally — your voice never leaves your device.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-transcribe">
         <div class="step-number">Step 03</div>
         <div class="step-icon">✨</div>
         <div class="step-title">Polish</div>
         <p class="step-desc">Grammar is fixed, filler words are removed, and your meaning is preserved — automatically, in the tone you choose.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-paste">
         <div class="step-number">Step 04</div>
         <div class="step-icon">📋</div>
         <div class="step-title">Paste</div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -71,6 +71,30 @@ const jsonLdFaq = JSON.stringify({
         "@type": "Answer",
         "text": "The default Parakeet engine handles English. The WhisperKit backend supports 90+ languages for multi-language dictation."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr is fully open source and available on GitHub. You can inspect the code, contribute, or build from source."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which apps does EnviousWispr work with?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr works with any app that accepts text input. It pastes directly into your active text field, whether that is Slack, VS Code, Gmail, Notion, Google Docs, Terminal, or any other app."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr run Whisper locally?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The WhisperKit backend runs OpenAI Whisper models locally via Apple Core ML. The default Parakeet engine uses NVIDIA's Parakeet TDT model, also running on-device. Both use Apple Silicon's Neural Engine for fast inference."
+      }
     }
   ]
 });


### PR DESCRIPTION
## Summary
- Add author attribution (Saurabh Vaish) with Person schema, `knowsAbout`, and `sameAs` links across all 22 blog posts
- Create dedicated author page at `/authors/saurabh-vaish/` with full Person JSON-LD
- Add HowTo schema to how-it-works page with user-focused steps
- Expand homepage FAQs with 3 new entries (open source, app compatibility, local Whisper)
- Add visual author bio section to blog post layout

## Context
Recomaze AEO audit scored us 37/100 with 0% AI visibility across ChatGPT and Perplexity. These changes improve E-E-A-T signals and structured data. Plan validated by GPT and Gemini council sessions.

## Test plan
- [x] `npm run build` passes (27 pages)
- [x] Person schema renders correctly in blog post HTML
- [x] HowTo schema renders on how-it-works page
- [x] New FAQs present in homepage JSON-LD
- [x] Author page builds at /authors/saurabh-vaish/
- [ ] Visual check after deploy (author bio section styling)
