### PR TITLE
feat(website): AEO improvements for AI engine visibility

### DIFF
--- a/website/src/content/blog/async-communication-better-when-you-speak.md
+++ b/website/src/content/blog/async-communication-better-when-you-speak.md
@@ -4,6 +4,7 @@ description: "Why dictating Slack messages, emails, and async updates beats typi
 pubDate: 2026-03-17
 tags: ["remote-work", "async-communication", "dictation", "productivity", "slack"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Most people type at 40 words per minute but speak at 150. In async-heavy remote work, that gap costs you hours every week -- and worse, it degrades the quality of what you write. By 3 PM, your hands are tired and your messages have gotten shorter, vaguer, and harder for your teammates to act on.

--- a/website/src/content/blog/building-commercial-software-solo-with-claude-code.md
+++ b/website/src/content/blog/building-commercial-software-solo-with-claude-code.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-26
 tags: ["claude-code", "vibe-coding", "solo-dev", "ai-tools", "productivity"]
 image: "/images/blog/claude-code-structure/three-pillars.jpg"
 draft: false
+author: "Saurabh Vaish"
 ---
 
 I've been building EnviousWispr, a commercial macOS voice-to-text app, entirely by myself using Claude Code. Along the way I made a lot of mistakes, rewrote things I didn't need to, and lost context between sessions more times than I'd like to admit.

--- a/website/src/content/blog/dictate-emails-speed-of-thought.md
+++ b/website/src/content/blog/dictate-emails-speed-of-thought.md
@@ -4,6 +4,7 @@ description: "Stop typing emails between meetings. Dictate on-device with speech
 pubDate: 2026-03-13
 tags: ["dictation", "email", "productivity", "executive", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 The average executive types around 40 words per minute. They speak 130 to 150. That's roughly 3-4x throughput on the single activity that dominates their day: writing emails — and that's a rough estimate, not a measured fact, but the gap is real and it compounds across dozens of messages a day.

--- a/website/src/content/blog/dictate-first-drafts-sound-like-you.md
+++ b/website/src/content/blog/dictate-first-drafts-sound-like-you.md
@@ -4,6 +4,7 @@ description: "Most dictation tools strip your voice. Here's how to dictate first
 pubDate: 2026-03-14
 tags: ["writing", "dictation", "workflow", "writing-style"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Every dictation tool on the market is lying to you about the same thing. They promise "natural-sounding text" and then hand you output that reads like it was written by a corporate chatbot. The filler words are gone, sure -- but so is your voice, your rhythm, every stylistic choice that makes your writing yours.

--- a/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+++ b/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
@@ -3,6 +3,7 @@ title: "Dictating Podcast Scripts on macOS Without Losing Flow"
 description: "Stop wrestling with blank pages. Dictate podcast scripts in your natural speaking voice using on-device post-processing and hands-free mode on macOS."
 pubDate: 2026-03-21
 tags: ["podcasting", "dictation", "workflow", "post-processing", "hands-free"]
+author: "Saurabh Vaish"
 ---
 
 You will never write a better podcast script than the one you speak out loud. That's not motivational fluff -- it's the fundamental mismatch that makes typed scripts sound wrong on mic. You type in "writing voice." You record in "speaking voice." They're different registers, and the gap between them is where your show's energy goes to die.

--- a/website/src/content/blog/dictation-for-developers-code-reviews.md
+++ b/website/src/content/blog/dictation-for-developers-code-reviews.md
@@ -4,6 +4,7 @@ description: "How developers use macOS voice dictation to write PR descriptions,
 pubDate: 2026-03-12
 tags: ["developers", "dictation", "productivity", "code-review"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 The biggest time sink in software development isn't writing code — it's everything around the code. PR descriptions, review comments, Slack threads, postmortems, design docs, README updates. Developers often spend a surprising share of their workday writing prose, not code — and most of that prose gets typed in the cracks between implementation work, breaking flow state every time.

--- a/website/src/content/blog/dictation-for-writers-skip-blank-page.md
+++ b/website/src/content/blog/dictation-for-writers-skip-blank-page.md
@@ -4,6 +4,7 @@ description: "Voice writing bypasses the blank page entirely. Learn how dictatio
 pubDate: 2026-03-14
 tags: ["writing", "dictation", "workflow", "creativity"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What if the blank page wasn't the starting point? What if, instead of sitting down to type your first sentence, you could skip straight to having 800 words of rough prose on the screen -- words that sound like you, organized roughly the way you think, ready to edit?

--- a/website/src/content/blog/dictation-parents-type-one-handed.md
+++ b/website/src/content/blog/dictation-parents-type-one-handed.md
@@ -4,6 +4,7 @@ description: "Voice typing for parents who can't sit at a keyboard. EnviousWispr
 pubDate: 2026-03-15
 tags: ["parents", "dictation", "hands-free", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 7:15 AM. Your baby is asleep on your left arm. Your right thumb is pecking out a reply to a daycare email on your phone. You misspell three words, autocorrect turns "pickup at 3" into something unrecognizable, and you give up. The email sits in drafts until bedtime -- if you remember it at all.

--- a/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
+++ b/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
@@ -4,6 +4,7 @@ description: "Remote work means typing all day — Slack, email, docs, tickets. 
 pubDate: 2026-03-17
 tags: ["dictation", "remote-work", "productivity", "voice-typing", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 2:30 PM on a Wednesday. You've been in three video calls since 9 AM. Now you're staring at four Slack threads, two emails, a project brief, and a standup summary -- all due before end of day. All requiring typing. Your wrists ache from the morning's messages, and you haven't even started the real writing yet.

--- a/website/src/content/blog/essay-outline-by-talking-it-out.md
+++ b/website/src/content/blog/essay-outline-by-talking-it-out.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-17
 tags: ["students", "essays", "dictation", "writing-style", "study-hack"]
 keywords: ["essay outline voice dictation", "dictate essay outline mac", "voice to outline", "speech to text essay", "writing outline by speaking", "mac dictation students", "free dictation app essays"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What if your essay outline was already in your head -- and all you had to do was say it out loud?

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -4,6 +4,7 @@ description: "Install EnviousWispr, grant two permissions, and start dictating i
 pubDate: 2026-03-11
 tags: ["getting-started", "tutorial", "setup", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 You'll be dictating polished text into your apps before you finish your coffee. No account to create, no API key to find, no subscription to debate. Download, grant two permissions, talk. That's the entire setup, and it takes under two minutes.

--- a/website/src/content/blog/hands-free-typing-toddler-climbs-you.md
+++ b/website/src/content/blog/hands-free-typing-toddler-climbs-you.md
@@ -4,6 +4,7 @@ description: "Hands-free typing for parents who never have both hands available.
 pubDate: 2026-03-15
 tags: ["parenting", "hands-free", "dictation", "privacy"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's 2 PM. Your toddler just woke up from a nap that was supposed to last another hour. You're three sentences into an email to your kid's teacher when a small human decides your lap is a climbing wall. One hand goes to the keyboard, the other goes to preventing a head injury. The email sits there, half-finished, for the next three hours.

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -4,6 +4,7 @@ description: "Fully private, on-device dictation for macOS that never sends your
 pubDate: 2026-03-11
 tags: ["accessibility", "privacy", "dictation", "offline"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 What happens to your primary input method when the Wi-Fi goes down? If voice input is how you write -- because typing hurts, or because it's simply not an option -- that's not a hypothetical question. It's the difference between a tool you can depend on and one that fails when you need it most.

--- a/website/src/content/blog/meeting-notes-polished-summaries.md
+++ b/website/src/content/blog/meeting-notes-polished-summaries.md
@@ -4,6 +4,7 @@ description: "Turn post-meeting chaos into structured summaries with action item
 pubDate: 2026-03-13
 tags: ["meetings", "dictation", "productivity", "writing-styles"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 You'll never need to type meeting notes again. Not because some AI will attend your meetings for you -- but because a thirty-second voice dump into your Mac, right after the meeting ends, produces a better summary than ten minutes of careful typing ever did.

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -3,6 +3,7 @@ title: "On-Device vs Cloud Dictation on macOS: What's Private"
 description: "A fair comparison of on-device and cloud dictation — how each handles your voice data, where recordings go, and what that means for your privacy on macOS."
 pubDate: 2026-03-23
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]
+author: "Saurabh Vaish"
 ---
 
 "Your data is processed securely." Every cloud dictation service says some version of this. Almost none of them tell you what it actually means -- where your audio goes, who can access it, how long it persists, or what happens to it after transcription. The assumption is that you won't ask.

--- a/website/src/content/blog/podcast-show-notes-to-blog-posts.md
+++ b/website/src/content/blog/podcast-show-notes-to-blog-posts.md
@@ -3,6 +3,7 @@ title: "Turn Podcast Show Notes Into Blog Posts with Dictation"
 description: "Repurpose podcast episodes into show notes and blog posts using on-device dictation. Speak your recap — polished text lands in your CMS in seconds on macOS."
 pubDate: 2026-03-22
 tags: ["podcasting", "workflow", "dictation", "content-creation"]
+author: "Saurabh Vaish"
 ---
 
 Imagine spending forty-five minutes writing show notes for a forty-five minute episode. Same amount of time producing the write-up as recording the conversation. After three months of that, a podcaster might have a backlog of twenty episodes with no written counterpart — no blog posts, no detailed descriptions, no newsletter recaps. The content exists, locked in audio form, because the writing step feels like doing the same job twice.

--- a/website/src/content/blog/switched-typing-to-dictating-git-commits.md
+++ b/website/src/content/blog/switched-typing-to-dictating-git-commits.md
@@ -4,6 +4,7 @@ description: "Dictating git commits produces better messages than typing. Here's
 pubDate: 2026-03-16
 tags: ["developer", "git", "workflow", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Imagine going back through six months of git history. The first three months are the usual graveyard: "fix bug," "update stuff," "misc changes." The last three months? Every commit has a subject line, a body, and actual reasoning. The code didn't change between those two periods. What changed was the input method — the developer switched from typing commit messages to speaking them.

--- a/website/src/content/blog/take-lecture-notes-by-speaking.md
+++ b/website/src/content/blog/take-lecture-notes-by-speaking.md
@@ -5,6 +5,7 @@ pubDate: 2026-03-17
 tags: ["students", "lecture-notes", "dictation", "how-to"]
 keywords: ["lecture notes by speaking", "voice notes for students", "dictate lecture notes mac", "speech to text lecture", "take notes without typing", "mac dictation students free", "hands-free note taking"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 It's a 9 AM organic chemistry lecture. The professor is three slides ahead, rattling off the difference between SN1 and SN2 mechanisms while you're still trying to spell "nucleophilic." Your fingers are moving as fast as they can, but by the time you finish one sentence, you've missed the next two. You look at your notes after class and half of them are gibberish.

--- a/website/src/content/blog/voice-coding-macos-without-cloud.md
+++ b/website/src/content/blog/voice-coding-macos-without-cloud.md
@@ -4,6 +4,7 @@ description: "How to use on-device voice dictation for developer coding workflow
 pubDate: 2026-03-16
 tags: ["voice-coding", "privacy", "developer", "macos", "dictation"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 Most voice-to-text tools are solving the wrong problem for developers. They optimize for casual messages and emails while ignoring the actual pain point: you spend half your day writing prose -- PR descriptions, code reviews, docs, Slack threads, incident reports -- and every word of it breaks your flow state. Meanwhile, those same tools happily stream recordings of your terminal, your architecture discussions, and your credentials to someone else's infrastructure.

--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -4,6 +4,7 @@ description: "RSI makes every keystroke a trade-off. Voice input offers a practi
 pubDate: 2026-03-12
 tags: ["accessibility", "rsi", "voice-input", "workflow", "hands-free"]
 draft: false
+author: "Saurabh Vaish"
 ---
 
 By some estimates, knowledge workers produce somewhere between 5,000 and 10,000 words per day across emails, messages, documents, and tickets. That's roughly 125,000 to 250,000 keystrokes -- every single workday, five days a week, for years. The human wrist was not designed for this.

--- a/website/src/content/blog/voice-to-prose-writing-workflow.md
+++ b/website/src/content/blog/voice-to-prose-writing-workflow.md
@@ -3,6 +3,7 @@ title: "Voice to Prose on macOS: A Realistic Writing Workflow"
 description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, writing style presets, and first-draft setup tips."
 pubDate: 2026-03-24
 tags: ["writing", "workflow", "dictation", "writing-style"]
+author: "Saurabh Vaish"
 ---
 
 A typical EnviousWispr session: dictate a first draft in about fifteen minutes while pacing the room, then spend another twenty minutes editing the typed version. Roughly thirty-five minutes for a finished article. The equivalent piece typed start to finish often takes an hour and forty minutes.

--- a/website/src/content/blog/welcome-to-enviouswispr.md
+++ b/website/src/content/blog/welcome-to-enviouswispr.md
@@ -3,6 +3,7 @@ title: "EnviousWispr: Free Private AI Dictation for macOS"
 description: "EnviousWispr is free on-device AI dictation for macOS. No cloud, no account — hold a hotkey, speak, and polished text lands on your clipboard in ~2 seconds."
 pubDate: 2026-03-25
 tags: ["announcement", "privacy", "dictation"]
+author: "Saurabh Vaish"
 ---
 
 What if you didn't have to choose between fast dictation and private dictation? What if a single tool could give you both -- cloud-quality transcription speed with the guarantee that your recordings never leave your Mac?

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -15,11 +15,12 @@ interface Props {
   updatedDate?: Date;
   tags?: string[];
   author?: string;
+  authorUrl?: string;
   image?: string;
   relatedPosts?: RelatedPost[];
 }
 
-const { title, description, pubDate, updatedDate, tags = [], author = 'Envious Labs', image, relatedPosts = [] } = Astro.props;
+const { title, description, pubDate, updatedDate, tags = [], author = 'Saurabh Vaish', authorUrl = 'https://enviouswispr.com/authors/saurabh-vaish/', image, relatedPosts = [] } = Astro.props;
 
 const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
@@ -38,9 +39,30 @@ const articleJsonLd = JSON.stringify({
   "datePublished": pubDate.toISOString(),
   ...(updatedDate && { "dateModified": updatedDate.toISOString() }),
   "author": {
-    "@type": "Organization",
+    "@type": "Person",
     "name": author,
-    "url": siteUrl,
+    "url": authorUrl,
+    "jobTitle": "Founder",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "Envious Labs",
+      "url": "https://enviouslabs.com",
+    },
+    "sameAs": [
+      "https://github.com/saurabhav88",
+      "https://www.linkedin.com/in/saurabh-a-vaish-568253a6/",
+      "https://x.com/saborav",
+    ],
+    "knowsAbout": [
+      "AI dictation",
+      "speech-to-text",
+      "on-device AI",
+      "macOS development",
+      "Apple Silicon",
+      "accessibility",
+      "privacy-first software",
+      "open source software",
+    ],
   },
   "publisher": {
     "@type": "Organization",
@@ -133,6 +155,18 @@ const breadcrumbJsonLd = JSON.stringify({
           <slot />
         </div>
       </article>
+
+      <aside class="author-bio" aria-label="About the author">
+        <div class="author-bio-inner">
+          <div class="author-bio-text">
+            <p class="author-bio-label">Written by</p>
+            <p class="author-bio-name">
+              {authorUrl ? <a href={authorUrl} rel="author">{author}</a> : author}
+            </p>
+            <p class="author-bio-desc">Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility.</p>
+          </div>
+        </div>
+      </aside>
 
       {relatedPosts.length > 0 && (
         <section class="related-posts" aria-label="Related posts">
@@ -419,6 +453,54 @@ const breadcrumbJsonLd = JSON.stringify({
     height: 1px;
     background: var(--border-hover);
     margin: 2.5em 0;
+  }
+
+  /* Author bio */
+  .author-bio {
+    margin-top: 48px;
+    padding: 24px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+  }
+
+  .author-bio-inner {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .author-bio-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-3);
+    margin-bottom: 6px;
+  }
+
+  .author-bio-name {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 8px;
+  }
+
+  .author-bio-name a {
+    color: var(--text);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .author-bio-name a:hover {
+    color: var(--accent);
+  }
+
+  .author-bio-desc {
+    font-size: 14px;
+    color: var(--text-2);
+    line-height: 1.6;
+    margin: 0;
   }
 
   /* Related posts */

--- a/website/src/pages/authors/saurabh-vaish.astro
+++ b/website/src/pages/authors/saurabh-vaish.astro
@@ -1,0 +1,219 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getPublishedPosts } from '../../utils/posts';
+
+const siteUrl = 'https://enviouswispr.com';
+const authorName = 'Saurabh Vaish';
+const authorUrl = `${siteUrl}/authors/saurabh-vaish/`;
+
+const posts = await getPublishedPosts();
+const authorPosts = posts.filter(p => !p.data.author || p.data.author === authorName);
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+const personJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": authorName,
+  "url": authorUrl,
+  "jobTitle": "Founder",
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": "https://enviouslabs.com",
+  },
+  "sameAs": [
+    "https://github.com/saurabhav88",
+    "https://www.linkedin.com/in/saurabh-a-vaish-568253a6/",
+    "https://x.com/saborav",
+  ],
+  "knowsAbout": [
+    "AI dictation",
+    "speech-to-text",
+    "on-device AI",
+    "macOS development",
+    "Apple Silicon",
+    "accessibility",
+    "privacy-first software",
+    "open source software",
+  ],
+  "description": "Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS.",
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": authorName, "item": authorUrl },
+  ],
+});
+---
+
+<BaseLayout
+  title={`${authorName} — EnviousWispr`}
+  description="Saurabh Vaish is the founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility."
+  canonicalPath="/authors/saurabh-vaish/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={personJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+  <div class="author-page">
+    <div class="author-container">
+      <a href="/blog/" class="back-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+        Blog
+      </a>
+
+      <header class="author-header">
+        <h1 class="author-name">{authorName}</h1>
+        <p class="author-bio">Founder of Envious Labs and creator of EnviousWispr, a free open-source AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility.</p>
+        <div class="author-links">
+          <a href="https://github.com/saurabhav88" rel="me noopener" target="_blank">GitHub</a>
+          <a href="https://www.linkedin.com/in/saurabh-a-vaish-568253a6/" rel="me noopener" target="_blank">LinkedIn</a>
+          <a href="https://x.com/saborav" rel="me noopener" target="_blank">X</a>
+        </div>
+      </header>
+
+      <section class="author-posts" aria-label="Posts by this author">
+        <h2 class="author-posts-heading">Posts</h2>
+        <div class="author-posts-list">
+          {authorPosts.map(post => (
+            <a href={`/blog/${post.id}/`} class="author-post-card">
+              <p class="author-post-title">{post.data.title}</p>
+              <p class="author-post-desc">{post.data.description.length > 140 ? post.data.description.slice(0, 140).trimEnd() + '...' : post.data.description}</p>
+              <time class="author-post-date" datetime={post.data.pubDate.toISOString()}>
+                {formatDate(post.data.pubDate)}
+              </time>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .author-page {
+    padding: 120px 0 96px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .author-container {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 32px;
+  }
+
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-3);
+    text-decoration: none;
+    margin-bottom: 40px;
+    transition: color 0.2s;
+  }
+  .back-link:hover { color: var(--accent); }
+
+  .author-header {
+    margin-bottom: 48px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .author-name {
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -1.5px;
+    color: var(--text);
+    margin-bottom: 16px;
+  }
+
+  .author-bio {
+    font-size: 17px;
+    line-height: 1.7;
+    color: var(--text-2);
+    margin-bottom: 20px;
+  }
+
+  .author-links {
+    display: flex;
+    gap: 16px;
+  }
+
+  .author-links a {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--accent);
+    text-decoration: none;
+    transition: opacity 0.2s;
+  }
+  .author-links a:hover { opacity: 0.7; }
+
+  .author-posts-heading {
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-3);
+    margin-bottom: 20px;
+  }
+
+  .author-posts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .author-post-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 20px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+    text-decoration: none;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  .author-post-card:hover {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .author-post-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.35;
+    margin: 0;
+  }
+  .author-post-card:hover .author-post-title { color: var(--accent); }
+
+  .author-post-desc {
+    font-size: 14px;
+    color: var(--text-2);
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .author-post-date {
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-3);
+    margin-top: 4px;
+  }
+
+  @media (max-width: 600px) {
+    .author-page { padding: 100px 0 64px; }
+    .author-container { padding: 0 20px; }
+    .author-name { font-size: 28px; }
+  }
+</style>

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
-const { title, description, pubDate, updatedDate, tags, author, image } = post.data;
+const { title, description, pubDate, updatedDate, tags, author, authorUrl, image } = post.data;
 
 const allPosts = await getPublishedPosts();
 const currentTags = tags ?? [];
@@ -42,6 +42,7 @@ const relatedPosts = allPosts
   updatedDate={updatedDate}
   tags={tags}
   author={author}
+  authorUrl={authorUrl}
   image={image}
   relatedPosts={relatedPosts}
 >

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -34,6 +34,52 @@ const breadcrumbJsonLd = JSON.stringify({
     },
   ],
 });
+
+const howToJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Dictate Text on macOS with EnviousWispr",
+  "description": "Use EnviousWispr to turn speech into polished, paste-ready text on your Mac. Everything runs on-device using Apple Silicon.",
+  "totalTime": "PT5M",
+  "tool": [
+    { "@type": "HowToTool", "name": "EnviousWispr for macOS" },
+    { "@type": "HowToTool", "name": "Microphone (built-in or external)" },
+  ],
+  "supply": [
+    { "@type": "HowToSupply", "name": "Mac with Apple Silicon (M1 or later)" },
+    { "@type": "HowToSupply", "name": "macOS 14 Sonoma or later" },
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Download and install EnviousWispr",
+      "text": "Download the free .dmg from the EnviousWispr website or GitHub releases page. Drag the app to Applications and launch it. Grant microphone access when macOS prompts you.",
+      "url": `${siteUrl}/how-it-works/#step-install`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Hold the hotkey and speak",
+      "text": "Press and hold your designated hotkey, then talk naturally. No need to slow down or speak formally. Just say what you mean.",
+      "url": `${siteUrl}/how-it-works/#step-record`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Release to transcribe",
+      "text": "When you release the hotkey, EnviousWispr transcribes your speech on-device using Apple Silicon. Your audio never leaves your Mac. AI polish cleans up grammar and filler words automatically.",
+      "url": `${siteUrl}/how-it-works/#step-transcribe`,
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Paste polished text",
+      "text": "Clean, polished text is pasted directly into whatever app you are using. Works in any text field, any app, without switching windows.",
+      "url": `${siteUrl}/how-it-works/#step-paste`,
+    },
+  ],
+});
 ---
 
 <BaseLayout
@@ -45,6 +91,7 @@ const breadcrumbJsonLd = JSON.stringify({
   <Fragment slot="head">
     <script type="application/ld+json" set:html={webPageJsonLd}></script>
     <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={howToJsonLd}></script>
   </Fragment>
 
 <style>
@@ -200,25 +247,25 @@ const breadcrumbJsonLd = JSON.stringify({
 <section class="section" aria-label="Pipeline Steps">
   <div class="container">
     <div class="steps-grid">
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-install">
         <div class="step-number">Step 01</div>
         <div class="step-icon">🎙</div>
         <div class="step-title">Record</div>
         <p class="step-desc">Press your hotkey and talk naturally. No need to slow down or speak formally — just say what you mean.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-record">
         <div class="step-number">Step 02</div>
         <div class="step-icon">⚡</div>
         <div class="step-title">Transcribe</div>
         <p class="step-desc">AI on your Mac converts speech to text instantly. Everything runs locally — your voice never leaves your device.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-transcribe">
         <div class="step-number">Step 03</div>
         <div class="step-icon">✨</div>
         <div class="step-title">Polish</div>
         <p class="step-desc">Grammar is fixed, filler words are removed, and your meaning is preserved — automatically, in the tone you choose.</p>
       </div>
-      <div class="step-card reveal">
+      <div class="step-card reveal" id="step-paste">
         <div class="step-number">Step 04</div>
         <div class="step-icon">📋</div>
         <div class="step-title">Paste</div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -71,6 +71,30 @@ const jsonLdFaq = JSON.stringify({
         "@type": "Answer",
         "text": "The default Parakeet engine handles English. The WhisperKit backend supports 90+ languages for multi-language dictation."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr is fully open source and available on GitHub. You can inspect the code, contribute, or build from source."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which apps does EnviousWispr work with?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr works with any app that accepts text input. It pastes directly into your active text field, whether that is Slack, VS Code, Gmail, Notion, Google Docs, Terminal, or any other app."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr run Whisper locally?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The WhisperKit backend runs OpenAI Whisper models locally via Apple Core ML. The default Parakeet engine uses NVIDIA's Parakeet TDT model, also running on-device. Both use Apple Silicon's Neural Engine for fast inference."
+      }
     }
   ]
 });


### PR DESCRIPTION
## Summary
- Add author attribution (Saurabh Vaish) with Person schema, `knowsAbout`, and `sameAs` links across all 22 blog posts
- Create dedicated author page at `/authors/saurabh-vaish/` with full Person JSON-LD
- Add HowTo schema to how-it-works page with user-focused steps
- Expand homepage FAQs with 3 new entries (open source, app compatibility, local Whisper)
- Add visual author bio section to blog post layout

## Context
Recomaze AEO audit scored us 37/100 with 0% AI visibility across ChatGPT and Perplexity. These changes improve E-E-A-T signals and structured data. Plan validated by GPT and Gemini council sessions.

## Test plan
- [x] `npm run build` passes (27 pages)
- [x] Person schema renders correctly in blog post HTML
- [x] HowTo schema renders on how-it-works page
- [x] New FAQs present in homepage JSON-LD
- [x] Author page builds at /authors/saurabh-vaish/
