### PR TITLE
fix: bug sweep — device check, paste fallback, telemetry, hookify

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -227,9 +227,19 @@ final class AppState {
                 self.isRecordingLocked = false
                 self.hotkeyService.unregisterCancelHotkey()
             }
-            // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label
+            // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label.
+            // On completion, check if paste fell back to clipboard-only (Tier 3) and show
+            // a transient "Copied to clipboard" notice instead of silently hiding.
+            let overlayIntent: OverlayIntent
+            if newState == .complete,
+               let tier = self.pipeline.currentTranscript?.metrics?.pasteTier,
+               tier == "clipboard_only" {
+                overlayIntent = .clipboardFallback
+            } else {
+                overlayIntent = self.pipeline.overlayIntent
+            }
             self.recordingOverlay.show(
-                intent: self.pipeline.overlayIntent,
+                intent: overlayIntent,
                 audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
                 isRecordingLocked: self.isRecordingLocked
             )
@@ -256,9 +266,17 @@ final class AppState {
                 self.isRecordingLocked = false
                 self.hotkeyService.unregisterCancelHotkey()
             }
-            // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label
+            // Intent-driven overlay — same clipboard fallback logic as Parakeet pipeline above.
+            let wkOverlayIntent: OverlayIntent
+            if newState == .complete,
+               let tier = self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier,
+               tier == "clipboard_only" {
+                wkOverlayIntent = .clipboardFallback
+            } else {
+                wkOverlayIntent = self.whisperKitPipeline.overlayIntent
+            }
             self.recordingOverlay.show(
-                intent: self.whisperKitPipeline.overlayIntent,
+                intent: wkOverlayIntent,
                 audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
                 isRecordingLocked: self.isRecordingLocked
             )
@@ -531,6 +549,26 @@ final class AppState {
                 }
             default: break
             }
+        }
+
+        // Fire dictation.invoked telemetry when starting (not stopping).
+        // Intent event: captures user action before engine/ASR work begins.
+        // Check that the active pipeline is NOT already in a recording/processing state.
+        let alreadyActive: Bool
+        if active is WhisperKitPipeline {
+            let s = whisperKitPipeline.state
+            alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel || s == .startingUp
+        } else {
+            let s = pipeline.state
+            alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
+        }
+        if !alreadyActive {
+            let targetApp = NSWorkspace.shared.frontmostApplication?.localizedName
+            TelemetryService.shared.dictationInvoked(
+                triggerSource: settings.recordingMode.rawValue,
+                inputMode: settings.recordingMode.rawValue,
+                targetApp: targetApp
+            )
         }
 
         await active.handle(event: .toggleRecording)

--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -77,6 +77,13 @@ final class RecordingOverlayPanel {
                 userInfo: [.announcement: "Processing transcription",
                            .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber])
             showPolishing(label: label)
+        case .clipboardFallback:
+            NSAccessibility.post(
+                element: NSApp.mainWindow as Any,
+                notification: .announcementRequested,
+                userInfo: [.announcement: "Text copied to clipboard",
+                           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber])
+            showClipboardFallback()
         }
     }
 
@@ -150,6 +157,41 @@ final class RecordingOverlayPanel {
         // window frame on lock transitions.
         .frame(width: 185, height: 64)
         showPanel(content: overlayView, width: 185, height: 64, y: y)
+    }
+
+    /// Show a transient "Copied to clipboard" notice that auto-dismisses after 2.5s.
+    func showClipboardFallback() {
+        guard panel == nil else {
+            // Transition from existing panel (recording/polishing) to clipboard notice
+            transitionToPolishing(label: "Paste failed \u{2014} \u{2318}V to paste")
+            scheduleAutoDismiss()
+            return
+        }
+        pendingCreateWork?.cancel()
+        pendingCreateWork = nil
+        generation &+= 1
+        let token = generation
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.generation == token else { return }
+            self.pendingCreateWork = nil
+            self.createPolishingPanel(label: "Paste failed \u{2014} \u{2318}V to paste")
+            self.scheduleAutoDismiss()
+        }
+        pendingCreateWork = work
+        DispatchQueue.main.async(execute: work)
+    }
+
+    /// Auto-dismiss timer for transient notices (clipboard fallback).
+    private var autoDismissTask: Task<Void, Never>?
+
+    private func scheduleAutoDismiss() {
+        autoDismissTask?.cancel()
+        autoDismissTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2.5))
+            guard !Task.isCancelled, let self, self.panel != nil else { return }
+            self.hide()
+        }
     }
 
     private func createPolishingPanel(label: String = "Polishing...") {
@@ -260,6 +302,8 @@ final class RecordingOverlayPanel {
         currentIntent = .hidden
         isRecordingLocked = false
         lockState.isLocked = false
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         generation &+= 1
         // Cancel any pending deferred panel creation so it never fires.
         // This handles the rapid-ESC race: if hide() is called before the

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -272,8 +272,26 @@ public final class AudioCaptureManager: AudioCaptureInterface {
             )
             let existingIsEngine = existing is AVAudioEngineSource
             let wantsEngine = decision.sourceType == .audioEngine
-            if existingIsEngine == wantsEngine {
-                // Route unchanged — reuse warm source
+
+            // Check full config signature, not just source type.
+            // Device/VP changes between recordings must trigger rebuild.
+            var configMatch = existingIsEngine == wantsEngine
+            if configMatch, let engineSource = existing as? AVAudioEngineSource {
+                // Compare effective device selection: preferredInputDeviceIDOverride
+                // takes priority, fall back to selectedInputDeviceUID when empty.
+                let oldEffective = engineSource.preferredInputDeviceIDOverride.isEmpty
+                    ? engineSource.selectedInputDeviceUID
+                    : engineSource.preferredInputDeviceIDOverride
+                let newEffective = preferredInputDeviceIDOverride.isEmpty
+                    ? selectedInputDeviceUID
+                    : preferredInputDeviceIDOverride
+                let deviceMatch = oldEffective == newEffective
+                let vpMatch = engineSource.noiseSuppressionEnabled == noiseSuppressionEnabled
+                configMatch = deviceMatch && vpMatch
+            }
+
+            if configMatch {
+                // Route and config unchanged, reuse warm source
                 lastRouteDecision = decision
                 Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
                 return existing

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -15,6 +15,9 @@ public enum OverlayIntent: Equatable, Sendable {
     case hidden
     case recording(audioLevel: Float)
     case processing(label: String)
+    /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
+    /// Auto-dismissed by the overlay panel after a short delay.
+    case clipboardFallback
 }
 
 /// Abstraction over dictation pipelines (Parakeet streaming, WhisperKit batch, etc.).

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -67,6 +67,9 @@ public final class SettingsManager {
 
     public var llmProvider: LLMProvider {
         didSet {
+            if oldValue != llmProvider {
+                TelemetryService.shared.providerChanged(from: oldValue.rawValue, to: llmProvider.rawValue)
+            }
             UserDefaults.standard.set(llmProvider.rawValue, forKey: "llmProvider")
             // Canonicalize model for the new provider
             if llmProvider == .appleIntelligence {


### PR DESCRIPTION
## Summary
- **ew-xee5**: Warm engine reuse now compares effective device selection (preferredInputDeviceIDOverride when set, selectedInputDeviceUID as fallback)
- **ew-0cui**: Paste Tier 3 clipboard-only fallback shows "Paste failed" overlay for 2.5s with accessibility announcement
- **ew-xvpk**: Wire dictationInvoked and providerChanged telemetry events
- **ew-qu3d**: Hookify block-xcodebuild regex only matches command-position invocations
- **ew-6991**: Already fixed in 01c4f42, closed

## Test plan
- [x] Release build passes
- [x] App launches and runs without crash
- [x] Manual recording test (5 recordings confirmed working)
- [ ] CI build-check passes
