### PR TITLE
feat: streaming/batch toggle + batch text loss fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "94d3683633a7d46753f342e9f3a88aa4b34f5ee59ddd23f33784d978e46073e5",
+  "originHash" : "d2f70a69c9dd79e8e47835d6cf4dcc2e625ca0a9eab047077b34d5cdc7534112",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"
+        "branch" : "46e96f4",
+        "revision" : "46e96f40bff968db80e53c45f084b6f9380c41c0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
-        .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "ab05466c6f0a52fd4f2a5acc94eabed9194a9f95"),
+        .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
         .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -59,6 +59,7 @@ final class PipelineSettingsSync {
         pipeline.wordCorrection.customWords = customWords
         pipeline.llmPolish.customWords = customWords
         pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
+        pipeline.useStreamingASR = settings.useStreamingASR
 
         // WhisperKit pipeline
         syncWhisperKitPipelineSettings(settings, customWords: customWords)
@@ -248,6 +249,8 @@ final class PipelineSettingsSync {
         case .useXPCAudioService:
             // Cold flag — requires app restart. No live propagation needed.
             break
+        case .useStreamingASR:
+            pipeline.useStreamingASR = settings.useStreamingASR
         }
     }
 

--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
@@ -84,7 +84,22 @@ struct SpeechEngineSettingsView: View {
                 }
             }
 
-            // ── Section 4: Cleanup ────────────────────────────────────────────
+            // ── Section 4: Transcription Mode ────────────────────────────────
+            if appState.settings.selectedBackend == .parakeet {
+                BrandedSection(header: "Transcription Mode") {
+                    BrandedRow(showDivider: false) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Toggle("Live transcription", isOn: $state.settings.useStreamingASR)
+                                .toggleStyle(BrandedToggleStyle())
+                            Text("Transcribes while you speak for faster results. Turn off for cleaner text on longer recordings.")
+                                .font(.stHelper)
+                                .foregroundStyle(.stTextTertiary)
+                        }
+                    }
+                }
+            }
+
+            // ── Section 5: Cleanup ────────────────────────────────────────────
             BrandedSection(header: "Cleanup") {
                 BrandedRow(showDivider: false) {
                     VStack(alignment: .leading, spacing: 4) {

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -56,6 +56,8 @@ public final class TranscriptionPipeline: DictationPipeline {
     private var silenceDetector: SilenceDetector?
     private var vadMonitorTask: Task<Void, Never>?
     private var recordingStartTime: Date?
+    /// User preference: use streaming ASR during recording (lower latency) or batch after stop (cleaner text).
+    public var useStreamingASR: Bool = true
     /// Whether streaming ASR was successfully started for the current recording.
     private var streamingASRActive = false
     /// Counters for diagnosing streaming buffer delivery (tail-cutoff instrumentation).
@@ -161,7 +163,7 @@ public final class TranscriptionPipeline: DictationPipeline {
         defer { if !streamingSetupSucceeded { deactivateStreamingForwarding() } }
 
         let supportsStreaming = await asrManager.activeBackendSupportsStreaming
-        if supportsStreaming {
+        if supportsStreaming && useStreamingASR {
             do {
                 try await asrManager.startStreaming(options: transcriptionOptions)
                 streamingASRActive = true

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -40,6 +40,7 @@ public final class SettingsManager {
         case environmentPreset
         case writingStylePreset
         case useXPCAudioService
+        case useStreamingASR
     }
 
     public var onChange: ((SettingKey) -> Void)?
@@ -229,6 +230,13 @@ public final class SettingsManager {
         }
     }
 
+    public var useStreamingASR: Bool {
+        didSet {
+            UserDefaults.standard.set(useStreamingASR, forKey: "useStreamingASR")
+            onChange?(.useStreamingASR)
+        }
+    }
+
     public var isDebugModeEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isDebugModeEnabled, forKey: "isDebugModeEnabled")
@@ -384,7 +392,7 @@ public final class SettingsManager {
         modelUnloadPolicy = ModelUnloadPolicy(
             rawValue: defaults.string(forKey: "modelUnloadPolicy") ?? ""
         ) ?? .never
-        restoreClipboardAfterPaste = defaults.object(forKey: "restoreClipboardAfterPaste") as? Bool ?? false
+        restoreClipboardAfterPaste = defaults.object(forKey: "restoreClipboardAfterPaste") as? Bool ?? true
         customSystemPrompt = defaults.string(forKey: "customSystemPrompt") ?? ""
         wordCorrectionEnabled = defaults.object(forKey: "wordCorrectionEnabled") as? Bool ?? true
         fillerRemovalEnabled = defaults.object(forKey: "fillerRemovalEnabled") as? Bool ?? true
@@ -400,6 +408,7 @@ public final class SettingsManager {
         environmentPreset = EnvironmentPreset(rawValue: defaults.string(forKey: "environmentPreset") ?? "") ?? .normal
         writingStylePreset = WritingStylePreset(rawValue: defaults.string(forKey: "writingStylePreset") ?? "") ?? .standard
         useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
+        useStreamingASR = defaults.object(forKey: "useStreamingASR") as? Bool ?? false
 
         // Canonicalize provider-coupled model names after all properties are loaded.
         if llmProvider == .appleIntelligence {


### PR DESCRIPTION
## Summary
- **Streaming/batch toggle**: "Live transcription" setting in Speech Engine, user-selectable
- **Batch ChunkProcessor fix**: FluidAudio fork @ 46e96f4 fixes >15s batch text loss (contextFrameAdjustment mismatch)
- **Better defaults**: batch mode default (cleaner raw output), restoreClipboardAfterPaste=true
- **88s TTS test**: both modes produce complete, correct transcripts

## Test plan
- [x] 88s TTS batch test: 1,382 chars, complete transcript
- [x] 88s TTS streaming test: complete transcript, 0.7s faster
- [x] Toggle visible in Settings (Parakeet only)
- [x] Setting persists across restart
- [x] Release build passes
- [ ] CI build-check
