### PR TITLE
fix(pipeline): instant first button press

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -340,7 +340,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             iconAnimator.transition(to: .error)
         } else if state == .recording {
             iconAnimator.transition(to: .recording)
-        } else if state == .transcribing || state == .polishing {
+        } else if state == .transcribing || state == .polishing || state == .loadingModel {
             iconAnimator.transition(to: .processing)
         } else {
             iconAnimator.transition(to: .idle)

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -199,15 +199,10 @@ final class AppState {
         // Sync WhisperKit setup service model variant
         whisperKitSetup.modelVariant = settings.whisperKitModel
 
-        // Restore persisted backend selection (ASRManager defaults to .parakeet)
-        if settings.selectedBackend != .parakeet {
-            Task {
-                await asrManager.switchBackend(to: settings.selectedBackend)
-                SentryBreadcrumb.updateASRBackend(settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
-            }
-        } else {
-            SentryBreadcrumb.updateASRBackend("parakeet")
-        }
+        // Restore persisted backend selection synchronously (no race with first record).
+        // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
+        asrManager.setInitialBackendType(settings.selectedBackend)
+        SentryBreadcrumb.updateASRBackend(settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
 
         // Wire settings change handler
         settings.onChange = { [weak self] key in
@@ -393,8 +388,14 @@ final class AppState {
             ) }
         }
 
-        // Pre-load WhisperKit model in background to eliminate cold-start delay.
-        // Detect cached model state first (setupState starts as .checking), then observe for .ready.
+        // Pre-load the selected backend's model in the background to eliminate cold-start delay.
+        // Parakeet: direct silent load (model files already downloaded during onboarding).
+        // WhisperKit: observation-based (waits for setupState to become .ready first).
+        if settings.selectedBackend == .parakeet {
+            Task { [weak self] in
+                await self?.asrManager.loadModelSilently()
+            }
+        }
         Task { [weak self] in
             await self?.whisperKitSetup.detectState()
             self?.startWhisperKitPreloadObservation()
@@ -595,7 +596,7 @@ final class AppState {
             whisperKitPipeline.autoPasteToActiveApp = false
             await whisperKitPipeline.handle(event: .cancelRecording)
         } else {
-            guard pipelineState == .recording else { return }
+            guard pipelineState == .recording || pipelineState == .loadingModel else { return }
             pipeline.autoPasteToActiveApp = false
             await pipeline.cancelRecording()
         }

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -17,6 +17,8 @@ public final class ASRManager: ASRManagerInterface {
     public var onServiceInterrupted: (() -> Void)?  // No-op for in-process — no XPC crash path
     private var idleTimer: Timer?
     private var lastTranscriptionTime: Date?
+    /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
+    private var inFlightLoadTask: Task<Void, any Error>?
 
     private var parakeetBackend = ParakeetBackend()
     private var whisperKitBackend = WhisperKitBackend()
@@ -38,6 +40,14 @@ public final class ASRManager: ASRManagerInterface {
         }
     }
 
+    /// Set the backend type synchronously at app startup. No unload (nothing loaded yet).
+    /// Must be called before any loadModel() or warmup task.
+    public func setInitialBackendType(_ type: ASRBackendType) {
+        activeBackendType = type
+        isModelLoaded = false
+        isStreaming = false
+    }
+
     /// Switch to a different backend. Unloads the previous one.
     public func switchBackend(to type: ASRBackendType) async {
         guard type != activeBackendType else { return }
@@ -57,29 +67,61 @@ public final class ASRManager: ASRManagerInterface {
     }
 
 
-    /// Load the active backend's model.
+    /// Load the active backend's model. Single-flight: concurrent callers await the same task.
     public func loadModel() async throws {
-        downloadProgress = 0
-        downloadPhase = "Preparing download..."
-        downloadDetail = ""
-
-        // For Parakeet, use the progress-reporting variant so in-process path also reports progress.
-        if activeBackendType == .parakeet {
-            try await parakeetBackend.prepare { [weak self] fraction, phase, detail in
-                Task { @MainActor [weak self] in
-                    guard let self, !self.isModelLoaded else { return }
-                    self.downloadProgress = fraction
-                    self.downloadPhase = phase
-                    self.downloadDetail = detail
-                }
-            }
-        } else {
-            try await activeBackend.prepare()
+        // If a load is already in progress, await it instead of starting a new one.
+        if let existing = inFlightLoadTask {
+            try await existing.value
+            return
         }
-        downloadProgress = 1.0
-        downloadPhase = ""
-        downloadDetail = ""
-        isModelLoaded = await activeBackend.isReady
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.downloadProgress = 0
+            self.downloadPhase = "Preparing download..."
+            self.downloadDetail = ""
+
+            // For Parakeet, use the progress-reporting variant so in-process path also reports progress.
+            if self.activeBackendType == .parakeet {
+                try await self.parakeetBackend.prepare { [weak self] fraction, phase, detail in
+                    Task { @MainActor [weak self] in
+                        guard let self, !self.isModelLoaded else { return }
+                        self.downloadProgress = fraction
+                        self.downloadPhase = phase
+                        self.downloadDetail = detail
+                    }
+                }
+            } else {
+                try await self.activeBackend.prepare()
+            }
+            self.downloadProgress = 1.0
+            self.downloadPhase = ""
+            self.downloadDetail = ""
+            self.isModelLoaded = await self.activeBackend.isReady
+        }
+        inFlightLoadTask = task
+        defer { inFlightLoadTask = nil }
+        try await task.value
+    }
+
+    /// Silent warmup: load the model in the background without mutating UI-visible download state.
+    /// Used at app launch. If a user-initiated load is already in progress, awaits it.
+    public func loadModelSilently() async {
+        guard !isModelLoaded else { return }
+        // If a load is already in progress, just await it silently.
+        if let existing = inFlightLoadTask {
+            try? await existing.value
+            return
+        }
+        do {
+            try await loadModel()
+        } catch {
+            // Silent warmup failure is non-fatal. Record button triggers lazy-load as fallback.
+            Task { await AppLogger.shared.log(
+                "Silent model warmup failed: \(error.localizedDescription)",
+                level: .info, category: "ASRManager"
+            ) }
+        }
     }
 
     /// Transcribe audio from a file URL.

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -20,7 +20,9 @@ public protocol ASRManagerInterface: AnyObject {
 
     // Model lifecycle
     func loadModel() async throws
+    func loadModelSilently() async
     func unloadModel() async
+    func setInitialBackendType(_ type: ASRBackendType)
     func switchBackend(to type: ASRBackendType) async
     func updateWhisperKitModel(_ variant: String) async
 

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -40,46 +40,78 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
     private var idleTimer: Timer?
     private var progressPollTimer: Timer?
+    /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
+    private var inFlightLoadTask: Task<Void, any Error>?
 
     public init() {}
 
     // MARK: - ASRManagerInterface: Model lifecycle
 
+    /// Load the active backend's model. Single-flight: concurrent callers await the same task.
     public func loadModel() async throws {
-        // Reset progress state before starting
-        downloadProgress = 0
-        downloadPhase = "Preparing download..."
-        downloadDetail = ""
-
-        ensureConnection()
-        resendConfigIfNeeded()
-
-        // Start polling the XPC service for progress at 4 Hz.
-        // This is the reliable path — request/response, no Mach port backpressure,
-        // no bidirectional callback issues. The XPC push callback is kept as a
-        // supplementary fast path but polling is the primary progress source.
-        startProgressPolling()
-
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-            let guard_ = OneShotContinuationASR(cont)
-            serviceProxy { proxy in
-                proxy.loadModel(
-                    backendType: self.activeBackendType.rawValue,
-                    modelVariant: self.lastModelVariant
-                ) { nsError in
-                    if let error = nsError { guard_.resume(throwing: error) }
-                    else { guard_.resume() }
-                }
-            } onProxyError: {
-                guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
-            }
+        // If a load is already in progress, await it instead of starting a new one.
+        if let existing = inFlightLoadTask {
+            try await existing.value
+            return
         }
-        // Stop polling and clear progress on completion
-        stopProgressPolling()
-        downloadProgress = 1.0
-        downloadPhase = ""
-        downloadDetail = ""
-        isModelLoaded = true
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            // Reset progress state before starting
+            self.downloadProgress = 0
+            self.downloadPhase = "Preparing download..."
+            self.downloadDetail = ""
+
+            self.ensureConnection()
+            self.resendConfigIfNeeded()
+
+            // Start polling the XPC service for progress at 4 Hz.
+            self.startProgressPolling()
+
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+                let guard_ = OneShotContinuationASR(cont)
+                self.serviceProxy { proxy in
+                    proxy.loadModel(
+                        backendType: self.activeBackendType.rawValue,
+                        modelVariant: self.lastModelVariant
+                    ) { nsError in
+                        if let error = nsError { guard_.resume(throwing: error) }
+                        else { guard_.resume() }
+                    }
+                } onProxyError: {
+                    guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+                }
+            }
+            // Stop polling and clear progress on completion
+            self.stopProgressPolling()
+            self.downloadProgress = 1.0
+            self.downloadPhase = ""
+            self.downloadDetail = ""
+            self.isModelLoaded = true
+        }
+        inFlightLoadTask = task
+        defer { inFlightLoadTask = nil }
+        try await task.value
+    }
+
+    /// Silent warmup: load the model in the background without mutating UI-visible download state.
+    /// Used at app launch. If a user-initiated load is already in progress, awaits it.
+    public func loadModelSilently() async {
+        guard !isModelLoaded else { return }
+        // If a load is already in progress, just await it silently.
+        if let existing = inFlightLoadTask {
+            try? await existing.value
+            return
+        }
+        do {
+            try await loadModel()
+        } catch {
+            // Silent warmup failure is non-fatal. Record button triggers lazy-load as fallback.
+            Task { await AppLogger.shared.log(
+                "Silent model warmup failed: \(error.localizedDescription)",
+                level: .info, category: "ASRManagerProxy"
+            ) }
+        }
     }
 
     private func startProgressPolling() {
@@ -116,6 +148,14 @@ public final class ASRManagerProxy: ASRManagerInterface {
             }
         }
         isModelLoaded = false
+    }
+
+    /// Set the backend type synchronously at app startup. No unload (nothing loaded yet).
+    /// Must be called before any loadModel() or warmup task.
+    public func setInitialBackendType(_ type: ASRBackendType) {
+        activeBackendType = type
+        isModelLoaded = false
+        isStreaming = false
     }
 
     public func switchBackend(to type: ASRBackendType) async {

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -39,7 +39,8 @@ public actor WhisperKitBackend: ASRBackend {
         guard !isReady else { return }  // Idempotent — skip if already loaded
 
         // Use cached model path from WhisperKitSetupService (no network call).
-        // Falls back to WhisperKit.download() if path not found (handles edge cases).
+        // Falls back to WhisperKit.download() if path not found (handles edge cases
+        // like user-initiated record when cache was cleared).
         let modelPath: String
         if let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) {
             modelPath = cached
@@ -48,6 +49,21 @@ public actor WhisperKitBackend: ASRBackend {
             modelPath = folder.path
         }
 
+        try await loadFromPath(modelPath)
+    }
+
+    /// Load model from local cache only. Returns false if model is not cached.
+    /// Used by silent/background warmup paths that must never trigger a network download.
+    public func prepareIfCached() async throws -> Bool {
+        guard !isReady else { return true }
+        guard let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) else {
+            return false  // Model not downloaded, skip silently
+        }
+        try await loadFromPath(cached)
+        return true
+    }
+
+    private func loadFromPath(_ modelPath: String) async throws {
         let config = WhisperKitConfig(
             model: modelVariant,
             modelFolder: modelPath,

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -73,6 +73,9 @@ public final class TranscriptionPipeline: DictationPipeline {
     private var isPreWarmed = false
     /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
     private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
+    /// Cancellable model load task. Cancelled by cancelRecording() during .loadingModel.
+    /// Late completion after cancel is guarded by checking state == .loadingModel before proceeding.
+    private var modelLoadTask: Task<Void, any Error>?
 
     public init(
         audioCapture: any AudioCaptureInterface,
@@ -136,18 +139,34 @@ public final class TranscriptionPipeline: DictationPipeline {
         // Cancel idle timer so model stays loaded during recording.
         asrManager.cancelIdleTimer()
 
-        // Ensure model is loaded (model should already be cached by WhisperKitSetupService)
+        // Ensure model is loaded (model should already be warm from launch-time preload).
+        // Wrap in a cancellable task so cancelRecording() can abort a cold-start load.
         if !asrManager.isModelLoaded {
             state = .loadingModel
             SentryBreadcrumb.add(stage: "asr", message: "Model loading", data: ["backend": asrManager.activeBackendType.rawValue])
-            do {
+            let loadTask = Task {
                 try await asrManager.loadModel()
+            }
+            modelLoadTask = loadTask
+            do {
+                try await loadTask.value
+            } catch is CancellationError {
+                // User cancelled during model load. Return to idle.
+                stopRequested = false
+                modelLoadTask = nil
+                state = .idle
+                return
             } catch {
                 SentryBreadcrumb.captureError(error, category: .modelLoadFailed, stage: "asr", extra: ["backend": asrManager.activeBackendType.rawValue])
                 stopRequested = false
+                modelLoadTask = nil
                 state = .error("Model load failed: \(error.localizedDescription)")
                 return
             }
+            modelLoadTask = nil
+            // Late-completion guard: if state changed while we were loading (e.g., cancel),
+            // do not proceed. The cancel handler already set state to .idle.
+            guard state == .loadingModel else { return }
             guard !Task.isCancelled else { return }
         }
 
@@ -825,6 +844,17 @@ public final class TranscriptionPipeline: DictationPipeline {
     /// Guards on `.recording` state — safe to call from any other state.
     public func cancelRecording() async {
         stopRequested = false
+
+        // Cancel during model loading: abort the load task and return to idle.
+        if state == .loadingModel {
+            modelLoadTask?.cancel()
+            modelLoadTask = nil
+            targetApp = nil
+            targetElement = nil
+            state = .idle
+            return
+        }
+
         guard state == .recording else { return }
 
         // Stop VAD monitoring task immediately

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -154,16 +154,24 @@ public final class WhisperKitPipeline: DictationPipeline {
 
     /// Silently load the WhisperKit model into RAM without changing pipeline state.
     /// Called after model download completes or on launch if model is already cached.
+    /// Uses prepareIfCached() to avoid triggering a silent network download.
     /// If user presses record before this finishes, startRecording() handles it with its own .loadingModel flow.
     public func prepareBackendSilently() async {
         let isBackendReady = await backend.isReady
         guard !isBackendReady else { return }
         do {
-            try await backend.prepare()
-            Task { await AppLogger.shared.log(
-                "WhisperKit model pre-loaded successfully (background)",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
+            let loaded = try await backend.prepareIfCached()
+            if loaded {
+                Task { await AppLogger.shared.log(
+                    "WhisperKit model pre-loaded successfully (background)",
+                    level: .info, category: "WhisperKitPipeline"
+                ) }
+            } else {
+                Task { await AppLogger.shared.log(
+                    "WhisperKit model not cached, skipping silent pre-load",
+                    level: .info, category: "WhisperKitPipeline"
+                ) }
+            }
         } catch {
             Task { await AppLogger.shared.log(
                 "WhisperKit model pre-load failed: \(error.localizedDescription)",
@@ -179,8 +187,9 @@ public final class WhisperKitPipeline: DictationPipeline {
         await audioCapture.preWarm()
         guard !Task.isCancelled else { return }
         isPreWarmed = true
-        // Defense-in-depth: ensure model is loaded (idempotent, no-op if ready)
-        Task { try? await backend.prepare() }
+        // Defense-in-depth: ensure model is loaded from cache (no download).
+        // If not cached, startRecording() handles the full load with user-visible UI.
+        Task { _ = try? await backend.prepareIfCached() }
     }
 
     public func toggleRecording() async {


### PR DESCRIPTION
## Summary

- **Parakeet launch-time warmup**: silent background model load on app start with single-flight coalescing (no duplicate loads if user races the warmup)
- **Backend selection race fix**: synchronous `setInitialBackendType()` replaces async Task that could route first record to wrong pipeline
- **WhisperKit no-silent-download**: new `prepareIfCached()` ensures background paths never trigger network downloads
- **Cancellable Parakeet loading**: cancel during `.loadingModel` now works (parity with WhisperKit) with late-completion guard
- **Menu bar icon**: `.loadingModel` now shows processing icon instead of idle

Closes ew-vkak. Council-reviewed (GPT + Gemini consensus on all 5 fixes).

## Test plan

- [ ] Cold boot: kill app, relaunch, first record press is instant (warmup completes in background)
- [ ] Race the warmup: press record immediately after launch, see "Loading model..." with processing icon, can cancel with Escape
- [ ] Menu bar icon shows spinning during user-initiated model load
- [ ] Cancel during model load returns to idle cleanly
- [ ] WhisperKit selected: no silent download triggered on launch
- [ ] Heart smoke: record, transcribe, paste works after warmup
