### PR TITLE
chore(ci): add post-merge build check on main

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -1,0 +1,58 @@
+name: Main Post-Merge Check
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: main-post-merge
+  cancel-in-progress: true
+
+jobs:
+  main-post-merge-build:
+    runs-on: [self-hosted, enviouswispr-release]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Detect code changes
+        id: changes
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "unknown")
+          echo "==> Changed files:"
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)'; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "==> Code changes detected — running post-merge build"
+          else
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            echo "==> Non-code changes only — skipping build"
+          fi
+
+      - name: Cache SPM dependencies
+        if: steps.changes.outputs.needs_build == 'true'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Build (release)
+        if: steps.changes.outputs.needs_build == 'true'
+        run: swift build -c release --arch arm64
+
+      - name: Post result
+        if: always()
+        env:
+          NEEDS_BUILD: ${{ steps.changes.outputs.needs_build }}
+        run: |
+          if [ "$NEEDS_BUILD" != "true" ]; then
+            echo "Non-code push (appcast, docs, etc.) — no build needed"
+          else
+            echo "Post-merge release build passed"
+          fi


### PR DESCRIPTION
## Summary

- Adds `main-post-merge.yml`: runs release build on every push to main as a safety net
- Skips non-code pushes (appcast, docs, content-engine) via change detection
- Distinct job name (`main-post-merge-build`) to avoid confusion with PR `build-check`
- Compensating control for disabling `strict_required_status_checks_policy` (already applied via API)

## Context

`strict` caused rebase cascades whenever main moved (release bot appcast commits, other PR merges). Disabling it means PRs no longer need to be rebased just because main advanced. This post-merge check catches the rare case where two PRs break each other.

## Test plan

- [ ] Workflow file is valid YAML
- [ ] CI-only change: pr-check detects no Swift changes, skips build
- [ ] After merge: verify workflow triggers on next push to main
