### PR TITLE
chore(release): bump version to 1.7.7

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.6</string>
+	<string>1.7.7</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.6</string>
+	<string>1.7.7</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary

- Version bump to 1.7.7 for release

## Changes in this release

- fix(pipeline): instant first button press - eliminate cold-boot model loading surprise (#93)
- chore(ci): add post-merge build check on main (#94)
