### PR TITLE
feat(audio): configurable warm engine timeout in Settings UI

### DIFF
--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -72,6 +72,7 @@ final class PipelineSettingsSync {
         }
         audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
         audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+        audioCapture.warmEnginePolicy = settings.warmEnginePolicy
 
         // VAD config to audio capture (used by XPC service-side VAD)
         audioCapture.configureVAD(
@@ -251,6 +252,8 @@ final class PipelineSettingsSync {
             break
         case .useStreamingASR:
             pipeline.useStreamingASR = settings.useStreamingASR
+        case .warmEnginePolicy:
+            audioCapture.warmEnginePolicy = settings.warmEnginePolicy
         }
     }
 

--- a/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
@@ -45,6 +45,30 @@ struct AudioSettingsView: View {
                     }
                 }
             }
+
+            BrandedSection(header: "Microphone Readiness") {
+                BrandedRow {
+                    Picker("Keep microphone ready", selection: $state.settings.warmEnginePolicy) {
+                        Text("Off").tag(WarmEnginePolicy.off)
+                        Text("10 seconds").tag(WarmEnginePolicy.seconds10)
+                        Text("30 seconds").tag(WarmEnginePolicy.seconds30)
+                        Text("60 seconds").tag(WarmEnginePolicy.seconds60)
+                        Text("Always").tag(WarmEnginePolicy.always)
+                    }
+                }
+                BrandedRow(showDivider: false) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Keeps the microphone engine active after dictation so the next recording starts instantly and captures your first words.")
+                            .font(.stHelper)
+                            .foregroundStyle(.stTextTertiary)
+                        if state.settings.warmEnginePolicy == .always {
+                            Text("Always keeps the microphone engine active. The macOS microphone indicator may remain visible and power usage may increase.")
+                                .font(.stHelper)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import CoreAudio
+import EnviousWisprCore
 
 /// Abstraction over audio capture — enables swapping between in-process and XPC implementations.
 @MainActor
@@ -20,6 +21,7 @@ public protocol AudioCaptureInterface: AnyObject {
     var noiseSuppressionEnabled: Bool { get set }
     var selectedInputDeviceUID: String { get set }
     var preferredInputDeviceIDOverride: String { get set }
+    var warmEnginePolicy: WarmEnginePolicy { get set }
 
     // Core lifecycle
     func startEnginePhase() async throws

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -65,8 +65,19 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// Idle teardown timer: shuts down the warm engine after inactivity.
     private var warmEngineTeardownTask: Task<Void, Never>?
 
-    /// How long to keep the engine warm after recording stops (seconds).
-    private static let warmEngineIdleTimeout: TimeInterval = 30
+    /// How long to keep the engine warm after recording stops.
+    /// Setting this property automatically reconciles with the current engine state.
+    public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
+        didSet {
+            guard oldValue != warmEnginePolicy else { return }
+            reconcileWarmEnginePolicy()
+        }
+    }
+
+    /// When the engine entered idle-warm state. Used to recalculate remaining
+    /// timeout when the policy changes mid-idle.
+    private var idleSince: ContinuousClock.Instant?
+    private let clock = ContinuousClock()
 
     /// The last route decision — for telemetry and debugging.
     private var lastRouteDecision: CaptureRouteDecision?
@@ -240,18 +251,90 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
     // MARK: - Warm Engine Management
 
-    /// Schedule full engine teardown after idle timeout.
-    /// Cancelled if a new recording starts before timeout fires.
+    /// Schedule engine teardown based on the current warm engine policy.
+    /// Called after every recording stops. Cancelled if a new recording starts.
     private func scheduleWarmEngineTeardown() {
         warmEngineTeardownTask?.cancel()
+        warmEngineTeardownTask = nil
+
+        switch warmEnginePolicy {
+        case .off:
+            performEngineTeardown()
+            return
+        case .always:
+            idleSince = clock.now
+            return
+        case .seconds10, .seconds30, .seconds60:
+            break
+        }
+
+        let timeout = policyTimeout(warmEnginePolicy)
+        idleSince = clock.now
         warmEngineTeardownTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(Self.warmEngineIdleTimeout))
+            try? await Task.sleep(for: timeout)
             guard !Task.isCancelled, let self, !self.isCapturing else { return }
-            if let source = self.activeSource {
-                Self.btRouteLog("Warm engine idle timeout — full teardown")
-                _ = await source.stop()
-                self.activeSource = nil
+            self.performEngineTeardown()
+        }
+    }
+
+    /// In-flight engine stop task. Stored so resolveSource() can cancel it
+    /// if a new recording starts before the stop completes, preventing two
+    /// engines from running simultaneously on the same hardware.
+    private var engineStopTask: Task<Void, Never>?
+
+    /// Tear down the warm engine. Clears activeSource synchronously before
+    /// awaiting stop to prevent stale async completions from clobbering new state.
+    private func performEngineTeardown() {
+        idleSince = nil
+        guard let source = activeSource else { return }
+        activeSource = nil
+        Self.btRouteLog("Warm engine teardown")
+        engineStopTask = Task { [weak self] in
+            _ = await source.stop()
+            self?.engineStopTask = nil
+        }
+    }
+
+    /// Reconcile engine state when the policy changes while idle.
+    /// Called automatically by the warmEnginePolicy setter.
+    private func reconcileWarmEnginePolicy() {
+        // If capturing, new policy applies on next stopCapture.
+        guard !isCapturing else { return }
+        // If engine is not warm, nothing to reconcile.
+        guard activeSource != nil else { return }
+
+        warmEngineTeardownTask?.cancel()
+        warmEngineTeardownTask = nil
+
+        switch warmEnginePolicy {
+        case .off:
+            performEngineTeardown()
+        case .always:
+            // Keep warm indefinitely, preserve idleSince.
+            break
+        case .seconds10, .seconds30, .seconds60:
+            let timeout = policyTimeout(warmEnginePolicy)
+            let elapsed = idleSince.map { clock.now - $0 } ?? .zero
+            if elapsed >= timeout {
+                performEngineTeardown()
+            } else {
+                let remaining = timeout - elapsed
+                warmEngineTeardownTask = Task { [weak self] in
+                    try? await Task.sleep(for: remaining)
+                    guard !Task.isCancelled, let self, !self.isCapturing else { return }
+                    self.performEngineTeardown()
+                }
             }
+        }
+    }
+
+    /// Map a timed policy case to a Duration.
+    private func policyTimeout(_ policy: WarmEnginePolicy) -> Duration {
+        switch policy {
+        case .seconds10: .seconds(10)
+        case .seconds30: .seconds(30)
+        case .seconds60: .seconds(60)
+        default: .seconds(30)
         }
     }
 
@@ -263,6 +346,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         // Cancel idle teardown — we're about to record
         warmEngineTeardownTask?.cancel()
         warmEngineTeardownTask = nil
+        // Cancel any in-flight engine stop from a previous teardown.
+        engineStopTask?.cancel()
+        engineStopTask = nil
 
         // If a source is already running (warm engine), check route compatibility
         if let existing = activeSource, existing.isRunning {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -37,6 +37,16 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     public var selectedInputDeviceUID: String = ""
     public var preferredInputDeviceIDOverride: String = ""
 
+    /// Cached warm engine policy -- forwarded to service, replayed after crash.
+    public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
+        didSet {
+            guard oldValue != warmEnginePolicy else { return }
+            serviceProxy { [self] proxy in
+                proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
+            }
+        }
+    }
+
     // MARK: - XPC connection state
 
     private var connection: NSXPCConnection?
@@ -239,6 +249,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
                 proxy.configureVAD(autoStop: vad.autoStop, silenceTimeout: vad.silenceTimeout,
                                    sensitivity: vad.sensitivity, energyGate: vad.energyGate)
             }
+            // Replay warm engine policy so service uses correct idle timeout.
+            proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
             needsReinit = false
         }
     }

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -128,6 +128,13 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
         }
     }
 
+    func setWarmEnginePolicy(_ rawValue: String) {
+        let policy = WarmEnginePolicy(rawValue: rawValue) ?? .seconds30
+        Task { @MainActor in
+            captureManager.warmEnginePolicy = policy
+        }
+    }
+
     // MARK: - Lifecycle
 
     func startEnginePhase(

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -32,6 +32,10 @@ import Foundation
     /// Set the selected input device UID (legacy path). Empty = system default.
     func setSelectedInputDeviceUID(_ uid: String)
 
+    /// Set the warm engine policy. Raw value of WarmEnginePolicy enum.
+    /// Replayed by the proxy after service crash via resendConfigIfNeeded().
+    func setWarmEnginePolicy(_ rawValue: String)
+
     // MARK: - Lifecycle (Step 3)
 
     /// Phase 1: start the audio engine, trigger BT codec switch, register config-change observer.

--- a/Sources/EnviousWisprCore/WarmEnginePolicy.swift
+++ b/Sources/EnviousWisprCore/WarmEnginePolicy.swift
@@ -1,0 +1,11 @@
+/// How long to keep the audio engine warm after recording stops.
+///
+/// A warm engine enables instant pre-roll capture on the next recording,
+/// eliminating first-word clipping. The tradeoff is power usage while warm.
+public enum WarmEnginePolicy: String, CaseIterable, Sendable {
+    case off
+    case seconds10
+    case seconds30
+    case seconds60
+    case always
+}

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -41,6 +41,7 @@ public final class SettingsManager {
         case writingStylePreset
         case useXPCAudioService
         case useStreamingASR
+        case warmEnginePolicy
     }
 
     public var onChange: ((SettingKey) -> Void)?
@@ -237,6 +238,13 @@ public final class SettingsManager {
         }
     }
 
+    public var warmEnginePolicy: WarmEnginePolicy {
+        didSet {
+            UserDefaults.standard.set(warmEnginePolicy.rawValue, forKey: "warmEnginePolicy")
+            onChange?(.warmEnginePolicy)
+        }
+    }
+
     public var isDebugModeEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isDebugModeEnabled, forKey: "isDebugModeEnabled")
@@ -409,6 +417,9 @@ public final class SettingsManager {
         writingStylePreset = WritingStylePreset(rawValue: defaults.string(forKey: "writingStylePreset") ?? "") ?? .standard
         useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
         useStreamingASR = defaults.object(forKey: "useStreamingASR") as? Bool ?? false
+        warmEnginePolicy = WarmEnginePolicy(
+            rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""
+        ) ?? .seconds30
 
         // Canonicalize provider-coupled model names after all properties are loaded.
         if llmProvider == .appleIntelligence {


### PR DESCRIPTION
## Summary
- Add "Keep microphone ready" picker to Settings > Microphone with Off/10s/30s/60s/Always options (default 30s, unchanged behavior)
- `WarmEnginePolicy` enum propagated through Core, Audio, Services, XPC (with crash replay), and UI layers (9 files)
- ContinuousClock-based `idleSince` tracking for mid-idle policy reconciliation
- `performEngineTeardown()` nils activeSource before async stop; `engineStopTask` tracked and cancelled by `resolveSource()` to prevent two-engine overlap

## Review
- GPT council: 2 rounds, 8 concerns addressed
- Codex: 5 areas reviewed, 1 fix (engineStopTask), 1 false positive

## Test plan
- [x] Release build passes
- [x] Test target compiles
- [x] Wispr-eyes: 7/7 scope items VERIFIED (picker, defaults, all options, helper text, orange warning appears/disappears)
- [x] Heart smoke: full pipeline completes (~1s)
- [x] Default behavior unchanged (30s)
