### PR TITLE
fix(pipeline): streaming batch rescue for Parakeet stop-time failures

### DIFF
--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -146,6 +146,7 @@ public actor ParakeetBackend: ASRBackend {
 
     public func finalizeStreaming() async throws -> ASRResult {
         guard let manager = streamingManager else { throw ASRError.streamingNotSupported }
+        defer { streamingManager = nil }
 
         let finalizeStart = CFAbsoluteTimeGetCurrent()
         let text = try await manager.finish()
@@ -153,8 +154,6 @@ public actor ParakeetBackend: ASRBackend {
 
         let totalElapsed = finalizeEnd - streamingStartTime
         let finalizeElapsed = finalizeEnd - finalizeStart
-
-        self.streamingManager = nil
 
         return ASRResult(
             text: text,

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -414,10 +414,12 @@ public final class TranscriptionPipeline: DictationPipeline {
 
         // Filter silence using VAD speech segments (used for batch fallback and logging).
         var samples: [Float]
+        var hasSpeechEvidence = false
         let isXPCMode = audioCapture is AudioCaptureProxy
         if isXPCMode {
             // XPC mode: get speech segments from service-side VAD.
             let segments = await audioCapture.getVADSegments()
+            hasSpeechEvidence = !segments.isEmpty
             if !segments.isEmpty {
                 samples = Self.filterSamples(from: rawSamples, segments: segments)
             } else {
@@ -425,9 +427,14 @@ public final class TranscriptionPipeline: DictationPipeline {
             }
         } else if let detector = silenceDetector {
             await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+            let segments = await detector.speechSegments
+            hasSpeechEvidence = !segments.isEmpty
             samples = await detector.filterSamples(from: rawSamples)
         } else {
             samples = rawSamples
+            // No VAD detector available -- cannot determine speech presence.
+            // Default to false to avoid misclassifying noise/silence as speech.
+            hasSpeechEvidence = false
         }
 
         Task { await AppLogger.shared.log(
@@ -459,10 +466,14 @@ public final class TranscriptionPipeline: DictationPipeline {
             // Use streaming finalize when available for lowest latency.
             // FluidAudio fork uses fresh decoder state per chunk + chunk-aware text assembly
             // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
-            // Falls back to batch transcription when streaming was not active.
+            // Streaming mode includes batch rescue: if finalize fails or returns empty
+            // despite VAD speech evidence, retry with batch decode using captured samples.
             let result: ASRResult
             if wasStreaming {
-                result = try await asrManager.finalizeStreaming()
+                result = try await transcribeWithStreamingRescue(
+                    samples: samples,
+                    hasSpeechEvidence: hasSpeechEvidence
+                )
             } else {
                 result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
             }
@@ -478,11 +489,14 @@ public final class TranscriptionPipeline: DictationPipeline {
                     snapshot: frozenSnapshot
                 )
                 frozenSnapshot = nil
-                state = .error("No speech detected — try speaking closer to the microphone")
-                Task { await AppLogger.shared.log(
-                    "ASR returned empty text, showing error to user",
+                let errorMsg = hasSpeechEvidence
+                    ? "Transcription failed — could not decode speech"
+                    : "No speech detected — try speaking closer to the microphone"
+                state = .error(errorMsg)
+                await AppLogger.shared.log(
+                    "ASR returned empty text (speechEvidence=\(hasSpeechEvidence)), showing error",
                     level: .info, category: "Pipeline"
-                ) }
+                )
                 return
             }
 
@@ -1019,7 +1033,53 @@ public final class TranscriptionPipeline: DictationPipeline {
         return result.isEmpty ? allSamples : result
     }
 
-    // MARK: - Streaming Finalization
+    // MARK: - Streaming Rescue
+
+    /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
+    /// and VAD detected speech. Heart-level rescue: captured samples are already available,
+    /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
+    private func transcribeWithStreamingRescue(
+        samples: [Float],
+        hasSpeechEvidence: Bool
+    ) async throws -> ASRResult {
+        // 1. Try streaming finalize (happy path)
+        do {
+            let result = try await asrManager.finalizeStreaming()
+            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                return result
+            }
+            // Streaming returned empty -- check rescue eligibility below
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            await AppLogger.shared.log(
+                "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
+                level: .info, category: "Pipeline"
+            )
+        }
+
+        // 2. No speech evidence means genuine silence, not a rescue candidate.
+        // Return an empty result so the caller handles it with the appropriate message.
+        guard hasSpeechEvidence else {
+            return ASRResult(text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+        }
+
+        // 3. Batch rescue: speech was detected but streaming failed to decode it.
+        await AppLogger.shared.log(
+            "Streaming rescue: speech evidence found, retrying batch (\(samples.count) samples)",
+            level: .info, category: "Pipeline"
+        )
+
+        let result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
+
+        await AppLogger.shared.log(
+            "Streaming rescue: batch produced \(result.text.count) chars",
+            level: .info, category: "Pipeline"
+        )
+
+        return result
+    }
 
     // MARK: - Text Processing
 


### PR DESCRIPTION
## Summary
- When Parakeet streaming `finalizeStreaming()` throws or returns empty despite VAD speech evidence, retry once with batch `transcribe()` using captured samples already in scope
- `defer { streamingManager = nil }` in ParakeetBackend ensures clean state after streaming failure
- Error message now differentiates "Transcription failed" (speech detected but decode failed) from "No speech detected" (genuine silence)

## Review
- GPT council: 3 rounds on session ew-58a-scope (full architecture docs provided)
- Codex: 6 areas reviewed, 1 fix applied (no-VAD fallback default)

## Test plan
- [x] Release build + test target compile
- [x] Rebuild-and-relaunch (6 processes)
- [x] Heart smoke: streaming mode recording completes in ~0.8s
- [x] Pipeline logs confirm streaming happy path (no rescue triggered)
- [x] Codex review: 5/6 clean, 1 fix applied and re-tested
