### PR TITLE
fix(pipeline): VAD gate prevents ASR hallucinations from ambient noise

### DIFF
--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -84,6 +84,13 @@ final class RecordingOverlayPanel {
                 userInfo: [.announcement: "Text copied to clipboard",
                            .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber])
             showClipboardFallback()
+        case .error(let message):
+            NSAccessibility.post(
+                element: NSApp.mainWindow as Any,
+                notification: .announcementRequested,
+                userInfo: [.announcement: "Error: \(message)",
+                           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber])
+            showError(message: message)
         }
     }
 
@@ -182,16 +189,68 @@ final class RecordingOverlayPanel {
         DispatchQueue.main.async(execute: work)
     }
 
-    /// Auto-dismiss timer for transient notices (clipboard fallback).
+    /// Auto-dismiss timer for transient notices (clipboard fallback, errors).
     private var autoDismissTask: Task<Void, Never>?
 
-    private func scheduleAutoDismiss() {
+    private func scheduleAutoDismiss(seconds: Double = 2.5) {
         autoDismissTask?.cancel()
         autoDismissTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(2.5))
+            try? await Task.sleep(for: .seconds(seconds))
             guard !Task.isCancelled, let self, self.panel != nil else { return }
             self.hide()
         }
+    }
+
+    /// Show a transient error notice that auto-dismisses after 3s.
+    func showError(message: String) {
+        guard panel == nil else {
+            transitionToError(message: message)
+            scheduleAutoDismiss(seconds: 3.0)
+            return
+        }
+        pendingCreateWork?.cancel()
+        pendingCreateWork = nil
+        generation &+= 1
+        let token = generation
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.generation == token else { return }
+            self.pendingCreateWork = nil
+            self.showPanel(
+                content: ErrorOverlayView(message: message).frame(width: 260, height: 44),
+                width: 260
+            )
+            self.scheduleAutoDismiss(seconds: 3.0)
+        }
+        pendingCreateWork = work
+        DispatchQueue.main.async(execute: work)
+    }
+
+    /// Transition an existing panel to an error display.
+    private func transitionToError(message: String) {
+        guard let existingPanel = panel else { return }
+        let y = existingPanel.frame.origin.y
+
+        panel = nil
+        pendingCreateWork?.cancel()
+        pendingCreateWork = nil
+        CATransaction.flush()
+        existingPanel.close()
+
+        generation &+= 1
+        let token = generation
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.generation == token else { return }
+            self.pendingCreateWork = nil
+            self.showPanel(
+                content: ErrorOverlayView(message: message).frame(width: 260, height: 44),
+                width: 260,
+                y: y
+            )
+        }
+        pendingCreateWork = work
+        DispatchQueue.main.async(execute: work)
     }
 
     private func createPolishingPanel(label: String = "Polishing...") {
@@ -612,6 +671,29 @@ struct PolishingOverlayView: View {
             Text(label)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.white)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(OverlayCapsuleBackground())
+    }
+}
+
+// MARK: - ErrorOverlayView
+
+/// Compact error indicator overlay shown when ASR fails despite speech evidence.
+struct ErrorOverlayView: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.red)
+                .font(.system(size: 16))
+
+            Text(message)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -18,6 +18,9 @@ public enum OverlayIntent: Equatable, Sendable {
     /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
     /// Auto-dismissed by the overlay panel after a short delay.
     case clipboardFallback
+    /// Transient error notice shown when ASR fails despite speech evidence.
+    /// Auto-dismissed by the overlay panel after 3 seconds.
+    case error(message: String)
 }
 
 /// Abstraction over dictation pipelines (Parakeet streaming, WhisperKit batch, etc.).

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -415,11 +415,15 @@ public final class TranscriptionPipeline: DictationPipeline {
         // Filter silence using VAD speech segments (used for batch fallback and logging).
         var samples: [Float]
         var hasSpeechEvidence = false
+        var vadSegmentCount = 0
+        var vadSpeechDurationMs = 0
         let isXPCMode = audioCapture is AudioCaptureProxy
         if isXPCMode {
             // XPC mode: get speech segments from service-side VAD.
             let segments = await audioCapture.getVADSegments()
             hasSpeechEvidence = !segments.isEmpty
+            vadSegmentCount = segments.count
+            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             if !segments.isEmpty {
                 samples = Self.filterSamples(from: rawSamples, segments: segments)
             } else {
@@ -429,18 +433,49 @@ public final class TranscriptionPipeline: DictationPipeline {
             await detector.finalizeSegments(totalSampleCount: rawSamples.count)
             let segments = await detector.speechSegments
             hasSpeechEvidence = !segments.isEmpty
+            vadSegmentCount = segments.count
+            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             samples = await detector.filterSamples(from: rawSamples)
         } else {
             samples = rawSamples
             // No VAD detector available -- cannot determine speech presence.
-            // Default to false to avoid misclassifying noise/silence as speech.
-            hasSpeechEvidence = false
+            // Default to true so that empty ASR results still fire Sentry errors
+            // (fail toward visibility rather than silently swallowing failures).
+            hasSpeechEvidence = true
         }
+        let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
 
         Task { await AppLogger.shared.log(
             "VAD filtered to \(samples.count) samples (\(String(format: "%.1f", Double(samples.count)/Double(max(rawSamples.count, 1))*100))% voiced)",
             level: .verbose, category: "Pipeline"
         ) }
+
+        // VAD gate: if no speech was detected, skip ASR entirely.
+        // Prevents noise-induced hallucinations ("Okay", "Yeah") from ambient sounds.
+        // The decoder hallucinates filler words from low-information audio; not
+        // invoking it eliminates the problem at the source.
+        if !hasSpeechEvidence {
+            if wasStreaming {
+                await asrManager.cancelStreaming()
+            }
+            SentryBreadcrumb.add(
+                stage: "asr", message: "VAD gate: no speech detected, skipping ASR",
+                level: .info,
+                data: [
+                    "backend": asrManager.activeBackendType.rawValue,
+                    "mode": wasStreaming ? "streaming" : "batch",
+                    "raw_sample_count": rawSamples.count,
+                    "peak_audio_level": peakAudioLevel,
+                ]
+            )
+            frozenSnapshot = nil
+            state = .idle
+            Task { await AppLogger.shared.log(
+                "VAD gate: no speech, skipping ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
+                level: .info, category: "Pipeline"
+            ) }
+            return
+        }
 
         // ASR backends require >= 1 second of audio.
         // If VAD filtering was too aggressive, fall back to raw samples.
@@ -482,21 +517,41 @@ public final class TranscriptionPipeline: DictationPipeline {
 
             let asrText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !asrText.isEmpty else {
-                SentryBreadcrumb.captureError(
-                    NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "ASR returned empty text"]),
-                    category: .asrEmptyResult, stage: "asr",
-                    extra: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"],
-                    snapshot: frozenSnapshot
-                )
+                if hasSpeechEvidence {
+                    // Real ASR failure: VAD detected speech but decoder returned nothing
+                    SentryBreadcrumb.captureError(
+                        NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"]),
+                        category: .asrEmptyResult, stage: "asr",
+                        extra: [
+                            "backend": asrManager.activeBackendType.rawValue,
+                            "mode": wasStreaming ? "streaming" : "batch",
+                            "has_speech_evidence": true,
+                            "raw_sample_count": rawSamples.count,
+                            "vad_segment_count": vadSegmentCount,
+                            "vad_speech_duration_ms": vadSpeechDurationMs,
+                            "peak_audio_level": peakAudioLevel,
+                        ],
+                        snapshot: frozenSnapshot
+                    )
+                    state = .error("Couldn't catch that -- try again")
+                    Task { await AppLogger.shared.log(
+                        "ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
+                        level: .info, category: "Pipeline"
+                    ) }
+                } else {
+                    // Expected: user held button without speaking
+                    SentryBreadcrumb.add(
+                        stage: "asr", message: "ASR empty (no speech detected)",
+                        level: .info,
+                        data: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"]
+                    )
+                    state = .idle
+                    Task { await AppLogger.shared.log(
+                        "No speech detected, returning to idle",
+                        level: .info, category: "Pipeline"
+                    ) }
+                }
                 frozenSnapshot = nil
-                let errorMsg = hasSpeechEvidence
-                    ? "Transcription failed — could not decode speech"
-                    : "No speech detected — try speaking closer to the microphone"
-                state = .error(errorMsg)
-                await AppLogger.shared.log(
-                    "ASR returned empty text (speechEvidence=\(hasSpeechEvidence)), showing error",
-                    level: .info, category: "Pipeline"
-                )
                 return
             }
 
@@ -1165,8 +1220,10 @@ public final class TranscriptionPipeline: DictationPipeline {
             return .processing(label: "Transcribing...")
         case .polishing:
             return .processing(label: "Polishing...")
-        case .idle, .complete, .error:
+        case .idle, .complete:
             return .hidden
+        case .error(let msg):
+            return .error(message: msg)
         }
     }
 

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -130,8 +130,10 @@ public final class WhisperKitPipeline: DictationPipeline {
             return .processing(label: "Transcribing...")
         case .polishing:
             return .processing(label: "Polishing...")
-        case .idle, .ready, .complete, .error:
+        case .idle, .ready, .complete:
             return .hidden
+        case .error(let msg):
+            return .error(message: msg)
         }
     }
 
@@ -352,10 +354,16 @@ public final class WhisperKitPipeline: DictationPipeline {
 
         // Post-capture VAD filtering — remove silence segments
         var samples: [Float]
+        var hasSpeechEvidence = false
+        var vadSegmentCount = 0
+        var vadSpeechDurationMs = 0
         let isXPCMode = audioCapture is AudioCaptureProxy
         if isXPCMode {
             // XPC mode: get speech segments from service-side VAD.
             let segments = await audioCapture.getVADSegments()
+            hasSpeechEvidence = !segments.isEmpty
+            vadSegmentCount = segments.count
+            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             if !segments.isEmpty {
                 samples = Self.filterSamples(from: rawSamples, segments: segments)
                 let pct = String(format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
@@ -368,6 +376,10 @@ public final class WhisperKitPipeline: DictationPipeline {
             }
         } else if let detector = silenceDetector {
             await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+            let segments = await detector.speechSegments
+            hasSpeechEvidence = !segments.isEmpty
+            vadSegmentCount = segments.count
+            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             samples = await detector.filterSamples(from: rawSamples)
             let pct = String(format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
             Task { await AppLogger.shared.log(
@@ -376,6 +388,35 @@ public final class WhisperKitPipeline: DictationPipeline {
             ) }
         } else {
             samples = rawSamples
+            // No VAD detector available -- default to true so empty ASR results
+            // still fire Sentry errors (fail toward visibility).
+            hasSpeechEvidence = true
+        }
+        let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
+
+        // VAD gate: if no speech was detected, skip ASR entirely.
+        // Prevents noise-induced hallucinations from ambient sounds.
+        if !hasSpeechEvidence {
+            if let worker = incrementalWorker {
+                await worker.cancel()
+                incrementalWorker = nil
+            }
+            SentryBreadcrumb.add(
+                stage: "asr", message: "VAD gate: no speech detected, skipping WhisperKit ASR",
+                level: .info,
+                data: [
+                    "backend": "whisperKit",
+                    "raw_sample_count": rawSamples.count,
+                    "peak_audio_level": peakAudioLevel,
+                ]
+            )
+            frozenSnapshot = nil
+            state = .idle
+            Task { await AppLogger.shared.log(
+                "VAD gate: no speech, skipping WhisperKit ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
+                level: .info, category: "WhisperKitPipeline"
+            ) }
+            return
         }
 
         // Fallback: if VAD was too aggressive, use raw
@@ -450,14 +491,41 @@ public final class WhisperKitPipeline: DictationPipeline {
             let asrEnd = CFAbsoluteTimeGetCurrent()
 
             guard !asrText.isEmpty else {
-                SentryBreadcrumb.captureError(
-                    NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "WhisperKit ASR returned empty text"]),
-                    category: .asrEmptyResult, stage: "asr",
-                    extra: ["backend": "whisperKit", "incremental": usedIncremental],
-                    snapshot: frozenSnapshot
-                )
+                if hasSpeechEvidence {
+                    // Real ASR failure: VAD detected speech but decoder returned nothing
+                    SentryBreadcrumb.captureError(
+                        NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "WhisperKit ASR returned empty text despite speech evidence"]),
+                        category: .asrEmptyResult, stage: "asr",
+                        extra: [
+                            "backend": "whisperKit",
+                            "incremental": usedIncremental,
+                            "has_speech_evidence": true,
+                            "raw_sample_count": rawSamples.count,
+                            "vad_segment_count": vadSegmentCount,
+                            "vad_speech_duration_ms": vadSpeechDurationMs,
+                            "peak_audio_level": peakAudioLevel,
+                        ],
+                        snapshot: frozenSnapshot
+                    )
+                    state = .error("Couldn't catch that -- try again")
+                    Task { await AppLogger.shared.log(
+                        "WhisperKit ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
+                        level: .info, category: "WhisperKitPipeline"
+                    ) }
+                } else {
+                    // Expected: user held button without speaking
+                    SentryBreadcrumb.add(
+                        stage: "asr", message: "WhisperKit ASR empty (no speech detected)",
+                        level: .info,
+                        data: ["backend": "whisperKit", "incremental": usedIncremental]
+                    )
+                    state = .idle
+                    Task { await AppLogger.shared.log(
+                        "WhisperKit: no speech detected, returning to idle",
+                        level: .info, category: "WhisperKitPipeline"
+                    ) }
+                }
                 frozenSnapshot = nil
-                state = .error("No speech detected — try speaking closer to the microphone")
                 return
             }
 

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -19,9 +19,16 @@ public final class CustomWordsManager {
     private let fileURL: URL
 
     public init() {
-        let appSupport = FileManager.default.urls(
+        guard let baseURL = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
-        ).first!.appendingPathComponent("EnviousWispr", isDirectory: true)
+        ).first else {
+            // Application Support is always available on macOS, but guard defensively.
+            let fallback = FileManager.default.temporaryDirectory.appendingPathComponent("EnviousWispr", isDirectory: true)
+            try? FileManager.default.createDirectory(at: fallback, withIntermediateDirectories: true)
+            fileURL = fallback.appendingPathComponent("custom-words.json")
+            return
+        }
+        let appSupport = baseURL.appendingPathComponent("EnviousWispr", isDirectory: true)
         try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
         fileURL = appSupport.appendingPathComponent("custom-words.json")
     }


### PR DESCRIPTION
## Summary
- Adds VAD gate that skips ASR entirely when no speech is detected, eliminating phantom text from ambient noise (AC, fans)
- Splits Sentry reporting: "user didn't speak" (breadcrumb) vs "speech detected but ASR failed" (error event with enriched diagnostics)
- Adds error overlay (red banner, 3s auto-dismiss) for real ASR failures instead of silently hiding
- Hardens CustomWordsManager.init() force unwrap

## Test plan
- [x] Silence quick-press x10: 0% phantom text (was 50%)
- [x] 1-word speech ("Okay", "Yes", "Hello", "Thanks"): all transcribed correctly
- [x] Multi-word speech: all transcribed correctly  
- [x] Streaming mode: VAD gate fires, cancelStreaming() called
- [x] Batch mode: VAD gate fires, transcribe() never called
- [x] Debug + release + test target builds pass
- [x] Council-validated (GPT + Gemini reviewed plan and code)
- [x] Codex code review passed
