### PR TITLE
chore(release): bump version to 1.7.8

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.7</string>
+	<string>1.7.8</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.7</string>
+	<string>1.7.8</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
- Version bump to 1.7.8 for release

## Changes since v1.7.7
- fix(pipeline): VAD gate prevents ASR hallucinations from ambient noise (#98)
- fix(pipeline): add streaming batch rescue for Parakeet stop-time failures (#97)
- feat(audio): configurable warm engine timeout in Settings UI (#96)
