### PR TITLE
feat(website): GitHub icon in nav + social links in footer

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -25,14 +25,29 @@ const year = new Date().getFullYear();
         </a>
         <p class="footer-tagline">Private AI dictation for macOS.</p>
       </div>
-      <nav class="footer-links" aria-label="Footer Navigation">
-        <a href="/#features">Features</a>
-        <a href="/how-it-works/">How It Works</a>
-        <a href="/#privacy">Privacy</a>
-        <a href="/blog/">Blog</a>
-        <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
-        <a href="https://x.com/EnviousLabs" target="_blank" rel="noopener">X / Twitter</a>
-      </nav>
+      <div class="footer-right">
+        <nav class="footer-links" aria-label="Footer Navigation">
+          <a href="/#features">Features</a>
+          <a href="/how-it-works/">How It Works</a>
+          <a href="/#privacy">Privacy</a>
+          <a href="/blog/">Blog</a>
+          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
+        </nav>
+        <div class="footer-social" aria-label="Social Links">
+          <a href="https://x.com/EnviousLabs" target="_blank" rel="noopener" aria-label="X (Twitter)">
+            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+          </a>
+          <a href="https://www.linkedin.com/company/envious-labs" target="_blank" rel="noopener" aria-label="LinkedIn">
+            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+          </a>
+          <a href="https://www.youtube.com/@EnviousLabs" target="_blank" rel="noopener" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true"><path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
+          </a>
+          <a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+          </a>
+        </div>
+      </div>
     </div>
     <div class="footer-bottom">
       &copy; {year} Envious Labs. BSL Licensed. &nbsp;&middot;&nbsp; Built with privacy in mind.

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -41,8 +41,15 @@ const { activePage = 'home' } = Astro.props;
     <ul class="nav-links" id="navLinks" role="list">
       <li><a href="/how-it-works/" class:list={[{ active: activePage === 'how-it-works' }]}>How It Works</a></li>
       <li><a href="/blog/">Blog</a></li>
+      <li class="nav-gh-mobile"><a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener" aria-label="GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true" style="vertical-align:middle;"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+        <span>GitHub</span>
+      </a></li>
     </ul>
     <div class="nav-cta-group">
+      <a href="https://github.com/saurabhav88/EnviousWispr" class="nav-gh" target="_blank" rel="noopener" aria-label="GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
       <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="nav-cta">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Download Free

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -167,14 +167,21 @@ body::after {
 .footer-links { display: flex; align-items: center; gap: 28px; flex-wrap: wrap; }
 .footer-links a { font-size: 14px; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
 .footer-links a:hover { color: var(--text-2); }
+.footer-right { display: flex; flex-direction: column; align-items: flex-end; gap: 16px; }
+.footer-social { display: flex; align-items: center; gap: 16px; }
+.footer-social a { color: var(--text-3); text-decoration: none; transition: color 0.2s; display: inline-flex; }
+.footer-social a:hover { color: var(--text); }
 .footer-bottom { padding-top: 20px; border-top: 1px solid var(--border); font-size: 12px; color: var(--text-3); text-align: center; }
 
 /* ── Responsive (shared) ── */
+.nav-gh-mobile { display: none; }
 @media(max-width:1024px) {
   :root { --section-pad: 64px; }
   .section-title,.section-title-left { font-size: 42px; }
   .nav-links { display: none; }
   .nav-toggle { display: block; }
+  .nav-gh-mobile { display: list-item; }
+  .nav-gh-mobile a { display: inline-flex; align-items: center; gap: 6px; }
 }
 @media(max-width:600px) {
   .container { padding: 0 20px; }
@@ -184,6 +191,7 @@ body::after {
 }
 @media(max-width:900px) {
   .footer-inner { flex-direction: column; }
+  .footer-right { align-items: flex-start; }
   .footer-links { flex-direction: column; gap: 14px; }
 }
 @media(prefers-reduced-motion:reduce) {


### PR DESCRIPTION
## Summary
- Added GitHub octocat icon to the header nav (next to Download Free button on desktop, in hamburger menu on mobile)
- Replaced single "X / Twitter" text link in footer with icon row: X, LinkedIn, YouTube, GitHub
- Responsive: mobile nav shows GitHub icon + label, footer social icons stack properly

## Test plan
- [x] Astro build passes
- [x] Desktop: GitHub icon visible in header next to Download button
- [x] Desktop: Footer shows nav links + social icon row
- [x] Mobile (390px): Hamburger menu includes GitHub with icon + label
- [x] Mobile: Footer stacks vertically with social icons

