### PR TITLE
fix(ollama): normalize model names in manage-models UI

### DIFF
--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -212,7 +212,15 @@ public final class OllamaSetupService {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
             guard let models = json?["models"] as? [[String: Any]] else { return }
-            downloadedModelNames = Set(models.compactMap { $0["name"] as? String })
+            downloadedModelNames = Set(models.compactMap { model -> String? in
+                guard let name = model["name"] as? String else { return nil }
+                // Ollama returns "llama3.2:latest" but catalog uses "llama3.2".
+                // Normalize by stripping the implicit ":latest" tag.
+                if name.hasSuffix(":latest") {
+                    return String(name.dropLast(":latest".count))
+                }
+                return name
+            })
         } catch {
             // Silently ignore — server may not be running
         }


### PR DESCRIPTION
## Summary
- Ollama's `/api/tags` returns names with `:latest` suffix (`llama3.2:latest`) but our catalog uses bare names (`llama3.2`)
- The manage-models UI showed "Download" for already-downloaded models because `Set.contains` failed on the mismatch
- Strip implicit `:latest` tag when building `downloadedModelNames`; non-latest tags (`llama3.2:1b`) are unaffected

## Test plan
- [x] Verified Ollama API accepts bare names for `/api/show` and `/api/delete`
- [x] Codex review confirmed no other consumers of `downloadedModelNames` break
- [x] Rebuilt, relaunched, confirmed "Delete" shows for downloaded Llama 3.2
- [x] Tested full dictation + Ollama polish cycle (Llama 3.2, Standard writing style)
- [x] Tested Ollama restart cycle: stop, start, polish still works
