### PR TITLE
fix(website): remove old Privacy anchor from footer nav

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -29,7 +29,6 @@ const year = new Date().getFullYear();
         <nav class="footer-links" aria-label="Footer Navigation">
           <a href="/#features">Features</a>
           <a href="/how-it-works/">How It Works</a>
-          <a href="/#privacy">Privacy</a>
           <a href="/blog/">Blog</a>
           <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
         </nav>


### PR DESCRIPTION
## Summary
- Removes the old `/#privacy` anchor link from footer nav
- Privacy policy is now at `/privacy-policy/` linked in footer bottom bar

## Test plan
- [ ] Verify footer nav no longer shows "Privacy" link
- [ ] Verify footer bottom bar still has Privacy Policy link
