### PR TITLE
fix(pipeline): restore paste-back activation + cold-start instrumentation

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -331,6 +331,7 @@ final class AppState {
                 isRecordingLocked: false
             )
 
+            let pttStart = ContinuousClock.now
             await active.handle(event: .preWarm)
             guard !Task.isCancelled else {
                 // PTT release arrived during preWarm — stop the engine that preWarm started
@@ -338,7 +339,19 @@ final class AppState {
                 self.recordingOverlay.show(intent: .hidden)
                 return
             }
+            let preWarmMs = {
+                let (s, a) = (ContinuousClock.now - pttStart).components
+                return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+            }()
             await active.handle(event: .toggleRecording)
+            let totalMs = {
+                let (s, a) = (ContinuousClock.now - pttStart).components
+                return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+            }()
+            Task { await AppLogger.shared.log(
+                "COLD-START [AppState] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet")",
+                level: .info, category: "Pipeline"
+            ) }
 
             if isWhisperKit {
                 if case .error = self.whisperKitPipeline.state {

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -54,6 +54,12 @@ private final class TapStoppedFlag: Sendable {
     }
 }
 
+/// Convert a Swift Duration to milliseconds as an Int for logging.
+private func ms(_ d: Duration) -> Int {
+    let (seconds, attoseconds) = d.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+}
+
 /// AVAudioEngine-based audio capture source. Supports voice processing (noise suppression)
 /// and Bluetooth codec switch recovery.
 ///
@@ -112,6 +118,7 @@ final class AVAudioEngineSource: AudioInputSource {
 
     func prepare() async throws {
         guard !engine.isRunning else { return }
+        let prepareStart = ContinuousClock.now
 
         activeTasks.removeAll()
 
@@ -119,10 +126,11 @@ final class AVAudioEngineSource: AudioInputSource {
         // CRITICAL: Must happen before setInputDevice(). If setInputDevice() runs first, it
         // instantiates an AUHAL. Then setVoiceProcessingEnabled(true) DESTROYS that AUHAL and
         // creates an AUVPIO. CoreAudio's BT I/O thread still holds a reference to the destroyed
-        // AUHAL → use-after-free → heap corruption → EXC_BAD_ACCESS.
+        // AUHAL -> use-after-free -> heap corruption -> EXC_BAD_ACCESS.
         //
         // Split-route check: when input != output device (e.g., built-in mic + BT headphones),
         // CoreAudio's AEC can't sync different hardware clocks. Disable VP in this case.
+        let vpStart = ContinuousClock.now
         let inputDeviceID = AudioDeviceEnumerator.defaultInputDeviceID()
         let outputDeviceID = AudioDeviceEnumerator.defaultOutputDeviceID()
         let isSplitRoute = inputDeviceID != nil && outputDeviceID != nil && inputDeviceID != outputDeviceID
@@ -144,9 +152,11 @@ final class AVAudioEngineSource: AudioInputSource {
         } else {
             try? engine.inputNode.setVoiceProcessingEnabled(false)
         }
+        let vpMs = ms(ContinuousClock.now - vpStart)
 
         // Step 2: Resolve input device — smart selection when in Auto mode.
         // SAFETY: Skip setInputDevice() entirely when BT output is active.
+        let deviceStart = ContinuousClock.now
         let btOutputActive: Bool
         if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
             btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
@@ -177,6 +187,7 @@ final class AVAudioEngineSource: AudioInputSource {
         }
         try setInputDevice(resolvedDeviceID)
         currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
+        let deviceMs = ms(ContinuousClock.now - deviceStart)
 
         // Create the capture stop token for this session
         let stopToken = TapStoppedFlag()
@@ -199,14 +210,17 @@ final class AVAudioEngineSource: AudioInputSource {
             }
         }
 
+        let engineStartTime = ContinuousClock.now
         btCrashLogger.info("Engine starting — stop token created, observer registered (queue: nil)")
         try engine.start()
+        let engineMs = ms(ContinuousClock.now - engineStartTime)
         btCrashLogger.info("Engine started successfully")
 
         // Install pre-roll tap immediately after engine start.
         // Format is stable for built-in mic (BT uses AVCaptureSessionSource).
         // The tap routes through a PreRollForwarder that buffers audio until
         // startCapture() activates live forwarding.
+        let tapStart = ContinuousClock.now
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
 
@@ -237,7 +251,9 @@ final class AVAudioEngineSource: AudioInputSource {
             stoppedFlag: stopToken
         )
         inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
-        AudioCaptureManager.btRouteLog("Pre-roll tap installed — capturing audio during setup latency")
+        let tapMs = ms(ContinuousClock.now - tapStart)
+        let totalMs = ms(ContinuousClock.now - prepareStart)
+        AudioCaptureManager.btRouteLog("COLD-START prepare(): total=\(totalMs)ms | vp=\(vpMs)ms device=\(deviceMs)ms engine.start=\(engineMs)ms tap=\(tapMs)ms | vp=\(effectiveNoiseSuppression) bt=\(btOutputActive)")
     }
 
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -301,18 +317,28 @@ final class AVAudioEngineSource: AudioInputSource {
         maxWait: TimeInterval = 1.5,
         pollInterval: TimeInterval = 0.2
     ) async -> Bool {
+        let stabStart = ContinuousClock.now
         let deadline = Date().addingTimeInterval(maxWait)
         var lastFormat = engine.inputNode.outputFormat(forBus: 0)
         try? await Task.sleep(for: .milliseconds(10))
         let recheck = engine.inputNode.outputFormat(forBus: 0)
-        if recheck == lastFormat { return true }
+        if recheck == lastFormat {
+            AudioCaptureManager.btRouteLog("COLD-START formatStab: stable on fast path (\(ms(ContinuousClock.now - stabStart))ms, 0 polls)")
+            return true
+        }
         lastFormat = recheck
+        var polls = 0
         while Date() < deadline {
             try? await Task.sleep(for: .seconds(pollInterval))
+            polls += 1
             let format = engine.inputNode.outputFormat(forBus: 0)
-            if format == lastFormat { return true }
+            if format == lastFormat {
+                AudioCaptureManager.btRouteLog("COLD-START formatStab: stable after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)")
+                return true
+            }
             lastFormat = format
         }
+        AudioCaptureManager.btRouteLog("COLD-START formatStab: TIMED OUT after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)")
         return false
     }
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -216,8 +216,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     }
 
     public func preWarm() async {
+        let preWarmStart = ContinuousClock.now
         let source = resolveSource()
-        guard !source.isRunning else { return }
+        let resolveMs = Self.ms(ContinuousClock.now - preWarmStart)
+        guard !source.isRunning else {
+            Self.btRouteLog("COLD-START preWarm(): engine already running (warm hit) resolveSource=\(resolveMs)ms")
+            return
+        }
         do {
             try await source.prepare()
         } catch {
@@ -227,7 +232,18 @@ public final class AudioCaptureManager: AudioCaptureInterface {
             ) }
             return
         }
-        _ = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+        let prepareMs = Self.ms(ContinuousClock.now - preWarmStart)
+        let stabStart = ContinuousClock.now
+        let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+        let stabMs = Self.ms(ContinuousClock.now - stabStart)
+        let totalMs = Self.ms(ContinuousClock.now - preWarmStart)
+        Self.btRouteLog("COLD-START preWarm(): total=\(totalMs)ms | resolve=\(resolveMs)ms prepare=\(prepareMs)ms formatStab=\(stabMs)ms stabilized=\(stabilized)")
+    }
+
+    /// Convert Duration to milliseconds for logging.
+    nonisolated private static func ms(_ d: Duration) -> Int {
+        let (seconds, attoseconds) = d.components
+        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     public func abortPreWarm() {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -188,9 +188,12 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
 
     public func preWarm() async {
+        let proxyStart = ContinuousClock.now
         ensureConnection()
         resendConfigIfNeeded()
+        let connMs = Self.ms(ContinuousClock.now - proxyStart)
         // Phase 1: start engine
+        let enginePhaseStart = ContinuousClock.now
         do {
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
                 let guard_ = OneShotContinuation(cont)
@@ -213,8 +216,22 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
             ) }
             return
         }
+        let enginePhaseMs = Self.ms(ContinuousClock.now - enginePhaseStart)
         // Phase 2: wait for format stabilization
+        let stabStart = ContinuousClock.now
         _ = await waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+        let stabMs = Self.ms(ContinuousClock.now - stabStart)
+        let totalMs = Self.ms(ContinuousClock.now - proxyStart)
+        Task { await AppLogger.shared.log(
+            "COLD-START [XPC proxy] preWarm: total=\(totalMs)ms | conn=\(connMs)ms enginePhase=\(enginePhaseMs)ms formatStab=\(stabMs)ms",
+            level: .info, category: "XPC"
+        ) }
+    }
+
+    /// Convert Duration to milliseconds for logging.
+    private static func ms(_ d: Duration) -> Int {
+        let (seconds, attoseconds) = d.components
+        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     public func abortPreWarm() {

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -103,14 +103,26 @@ public final class TranscriptionPipeline: DictationPipeline {
     }
 
     /// Pre-warm the audio input to trigger any Bluetooth codec switch before recording.
-    /// Called on PTT key-down to hide the 0.5–2s Bluetooth negotiation latency.
+    /// Called on PTT key-down to hide the 0.5-2s Bluetooth negotiation latency.
     /// Sets `isPreWarmed` so `startRecording()` skips engine phase 1.
     public func preWarmAudioInput() async {
         guard !state.isActive, state != .recording else { return }
         stopRequested = false
+        let start = ContinuousClock.now
         await audioCapture.preWarm()
         guard !Task.isCancelled else { return }
         isPreWarmed = true
+        let totalMs = Self.durationMs(ContinuousClock.now - start)
+        Task { await AppLogger.shared.log(
+            "COLD-START [Parakeet] preWarmAudioInput total=\(totalMs)ms",
+            level: .info, category: "Pipeline"
+        ) }
+    }
+
+    /// Convert Duration to milliseconds for logging.
+    private static func durationMs(_ d: Duration) -> Int {
+        let (seconds, attoseconds) = d.components
+        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     /// Toggle recording: start if idle, stop if recording.
@@ -644,11 +656,17 @@ public final class TranscriptionPipeline: DictationPipeline {
                 }
 
                 // Tier 2: Activate target app + CGEvent Cmd+V
+                // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
+                // restrictions on background processes stealing focus. The deprecated
+                // NSRunningApplication.activate(options: .activateIgnoringOtherApps)
+                // has no effect on macOS 14+.
                 if tier == .clipboardOnly, let app = targetApp, !app.isTerminated {
                     let pollInterval = TimingConstants.activationPollIntervalMs
                     let timeout = TimingConstants.activationTimeoutMs
-                    // Activate once, then poll. Retry activation at longer intervals.
-                    app.activate(options: .activateIgnoringOtherApps)
+
+                    // AX force-activate, then poll for frontmost confirmation.
+                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                    app.activate()
                     var elapsed = 0
                     while elapsed < timeout {
                         try? await Task.sleep(for: .milliseconds(pollInterval))
@@ -657,7 +675,8 @@ public final class TranscriptionPipeline: DictationPipeline {
                             break
                         }
                         if elapsed % 300 < pollInterval {
-                            app.activate(options: .activateIgnoringOtherApps)
+                            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                            app.activate()
                         }
                     }
 
@@ -676,8 +695,9 @@ public final class TranscriptionPipeline: DictationPipeline {
                             PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
                         }
                     } else {
-                        // Tier 2b: AppleScript Edit > Paste (needs frontmost, try one more activation)
-                        app.activate(options: .activateIgnoringOtherApps)
+                        // Tier 2b: AppleScript Edit > Paste
+                        _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                        app.activate()
                         try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
 
                         let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -186,12 +186,24 @@ public final class WhisperKitPipeline: DictationPipeline {
 
     public func preWarmAudioInput() async {
         guard !state.isActive, state != .recording else { return }
+        let start = ContinuousClock.now
         await audioCapture.preWarm()
         guard !Task.isCancelled else { return }
         isPreWarmed = true
+        let totalMs = Self.durationMs(ContinuousClock.now - start)
+        Task { await AppLogger.shared.log(
+            "COLD-START [WhisperKit] preWarmAudioInput total=\(totalMs)ms",
+            level: .info, category: "Pipeline"
+        ) }
         // Defense-in-depth: ensure model is loaded from cache (no download).
         // If not cached, startRecording() handles the full load with user-visible UI.
         Task { _ = try? await backend.prepareIfCached() }
+    }
+
+    /// Convert Duration to milliseconds for logging.
+    private static func durationMs(_ d: Duration) -> Int {
+        let (seconds, attoseconds) = d.components
+        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     public func toggleRecording() async {
@@ -980,10 +992,14 @@ public final class WhisperKitPipeline: DictationPipeline {
         }
 
         // Tier 2: Activate target app + CGEvent Cmd+V
+        // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
+        // restrictions on background processes stealing focus.
         if tier == .clipboardOnly, let app = targetApp, !app.isTerminated {
             let pollInterval = TimingConstants.activationPollIntervalMs
             let timeout = TimingConstants.activationTimeoutMs
-            app.activate(options: .activateIgnoringOtherApps)
+
+            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+            app.activate()
             var elapsed = 0
             while elapsed < timeout {
                 try? await Task.sleep(for: .milliseconds(pollInterval))
@@ -992,7 +1008,8 @@ public final class WhisperKitPipeline: DictationPipeline {
                     break
                 }
                 if elapsed % 300 < pollInterval {
-                    app.activate(options: .activateIgnoringOtherApps)
+                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                    app.activate()
                 }
             }
 
@@ -1010,7 +1027,8 @@ public final class WhisperKitPipeline: DictationPipeline {
                 }
             } else {
                 // Tier 2b: AppleScript Edit > Paste
-                app.activate(options: .activateIgnoringOtherApps)
+                _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                app.activate()
                 try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
                 let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste
                     ? PasteService.saveClipboard()

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -249,6 +249,22 @@ public enum PasteService {
         dispatchCmdV()
     }
 
+    // MARK: - App Activation via Accessibility
+
+    /// Force-activate an app by PID using the Accessibility API.
+    /// Bypasses macOS 14+ restrictions on background processes stealing focus.
+    /// Requires Accessibility permission (AXIsProcessTrusted).
+    public static func forceActivateApp(pid: pid_t) -> Bool {
+        guard AXIsProcessTrusted() else { return false }
+        let axApp = AXUIElementCreateApplication(pid)
+        let result = AXUIElementSetAttributeValue(
+            axApp,
+            "AXFrontmost" as CFString,
+            true as CFTypeRef
+        )
+        return result == .success
+    }
+
     // MARK: - Private
 
     /// Send Cmd+V keystroke via CGEvent. Returns true on success.


### PR DESCRIPTION
## Summary
- **P0 fix**: Replace deprecated `activateIgnoringOtherApps` with AX force-activate (`kAXFrontmostAttribute`) for paste-back. macOS 14+ silently ignores the deprecated flag for background/menu bar apps, breaking Tier 2 paste entirely.
- **Instrumentation**: Add `ContinuousClock` timing across cold-start audio path (prepare, format stabilization, preWarm, XPC proxy). Logs to `bt-route.log` with `COLD-START` prefix. Measured ~100ms on M4 Pro.

## Test plan
- [x] Cross-app paste-back: start recording in Terminal, switch to Chrome, release. Text pastes back to Terminal.
- [x] Cold-start timing: wait for engine idle timeout (30s), press PTT. Logs show ~100ms prepare time.
- [x] Warm path unaffected: consecutive recordings reuse warm engine with 500ms pre-roll.
- [x] Build passes (release mode, no new warnings)
