### PR TITLE
feat(overlay): contextual error notifications for failure paths

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -31,6 +31,10 @@ final class AppState {
     /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
     private var whisperKitPreloadTask: Task<Void, Never>?
 
+    /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+    /// Cancelled when a new recording starts or a higher-priority notification is shown.
+    private var postCompletionWarningTask: Task<Void, Never>?
+
     // Pipelines — initialized after sub-systems
     let pipeline: TranscriptionPipeline
     let whisperKitPipeline: WhisperKitPipeline
@@ -131,8 +135,10 @@ final class AppState {
             } else if wkState == .recording {
                 self.whisperKitPipeline.handleEngineInterruption()
             }
-            // Dismiss recording overlay if showing
-            self.recordingOverlay.hide()
+            // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
+            // sets state = .error(...), which fires onStateChange and shows the error
+            // overlay. Calling hide() immediately after would dismiss it before the
+            // user can read it. The error overlay auto-dismisses after 3 seconds.
         }
 
         // Observe audio route changes for Sentry context enrichment.
@@ -164,7 +170,9 @@ final class AppState {
             } else if wkState == .recording || wkState == .transcribing {
                 self.whisperKitPipeline.handleASRServiceInterruption()
             }
-            self.recordingOverlay.hide()
+            // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
+            // the pipeline sets .error(...) state which shows the error overlay via
+            // onStateChange. The error overlay auto-dismisses after 3 seconds.
         }
 
         // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
@@ -223,14 +231,26 @@ final class AppState {
                 self.hotkeyService.unregisterCancelHotkey()
             }
             // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label.
-            // On completion, check if paste fell back to clipboard-only (Tier 3) and show
-            // a transient "Copied to clipboard" notice instead of silently hiding.
+            // On completion, compute a single post-completion notification by priority:
+            //   1. clipboardFallback (paste fell back to clipboard-only)
+            //   2. warning (polish failed but text was delivered)
+            //   3. hidden (success, no notification needed)
             let overlayIntent: OverlayIntent
-            if newState == .complete,
-               let tier = self.pipeline.currentTranscript?.metrics?.pasteTier,
-               tier == "clipboard_only" {
-                overlayIntent = .clipboardFallback
+            if newState == .complete {
+                let isClipboardFallback = self.pipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
+                let polishFailed = self.pipeline.lastPolishError != nil
+                if isClipboardFallback {
+                    overlayIntent = .clipboardFallback
+                } else if polishFailed {
+                    // Show polish warning after a brief delay so the completion
+                    // transition feels natural. Cancellable if a new recording starts.
+                    overlayIntent = self.pipeline.overlayIntent
+                    self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+                } else {
+                    overlayIntent = self.pipeline.overlayIntent
+                }
             } else {
+                self.postCompletionWarningTask?.cancel()
                 overlayIntent = self.pipeline.overlayIntent
             }
             self.recordingOverlay.show(
@@ -261,13 +281,21 @@ final class AppState {
                 self.isRecordingLocked = false
                 self.hotkeyService.unregisterCancelHotkey()
             }
-            // Intent-driven overlay — same clipboard fallback logic as Parakeet pipeline above.
+            // Intent-driven overlay — same post-completion priority logic as Parakeet above.
             let wkOverlayIntent: OverlayIntent
-            if newState == .complete,
-               let tier = self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier,
-               tier == "clipboard_only" {
-                wkOverlayIntent = .clipboardFallback
+            if newState == .complete {
+                let isClipboardFallback = self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
+                let polishFailed = self.whisperKitPipeline.lastPolishError != nil
+                if isClipboardFallback {
+                    wkOverlayIntent = .clipboardFallback
+                } else if polishFailed {
+                    wkOverlayIntent = self.whisperKitPipeline.overlayIntent
+                    self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+                } else {
+                    wkOverlayIntent = self.whisperKitPipeline.overlayIntent
+                }
             } else {
+                self.postCompletionWarningTask?.cancel()
                 wkOverlayIntent = self.whisperKitPipeline.overlayIntent
             }
             self.recordingOverlay.show(
@@ -298,6 +326,9 @@ final class AppState {
         }
         hotkeyService.onStartRecording = { [weak self] in
             guard let self else { return }
+            // Cancel any pending post-completion warning from the previous session
+            // before showing the new recording overlay.
+            self.postCompletionWarningTask?.cancel()
             let isWhisperKit = self.asrManager.activeBackendType == .whisperKit
             let active = self.activePipeline
 
@@ -487,6 +518,22 @@ final class AppState {
         return pipeline.currentTranscript
     }
 
+    /// Schedule a deferred post-completion warning overlay. Cancellable and session-scoped:
+    /// cancelled if a new recording starts (any non-complete state change cancels it).
+    /// Uses the pipeline's current state as a guard to avoid showing stale warnings.
+    private func schedulePostCompletionWarning(message: String) {
+        postCompletionWarningTask?.cancel()
+        postCompletionWarningTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled, let self else { return }
+            // Only show if we're still in the completed state (no new recording started)
+            let parakeetComplete = self.pipeline.state == .complete
+            let whisperKitComplete = self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
+            guard parakeetComplete || whisperKitComplete else { return }
+            self.recordingOverlay.show(intent: .warning(message: message))
+        }
+    }
+
     /// Reset the currently active pipeline to idle. Used by UI "dismiss" actions.
     func resetActivePipeline() {
         if asrManager.activeBackendType == .whisperKit {
@@ -539,6 +586,7 @@ final class AppState {
 
     /// Toggle recording on/off (plain, no forced LLM).
     func toggleRecording() async {
+        postCompletionWarningTask?.cancel()
         let active = activePipeline
         // Set auto-paste before toggle
         if active is WhisperKitPipeline {

--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -84,6 +84,13 @@ final class RecordingOverlayPanel {
                 userInfo: [.announcement: "Text copied to clipboard",
                            .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber])
             showClipboardFallback()
+        case .warning(let message):
+            NSAccessibility.post(
+                element: NSApp.mainWindow as Any,
+                notification: .announcementRequested,
+                userInfo: [.announcement: "Warning: \(message)",
+                           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber])
+            showWarning(message: message)
         case .error(let message):
             NSAccessibility.post(
                 element: NSApp.mainWindow as Any,
@@ -201,11 +208,21 @@ final class RecordingOverlayPanel {
         }
     }
 
+    /// Show a transient warning notice that auto-dismisses after 2.5s.
+    func showWarning(message: String) {
+        showNotification(message: message, style: .warning)
+    }
+
     /// Show a transient error notice that auto-dismisses after 3s.
     func showError(message: String) {
+        showNotification(message: message, style: .error)
+    }
+
+    /// Unified handler for transient notification overlays (errors and warnings).
+    private func showNotification(message: String, style: NotificationStyle) {
         guard panel == nil else {
-            transitionToError(message: message)
-            scheduleAutoDismiss(seconds: 3.0)
+            transitionToNotification(message: message, style: style)
+            scheduleAutoDismiss(seconds: style.autoDismissSeconds)
             return
         }
         pendingCreateWork?.cancel()
@@ -217,21 +234,23 @@ final class RecordingOverlayPanel {
             guard let self, self.generation == token else { return }
             self.pendingCreateWork = nil
             self.showPanel(
-                content: ErrorOverlayView(message: message).frame(width: 260, height: 44),
-                width: 260
+                content: NotificationOverlayView(message: message, style: style).frame(width: 280, height: 44),
+                width: 280
             )
-            self.scheduleAutoDismiss(seconds: 3.0)
+            self.scheduleAutoDismiss(seconds: style.autoDismissSeconds)
         }
         pendingCreateWork = work
         DispatchQueue.main.async(execute: work)
     }
 
-    /// Transition an existing panel to an error display.
-    private func transitionToError(message: String) {
+    /// Transition an existing panel to a notification display.
+    private func transitionToNotification(message: String, style: NotificationStyle) {
         guard let existingPanel = panel else { return }
         let y = existingPanel.frame.origin.y
 
         panel = nil
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         pendingCreateWork?.cancel()
         pendingCreateWork = nil
         CATransaction.flush()
@@ -244,8 +263,8 @@ final class RecordingOverlayPanel {
             guard let self, self.generation == token else { return }
             self.pendingCreateWork = nil
             self.showPanel(
-                content: ErrorOverlayView(message: message).frame(width: 260, height: 44),
-                width: 260,
+                content: NotificationOverlayView(message: message, style: style).frame(width: 280, height: 44),
+                width: 280,
                 y: y
             )
         }
@@ -265,6 +284,10 @@ final class RecordingOverlayPanel {
         let y = existingPanel.frame.origin.y
 
         panel = nil
+        // Cancel any stale auto-dismiss timer from a transient notification
+        // (error/warning/clipboard fallback) so it doesn't hide the new panel.
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         // Cancel any pre-existing deferred work before queuing new work. Without
         // this, a stale DispatchWorkItem could hold a reference that the new token
         // won't invalidate until it actually runs on the next drain cycle.
@@ -296,6 +319,8 @@ final class RecordingOverlayPanel {
         let y = existingPanel.frame.origin.y
 
         panel = nil
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         pendingCreateWork?.cancel()
         pendingCreateWork = nil
         CATransaction.flush()
@@ -678,16 +703,46 @@ struct PolishingOverlayView: View {
     }
 }
 
-// MARK: - ErrorOverlayView
+// MARK: - NotificationStyle
 
-/// Compact error indicator overlay shown when ASR fails despite speech evidence.
-struct ErrorOverlayView: View {
+/// Visual style for transient overlay notifications (errors and warnings).
+enum NotificationStyle {
+    case error
+    case warning
+
+    var iconName: String {
+        switch self {
+        case .error: "xmark.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        }
+    }
+
+    var iconColor: Color {
+        switch self {
+        case .error: .red
+        case .warning: .orange
+        }
+    }
+
+    var autoDismissSeconds: Double {
+        switch self {
+        case .error: 3.0
+        case .warning: 2.5
+        }
+    }
+}
+
+// MARK: - NotificationOverlayView
+
+/// Compact notification overlay for errors (red) and warnings (orange).
+struct NotificationOverlayView: View {
     let message: String
+    let style: NotificationStyle
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: "xmark.circle.fill")
-                .foregroundStyle(.red)
+            Image(systemName: style.iconName)
+                .foregroundStyle(style.iconColor)
                 .font(.system(size: 16))
 
             Text(message)

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -18,6 +18,9 @@ public enum OverlayIntent: Equatable, Sendable {
     /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
     /// Auto-dismissed by the overlay panel after a short delay.
     case clipboardFallback
+    /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
+    /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
+    case warning(message: String)
     /// Transient error notice shown when ASR fails despite speech evidence.
     /// Auto-dismissed by the overlay panel after 3 seconds.
     case error(message: String)


### PR DESCRIPTION
## Summary
- Fix error overlays for audio disconnect and XPC crash being immediately hidden by redundant `.hide()` calls in AppState interruption handlers
- Add `.warning(message)` overlay intent (orange icon, 2.5s auto-dismiss) for degraded-but-delivered results (e.g. polish failed)
- Replace duplicated `ErrorOverlayView` with shared `NotificationOverlayView` + `NotificationStyle` enum
- Add `autoDismissTask` cancellation to all panel transition methods to prevent stale timers

## Test plan
- [ ] Rebuild and launch: app starts without crash
- [ ] Normal dictation flow: recording, polishing, paste all work as before
- [ ] Error overlay persists for 3s when XPC service is killed mid-recording (was instantly hidden)
- [ ] Polish failure shows orange "Polish failed -- using raw text" warning after completion

Closes ew-1fu
