### PR TITLE
fix(vad): scale VAD thresholds by sensitivity to capture whispered speech

### DIFF
--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -33,16 +33,31 @@ public struct SmoothedVADConfig: Sendable {
         return fromSensitivity(preset.vadSensitivity)
     }
 
-    public static func fromSensitivity(_ sensitivity: Float) -> SmoothedVADConfig {
-        let onset = 0.7 - (sensitivity * 0.4)       // 0.3 at sens=1.0, 0.7 at sens=0.0
+    public static func fromSensitivity(_ sensitivity: Float, energyGate: Bool = false) -> SmoothedVADConfig {
+        let onset = 0.6 - (sensitivity * 0.375)     // 0.225 at sens=1.0, 0.6 at sens=0.0
         let offset = max(0.1, onset - 0.15)
+        let alpha = 0.3 + (sensitivity * 0.2)        // 0.32 at sens=0.1, 0.46 at sens=0.8
         let hangover = sensitivity > 0.7 ? 4 : 3
         let confirmation = sensitivity < 0.3 ? 2 : 1
+
+        // Energy gate scales with sensitivity. Disabled on high sensitivity (Quiet)
+        // to avoid blocking whispered speech before Silero can evaluate it.
+        let energy: Float
+        if !energyGate {
+            energy = 0.0
+        } else if sensitivity >= 0.7 {
+            energy = 0.0
+        } else {
+            energy = 0.005 * (1.0 - sensitivity * 0.6)
+        }
+
         return SmoothedVADConfig(
+            emaAlpha: alpha,
             onsetThreshold: onset,
             offsetThreshold: offset,
             onsetConfirmationChunks: confirmation,
-            hangoverChunks: hangover
+            hangoverChunks: hangover,
+            energyGateThreshold: energy
         )
     }
 }

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -7,9 +7,6 @@ import EnviousWisprAudio
 /// to the XPC protocol. All capture logic runs in the service process; the host app
 /// receives buffers and state changes via AudioServiceClientProtocol callbacks.
 final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Sendable {
-    /// The XPC connection back to the host — set by AudioServiceDelegate.
-    weak var connection: NSXPCConnection?
-
     /// Client proxy for sending callbacks to the host app.
     /// Resolved from connection.remoteObjectProxy — set by AudioServiceDelegate.
     var clientProxy: (any AudioServiceClientProtocol)?
@@ -217,8 +214,7 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
 
         // If VAD is already running mid-session, rebuild the detector with new config.
         if let detector = silenceDetector {
-            var config = SmoothedVADConfig.fromSensitivity(sensitivity)
-            if energyGate { config.energyGateThreshold = 0.005 }
+            let config = SmoothedVADConfig.fromSensitivity(sensitivity, energyGate: energyGate)
             Task { await detector.updateConfig(config) }
         }
     }
@@ -261,8 +257,7 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     /// Start the VAD monitoring task. Called after beginCapture succeeds.
     @MainActor
     private func startVADMonitoring() {
-        var config = SmoothedVADConfig.fromSensitivity(vadSensitivity)
-        if vadEnergyGate { config.energyGateThreshold = 0.005 }
+        let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
 
         let detector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
         self.silenceDetector = detector

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -7,6 +7,8 @@ import EnviousWisprAudio
 /// to the XPC protocol. All capture logic runs in the service process; the host app
 /// receives buffers and state changes via AudioServiceClientProtocol callbacks.
 final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Sendable {
+    /// The XPC connection back to the host — set by AudioServiceDelegate.
+    weak var connection: NSXPCConnection?
     /// Client proxy for sending callbacks to the host app.
     /// Resolved from connection.remoteObjectProxy — set by AudioServiceDelegate.
     var clientProxy: (any AudioServiceClientProtocol)?

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -1003,10 +1003,7 @@ public final class TranscriptionPipeline: DictationPipeline {
 
         if !isXPCMode {
             // Build SmoothedVAD config from sensitivity setting
-            var config = SmoothedVADConfig.fromSensitivity(vadSensitivity)
-            if vadEnergyGate {
-                config.energyGateThreshold = 0.005
-            }
+            let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
 
             // Lazily create detector
             if silenceDetector == nil {

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -809,10 +809,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         let isXPCMode = audioCapture is AudioCaptureProxy
 
         if !isXPCMode {
-            var config = SmoothedVADConfig.fromSensitivity(vadSensitivity)
-            if vadEnergyGate {
-                config.energyGateThreshold = 0.005
-            }
+            let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
 
             if silenceDetector == nil {
                 silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)


### PR DESCRIPTION
## Summary
- **P0 fix:** Whisper-level speech was silently discarded even on Quiet preset
- Root cause: VAD gate (PR #98) + fixed energy gate + slow EMA smoothing compounded to reject quiet speech
- `SmoothedVADConfig.fromSensitivity()` now derives all sensitivity-dependent params (onset, offset, EMA alpha, energy gate) in one place
- On Quiet: energy gate disabled, faster EMA (0.46), lower onset (0.30). Noisy barely changed.
- 4 hardcoded `energyGateThreshold = 0.005` call sites replaced with centralized config

## Test plan
- [x] Whispered speech captured on Quiet preset
- [x] Whispered speech rejected on Normal preset (correct behavior)
- [x] GPT council validated approach
- [x] Codex review: ship-with-nits, no blocking issues
- [x] Release build clean

Closes #ew-0oj2
