### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.8</string>
+	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.8</string>
+	<string>1.8.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
- Version bump to 1.8.0 for release

## Changes since v1.7.8
- fix(polish): harden Apple Intelligence against over-polishing and content loss
- fix(vad): scale VAD thresholds by sensitivity to capture whispered speech
- feat(overlay): contextual error notifications for failure paths
- fix(pipeline): restore paste-back activation + cold-start timing
- fix(ollama): normalize model names in manage-models UI
- refactor(core): move KeySymbols to Services
- test(core): expand Swift Testing to 6 suites with CI hard gate
