### PR TITLE
fix(website): correct Remark42 embed script path

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -742,7 +742,7 @@ const breadcrumbJsonLd = JSON.stringify({
 
     const d = document;
     const s = d.createElement('script');
-    s.src = remark_config.host + '/web/embed.es2015.js';
+    s.src = remark_config.host + '/web/embed.js';
     s.defer = true;
     (d.head || d.body).appendChild(s);
   }


### PR DESCRIPTION
## Summary
- Fix embed script path from `embed.es2015.js` (doesn't exist) to `embed.js`
- Comments widget was not rendering because the script 404'd

## Test plan
- [ ] Visit a blog post and verify the comment widget renders
