### PR TITLE
fix(website): fix Remark42 comment widget rendering

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -195,9 +195,9 @@ const breadcrumbJsonLd = JSON.stringify({
         </section>
       )}
 
-      <section class="blog-comments" aria-label="Comments" id="remark42">
+      <section class="blog-comments" aria-label="Comments">
         <h2 class="comments-heading">Comments</h2>
-        <div id="remark42-comments"></div>
+        <div id="remark42"></div>
       </section>
 
       <nav class="blog-post-nav" aria-label="Post navigation">
@@ -726,24 +726,18 @@ const breadcrumbJsonLd = JSON.stringify({
   });
 </script>
 
-<script>
+<script is:inline>
   // Remark42 comments - only load on production
   if (window.location.hostname === 'enviouswispr.com') {
-    const remark_config = {
+    var remark_config = {
       host: 'https://comments.enviouswispr.com',
       site_id: 'enviouswispr',
       url: window.location.origin + window.location.pathname,
-      components: ['embed'],
       max_shown_comments: 15,
       theme: 'dark',
       page_title: document.title,
     };
-    window.remark_config = remark_config;
 
-    const d = document;
-    const s = d.createElement('script');
-    s.src = remark_config.host + '/web/embed.js';
-    s.defer = true;
-    (d.head || d.body).appendChild(s);
+    !function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);
   }
 </script>


### PR DESCRIPTION
## Summary
- Fix div ID: `remark42-comments` -> `remark42` (Remark42 requires this exact ID)
- Add `is:inline` to script tag (Astro was stripping the script during build)
- Use official Remark42 loader script

Visually validated in Playwright before deploying.

## Test plan
- [x] Verified widget renders in local test page via Playwright screenshot
- [ ] Verify on production after deploy
