### PR TITLE
fix(website): black download button on blog CTA

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -625,18 +625,18 @@ const breadcrumbJsonLd = JSON.stringify({
     align-items: center;
     gap: 8px;
     padding: 10px 20px;
-    background: var(--accent);
+    background: var(--text);
     color: #fff;
     font-size: 14px;
     font-weight: 600;
-    border-radius: var(--radius-pill);
+    border-radius: var(--radius-btn);
     text-decoration: none;
     white-space: nowrap;
     transition: background 0.2s, transform 0.1s;
   }
 
   .blog-cta-btn:hover {
-    background: var(--accent-hover);
+    background: #2a2035;
   }
 
   .blog-cta-btn:active {


### PR DESCRIPTION
## Summary
- Change blog post download CTA from purple to black to match nav download button
- Remove unused custom_css config from Remark42
