### PR TITLE
feat(website): 11 competitor comparison pages with SEO

### DIFF
--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -1,0 +1,775 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Apple Dictation: Mac Voice-to-Text",
+  "description": "Compare EnviousWispr vs Apple Dictation on speed, AI polish, custom words, and timeout limits. Both free, both on-device, but EnviousWispr goes further.",
+  "url": `${siteUrl}/compare/apple-dictation/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Apple Dictation",
+      "item": `${siteUrl}/compare/apple-dictation/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is there a better alternative to Apple Dictation on Mac?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr is a free, on-device alternative that adds AI polish, custom vocabulary, and no timeout limit. It runs alongside Apple Dictation without interfering. Both use Apple Silicon for local processing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I add custom words to Mac dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Apple Dictation does not support custom vocabulary. EnviousWispr lets you add custom words for names, brands, and technical terms. The app applies them during transcription so specialized words come out correctly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does Apple Dictation stop listening after 30 seconds?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Apple Dictation has a built-in inactivity timeout. If you pause speaking for too long, it stops. EnviousWispr has no timeout, so you can pause to think and continue dictating without restarting."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr replace Apple Dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It runs alongside Apple Dictation, not instead of it. You can keep Apple Dictation enabled for quick one-liners and use EnviousWispr for longer dictation where you want AI polish and custom words. They use different hotkeys and do not conflict."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via Apple Intelligence or Ollama. No internet required for the full pipeline."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How accurate is EnviousWispr compared to Apple Dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr uses Parakeet TDT, a modern ASR model, combined with AI polish that fixes misrecognitions and grammar. Apple Dictation achieves ~90% in quiet conditions but degrades with background noise. EnviousWispr's AI polish layer provides an additional correction pass that Apple Dictation lacks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can EnviousWispr remove filler words from dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. When AI polish is enabled, filler words like um, uh, you know, and like are stripped automatically. Apple Dictation transcribes them as-is."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr support voice commands like Apple Dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Apple Dictation supports voice commands such as new paragraph, comma, and emoji names. EnviousWispr does not process voice commands during recording. Instead, AI polish handles punctuation, paragraph breaks, and formatting automatically based on context."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use both Apple Dictation and EnviousWispr at the same time?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. They use separate hotkeys and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and transcript history."
+      }
+    }
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Apple Dictation: Mac Voice-to-Text"
+  description="Compare EnviousWispr vs Apple Dictation on speed, AI polish, and custom words. Both free, both on-device. See why a dedicated app goes further."
+  activePage="compare"
+  canonicalPath="/compare/apple-dictation/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Apple Dictation</span>
+    </div>
+    <h1 class="reveal">Apple Dictation is fine. Here is what a dedicated app adds.</h1>
+    <p class="page-header-sub reveal">Both free. Both on-device. But EnviousWispr adds AI polish, custom vocabulary, and no timeout. A dedicated dictation app for people who dictate seriously.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        No timeout
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+        AI polish
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        Custom words
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">Apple Dictation is a solid default. Here is where a dedicated dictation app pulls ahead.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Apple Dictation</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Apple Dictation claims verified against Apple support documentation and firsthand testing on macOS 15.
+             Confidence: source-verified from Apple's public support pages.
+             Sources:
+               - Timeout: Apple Support HT210539 - dictation stops after ~30s of silence or inactivity
+               - On-device processing: Apple Support - on-device on Apple Silicon, cloud fallback on Intel
+               - Accuracy: published third-party benchmarks (90-92% clean, degrades with noise)
+               - Custom vocabulary: not available in macOS Dictation settings
+               - AI polish / filler removal / writing style: not features of Apple Dictation
+               - Voice commands: Apple Support - "new paragraph", "comma", emoji dictation
+               - Mixed input: macOS 14+ allows keyboard + dictation simultaneously
+               - Transcript history: Apple Dictation does not store past transcriptions
+               - Locales: Apple Support - dozens of languages supported
+               - Hands-free: Apple Dictation requires manual activation per session
+             EnviousWispr claims from production PostHog data (environment=production). -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription.</span></td>
+            <td><span class="table-highlight">Free, built into macOS</span></td>
+          </tr>
+          <tr>
+            <td>Setup required</td>
+            <td>One-time download + model install (~2 min)</td>
+            <td><span class="table-highlight">None. Already installed.</span></td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Apple ID (for macOS itself)</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (<a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a>)</td>
+            <td>On-device (Apple Silicon); cloud fallback on Intel</td>
+          </tr>
+          <tr>
+            <td>Timeout</td>
+            <td><span class="table-highlight">No timeout.</span> Handles 1-2 minute dictation bursts.</td>
+            <td>Stops after ~30s of silence</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence</span>, Ollama (on-device), or BYO OpenAI/Gemini key</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span>, automatic via AI polish</td>
+            <td><span class="table-cross">No</span> (transcribes "um", "uh" faithfully)</td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td><span class="table-check">Yes</span> (casual, professional, concise via LLM prompt)</td>
+            <td><span class="table-cross">No</span></td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-highlight">Custom words</span> with 6-pass fuzzy matching + AI alias suggestions</td>
+            <td><span class="table-cross">Not available</span></td>
+          </tr>
+          <tr>
+            <td>Transcription speed</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Real-time streaming (words appear as you speak)</td>
+          </tr>
+          <tr>
+            <td>Accuracy (clean audio)</td>
+            <td>High (Parakeet TDT 0.6B + AI polish correction)</td>
+            <td>90-92% (degrades significantly with background noise)</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Yes</span> (always-listening VAD, no warm-up gap)</td>
+            <td>Can miss the first word while the mic activates</td>
+          </tr>
+          <tr>
+            <td>Punctuation</td>
+            <td>Auto-punctuation + AI polish reformats</td>
+            <td>Auto-punctuation, emoji dictation, voice commands</td>
+          </tr>
+          <tr>
+            <td>Voice commands</td>
+            <td><span class="table-cross">Not supported</span></td>
+            <td><span class="table-highlight">"New paragraph", "comma", "smiley face"</span></td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> (saves and restores clipboard around paste)</td>
+            <td><span class="table-cross">No</span> (inserts directly at cursor)</td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes</span> (configurable VAD sensitivity)</td>
+            <td>Stops listening entirely after ~30s silence</td>
+          </tr>
+          <tr>
+            <td>Transcript history</td>
+            <td><span class="table-check">Yes</span> (searchable transcript log)</td>
+            <td><span class="table-cross">No history</span></td>
+          </tr>
+          <tr>
+            <td>Language support</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>Dozens of locales</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>Keyboard-driven hotkey, menu bar app, VoiceOver compatible</td>
+            <td>Deep OS integration, mixed keyboard + dictation input</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> (after one-time model download)</td>
+            <td>Yes on Apple Silicon; No on Intel</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td>macOS (Apple Silicon required)</td>
+            <td><span class="table-highlight">macOS, iOS, iPadOS, visionOS</span></td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">EnviousWispr latency from production PostHog data (environment=production) on Apple Silicon Macs. Apple Dictation accuracy from published third-party benchmarks. Apple Dictation features verified against Apple Support documentation and firsthand testing on macOS 15. Last verified: April 2026.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why Upgrade</div>
+      <h2 class="section-title">What a dedicated dictation app gives you</h2>
+      <p class="section-sub">Apple Dictation works. EnviousWispr works harder. Here is what changes when you move beyond the built-in. For more on why on-device matters, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🧠</div>
+        <div class="advantage-title">AI polish cleans your words</div>
+        <p class="advantage-desc">Apple Dictation gives you raw transcription. EnviousWispr pipes text through <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">AI polish</a> to remove filler words, fix grammar, and format paragraphs. Choose Apple Intelligence, Ollama, or your own OpenAI/Gemini key.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Custom words that stick</div>
+        <p class="advantage-desc">Names, product terms, technical jargon. Apple Dictation has no custom vocabulary feature. EnviousWispr lets you add <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">custom words</a> so "Parakeet TDT" and "Kubernetes" come out right every time.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⏱️</div>
+        <div class="advantage-title">No 30-second timeout</div>
+        <p class="advantage-desc">Apple Dictation stops listening after roughly 30 seconds of inactivity. EnviousWispr has no timeout. Dictate a full paragraph, pause to think, keep going. Designed for 1-2 minute bursts without interruption.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">0.43s to finished text</div>
+        <p class="advantage-desc">Median time from end of speech to text in clipboard: 0.43 seconds without polish, 1.5 seconds with AI polish. Processed locally on the <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a>. No network dependency.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔇</div>
+        <div class="advantage-title">Filler words removed</div>
+        <p class="advantage-desc">Uh, um, you know, like. Apple Dictation transcribes them faithfully. EnviousWispr's AI polish strips them out so your text reads like writing, not a transcript.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔍</div>
+        <div class="advantage-title">Auditable source code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. See exactly how your audio is processed. Apple Dictation is a black box built into the OS.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Dedicated models, dedicated speed</h2>
+      <p class="section-sub">EnviousWispr uses purpose-built ASR models optimized for Apple Silicon. The result is fast, accurate transcription with optional AI refinement.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0s</div>
+        <div class="speed-label">Timeout limit</div>
+        <div class="speed-detail">No cutoff. Dictate as long as you need.</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dives -->
+<section class="section" aria-label="Under the Hood">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">Where a dedicated app goes deeper</h2>
+      <p class="section-sub">Apple Dictation gives you raw speech-to-text. EnviousWispr adds layers that turn dictation into polished writing.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">📖</div>
+        <div class="deep-dive-title">Custom vocabulary and smart correction</div>
+        <div class="deep-dive-body">
+          <p>Apple Dictation has no custom vocabulary feature. If you work with specialized terminology, product names, or technical jargon, you get whatever the built-in model guesses. "Parakeet TDT" might come out as "parakeet teddy." "Kubernetes" might become "Cooper Netties."</p>
+          <p>EnviousWispr lets you add custom words with a 6-pass fuzzy matching system. Each word can have aliases (phonetic variants the ASR model might produce), and the app suggests aliases automatically using AI analysis of likely misrecognitions. When the model outputs "envious whisper," the custom words system corrects it to "EnviousWispr" before the text reaches your clipboard.</p>
+          <p>This works at the post-processing layer, so it applies regardless of which ASR backend you use. Add a word once, and it corrects everywhere.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Custom words are matched using Levenshtein distance, phonetic similarity, case-insensitive comparison, substring containment, and word-boundary-aware replacement. AI alias suggestions use the LLM to predict how speech recognition models typically mangle specific terms.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🧠</div>
+        <div class="deep-dive-title">AI polish transforms raw speech</div>
+        <div class="deep-dive-body">
+          <p>Apple Dictation gives you exactly what you said, including every "um," "uh," "you know," and false start. For quick one-liners, that is fine. For anything longer, you end up editing the transcript to make it readable.</p>
+          <p>EnviousWispr pipes transcription through an AI polish step that removes filler words, fixes grammar, formats paragraphs, and adjusts tone. You can choose Apple Intelligence (fully on-device), Ollama (local open-source models), or bring your own OpenAI or Gemini API key.</p>
+          <p>The polish layer includes hallucination safeguards: short transcripts bypass the LLM entirely, output length is validated against input length, and preamble artifacts ("Certainly! Here is...") are stripped automatically. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or rewrite.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Context-aware prompts include the target app name, detected language, and ASR error patterns. Sandwich framing wraps the transcript in &lt;transcript&gt; tags to prevent prompt injection. Output exceeding 3x input length is rejected as probable hallucination, falling back to raw text.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Apple Dictation Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Apple Dictation if you only need occasional built-in dictation</h2>
+      <p class="section-sub">Apple Dictation is built into the OS for a reason. It does some things that a third-party app cannot match:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚀</div>
+        <div class="advantage-title">Zero setup required</div>
+        <p class="advantage-desc">Apple Dictation is already on your Mac. Turn it on in System Settings, press the microphone key, and start talking. No download, no model installation, no permissions to grant. It just works.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📱</div>
+        <div class="advantage-title">Works on every Apple device</div>
+        <p class="advantage-desc">iPhone, iPad, Mac, Vision Pro. Apple Dictation follows you across the ecosystem with consistent behavior. EnviousWispr is macOS only and requires Apple Silicon.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🗣️</div>
+        <div class="advantage-title">Voice commands for formatting</div>
+        <p class="advantage-desc">Say "new paragraph," "comma," "exclamation mark," or even "smiley face" and Apple Dictation inserts the right character. EnviousWispr does not support voice commands for punctuation or formatting.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌍</div>
+        <div class="advantage-title">No separate app needed</div>
+        <p class="advantage-desc">Apple Dictation is part of the operating system. No menu bar icon, no extra process, no Accessibility permissions to approve. For light dictation use, the built-in option carries zero overhead.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⌨️</div>
+        <div class="advantage-title">Mixed keyboard and voice input</div>
+        <p class="advantage-desc">On macOS 14+, you can type on the keyboard while Dictation is active. Switch freely between voice and keys mid-sentence. EnviousWispr uses a record-then-paste model, so you speak first, then the text appears.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you dictate more than a few sentences at a time and want polished output with custom vocabulary, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. It runs alongside Apple Dictation with no conflicts.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a better alternative to Apple Dictation on Mac?</div>
+        <p class="faq-a">EnviousWispr is a free, on-device alternative that adds AI polish, custom vocabulary, and no timeout limit. It runs alongside Apple Dictation without interfering. Both use Apple Silicon for local processing.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I add custom words to Mac dictation?</div>
+        <p class="faq-a">Apple Dictation does not support custom vocabulary. EnviousWispr lets you add custom words for names, brands, and technical terms. The app applies them during transcription so specialized words come out correctly.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Why does Apple Dictation stop listening after 30 seconds?</div>
+        <p class="faq-a">Apple Dictation has a built-in inactivity timeout. If you pause speaking for too long, it stops. EnviousWispr has no timeout, so you can pause to think and continue dictating without restarting.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr replace Apple Dictation?</div>
+        <p class="faq-a">It runs alongside Apple Dictation, not instead of it. You can keep Apple Dictation enabled for quick one-liners and use EnviousWispr for longer dictation where you want AI polish and custom words. They use different hotkeys and do not conflict.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free?</div>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">GitHub</a> under a BSL 1.1 license.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via Apple Intelligence or Ollama. No internet required for the full pipeline.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">How accurate is EnviousWispr compared to Apple Dictation?</div>
+        <p class="faq-a">EnviousWispr uses Parakeet TDT, a modern ASR model, combined with AI polish that fixes misrecognitions and grammar. Apple Dictation achieves ~90% in quiet conditions (third-party tests) in clean environments but degrades significantly with background noise. EnviousWispr's AI polish layer provides an additional correction pass that Apple Dictation lacks.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can EnviousWispr remove filler words from dictation?</div>
+        <p class="faq-a">Yes. When AI polish is enabled, filler words like "um," "uh," "you know," and "like" are stripped automatically. Apple Dictation transcribes them as-is. If you dictate longer passages, filler removal makes a noticeable difference in readability.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr support voice commands like Apple Dictation?</div>
+        <p class="faq-a">No. Apple Dictation supports voice commands such as "new paragraph," "comma," and emoji names. EnviousWispr does not process voice commands during recording. Instead, AI polish handles punctuation, paragraph breaks, and formatting automatically based on context.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use both Apple Dictation and EnviousWispr at the same time?</div>
+        <p class="faq-a">Yes. They use separate hotkeys and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and transcript history. They do not interfere with each other.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Dragon</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Try free dictation that works in any Mac app</h2>
+    <p class="reveal">Free to download. No account required. Runs alongside Apple Dictation.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare-apple-dictation">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/compare/" class="back-link">See all comparisons</a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -1,0 +1,843 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Dragon: Free Mac Dictation Alternative",
+  "description": "Compare EnviousWispr vs Dragon (Nuance) on price, privacy, platform support, and speed. Free on-device dictation for Apple Silicon Macs. No $700 license fee.",
+  "url": `${siteUrl}/compare/dragon/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Dragon",
+      "item": `${siteUrl}/compare/dragon/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is there a free Dragon alternative for Mac?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr is free, runs natively on macOS with Apple Silicon, and processes speech on-device. Dragon discontinued its Mac version in 2018, so EnviousWispr fills that gap without costing $700."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Dragon still work on Mac?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Nuance discontinued Dragon for Mac in 2018. The last Mac version does not run on modern macOS with Apple Silicon. If you need dictation on a Mac, EnviousWispr is a current, actively maintained option."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Dragon dictation free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Dragon Professional Individual costs approximately $699 for a one-time license. The consumer version (Dragon Home) has been discontinued. EnviousWispr is completely free with no license fee or subscription."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to train EnviousWispr to recognize my voice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr uses modern neural speech models that work accurately from the first sentence. Dragon improves accuracy as you use it and make corrections."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using Apple Intelligence or a local Ollama model."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can EnviousWispr do voice commands like Dragon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr focuses on dictation: converting speech to text as fast as possible. It does not support macro commands or application control the way Dragon Professional does."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happened to Dragon after Microsoft bought Nuance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot). Dragon Professional Individual is still sold but receives minimal updates."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency. Dragon is entirely closed source."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can EnviousWispr match Dragon's accuracy for medical or legal terms?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For general dictation, EnviousWispr's neural models are highly accurate out of the box. For specialized medical or legal terminology, Dragon's purpose-built editions have purpose-trained vocabularies that EnviousWispr does not replicate. EnviousWispr's Custom Words feature lets you add terms manually."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "I used Dragon on Mac before 2018. Is EnviousWispr a replacement?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For dictation, yes. EnviousWispr handles the core workflow Dragon Mac users relied on: speak, transcribe, paste into any app. It adds AI polish that Dragon never had. The main gap is voice commands."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work with external microphones?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr uses whatever microphone macOS has selected as the input device. USB microphones, Bluetooth headsets, and audio interfaces all work."
+      }
+    }
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Dragon: Free Mac Dictation"
+  description="Dragon costs $700 and dropped Mac support. EnviousWispr is free on-device dictation for Apple Silicon Macs. No account required."
+  activePage="compare"
+  canonicalPath="/compare/dragon/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Dragon</span>
+    </div>
+    <h1 class="reveal">Dragon is $700, Windows-only, and discontinued on Mac</h1>
+    <p class="page-header-sub reveal">Dragon pioneered dictation. But it dropped Mac support, costs $700, and has no AI polish. EnviousWispr is free, runs on Apple Silicon, and works offline.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, not $700
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        Native macOS, not Windows
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">Dragon NaturallySpeaking set the standard for dictation software. Here is how it compares to EnviousWispr in 2026.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Dragon (Nuance)</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Dragon claims verified against nuance.com, Microsoft product pages, and archived documentation.
+             Confidence: source-verified from public websites and archived product listings.
+             Sources:
+               - Pricing: nuance.com/dragon.html (accessed 2026-04-03) - Dragon Professional ~$699 one-time
+               - Mac discontinuation: Nuance announcement (2018), confirmed no Mac version available (accessed 2026-04-03)
+               - Consumer version: Dragon Home discontinued; only Professional Individual remains (accessed 2026-04-03)
+               - Microsoft acquisition: Microsoft completed Nuance acquisition March 2022 (public record)
+               - On-device processing: Dragon processes locally after installation (product documentation)
+               - Custom vocabularies: Dragon Professional feature page (accessed 2026-04-03)
+               - Voice commands: Dragon Professional supports voice editing, formatting, navigation, and custom macros (product documentation)
+               - Auto-punctuation: Dragon Professional includes automatic punctuation (product documentation)
+               - Medical/legal editions: Dragon Medical One, Dragon Legal Individual exist as specialized products (nuance.com)
+               - Accuracy claim: Nuance markets "up to 99% recognition accuracy" (product page, accessed 2026-04-03)
+             Firsthand testing: Dragon was not tested firsthand for this comparison.
+             All claims are source-verified from official pages and public records. Last verified: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription, no license fee.</span></td>
+            <td>~$699 one-time (Professional)*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes, Nuance account + product activation</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td><span class="table-highlight">macOS</span> (Apple Silicon)</td>
+            <td>Windows only (Mac version discontinued 2018)</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Neural Engine)</td>
+            <td>On-device (after installation)</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your computer</td>
+            <td><span class="table-check">Never.</span> If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td><span class="table-check">No</span> (local processing)</td>
+          </tr>
+          <tr>
+            <td>Offline transcription</td>
+            <td><span class="table-check">Yes</span> (after model download)</td>
+            <td><span class="table-check">Yes</span> (after installation)</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-highlight">Yes.</span> Apple Intelligence or local Ollama models.</td>
+            <td><span class="table-cross">No AI polish at all</span></td>
+          </tr>
+          <tr>
+            <td>AI polish / LLM providers</td>
+            <td><span class="table-highlight">5 providers:</span> Apple Intelligence, Ollama, OpenAI, Gemini, Groq</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td><span class="table-highlight">Context-aware Smart Polish</span> adjusts for target app</td>
+            <td><span class="table-cross">None.</span> Raw transcript only.</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td>Proprietary Nuance engine (decades of refinement)</td>
+          </tr>
+          <tr>
+            <td>Voice training required</td>
+            <td><span class="table-check">No.</span> Works immediately.</td>
+            <td>Improves with use; Nuance claims 99% from first use</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td>Custom words for names and terms</td>
+            <td><span class="table-check">Custom vocabularies</span> + macro commands + auto-learning</td>
+          </tr>
+          <tr>
+            <td>Voice commands</td>
+            <td><span class="table-cross">Not supported</span></td>
+            <td><span class="table-check">Yes.</span> Edit by voice, navigate, format, custom macros.</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Yes.</span> VAD detects speech onset; no clipping.</td>
+            <td><span class="table-check">Yes.</span> Always-listening mode with wake word.</td>
+          </tr>
+          <tr>
+            <td>Starts listening instantly</td>
+            <td><span class="table-highlight">Hotkey press, immediate recording.</span></td>
+            <td>Always-listening or manual microphone toggle</td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes.</span> Three-tier paste with app reactivation.</td>
+            <td><span class="table-check">Yes.</span> Types into the active window cursor position.</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes.</span> Clipboard saved and restored after paste.</td>
+            <td>Not applicable (types directly, does not use clipboard)</td>
+          </tr>
+          <tr>
+            <td>Auto-punctuation</td>
+            <td><span class="table-check">Yes.</span> Neural model + AI polish handle punctuation.</td>
+            <td><span class="table-check">Yes.</span> Built-in auto-punctuation.</td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes.</span> Configurable silence timeout.</td>
+            <td><span class="table-check">Yes.</span> Configurable pause settings.</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>Menu bar app; global hotkey; works in any text field</td>
+            <td>Full accessibility suite; navigation by voice</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Near-instant (local processing, but older engine)</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Active development</td>
+            <td><span class="table-check">Yes.</span> Shipping updates regularly.</td>
+            <td><span class="table-cross">Effectively abandoned.</span> Microsoft/Nuance focus shifted to enterprise and healthcare.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Dragon Professional Individual pricing from <a href="https://www.nuance.com/dragon.html" style="color: var(--text-3); text-decoration: underline;">nuance.com</a> as of April 2026. Consumer Dragon Home has been discontinued. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Dragon claims source-verified from official Nuance pages and product documentation; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why Mac users choose EnviousWispr over Dragon</h2>
+      <p class="section-sub">Dragon left the Mac behind. EnviousWispr was built for it.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free, not $700</div>
+        <p class="advantage-desc">Dragon Professional costs roughly $699 for a single license. EnviousWispr is free. No subscription, no license key, no activation server. Download and use it.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🍎</div>
+        <div class="advantage-title">Actually runs on Mac</div>
+        <p class="advantage-desc">Nuance discontinued Dragon for Mac in 2018. If you are on macOS, Dragon is not an option. EnviousWispr is built natively for Apple Silicon and takes full advantage of the Neural Engine. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✨</div>
+        <div class="advantage-title">AI polish built in</div>
+        <p class="advantage-desc">Dragon gives you a raw transcript. EnviousWispr can clean up filler words, fix punctuation, and restructure sentences using Apple Intelligence or a local Ollama model. No extra software, no cloud dependency unless you choose it.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Works instantly</div>
+        <p class="advantage-desc">Dragon claims up to 99% accuracy from first use, improving further with corrections over time. EnviousWispr works immediately. Modern speech models like <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> are accurate out of the box.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔄</div>
+        <div class="advantage-title">Actively maintained</div>
+        <p class="advantage-desc">Dragon has not received meaningful updates since Microsoft acquired Nuance in 2022. Their focus shifted to enterprise healthcare. EnviousWispr ships updates regularly with new models, features, and performance improvements.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Dragon is closed source with no public bug tracker.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Architecture / Privacy Deep Dive -->
+<section class="section" aria-label="Architecture Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Architecture</div>
+      <h2 class="section-title">Two generations of on-device dictation</h2>
+      <p class="section-sub">Both Dragon and EnviousWispr process speech locally. The difference is what happens after the transcript. For more on why on-device matters, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is transcribed by the Neural Engine using Parakeet TDT or WhisperKit. Nothing uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish cleans up the transcript. Runs on-device with Apple Intelligence or Ollama, or with your own cloud API key if you choose.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted into your active app. Audio is discarded.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Dragon (Nuance)
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Windows PC's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is transcribed locally by Dragon's proprietary engine. Processing stays on-device.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Raw transcript is inserted. No AI polish, no cleanup, no sentence restructuring.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>You manually edit the text to fix filler words, punctuation, and phrasing.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Deep Dive -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Deep Dive</div>
+      <h2 class="section-title">The details that matter for Mac users</h2>
+      <p class="section-sub">Dragon was the gold standard for Windows dictation. But two fundamental gaps make it irrelevant for Mac users in 2026.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🍎</div>
+        <div class="deep-dive-title">Actually runs on your Mac</div>
+        <div class="deep-dive-body">
+          <p>Nuance discontinued Dragon for Mac in 2018. The last Mac version (6.0.8) predates Apple Silicon entirely. It does not run on modern macOS, and Nuance has no plans to bring it back. If you search for "Dragon Mac," you will find forum posts from frustrated users and no download link.</p>
+          <p>EnviousWispr is built natively for Apple Silicon. It uses Core ML and the Neural Engine directly, meaning transcription runs on dedicated ML hardware rather than general-purpose CPU cores. The app is a lightweight menu bar utility that launches in seconds and uses minimal memory.</p>
+          <p>This is not a compatibility layer or a port. Every component, from audio capture to paste-back, uses native macOS APIs: AVFoundation for audio, Accessibility API for text insertion, and Core ML for model inference.</p>
+          <div class="deep-dive-detail">
+            <strong>Technical detail:</strong> EnviousWispr runs Parakeet TDT (600M parameters) and WhisperKit models through Core ML on Apple Silicon's Neural Engine. Dragon's proprietary engine was optimized for x86 Windows with no Apple Silicon path. The last Dragon Mac release cannot even launch on macOS 14+.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">✨</div>
+        <div class="deep-dive-title">Modern AI polish, not just raw transcript</div>
+        <div class="deep-dive-body">
+          <p>Dragon gives you a transcript and expects you to fix it. It has no concept of LLM-based post-processing. Dragon was built in an era before large language models existed, and Nuance has not retrofitted this capability.</p>
+          <p>EnviousWispr integrates five LLM providers for Smart Polish: Apple Intelligence (fully on-device), Ollama (local models like Llama or Mistral), and cloud options via OpenAI, Gemini, or Groq if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
+          <p>The system is context-aware. Dictating into Slack? The polish keeps it conversational. Writing an email? It formalizes. And all cloud providers only receive the text transcript, never your audio.</p>
+          <div class="deep-dive-detail">
+            <strong>Technical detail:</strong> Smart Polish uses sandwich prompt framing with XML-tagged transcript boundaries to prevent hallucination. Output validation rejects responses longer than 3x the input. Short transcripts (3 words or fewer) bypass the LLM entirely. Preamble stripping removes "Certainly!" artifacts automatically.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Modern models, modern hardware</h2>
+      <p class="section-sub">EnviousWispr runs neural speech models on Apple Silicon's dedicated ML hardware. The result is sub-second transcription with no training needed.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0s</div>
+        <div class="speed-label">Training required</div>
+        <div class="speed-detail">Accurate from the first sentence</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Dragon Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Where Dragon genuinely wins</h2>
+      <p class="section-sub">Dragon pioneered voice dictation and spent decades refining it. These are real strengths, not legacy talking points:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎯</div>
+        <div class="advantage-title">Decades of accuracy refinement</div>
+        <p class="advantage-desc">Dragon has been tuning its speech engine since the 1990s. Nuance claims up to 99% accuracy from first use, improving further as you make corrections. The engine learns your voice, your vocabulary, and your correction patterns over time. That adaptive accuracy loop is genuinely impressive.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🗣️</div>
+        <div class="advantage-title">Voice command editing</div>
+        <p class="advantage-desc">Dragon lets you edit, format, and navigate entirely by voice. Say "select previous sentence" or "bold that" and it works. You can create custom voice macros for repetitive tasks. EnviousWispr is dictation-only; it does not support voice-driven editing or navigation.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🏥</div>
+        <div class="advantage-title">Medical and legal editions</div>
+        <p class="advantage-desc">Dragon Medical One and Dragon Legal Individual ship with specialized vocabularies for clinical notes, legal briefs, and industry-specific terminology. These are purpose-built products with EHR integrations. EnviousWispr targets general dictation, not regulated industry workflows.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🏢</div>
+        <div class="advantage-title">Enterprise deployments</div>
+        <p class="advantage-desc">Dragon has decades of enterprise deployment experience with IT admin tools, network licensing, and compliance certifications. Organizations with existing Dragon infrastructure have switching costs that go beyond the software itself.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you are on a Mac and want free, actively maintained dictation with AI polish, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free Dragon alternative for Mac?</div>
+        <p class="faq-a">Yes. EnviousWispr is free, runs natively on macOS with Apple Silicon, and processes speech on-device. Dragon discontinued its Mac version in 2018, so EnviousWispr fills that gap without costing $700.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Dragon still work on Mac?</div>
+        <p class="faq-a">No. Nuance discontinued Dragon for Mac in 2018. The last Mac version does not run on modern macOS with Apple Silicon. If you need dictation on a Mac, EnviousWispr is a current, actively maintained option.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is Dragon dictation free?</div>
+        <p class="faq-a">No. Dragon Professional Individual costs approximately $699 for a one-time license. The consumer version (Dragon Home) has been discontinued. EnviousWispr is completely free with no license fee or subscription.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Do I need to train EnviousWispr to recognize my voice?</div>
+        <p class="faq-a">No. EnviousWispr uses modern neural speech models that work accurately from the first sentence. Dragon improves accuracy as you use it and make corrections, though Nuance claims 99% accuracy from first use. EnviousWispr skips that entirely.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using Apple Intelligence or a local Ollama model. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a> for setup.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can EnviousWispr do voice commands like Dragon?</div>
+        <p class="faq-a">EnviousWispr focuses on dictation: converting speech to text as fast as possible. It does not support macro commands or application control the way Dragon Professional does. If you need voice-driven automation, Dragon's scripting features are more extensive.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What happened to Dragon after Microsoft bought Nuance?</div>
+        <p class="faq-a">Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot). Dragon Professional Individual is still sold but receives minimal updates.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a>. It is not an OSI-approved open source license, but it gives you full transparency. Dragon is entirely closed source.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can EnviousWispr match Dragon's accuracy for medical or legal terms?</div>
+        <p class="faq-a">For general dictation, EnviousWispr's neural models are highly accurate out of the box. For specialized medical or legal terminology, Dragon's purpose-built editions (Dragon Medical One, Dragon Legal Individual) have purpose-trained vocabularies that EnviousWispr does not replicate. EnviousWispr's Custom Words feature lets you add names and terms manually, but it is not a substitute for a medical dictionary with tens of thousands of clinical terms.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">I used Dragon on Mac before 2018. Is EnviousWispr a replacement?</div>
+        <p class="faq-a">For dictation, yes. EnviousWispr handles the core workflow Dragon Mac users relied on: speak, transcribe, paste into any app. It adds AI polish that Dragon never had. The main gap is voice commands. Dragon let you edit and navigate by voice; EnviousWispr is focused purely on converting speech to polished text.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work with external microphones?</div>
+        <p class="faq-a">Yes. EnviousWispr uses whatever microphone macOS has selected as the input device. USB microphones, Bluetooth headsets, and audio interfaces all work. Dragon similarly supports external microphones on Windows. You can select your preferred input device in System Settings before recording.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Superwhisper</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Dragon left the Mac. We did not.</h2>
+    <p class="reveal">Free to download. No account required. No $700 license fee.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+<!-- Footnote -->
+<footer style="padding: 24px 0 48px; text-align: center;">
+  <div class="container">
+    <p style="font-size: 11px; color: var(--text-3); max-width: 640px; margin: 0 auto; line-height: 1.65;">
+      <strong>Methodology:</strong> Dragon claims were sourced from <a href="https://www.nuance.com/dragon.html" style="color: var(--text-3); text-decoration: underline;">nuance.com</a>, Microsoft product announcements, archived product pages, and official product documentation. Dragon was not firsthand-tested for this comparison. Where Dragon has genuine strengths (voice commands, medical/legal editions, adaptive accuracy), we say so. EnviousWispr performance data comes from production PostHog analytics on Apple Silicon Macs. All competitor claims were last verified on 2026-04-04. If you spot an error, please <a href="https://github.com/AirSkye/EnviousWispr/issues" style="color: var(--text-3); text-decoration: underline;">open an issue</a>.
+    </p>
+  </div>
+</footer>
+
+</BaseLayout>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -1,0 +1,746 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Google Docs Voice Typing: Dictation Beyond the Browser",
+  "description": "Compare EnviousWispr and Google Docs Voice Typing. Both free, but EnviousWispr works system-wide, offline, and on-device. No browser or Google account required.",
+  "url": `${siteUrl}/compare/google-docs-voice-typing/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Is there a Google Docs voice typing alternative that works outside the browser?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. EnviousWispr is a native Mac app that works in any text field system-wide. Dictate into Slack, VS Code, email, Notes, or any other app. No browser required." } },
+    { "@type": "Question", "name": "Can I dictate outside Google Docs for free?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. EnviousWispr is free, with no subscription, no usage limits, and no account required. Download and start dictating in any app on your Mac." } },
+    { "@type": "Question", "name": "Does EnviousWispr work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider." } },
+    { "@type": "Question", "name": "Does Google Docs voice typing send my audio to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Google Docs voice typing requires an internet connection and processes your audio on Google's servers. EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine." } },
+    { "@type": "Question", "name": "Does EnviousWispr have voice commands like Google Docs?", "acceptedAnswer": { "@type": "Answer", "text": "Not yet. Google Docs supports voice commands (select, format, navigate) in English. EnviousWispr focuses on fast, accurate transcription with AI polish. Voice commands may come in a future release." } },
+    { "@type": "Question", "name": "What Mac do I need?", "acceptedAnswer": { "@type": "Answer", "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast." } },
+    { "@type": "Question", "name": "Can EnviousWispr remove filler words?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. EnviousWispr automatically removes um, uh, like, and other filler words. Google Docs voice typing transcribes everything as spoken, including fillers." } },
+    { "@type": "Question", "name": "Is EnviousWispr open source?", "acceptedAnswer": { "@type": "Answer", "text": "Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code on GitHub. Contributions are welcome." } },
+    { "@type": "Question", "name": "Can I use Google Docs voice typing in Slack, VS Code, or other apps?", "acceptedAnswer": { "@type": "Answer", "text": "No. Google Docs Voice Typing only works inside Google Docs and Google Slides in a supported browser. If you need to dictate into Slack, VS Code, email clients, terminals, or any other app, you need a system-wide tool like EnviousWispr." } },
+    { "@type": "Question", "name": "Does Google Docs voice typing add punctuation automatically?", "acceptedAnswer": { "@type": "Answer", "text": "Only to a limited extent. In most languages, you need to say period, comma, question mark, and other punctuation aloud. EnviousWispr handles punctuation automatically through its ASR engine and optional LLM polish." } },
+    { "@type": "Question", "name": "Can I teach Google Docs voice typing my company's terminology?", "acceptedAnswer": { "@type": "Answer", "text": "No. Google Docs Voice Typing has no custom vocabulary feature. EnviousWispr's Custom Words feature lets you define exact spellings for names, jargon, and domain-specific terms that get applied every time you dictate." } },
+  ]
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Google Docs Voice Typing",
+      "item": `${siteUrl}/compare/google-docs-voice-typing/`,
+    },
+  ],
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Google Docs Voice Typing"
+  description="Compare EnviousWispr vs Google Docs Voice Typing. Both free. EnviousWispr works in any app, offline, on-device. No Chrome required."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/google-docs-voice-typing/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Google Docs Voice Typing</span>
+    </div>
+    <h1 class="reveal">Dictation that works everywhere, not just Google Docs</h1>
+    <p class="page-header-sub reveal">Google's voice typing is locked to Chrome and Google Docs. EnviousWispr works in any text field on your Mac, on-device, with no account required. Both are free.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        System-wide, not browser-only
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Google Docs Voice Typing</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Google Docs Voice Typing claims verified against support.google.com/docs/answer/4492226.
+             Confidence: source-verified from official Google support page.
+             Sources:
+               - Pricing: Free with Google account (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Browser: Chrome, Edge, and Safari on desktop (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Cloud processing: Requires internet, audio sent to Google servers (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - App scope: Google Docs and Google Slides only (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Languages: ~100 languages supported (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Voice commands: English only, formatting and editing commands (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Auto-punctuation: limited; users must say most punctuation marks (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Custom vocabulary: not supported (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+               - Accessibility: keyboard-free input within Google Docs (support.google.com/docs/answer/4492226, accessed 2026-04-04)
+             Firsthand testing: Google Docs Voice Typing was not tested firsthand for this comparison.
+             All claims are source-verified from official Google support pages. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No account required.</span></td>
+            <td>Free (requires Google account)</td>
+          </tr>
+          <tr>
+            <td>Works in any app</td>
+            <td><span class="table-check">Yes.</span> <span class="table-highlight">Any text field</span> on macOS, system-wide</td>
+            <td><span class="table-cross">No.</span> Google Docs and Google Slides only, in Chrome</td>
+          </tr>
+          <tr>
+            <td>Browser requirement</td>
+            <td><span class="table-check">None.</span> Native Mac app.</td>
+            <td>Chrome, Edge, or Safari (desktop)</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon Neural Engine)</td>
+            <td>Cloud (Google servers)</td>
+          </tr>
+          <tr>
+            <td>Internet required</td>
+            <td><span class="table-check">No</span> for transcription (after initial model download)</td>
+            <td>Yes, always</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, fully local)</td>
+            <td><span class="table-cross">No.</span> Entire tool requires internet.</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> (Custom Words for names, jargon, acronyms)</td>
+            <td><span class="table-cross">No</span></td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes.</span> Automatic "um", "uh", "like" removal.</td>
+            <td><span class="table-cross">No.</span> Transcribes fillers as spoken.</td>
+          </tr>
+          <tr>
+            <td>Auto-punctuation</td>
+            <td><span class="table-check">Yes.</span> ASR + LLM handle punctuation automatically.</td>
+            <td>Limited. You must say "period", "comma", etc. for most punctuation.</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Yes.</span> VAD + buffered audio captures from the first syllable.</td>
+            <td>Can miss the first word if recognition takes a moment to start.</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes.</span> Clipboard saved before paste and restored after.</td>
+            <td>N/A. Text is inserted directly into Google Docs.</td>
+          </tr>
+          <tr>
+            <td>Voice commands</td>
+            <td>Not yet</td>
+            <td><span class="table-highlight">Yes</span> (formatting, editing, navigation; English only)</td>
+          </tr>
+          <tr>
+            <td>Languages</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>~100 languages</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td>macOS (Apple Silicon)</td>
+            <td>Any OS with Chrome (desktop)</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>System-wide keyboard-free input for any macOS app</td>
+            <td>Keyboard-free input within Google Docs only</td>
+          </tr>
+          <tr>
+            <td>Multi-language in one session</td>
+            <td>Switch engines per session (Parakeet for English, WhisperKit for others)</td>
+            <td>Select one language at a time in the voice typing menu</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td>Google Cloud Speech API</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Depends on network + Google server load</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">Google Docs Voice Typing claims source-verified from <a href="https://support.google.com/docs/answer/4492226" style="color: var(--text-3); text-decoration: underline;">support.google.com/docs/answer/4492226</a> as of April 2026; not firsthand-tested. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Table expanded with 18 comparison rows covering app scope, AI features, privacy, and platform differences. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why dictate outside Google Docs</h2>
+      <p class="section-sub">Google's voice typing is convenient inside Docs. But dictation should not be limited to one app in one browser.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🖥️</div>
+        <div class="advantage-title">Works in any text field</div>
+        <p class="advantage-desc">Slack, VS Code, email, notes, terminal. EnviousWispr is a system-wide dictation tool. Google's voice typing only works inside Google Docs and Google Slides in Chrome.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">On-device transcription</div>
+        <p class="advantage-desc">Your audio never leaves your Mac. It is processed by the <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a> on Apple Silicon. Google sends your audio to cloud servers for processing. Private by architecture, not by promise. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✈️</div>
+        <div class="advantage-title">Works offline</div>
+        <p class="advantage-desc">On a plane, in a cafe with spotty Wi-Fi, or on a train. EnviousWispr transcribes without internet after the initial model download. Google's voice typing requires a constant connection.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✨</div>
+        <div class="advantage-title">AI polish and cleanup</div>
+        <p class="advantage-desc">EnviousWispr removes filler words, fixes grammar, and polishes your text with AI. Use Apple Intelligence on-device or bring your own API key. Google's voice typing gives you raw dictation only.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📝</div>
+        <div class="advantage-title">Custom vocabulary</div>
+        <p class="advantage-desc">Teach EnviousWispr your team names, product terms, and acronyms with Custom Words. Google's voice typing has no custom vocabulary support.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Fast local transcription</div>
+        <p class="advantage-desc">Median time to text is 0.43s on Apple Silicon. No network round-trips, no server queues. Immune to bad Wi-Fi, unlike cloud-dependent dictation.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">The most important question for any dictation tool. Here is the data flow for each app. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted into any app. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Google Docs Voice Typing
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your microphone while in Google Docs on Chrome.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is sent to Google's cloud servers for speech recognition.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Transcribed text is returned and inserted into your Google Doc.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Audio processing is subject to <a href="https://policies.google.com/privacy" style="color: var(--text-2); text-decoration: underline;">Google's privacy policy</a>. You control your Google account settings, but the audio does leave your device.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Deep Dive -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Deep Dive</div>
+      <h2 class="section-title">The details that matter</h2>
+      <p class="section-sub">Two areas where the architectural difference between EnviousWispr and Google Docs Voice Typing is most visible.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🖥️</div>
+        <div class="deep-dive-title">Works in every app, not just Google Docs</div>
+        <div class="deep-dive-body">
+          <p>Google Docs Voice Typing is a feature inside Google Docs. It works well there, but only there. If you switch to Slack, an email client, VS Code, a terminal, or any other app, you lose dictation entirely. You have to copy text out of a Google Doc and paste it where you actually need it.</p>
+          <p>EnviousWispr is a system-wide dictation tool. Hold a hotkey, speak, and the transcribed text is pasted directly into whatever text field has focus. It works in every macOS application: native apps, Electron apps, web browsers, terminals, IDEs, messaging tools. There is no copy-paste detour.</p>
+          <p>For people who write in many apps throughout the day, this is the core difference. Dictation should follow you across your workflow, not lock you into one browser tab.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> EnviousWispr captures the frontmost app and text field at recording start. After transcription, it re-activates that exact app and inserts text via the Accessibility API. If direct insertion fails, it falls back to simulated Cmd+V, then to AppleScript. Your clipboard is saved before the operation and restored after.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🔒</div>
+        <div class="deep-dive-title">Privacy: on-device vs cloud</div>
+        <div class="deep-dive-body">
+          <p>Google Docs Voice Typing requires a constant internet connection. Your audio is streamed to Google's servers, processed by their speech recognition API, and the text result is sent back. Google's <a href="https://policies.google.com/privacy" style="color: var(--accent); text-decoration: underline;">privacy policy</a> governs how that audio data is handled.</p>
+          <p>EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine. The audio buffer never leaves your device. After transcription, the audio is discarded. If you use on-device AI polish (Apple Intelligence or Ollama), the entire pipeline is local. No audio or text is uploaded anywhere.</p>
+          <p>If you opt into a cloud LLM for polish (OpenAI, Gemini), only the text transcript is sent, never the audio, and you provide your own API key. You control the relationship with the provider directly.</p>
+          <div class="deep-dive-detail">
+            <strong>Privacy by architecture:</strong> EnviousWispr does not have a server. There is no account system, no cloud backend, and no telemetry on your dictated content. The app sends anonymous usage analytics (PostHog) and crash reports (Sentry), but your actual text and audio never leave your machine.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Fast because there is no upload step</h2>
+      <p class="section-sub">On Apple Silicon Macs, EnviousWispr transcribes speech locally. No network round-trip before text appears.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Google Docs Voice Typing Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Google Voice Typing if you live entirely in Google Docs</h2>
+      <p class="section-sub">Google's voice typing has real advantages in specific workflows. It may be a better fit in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚀</div>
+        <div class="advantage-title">Zero setup if you already use Docs</div>
+        <p class="advantage-desc">If you live in Google Docs and use Chrome, voice typing is built in. No download, no setup, no model to install. Just open a document and start talking. That is genuinely hard to beat for convenience.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">💸</div>
+        <div class="advantage-title">Free with no download</div>
+        <p class="advantage-desc">There is nothing to install. Voice typing is a feature of Google Docs, available to anyone with a Google account. No disk space, no model downloads, no configuration.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌍</div>
+        <div class="advantage-title">Works on any OS with Chrome</div>
+        <p class="advantage-desc">Windows, Linux, ChromeOS, macOS. If Chrome runs, voice typing works. EnviousWispr is macOS only and requires Apple Silicon.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🗣️</div>
+        <div class="advantage-title">Voice commands for formatting</div>
+        <p class="advantage-desc">Say "bold", "italic", "new line", "select all", or "undo" while dictating in Google Docs. These formatting commands (English only) let you edit hands-free inside the document. EnviousWispr does not have voice commands yet.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌐</div>
+        <div class="advantage-title">~100 languages out of the box</div>
+        <p class="advantage-desc">Google supports roughly 100 languages for voice typing with no extra configuration. EnviousWispr's primary engine (Parakeet) is English-focused; WhisperKit supports 90+ but with varying accuracy.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If your workflow lives entirely inside Google Docs, their voice typing is a solid choice. If you need dictation across your whole Mac, in any app, with AI polish and privacy, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a Google Docs voice typing alternative that works outside the browser?</div>
+        <p class="faq-a">Yes. EnviousWispr is a native Mac app that works in any text field system-wide. Dictate into Slack, VS Code, email, Notes, or any other app. No browser required.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I dictate outside Google Docs for free?</div>
+        <p class="faq-a">Yes. EnviousWispr is free, with no subscription, no usage limits, and no account required. Download and start dictating in any app on your Mac. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Google Docs voice typing send my audio to the cloud?</div>
+        <p class="faq-a">Yes. Google Docs voice typing requires an internet connection and processes your audio on Google's servers. EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr have voice commands like Google Docs?</div>
+        <p class="faq-a">Not yet. Google Docs supports voice commands (select, format, navigate) in English. EnviousWispr focuses on fast, accurate transcription with AI polish. Voice commands may come in a future release.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can EnviousWispr remove filler words?</div>
+        <p class="faq-a">Yes. EnviousWispr automatically removes "um", "uh", "like", and other filler words. Google Docs voice typing transcribes everything as spoken, including fillers.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use Google Docs voice typing in Slack, VS Code, or other apps?</div>
+        <p class="faq-a">No. Google Docs Voice Typing only works inside Google Docs and Google Slides in a supported browser. If you need to dictate into Slack, VS Code, email clients, terminals, or any other app, you need a system-wide tool like EnviousWispr.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Google Docs voice typing add punctuation automatically?</div>
+        <p class="faq-a">Only to a limited extent. In most languages, you need to say "period", "comma", "question mark", and other punctuation aloud. EnviousWispr handles punctuation automatically through its ASR engine and optional LLM polish, so you can speak naturally without thinking about punctuation.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I teach Google Docs voice typing my company's terminology?</div>
+        <p class="faq-a">No. Google Docs Voice Typing has no custom vocabulary feature. If it misrecognizes a product name, acronym, or technical term, there is no way to correct it. EnviousWispr's Custom Words feature lets you define exact spellings for names, jargon, and domain-specific terms that get applied every time you dictate.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Try dictation that works outside Google Docs</h2>
+    <p class="reveal">Free to download. No account required. Works in every app on your Mac.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -1,0 +1,156 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+  ],
+});
+
+const cloudTools = [
+  { name: "WisprFlow", slug: "wisprflow", angle: "Cloud subscription vs free on-device dictation" },
+  { name: "Otter.ai", slug: "otter-ai", angle: "Meeting transcription vs real-time dictation" },
+  { name: "Notta", slug: "notta", angle: "Cloud transcription vs private on-device speech-to-text" },
+  { name: "Google Docs Voice Typing", slug: "google-docs-voice-typing", angle: "Browser-only dictation vs system-wide on any Mac app" },
+];
+
+const onDeviceApps = [
+  { name: "Superwhisper", slug: "superwhisper", angle: "Two on-device Mac apps, different trade-offs on price and speed" },
+  { name: "MacWhisper", slug: "macwhisper", angle: "File transcription app vs live dictation tool" },
+  { name: "VoiceInk", slug: "voiceink", angle: "Two whisper-based Mac apps, head to head on features" },
+  { name: "Willow Voice", slug: "willow-voice", angle: "Cloud-first subscription vs free on-device alternative" },
+];
+
+const legacyDev = [
+  { name: "Dragon", slug: "dragon", angle: "Legacy enterprise dictation vs modern Apple Silicon native" },
+  { name: "Apple Dictation", slug: "apple-dictation", angle: "Built-in macOS dictation vs dedicated dictation app" },
+  { name: "whisper.cpp", slug: "whisper-cpp", angle: "Developer CLI vs ready-to-use Mac dictation app" },
+];
+---
+
+<BaseLayout
+  title="EnviousWispr Comparisons: Free Mac Dictation vs Alternatives"
+  description="See how EnviousWispr compares to WisprFlow, Dragon, Apple Dictation, Otter.ai, and more. Free on-device Mac dictation."
+  activePage="compare"
+  canonicalPath="/compare/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+<style>
+.compare-hero { padding: 100px 0 48px; text-align: center; }
+.compare-hero h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; }
+.compare-hero p { font-size: 18px; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+
+.compare-group { margin-bottom: 48px; }
+.compare-group-label {
+  font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px;
+  color: var(--text-3); margin-bottom: 16px;
+}
+.compare-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;
+}
+.compare-card {
+  display: block; padding: 24px; border-radius: var(--radius-card);
+  border: 1px solid var(--border-hover); background: #fff;
+  text-decoration: none; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.compare-card:hover {
+  border-color: var(--accent); box-shadow: 0 2px 12px rgba(124,58,237,0.08);
+}
+.compare-card-name {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 6px;
+}
+.compare-card-angle {
+  font-size: 14px; color: var(--text-2); line-height: 1.5;
+}
+.compare-card-arrow {
+  display: inline-block; margin-top: 12px; font-size: 13px; font-weight: 600; color: var(--accent);
+}
+
+.compare-cta { text-align: center; padding: 48px 0 80px; }
+.compare-cta p { font-size: 16px; color: var(--text-2); margin-bottom: 20px; }
+.compare-cta .btn-primary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 28px; border-radius: 100px; font-size: 15px; font-weight: 700;
+  background: var(--accent); color: #fff; text-decoration: none;
+  transition: background 0.15s;
+}
+.compare-cta .btn-primary:hover { background: var(--accent-hover); }
+</style>
+
+<div class="compare-hero">
+  <div class="container">
+    <h1>How EnviousWispr compares</h1>
+    <p>Honest, side-by-side comparisons with every major dictation tool.</p>
+  </div>
+</div>
+
+<div class="container">
+  <div class="compare-group">
+    <div class="compare-group-label">Cloud dictation</div>
+    <div class="compare-grid">
+      {cloudTools.map(tool => (
+        <a href={`/compare/${tool.slug}/`} class="compare-card">
+          <div class="compare-card-name">vs {tool.name}</div>
+          <div class="compare-card-angle">{tool.angle}</div>
+          <span class="compare-card-arrow">Read comparison &rarr;</span>
+        </a>
+      ))}
+    </div>
+  </div>
+
+  <div class="compare-group">
+    <div class="compare-group-label">On-device Mac apps</div>
+    <div class="compare-grid">
+      {onDeviceApps.map(tool => (
+        <a href={`/compare/${tool.slug}/`} class="compare-card">
+          <div class="compare-card-name">vs {tool.name}</div>
+          <div class="compare-card-angle">{tool.angle}</div>
+          <span class="compare-card-arrow">Read comparison &rarr;</span>
+        </a>
+      ))}
+    </div>
+  </div>
+
+  <div class="compare-group">
+    <div class="compare-group-label">Legacy & developer tools</div>
+    <div class="compare-grid">
+      {legacyDev.map(tool => (
+        <a href={`/compare/${tool.slug}/`} class="compare-card">
+          <div class="compare-card-name">vs {tool.name}</div>
+          <div class="compare-card-angle">{tool.angle}</div>
+          <span class="compare-card-arrow">Read comparison &rarr;</span>
+        </a>
+      ))}
+    </div>
+  </div>
+</div>
+
+<div class="compare-cta">
+  <div class="container">
+    <p>Ready to try the fastest free dictation on Mac?</p>
+    <a href="/#download" class="btn-primary">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      Download Free
+    </a>
+  </div>
+</div>
+
+</BaseLayout>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -1,0 +1,816 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs MacWhisper: Real-Time Dictation vs File Transcription",
+  "description": "Compare EnviousWispr and MacWhisper for Mac dictation. EnviousWispr is purpose-built for real-time voice-to-text with sub-second latency. MacWhisper excels at file transcription and subtitle export.",
+  "url": `${siteUrl}/compare/macwhisper/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs MacWhisper",
+      "item": `${siteUrl}/compare/macwhisper/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr a MacWhisper alternative?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They solve different problems. MacWhisper is a transcription tool for importing and processing audio files. EnviousWispr is a dictation tool for typing by voice in real time. If you want to replace your keyboard with your voice, EnviousWispr is the better fit. If you need to transcribe recordings, MacWhisper is purpose-built for that."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Every feature is available at no cost. The source code is on GitHub under BSL 1.1."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via Apple Intelligence or Ollama. Cloud polish with your own API key is optional."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use MacWhisper for dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "MacWhisper has a real-time transcription mode, but its primary design is file-based transcription. EnviousWispr's entire pipeline is optimized for dictation latency, with hotkey activation, VAD, and direct clipboard paste delivering text in under a second."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr support subtitle export?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr is a dictation tool, not a transcription tool. It does not import files or export subtitles. For those workflows, MacWhisper is the right tool."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free MacWhisper alternative for dictation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr provides free, on-device real-time dictation on Apple Silicon Macs. No account, no subscription, no usage caps. It uses Parakeet TDT and WhisperKit for sub-second transcription."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will my audio be used for training?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use both EnviousWispr and MacWhisper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. They solve different problems and do not conflict. Use EnviousWispr for real-time dictation and MacWhisper for transcribing recordings, generating subtitles, or batch-processing audio files. Many users benefit from having both."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr support speaker diarization?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr is designed for single-speaker real-time dictation. If you need to identify multiple speakers in a recording, MacWhisper supports speaker diarization."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens to my clipboard when EnviousWispr pastes text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr saves your clipboard contents before pasting dictated text and restores them afterward. Whatever you had copied before dictating will still be on your clipboard when you press Cmd+V next."
+      }
+    },
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs MacWhisper: Dictation vs Transcription"
+  description="Compare EnviousWispr vs MacWhisper. Free real-time dictation with 0.43s latency vs file transcription and subtitle export. On-device, no subscription."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/macwhisper/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">MacWhisper</span>
+    </div>
+    <h1 class="reveal">MacWhisper transcribes files. EnviousWispr transcribes you.</h1>
+    <p class="page-header-sub reveal">MacWhisper transcribes audio files. EnviousWispr turns your voice into text as you speak, in under a second. Different tools for different jobs.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">MacWhisper and EnviousWispr both run Whisper-family models on your Mac. They solve different problems.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>MacWhisper</th>
+          </tr>
+        </thead>
+        <!-- Evidence: MacWhisper claims verified against goodsnooze.gumroad.com/l/macwhisper,
+             macwhisper.com, and App Store listing on 2026-04-04.
+             Confidence: source-verified from public Gumroad page, product website, and App Store.
+             Sources:
+               - Pricing: Gumroad (Pro ~$30 one-time), App Store ($29.99/yr or $99.99 lifetime, AI Assistant $9.99/mo)
+               - Features: goodsnooze.gumroad.com/l/macwhisper feature list, macwhisper.com
+               - Architecture: on-device Whisper models, optional cloud for AI Assistant
+             Firsthand testing: MacWhisper was not tested firsthand for this comparison.
+             All claims are source-verified from official pages. Last verified: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Primary use case</td>
+            <td><span class="table-highlight">Real-time dictation</span> into any app</td>
+            <td>File transcription (audio/video import, batch processing)</td>
+          </tr>
+          <tr>
+            <td>Real-time dictation</td>
+            <td><span class="table-check">Yes</span> (hold hotkey, speak, release, text appears)</td>
+            <td>Secondary feature; designed for post-recording transcription</td>
+          </tr>
+          <tr>
+            <td>File/video transcription</td>
+            <td><span class="table-cross">No</span> (dictation only)</td>
+            <td><span class="table-check">Yes</span> (drag-and-drop, batch, YouTube URLs, watch folders)</td>
+          </tr>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription.</span></td>
+            <td>Free tier (limited models); Pro ~$30 one-time or $29.99/yr; Lifetime $99.99*</td>
+          </tr>
+          <tr>
+            <td>Dictation latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Not optimized for real-time input latency</td>
+          </tr>
+          <tr>
+            <td>Warm engine / instant start</td>
+            <td><span class="table-check">Yes</span> (model stays loaded in memory)</td>
+            <td>Model loads per transcription job</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-highlight">Pre-roll buffer</span> catches speech before you press the hotkey</td>
+            <td>N/A (file-based workflow)</td>
+          </tr>
+          <tr>
+            <td>Hands-free dictation</td>
+            <td><span class="table-check">Yes</span> (hold or toggle hotkey modes)</td>
+            <td>N/A (manual file import workflow)</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td>AI Assistant add-on ($9.99/mo), cloud-based</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> (teach it names, jargon, acronyms; 6-pass fuzzy matching)</td>
+            <td>Prompt-based corrections</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span> (automatic "um", "uh", "you know" removal)</td>
+            <td>Not a built-in feature</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> (saves and restores your clipboard around paste)</td>
+            <td>N/A (no paste workflow)</td>
+          </tr>
+          <tr>
+            <td>Speaker diarization</td>
+            <td><span class="table-cross">No</span> (single-speaker dictation)</td>
+            <td><span class="table-check">Yes</span> (identify who said what)</td>
+          </tr>
+          <tr>
+            <td>Subtitle export (SRT/VTT)</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Batch processing</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span> (queue multiple files, watch folders)</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td>OpenAI Whisper models (various sizes)</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> (after model download)</td>
+            <td><span class="table-check">Yes</span> (core transcription; AI Assistant requires internet)</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td>macOS only (Apple Silicon)</td>
+            <td>macOS + iOS (App Store version)</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*MacWhisper pricing from Gumroad and App Store listings as of April 2026. EnviousWispr latency from production PostHog data on Apple Silicon Macs. MacWhisper claims source-verified from goodsnooze.gumroad.com and macwhisper.com; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why dictation users choose EnviousWispr</h2>
+      <p class="section-sub">If your goal is typing by voice in real time, EnviousWispr was built from the ground up for that single job.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free, no tiers</div>
+        <p class="advantage-desc">No free-vs-pro split. Every feature, every model, zero cost. MacWhisper's free tier limits you to smaller Whisper models; full access requires a Pro purchase.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Sub-second dictation</div>
+        <p class="advantage-desc">0.43s median from end of speech to text in your active app. Purpose-built pipeline with VAD, Parakeet TDT, and direct clipboard paste. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>. MacWhisper's real-time mode is secondary to its file transcription focus.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎯</div>
+        <div class="advantage-title">Purpose-built for dictation</div>
+        <p class="advantage-desc">Hold a hotkey, speak, release, text appears. That is the entire product. No file import dialogs, no batch queues, no export formats. One job, done well.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔑</div>
+        <div class="advantage-title">Your choice of AI polish</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. MacWhisper's AI Assistant is a separate $9.99/mo subscription.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📝</div>
+        <div class="advantage-title">Custom words dictionary</div>
+        <p class="advantage-desc">Teach EnviousWispr your names, technical terms, and acronyms. The post-processing engine corrects transcription in real time, so "kubernetes" comes out right the first time.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">Both tools process core transcription on-device. The difference is what happens next. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          MacWhisper
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You import an audio or video file, or record directly in the app.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Core transcription runs on-device using local Whisper models. Audio stays on your Mac for this step.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>If you use the AI Assistant add-on, text is sent to cloud servers for summarization, translation, or Q&amp;A.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Transcripts are stored locally. Cloud interaction only occurs with the optional AI Assistant feature.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Built for real-time, not batch</h2>
+      <p class="section-sub">EnviousWispr's pipeline is optimized for the moment between releasing your hotkey and seeing text. Every millisecond matters in dictation.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dive -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">What real-time dictation actually requires</h2>
+      <p class="section-sub">File transcription and real-time dictation have fundamentally different engineering challenges. Here is what EnviousWispr does that a file transcription tool does not need to.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎙️</div>
+        <div class="deep-dive-title">Real-time dictation workflow</div>
+        <div class="deep-dive-body">
+          <p>MacWhisper processes files after the fact: you import a recording, wait for transcription, then copy the result. That is a perfectly valid workflow for meetings, podcasts, and video content.</p>
+          <p>EnviousWispr works in real time. You hold a hotkey, speak, and release. In the background, a pre-roll audio buffer captures your first words before you even press the key. The ASR model stays warm in memory, so there is no cold-start delay. Voice activity detection trims silence automatically. Text is pasted directly into whatever app had focus.</p>
+          <p>The difference is not just speed. It is the entire interaction model. You never leave your document, never switch apps, never copy-paste. Your voice becomes an input method, not a separate step.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Pre-roll buffer captures 300ms of audio before hotkey press so first words are never lost. Parakeet TDT model stays loaded in memory for instant inference. VAD-based silence trimming sends only speech to the model. Three-tier paste system (AX direct insertion, CGEvent Cmd+V, AppleScript fallback) delivers text to the active field with clipboard preservation.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">✨</div>
+        <div class="deep-dive-title">Beyond raw transcription</div>
+        <div class="deep-dive-body">
+          <p>MacWhisper gives you Whisper output. That is already useful for file transcription, where you can review and edit at your leisure. For real-time dictation, raw ASR output is not good enough. You need text that is ready to use the moment it appears.</p>
+          <p>EnviousWispr runs a 6-pass fuzzy word correction pipeline on every transcription. Your custom vocabulary (names, technical terms, acronyms) is matched against the ASR output using phonetic similarity, edit distance, and context-aware scoring. Filler words like "um", "uh", and "you know" are stripped automatically.</p>
+          <p>On top of that, optional AI polish reformats the text for grammar, punctuation, and readability. It runs on-device with Apple Intelligence or Ollama, or via your own OpenAI/Gemini key. The result is polished, ready-to-send text, not a rough transcript that needs manual cleanup.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Post-processing pipeline applies custom word correction (phonetic matching, Levenshtein distance, bigram context), filler removal, and optional LLM polish. AI polish uses sandwich framing with XML tags to prevent hallucination, plus output length validation to reject fabricated responses. Short transcripts bypass LLM entirely.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where MacWhisper Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose MacWhisper if you mostly transcribe recordings and files</h2>
+      <p class="section-sub">MacWhisper is an excellent tool for a different job. If any of these describe your workflow, it may be the right pick:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📁</div>
+        <div class="advantage-title">You transcribe audio and video files</div>
+        <p class="advantage-desc">MacWhisper excels at importing files, batch-processing folders, and transcribing YouTube URLs. EnviousWispr does not support file transcription at all.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎬</div>
+        <div class="advantage-title">You need subtitles or SRT export</div>
+        <p class="advantage-desc">MacWhisper exports SRT, VTT, and other subtitle formats with timestamps. If you produce video content or podcasts, this is a core workflow that EnviousWispr does not offer.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🗣️</div>
+        <div class="advantage-title">You need speaker diarization</div>
+        <p class="advantage-desc">MacWhisper can identify different speakers in a recording and label who said what. EnviousWispr is single-speaker dictation only.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📂</div>
+        <div class="advantage-title">You want batch or watch-folder automation</div>
+        <p class="advantage-desc">MacWhisper can queue multiple files and monitor a folder for automatic transcription. Great for podcast production pipelines and automated workflows.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎥</div>
+        <div class="advantage-title">You transcribe video content</div>
+        <p class="advantage-desc">MacWhisper handles video files and YouTube URLs directly. If your workflow involves transcribing existing video, it is built for that. EnviousWispr only captures live speech.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">💰</div>
+        <div class="advantage-title">You prefer a one-time purchase</div>
+        <p class="advantage-desc">MacWhisper Pro is a one-time purchase (~$30 via Gumroad). No ongoing costs for core features. EnviousWispr is free, but if you value the commercial support model, MacWhisper offers it.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If your primary need is typing by voice with sub-second latency, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. If you need file transcription, subtitles, or speaker diarization, MacWhisper is a solid choice.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr a MacWhisper alternative?</div>
+        <p class="faq-a">They solve different problems. MacWhisper is a transcription tool for importing and processing audio files. EnviousWispr is a dictation tool for typing by voice in real time. If you want to replace your keyboard with your voice, EnviousWispr is the better fit. If you need to transcribe recordings, MacWhisper is purpose-built for that.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free?</div>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Every feature is available at no cost. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a>. The source code is on GitHub under BSL 1.1.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via Apple Intelligence or Ollama. Cloud polish with your own API key is optional.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use MacWhisper for dictation?</div>
+        <p class="faq-a">MacWhisper has a real-time transcription mode, but its primary design is file-based transcription. EnviousWispr's entire pipeline is optimized for dictation latency, with hotkey activation, VAD, and direct clipboard paste delivering text in under a second.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr support subtitle export?</div>
+        <p class="faq-a">No. EnviousWispr is a dictation tool, not a transcription tool. It does not import files or export subtitles. For those workflows, MacWhisper is the right tool.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free MacWhisper alternative for dictation?</div>
+        <p class="faq-a">Yes. EnviousWispr provides free, on-device real-time dictation on Apple Silicon Macs. No account, no subscription, no usage caps. It uses Parakeet TDT and WhisperKit for sub-second transcription.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Will my audio be used for training?</div>
+        <p class="faq-a">No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use both EnviousWispr and MacWhisper?</div>
+        <p class="faq-a">Absolutely. They solve different problems and do not conflict. Use EnviousWispr for real-time dictation (typing emails, notes, messages by voice) and MacWhisper for transcribing recordings, generating subtitles, or batch-processing audio files. Many users benefit from having both.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr support speaker diarization?</div>
+        <p class="faq-a">No. EnviousWispr is designed for single-speaker real-time dictation, where you are the only person speaking. If you need to identify multiple speakers in a recording, MacWhisper supports speaker diarization.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What happens to my clipboard when EnviousWispr pastes text?</div>
+        <p class="faq-a">EnviousWispr saves your clipboard contents before pasting dictated text and restores them afterward. Whatever you had copied before dictating will still be on your clipboard when you press Cmd+V next.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Stop uploading files. Start typing with your voice.</h2>
+    <p class="reveal">Free to download. No account required. Sub-second voice-to-text on your Mac.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -1,0 +1,810 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Notta: Real-Time Dictation vs Meeting Transcription",
+  "description": "Compare EnviousWispr and Notta.ai. One is real-time dictation for typing on Mac. The other is meeting transcription across platforms. See which fits your workflow.",
+  "url": `${siteUrl}/compare/notta/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Notta",
+      "item": `${siteUrl}/compare/notta/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Are EnviousWispr and Notta competitors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not really. They solve different problems. Notta is a meeting transcription platform: it records calls, identifies speakers, and generates summaries. EnviousWispr is a real-time dictation tool: hold a key, speak, and text appears at your cursor. If you want to dictate emails and messages, EnviousWispr is the right tool. If you want meeting notes, Notta is."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can EnviousWispr transcribe meetings?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr is designed for single-speaker dictation into text fields. It does not record calls, join meeting rooms, or identify multiple speakers. For meeting transcription, Notta or a similar tool is the right choice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will my audio be used for training?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Notta have a free plan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.25/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use EnviousWispr to take notes during meetings?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You can dictate your own notes during a meeting by holding your hotkey and speaking. But EnviousWispr does not record the meeting itself, does not join call rooms, and does not transcribe other participants. For full meeting transcription with speaker identification, Notta or a similar meeting tool is what you need."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Notta work for dictation like EnviousWispr?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Notta has a recording mode where you can speak and get a transcript, but it stays inside Notta's app. It does not paste text into your active text field the way EnviousWispr does. Notta is designed around meetings and long recordings, not quick dictation into emails, Slack, or documents."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "I need both meeting notes and dictation. Can I use both?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. They do not overlap. Use Notta for meeting transcription and team collaboration. Use EnviousWispr for quick voice typing into any app on your Mac. They serve different workflows and work fine side by side."
+      }
+    },
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Notta: Dictation vs Meeting Notes"
+  description="Compare EnviousWispr vs Notta. Free on-device Mac dictation vs cloud meeting transcription. Different tools for different jobs."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/notta/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card { background: #fff; border: 1px solid var(--border-hover); border-radius: var(--radius-card); padding: 36px 32px; position: relative; overflow: hidden; }
+.deep-dive-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: var(--rainbow-full); }
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail { margin-top: 16px; padding: 14px 18px; border-radius: 10px; background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08); font-size: 13px; color: var(--text-2); line-height: 1.6; }
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Notta</span>
+    </div>
+    <h1 class="reveal">Notta records meetings. EnviousWispr lets you type by speaking.</h1>
+    <p class="page-header-sub reveal">Notta records and transcribes meetings. EnviousWispr turns your voice into typed text instantly. Different tools for different jobs.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">These are fundamentally different tools. This table shows where they overlap and where they diverge.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Notta</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Notta claims verified against notta.ai on 2026-04-04.
+             Confidence: source-verified from public website and pricing page.
+             Sources:
+               - Pricing: notta.ai/en/pricing (accessed 2026-04-04)  -  Free 120 min/mo, Pro $8.25/mo annual ($15/mo monthly), Business $44/mo
+               - Platforms: notta.ai (accessed 2026-04-04)  -  Web, iOS, Android, Chrome, Mac, Windows
+               - Cloud processing: notta.ai  -  all transcription is cloud-based
+               - Meeting features: notta.ai  -  bot joins Zoom/Meet/Teams/Webex, speaker ID, AI summaries
+               - Languages: notta.ai  -  58 languages, transcript translation
+               - Accuracy: notta.ai  -  98.86% accuracy (per Notta) claimed
+               - Custom vocabulary: Business plan only ($44/mo)
+               - No real-time dictation into external apps: transcripts stay in Notta's interface
+             Firsthand testing: Notta was not tested firsthand for this comparison.
+             All claims are source-verified from official pages.
+             Last updated: 2026-04-04 -->
+        <tbody>
+          <tr>
+            <td>Primary use case</td>
+            <td><span class="table-highlight">Real-time dictation</span> into any text field</td>
+            <td>Meeting recording and transcription</td>
+          </tr>
+          <tr>
+            <td>Real-time dictation into any app</td>
+            <td><span class="table-check">Yes</span> - text appears at your cursor in any macOS app</td>
+            <td><span class="table-cross">No</span> - transcripts live inside Notta's app</td>
+          </tr>
+          <tr>
+            <td>Meeting recording</td>
+            <td><span class="table-cross">No</span> (not a meeting tool)</td>
+            <td><span class="table-check">Yes</span> - bot joins Zoom, Meet, Teams, Webex</td>
+          </tr>
+          <tr>
+            <td>Speaker identification</td>
+            <td><span class="table-cross">No</span> (single-speaker dictation)</td>
+            <td><span class="table-check">Yes</span>, multi-speaker diarization</td>
+          </tr>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription.</span></td>
+            <td>Free (120 min/mo), Pro $8.25/mo (annual), Business $44/mo*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon)</td>
+            <td>Cloud servers</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> for transcription (after models download)</td>
+            <td><span class="table-cross">No</span></td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Near real-time (cloud-dependent)</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Yes</span> - VAD detects speech onset, no clipping</td>
+            <td>Varies (meeting bot may miss first seconds of a speaker turn)</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td>AI summaries and action items from meetings</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span> - Apple Intelligence or Ollama run locally</td>
+            <td><span class="table-cross">No</span> - AI features require cloud</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> (custom words with phonetic hints)</td>
+            <td>Custom vocabulary on Business plan ($44/mo)</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> - saves and restores your clipboard around paste</td>
+            <td>N/A (transcripts stay in Notta's interface)</td>
+          </tr>
+          <tr>
+            <td>Hands-free dictation</td>
+            <td><span class="table-check">Yes</span> - configurable hotkey, hold-to-record or toggle mode</td>
+            <td><span class="table-cross">No</span> - designed for meeting recording, not hands-free typing</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS (Apple Silicon)</td>
+            <td>Web, iOS, Android, Chrome extension, Mac, Windows</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td>Cloud speech API</td>
+          </tr>
+          <tr>
+            <td>Languages</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>58 languages, transcript translation</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>Built for users who need to type by voice; works with any macOS app including assistive tools</td>
+            <td>Focused on meeting productivity, not assistive typing</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Notta's public pricing page (notta.ai/en/pricing) as of April 2026. Pro price shown is annual billing; monthly is $15/mo. Business plan at $44/mo includes custom vocabulary. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Notta claims source-verified from notta.ai; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why dictation users pick EnviousWispr</h2>
+      <p class="section-sub">If your goal is to type faster with your voice, not transcribe meetings, EnviousWispr is purpose-built for that.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free, no caps</div>
+        <p class="advantage-desc">No subscription, no 120-minute monthly limit, no usage tiers. Notta's free plan caps you at 120 minutes per month. Their Pro plan starts at $8.25/mo billed annually.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">On-device transcription</div>
+        <p class="advantage-desc">Your audio never leaves your Mac. It is processed by the <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a> on Apple Silicon, never uploaded, never stored elsewhere. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>. Private by architecture, not by promise.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Instant text output</div>
+        <p class="advantage-desc">0.43s median from end-of-speech to text in your cursor. No waiting for cloud processing, no network dependency. Dictate an email, a Slack message, a doc paragraph, and it appears immediately.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚫</div>
+        <div class="advantage-title">No account, no signup</div>
+        <p class="advantage-desc">Download, open, start dictating. No email, no login, no workspace to configure. Notta requires account creation and workspace setup before you can transcribe anything.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✈️</div>
+        <div class="advantage-title">Works offline</div>
+        <p class="advantage-desc">After models download once, transcription works without internet. Dictate on a plane, in a cafe with bad Wi-Fi, or anywhere you can open your laptop. Notta requires a network connection for all transcription.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source tools ask you to trust their privacy claims on faith.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">The most important question for any voice tool. Here is the data flow for each app. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted into your cursor. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Notta
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak or a meeting bot records the call audio.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is uploaded to Notta's cloud servers for transcription.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Transcribed text is processed by cloud AI for summaries and action items.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Transcripts are stored on Notta's servers, accessible via your account.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Fast because there is no upload step</h2>
+      <p class="section-sub">On Apple Silicon Macs, EnviousWispr transcribes speech locally. No network round-trip before text appears.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dives -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Deep Dive</div>
+      <h2 class="section-title">Different tools for different jobs</h2>
+      <p class="section-sub">Notta and EnviousWispr both involve speech and text, but they solve fundamentally different problems.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎯</div>
+        <div class="deep-dive-title">Dictation vs meeting transcription</div>
+        <div class="deep-dive-body">
+          <p>Notta records meetings. Its bot joins your Zoom, Google Meet, Teams, or Webex call, captures everything, identifies speakers, and produces a searchable transcript. The output lives inside Notta's app. It is a meeting productivity tool.</p>
+          <p>EnviousWispr puts text where you type, in real time. Hold a hotkey, speak, release. Text appears in your email draft, Slack message, code editor, or Google Doc. There is no separate transcript window, no copy-pasting, no switching tabs. It replaces your keyboard for moments when speaking is faster than typing.</p>
+          <p>If you sit in meetings all day and need transcripts, Notta is the right tool. If you write emails, Slack messages, and documents by voice, EnviousWispr is purpose-built for that workflow.</p>
+          <div class="deep-dive-detail">
+            <strong>Key difference:</strong> Notta produces transcripts you read later. EnviousWispr produces text you use right now, in whatever app has focus.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">Privacy: on-device vs cloud</div>
+        <div class="deep-dive-body">
+          <p>Notta uploads all audio to its cloud servers. Transcripts are stored online and processed by Notta's AI for summaries, action items, and search indexing. Your voice data lives on their infrastructure.</p>
+          <p>EnviousWispr processes audio entirely on your Mac's Apple Silicon chip. Nothing is uploaded. The audio buffer is discarded after transcription. If you enable AI polish with a cloud provider, only the text transcript (not audio) is sent, using your own API key.</p>
+          <p>For meeting transcription, cloud processing is a reasonable tradeoff: you need speaker identification, long-form recording, and team collaboration that requires server-side infrastructure. For dictation of personal messages, medical notes, legal correspondence, or anything sensitive, on-device processing means your words never leave your control.</p>
+          <div class="deep-dive-detail">
+            <strong>The tradeoff:</strong> Notta's cloud approach enables speaker identification, team workspaces, and cross-meeting search. EnviousWispr's local approach means zero data exposure but no multi-speaker capabilities.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Notta Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Notta if you need meeting notes and team collaboration</h2>
+      <p class="section-sub">Notta is a capable meeting platform. It is the better choice in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎙️</div>
+        <div class="advantage-title">Meeting transcription</div>
+        <p class="advantage-desc">Notta's core strength is recording meetings. Its bot joins Zoom, Google Meet, Teams, and Webex calls automatically, identifies speakers, and generates AI summaries with action items. EnviousWispr does not do meeting recording at all.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🗣️</div>
+        <div class="advantage-title">Speaker diarization</div>
+        <p class="advantage-desc">Notta identifies who said what in multi-person conversations. EnviousWispr is a single-speaker dictation tool and has no speaker identification.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">👥</div>
+        <div class="advantage-title">Team collaboration</div>
+        <p class="advantage-desc">Notta's Business and Enterprise plans offer shared workspaces, team transcript libraries, and collaborative editing. EnviousWispr is a personal dictation tool with no team features.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔗</div>
+        <div class="advantage-title">Meeting integrations</div>
+        <p class="advantage-desc">Notta integrates with Zoom, Google Meet, Microsoft Teams, Webex, Salesforce, HubSpot, and Notion. It fits into an existing meeting workflow. EnviousWispr is a standalone dictation utility.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📱</div>
+        <div class="advantage-title">Cross-platform access</div>
+        <p class="advantage-desc">Notta works on Web, iOS, Android, Chrome, Mac, and Windows. EnviousWispr is macOS only on Apple Silicon. If you need transcription on your phone or a Windows machine, Notta covers more ground.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If your goal is to type with your voice into emails, Slack, docs, and code comments, not record meetings, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Are EnviousWispr and Notta competitors?</div>
+        <p class="faq-a">Not really. They solve different problems. Notta is a meeting transcription platform: it records calls, identifies speakers, and generates summaries. EnviousWispr is a real-time dictation tool: hold a key, speak, and text appears in your cursor. If you want to dictate emails and messages, EnviousWispr is the right tool. If you want meeting notes, Notta is.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free?</div>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a>. The source code is available on GitHub under a BSL 1.1 license.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can EnviousWispr transcribe meetings?</div>
+        <p class="faq-a">No. EnviousWispr is designed for single-speaker dictation into text fields. It does not record calls, join meeting rooms, or identify multiple speakers. For meeting transcription, Notta or a similar tool is the right choice.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Will my audio be used for training?</div>
+        <p class="faq-a">No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Notta have a free plan?</div>
+        <p class="faq-a">Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.25/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use EnviousWispr to take notes during meetings?</div>
+        <p class="faq-a">You can dictate your own notes during a meeting by holding your hotkey and speaking. But EnviousWispr does not record the meeting itself, does not join call rooms, and does not transcribe other participants. For full meeting transcription with speaker identification, Notta or a similar meeting tool is what you need.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Notta work for dictation like EnviousWispr?</div>
+        <p class="faq-a">Notta has a recording mode where you can speak and get a transcript, but it stays inside Notta's app. It does not paste text into your active text field the way EnviousWispr does. Notta is designed around meetings and long recordings, not quick dictation into emails, Slack, or documents.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">I need both meeting notes and dictation. Can I use both?</div>
+        <p class="faq-a">Yes. They do not overlap. Use Notta (or a similar tool) for meeting transcription and team collaboration. Use EnviousWispr for quick voice typing into any app on your Mac. They serve different workflows and work fine side by side.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Start dictating anywhere on your Mac</h2>
+    <p class="reveal">Free to download. No account required. No cloud transcription.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -1,0 +1,841 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Otter.ai: Dictation vs Meeting Transcription",
+  "description": "Compare EnviousWispr and Otter.ai. One is real-time dictation for typing by voice. The other is meeting transcription. See which fits your workflow.",
+  "url": `${siteUrl}/compare/otter-ai/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Otter.ai",
+      "item": `${siteUrl}/compare/otter-ai/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr an Otter.ai alternative?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They solve different problems. Otter.ai is for meeting transcription: recording calls, identifying speakers, generating summaries. EnviousWispr is for dictation: speaking text into any app on your Mac. If you are looking for an Otter alternative specifically for typing by voice, EnviousWispr is built for that."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use EnviousWispr to transcribe meetings?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr is a dictation tool, not a meeting recorder. It transcribes your voice in real time and pastes the text where your cursor is. For meeting transcription with speaker identification and summaries, Otter.ai is the better choice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free dictation alternative to Otter.ai?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. If what you actually need is dictation (typing by speaking into emails, Slack, documents), EnviousWispr does that for free with no account, no subscription, and no usage limits. Otter's free tier limits you to 300 minutes per month."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will my audio be used for training?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use both Otter.ai and EnviousWispr?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. Many users run Otter for meeting transcription and EnviousWispr for day-to-day dictation. They do not conflict. Use Otter when you need to record and summarize a call, and EnviousWispr when you want to type by speaking."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Otter.ai work as a dictation tool?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Otter.ai is designed for meeting transcription, not for typing by voice into other apps. It records conversations and produces transcripts inside its own interface. To get that text into an email or document, you need to copy and paste. EnviousWispr is the opposite: it pastes text directly into whatever app you are using, with no intermediate step."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Otter.ai transcribe on-device?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Otter.ai is cloud-only. All audio is uploaded to their servers for transcription, speaker identification, and AI processing. There is no offline or on-device mode. EnviousWispr runs entirely on your Mac's Apple Silicon chip and works without internet."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Otter.ai free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required."
+      }
+    },
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Otter.ai: Dictation vs Meeting Notes"
+  description="Compare EnviousWispr vs Otter.ai. Otter transcribes meetings. EnviousWispr lets you type by speaking. Free, on-device, no account. See the differences."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/otter-ai/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Otter.ai</span>
+    </div>
+    <h1 class="reveal">Otter.ai summarizes meetings. EnviousWispr lets you dictate instantly.</h1>
+    <p class="page-header-sub reveal">Otter.ai transcribes meetings. EnviousWispr lets you type by speaking. Different tools for different jobs. If you want to dictate emails, Slack messages, and docs, EnviousWispr is purpose-built for that.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">Otter.ai and EnviousWispr solve fundamentally different problems. This table highlights where they overlap and where they diverge.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Otter.ai</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Otter.ai claims verified against otter.ai and otter.ai/pricing on 2026-04-03.
+             Confidence: source-verified from public website.
+             Sources:
+               - Pricing: otter.ai/pricing (accessed 2026-04-03)  -  Free 300 min/mo, Pro $8.49/mo annual, Business $19.99/mo
+               - Platforms: otter.ai  -  Web, iOS, Android, Chrome extension (accessed 2026-04-03)
+               - Processing: Cloud-only, no on-device option (accessed 2026-04-03)
+               - Features: Meeting transcription, speaker diarization, AI summaries, Zoom/Meet/Teams integration, search across transcripts, collaboration (accessed 2026-04-03)
+             Firsthand testing: Otter.ai was not tested firsthand for this comparison.
+             All claims are source-verified from official pages. Last verified: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Primary use case</td>
+            <td><span class="table-highlight">Real-time dictation</span> into any text field</td>
+            <td>Meeting transcription, recording, and summaries</td>
+          </tr>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription.</span></td>
+            <td>Free tier (300 min/mo, 30 min max); Pro $8.49/mo (annual); Business $19.99/mo*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes, email or Google signup</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon Neural Engine)</td>
+            <td>Cloud servers</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your device</td>
+            <td><span class="table-check">Never.</span> If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td>Yes, audio uploaded to Otter's servers for transcription and storage</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> (after initial model download)</td>
+            <td><span class="table-cross">No</span></td>
+          </tr>
+          <tr>
+            <td>Dictate into any app</td>
+            <td><span class="table-check">Yes</span> - text pastes directly into your active text field</td>
+            <td><span class="table-cross">No</span> - transcripts live inside Otter's app; copy-paste required</td>
+          </tr>
+          <tr>
+            <td>Meeting recording</td>
+            <td><span class="table-cross">No</span> - not a meeting tool</td>
+            <td><span class="table-check">Yes</span> - joins Zoom, Meet, and Teams automatically</td>
+          </tr>
+          <tr>
+            <td>Speaker identification</td>
+            <td><span class="table-cross">No</span> - single-speaker dictation</td>
+            <td><span class="table-check">Yes</span> - identifies who said what</td>
+          </tr>
+          <tr>
+            <td>Team collaboration</td>
+            <td><span class="table-cross">No</span> - personal dictation tool</td>
+            <td><span class="table-check">Yes</span> - shared transcripts, comments, highlights</td>
+          </tr>
+          <tr>
+            <td>Search across transcripts</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span> - search all past meeting transcripts</td>
+          </tr>
+          <tr>
+            <td>Native Mac desktop app</td>
+            <td><span class="table-check">Yes</span> - native macOS menu bar app</td>
+            <td><span class="table-cross">No</span> - web app and Chrome extension on desktop</td>
+          </tr>
+          <tr>
+            <td>AI polish / AI features</td>
+            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your key</td>
+            <td>AI summaries, action items, chat with transcripts (cloud)</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Yes</span> - voice activity detection starts recording instantly</td>
+            <td>N/A - meeting recording, not push-to-talk dictation</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> - saves and restores your clipboard after pasting</td>
+            <td>N/A - no paste-into-app workflow</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> - custom words for names, jargon, acronyms</td>
+            <td>Custom vocabulary on paid plans</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td>Proprietary cloud ASR</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS (Apple Silicon)</td>
+            <td>Web, iOS, Android, Chrome extension</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Near real-time (depends on network and server load)</td>
+          </tr>
+          <tr>
+            <td>Hands-free dictation</td>
+            <td><span class="table-check">Yes</span> - configurable hotkey, hold-to-record or toggle mode</td>
+            <td><span class="table-cross">No</span> - designed for meeting recording, not hands-free typing</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>Built for users who need to type by voice; works with any macOS app including assistive tools</td>
+            <td>Focused on meeting productivity, not assistive typing</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Otter.ai's public pricing and feature pages as of April 2026. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Otter.ai claims source-verified from otter.ai and otter.ai/pricing; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why dictation users choose EnviousWispr</h2>
+      <p class="section-sub">If your goal is to type by speaking, not to transcribe meetings, EnviousWispr was built specifically for that workflow.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free with no caps</div>
+        <p class="advantage-desc">No 300-minute monthly limit. No 30-minute session cap. No paid tiers. Download and dictate as much as you want. Otter's free plan limits you to 300 minutes per month, and Pro costs $8.49/mo billed annually.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">On-device transcription</div>
+        <p class="advantage-desc">Your audio is processed by the <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a> on Apple Silicon, never uploaded, never stored elsewhere. Otter uploads audio to cloud servers and stores transcripts online. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Built for text fields</div>
+        <p class="advantage-desc">Hold your hotkey, speak, release. Text appears in whatever app you are using: email, Slack, your IDE, a Google Doc. No tab switching, no copy-pasting from a separate transcript window.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚫</div>
+        <div class="advantage-title">No account, no signup</div>
+        <p class="advantage-desc">Download, open, start dictating. EnviousWispr never asks for your email, never requires a login, never phones home. Otter requires account creation before you can use any feature.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✈️</div>
+        <div class="advantage-title">Works offline</div>
+        <p class="advantage-desc">After the initial model download, transcription works without internet. Dictate on a plane, in a coffee shop with bad Wi-Fi, or anywhere else. Otter requires an active internet connection for all transcription.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source tools ask you to trust their privacy claims on faith.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">The most important question for any speech tool. Here is the data flow for each app. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted into your active text field. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Otter.ai
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak, or Otter joins your meeting as a bot.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is uploaded to Otter's cloud servers for transcription and speaker identification.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Transcripts are stored in Otter's cloud. AI features (summaries, action items) process the text on their servers.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>You access transcripts through the web app or mobile app. Audio and text remain on Otter's servers.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Fast because there is no upload step</h2>
+      <p class="section-sub">On Apple Silicon Macs, EnviousWispr transcribes speech locally. No network round-trip before text appears in your active app.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dives -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Deep Dive</div>
+      <h2 class="section-title">Different tools for different jobs</h2>
+      <p class="section-sub">Otter.ai and EnviousWispr look similar on the surface (both involve speech and text) but solve fundamentally different problems.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎯</div>
+        <div class="deep-dive-title">Dictation vs transcription</div>
+        <div class="deep-dive-body">
+          <p>Otter.ai records meetings. It joins your Zoom, Meet, or Teams call, captures everything, identifies speakers, and produces a searchable transcript after the fact. The output lives inside Otter's app. It is a meeting productivity tool.</p>
+          <p>EnviousWispr puts text where you type, in real time. Hold a hotkey, speak, release. Text appears in your email draft, Slack message, code editor, or Google Doc. There is no separate transcript window, no copy-pasting, no switching tabs. It replaces your keyboard for moments when speaking is faster than typing.</p>
+          <p>If you sit in meetings all day and need transcripts, Otter is the right tool. If you write emails, Slack messages, and documents by voice, EnviousWispr is purpose-built for that workflow.</p>
+          <div class="deep-dive-detail">
+            <strong>Key difference:</strong> Otter produces transcripts you read later. EnviousWispr produces text you use right now, in whatever app has focus.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">Privacy: on-device vs cloud</div>
+        <div class="deep-dive-body">
+          <p>Otter.ai uploads all audio to its cloud servers. Transcripts are stored online and processed by Otter's AI for summaries, action items, and search indexing. Your voice data lives on their infrastructure.</p>
+          <p>EnviousWispr processes audio entirely on your Mac's Apple Silicon chip. Nothing is uploaded. The audio buffer is discarded after transcription. If you enable AI polish with a cloud provider, only the text transcript (not audio) is sent, using your own API key.</p>
+          <p>For meeting transcription, cloud processing is a reasonable tradeoff: you need speaker identification and long-form support that requires server-side models. For dictation of personal messages, medical notes, legal correspondence, or anything sensitive, on-device processing means your words never leave your control.</p>
+          <div class="deep-dive-detail">
+            <strong>The tradeoff:</strong> Otter's cloud approach enables features like speaker identification and cross-meeting search. EnviousWispr's local approach means zero data exposure but no multi-speaker capabilities.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Otter.ai Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Otter.ai if you need meeting transcription and team collaboration</h2>
+      <p class="section-sub">Otter.ai is excellent at what it does. If your primary need is recording, transcribing, and collaborating on meetings, it is the better tool:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎙️</div>
+        <div class="advantage-title">Meeting transcription and recording</div>
+        <p class="advantage-desc">Otter is built for transcribing multi-person meetings. It joins Zoom, Google Meet, and Teams calls automatically, records, and generates searchable transcripts. EnviousWispr does not do meeting transcription at all.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">👥</div>
+        <div class="advantage-title">Speaker identification</div>
+        <p class="advantage-desc">Otter identifies who said what in a conversation with speaker diarization. EnviousWispr is single-speaker dictation only.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🤝</div>
+        <div class="advantage-title">Team collaboration</div>
+        <p class="advantage-desc">Otter lets teams share transcripts, comment, highlight key moments, and extract action items. It is a collaborative workspace for meeting notes. EnviousWispr is a personal dictation tool.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📊</div>
+        <div class="advantage-title">AI meeting summaries</div>
+        <p class="advantage-desc">Otter generates automatic summaries, action items, and key takeaways from meetings. It can answer questions about past conversations. These are features EnviousWispr does not offer.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔗</div>
+        <div class="advantage-title">Zoom, Teams, and Meet integration</div>
+        <p class="advantage-desc">Otter joins your video calls as a bot, records automatically, and produces transcripts without manual setup. EnviousWispr has no meeting integrations at all.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔍</div>
+        <div class="advantage-title">Search across meetings</div>
+        <p class="advantage-desc">Otter indexes all your past transcripts and lets you search across them. Find what was said in any meeting, by any speaker. EnviousWispr has no transcript history or search.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📱</div>
+        <div class="advantage-title">Cross-platform availability</div>
+        <p class="advantage-desc">Otter works on web, iOS, and Android. EnviousWispr is macOS only with Apple Silicon required.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⏱️</div>
+        <div class="advantage-title">Long-form recording</div>
+        <p class="advantage-desc">Otter handles hour-long meetings and lectures. EnviousWispr is optimized for short dictation bursts of one to two minutes.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you need meeting transcription, use Otter. If you want to type by speaking into any text field on your Mac, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. Many people use both.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr an Otter.ai alternative?</div>
+        <p class="faq-a">They solve different problems. Otter.ai is for meeting transcription: recording calls, identifying speakers, generating summaries. EnviousWispr is for dictation: speaking text into any app on your Mac. If you are looking for an Otter alternative specifically for typing by voice, EnviousWispr is built for that.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use EnviousWispr to transcribe meetings?</div>
+        <p class="faq-a">No. EnviousWispr is a dictation tool, not a meeting recorder. It transcribes your voice in real time and pastes the text where your cursor is. For meeting transcription with speaker identification and summaries, Otter.ai is the better choice.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free dictation alternative to Otter.ai?</div>
+        <p class="faq-a">Yes. If what you actually need is dictation (typing by speaking into emails, Slack, documents), EnviousWispr does that for free with no account, no subscription, and no usage limits. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a>. Otter's free tier limits you to 300 minutes per month.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Will my audio be used for training?</div>
+        <p class="faq-a">No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use both Otter.ai and EnviousWispr?</div>
+        <p class="faq-a">Absolutely. Many users run Otter for meeting transcription and EnviousWispr for day-to-day dictation. They do not conflict. Use Otter when you need to record and summarize a call, and EnviousWispr when you want to type by speaking.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Otter.ai work as a dictation tool?</div>
+        <p class="faq-a">Otter.ai is designed for meeting transcription, not for typing by voice into other apps. It records conversations and produces transcripts inside its own interface. To get that text into an email or document, you need to copy and paste. EnviousWispr is the opposite: it pastes text directly into whatever app you are using, with no intermediate step.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can Otter.ai transcribe on-device?</div>
+        <p class="faq-a">No. Otter.ai is cloud-only. All audio is uploaded to their servers for transcription, speaker identification, and AI processing. There is no offline or on-device mode. EnviousWispr runs entirely on your Mac's Apple Silicon chip and works without internet.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is Otter.ai free?</div>
+        <p class="faq-a">Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Want to type by speaking?</h2>
+    <p class="reveal">Free to download. No account required. On-device transcription.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -1,0 +1,829 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Superwhisper: Free Mac Dictation",
+  "description": "Compare EnviousWispr and Superwhisper on price, speech engines, offline support, and speed. Free on-device dictation with Parakeet for Apple Silicon Macs.",
+  "url": `${siteUrl}/compare/superwhisper/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Superwhisper",
+      "item": `${siteUrl}/compare/superwhisper/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is there a free alternative to Superwhisper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for English and WhisperKit for 90+ languages."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is EnviousWispr different from Superwhisper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both are Mac-native and run on-device. The key differences: EnviousWispr is free (Superwhisper Pro costs ~$8.49/mo), uses dual ASR engines (Parakeet TDT for English accuracy, WhisperKit for multilingual), and is source-available on GitHub. Superwhisper has meeting transcription, an iOS app, Windows support, and more writing modes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does EnviousWispr compare to Superwhisper for accuracy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For English dictation, EnviousWispr uses NVIDIA Parakeet TDT v2, which benchmarks higher than Whisper large-v3 on standard English speech datasets. For other languages, both apps use Whisper-based engines with comparable accuracy."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use EnviousWispr completely offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using Apple Intelligence (macOS 15+) or Ollama with a local model."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Superwhisper have offline AI polish?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Superwhisper's transcription works offline via Whisper. However, their AI polish features appear to require cloud connectivity. EnviousWispr's Apple Intelligence and Ollama integrations run entirely on your Mac."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Parakeet TDT?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Parakeet TDT is an English speech recognition model from NVIDIA. It is purpose-built for accurate English transcription and runs on the Apple Neural Engine at ~110x real-time."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I switch from Superwhisper easily?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works."
+      }
+    }
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Superwhisper: Free Mac Dictation"
+  description="Compare EnviousWispr vs Superwhisper: price, engines, offline, and speed. Free on-device dictation for Apple Silicon. No subscription."
+  activePage="compare"
+  canonicalPath="/compare/superwhisper/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Superwhisper</span>
+    </div>
+    <h1 class="reveal">The free Superwhisper alternative for Mac</h1>
+    <p class="page-header-sub reveal">Both are Mac-native and on-device. The difference: EnviousWispr is free, and uses Parakeet TDT for better English accuracy alongside WhisperKit.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        Parakeet TDT + WhisperKit
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Superwhisper</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Superwhisper claims verified against superwhisper.com on 2026-04-04.
+             Sources:
+               - superwhisper.com homepage (accessed 2026-04-04): features, pricing tiers, AI model list, writing modes, custom vocabulary, meeting transcription, iOS app, offline mode, 100+ languages
+               - superwhisper.com (accessed 2026-04-04): Pro ~$8.49/mo, Lifetime option available, free tier with 15-min trial
+             Confidence: source-verified from public website. Superwhisper was not tested firsthand.
+             Features marked "Not specified" were not found on superwhisper.com as of 2026-04-04.
+             Last verified: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free to use. No subscription, no word limits.</span></td>
+            <td>Free tier (15-min trial); Pro ~$8.49/mo; Lifetime purchase available*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes, for Pro features</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><span class="table-highlight"><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></span> (dual engines, on-device)</td>
+            <td>Whisper (on-device, multiple model sizes)</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Neural Engine)</td>
+            <td>On-device (Whisper); optional cloud AI for polish</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your Mac</td>
+            <td><span class="table-check">Never.</span> Audio stays on your Mac. If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td>Not for transcription. Cloud AI features send text to third-party APIs.</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> (after models download)</td>
+            <td><span class="table-check">Yes</span> (on-device Whisper mode)</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence or Ollama on-device;</span> OpenAI/Gemini with your own key</td>
+            <td>Cloud AI via GPT-5, Claude, Llama 4, Grok, Gemini, Ministral (requires Pro)</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, fully on-device)</td>
+            <td>Not specified (cloud AI models listed require internet)</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Not published</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> (names, terms, jargon; post-processing word replacement)</td>
+            <td><span class="table-check">Yes</span> (names, abbreviations, specialized terms)</td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td>Context-aware Smart Polish adapts to target app</td>
+            <td>Multiple modes: Formal, Casual, Legal, Chat, plus custom modes</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span> (built-in, runs before AI polish)</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-highlight">Pre-roll buffer</span> captures audio before you press the hotkey</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Starts listening instantly</td>
+            <td><span class="table-check">Yes</span> (ASR engine pre-warmed at launch)</td>
+            <td>Push-to-talk (hold, speak, release)</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> (clipboard saved before paste, restored after)</td>
+            <td>Automatic pasting; clipboard preservation not specified</td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes</span> (target app reactivation via Accessibility API, three-tier paste fallback)</td>
+            <td>Pastes in active app at time of completion</td>
+          </tr>
+          <tr>
+            <td>AI hallucination safeguards</td>
+            <td><span class="table-highlight">3-layer defense:</span> short-circuit, length validation, sandwich framing</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Meeting transcription</td>
+            <td><span class="table-cross">No</span> (built for 1-2 minute dictation)</td>
+            <td><span class="table-check">Yes</span> (live meeting recording with automatic notes)</td>
+          </tr>
+          <tr>
+            <td>Multi-language</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>100+ languages with translation to English</td>
+          </tr>
+          <tr>
+            <td>File transcription</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span> (audio and video file transcription)</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>iOS app</td>
+            <td>macOS only today</td>
+            <td><span class="table-check">Yes</span> (iOS companion app)</td>
+          </tr>
+          <tr>
+            <td>Platform support</td>
+            <td>macOS (Apple Silicon)</td>
+            <td>macOS (Apple Silicon + Intel), iOS, Windows</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>VoiceOver-compatible settings, keyboard-navigable</td>
+            <td>Not specified</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Superwhisper's public website (superwhisper.com) as of April 2026. Pricing: free tier, Pro ~$8.49/mo (yearly discount available), lifetime purchase option. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Superwhisper features source-verified from superwhisper.com; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why Mac users switch from Superwhisper</h2>
+      <p class="section-sub">Both apps run on-device. Here is what sets EnviousWispr apart.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free to use</div>
+        <p class="advantage-desc">No subscription, no usage caps, no freemium tiers. Superwhisper Pro costs ~$8.49/mo or a lifetime fee. EnviousWispr gives you on-device transcription and AI polish at no cost.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🧠</div>
+        <div class="advantage-title">Parakeet TDT, not just Whisper</div>
+        <p class="advantage-desc">Superwhisper uses Whisper for on-device transcription. EnviousWispr runs <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">NVIDIA Parakeet TDT</a> as its primary English engine, which delivers stronger accuracy on English dictation. WhisperKit is available as a fallback for 90+ languages. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">0.43s median latency</div>
+        <p class="advantage-desc">Measured in production on Apple Silicon Macs. Text appears almost instantly after you stop speaking. No waiting for model warm-up or network round-trips.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚫</div>
+        <div class="advantage-title">No account, no signup</div>
+        <p class="advantage-desc">Download, open, start dictating. EnviousWispr never asks for your email or payment information. No trial period that expires.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔑</div>
+        <div class="advantage-title">Your choice of AI polish</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text. Superwhisper's cloud AI requires a Pro subscription.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">Both apps transcribe on-device. The difference is what happens next. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally (Apple Intelligence or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Superwhisper
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is transcribed on-device via Whisper. So far, similar to EnviousWispr.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>If you enable AI features, your transcript text is sent to third-party cloud APIs (GPT, Claude, or Llama hosted services).</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is returned over the network and pasted on your device. Third-party data handling policies apply.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Parakeet TDT: built for speed</h2>
+      <p class="section-sub">EnviousWispr uses NVIDIA Parakeet TDT, a purpose-built English ASR model that runs natively on the Apple Neural Engine. No network dependency, no server queues.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dive: Technical Advantages -->
+<section class="section" aria-label="Technical Deep Dives">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">What the feature table does not show</h2>
+      <p class="section-sub">Both apps do on-device Whisper transcription. The technical differences are in the engines and the post-processing pipeline.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🔀</div>
+        <div class="deep-dive-title">Dual ASR engines vs. Whisper alone</div>
+        <div class="deep-dive-body">
+          <p>Superwhisper uses OpenAI Whisper with multiple model sizes (likely tiny through large). It is a proven, broadly capable model that handles 100+ languages well. For multilingual dictation, it is excellent.</p>
+          <p>EnviousWispr takes a different approach for English: NVIDIA Parakeet TDT v2, a CTC/TDT hybrid model that runs at ~110x real-time on the Apple Neural Engine. It was trained specifically for English speech recognition and benchmarks higher on English dictation accuracy than Whisper large-v3. For non-English languages, EnviousWispr falls back to WhisperKit (an Apple Silicon-optimized Whisper implementation).</p>
+          <p>The result is two engines chosen for their strengths: Parakeet for English speed and accuracy, WhisperKit for language breadth. Superwhisper uses one engine for everything.</p>
+          <div class="deep-dive-detail">
+            <strong>Why it matters:</strong> Parakeet TDT's ~110x real-time factor means a 30-second dictation transcribes in under 300ms. Whisper large-v3 is accurate but slower. By using the right engine for the right language, EnviousWispr gets both speed and accuracy without compromise.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">AI polish that does not fabricate</div>
+        <div class="deep-dive-body">
+          <p>When you run speech through an LLM for cleanup, there is a real risk: the AI can hallucinate extra sentences, "answer" your dictation as if it were a question, or inject preamble like "Certainly! Here is the corrected text." These are not theoretical problems. They happen with basic LLM integrations.</p>
+          <p>EnviousWispr uses three layers of defense. Short transcripts (three words or fewer) bypass the LLM entirely because there is nothing to polish. Medium transcripts get aggressive prompt reinforcement to prevent creative expansion. All output is validated: if the response is more than three times longer than the input, it is rejected as probable hallucination and the raw transcript is used instead.</p>
+          <p>The LLM prompt itself is context-aware. It tells the model it is processing speech-to-text output, gives examples of phonetic misrecognition patterns, and adjusts for the app you were dictating into. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or execute.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Sandwich framing wraps transcript in &lt;transcript&gt; tags to prevent prompt injection. Preamble stripping removes "Certainly!" artifacts. Context-aware prompts include detected language, ASR error patterns, and target app name. Output length validation rejects fabricated responses. Superwhisper offers writing modes (Formal, Casual, Legal, Chat), but does not document hallucination-specific safeguards.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Superwhisper Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Superwhisper if you need its broader feature set</h2>
+      <p class="section-sub">Superwhisper is a more mature product with features EnviousWispr does not have yet. It may be a better fit in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎙</div>
+        <div class="advantage-title">You need meeting transcription</div>
+        <p class="advantage-desc">Superwhisper supports live meeting recording and automatic note generation. EnviousWispr is built for short dictation (1-2 minutes), not meeting-length recording. If transcribing meetings is your primary use case, Superwhisper handles it today.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📱</div>
+        <div class="advantage-title">You want cross-platform support</div>
+        <p class="advantage-desc">Superwhisper has an iOS companion app and Windows support. EnviousWispr is macOS-only on Apple Silicon. If you need dictation on your iPhone or a Windows machine, Superwhisper covers more ground.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📅</div>
+        <div class="advantage-title">You want a longer track record</div>
+        <p class="advantage-desc">Superwhisper has been around longer, with more users, more community feedback, and integrations with 30+ applications. EnviousWispr is newer and shipping fast, but Superwhisper has the maturity advantage.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎨</div>
+        <div class="advantage-title">You want more writing modes</div>
+        <p class="advantage-desc">Superwhisper offers predefined modes (Formal, Casual, Legal, Chat) and lets you create custom modes with fine control over formatting. EnviousWispr's Smart Polish adapts to your target app, but does not yet offer the same breadth of preset writing styles.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">💰</div>
+        <div class="advantage-title">You prefer a one-time purchase</div>
+        <p class="advantage-desc">Superwhisper offers a lifetime purchase option. EnviousWispr is free, so this is not about cost. But if you value the certainty of a one-time payment over a free product that could change, Superwhisper gives you that option.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎧</div>
+        <div class="advantage-title">You need file transcription</div>
+        <p class="advantage-desc">Superwhisper can transcribe audio and video files, not just live speech. EnviousWispr is a real-time dictation tool and does not support file-based transcription.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you primarily dictate on Mac and care most about speed, cost, and English accuracy, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. You can always use both.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free alternative to Superwhisper?</div>
+        <p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It uses Parakeet TDT for English and WhisperKit for 90+ languages.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">How is EnviousWispr different from Superwhisper?</div>
+        <p class="faq-a">Both are Mac-native and run on-device. The key differences: EnviousWispr is free (Superwhisper Pro costs ~$8.49/mo), uses dual ASR engines (Parakeet TDT for English accuracy, WhisperKit for multilingual), and is source-available on GitHub. Superwhisper has meeting transcription, an iOS app, Windows support, and more writing modes that EnviousWispr does not offer yet.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">How does EnviousWispr compare to Superwhisper for accuracy?</div>
+        <p class="faq-a">For English dictation, EnviousWispr uses NVIDIA Parakeet TDT v2, which benchmarks higher than Whisper large-v3 on standard English speech datasets. For other languages, both apps use Whisper-based engines with comparable accuracy. Superwhisper offers more Whisper model size choices, which lets you trade speed for accuracy on older hardware.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use EnviousWispr completely offline?</div>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using Apple Intelligence (macOS 15+) or Ollama with a local model. Cloud AI providers like OpenAI or Gemini are optional and require your own API key.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Superwhisper have offline AI polish?</div>
+        <p class="faq-a">Superwhisper's transcription works offline via Whisper. However, their AI polish features (writing modes powered by GPT, Claude, Llama, etc.) appear to require cloud connectivity. Their website does not specify an offline AI polish option. EnviousWispr's Apple Intelligence and Ollama integrations run entirely on your Mac.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free?</div>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What is Parakeet TDT?</div>
+        <p class="faq-a">Parakeet TDT is an English speech recognition model from NVIDIA. It is purpose-built for accurate English transcription and runs on the Apple Neural Engine at ~110x real-time. It delivers stronger English accuracy than Whisper for dictation use cases.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I switch from Superwhisper easily?</div>
+        <p class="faq-a">Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs WisprFlow</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Why pay for on-device dictation? Download free.</h2>
+    <p class="reveal">Free to download. No account required. Parakeet TDT for English accuracy.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -1,0 +1,839 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs VoiceInk: Free Mac Dictation Compared",
+  "description": "Compare EnviousWispr and VoiceInk on speed, pricing, speech engines, and AI polish. Two on-device Mac dictation apps, one is free.",
+  "url": `${siteUrl}/compare/voiceink/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs VoiceInk",
+      "item": `${siteUrl}/compare/voiceink/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free compared to VoiceInk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr has no purchase price, no subscription, and no usage limits. VoiceInk charges a one-time fee starting at $39.99."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Both are on-device. Why does the speech engine matter?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Different engines have different speed and accuracy profiles. EnviousWispr uses Parakeet TDT, a CTC-Transducer model optimized for Apple's Neural Engine, which delivers 0.43s median latency for English. VoiceInk uses whisper.cpp, a solid engine, but Parakeet is purpose-built for fast English transcription."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr support languages other than English?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Parakeet TDT handles English. For other languages, EnviousWispr switches to WhisperKit, which supports 90+ languages. VoiceInk supports 100+ languages through whisper.cpp."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does custom vocabulary compare between the two apps?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr uses a 6-pass fuzzy matching system with Levenshtein distance, Soundex phonetic matching, and bigram similarity to catch misrecognized words even when the ASR output is phonetically close but spelled differently. VoiceInk offers a personal dictionary with find-and-replace rules."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I switch from VoiceInk to EnviousWispr easily?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which app is better for non-English languages?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "VoiceInk supports 100+ languages through whisper.cpp and may have an edge in multilingual breadth. EnviousWispr supports 90+ languages via WhisperKit. For English specifically, EnviousWispr is faster thanks to Parakeet TDT."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "EnviousWispr requires Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. VoiceInk also requires macOS 14+. Both apps target modern Macs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free alternative to VoiceInk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline. No account or payment required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code on GitHub. VoiceInk uses GPL v3, an OSI-approved open source license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does VoiceInk have AI text enhancement?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), and cloud providers with your own API key, plus built-in hallucination safeguards."
+      }
+    }
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs VoiceInk: Free Mac Dictation Compared"
+  description="Compare EnviousWispr vs VoiceInk on price, speed, speech engines, and AI polish. Both are on-device Mac dictation apps. EnviousWispr is free."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/voiceink/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">VoiceInk</span>
+    </div>
+    <h1 class="reveal">EnviousWispr vs VoiceInk: free on-device Mac dictation</h1>
+    <p class="page-header-sub reveal">Both keep your audio on your Mac. EnviousWispr adds a faster speech engine, a deeper AI polish pipeline, and costs nothing.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        Both on-device
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free vs $39.99
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">An honest look at how the two on-device dictation apps compare across pricing, speed, engines, and features.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>VoiceInk</th>
+          </tr>
+        </thead>
+        <!-- Evidence: VoiceInk claims verified against tryvoiceink.com and github.com/Beingpax/VoiceInk on 2026-04-04.
+             Confidence: source-verified from public website and GitHub repository.
+             Sources:
+               - Pricing: tryvoiceink.com (accessed 2026-04-04) - Pro $39.99, one-time purchase
+               - On-device: tryvoiceink.com features page - fully on-device, no internet required
+               - Speech engine: whisper.cpp (stated on website and GitHub)
+               - Languages: 100+ languages (stated on website)
+               - Power Mode: per-app settings (stated on website)
+               - Screen context: captures screen content for contextual formatting
+               - AI formatting: system prompts with LLM providers
+               - Custom vocabulary: personal dictionary with replacements
+               - License: GPL v3, open source on GitHub
+             Firsthand testing: VoiceInk was not tested firsthand for this comparison.
+             All claims are source-verified from official pages.
+             Last verified: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No payment ever.</span></td>
+            <td>$39.99 one-time*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>No</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon)</td>
+            <td>On-device (whisper.cpp)</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your Mac</td>
+            <td><span class="table-check">Never.</span> If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td><span class="table-check">Never.</span> Fully offline capable.</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> (after model download)</td>
+            <td><span class="table-check">Yes</span> (after model download)</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">whisper.cpp</a></td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">5 providers:</span> Apple Intelligence, Ollama (both on-device), OpenAI, Gemini, Groq (BYO key)</td>
+            <td>AI formatting via system prompts with LLM providers</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, no API key needed)</td>
+            <td><span class="table-cross">Requires cloud LLM</span> for AI formatting</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span> (built-in regex pass, runs before AI polish)</td>
+            <td>Via AI formatting prompts</td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td>Clean prose style via AI polish prompt</td>
+            <td><span class="table-highlight">Power Mode</span> with per-app custom prompts</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-highlight">6-pass fuzzy matching</span> (Levenshtein + Soundex + bigram)</td>
+            <td>Personal dictionary (find-and-replace)</td>
+          </tr>
+          <tr>
+            <td>AI hallucination safeguards</td>
+            <td><span class="table-check">Yes</span> (length validation, preamble stripping, short-text bypass)</td>
+            <td>Not documented</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Pre-roll buffer</span> captures audio before you finish pressing the hotkey</td>
+            <td>Standard recording start</td>
+          </tr>
+          <tr>
+            <td>Starts listening instantly</td>
+            <td><span class="table-check">Warm engine</span> (model stays loaded between recordings)</td>
+            <td>Model loaded at startup</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> (clipboard saved before paste, restored after)</td>
+            <td>Not documented</td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes</span> (three-tier paste with target app reactivation)</td>
+            <td>Pastes into active app</td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes</span> (VAD-based silence detection)</td>
+            <td><span class="table-check">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Multi-language</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>100+ languages</td>
+          </tr>
+          <tr>
+            <td>Per-app settings</td>
+            <td>Global hotkey and settings</td>
+            <td><span class="table-highlight">Power Mode</span> with per-app prompts</td>
+          </tr>
+          <tr>
+            <td>Screen context</td>
+            <td><span class="table-cross">No</span></td>
+            <td><span class="table-check">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>VoiceOver labels, keyboard-navigable settings</td>
+            <td>Standard macOS controls</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Depends on model size and hardware</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
+            <td><a href="https://github.com/Beingpax/VoiceInk" style="color: var(--accent); text-decoration: underline;">Open source</a> (GPL v3)</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td>macOS (Apple Silicon, 14+)</td>
+            <td>macOS (14+)</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*VoiceInk pricing: $39.99 one-time (Pro). Based on tryvoiceink.com as of April 2026. EnviousWispr latency from production PostHog data on Apple Silicon Macs. VoiceInk claims source-verified from tryvoiceink.com and GitHub; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why choose EnviousWispr over VoiceInk</h2>
+      <p class="section-sub">Both apps keep your audio private. Here is where EnviousWispr pulls ahead.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Completely free</div>
+        <p class="advantage-desc">No tiers, no license keys, no payment. VoiceInk charges $39.99 for a one-time purchase. EnviousWispr costs nothing.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#9889;</div>
+        <div class="advantage-title">Faster English transcription</div>
+        <p class="advantage-desc">Parakeet TDT is purpose-built for English and runs on Apple's Neural Engine. 0.43s median latency. WhisperKit handles 90+ other languages when you need them.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#129504;</div>
+        <div class="advantage-title">5 AI polish providers</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run fully on-device with no API key. Or bring your own OpenAI, Gemini, or Groq key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#128295;</div>
+        <div class="advantage-title">Dual speech engines</div>
+        <p class="advantage-desc">Parakeet TDT for speed on English. WhisperKit for multilingual coverage. Two engines, one app, automatic routing. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>. VoiceInk uses whisper.cpp only.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#128218;</div>
+        <div class="advantage-title">Smarter word correction</div>
+        <p class="advantage-desc">A 6-pass fuzzy matching system catches misrecognized words that simple find-and-replace would miss. Levenshtein distance, Soundex phonetic matching, and bigram similarity work together to correct names, jargon, and technical terms.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#128736;</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify privacy claims yourself. VoiceInk is also open source under GPL v3, so both apps offer transparency.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">Both apps process audio on your Mac. The difference is in how polish and formatting work. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by Parakeet TDT or WhisperKit on the Neural Engine. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally (Apple Intelligence or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          VoiceInk
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed locally by whisper.cpp. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI formatting applies system prompts via cloud LLM to shape the output text.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Formatted text is pasted into the active app.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Parakeet TDT vs whisper.cpp</h2>
+      <p class="section-sub">Both run on-device, but the engine matters. Parakeet TDT is a CTC-Transducer model optimized for Apple's Neural Engine. It is measurably faster for English transcription.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">Parakeet TDT on Apple Silicon</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Both apps work fully offline</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">EnviousWispr latency based on production data from Apple Silicon Macs. VoiceInk latency depends on chosen Whisper model size and hardware. Results vary by settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dive -->
+<section class="section" aria-label="Technical Deep Dives">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">The details that make dictation reliable</h2>
+      <p class="section-sub">On-device transcription is only half the problem. What happens between speech and pasted text determines whether dictation feels trustworthy.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">&#127919;</div>
+        <div class="deep-dive-title">Paste workflow that does not lose your text</div>
+        <div class="deep-dive-body">
+          <p>Dictation apps face a subtle problem: between when you stop recording and when text is pasted, you might switch apps, click a different field, or have something important on your clipboard. If the app does not account for this, your text ends up in the wrong place or overwrites what you had copied.</p>
+          <p>EnviousWispr captures which app had focus when you started recording. A pre-roll audio buffer ensures the very first word is never clipped, even if you start speaking before the hotkey is fully pressed. The ASR engine stays warm between recordings, so there is no cold-start delay.</p>
+          <p>After transcription, the app re-activates the original target app and uses a three-tier paste system: Accessibility API direct insertion first, then simulated Cmd+V, then AppleScript as a last resort. Your clipboard contents are saved before the operation and restored after, so nothing is lost.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Pre-roll buffer captures ~200ms of audio before hotkey release. Warm engine keeps the ASR model loaded in memory. Three-tier paste (AX insertion, CGEvent Cmd+V, AppleScript) with clipboard snapshot and restoration. Target app reactivation uses Accessibility API force-activation to bypass macOS background process restrictions.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">&#128221;</div>
+        <div class="deep-dive-title">Custom vocabulary that catches phonetic mismatches</div>
+        <div class="deep-dive-body">
+          <p>Every speech-to-text engine struggles with names, acronyms, and domain-specific terms. Simple find-and-replace dictionaries only work when the ASR output exactly matches the expected error. But ASR errors are phonetic: "Envious Whisper" instead of "EnviousWispr," or "park it" instead of "Parakeet."</p>
+          <p>EnviousWispr runs custom vocabulary through a 6-pass fuzzy matching pipeline. First, exact matches are applied. Then Levenshtein distance catches close misspellings. Soundex phonetic encoding finds words that sound alike but are spelled differently. Bigram similarity catches partial matches. Case-insensitive and word-boundary passes handle the remaining edge cases.</p>
+          <p>The result: you add "EnviousWispr" to your custom words once, and it corrects "envious whisper," "envious wisper," and "envious whispr" automatically. VoiceInk's personal dictionary is useful for exact replacements, but phonetic misrecognitions require the fuzzy matching approach.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> 6-pass pipeline: exact match, Levenshtein distance (edit distance threshold), Soundex phonetic encoding, bigram character-pair similarity, case-insensitive match, word-boundary match. Each pass runs independently, so a word can be caught by any matching strategy. Custom words support both "correct this term" and "replace X with Y" modes.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where VoiceInk Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose VoiceInk if these matter more to you</h2>
+      <p class="section-sub">VoiceInk is a solid, lightweight dictation app. It may be a better fit in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#128176;</div>
+        <div class="advantage-title">One-time purchase, no updates to worry about</div>
+        <p class="advantage-desc">VoiceInk is a one-time $39.99 purchase. You pay once and own it. EnviousWispr is free today, but as a younger project its long-term model is still evolving. If you prefer the certainty of a single purchase, VoiceInk is straightforward.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#127919;</div>
+        <div class="advantage-title">Per-app settings and screen context</div>
+        <p class="advantage-desc">VoiceInk's Power Mode lets you configure different prompts and behaviors for each application, and can read what is on your screen to provide more relevant formatting. EnviousWispr uses global settings and does not have screen context awareness.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#129520;</div>
+        <div class="advantage-title">Simpler, lighter app</div>
+        <p class="advantage-desc">VoiceInk does one thing well with a clean interface and minimal setup. EnviousWispr has more moving parts (dual engines, multi-provider AI polish, fuzzy vocabulary). If you want the simplest possible dictation tool, VoiceInk may feel more focused.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#128220;</div>
+        <div class="advantage-title">GPL open source license</div>
+        <p class="advantage-desc">VoiceInk is licensed under GPL v3, an OSI-approved open source license. EnviousWispr uses BSL 1.1, which is source-available but not OSI-approved. If license type matters to you, VoiceInk has the edge.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#127758;</div>
+        <div class="advantage-title">Broader multilingual support</div>
+        <p class="advantage-desc">VoiceInk supports 100+ languages through whisper.cpp and has been tuned for multilingual workflows. EnviousWispr supports 90+ via WhisperKit, but Parakeet TDT (the fast engine) is English-only. If you dictate heavily in non-English languages, VoiceInk may be more polished for that use case.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">&#9201;</div>
+        <div class="advantage-title">Potentially faster setup</div>
+        <p class="advantage-desc">VoiceInk has a straightforward download-and-go experience. EnviousWispr requires granting Accessibility permissions and downloading an ASR model on first launch. Both are fast, but VoiceInk may feel quicker to get started with.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you primarily dictate in English and want the fastest transcription at zero cost, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. If VoiceInk's per-app settings or screen context awareness are important to your workflow, it is worth the $39.99.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free compared to VoiceInk?</div>
+        <p class="faq-a">Yes. EnviousWispr has no purchase price, no subscription, and no usage limits. VoiceInk charges a one-time fee of $39.99.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Both are on-device. Why does the speech engine matter?</div>
+        <p class="faq-a">Different engines have different speed and accuracy profiles. EnviousWispr uses Parakeet TDT, a CTC-Transducer model optimized for Apple's Neural Engine, which delivers 0.43s median latency for English. VoiceInk uses whisper.cpp, a solid engine, but Parakeet is purpose-built for fast English transcription.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr support languages other than English?</div>
+        <p class="faq-a">Yes. Parakeet TDT handles English. For other languages, EnviousWispr switches to WhisperKit, which supports 90+ languages. VoiceInk supports 100+ languages through whisper.cpp.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">How does custom vocabulary compare between the two apps?</div>
+        <p class="faq-a">EnviousWispr uses a 6-pass fuzzy matching system with Levenshtein distance, Soundex phonetic matching, and bigram similarity to catch misrecognized words even when the ASR output is phonetically close but spelled differently. VoiceInk offers a personal dictionary with find-and-replace rules, which works well for exact substitutions but may miss phonetic errors.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What is AI polish and does VoiceInk have it?</div>
+        <p class="faq-a">AI polish is a post-transcription step that fixes grammar, removes filler words, and formats your text using a language model. EnviousWispr supports Apple Intelligence, Ollama (both on-device), and cloud providers with your own API key. VoiceInk offers AI formatting through system prompts with cloud LLM providers.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Which app is better for non-English languages?</div>
+        <p class="faq-a">VoiceInk supports 100+ languages through whisper.cpp and has been optimized for multilingual use. EnviousWispr supports 90+ via WhisperKit but its fastest engine (Parakeet TDT) is English-only. For non-English dictation, VoiceInk may have an edge in language breadth and tuning.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does VoiceInk have AI text enhancement?</div>
+        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), OpenAI, Gemini, and Groq, plus built-in hallucination safeguards that reject fabricated output.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I switch from VoiceInk easily?</div>
+        <p class="faq-a">Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">EnviousWispr requires Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. VoiceInk also requires macOS 14+. Both apps target modern Macs.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free alternative to VoiceInk?</div>
+        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 5 providers. No account or payment required.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license like VoiceInk's GPL v3, but it gives you full transparency into how the app works.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Ready to try free on-device dictation?</h2>
+    <p class="reveal">Free to download. No account required. Faster than whisper.cpp for English.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -1,0 +1,735 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs whisper.cpp: Mac Dictation App vs Developer CLI",
+  "description": "Compare EnviousWispr and whisper.cpp for Mac dictation. Same on-device philosophy, but EnviousWispr gives you a hold-to-talk workflow, AI polish, and custom words without touching a terminal.",
+  "url": `${siteUrl}/compare/whisper-cpp/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Is there a GUI for whisper.cpp on Mac?", "acceptedAnswer": { "@type": "Answer", "text": "whisper.cpp itself is a command-line tool with no GUI. Several third-party apps wrap whisper.cpp with a graphical interface. EnviousWispr uses purpose-built engines (Parakeet TDT, WhisperKit) optimized for Apple Silicon, wrapped in a native Mac app with a hold-to-talk hotkey and automatic clipboard pasting." } },
+    { "@type": "Question", "name": "Can I use whisper.cpp for live dictation on Mac?", "acceptedAnswer": { "@type": "Answer", "text": "whisper.cpp has a real-time streaming mode, but it outputs to the terminal. There is no hotkey, no clipboard integration, and no paste-into-app workflow. EnviousWispr provides the full dictation experience." } },
+    { "@type": "Question", "name": "Does EnviousWispr use whisper.cpp internally?", "acceptedAnswer": { "@type": "Answer", "text": "No. EnviousWispr uses Parakeet TDT (NVIDIA's CTC-based model) and WhisperKit (a Swift-native Whisper implementation via Core ML and the Neural Engine), not whisper.cpp's C/C++ approach." } },
+    { "@type": "Question", "name": "Is EnviousWispr faster than whisper.cpp?", "acceptedAnswer": { "@type": "Answer", "text": "For live dictation on Apple Silicon Macs, EnviousWispr achieves a 0.43s median latency using engines tuned for the Neural Engine. whisper.cpp performance varies widely by model size, hardware, and build flags." } },
+    { "@type": "Question", "name": "Is EnviousWispr open source?", "acceptedAnswer": { "@type": "Answer", "text": "Source-available under the Business Source License 1.1. You can read, build, and inspect every line on GitHub. whisper.cpp is MIT licensed, which is more permissive for derivative works." } },
+    { "@type": "Question", "name": "What is the best whisper dictation tool for Mac?", "acceptedAnswer": { "@type": "Answer", "text": "If you want a developer library for scripting and batch processing, whisper.cpp is the standard. If you want a native Mac app with a hotkey, AI polish, custom words, and automatic clipboard pasting, EnviousWispr is built for that workflow." } },
+    { "@type": "Question", "name": "Can whisper.cpp do AI polish or custom words?", "acceptedAnswer": { "@type": "Answer", "text": "No. whisper.cpp outputs raw transcription. Any post-processing requires additional tools or scripts. EnviousWispr includes AI polish and custom words as built-in features." } },
+    { "@type": "Question", "name": "Do I need to know how to code to use EnviousWispr?", "acceptedAnswer": { "@type": "Answer", "text": "No. Download the DMG, drag to Applications, open, and start dictating. whisper.cpp requires comfort with the terminal, compiling from source, and managing model files manually." } },
+    { "@type": "Question", "name": "I already use whisper.cpp for dictation. Why would I switch?", "acceptedAnswer": { "@type": "Answer", "text": "If your whisper.cpp workflow already does everything you need, there is no reason to switch. But if you find yourself manually copying from the terminal, wishing for a hotkey, or wanting AI to clean up your text, EnviousWispr packages all of that into a single hold-to-talk experience." } },
+    { "@type": "Question", "name": "Can I use whisper.cpp and EnviousWispr together?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. They serve different purposes and do not conflict. Use EnviousWispr for live dictation while typing, and whisper.cpp for batch transcription of audio files, podcast processing, or integration into developer scripts." } },
+  ]
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs whisper.cpp",
+      "item": `${siteUrl}/compare/whisper-cpp/`,
+    },
+  ],
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs whisper.cpp: App vs Developer CLI"
+  description="Compare EnviousWispr and whisper.cpp. Both on-device. EnviousWispr adds GUI, hotkeys, AI polish, and clipboard integration. No terminal needed."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/whisper-cpp/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card { background: #fff; border: 1px solid var(--border-hover); border-radius: var(--radius-card); padding: 36px 32px; position: relative; overflow: hidden; }
+.deep-dive-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: var(--rainbow-full); }
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail { margin-top: 16px; padding: 14px 18px; border-radius: 10px; background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08); font-size: 13px; color: var(--text-2); line-height: 1.6; }
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">whisper.cpp</span>
+    </div>
+    <h1 class="reveal">All the power of whisper.cpp. None of the terminal.</h1>
+    <p class="page-header-sub reveal">whisper.cpp proved on-device speech recognition works. EnviousWispr wraps that philosophy into a native Mac app with a hotkey, AI polish, and clipboard workflow.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, no terminal needed
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">whisper.cpp is a developer library. EnviousWispr is a finished Mac app. Here is how they compare for daily dictation use.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>whisper.cpp</th>
+          </tr>
+        </thead>
+        <!-- Evidence: whisper.cpp claims verified against github.com/ggerganov/whisper.cpp on 2026-04-04.
+             Confidence: source-verified from official GitHub repository and README.
+             Sources:
+               - License: MIT (GitHub repo license file)
+               - Platforms: macOS, Linux, Windows, Android, iOS (README)
+               - Installation: compile from source or Homebrew (README)
+               - GUI: none built-in; third-party wrappers exist
+               - Models: OpenAI Whisper models, ggml format
+               - CLI behavior: model loaded per invocation, output to stdout/file
+               - No clipboard, hotkey, AI polish, or custom vocabulary features
+               - Community ecosystem: third-party GUIs, bindings for Python/Go/Rust/etc.
+             Firsthand testing: whisper.cpp was not tested firsthand for this comparison.
+             All claims are source-verified from the official repository.
+             Last updated: 2026-04-04. -->
+        <tbody>
+          <tr>
+            <td>Type</td>
+            <td><span class="table-highlight">Complete native Mac app</span> with GUI, menu bar, overlay</td>
+            <td>C/C++ library and command-line tool</td>
+          </tr>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No subscription.</span></td>
+            <td>Free (MIT license)</td>
+          </tr>
+          <tr>
+            <td>Setup required</td>
+            <td>Download DMG, drag to Applications</td>
+            <td>Compile from source or <code>brew install whisper-cpp</code></td>
+          </tr>
+          <tr>
+            <td>GUI / visual feedback</td>
+            <td><span class="table-check">Yes</span>. Floating overlay + menu bar indicator.</td>
+            <td><span class="table-cross">None</span>. Terminal output only.</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon Neural Engine)</td>
+            <td>On-device (CPU/GPU, any platform)</td>
+          </tr>
+          <tr>
+            <td>Hotkey activation</td>
+            <td><span class="table-check">Hold-to-talk</span>, release to transcribe, auto-paste</td>
+            <td><span class="table-cross">None</span>. Manual CLI invocation per file.</td>
+          </tr>
+          <tr>
+            <td>Paste into apps</td>
+            <td><span class="table-check">Three-tier paste</span>: Accessibility, keyboard shortcut, or clipboard fallback</td>
+            <td><span class="table-cross">None</span>. Output goes to stdout or a file.</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span>. Your clipboard is saved and restored after paste.</td>
+            <td><span class="table-cross">N/A</span>. Does not interact with clipboard.</td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">5 providers</span>: Apple Intelligence, Ollama, OpenAI, Gemini, Groq</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span>. Apple Intelligence and Ollama run fully on-device.</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span>. Fuzzy matching corrects names, acronyms, jargon.</td>
+            <td><span class="table-cross">None</span></td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span>. "Um", "uh", "like" stripped automatically.</td>
+            <td><span class="table-cross">None</span>. Raw transcript only.</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Pre-roll buffer</span> catches speech that starts before the hotkey press.</td>
+            <td><span class="table-cross">N/A</span>. Processes pre-recorded files.</td>
+          </tr>
+          <tr>
+            <td>Warm engine / instant start</td>
+            <td><span class="table-check">Yes</span>. Models stay loaded in memory for instant inference.</td>
+            <td>Depends on your integration. CLI loads model per invocation.</td>
+          </tr>
+          <tr>
+            <td>Speech engine</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (Apple Silicon optimized)</td>
+            <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">whisper.cpp</a> (C/C++ port of OpenAI Whisper)</td>
+          </tr>
+          <tr>
+            <td>Multi-language</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>90+ (OpenAI Whisper models)</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS (Apple Silicon)</td>
+            <td>macOS, Linux, Windows, Android, iOS</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
+            <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">Open source</a> (MIT)</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Varies by model size and hardware</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">EnviousWispr latency from production PostHog data on Apple Silicon Macs. whisper.cpp claims source-verified from <a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--text-3); text-decoration: underline;">github.com/ggerganov/whisper.cpp</a>; not firsthand-tested. Last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why users choose a finished app over a CLI</h2>
+      <p class="section-sub">whisper.cpp is a building block. EnviousWispr is the thing you actually use to dictate.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🖱️</div>
+        <div class="advantage-title">No terminal required</div>
+        <p class="advantage-desc">Download, open, hold your hotkey, speak. No compiling, no command flags, no audio format conversion. EnviousWispr handles the entire workflow from microphone to clipboard.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⌨️</div>
+        <div class="advantage-title">Hold-to-talk hotkey</div>
+        <p class="advantage-desc">Hold a key to record, release to transcribe. Text appears in your active app instantly. whisper.cpp processes pre-recorded audio files. There is no live dictation workflow.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">✨</div>
+        <div class="advantage-title">AI polish and custom words</div>
+        <p class="advantage-desc">Raw transcription is just the start. EnviousWispr cleans up filler words, fixes punctuation, and applies your custom vocabulary. whisper.cpp gives you raw output only.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📋</div>
+        <div class="advantage-title">Clipboard integration</div>
+        <p class="advantage-desc">Transcribed text is automatically pasted into whatever app you are working in. No copy-paste from a terminal window, no piping stdout into another tool.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Apple Silicon optimized</div>
+        <p class="advantage-desc">EnviousWispr uses <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a>, both purpose-built for the Neural Engine on Apple Silicon. whisper.cpp targets broad hardware compatibility, not peak Mac performance. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔄</div>
+        <div class="advantage-title">Automatic updates</div>
+        <p class="advantage-desc">EnviousWispr updates itself via Sparkle. whisper.cpp requires you to pull and rebuild, or wait for Homebrew to update the formula.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- How They Relate -->
+<section class="section" aria-label="Architecture Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">How They Relate</div>
+      <h2 class="section-title">Library vs. product</h2>
+      <p class="section-sub">whisper.cpp is a foundational library that many Mac dictation apps build on. EnviousWispr takes a different approach, using purpose-built engines optimized for Apple Silicon. Read more about <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>Hold your hotkey and speak.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is captured and processed on-device by Parakeet TDT or WhisperKit, optimized for the Neural Engine.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish cleans up the transcript. Custom words correct domain-specific terms.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Final text is pasted into your active app. Done.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          whisper.cpp
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>Record audio separately (another tool, ffmpeg, or a script).</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Convert to 16kHz WAV format if needed.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Run the whisper.cpp CLI with the audio file and model flags.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Read the raw transcript from stdout. Copy and paste it yourself.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Optimized for Apple Silicon, not just compatible</h2>
+      <p class="section-sub">whisper.cpp runs on everything. EnviousWispr is tuned specifically for the Neural Engine on M-series Macs, which means faster inference for the same model quality.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0</div>
+        <div class="speed-label">Manual steps</div>
+        <div class="speed-detail">No file conversion, no copy-paste</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dive -->
+<section class="section" aria-label="Deep Dive">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Deep Dive</div>
+      <h2 class="section-title">What happens between speech and polished text</h2>
+      <p class="section-sub">whisper.cpp gives you a transcription engine. EnviousWispr gives you a dictation workflow. The difference is everything that happens around the transcription.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎙️</div>
+        <div class="deep-dive-title">From speech to polished text in one step</div>
+        <div class="deep-dive-body">
+          <p>whisper.cpp gives you raw Whisper output in a terminal. You record audio separately, convert it to the right format, run a command, and read the result from stdout.</p>
+          <p>EnviousWispr captures speech, transcribes via Parakeet TDT or WhisperKit, corrects with fuzzy word matching, strips filler words, polishes with AI, and pastes into your active app. One hotkey press, one result.</p>
+          <div class="deep-dive-detail">
+            <strong>The pipeline:</strong> pre-roll buffer catches early speech, VAD detects voice activity, the warm engine transcribes instantly, custom words fix domain terms, AI polish cleans grammar and punctuation, three-tier paste delivers the text. All of this runs in under 1.5 seconds.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">⚙️</div>
+        <div class="deep-dive-title">The workflow that whisper.cpp does not have</div>
+        <div class="deep-dive-body">
+          <p>Dictation is more than transcription. The details that make it usable as a daily driver are the ones whisper.cpp was never designed to provide.</p>
+          <p>Pre-roll buffer means you never lose the first word. A warm engine means zero cold-start delay. Target app reactivation brings focus back to where you were typing. Clipboard preservation means your copied content survives the paste. Three-tier paste tries Accessibility API first, keyboard shortcut second, clipboard fallback third.</p>
+          <div class="deep-dive-detail">
+            <strong>Why this matters:</strong> Every one of these features was built because a real user hit a real friction point. whisper.cpp is an excellent transcription engine. EnviousWispr is the product layer that makes transcription disappear into your workflow.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where whisper.cpp Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose whisper.cpp if you want full control and do not mind setup</h2>
+      <p class="section-sub">whisper.cpp is one of the most important open-source speech projects. It may be the right tool in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔧</div>
+        <div class="advantage-title">You are building a product</div>
+        <p class="advantage-desc">whisper.cpp is a library meant to be embedded. If you are building your own app, plugin, or transcription pipeline, whisper.cpp gives you the raw engine under MIT license. EnviousWispr is the finished product, not a component.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🐧</div>
+        <div class="advantage-title">You need Linux or Windows</div>
+        <p class="advantage-desc">whisper.cpp runs on macOS, Linux, Windows, Android, and iOS. EnviousWispr is macOS only. If you need cross-platform speech recognition, whisper.cpp is the clear choice.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📜</div>
+        <div class="advantage-title">You want MIT licensing</div>
+        <p class="advantage-desc">whisper.cpp is MIT licensed with no restrictions. EnviousWispr is source-available under BSL 1.1. If you need to fork and build a competing product, whisper.cpp has more permissive terms.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎛️</div>
+        <div class="advantage-title">You want full control over models</div>
+        <p class="advantage-desc">whisper.cpp lets you swap any ggml-format Whisper model, tune beam search parameters, choose output formats (SRT, VTT, JSON), and integrate into custom scripts. Total flexibility for power users.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📂</div>
+        <div class="advantage-title">You are batch-processing audio files</div>
+        <p class="advantage-desc">whisper.cpp excels at transcribing recordings, podcasts, meetings, and video files in bulk. EnviousWispr is designed for live dictation, not file-based batch transcription.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌍</div>
+        <div class="advantage-title">You need deep multilingual support</div>
+        <p class="advantage-desc">whisper.cpp supports 90+ languages natively with any Whisper model. EnviousWispr's primary engine (Parakeet) is English-focused, with multilingual support via WhisperKit as a secondary option.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌐</div>
+        <div class="advantage-title">You want the community ecosystem</div>
+        <p class="advantage-desc">whisper.cpp has bindings for Python, Go, Rust, Ruby, and more. A large community contributes optimizations, model conversions, and integrations. If you want to plug speech recognition into an existing toolchain, whisper.cpp has the broadest ecosystem.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you want a ready-to-use Mac dictation app with a hotkey, AI polish, and clipboard workflow, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. If you want a developer library, <a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">whisper.cpp</a> is excellent.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a GUI for whisper.cpp on Mac?</div>
+        <p class="faq-a">whisper.cpp itself is a command-line tool with no GUI. Several third-party apps (VoiceInk, MacWhisper, and others) wrap whisper.cpp with a graphical interface. EnviousWispr takes a different approach: it uses purpose-built engines (Parakeet TDT, WhisperKit) optimized for Apple Silicon, wrapped in a native Mac app with a hold-to-talk hotkey and automatic clipboard pasting.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use whisper.cpp for live dictation on Mac?</div>
+        <p class="faq-a">whisper.cpp has a real-time streaming mode (<code>stream</code> example), but it outputs to the terminal. There is no hotkey, no clipboard integration, and no paste-into-app workflow. You would need to build that yourself or use an app like EnviousWispr that provides the full dictation experience.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr use whisper.cpp internally?</div>
+        <p class="faq-a">No. EnviousWispr uses <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation optimized for Core ML and the Neural Engine) and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model). Both are optimized for Apple Silicon rather than broad hardware compatibility.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr faster than whisper.cpp?</div>
+        <p class="faq-a">For live dictation on Apple Silicon Macs, EnviousWispr achieves a 0.43s median latency using engines tuned for the Neural Engine. whisper.cpp performance varies widely by model size, hardware, and build flags. On the same Mac hardware, Neural Engine-optimized inference is generally faster than CPU or GPU inference for Whisper-class models.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. You can read, build, and inspect every line on GitHub. whisper.cpp is MIT licensed, which is more permissive for derivative works. If you want to audit the code, both projects are transparent.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What is the best whisper dictation tool for Mac?</div>
+        <p class="faq-a">It depends on what you need. If you want a developer library for scripting and batch processing, whisper.cpp is the standard. If you want a native Mac app with a hotkey, AI polish, custom words, and automatic clipboard pasting, <a href="/#download" style="color: var(--accent); text-decoration: underline;">EnviousWispr</a> is built for that workflow.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can whisper.cpp do AI polish or custom words?</div>
+        <p class="faq-a">No. whisper.cpp outputs raw transcription. Any post-processing (punctuation cleanup, filler word removal, vocabulary correction) requires additional tools or scripts. EnviousWispr includes AI polish and custom words as built-in features.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Do I need to know how to code to use EnviousWispr?</div>
+        <p class="faq-a">No. Download the DMG, drag to Applications, open, and start dictating. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>. whisper.cpp requires comfort with the terminal, compiling from source (or using Homebrew), and managing model files manually.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">I already use whisper.cpp for dictation. Why would I switch?</div>
+        <p class="faq-a">If your whisper.cpp workflow already does everything you need, there is no reason to switch. But if you find yourself manually copying from the terminal, wishing for a hotkey, wanting AI to clean up your text, or spending time on custom scripts to pipe output into apps, EnviousWispr packages all of that into a single hold-to-talk experience. The time savings compound with every dictation.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr use whisper.cpp under the hood?</div>
+        <p class="faq-a">No. EnviousWispr uses two different engines: <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model) and <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation). WhisperKit runs Whisper models via Core ML and the Neural Engine, which is a different implementation path than whisper.cpp's C/C++ approach. Both are valid ways to run on-device speech recognition, optimized for different goals.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I use whisper.cpp and EnviousWispr together?</div>
+        <p class="faq-a">Yes. They serve different purposes and do not conflict. Use EnviousWispr for live dictation while typing, and whisper.cpp for batch transcription of audio files, podcast processing, or integration into developer scripts. Many technical users keep both.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Ready to dictate without the terminal?</h2>
+    <p class="reveal">Free to download. No account required. On-device transcription.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -1,0 +1,735 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs Willow Voice: Free On-Device Mac Dictation",
+  "description": "Compare EnviousWispr and Willow Voice on privacy, pricing, offline support, and speed. Free on-device dictation for Apple Silicon Macs vs cloud-first subscription.",
+  "url": `${siteUrl}/compare/willow-voice/`,
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Is there a free alternative to Willow Voice?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account, no word limits, and no subscription required. It works offline and keeps your audio on your device." } },
+    { "@type": "Question", "name": "Is EnviousWispr really free with no limits?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. No subscription, no usage caps, no word-per-week limits. Willow Voice's free tier caps you at 2,000 words per week. EnviousWispr has no such restriction." } },
+    { "@type": "Question", "name": "Does Willow Voice work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Willow Voice is cloud-based and requires an internet connection for transcription. EnviousWispr was built on-device from the start. Parakeet TDT and WhisperKit run natively on Apple Silicon, delivering 0.43s median latency without any cloud dependency." } },
+    { "@type": "Question", "name": "Does EnviousWispr work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider." } },
+    { "@type": "Question", "name": "Will my audio be used for training?", "acceptedAnswer": { "@type": "Answer", "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else." } },
+    { "@type": "Question", "name": "Can I switch from Willow Voice easily?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS." } },
+    { "@type": "Question", "name": "What Mac do I need?", "acceptedAnswer": { "@type": "Answer", "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast." } },
+    { "@type": "Question", "name": "Does EnviousWispr use the cloud at all?", "acceptedAnswer": { "@type": "Answer", "text": "Transcription is always on-device. If you choose to enable AI polish with a cloud provider, only the text transcript is sent using your own API key. You can also polish with a local model for fully offline operation." } },
+    { "@type": "Question", "name": "Is EnviousWispr open source?", "acceptedAnswer": { "@type": "Answer", "text": "Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code on GitHub. Contributions are welcome." } },
+    { "@type": "Question", "name": "How does EnviousWispr handle filler words like um and uh?", "acceptedAnswer": { "@type": "Answer", "text": "EnviousWispr automatically strips filler words from transcripts before they reach your text field. This happens at the post-processing stage, before AI polish, so even without an LLM enabled your text comes out clean." } },
+    { "@type": "Question", "name": "What happens to my clipboard when EnviousWispr pastes text?", "acceptedAnswer": { "@type": "Answer", "text": "EnviousWispr saves your clipboard contents before pasting transcribed text, then restores them afterward. Whatever you had copied before dictating is still there when you press Cmd+V next." } },
+  ]
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs Willow Voice",
+      "item": `${siteUrl}/compare/willow-voice/`,
+    },
+  ],
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs Willow Voice: Free On-Device Mac Dictation"
+  description="Compare EnviousWispr vs Willow Voice: price, privacy, offline, speed. Free on-device dictation for Apple Silicon. No subscription."
+  activePage="compare"
+  ogType="article"
+  canonicalPath="/compare/willow-voice/"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+.table-muted { color: var(--text-3); font-style: italic; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .deep-dive-grid { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">Willow Voice</span>
+    </div>
+    <h1 class="reveal">The free, on-device Willow Voice alternative for Mac</h1>
+    <p class="page-header-sub reveal">Both turn speech into polished text. The difference: EnviousWispr runs entirely on your Mac, costs nothing, and never sends your audio to the cloud.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>Willow Voice</th>
+          </tr>
+        </thead>
+        <!-- Evidence: Willow Voice claims verified against willowvoice.com on 2026-04-04.
+             Confidence: source-verified from public website and pricing page.
+             Sources:
+               - Homepage: willowvoice.com (accessed 2026-04-04) - AI editing, style matching, context awareness, voice commands, noise handling, multi-language
+               - Pricing: willowvoice.com/pricing (accessed 2026-04-04) - Free (2,000 words/week), Individual $12/mo annual, Team $10/mo/seat, Enterprise custom
+               - Platforms: willowvoice.com - Mac, Windows, iOS (Android mentioned on pricing page)
+               - Cloud processing: willowvoice.com - cloud-based (no offline mode found on site)
+               - Security: willowvoice.com - SOC 2, HIPAA, zero data retention, privacy mode (Enterprise tier)
+               - Backing: YC-backed
+             Firsthand testing: Willow Voice was not tested firsthand for this comparison.
+             "Not specified" is used for any feature not explicitly documented on their site. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free to use. No subscription.</span></td>
+            <td>Free tier (2,000 words/week), then $12/mo*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon)</td>
+            <td>Cloud-based</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your device</td>
+            <td><span class="table-check">Never.</span> Audio stays on your Mac. If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td>Yes, audio sent to servers</td>
+          </tr>
+          <tr>
+            <td>Works offline</td>
+            <td><span class="table-check">Yes</span> for transcription (after models download)</td>
+            <td><span class="table-cross">No</span></td>
+          </tr>
+          <tr>
+            <td>AI polish</td>
+            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td>AI rewrite and style matching (cloud)</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-check">Yes</span> via Apple Intelligence or local Ollama models</td>
+            <td><span class="table-cross">No</span> (cloud-dependent)</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td>Cloud speech API</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td><span class="table-check">Yes</span> with phonetic matching and regex-powered word correction</td>
+            <td><span class="table-check">Yes</span> (dictionary customization)</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span> (automatic "um", "uh", "like" removal)</td>
+            <td><span class="table-muted">Not specified</span></td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td><span class="table-check">Yes</span> (choose from 5 AI providers, custom prompts)</td>
+            <td><span class="table-check">Yes</span> (style matching, AI mode)</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes</span> (clipboard saved before paste, restored after)</td>
+            <td><span class="table-muted">Not specified</span></td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes</span> (captures target app at recording start, re-activates before paste)</td>
+            <td><span class="table-muted">Not specified</span></td>
+          </tr>
+          <tr>
+            <td>AI hallucination safeguards</td>
+            <td><span class="table-check">Yes</span> (length validation, preamble stripping, short-text bypass)</td>
+            <td><span class="table-muted">Not specified</span></td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes</span> (VAD-based, configurable sensitivity)</td>
+            <td><span class="table-muted">Not specified</span></td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS only (Apple Silicon)</td>
+            <td>Mac, Windows, iOS, Android</td>
+          </tr>
+          <tr>
+            <td>Multi-language</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>100+ languages</td>
+          </tr>
+          <tr>
+            <td>Enterprise compliance</td>
+            <td>Not applicable (single-user, on-device)</td>
+            <td>SOC 2, HIPAA (Enterprise tier only)</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Depends on network + server load</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Willow Voice's public pricing page as of April 2026 ($12/mo billed annually for the Individual plan). EnviousWispr latency from production PostHog data on Apple Silicon Macs. Willow Voice claims source-verified from willowvoice.com; not firsthand-tested. "Not specified" means the feature is not documented on their public site. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why Mac users switch from Willow Voice</h2>
+      <p class="section-sub">Willow Voice is cloud-first with a subscription model. EnviousWispr was built around a different premise: your voice data belongs on your device.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free, no caps</div>
+        <p class="advantage-desc">No subscription, no word limits, no freemium tiers. Willow Voice caps its free plan at 2,000 words per week. The paid plan costs $12/mo billed annually, or $144 per year. EnviousWispr is free with no limits.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">On-device by design</div>
+        <p class="advantage-desc">Willow Voice processes audio on cloud servers. EnviousWispr processes every recording on your Mac's <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a>. Privacy is the architecture, not an option. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Fast local transcription</div>
+        <p class="advantage-desc">Median time to text is 0.43s on Apple Silicon. With AI polish, 1.5s. No network round-trips, no server queues. Immune to bad Wi-Fi, VPN latency, or cloud outages.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚫</div>
+        <div class="advantage-title">No account, no signup</div>
+        <p class="advantage-desc">Download, open, start dictating. EnviousWispr never asks for your email, never requires a login, never phones home. No trial period, no conversion nag.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔑</div>
+        <div class="advantage-title">Your choice of AI polish</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Deep Dives -->
+<section class="section" aria-label="Deep Dives">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Under the Hood</div>
+      <h2 class="section-title">The details that make dictation reliable</h2>
+      <p class="section-sub">Cloud dictation tools outsource the hard problems to servers. EnviousWispr solves them locally, and the result is a more dependable workflow.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎯</div>
+        <div class="deep-dive-title">Your text always lands where it should</div>
+        <div class="deep-dive-body">
+          <p>Cloud dictation has a timing problem. While your audio uploads, transcribes, and returns, you might switch apps, click a different field, or start reading something else. When the text finally arrives, it can paste into the wrong place or overwrite your clipboard.</p>
+          <p>EnviousWispr captures which app and which text field had focus when you started recording. After transcription, it re-activates that exact app and inserts text directly via the Accessibility API. If direct insertion fails, it falls back to simulated Cmd+V, then to AppleScript. Your clipboard is saved before the operation and restored after.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Three-tier paste system (AX direct insertion, CGEvent Cmd+V, AppleScript fallback) with full clipboard snapshot and restoration. Target app reactivation uses Accessibility API force-activation to bypass macOS background process restrictions.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">AI polish that does not fabricate</div>
+        <div class="deep-dive-body">
+          <p>When you run speech through an LLM for cleanup, there is a real risk: the AI can hallucinate extra sentences, "answer" your dictation as if it were a question, or inject preamble like "Certainly! Here is the corrected text." These are not theoretical problems. They happen with basic LLM integrations.</p>
+          <p>EnviousWispr uses three layers of defense. Short transcripts (three words or fewer) bypass the LLM entirely because there is nothing to polish. Medium transcripts get aggressive prompt reinforcement to prevent creative expansion. All output is validated: if the response is more than three times longer than the input, it is rejected as probable hallucination and the raw transcript is used instead.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Sandwich framing wraps transcript in &lt;transcript&gt; tags to prevent prompt injection. Preamble stripping removes "Certainly!" artifacts. Context-aware prompts include detected language, ASR error patterns, and target app name. Output length validation rejects fabricated responses.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">The most important question for any dictation tool. Here is the data flow for each app. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Willow Voice (default mode)
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is sent to Willow Voice's cloud servers for transcription.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Transcribed text is processed by a cloud LLM for AI rewrite and style matching.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is returned over the network and pasted on your device.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Fast because there is no upload step</h2>
+      <p class="section-sub">On Apple Silicon Macs, EnviousWispr transcribes speech locally. No network round-trip before text appears.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where Willow Voice Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">Choose Willow Voice if you need cross-platform or enterprise compliance</h2>
+      <p class="section-sub">Willow Voice is a well-funded, YC-backed product with broad platform support and enterprise features. It may be a better fit in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🖥️</div>
+        <div class="advantage-title">You need cross-platform support</div>
+        <p class="advantage-desc">Willow Voice runs on Mac, Windows, iOS, and Android. EnviousWispr is macOS only. If you dictate across multiple operating systems, Willow covers all of them.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🏢</div>
+        <div class="advantage-title">Your team needs enterprise compliance</div>
+        <p class="advantage-desc">Willow Voice offers SOC 2 and HIPAA compliance on its Enterprise tier, with team pricing at $10/mo per seat. EnviousWispr is a single-user desktop app without enterprise certifications.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🌍</div>
+        <div class="advantage-title">You dictate in many languages daily</div>
+        <p class="advantage-desc">Willow Voice supports 100+ languages through its cloud engine with automatic grammar and formatting. EnviousWispr's best engine (Parakeet) is English-only; WhisperKit covers 90+ languages but with higher latency on less common ones.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔊</div>
+        <div class="advantage-title">You want voice commands built in</div>
+        <p class="advantage-desc">Willow Voice supports formatting voice commands like "dash," "new line," and "bullet point" natively. EnviousWispr focuses on natural dictation with AI polish handling formatting, rather than explicit voice commands.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you are Mac-first and care most about privacy, offline transcription, and price, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free alternative to Willow Voice?</div>
+        <p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account, no word limits, and no subscription required. It works offline and keeps your audio on your device.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free with no limits?</div>
+        <p class="faq-a">Yes. No subscription, no usage caps, no word-per-week limits. Willow Voice's free tier caps you at 2,000 words per week. EnviousWispr has no such restriction. The source code is available on GitHub under a BSL 1.1 license.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does Willow Voice work offline?</div>
+        <p class="faq-a">Willow Voice is cloud-based and requires an internet connection for transcription. EnviousWispr was built on-device from the start. Parakeet TDT and WhisperKit run natively on Apple Silicon, delivering 0.43s median latency without any cloud dependency.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Will my audio be used for training?</div>
+        <p class="faq-a">No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I switch from Willow Voice easily?</div>
+        <p class="faq-a">Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr use the cloud at all?</div>
+        <p class="faq-a">Transcription is always on-device. If you choose to enable AI polish with a cloud provider (OpenAI, Gemini), only the text transcript is sent using your own API key. You can also polish with a local model for fully offline operation. The choice is yours.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">How does EnviousWispr handle filler words like "um" and "uh"?</div>
+        <p class="faq-a">EnviousWispr automatically strips filler words (um, uh, like, you know) from transcripts before they reach your text field. This happens at the post-processing stage, before AI polish, so even without an LLM enabled your text comes out clean.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What happens to my clipboard when EnviousWispr pastes text?</div>
+        <p class="faq-a">EnviousWispr saves your clipboard contents before pasting transcribed text, then restores them afterward. Whatever you had copied before dictating is still there when you press Cmd+V next.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/wisprflow/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs WisprFlow</a>
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs VoiceInk</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Try the free Willow alternative for Mac</h2>
+    <p class="reveal">Free to download. No account required. No cloud transcription.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -1,0 +1,825 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "EnviousWispr vs WisprFlow: Free Private Mac Dictation",
+  "description": "See how EnviousWispr and WisprFlow compare on privacy, speed, pricing, and architecture. Free on-device dictation vs. cloud subscription.",
+  "url": `${siteUrl}/compare/wisprflow/`,
+  "datePublished": "2026-04-03",
+  "dateModified": "2026-04-03",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": siteUrl,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "EnviousWispr vs WisprFlow",
+      "item": `${siteUrl}/compare/wisprflow/`,
+    },
+  ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will my audio be used for training?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I switch from WisprFlow easily?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr use the cloud at all?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription is always on-device. If you choose to enable AI polish with a cloud provider (OpenAI, Gemini), only the text transcript is sent using your own API key. You can also polish with a local model for fully offline operation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free alternative to WisprFlow?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It works offline and keeps your audio on your device."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr clip the first word like other dictation apps?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr uses a continuous pre-roll audio buffer that captures the 500 milliseconds before you press the hotkey. Even if you start speaking the instant you press the key, the first word is captured."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens to my clipboard when EnviousWispr pastes text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nothing. EnviousWispr saves your clipboard contents before pasting and restores them after. Whatever you had copied before dictating is still there when it finishes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I add custom words for names, brands, or jargon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr has a custom vocabulary system with fuzzy matching that catches pronunciation variants. You can add words with aliases, and the vocabulary is also fed into the AI polish prompt for double-layer correction."
+      }
+    }
+  ]
+});
+
+---
+
+<BaseLayout
+  title="EnviousWispr vs WisprFlow: Free Private Mac Dictation"
+  description="Compare EnviousWispr vs WisprFlow on price, privacy, offline support, and speed. Free on-device dictation for Apple Silicon Macs. No account required."
+  activePage="compare"
+  canonicalPath="/compare/wisprflow/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
+  </Fragment>
+
+<style>
+/* ── Page Header ── */
+.page-header { padding: 100px 0 48px; text-align: center; position: relative; z-index: 1; }
+.vs-badge {
+  display: inline-flex; align-items: center; gap: 14px; margin-bottom: 20px;
+  font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-3);
+}
+.vs-brand { font-size: 18px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); }
+.vs-brand.accent { color: var(--accent); }
+.vs-circle {
+  width: 36px; height: 36px; border-radius: 50%; border: 2px solid var(--border-hover);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 800; color: var(--text-3); background: #fff;
+}
+.page-header h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; max-width: 700px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.hero-pills { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
+.hero-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 100px; font-size: 13px; font-weight: 600;
+  background: rgba(124,58,237,0.06); color: var(--accent); border: 1px solid rgba(124,58,237,0.12);
+}
+.hero-pill svg { flex-shrink: 0; }
+.hero-cta { margin-top: 28px; }
+.hero-meta { font-size: 12px; color: var(--text-3); margin-top: 16px; }
+
+/* ── Comparison Table ── */
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover);
+  background: #fff;
+}
+.compare-table {
+  width: 100%; border-collapse: collapse; font-size: 15px;
+  min-width: 640px;
+}
+.compare-table thead th {
+  padding: 20px 24px; font-size: 16px; font-weight: 700;
+  text-align: left; border-bottom: 2px solid var(--border-hover);
+  background: rgba(248,245,255,0.5);
+}
+.compare-table thead th:first-child { width: 34%; }
+.compare-table thead th:nth-child(2) {
+  background: rgba(124,58,237,0.06);
+  color: var(--accent);
+}
+.compare-table tbody td {
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+  vertical-align: top; line-height: 1.55;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child {
+  font-weight: 600; color: var(--text);
+}
+.compare-table tbody td:nth-child(2) {
+  background: rgba(124,58,237,0.02);
+}
+.compare-table tbody td:nth-child(3) {
+  color: var(--text-2);
+}
+.table-check { color: var(--green); font-weight: 700; }
+.table-cross { color: var(--text-3); }
+.table-highlight { color: var(--accent); font-weight: 600; }
+
+/* ── Advantage Cards ── */
+.advantages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.advantage-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 24px;
+  position: relative; overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.advantage-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.advantage-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.advantage-icon { font-size: 28px; margin-bottom: 14px; line-height: 1; }
+.advantage-title { font-size: 18px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 8px; color: var(--text); }
+.advantage-desc { font-size: 14px; color: var(--text-2); line-height: 1.65; }
+
+/* ── Privacy Section ── */
+.privacy-split { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.privacy-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 32px 28px;
+}
+.privacy-card.ew {
+  border-color: rgba(0,200,128,0.25);
+  background: linear-gradient(135deg, rgba(0,200,128,0.03), rgba(248,245,255,0.5));
+}
+.privacy-card.wf {
+  border-color: rgba(230,37,58,0.15);
+  background: linear-gradient(135deg, rgba(230,37,58,0.02), rgba(248,245,255,0.5));
+}
+.privacy-card-label {
+  font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;
+  margin-bottom: 16px; display: flex; align-items: center; gap: 8px;
+}
+.privacy-card.ew .privacy-card-label { color: var(--green); }
+.privacy-card.wf .privacy-card-label { color: var(--red); }
+.privacy-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 10px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
+}
+.privacy-step:last-child { border-bottom: none; }
+.privacy-step-num {
+  flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.privacy-card.ew .privacy-step-num { background: rgba(0,200,128,0.12); color: var(--green); }
+.privacy-card.wf .privacy-step-num { background: rgba(230,37,58,0.08); color: var(--red); }
+
+/* ── Speed Stats ── */
+.speed-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.speed-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 28px 20px; text-align: center;
+}
+.speed-value {
+  font-size: 42px; font-weight: 800; letter-spacing: -2px; line-height: 1; margin-bottom: 6px;
+  background: var(--rainbow-full);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
+.speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
+/* ── FAQ ── */
+.faq-list { max-width: 720px; margin: 0 auto; }
+.faq-item {
+  border-bottom: 1px solid var(--border-hover); padding: 24px 0;
+}
+.faq-item:last-child { border-bottom: none; }
+.faq-q {
+  font-size: 17px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.3px;
+}
+.faq-a { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+
+/* ── CTA ── */
+.cta-section { padding: var(--section-pad) 0; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 40px; font-weight: 800; letter-spacing: -2px; margin-bottom: 12px; }
+.cta-section p { font-size: 17px; color: var(--text-2); margin-bottom: 36px; }
+.cta-actions { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; }
+.back-link { font-size: 15px; font-weight: 500; color: var(--text-3); text-decoration: none; transition: color 0.2s; }
+.back-link:hover { color: var(--accent); }
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .advantages-grid { grid-template-columns: repeat(2, 1fr); }
+  .privacy-split { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: repeat(3, 1fr); }
+  .page-header h1 { font-size: 42px; letter-spacing: -2px; }
+}
+@media (max-width: 600px) {
+  .advantages-grid { grid-template-columns: 1fr; }
+  .speed-stats { grid-template-columns: 1fr; }
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .compare-table-wrap { margin: 0 -20px; border-radius: 0; border-left: none; border-right: none; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <div class="vs-badge reveal">
+      <span class="vs-brand accent">EnviousWispr</span>
+      <span class="vs-circle">VS</span>
+      <span class="vs-brand">WisprFlow</span>
+    </div>
+    <h1 class="reveal">The free, private WisprFlow alternative for Mac</h1>
+    <p class="page-header-sub reveal">Same idea: hold a key, speak, get polished text. The difference is your audio never leaves your Mac, and it costs nothing.</p>
+    <div class="hero-pills reveal">
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        On-device, not cloud
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        Free, no subscription
+      </span>
+      <span class="hero-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        0.43s median latency
+      </span>
+    </div>
+    <div class="hero-cta reveal">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/" style="color: var(--text-3); text-decoration: underline;">Saurabh Vaish</a> · Last reviewed: April 2026</p>
+  </div>
+</header>
+
+<!-- Side-by-Side Table -->
+<section class="section" aria-label="Feature Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Side by Side</div>
+      <h2 class="section-title">Feature comparison</h2>
+      <p class="section-sub">An honest look at how the two tools stack up across the dimensions that matter most.</p>
+    </div>
+    <div class="compare-table-wrap reveal">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>EnviousWispr</th>
+            <th>WisprFlow</th>
+          </tr>
+        </thead>
+        <!-- Evidence: WisprFlow claims verified against wisprflow.ai on 2026-04-04.
+             Confidence: source-verified from public website pages.
+             Sources:
+               - Pricing: wisprflow.ai/pricing (accessed 2026-04-04) — Free basic (2,000 words/week), Pro $15/mo monthly or $12/mo annual
+               - Account: wisprflow.ai signup flow requires email (accessed 2026-04-04)
+               - Cloud processing: wisprflow.ai/privacy — "Transcription always happens in the cloud" (accessed 2026-04-04)
+               - Features: wisprflow.ai/features (accessed 2026-04-04) — dictionary, snippets, tones, filler removal, backtrack, auto-punctuation, whisper mode, 100+ languages, syntax awareness
+               - Accessibility: wisprflow.ai/accessibility (accessed 2026-04-04) — hands-free dictation focus
+               - Platforms: Mac, Windows, iPhone, Android (accessed 2026-04-04)
+             Firsthand testing: WisprFlow was not tested firsthand for this comparison.
+             All claims are source-verified from official pages. -->
+        <tbody>
+          <tr>
+            <td>Price</td>
+            <td><span class="table-highlight">Free. No limits, no subscription.</span></td>
+            <td>Free tier (2,000 words/week); Pro $12-15/mo for unlimited*</td>
+          </tr>
+          <tr>
+            <td>Account required</td>
+            <td><span class="table-check">No</span></td>
+            <td>Yes, email signup</td>
+          </tr>
+          <tr>
+            <td>Audio processing</td>
+            <td><span class="table-highlight">On-device</span> (Apple Silicon)</td>
+            <td>Cloud servers</td>
+          </tr>
+          <tr>
+            <td>Audio leaves your Mac</td>
+            <td><span class="table-check">Never.</span> Audio stays on your Mac. If you enable cloud AI polish, only the text transcript is sent.</td>
+            <td>Yes, audio uploaded for transcription</td>
+          </tr>
+          <tr>
+            <td>Offline AI polish</td>
+            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via Apple Intelligence or Ollama. Cloud options (OpenAI, Gemini) available with your own key.</td>
+            <td><span class="table-cross">No.</span> Requires internet for both transcription and AI editing.</td>
+          </tr>
+          <tr>
+            <td>Speech engines</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td>Cloud speech API</td>
+          </tr>
+          <tr>
+            <td>Multi-language</td>
+            <td>English (Parakeet), 90+ via WhisperKit</td>
+            <td>100+ languages with auto-detection</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS only today</td>
+            <td>Mac, Windows, iPhone, Android</td>
+          </tr>
+          <tr>
+            <td>Source code</td>
+            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td>Closed source</td>
+          </tr>
+          <tr>
+            <td>Transcription latency</td>
+            <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
+            <td>Depends on network + server load</td>
+          </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td>Add names, brands, jargon with fuzzy matching that catches pronunciation variants.</td>
+            <td>Personal dictionary; auto-learns from corrections. Shared dictionary for teams.</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span></td>
+            <td><span class="table-check">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td>Four presets (Standard, Formal, Friendly, Custom) or write your own system prompt.</td>
+            <td>Auto-adjusts tone per app (English, desktop only).</td>
+          </tr>
+          <tr>
+            <td>Snippets / shortcuts</td>
+            <td><span class="table-cross">Not yet</span></td>
+            <td><span class="table-check">Yes.</span> Voice-triggered text shortcuts with shared snippets for teams.</td>
+          </tr>
+          <tr>
+            <td>Command mode</td>
+            <td><span class="table-cross">Not yet</span></td>
+            <td><span class="table-check">Yes</span> (Pro only). Edit and rewrite with voice commands.</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Never clips.</span> A 500ms pre-roll buffer captures audio before recording officially starts.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Starts listening instantly</td>
+            <td><span class="table-check">Yes.</span> Engine pre-warms on key-down, hiding cold-start and Bluetooth latency.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes.</span> Saves and restores your clipboard after every paste.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes.</span> Remembers which app and text field were focused, re-activates before pasting.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>AI hallucination safeguards</td>
+            <td><span class="table-check">Yes.</span> Three-layer defense: short-transcript bypass, reinforcement, output validation.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Hands-free dictation</td>
+            <td><span class="table-check">Yes.</span> Double-press to lock recording. Triple-press to cancel.</td>
+            <td>Accessibility-focused hands-free support</td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes.</span> Neural voice activity detection stops recording when you finish speaking.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>VoiceOver announcements for recording state changes.</td>
+            <td>Dedicated accessibility page; hands-free focus for mobility/pain/vision challenges.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*WisprFlow pricing and features verified from wisprflow.ai/pricing and wisprflow.ai/features as of April 2026. Pro is $15/mo billed monthly or $12/mo billed annually. EnviousWispr latency from production PostHog data on Apple Silicon Macs. WisprFlow was not firsthand-tested. "Not specified" means the feature is not documented on WisprFlow's public pages. Competitor claims last verified: 2026-04-04.</p>
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="/#download" class="btn-primary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Why EnviousWispr -->
+<section class="section" aria-label="Advantages">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill green">Why EnviousWispr</div>
+      <h2 class="section-title">Why Mac users switch from WisprFlow</h2>
+      <p class="section-sub">EnviousWispr was built to give you everything a premium dictation tool offers, without the tradeoffs.</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">$0</div>
+        <div class="advantage-title">Free to use</div>
+        <p class="advantage-desc">No subscription, no usage caps, no freemium tiers. Download it, use it, done. WisprFlow costs $15/mo at time of writing, which adds up to $180 per year.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔒</div>
+        <div class="advantage-title">On-device transcription</div>
+        <p class="advantage-desc">Your audio does not leave your Mac. It is processed by the <a href="https://developer.apple.com/machine-learning/core-ml/" style="color: var(--accent); text-decoration: underline;">Neural Engine</a> on Apple Silicon, never uploaded, never stored elsewhere. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>. Private by architecture, not by promise.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">⚡</div>
+        <div class="advantage-title">Fast local transcription</div>
+        <p class="advantage-desc">Median time to text is 0.43s on Apple Silicon. With AI polish, 1.5s. No network round-trips, no server queues. Immune to bad Wi-Fi.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🚫</div>
+        <div class="advantage-title">No account, no signup</div>
+        <p class="advantage-desc">Download, open, start dictating. EnviousWispr never asks for your email, never requires a login, never phones home. WisprFlow requires account creation before you can use it.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🔑</div>
+        <div class="advantage-title">Your choice of AI polish</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📖</div>
+        <div class="advantage-title">Auditable code</div>
+        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Privacy Deep Dive -->
+<section class="section" aria-label="Privacy Comparison">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill cyan">Privacy</div>
+      <h2 class="section-title">Where does your voice go?</h2>
+      <p class="section-sub">The most important question for any dictation tool. Here is the data flow for each app. For a deeper dive, read <a href="/blog/on-device-vs-cloud-dictation-privacy/" style="color: var(--accent); text-decoration: underline;">on-device vs cloud dictation privacy</a>.</p>
+    </div>
+    <div class="privacy-split">
+      <div class="privacy-card ew reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          EnviousWispr
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is processed by the Neural Engine on your Apple Silicon chip. Nothing is uploaded.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>AI polish runs locally or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is pasted. Audio is discarded. No logs, no telemetry on your content.</div>
+        </div>
+      </div>
+      <div class="privacy-card wf reveal">
+        <div class="privacy-card-label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          WisprFlow
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">1</div>
+          <div>You speak into your Mac's microphone.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">2</div>
+          <div>Audio is uploaded to cloud servers for transcription via a third-party API.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">3</div>
+          <div>Transcribed text is sent to a cloud LLM for polishing.</div>
+        </div>
+        <div class="privacy-step">
+          <div class="privacy-step-num">4</div>
+          <div>Polished text is returned over the network and pasted on your device.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Speed Section -->
+<section class="section" aria-label="Speed">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill amber">Speed</div>
+      <h2 class="section-title">Fast because there is no upload step</h2>
+      <p class="section-sub">On Apple Silicon Macs, EnviousWispr transcribes speech locally. No network round-trip before text appears.</p>
+    </div>
+    <div class="speed-stats">
+      <div class="speed-card reveal">
+        <div class="speed-value">0.43s</div>
+        <div class="speed-label">Median transcription</div>
+        <div class="speed-detail">From end of speech to raw text</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">1.5s</div>
+        <div class="speed-label">With AI polish</div>
+        <div class="speed-detail">Apple Intelligence on-device</div>
+      </div>
+      <div class="speed-card reveal">
+        <div class="speed-value">0ms</div>
+        <div class="speed-label">Network overhead</div>
+        <div class="speed-detail">Immune to bad Wi-Fi</div>
+      </div>
+    </div>
+    <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
+  </div>
+</section>
+
+<!-- Deep Dives -->
+<section class="section" aria-label="Under the Hood">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">The details that make dictation reliable</h2>
+      <p class="section-sub">Cloud dictation tools outsource the hard problems to servers. EnviousWispr solves them locally, and the result is a more dependable workflow.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎯</div>
+        <div class="deep-dive-title">Your text always lands where it should</div>
+        <div class="deep-dive-body">
+          <p>Cloud dictation has a timing problem. While your audio uploads, transcribes, and returns, you might switch apps, click a different field, or start reading something else. When the text finally arrives, it can paste into the wrong place or overwrite your clipboard.</p>
+          <p>EnviousWispr captures which app and which text field had focus when you started recording. After transcription, it re-activates that exact app and inserts text directly via the Accessibility API. If direct insertion fails, it falls back to simulated Cmd+V, then to AppleScript. Your clipboard is saved before the operation and restored after.</p>
+          <p>The result: text goes where you intended, every time, without trashing what you had copied.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Three-tier paste system (AX direct insertion, CGEvent Cmd+V, AppleScript fallback) with full clipboard snapshot and restoration. Target app reactivation uses Accessibility API force-activation to bypass macOS background process restrictions.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">AI polish that does not fabricate</div>
+        <div class="deep-dive-body">
+          <p>When you run speech through an LLM for cleanup, there is a real risk: the AI can hallucinate extra sentences, "answer" your dictation as if it were a question, or inject preamble like "Certainly! Here is the corrected text." These are not theoretical problems. They happen with basic LLM integrations.</p>
+          <p>EnviousWispr uses three layers of defense. Short transcripts (three words or fewer) bypass the LLM entirely because there is nothing to polish. Medium transcripts get aggressive prompt reinforcement to prevent creative expansion. All output is validated: if the response is more than three times longer than the input, it is rejected as probable hallucination and the raw transcript is used instead.</p>
+          <p>The LLM prompt itself is context-aware. It tells the model it is processing speech-to-text output, gives examples of phonetic misrecognition patterns, and adjusts for the app you were dictating into. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or execute.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Sandwich framing wraps transcript in &lt;transcript&gt; tags to prevent prompt injection. Preamble stripping removes "Certainly!" artifacts. Context-aware prompts include detected language, ASR error patterns, and target app name. Output length validation rejects fabricated responses.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Fair Acknowledgment -->
+<section class="section" aria-label="Where WisprFlow Wins">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Being Honest</div>
+      <h2 class="section-title">When WisprFlow might be the better choice</h2>
+      <p class="section-sub">WisprFlow is a solid product with a longer track record. It may be a better fit in these situations:</p>
+    </div>
+    <div class="advantages-grid">
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">📱</div>
+        <div class="advantage-title">You need cross-platform</div>
+        <p class="advantage-desc">WisprFlow runs on Mac, Windows, iPhone, and Android with settings synced across devices. EnviousWispr is macOS only right now.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🎨</div>
+        <div class="advantage-title">You want more features today</div>
+        <p class="advantage-desc">WisprFlow has a broader feature set: voice command mode for editing, snippet shortcuts, per-app tone adjustment, whisper mode, backtrack correction, and team collaboration tools. EnviousWispr is catching up, but WisprFlow is ahead on features right now.</p>
+      </div>
+      <div class="advantage-card reveal">
+        <div class="advantage-icon">🏢</div>
+        <div class="advantage-title">You need enterprise compliance</div>
+        <p class="advantage-desc">WisprFlow offers SOC 2 Type II, ISO 27001, enforced HIPAA compliance, SSO/SAML, and team admin controls. EnviousWispr is built for individual privacy, not enterprise compliance workflows.</p>
+      </div>
+    </div>
+    <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you are Mac-first and care most about privacy, offline transcription, and price, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="section" aria-label="Frequently Asked Questions">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">FAQ</div>
+      <h2 class="section-title">Common questions</h2>
+    </div>
+    <div class="faq-list">
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr really free?</div>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr work offline?</div>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Will my audio be used for training?</div>
+        <p class="faq-a">No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I switch from WisprFlow easily?</div>
+        <p class="faq-a">Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">2-minute getting started guide</a>.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What Mac do I need?</div>
+        <p class="faq-a">Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr use the cloud at all?</div>
+        <p class="faq-a">Transcription is always on-device. If you choose to enable AI polish with a cloud provider (OpenAI, Gemini), only the text transcript is sent using your own API key. You can also polish with a local model for fully offline operation. The choice is yours.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is there a free alternative to WisprFlow?</div>
+        <p class="faq-a">Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It works offline and keeps your audio on your device.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Is EnviousWispr open source?</div>
+        <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr clip the first word like other dictation apps?</div>
+        <p class="faq-a">No. EnviousWispr uses a continuous pre-roll audio buffer that captures the 500 milliseconds before you press the hotkey. Even if you start speaking the instant you press the key, the first word is captured. This is a hardware-level solution, not a software workaround.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What happens to my clipboard when EnviousWispr pastes text?</div>
+        <p class="faq-a">Nothing. EnviousWispr saves your clipboard contents before pasting and restores them after. Whatever you had copied before dictating is still there when it finishes. It also detects third-party clipboard managers and avoids interfering with them.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I add custom words for names, brands, or jargon?</div>
+        <p class="faq-a">Yes. EnviousWispr has a custom vocabulary system with fuzzy matching that catches pronunciation variants. You can add words with aliases, and on macOS 26+, Apple Intelligence can automatically suggest how the speech engine might mishear your terms. The vocabulary is also fed into the AI polish prompt for double-layer correction.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs whisper.cpp</a>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Ready to try private dictation?</h2>
+    <p class="reveal">Free to download. No account required. No cloud transcription.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="compare">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download Free
+      </a>
+      <a href="/" class="back-link">Back to Home</a>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>


### PR DESCRIPTION
## Summary
- 11 comparison pages (WisprFlow, SuperWhisper, Dragon, Apple Dictation, Otter.ai, MacWhisper, VoiceInk, Willow Voice, Google Docs Voice Typing, Notta, whisper-cpp)
- New `/compare/` hub page grouping all comparisons
- Each page: 18-24 row feature table, 2 deep-dive sections, honest positioning, FAQ
- Full SEO: Article + FAQPage JSON-LD, og:type article, trimmed titles/descriptions, cross-linking

## Test plan
- [ ] Verify build passes (41 pages)
- [ ] Spot-check 2-3 pages for correct competitor data
- [ ] Verify /compare/ index page renders correctly
- [ ] Check structured data with Google Rich Results Test
