### PR TITLE
fix(website): SEO audit fixes for indexing

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -34,6 +34,7 @@ const BLOG_POST_DATES = (() => {
 export default defineConfig({
   site: 'https://enviouswispr.com',
   output: 'static',
+  trailingSlash: 'always',
   integrations: [
     sitemap({
       serialize(item) {

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -29,6 +29,7 @@ const year = new Date().getFullYear();
         <nav class="footer-links" aria-label="Footer Navigation">
           <a href="/#features">Features</a>
           <a href="/how-it-works/">How It Works</a>
+          <a href="/compare/">Compare</a>
           <a href="/blog/">Blog</a>
           <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg">Download</a>
         </nav>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -40,6 +40,7 @@ const { activePage = 'home' } = Astro.props;
     </a>
     <ul class="nav-links" id="navLinks" role="list">
       <li><a href="/how-it-works/" class:list={[{ active: activePage === 'how-it-works' }]}>How It Works</a></li>
+      <li><a href="/compare/" class:list={[{ active: activePage === 'compare' }]}>Compare</a></li>
       <li><a href="/blog/">Blog</a></li>
       <li class="nav-gh-mobile"><a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true" style="vertical-align:middle;"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -139,4 +139,6 @@ Now that you're set up, explore what EnviousWispr can do for your specific workf
 
 That's the full EnviousWispr tutorial — from install to your first dictation in under two minutes, with optional customization whenever you're ready for it. Free and open source — just download and go. A hotkey, your voice, and polished text in whatever app you're working in.
 
-[Download EnviousWispr free](/#download) and start dictating — or grab it directly from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases).
+[Download EnviousWispr free](/#download) and start dictating, or grab it directly from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases).
+
+*Switching from another tool? See how EnviousWispr compares: [vs WisprFlow](/compare/wisprflow/), [vs Superwhisper](/compare/superwhisper/), [vs Apple Dictation](/compare/apple-dictation/), or [browse all comparisons](/compare/).*

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -168,4 +168,6 @@ For people who rely on voice input as their primary way of writing, those aren't
 - [On-Device vs Cloud Dictation: What Stays Private](/blog/on-device-vs-cloud-dictation-privacy/) — a detailed comparison of where your recordings go with different tools
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/) — from download to first dictation
 
-If you want to try it, [download EnviousWispr free](/#download) and start dictating — or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Skip the sign-up form -- there isn't one. Just the app and your voice, with no audio leaving your Mac.
+If you want to try it, [download EnviousWispr free](/#download) and start dictating, or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Skip the sign-up form. There isn't one. Just the app and your voice, with no audio leaving your Mac.
+
+*See how EnviousWispr compares to built-in options: [vs Apple Dictation](/compare/apple-dictation/), [vs Google Docs Voice Typing](/compare/google-docs-voice-typing/), or [browse all comparisons](/compare/).*

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -150,3 +150,7 @@ It depends on the provider. Some delete audio immediately after transcription. O
 ### Can I use on-device dictation on older Macs?
 
 On-device transcription with modern Whisper models works best on Apple Silicon (M1 and later). Older Intel Macs can run smaller models but with slower performance and reduced accuracy. For the best experience, an M-series Mac is recommended.
+
+---
+
+*Curious how specific tools compare? See our side-by-side breakdowns: [EnviousWispr vs WisprFlow](/compare/wisprflow/), [vs Apple Dictation](/compare/apple-dictation/), or [browse all comparisons](/compare/).*

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -57,8 +57,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   <meta name="twitter:image" content={ogImageUrl} />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="theme-color" content="#f8f5ff" />
-  <!-- Google Search Console verification (replace content value after GSC setup) -->
-  <!-- <meta name="google-site-verification" content="VERIFICATION_CODE_HERE" /> -->
+  <link rel="alternate" type="application/rss+xml" title="EnviousWispr Blog" href="/rss.xml" />
   <slot name="head" />
   <!-- PostHog Analytics -->
   <script>

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -5,7 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout
   title="Page Not Found — EnviousWispr"
   description="This page doesn't exist. Head back to EnviousWispr to download the app or read the blog."
-  canonicalPath="/404/"
   noindex
 >
 

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -8,6 +8,27 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))].sort();
 
 const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+const siteUrl = 'https://enviouswispr.com';
+
+const collectionJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "EnviousWispr Blog",
+  "description": "Product updates, release notes, and deep dives on private AI dictation, on-device speech recognition, and fast Mac productivity tools.",
+  "url": `${siteUrl}/blog/`,
+  "isPartOf": { "@type": "WebSite", "url": siteUrl, "name": "EnviousWispr" },
+  "publisher": { "@type": "Organization", "name": "Envious Labs", "url": siteUrl },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": `${siteUrl}/blog/` },
+  ],
+});
 ---
 
 <BaseLayout
@@ -15,6 +36,10 @@ const formatDate = (d: Date) =>
   description="The EnviousWispr blog: product updates, release notes, and deep dives on private AI dictation, on-device speech recognition, and fast Mac productivity tools."
   activePage="blog"
 >
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={collectionJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
   <section class="blog-page">
     <div class="container">
 

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Apple Dictation",
       "item": `${siteUrl}/compare/apple-dictation/`,
     },

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Dragon",
       "item": `${siteUrl}/compare/dragon/`,
     },

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -59,6 +59,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Google Docs Voice Typing",
       "item": `${siteUrl}/compare/google-docs-voice-typing/`,
     },

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs MacWhisper",
       "item": `${siteUrl}/compare/macwhisper/`,
     },

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Notta",
       "item": `${siteUrl}/compare/notta/`,
     },

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Otter.ai",
       "item": `${siteUrl}/compare/otter-ai/`,
     },

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Superwhisper",
       "item": `${siteUrl}/compare/superwhisper/`,
     },

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -41,6 +41,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs VoiceInk",
       "item": `${siteUrl}/compare/voiceink/`,
     },

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -58,6 +58,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs whisper.cpp",
       "item": `${siteUrl}/compare/whisper-cpp/`,
     },

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -59,6 +59,12 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs Willow Voice",
       "item": `${siteUrl}/compare/willow-voice/`,
     },

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -41,10 +41,111 @@ const breadcrumbJsonLd = JSON.stringify({
     {
       "@type": "ListItem",
       "position": 2,
+      "name": "Comparisons",
+      "item": `${siteUrl}/compare/`,
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
       "name": "EnviousWispr vs WisprFlow",
       "item": `${siteUrl}/compare/wisprflow/`,
     },
   ],
+});
+
+const faqJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on GitHub under a BSL 1.1 license."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr work offline?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription runs entirely on-device and works without internet. AI polish requires an LLM; you can use a local model for fully offline operation or bring your own API key for a cloud provider."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will my audio be used for training?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Your audio is processed on your Mac and discarded after transcription. It never leaves your device, so it cannot be used for anything else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I switch from WisprFlow easily?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download EnviousWispr, set your hotkey, and start dictating. There is no data to migrate. Both apps work in any text field on macOS."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Mac do I need?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or newer. The Neural Engine on Apple Silicon is what makes on-device transcription fast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr use the cloud at all?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transcription is always on-device. If you choose to enable AI polish with a cloud provider (OpenAI, Gemini), only the text transcript is sent using your own API key. You can also polish with a local model for fully offline operation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free alternative to WisprFlow?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr offers on-device transcription on Apple Silicon Macs, completely free, with no account or subscription required. It works offline and keeps your audio on your device."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is EnviousWispr open source?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does EnviousWispr clip the first word like other dictation apps?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. EnviousWispr uses a continuous pre-roll audio buffer that captures the 500 milliseconds before you press the hotkey. Even if you start speaking the instant you press the key, the first word is captured."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens to my clipboard when EnviousWispr pastes text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nothing. EnviousWispr saves your clipboard contents before pasting and restores them after. Whatever you had copied before dictating is still there when it finishes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I add custom words for names, brands, or jargon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. EnviousWispr has a custom vocabulary system with fuzzy matching that catches pronunciation variants. You can add words with aliases, and the vocabulary is also fed into the AI polish prompt for double-layer correction."
+      }
+    }
+  ]
 });
 
 ---
@@ -54,10 +155,12 @@ const breadcrumbJsonLd = JSON.stringify({
   description="Compare EnviousWispr vs WisprFlow on price, privacy, offline support, and speed. Free on-device dictation for Apple Silicon Macs. No account required."
   activePage="compare"
   canonicalPath="/compare/wisprflow/"
+  ogType="article"
 >
   <Fragment slot="head">
     <script type="application/ld+json" set:html={articleJsonLd}></script>
     <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={faqJsonLd}></script>
   </Fragment>
 
 <style>
@@ -189,6 +292,32 @@ const breadcrumbJsonLd = JSON.stringify({
 .speed-label { font-size: 14px; color: var(--text-2); font-weight: 500; }
 .speed-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
 
+/* ── Deep Dive ── */
+.deep-dive-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+.deep-dive-card {
+  background: #fff; border: 1px solid var(--border-hover);
+  border-radius: var(--radius-card); padding: 36px 32px;
+  position: relative; overflow: hidden;
+}
+.deep-dive-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--rainbow-full);
+}
+.deep-dive-icon { font-size: 32px; margin-bottom: 16px; line-height: 1; }
+.deep-dive-title { font-size: 22px; font-weight: 800; letter-spacing: -0.8px; margin-bottom: 12px; color: var(--text); }
+.deep-dive-body { font-size: 15px; color: var(--text-2); line-height: 1.7; }
+.deep-dive-body p { margin-bottom: 12px; }
+.deep-dive-body p:last-child { margin-bottom: 0; }
+.deep-dive-detail {
+  margin-top: 16px; padding: 14px 18px; border-radius: 10px;
+  background: rgba(124,58,237,0.04); border: 1px solid rgba(124,58,237,0.08);
+  font-size: 13px; color: var(--text-2); line-height: 1.6;
+}
+.deep-dive-detail strong { color: var(--text); }
+@media (max-width: 900px) {
+  .deep-dive-grid { grid-template-columns: 1fr; }
+}
+
 /* ── FAQ ── */
 .faq-list { max-width: 720px; margin: 0 auto; }
 .faq-item {
@@ -274,21 +403,22 @@ const breadcrumbJsonLd = JSON.stringify({
             <th>WisprFlow</th>
           </tr>
         </thead>
-        <!-- Evidence: WisprFlow claims verified against wisprflow.com on 2026-04-03.
-             Confidence: source-verified from public website and App Store listing.
+        <!-- Evidence: WisprFlow claims verified against wisprflow.ai on 2026-04-04.
+             Confidence: source-verified from public website pages.
              Sources:
-               - Pricing: wisprflow.com/pricing (accessed 2026-04-03) — $14.99/mo billed monthly
-               - Account: wisprflow.com signup flow requires email (accessed 2026-04-03)
-               - Cloud processing: wisprflow.com/privacy — audio sent to cloud for transcription (accessed 2026-04-03)
-               - iOS app: Apple App Store listing (accessed 2026-04-03)
-               - Multi-language: wisprflow.com feature page (accessed 2026-04-03)
+               - Pricing: wisprflow.ai/pricing (accessed 2026-04-04) — Free basic (2,000 words/week), Pro $15/mo monthly or $12/mo annual
+               - Account: wisprflow.ai signup flow requires email (accessed 2026-04-04)
+               - Cloud processing: wisprflow.ai/privacy — "Transcription always happens in the cloud" (accessed 2026-04-04)
+               - Features: wisprflow.ai/features (accessed 2026-04-04) — dictionary, snippets, tones, filler removal, backtrack, auto-punctuation, whisper mode, 100+ languages, syntax awareness
+               - Accessibility: wisprflow.ai/accessibility (accessed 2026-04-04) — hands-free dictation focus
+               - Platforms: Mac, Windows, iPhone, Android (accessed 2026-04-04)
              Firsthand testing: WisprFlow was not tested firsthand for this comparison.
              All claims are source-verified from official pages. -->
         <tbody>
           <tr>
             <td>Price</td>
-            <td><span class="table-highlight">Free to use. No subscription.</span></td>
-            <td>~$15/mo subscription*</td>
+            <td><span class="table-highlight">Free. No limits, no subscription.</span></td>
+            <td>Free tier (2,000 words/week); Pro $12-15/mo for unlimited*</td>
           </tr>
           <tr>
             <td>Account required</td>
@@ -306,14 +436,9 @@ const breadcrumbJsonLd = JSON.stringify({
             <td>Yes, audio uploaded for transcription</td>
           </tr>
           <tr>
-            <td>Works offline</td>
-            <td><span class="table-check">Yes</span> for transcription (after models download)</td>
-            <td><span class="table-cross">No</span></td>
-          </tr>
-          <tr>
-            <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
-            <td>Cloud LLM (provider-managed)</td>
+            <td>Offline AI polish</td>
+            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via Apple Intelligence or Ollama. Cloud options (OpenAI, Gemini) available with your own key.</td>
+            <td><span class="table-cross">No.</span> Requires internet for both transcription and AI editing.</td>
           </tr>
           <tr>
             <td>Speech engines</td>
@@ -323,7 +448,12 @@ const breadcrumbJsonLd = JSON.stringify({
           <tr>
             <td>Multi-language</td>
             <td>English (Parakeet), 90+ via WhisperKit</td>
-            <td>Multi-language</td>
+            <td>100+ languages with auto-detection</td>
+          </tr>
+          <tr>
+            <td>Platforms</td>
+            <td>macOS only today</td>
+            <td>Mac, Windows, iPhone, Android</td>
           </tr>
           <tr>
             <td>Source code</td>
@@ -331,19 +461,79 @@ const breadcrumbJsonLd = JSON.stringify({
             <td>Closed source</td>
           </tr>
           <tr>
-            <td>iOS app</td>
-            <td>macOS only today</td>
-            <td>Available</td>
-          </tr>
-          <tr>
             <td>Transcription latency</td>
             <td><span class="table-highlight">0.43s median</span>; ~1.5s with AI polish</td>
             <td>Depends on network + server load</td>
           </tr>
+          <tr>
+            <td>Custom vocabulary</td>
+            <td>Add names, brands, jargon with fuzzy matching that catches pronunciation variants.</td>
+            <td>Personal dictionary; auto-learns from corrections. Shared dictionary for teams.</td>
+          </tr>
+          <tr>
+            <td>Filler word removal</td>
+            <td><span class="table-check">Yes</span></td>
+            <td><span class="table-check">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Writing style control</td>
+            <td>Four presets (Standard, Formal, Friendly, Custom) or write your own system prompt.</td>
+            <td>Auto-adjusts tone per app (English, desktop only).</td>
+          </tr>
+          <tr>
+            <td>Snippets / shortcuts</td>
+            <td><span class="table-cross">Not yet</span></td>
+            <td><span class="table-check">Yes.</span> Voice-triggered text shortcuts with shared snippets for teams.</td>
+          </tr>
+          <tr>
+            <td>Command mode</td>
+            <td><span class="table-cross">Not yet</span></td>
+            <td><span class="table-check">Yes</span> (Pro only). Edit and rewrite with voice commands.</td>
+          </tr>
+          <tr>
+            <td>First-word capture</td>
+            <td><span class="table-check">Never clips.</span> A 500ms pre-roll buffer captures audio before recording officially starts.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Starts listening instantly</td>
+            <td><span class="table-check">Yes.</span> Engine pre-warms on key-down, hiding cold-start and Bluetooth latency.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Clipboard preservation</td>
+            <td><span class="table-check">Yes.</span> Saves and restores your clipboard after every paste.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Text lands in the right app</td>
+            <td><span class="table-check">Yes.</span> Remembers which app and text field were focused, re-activates before pasting.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>AI hallucination safeguards</td>
+            <td><span class="table-check">Yes.</span> Three-layer defense: short-transcript bypass, reinforcement, output validation.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Hands-free dictation</td>
+            <td><span class="table-check">Yes.</span> Double-press to lock recording. Triple-press to cancel.</td>
+            <td>Accessibility-focused hands-free support</td>
+          </tr>
+          <tr>
+            <td>Auto-stop on silence</td>
+            <td><span class="table-check">Yes.</span> Neural voice activity detection stops recording when you finish speaking.</td>
+            <td>Not specified</td>
+          </tr>
+          <tr>
+            <td>Accessibility</td>
+            <td>VoiceOver announcements for recording state changes.</td>
+            <td>Dedicated accessibility page; hands-free focus for mobility/pain/vision challenges.</td>
+          </tr>
         </tbody>
       </table>
     </div>
-    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on WisprFlow's public pricing page as of April 2026. EnviousWispr latency from production PostHog data on Apple Silicon Macs. WisprFlow claims source-verified from wisprflow.com; not firsthand-tested. Competitor claims last verified: 2026-04-03.</p>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*WisprFlow pricing and features verified from wisprflow.ai/pricing and wisprflow.ai/features as of April 2026. Pro is $15/mo billed monthly or $12/mo billed annually. EnviousWispr latency from production PostHog data on Apple Silicon Macs. WisprFlow was not firsthand-tested. "Not specified" means the feature is not documented on WisprFlow's public pages. Competitor claims last verified: 2026-04-04.</p>
     <div style="text-align: center; margin-top: 28px;">
       <a href="/#download" class="btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -482,6 +672,43 @@ const breadcrumbJsonLd = JSON.stringify({
   </div>
 </section>
 
+<!-- Deep Dives -->
+<section class="section" aria-label="Under the Hood">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill">Under the Hood</div>
+      <h2 class="section-title">The details that make dictation reliable</h2>
+      <p class="section-sub">Cloud dictation tools outsource the hard problems to servers. EnviousWispr solves them locally, and the result is a more dependable workflow.</p>
+    </div>
+    <div class="deep-dive-grid">
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🎯</div>
+        <div class="deep-dive-title">Your text always lands where it should</div>
+        <div class="deep-dive-body">
+          <p>Cloud dictation has a timing problem. While your audio uploads, transcribes, and returns, you might switch apps, click a different field, or start reading something else. When the text finally arrives, it can paste into the wrong place or overwrite your clipboard.</p>
+          <p>EnviousWispr captures which app and which text field had focus when you started recording. After transcription, it re-activates that exact app and inserts text directly via the Accessibility API. If direct insertion fails, it falls back to simulated Cmd+V, then to AppleScript. Your clipboard is saved before the operation and restored after.</p>
+          <p>The result: text goes where you intended, every time, without trashing what you had copied.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Three-tier paste system (AX direct insertion, CGEvent Cmd+V, AppleScript fallback) with full clipboard snapshot and restoration. Target app reactivation uses Accessibility API force-activation to bypass macOS background process restrictions.
+          </div>
+        </div>
+      </div>
+      <div class="deep-dive-card reveal">
+        <div class="deep-dive-icon">🛡️</div>
+        <div class="deep-dive-title">AI polish that does not fabricate</div>
+        <div class="deep-dive-body">
+          <p>When you run speech through an LLM for cleanup, there is a real risk: the AI can hallucinate extra sentences, "answer" your dictation as if it were a question, or inject preamble like "Certainly! Here is the corrected text." These are not theoretical problems. They happen with basic LLM integrations.</p>
+          <p>EnviousWispr uses three layers of defense. Short transcripts (three words or fewer) bypass the LLM entirely because there is nothing to polish. Medium transcripts get aggressive prompt reinforcement to prevent creative expansion. All output is validated: if the response is more than three times longer than the input, it is rejected as probable hallucination and the raw transcript is used instead.</p>
+          <p>The LLM prompt itself is context-aware. It tells the model it is processing speech-to-text output, gives examples of phonetic misrecognition patterns, and adjusts for the app you were dictating into. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or execute.</p>
+          <div class="deep-dive-detail">
+            <strong>How it works:</strong> Sandwich framing wraps transcript in &lt;transcript&gt; tags to prevent prompt injection. Preamble stripping removes "Certainly!" artifacts. Context-aware prompts include detected language, ASR error patterns, and target app name. Output length validation rejects fabricated responses.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- Fair Acknowledgment -->
 <section class="section" aria-label="Where WisprFlow Wins">
   <div class="container">
@@ -493,18 +720,18 @@ const breadcrumbJsonLd = JSON.stringify({
     <div class="advantages-grid">
       <div class="advantage-card reveal">
         <div class="advantage-icon">📱</div>
-        <div class="advantage-title">You need iPhone dictation</div>
-        <p class="advantage-desc">WisprFlow has a shipping iOS app. EnviousWispr is macOS only right now.</p>
+        <div class="advantage-title">You need cross-platform</div>
+        <p class="advantage-desc">WisprFlow runs on Mac, Windows, iPhone, and Android with settings synced across devices. EnviousWispr is macOS only right now.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎨</div>
-        <div class="advantage-title">You want a mature cloud workflow out of the box</div>
-        <p class="advantage-desc">WisprFlow has been shipping longer with a more refined onboarding experience and managed cloud infrastructure. EnviousWispr prioritizes speed and privacy.</p>
+        <div class="advantage-title">You want more features today</div>
+        <p class="advantage-desc">WisprFlow has a broader feature set: voice command mode for editing, snippet shortcuts, per-app tone adjustment, whisper mode, backtrack correction, and team collaboration tools. EnviousWispr is catching up, but WisprFlow is ahead on features right now.</p>
       </div>
       <div class="advantage-card reveal">
-        <div class="advantage-icon">📅</div>
-        <div class="advantage-title">You want a longer track record</div>
-        <p class="advantage-desc">WisprFlow has been around longer, with more users and more reviews. EnviousWispr is newer and shipping fast.</p>
+        <div class="advantage-icon">🏢</div>
+        <div class="advantage-title">You need enterprise compliance</div>
+        <p class="advantage-desc">WisprFlow offers SOC 2 Type II, ISO 27001, enforced HIPAA compliance, SSO/SAML, and team admin controls. EnviousWispr is built for individual privacy, not enterprise compliance workflows.</p>
       </div>
     </div>
     <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If you are Mac-first and care most about privacy, offline transcription, and price, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>.</p>
@@ -551,6 +778,37 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="faq-q">Is EnviousWispr open source?</div>
         <p class="faq-a">Source-available under the Business Source License 1.1. That means you can read, build, and inspect every line of code on GitHub. It is not an OSI-approved open source license, but it gives you full transparency into how the app works. Contributions are welcome.</p>
       </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Does EnviousWispr clip the first word like other dictation apps?</div>
+        <p class="faq-a">No. EnviousWispr uses a continuous pre-roll audio buffer that captures the 500 milliseconds before you press the hotkey. Even if you start speaking the instant you press the key, the first word is captured. This is a hardware-level solution, not a software workaround.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">What happens to my clipboard when EnviousWispr pastes text?</div>
+        <p class="faq-a">Nothing. EnviousWispr saves your clipboard contents before pasting and restores them after. Whatever you had copied before dictating is still there when it finishes. It also detects third-party clipboard managers and avoids interfering with them.</p>
+      </div>
+      <div class="faq-item reveal">
+        <div class="faq-q">Can I add custom words for names, brands, or jargon?</div>
+        <p class="faq-a">Yes. EnviousWispr has a custom vocabulary system with fuzzy matching that catches pronunciation variants. You can add words with aliases, and on macOS 26+, Apple Intelligence can automatically suggest how the speech engine might mishear your terms. The vocabulary is also fed into the AI polish prompt for double-layer correction.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Related Comparisons -->
+<section class="section" aria-label="Related Comparisons" style="padding-top: 0;">
+  <div class="container">
+    <p style="font-size: 14px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px;">Compare with other tools</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+      <a href="/compare/superwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Superwhisper</a>
+      <a href="/compare/dragon/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Dragon</a>
+      <a href="/compare/apple-dictation/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Apple Dictation</a>
+      <a href="/compare/otter-ai/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Otter.ai</a>
+      <a href="/compare/macwhisper/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs MacWhisper</a>
+      <a href="/compare/voiceink/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs VoiceInk</a>
+      <a href="/compare/willow-voice/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Willow Voice</a>
+      <a href="/compare/google-docs-voice-typing/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Google Docs</a>
+      <a href="/compare/notta/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs Notta</a>
+      <a href="/compare/whisper-cpp/" style="padding: 8px 16px; border-radius: 100px; font-size: 13px; font-weight: 600; color: var(--text-2); border: 1px solid var(--border-hover); text-decoration: none; transition: all 0.2s;">vs whisper.cpp</a>
     </div>
   </div>
 </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -13,7 +13,7 @@ const jsonLd = JSON.stringify({
   "description": "Private AI dictation for macOS. On-device speech-to-text with AI polish. Your voice never leaves your Mac.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "downloadUrl": "https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg",
-  "softwareVersion": "1.5.4",
+  "softwareVersion": "1.8.0",
   "author": { "@type": "Organization", "name": "Envious Labs" },
   "url": "https://enviouswispr.com/"
 });
@@ -663,6 +663,30 @@ const jsonLdFaq = JSON.stringify({
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════
+       Compare Section
+       ═══════════════════════════════════════════════════════ -->
+  <section class="section" id="compare" aria-labelledby="compare-heading">
+    <div class="container">
+      <div class="section-head reveal">
+        <div class="section-label-pill">Honest Comparisons</div>
+        <h2 class="section-title" id="compare-heading">See how we stack up</h2>
+        <p class="section-sub">Side-by-side comparisons with every major dictation tool. We show where we win and where competitors are ahead.</p>
+      </div>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;justify-content:center;" class="reveal">
+        <a href="/compare/wisprflow/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs WisprFlow</a>
+        <a href="/compare/superwhisper/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs Superwhisper</a>
+        <a href="/compare/dragon/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs Dragon</a>
+        <a href="/compare/apple-dictation/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs Apple Dictation</a>
+        <a href="/compare/otter-ai/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs Otter.ai</a>
+        <a href="/compare/macwhisper/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs MacWhisper</a>
+      </div>
+      <div style="text-align:center;margin-top:20px;" class="reveal">
+        <a href="/compare/" style="font-size:14px;font-weight:600;color:var(--accent);text-decoration:none;">View all comparisons &rarr;</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Add "Compare" to nav and footer (compare pages were completely orphaned)
- Add compare section on homepage linking to top competitors
- Add `trailingSlash: 'always'` to prevent duplicate content
- Fix softwareVersion 1.5.4 -> 1.8.0 in homepage schema
- 3-level breadcrumbs on all 11 compare pages (Home > Comparisons > vs X)
- CollectionPage + BreadcrumbList schema on blog index
- RSS autodiscovery link in head
- Remove canonical from 404 page
- Blog posts cross-link to compare pages (3 posts updated)
- WisprFlow page with full SEO updates

## Test plan
- [ ] Verify Compare link appears in nav and footer
- [ ] Verify homepage has compare section
- [ ] Verify blog index has CollectionPage JSON-LD
- [ ] Verify breadcrumbs show 3 levels on compare pages
- [ ] Build passes (41 pages)
