### PR TITLE
chore: remove unused imports and redundant public modifiers

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import EnviousWisprCore
 import EnviousWisprStorage
-import EnviousWisprPostProcessing
 import EnviousWisprAudio
 import EnviousWisprServices
 import EnviousWisprASR

--- a/Sources/EnviousWispr/App/MenuBarIconAnimator.swift
+++ b/Sources/EnviousWispr/App/MenuBarIconAnimator.swift
@@ -1,5 +1,4 @@
 import AppKit
-import EnviousWisprCore
 
 /// Manages animated menu bar icon states using Core Graphics rendering.
 ///

--- a/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
+++ b/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 /// Compact amber banner shown when Accessibility permission is missing.
 ///

--- a/Sources/EnviousWispr/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWispr/Views/Components/HotkeyRecorderView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 import EnviousWisprServices
 import AppKit
 

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingDesignTokens.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingDesignTokens.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 // MARK: - Onboarding Color Palette
 

--- a/Sources/EnviousWispr/Views/Onboarding/RainbowLipsView.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/RainbowLipsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 // MARK: - LipsAnimationState
 

--- a/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 /// Clipboard behavior settings.
 struct ClipboardSettingsView: View {

--- a/Sources/EnviousWispr/Views/Settings/PermissionsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/PermissionsSettingsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 /// Microphone and Accessibility permission status.
 struct PermissionsSettingsView: View {

--- a/Sources/EnviousWispr/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsComponents.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 // MARK: - Settings Content Container
 

--- a/Sources/EnviousWispr/Views/Settings/SettingsDesignTokens.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsDesignTokens.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 // MARK: - Settings Color Palette
 

--- a/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 /// Sidebar navigation sections for the unified window.
 enum SettingsSection: String, CaseIterable, Identifiable {

--- a/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import EnviousWisprCore
 
 /// Global hotkey configuration.
 struct ShortcutsSettingsView: View {

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -60,13 +60,13 @@ public extension ASRBackend {
 }
 
 /// Errors that can occur during ASR operations.
-public enum ASRError: LocalizedError, Sendable {
+enum ASRError: LocalizedError, Sendable {
     case notReady
     case streamingNotSupported
     case streamingTimeout
     case transcriptionFailed(String)
 
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .notReady: return "ASR backend is not ready. Call prepare() first."
         case .streamingNotSupported: return "This ASR backend does not support streaming transcription."

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -16,10 +16,10 @@ import CryptoKit
 /// 3. If stalled or failed, fall back to Cloudflare R2 direct download
 /// 4. Verify SHA-256 checksum of key model files
 /// 5. Load models via FluidAudio's compile path
-public actor ModelDownloadManager {
+actor ModelDownloadManager {
 
     /// Progress callback: (fractionCompleted, phaseString, detailString)
-    public typealias ProgressCallback = @Sendable (Double, String, String) -> Void
+    typealias ProgressCallback = @Sendable (Double, String, String) -> Void
 
     // MARK: - Configuration
 
@@ -43,13 +43,13 @@ public actor ModelDownloadManager {
         return appSupport.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
     }()
 
-    public init() {}
+    init() {}
 
     // MARK: - Public API
 
     /// Download and load Parakeet v3 models with stall detection and optional R2 fallback.
     /// Returns loaded AsrModels ready for transcription.
-    public func downloadAndLoad(progressCallback: ProgressCallback?) async throws -> AsrModels {
+    func downloadAndLoad(progressCallback: ProgressCallback?) async throws -> AsrModels {
         let stallTracker = StallTracker(timeout: Self.stallTimeout)
 
         do {
@@ -201,7 +201,7 @@ public actor ModelDownloadManager {
     /// Logs a warning if verification fails but does NOT block — the model may still work.
     /// This is a defense-in-depth measure, not a hard gate.
     /// Static because it only reads from disk — no actor state needed.
-    public static func verifyChecksum() {
+    static func verifyChecksum() {
         guard !Self.encoderChecksum.isEmpty else { return }
 
         let encoderModel = Self.modelCacheDir

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -1,5 +1,4 @@
 @preconcurrency import WhisperKit
-import EnviousWisprCore
 import Foundation
 
 /// Free function (nonisolated) that wraps WhisperKit.download() and relays progress

--- a/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
+++ b/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
@@ -1,10 +1,9 @@
 @preconcurrency import AVFoundation
-import EnviousWisprCore
 
 /// Handles audio format conversion and buffer processing.
-public enum AudioBufferProcessor {
+enum AudioBufferProcessor {
     /// Calculate RMS audio level from a buffer (0.0 - 1.0).
-    public static func calculateRMS(_ buffer: AVAudioPCMBuffer) -> Float {
+    static func calculateRMS(_ buffer: AVAudioPCMBuffer) -> Float {
         guard let channelData = buffer.floatChannelData,
               buffer.frameLength > 0 else { return 0 }
 

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -1,5 +1,4 @@
 import CoreAudio
-import EnviousWisprCore
 import Foundation
 
 /// Represents an audio input device discovered via CoreAudio.

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -1,5 +1,4 @@
 import CoreAudio
-import EnviousWisprCore
 
 /// Policy for selecting the audio capture source.
 /// `.automatic` decides based on output route + input intent.

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -62,7 +62,7 @@ public struct SmoothedVADConfig: Sendable {
     }
 }
 
-public enum SmoothedVADPhase: Sendable {
+enum SmoothedVADPhase: Sendable {
     case idle
     case speech
     case hangover(chunksRemaining: Int)

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import EnviousWisprCore
 
 /// Manages API key storage and retrieval using secure file-based storage.
 ///
@@ -127,12 +126,12 @@ public struct KeychainManager: Sendable {
     }
 }
 
-public enum KeyStoreError: LocalizedError, Sendable {
+enum KeyStoreError: LocalizedError, Sendable {
     case storeFailed(OSStatus)
     case retrieveFailed(OSStatus)
     case deleteFailed(OSStatus)
 
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .storeFailed(let s): return "Key store failed: \(s)"
         case .retrieveFailed(let s): return "Key retrieve failed: \(s)"

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -1,15 +1,14 @@
 import Foundation
-import EnviousWisprCore
 
 /// Shared retry infrastructure for LLM connectors.
 /// Centralizes retry-eligibility logic so all connectors use the same rules.
-public enum LLMRetryPolicy {
+enum LLMRetryPolicy {
     /// Default retry delays: 1s, then 3s.
-    public static let defaultDelays: [UInt64] = [1_000_000_000, 3_000_000_000]
-    public static let defaultMaxRetries = 2
+    static let defaultDelays: [UInt64] = [1_000_000_000, 3_000_000_000]
+    static let defaultMaxRetries = 2
 
     /// Determine if an error is transient and worth retrying.
-    public static func isRetryable(_ error: Error) -> Bool {
+    static func isRetryable(_ error: Error) -> Bool {
         if let llmError = error as? LLMError {
             switch llmError {
             case .rateLimited: return true

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import EnviousWisprCore
 import AppKit
 
 /// States in the Ollama guided-setup flow.

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -1,5 +1,4 @@
 import Foundation
-import EnviousWisprCore
 
 /// Events that any dictation pipeline must handle.
 public enum PipelineEvent: Sendable {

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -1,5 +1,4 @@
 import Foundation
-import EnviousWisprCore
 
 /// Context passed through the text processing chain after ASR transcription.
 public struct TextProcessingContext: Sendable {
@@ -32,7 +31,7 @@ public struct TextProcessingContext: Sendable {
 /// Steps run in order after transcription. Each step receives the context
 /// from the previous step and returns a modified context.
 @MainActor
-public protocol TextProcessingStep {
+protocol TextProcessingStep {
     /// Human-readable name for logging.
     var name: String { get }
     /// Whether this step should run. Checked before each invocation.


### PR DESCRIPTION
## Summary
- Remove 21 unused imports across all modules (Periphery-verified)
- Downgrade ~15 redundant public declarations to internal
- Zero functional changes

## Test plan
- [x] swift build passes
- [x] All changes are mechanical removals verified by Periphery static analysis
