### PR TITLE
chore: remove dead code in limb-path modules

### DIFF
--- a/Sources/EnviousWispr/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWispr/App/BenchmarkSuite.swift
@@ -11,22 +11,17 @@ final class BenchmarkSuite {
     struct Result: Identifiable, Sendable {
         let id = UUID()
         let label: String
-        let audioDuration: TimeInterval
         let processingTime: TimeInterval
         /// Real-time factor: how many seconds of audio are processed per second.
         let rtf: Double
-        let backend: ASRBackendType
     }
 
     /// Results from a full pipeline benchmark run.
     struct PipelineBenchmarkResult: Sendable {
         let batchASRTime: TimeInterval
-        let batchTranscript: String
         let streamingFinalizeTime: TimeInterval?
-        let streamingTranscript: String?
         let werDelta: Double?
         let audioDuration: TimeInterval
-        let backend: ASRBackendType
     }
 
     private(set) var results: [Result] = []
@@ -59,7 +54,6 @@ final class BenchmarkSuite {
         }
 
         let durations: [TimeInterval] = [5, 15, 30]
-        let backend = asrManager.activeBackendType
 
         for duration in durations {
             progress = "Testing \(Int(duration))s audio..."
@@ -71,10 +65,8 @@ final class BenchmarkSuite {
 
             results.append(Result(
                 label: "\(Int(duration))s",
-                audioDuration: duration,
                 processingTime: elapsed,
-                rtf: duration / elapsed,
-                backend: backend
+                rtf: duration / elapsed
             ))
         }
 
@@ -92,8 +84,6 @@ final class BenchmarkSuite {
             isRunning = false
             return
         }
-
-        let backend = asrManager.activeBackendType
 
         // Load test audio — try jfk.wav from WhisperKit test resources, fall back to synthetic
         let testAudioDuration: TimeInterval
@@ -185,12 +175,9 @@ final class BenchmarkSuite {
 
         pipelineResult = PipelineBenchmarkResult(
             batchASRTime: batchTime,
-            batchTranscript: batchTranscript,
             streamingFinalizeTime: streamingFinalizeTime,
-            streamingTranscript: streamingTranscript,
             werDelta: werDelta,
-            audioDuration: testAudioDuration,
-            backend: backend
+            audioDuration: testAudioDuration
         )
 
         progress = "Pipeline benchmark complete"

--- a/Sources/EnviousWispr/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWispr/App/CustomWordsCoordinator.swift
@@ -39,13 +39,6 @@ final class CustomWordsCoordinator {
         }
     }
 
-    /// Convenience: remove by canonical string.
-    func remove(canonical: String) {
-        guard let match = customWords.first(where: { $0.canonical == canonical }) else { return }
-        let matchID = match.id
-        remove(id: matchID)
-    }
-
     func update(_ word: CustomWord) {
         do {
             try manager.update(word: word, in: &customWords)

--- a/Sources/EnviousWispr/App/MenuBarIconAnimator.swift
+++ b/Sources/EnviousWispr/App/MenuBarIconAnimator.swift
@@ -30,7 +30,7 @@ final class MenuBarIconAnimator {
     // MARK: - Configuration
 
     /// Call once from setupStatusItem() after creating the button.
-    func configure(button: NSStatusBarButton, idleImage: NSImage? = nil) {
+    func configure(button: NSStatusBarButton) {
         self.button = button
         self.idleImage = renderIdleLips()
         self.errorImage = renderErrorLips()

--- a/Sources/EnviousWispr/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWispr/App/TranscriptCoordinator.swift
@@ -22,12 +22,6 @@ final class TranscriptCoordinator {
 
     var transcriptCount: Int { transcripts.count }
 
-    var averageProcessingSpeed: Double {
-        let withTimes = transcripts.filter { $0.processingTime > 0 }
-        guard !withTimes.isEmpty else { return 0 }
-        return withTimes.map(\.processingTime).reduce(0, +) / Double(withTimes.count)
-    }
-
     init(store: TranscriptStore) {
         self.store = store
     }

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -100,7 +100,7 @@ final class OnboardingV2ViewModel {
 
         checklistStatuses[0] = .inProgress
         preventSleep()
-        startProgressPolling(asrManager: asrManager)
+        startProgressPolling()
         do {
             try await asrManager.loadModel()
             stopProgressPolling()
@@ -155,7 +155,7 @@ final class OnboardingV2ViewModel {
     /// Start polling the shared progress file at ~8 Hz.
     /// The XPC ASR service writes progress to a temp file; we read it here.
     /// This bypasses all XPC serialization issues.
-    func startProgressPolling(asrManager: any ASRManagerInterface) {
+    func startProgressPolling() {
         stopProgressPolling()
         let progressFile = ProgressFile.shared
         let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
@@ -285,7 +285,7 @@ struct OnboardingV2View: View {
                 SettingUpScreenV2(viewModel: viewModel)
                     .transition(Self.screenTransition)
             case .ready:
-                ReadyScreenV2(viewModel: viewModel, onComplete: {
+                ReadyScreenV2(onComplete: {
                     viewModel.finishOnboarding(settings: appState.settings)
                     onComplete()
                 })
@@ -799,7 +799,6 @@ private struct PermissionRow: View {
 // MARK: - Screen 3: Ready
 
 private struct ReadyScreenV2: View {
-    var viewModel: OnboardingV2ViewModel
     @Environment(AppState.self) private var appState
     let onComplete: () -> Void
 

--- a/Sources/EnviousWisprCore/AppSettings.swift
+++ b/Sources/EnviousWisprCore/AppSettings.swift
@@ -32,18 +32,6 @@ public enum PipelineState: Equatable, Sendable {
         }
     }
 
-    public var statusText: String {
-        switch self {
-        case .idle: return "Ready"
-        case .loadingModel: return "Loading model..."
-        case .recording: return "Recording..."
-        case .transcribing: return "Transcribing..."
-        case .polishing: return "Polishing..."
-        case .complete: return "Done"
-        case .error(let msg): return "Error: \(msg)"
-        }
-    }
-
 }
 
 /// Policy controlling when idle ASR models are unloaded from memory.

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -19,13 +19,6 @@ public enum AIGateStatus: String, Sendable, Codable {
     case unknown
 }
 
-/// Three-state value for leaf observations that may not be deterministic.
-public enum AITriState: String, Sendable {
-    case yes
-    case no
-    case unknown
-}
-
 /// Explicit, stable failure reasons for Apple Intelligence availability.
 /// Each maps to a specific diagnostic condition — not freeform strings.
 public enum AIFailureReason: String, Sendable, CaseIterable, Codable {

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -32,6 +32,3 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     }
 }
 
-extension Array where Element == CustomWord {
-    public var canonicals: [String] { map(\.canonical) }
-}

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -15,17 +15,6 @@ public protocol TranscriptPolisher: Sendable {
     ) async throws -> LLMResult
 }
 
-public extension TranscriptPolisher {
-    /// Convenience overload without streaming callback — preserves backward compatibility.
-    func polish(
-        text: String,
-        instructions: PolishInstructions,
-        config: LLMProviderConfig
-    ) async throws -> LLMResult {
-        try await polish(text: text, instructions: instructions, config: config, onToken: nil)
-    }
-}
-
 // MARK: - Preamble Stripping
 
 extension String {

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -107,7 +107,7 @@ public final class LLMPolishStep: TextProcessingStep {
         // append custom vocabulary (not full enrichment) to avoid overriding the on-device prompt.
         let enriched: PolishInstructions
         if llmProvider == .appleIntelligence {
-            enriched = appleIntelligenceInstructions(polishInstructions, context: context)
+            enriched = appleIntelligenceInstructions(polishInstructions)
         } else {
             enriched = enrichedInstructions(polishInstructions, context: context)
         }
@@ -340,8 +340,7 @@ public final class LLMPolishStep: TextProcessingStep {
     /// We append compressed enrichment (ASR awareness, tone preservation) and custom
     /// vocabulary. Full cloud-style enrichment is too verbose for the small on-device model.
     private func appleIntelligenceInstructions(
-        _ base: PolishInstructions,
-        context: TextProcessingContext
+        _ base: PolishInstructions
     ) -> PolishInstructions {
         var systemPrompt = base.systemPrompt
 

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -7,22 +7,17 @@ public struct TextProcessingContext: Sendable {
     public var text: String
     /// Optional polished/enhanced version of the text.
     public var polishedText: String?
-    /// The original unmodified ASR output (read-only reference).
-    public let originalASRText: String
     /// Detected language from ASR.
     public let language: String?
     /// LLM provider used for polishing (e.g. "openai", "ollama").
     public var llmProvider: String?
     /// LLM model used for polishing (e.g. "gpt-4o-mini").
     public var llmModel: String?
-    /// Target app bundle ID (e.g. "com.apple.Terminal"). Nil if unknown or re-polish path.
-    public var targetAppBundleID: String?
     /// Target app display name (e.g. "Terminal"). Nil if unknown or re-polish path.
     public var targetAppName: String?
 
-    public init(text: String, originalASRText: String, language: String?) {
+    public init(text: String, language: String?) {
         self.text = text
-        self.originalASRText = originalASRText
         self.language = language
     }
 }

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -603,8 +603,7 @@ public final class TranscriptionPipeline: DictationPipeline {
                     level: .info, category: "Pipeline"
                 ) }
                 lastPolishError = error.localizedDescription
-                context = TextProcessingContext(text: asrText, originalASRText: asrText, language: result.language)
-                context.targetAppBundleID = targetApp?.bundleIdentifier
+                context = TextProcessingContext(text: asrText, language: result.language)
                 context.targetAppName = targetApp?.localizedName
             }
             let polishEnd = CFAbsoluteTimeGetCurrent()
@@ -789,7 +788,6 @@ public final class TranscriptionPipeline: DictationPipeline {
         do {
             var context = TextProcessingContext(
                 text: transcript.text,
-                originalASRText: transcript.text,
                 language: transcript.language
             )
             context = try await llmPolishStep.process(context)
@@ -1158,10 +1156,8 @@ public final class TranscriptionPipeline: DictationPipeline {
     private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
         var context = TextProcessingContext(
             text: asrText,
-            originalASRText: asrText,
             language: language
         )
-        context.targetAppBundleID = targetApp?.bundleIdentifier
         context.targetAppName = targetApp?.localizedName
         Task {
             await AppLogger.shared.log(

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -572,8 +572,7 @@ public final class WhisperKitPipeline: DictationPipeline {
                     }
                 }
                 lastPolishError = error.localizedDescription
-                context = TextProcessingContext(text: asrText, originalASRText: asrText, language: asrLanguage)
-                context.targetAppBundleID = targetApp?.bundleIdentifier
+                context = TextProcessingContext(text: asrText, language: asrLanguage)
                 context.targetAppName = targetApp?.localizedName
             }
             let polishEnd = CFAbsoluteTimeGetCurrent()
@@ -933,10 +932,8 @@ public final class WhisperKitPipeline: DictationPipeline {
     private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
         var context = TextProcessingContext(
             text: asrText,
-            originalASRText: asrText,
             language: language
         )
-        context.targetAppBundleID = targetApp?.bundleIdentifier
         context.targetAppName = targetApp?.localizedName
         for step in textProcessingSteps where step.isEnabled {
             let stepName = step.name

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -112,15 +112,6 @@ public final class CustomWordsManager {
         return mergedWords(file: file)
     }
 
-    public func save(_ words: [CustomWord]) throws {
-        var file = loadFile() ?? CustomWordsFile()
-        let builtinCanonicals = Set(Self.builtinDefaults.map { $0.word.canonical.lowercased() })
-        file.words = words
-            .filter { !builtinCanonicals.contains($0.canonical.lowercased()) }
-            .sorted { $0.canonical.localizedCaseInsensitiveCompare($1.canonical) == .orderedAscending }
-        try saveFile(file)
-    }
-
     public func add(canonical: String, to words: inout [CustomWord]) throws {
         let trimmed = canonical.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -141,25 +132,6 @@ public final class CustomWordsManager {
         }
 
         file.words.append(CustomWord(canonical: trimmed))
-        try saveFile(file)
-        words = mergedWords(file: file)
-    }
-
-    public func add(word: CustomWord, to words: inout [CustomWord]) throws {
-        guard !words.contains(where: { $0.id == word.id }) else { return }
-        var file = loadFile() ?? CustomWordsFile()
-
-        // If this matches a deleted built-in, restore it
-        if let builtin = Self.builtinDefaults.first(where: {
-            $0.word.canonical.lowercased() == word.canonical.lowercased()
-        }) {
-            file.deletedBuiltinIds.removeAll { $0 == builtin.id }
-            try saveFile(file)
-            words = mergedWords(file: file)
-            return
-        }
-
-        file.words.append(word)
         try saveFile(file)
         words = mergedWords(file: file)
     }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -304,13 +304,6 @@ public struct WordCorrector: Sendable {
         return (corrected.joined(separator: " "), replacements)
     }
 
-    // MARK: - Legacy Bridge
-
-    public func correct(_ text: String, against wordList: [String]) -> (corrected: String, replacements: Int) {
-        let words = wordList.map { CustomWord(canonical: $0) }
-        return correct(text, against: words)
-    }
-
     // MARK: - Scoring
 
     public func score(_ candidate: String, against target: String) -> Double {

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -502,9 +502,6 @@ public final class HotkeyService {
         return recordingMode == .pushToTalk ? "Hold \(formatted)" : formatted
     }
 
-    public var cancelHotkeyDescription: String {
-        KeySymbols.formatHotkey(keyCode: cancelKeyCode, modifiers: cancelModifiers)
-    }
 }
 
 // MARK: - Carbon Helpers
@@ -524,7 +521,7 @@ private let hotkeySignature: OSType = {
 /// via RegisterEventHotKey. Modifier-only hotkeys are handled separately via
 /// NSEvent flagsChanged monitors, which work globally regardless of app focus.
 private func carbonHotkeyHandler(
-    _ nextHandler: EventHandlerCallRef?,
+    _: EventHandlerCallRef?,
     _ event: EventRef?,
     _ userData: UnsafeMutableRawPointer?
 ) -> OSStatus {

--- a/Sources/EnviousWisprServices/KeySymbols.swift
+++ b/Sources/EnviousWisprServices/KeySymbols.swift
@@ -140,18 +140,6 @@ public enum KeySymbols {
         format(keyCode: keyCode, modifiers: modifiers)
     }
 
-    /// Returns the single symbol glyph for a modifier key code (e.g. 58 → "⌥").
-    /// Returns nil if the key code is not a modifier key.
-    public static func symbolForModifierKeyCode(_ keyCode: UInt16) -> String? {
-        switch keyCode {
-        case 55, 54: return "⌘"
-        case 58, 61: return "⌥"
-        case 59, 62: return "⌃"
-        case 56, 60: return "⇧"
-        default: return nil
-        }
-    }
-
     /// Format just modifiers for push-to-talk display.
     /// When a keyCode is provided the label distinguishes left vs. right physical keys.
     public static func formatModifierOnly(_ flags: NSEvent.ModifierFlags, keyCode: UInt16? = nil) -> String {

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -58,30 +58,6 @@ public final class TranscriptStore {
         return transcripts
     }
 
-    /// Synchronous load for cases where async isn't suitable.
-    /// Prefer loadAll() async when possible to keep UI responsive.
-    public func loadAllSync() throws -> [Transcript] {
-        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
-
-        let files = try FileManager.default.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: nil
-        )
-
-        let decoder = JSONDecoder()
-        let transcripts = files
-            .filter { $0.pathExtension == "json" }
-            .compactMap { url -> Transcript? in
-                do {
-                    let data = try Data(contentsOf: url)
-                    return try decoder.decode(Transcript.self, from: data)
-                } catch {
-                    return nil
-                }
-            }
-        return transcripts.sorted { $0.createdAt > $1.createdAt }
-    }
-
     /// Delete a transcript by ID.
     public func delete(id: UUID) throws {
         let url = directory.appendingPathComponent("\(id.uuidString).json")


### PR DESCRIPTION
## Summary
- Remove ~25 dead code findings across App shell, LLM, Pipeline, PostProcessing, Services, Storage, Core modules
- Categories: unused functions, assign-only properties, unused parameters
- All limb-path (non-critical) code, zero risk to heart path
- Verified by Periphery static analysis and `swift build`

## Test plan
- [x] `swift build` passes
- [x] All removals verified by Periphery static analysis
- [x] No heart-path modules affected
