### PR TITLE
chore: remove dead code in heart-path modules

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -124,11 +124,6 @@ public final class ASRManager: ASRManagerInterface {
         }
     }
 
-    /// Transcribe audio from a file URL.
-    public func transcribe(audioURL: URL, options: TranscriptionOptions = .default) async throws -> ASRResult {
-        try await activeBackend.transcribe(audioURL: audioURL, options: options)
-    }
-
     /// Transcribe raw audio samples (16kHz mono Float32).
     public func transcribe(audioSamples: [Float], options: TranscriptionOptions = .default) async throws -> ASRResult {
         try await activeBackend.transcribe(audioSamples: audioSamples, options: options)

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -10,10 +10,11 @@ public protocol ASRManagerInterface: AnyObject {
     // Observable state
     var activeBackendType: ASRBackendType { get }
     var isModelLoaded: Bool { get }
-    var isStreaming: Bool { get }
+    var isStreaming: Bool { get } // periphery:ignore - read via existential type (ASRManagerProxy)
 
     // Download progress (0.0–1.0), phase description, and detail string.
     // Updated during loadModel() when model download is in progress.
+    // periphery:ignore:all - read via existential type in OnboardingV2View progress polling
     var downloadProgress: Double { get }
     var downloadPhase: String { get }
     var downloadDetail: String { get }
@@ -21,7 +22,7 @@ public protocol ASRManagerInterface: AnyObject {
     // Model lifecycle
     func loadModel() async throws
     func loadModelSilently() async
-    func unloadModel() async
+    func unloadModel() async // periphery:ignore - called via existential type (ASRManager idle timer)
     func setInitialBackendType(_ type: ASRBackendType)
     func switchBackend(to type: ASRBackendType) async
     func updateWhisperKitModel(_ variant: String) async

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -13,9 +13,6 @@ public protocol ASRBackend: Actor {
     /// Load/initialize the model. Call once before transcription.
     func prepare() async throws
 
-    /// Batch transcription from a file URL.
-    func transcribe(audioURL: URL, options: TranscriptionOptions) async throws -> ASRResult
-
     /// Batch transcription from raw Float32 samples (16kHz mono).
     func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
 

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -16,6 +16,7 @@ import CryptoKit
 /// 3. If stalled or failed, fall back to Cloudflare R2 direct download
 /// 4. Verify SHA-256 checksum of key model files
 /// 5. Load models via FluidAudio's compile path
+// periphery:ignore - verifyChecksum() and StallTracker are used by ParakeetBackend; actor instance methods are vestigial
 actor ModelDownloadManager {
 
     /// Progress callback: (fractionCompleted, phaseString, detailString)
@@ -225,6 +226,7 @@ actor ModelDownloadManager {
 
 // MARK: - Errors
 
+// periphery:ignore - used within ModelDownloadManager.downloadAndLoad()
 public enum ModelDownloadError: LocalizedError {
     case stallDetected
     case invalidFallbackURL

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -86,24 +86,6 @@ public actor ParakeetBackend: ASRBackend {
         isReady = true
     }
 
-    public func transcribe(audioURL: URL, options: TranscriptionOptions) async throws -> ASRResult {
-        guard isReady, let manager = fluidAsrManager else { throw ASRError.notReady }
-
-        let startTime = CFAbsoluteTimeGetCurrent()
-        // fluidResult type is inferred from AsrManager.transcribe() return type
-        let fluidResult = try await manager.transcribe(audioURL, source: .system)
-        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-
-        // Unqualified ASRResult resolves to our module's type (has backendType parameter)
-        return ASRResult(
-            text: fluidResult.text,
-            language: "en",
-            duration: fluidResult.duration,
-            processingTime: elapsed,
-            backendType: .parakeet
-        )
-    }
-
     public func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
         guard isReady, let manager = fluidAsrManager else { throw ASRError.notReady }
 

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -75,22 +75,6 @@ public actor WhisperKitBackend: ASRBackend {
         isReady = true
     }
 
-    public func transcribe(audioURL: URL, options: TranscriptionOptions) async throws -> ASRResult {
-        guard isReady, let kit = whisperKit else { throw ASRError.notReady }
-
-        let decodeOptions = makeDecodeOptions(from: options, sampleCount: 0)
-        let startTime = CFAbsoluteTimeGetCurrent()
-        let results: [TranscriptionResult]
-        do {
-            results = try await kit.transcribe(audioPath: audioURL.path, decodeOptions: decodeOptions)
-        } catch {
-            throw ASRError.transcriptionFailed(error.localizedDescription)
-        }
-        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-
-        return mapResults(results, processingTime: elapsed)
-    }
-
     public func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
         guard isReady, let kit = whisperKit else { throw ASRError.notReady }
 

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -7,7 +7,7 @@ public struct IncrementalResult: Sendable {
     public let text: String?
     public let samplesCovered: Int
     public let decodeCount: Int
-    public let totalDecodeTimeMs: Int
+    public let totalDecodeTimeMs: Int // periphery:ignore - telemetry field, populated for diagnostics
     public let accepted: Bool
     public let mode: String
     public let strategy: String
@@ -59,6 +59,7 @@ public actor WhisperKitIncrementalWorker {
         }
     }
 
+    // periphery:ignore:parameters speechSegments - kept for API compatibility; energy-based gate replaced VAD segment check
     public func finalize(
         finalSamples: [Float],
         speechSegments: [SpeechSegment]

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -8,12 +8,12 @@ import EnviousWisprASR
 /// Owns ParakeetBackend (and WhisperKitBackend in Stage D). All inference runs in this
 /// XPC service process — model memory is isolated from the main app.
 final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable {
-    weak var connection: NSXPCConnection?
+    weak var connection: NSXPCConnection? // periphery:ignore - XPC connection lifecycle; set by delegate, prevents premature release
 
     /// The active ASR backend — only one loaded at a time.
     private var parakeetBackend: ParakeetBackend?
     private var whisperKitBackend: WhisperKitBackend?
-    private var activeBackendType: String?
+    private var activeBackendType: String? // periphery:ignore - tracks loaded backend for diagnostics and unload routing
 
     /// Streaming state flag — only Parakeet supports streaming.
     private var isStreamingActive = false

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -94,7 +94,7 @@ final class AVAudioEngineSource: AudioInputSource {
     // MARK: - Private state
 
     private var engine = AVAudioEngine()
-    private var converter: AVAudioConverter?
+    private var converter: AVAudioConverter? // periphery:ignore - retains converter to prevent deallocation while tap is active
     private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
     private var configChangeObserver: (any NSObjectProtocol)?
     private var activeTasks: [Task<Void, Never>] = []
@@ -111,8 +111,6 @@ final class AVAudioEngineSource: AudioInputSource {
 
     nonisolated static let targetSampleRate: Double = 16000
     nonisolated static let targetChannels: AVAudioChannelCount = 1
-    nonisolated static let maxRecordingDurationSeconds: Double = 600
-    nonisolated static let maxRecordingSamples: Int = Int(maxRecordingDurationSeconds * targetSampleRate)
 
     // MARK: - Lifecycle
 
@@ -377,11 +375,6 @@ final class AVAudioEngineSource: AudioInputSource {
             }
         }
         noiseSuppressionEnabled = noiseSuppression
-    }
-
-    /// Track a spawned Task so it can be cancelled during teardown.
-    func trackTask(_ task: Task<Void, Never>) {
-        activeTasks.append(task)
     }
 
     // MARK: - Private: Engine Teardown

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -299,7 +299,6 @@ private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuf
 
     /// Set after init by the AsyncStream closure.
     var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
-    private let targetFormat: AVAudioFormat
     private let forwarder: PreRollForwarder
 
     /// Track whether first buffer format has been validated.
@@ -308,7 +307,7 @@ private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBuf
     private var formatMismatch = false
 
     init(targetFormat: AVAudioFormat, forwarder: PreRollForwarder) {
-        self.targetFormat = targetFormat
+        _ = targetFormat // validated at init site; format checking done in captureOutput
         self.forwarder = forwarder
     }
 

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -26,7 +26,7 @@ public protocol AudioCaptureInterface: AnyObject {
     // Core lifecycle
     func startEnginePhase() async throws
     func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer>
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>
+    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> // periphery:ignore - convenience method combining engine + capture phases
     func stopCapture() async -> [Float]
     func rebuildEngine()
     func buildEngine(noiseSuppression: Bool)

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -53,7 +53,6 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
     /// Target format: 16kHz, mono, Float32 — required by both Parakeet and WhisperKit.
     public nonisolated static let targetSampleRate: Double = 16000
-    public nonisolated static let targetChannels: AVAudioChannelCount = 1
 
     /// The active capture source. Created on buildEngine/startEnginePhase.
     /// Either AVAudioEngineSource (no BT) or AVCaptureSessionSource (BT output active).
@@ -156,6 +155,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         return stream
     }
 
+    // periphery:ignore - protocol conformance (AudioCaptureInterface); convenience for single-phase callers
     public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
         guard !isCapturing else {
             return AsyncStream { $0.finish() }
@@ -253,16 +253,6 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     public func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
         guard let source = activeSource else { return true }
         return await source.waitForFormatStabilization(maxWait: maxWait, pollInterval: pollInterval)
-    }
-
-    /// Inject pre-recorded samples directly into the capture buffer for benchmark/testing.
-    public func injectSamples(_ samples: [Float]) {
-        capturedSamples = samples
-    }
-
-    /// Track a spawned Task so it can be cancelled during teardown.
-    public func trackTask(_ task: Task<Void, Never>) {
-        (activeSource as? AVAudioEngineSource)?.trackTask(task)
     }
 
     // MARK: - Warm Engine Management

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -137,6 +137,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         return stream
     }
 
+    // periphery:ignore - protocol conformance (AudioCaptureInterface)
     public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
         guard !isCapturing else { return AsyncStream { $0.finish() } }
         try await startEnginePhase()

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -6,8 +6,6 @@ public struct AudioInputDevice: Sendable, Identifiable, Hashable {
     public let id: AudioDeviceID
     public let name: String
     public let uid: String
-    public let manufacturer: String
-    public let inputChannelCount: Int
 }
 
 /// Enumerates audio input devices using CoreAudio HAL.
@@ -49,14 +47,11 @@ public enum AudioDeviceEnumerator {
 
             let name = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceNameCFString) ?? "Unknown"
             let uid = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID) ?? ""
-            let manufacturer = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceManufacturerCFString) ?? ""
 
             return AudioInputDevice(
                 id: deviceID,
                 name: name,
-                uid: uid,
-                manufacturer: manufacturer,
-                inputChannelCount: channelCount
+                uid: uid
             )
         }
     }

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -28,7 +28,7 @@ protocol AudioInputSource: AnyObject {
     func deactivateCapture()
 
     // State
-    var isCapturing: Bool { get }
+    var isCapturing: Bool { get } // periphery:ignore - used by conformers for internal guards
     var isRunning: Bool { get }
 
     // Engine-specific (no-op for AVCaptureSessionSource)

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -75,6 +75,7 @@ struct CaptureRouteResolver {
         }
     }
 
+    // periphery:ignore:parameters noiseSuppression - reserved for future VP-aware routing decisions
     private func resolveAutomatic(preferredInputDeviceUID: String, noiseSuppression: Bool) -> CaptureRouteDecision {
         let btOutputActive: Bool
         if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -7,7 +7,7 @@ public struct SmoothedVADConfig: Sendable {
     public var onsetThreshold: Float = 0.5
     public var offsetThreshold: Float = 0.35
     public var onsetConfirmationChunks: Int = 1
-    public var hangoverChunks: Int = 3
+    public var hangoverChunks: Int = 3 // periphery:ignore - public config field; SilenceDetector uses effectiveHangoverChunks but callers may set this
     public var prebufferChunks: Int = 2
     public var energyGateThreshold: Float = 0.0
 
@@ -27,10 +27,6 @@ public struct SmoothedVADConfig: Sendable {
         self.hangoverChunks = hangoverChunks
         self.prebufferChunks = prebufferChunks
         self.energyGateThreshold = energyGateThreshold
-    }
-
-    public static func fromPreset(_ preset: EnvironmentPreset) -> SmoothedVADConfig {
-        return fromSensitivity(preset.vadSensitivity)
     }
 
     public static func fromSensitivity(_ sensitivity: Float, energyGate: Bool = false) -> SmoothedVADConfig {
@@ -276,13 +272,6 @@ public actor SilenceDetector {
             result.append(contentsOf: allSamples[range.start..<range.end])
         }
         return result.isEmpty ? allSamples : result
-    }
-
-    /// Release the VAD model from memory.
-    public func unload() {
-        vadManager = nil
-        isReady = false
-        reset()
     }
 
     // MARK: - Private Helpers

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -8,7 +8,7 @@ import EnviousWisprAudio
 /// receives buffers and state changes via AudioServiceClientProtocol callbacks.
 final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Sendable {
     /// The XPC connection back to the host — set by AudioServiceDelegate.
-    weak var connection: NSXPCConnection?
+    weak var connection: NSXPCConnection? // periphery:ignore - XPC connection lifecycle; set by delegate, prevents premature release
     /// Client proxy for sending callbacks to the host app.
     /// Resolved from connection.remoteObjectProxy — set by AudioServiceDelegate.
     var clientProxy: (any AudioServiceClientProtocol)?


### PR DESCRIPTION
## Summary
- Remove unused `transcribe(audioURL:options:)` from ASRBackend protocol and all conformers (ParakeetBackend, WhisperKitBackend, ASRManager)
- Remove dead functions and properties: `trackTask()`, `injectSamples()`, `targetChannels`, `maxRecordingDuration/Samples`, `fromPreset()`, `SilenceDetector.unload()`, `AudioInputDevice.manufacturer/inputChannelCount`, `CaptureDelegate.targetFormat`
- Suppress (`periphery:ignore`) findings that are XPC lifecycle retention, existential-type reads, protocol conformance, or reserved parameters
- 18 files changed, 19 insertions, 89 deletions

## Test plan
- [x] `swift build` passes
- [x] Each removal verified by reading the code and grepping callers (not just Periphery output)
- [x] XPC contract methods preserved with suppression comments
- [x] Protocol removals checked against all conformers and call sites
- [x] No heart-path runtime behavior changed
