### PR TITLE
fix(website): correct GitHub repo links on all compare pages

### DIFF
--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -524,7 +524,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
         </tbody>
@@ -577,7 +577,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔍</div>
         <div class="advantage-title">Auditable source code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. See exactly how your audio is processed. Apple Dictation is a black box built into the OS.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. See exactly how your audio is processed. Apple Dictation is a black box built into the OS.</p>
       </div>
     </div>
   </div>
@@ -714,7 +714,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr really free?</div>
-        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">GitHub</a> under a BSL 1.1 license.</p>
+        <p class="faq-a">Yes. No subscription, no usage limits, no account required. Download and use it. The source code is available on <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">GitHub</a> under a BSL 1.1 license.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -527,7 +527,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -585,7 +585,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Dragon is closed source with no public bug tracker.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Dragon is closed source with no public bug tracker.</p>
       </div>
     </div>
   </div>
@@ -786,7 +786,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>
-        <p class="faq-a">Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a>. It is not an OSI-approved open source license, but it gives you full transparency. Dragon is entirely closed source.</p>
+        <p class="faq-a">Source-available under the Business Source License 1.1. You can read, build, and inspect every line of code <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a>. It is not an OSI-approved open source license, but it gives you full transparency. Dragon is entirely closed source.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can EnviousWispr match Dragon's accuracy for medical or legal terms?</div>
@@ -842,7 +842,7 @@ const faqJsonLd = JSON.stringify({
 <footer style="padding: 24px 0 48px; text-align: center;">
   <div class="container">
     <p style="font-size: 11px; color: var(--text-3); max-width: 640px; margin: 0 auto; line-height: 1.65;">
-      <strong>Methodology:</strong> Dragon claims were sourced from <a href="https://www.nuance.com/dragon.html" style="color: var(--text-3); text-decoration: underline;">nuance.com</a>, Microsoft product announcements, archived product pages, and official product documentation. Dragon was not firsthand-tested for this comparison. Where Dragon has genuine strengths (voice commands, medical/legal editions, adaptive accuracy), we say so. EnviousWispr performance data comes from production PostHog analytics on Apple Silicon Macs. All competitor claims were last verified on 2026-04-04. If you spot an error, please <a href="https://github.com/AirSkye/EnviousWispr/issues" style="color: var(--text-3); text-decoration: underline;">open an issue</a>.
+      <strong>Methodology:</strong> Dragon claims were sourced from <a href="https://www.nuance.com/dragon.html" style="color: var(--text-3); text-decoration: underline;">nuance.com</a>, Microsoft product announcements, archived product pages, and official product documentation. Dragon was not firsthand-tested for this comparison. Where Dragon has genuine strengths (voice commands, medical/legal editions, adaptive accuracy), we say so. EnviousWispr performance data comes from production PostHog analytics on Apple Silicon Macs. All competitor claims were last verified on 2026-04-04. If you spot an error, please <a href="https://github.com/saurabhav88/EnviousWispr/issues" style="color: var(--text-3); text-decoration: underline;">open an issue</a>.
     </p>
   </div>
 </footer>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -434,7 +434,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -499,7 +499,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -557,7 +557,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -503,7 +503,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
         </tbody>
@@ -556,7 +556,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source tools ask you to trust their privacy claims on faith.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source tools ask you to trust their privacy claims on faith.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -504,7 +504,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -572,7 +572,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source tools ask you to trust their privacy claims on faith.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source tools ask you to trust their privacy claims on faith.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -506,7 +506,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -574,7 +574,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -522,7 +522,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
+            <td><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
             <td><a href="https://github.com/Beingpax/VoiceInk" style="color: var(--accent); text-decoration: underline;">Open source</a> (GPL v3)</td>
           </tr>
           <tr>
@@ -580,7 +580,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#128736;</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify privacy claims yourself. VoiceInk is also open source under GPL v3, so both apps offer transparency.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify privacy claims yourself. VoiceInk is also open source under GPL v3, so both apps offer transparency.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -415,7 +415,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
+            <td><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a> (BSL 1.1)</td>
             <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">Open source</a> (MIT)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -430,7 +430,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -488,7 +488,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -458,7 +458,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Source code</td>
-            <td><span class="table-highlight"><a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
+            <td><span class="table-highlight"><a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">Source-available</a></span> on GitHub (BSL 1.1)</td>
             <td>Closed source</td>
           </tr>
           <tr>
@@ -581,7 +581,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
         <div class="advantage-title">Auditable code</div>
-        <p class="advantage-desc">Every line is <a href="https://github.com/AirSkye/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
+        <p class="advantage-desc">Every line is <a href="https://github.com/saurabhav88/EnviousWispr" style="color: var(--accent); text-decoration: underline;">on GitHub</a> under BSL 1.1. Verify what it does. Report issues directly. Contribute improvements. Closed-source dictation tools ask you to trust their privacy claims on faith.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Fix 23 broken GitHub repo links across all 11 comparison pages
- Links pointed to `github.com/AirSkye/EnviousWispr` (hallucinated username from original generation session)
- Corrected to `github.com/saurabhav88/EnviousWispr`
- These links are the "source-available on GitHub" trust argument, so they were actively undermining credibility

## Test plan
- [x] grep confirms zero remaining `AirSkye` references
- [x] All 23 replacements verified
