### PR TITLE
fix(website): add authorUrl to blog schema and skip-nav link

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -11,6 +11,7 @@ const blog = defineCollection({
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
     author: z.string().default('Envious Labs'),
+    authorUrl: z.string().url().optional(),
     image: z.string().optional(),
     keywords: z.array(z.string()).optional(),
   }),

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -62,9 +62,10 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   <slot name="head" />
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <div class="dot-grid" aria-hidden="true"></div>
   <Nav activePage={activePage} />
-  <main>
+  <main id="main-content">
     <slot />
   </main>
   <Footer />

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -45,6 +45,25 @@
   box-shadow: 0 0 20px rgba(124,58,237,0.15), 0 0 40px rgba(0,255,255,0.08), 0 0 60px rgba(255,42,64,0.05);
 }
 
+/* Skip-to-content link (WCAG 2.1 SC 2.4.1) */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 10000;
+  padding: 8px 16px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--radius-btn);
+  text-decoration: none;
+  transition: top 0.15s;
+}
+.skip-link:focus {
+  top: 16px;
+}
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
 html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 body { font-family: var(--font-body); background: var(--bg); color: var(--text); line-height: 1.6; overflow-x: hidden; }


### PR DESCRIPTION
## Summary
- Add `authorUrl` field to blog content schema so frontmatter values flow through to Schema.org JSON-LD
- Add WCAG 2.1 skip-to-content link (hidden until Tab focus, appears at top of page)

## Test plan
- [x] authorUrl now accepted in blog frontmatter without Astro silently dropping it
- [x] Skip link visible on Tab press, scrolls to main content
- [x] Skip link styled with brand accent, hidden when not focused
