### PR TITLE
fix(llm): defensive hardening across LLM connectors

### DIFF
--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -252,7 +252,7 @@ public struct GeminiConnector: TranscriptPolisher {
                 if !LLMRetryPolicy.isRetryable(error) { throw error }
             }
         }
-        throw lastError!
+        throw lastError ?? LLMError.requestFailed("All retries exhausted")
     }
 
     private func getAPIKey(config: LLMProviderConfig) throws -> String {

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -55,7 +55,9 @@ public struct KeychainManager: Sendable {
     /// Writes to a temp file at 0600 first, then renames — avoids a TOCTOU window
     /// where the file is briefly world-readable.
     public func store(key: String, value: String) throws {
-        guard let data = value.data(using: .utf8) else { return }
+        guard let data = value.data(using: .utf8) else {
+            throw KeyStoreError.storeFailed(-1)
+        }
 
         try ensureDirectoryExists()
 

--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -216,7 +216,7 @@ public struct LLMModelDiscovery: Sendable {
         request.timeoutInterval = 5
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else {
                 throw LLMError.providerUnavailable

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -99,12 +99,10 @@ public struct OllamaConnector: TranscriptPolisher {
                     (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
                 } catch let urlError as URLError {
                     switch urlError.code {
-                    case .cannotConnectToHost, .cannotFindHost, .notConnectedToInternet:
-                        throw LLMError.providerUnavailable
-                    case .timedOut, .networkConnectionLost:
-                        throw urlError  // retryable — will be caught below
+                    case .notConnectedToInternet, .cannotFindHost:
+                        throw LLMError.providerUnavailable  // not transient, fail fast
                     default:
-                        throw LLMError.requestFailed("Network error: \(urlError.localizedDescription)")
+                        throw urlError  // let LLMRetryPolicy.isRetryable() decide
                     }
                 }
 
@@ -138,7 +136,11 @@ public struct OllamaConnector: TranscriptPolisher {
                 if !LLMRetryPolicy.isRetryable(error) { throw error }
             }
         }
-        throw lastError!
+        // Convert exhausted connection errors to domain error for UI
+        if let urlError = lastError as? URLError, urlError.code == .cannotConnectToHost {
+            throw LLMError.providerUnavailable
+        }
+        throw lastError ?? LLMError.requestFailed("All retries exhausted")
     }
 
     private static func friendlyMessage(for statusCode: Int) -> String {

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -119,7 +119,7 @@ public struct OpenAIConnector: TranscriptPolisher {
                 if !LLMRetryPolicy.isRetryable(error) { throw error }
             }
         }
-        throw lastError!
+        throw lastError ?? LLMError.requestFailed("All retries exhausted")
     }
 
     private static func friendlyMessage(for statusCode: Int) -> String {


### PR DESCRIPTION
## Summary
- Replace `lastError!` force-unwrap with nil-coalescing fallback in all 3 connector retry loops
- Fix OllamaConnector retry bypass: `cannotConnectToHost` now retries 2x (Ollama startup race), then converts to `providerUnavailable`
- Fix KeychainManager.store() silent return on nil UTF-8 encoding
- Fix LLMModelDiscovery using `URLSession.shared` instead of `LLMNetworkSession.shared.session`

Council-validated: GPT and Gemini both caught a flow bug in the initial Fix 2 proposal (non-retryable errors exit before post-loop conversion). Corrected design keeps `cannotFindHost` and `notConnectedToInternet` as fail-fast, only `cannotConnectToHost` retries.

## Test plan
- [x] `swift build` passes
- [x] `scripts/swift-test.sh` passes (including LLMRetryPolicy tests)
- [x] All changes are limb-path (LLM module only), zero heart-path risk
