### PR TITLE
fix(core): crash in WERCalculator when hypothesis is empty

### DIFF
--- a/Sources/EnviousWisprCore/WERCalculator.swift
+++ b/Sources/EnviousWisprCore/WERCalculator.swift
@@ -26,6 +26,11 @@ public enum WERCalculator {
         let n = refWords.count
         let m = hypWords.count
 
+        // Empty hypothesis: every reference word is a deletion
+        guard m > 0 else {
+            return Result(wer: 1.0)
+        }
+
         // DP table for edit distance
         var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
 


### PR DESCRIPTION
## Summary
Fix `Range requires lowerBound <= upperBound` crash in `WERCalculator.calculate()` when hypothesis is empty. The inner DP loop `for j in 1...m` creates an invalid range `1...0` when `m == 0`.

This was misdiagnosed as an "intermittent Swift runtime bug" because parallel test scheduling made it appear random. In serial mode it crashed every time at the `emptyHypothesis` test.

Fix: short-circuit when `m == 0` (all reference words are deletions, WER = 1.0).

## Test plan
- [x] 5/5 consecutive `scripts/swift-test.sh` runs pass with zero crashes
- [x] 72 test assertions pass on every run
- [x] `emptyHypothesis` test now completes correctly
