### PR TITLE
refactor(pipeline): Phase 1 - PasteCascadeExecutor extraction

### DIFF
--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -1,0 +1,106 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Input for a paste delivery operation. Captures session-scoped target info.
+@MainActor
+internal struct PasteDeliveryRequest {
+    let text: String
+    let targetApp: NSRunningApplication?
+    let targetElement: AXUIElement?
+    let restoreClipboardAfterPaste: Bool
+}
+
+/// Result of a paste delivery operation.
+internal struct PasteDeliveryResult {
+    let tier: PasteTier
+    let durationMs: Int
+}
+
+/// Executes the tiered paste cascade: AX direct -> CGEvent Cmd+V -> AppleScript -> clipboard.
+///
+/// Thin orchestrator over PasteService static methods. Both pipelines call this
+/// instead of owning their own paste logic. The cascade is OS-integration code
+/// that must exist in exactly one place to prevent drift.
+@MainActor
+internal final class PasteCascadeExecutor {
+
+    func deliver(_ request: PasteDeliveryRequest) async -> PasteDeliveryResult {
+        let pasteStart = CFAbsoluteTimeGetCurrent()
+        let bundleId = request.targetApp?.bundleIdentifier ?? "unknown"
+        var tier: PasteTier = .clipboardOnly
+
+        // Tier 1: AX direct insertion
+        if let element = request.targetElement {
+            if PasteService.insertViaAccessibility(request.text, element: element) {
+                tier = .axDirect
+            }
+        }
+
+        // Tier 2: Activate target app + CGEvent Cmd+V
+        // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
+        // restrictions on background processes stealing focus.
+        if tier == .clipboardOnly, let app = request.targetApp, !app.isTerminated {
+            let pollInterval = TimingConstants.activationPollIntervalMs
+            let timeout = TimingConstants.activationTimeoutMs
+
+            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+            app.activate()
+            var elapsed = 0
+            while elapsed < timeout {
+                try? await Task.sleep(for: .milliseconds(pollInterval))
+                elapsed += pollInterval
+                if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
+                    break
+                }
+                if elapsed % 300 < pollInterval {
+                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                    app.activate()
+                }
+            }
+
+            let activated = NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+
+            if activated {
+                let snapshot: ClipboardSnapshot? = request.restoreClipboardAfterPaste
+                    ? PasteService.saveClipboard()
+                    : nil
+                let changeCountAfterPaste = PasteService.pasteToActiveApp(request.text)
+                tier = .cgEvent
+                if let snapshot {
+                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
+                }
+            } else {
+                // Tier 2b: AppleScript Edit > Paste
+                _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+                app.activate()
+                try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+                let snapshot: ClipboardSnapshot? = request.restoreClipboardAfterPaste
+                    ? PasteService.saveClipboard()
+                    : nil
+                let changeCount = PasteService.copyToClipboardReturningChangeCount(request.text)
+                if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
+                    tier = .appleScript
+                }
+                if let snapshot {
+                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
+                }
+            }
+        }
+
+        // Tier 3: Clipboard fallback
+        if tier == .clipboardOnly {
+            PasteService.copyToClipboard(request.text)
+        }
+
+        let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)
+        Task { await AppLogger.shared.log(
+            "Paste cascade: tier=\(tier.rawValue), app=\(bundleId), duration=\(durationMs)ms",
+            level: .info, category: "PipelineTiming"
+        ) }
+        return PasteDeliveryResult(tier: tier, durationMs: durationMs)
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -36,6 +36,9 @@ public final class TranscriptionPipeline: DictationPipeline {
     public var transcriptionOptions: TranscriptionOptions = .default
     public var lastPolishError: String?
 
+    // Shared services
+    private let pasteExecutor = PasteCascadeExecutor()
+
     // Text processing steps
     private let wordCorrectionStep = WordCorrectionStep()
     private let fillerRemovalStep = FillerRemovalStep()
@@ -642,93 +645,10 @@ public final class TranscriptionPipeline: DictationPipeline {
             var pasteMs: Int?
             let pasteTargetApp = targetApp?.bundleIdentifier
             if autoPasteToActiveApp {
-                // Append trailing space so consecutive dictations are separated
                 let text = PasteService.appendTrailingSpace(transcript.displayText)
-                let bundleId = pasteTargetApp ?? "unknown"
-                var tier: PasteTier = .clipboardOnly
-
-                // Tier 1: AX direct insertion — zero disruption, no clipboard, no focus change.
-                if let element = targetElement {
-                    if PasteService.insertViaAccessibility(text, element: element) {
-                        tier = .axDirect
-                    }
-                }
-
-                // Tier 2: Activate target app + CGEvent Cmd+V
-                // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
-                // restrictions on background processes stealing focus. The deprecated
-                // NSRunningApplication.activate(options: .activateIgnoringOtherApps)
-                // has no effect on macOS 14+.
-                if tier == .clipboardOnly, let app = targetApp, !app.isTerminated {
-                    let pollInterval = TimingConstants.activationPollIntervalMs
-                    let timeout = TimingConstants.activationTimeoutMs
-
-                    // AX force-activate, then poll for frontmost confirmation.
-                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                    app.activate()
-                    var elapsed = 0
-                    while elapsed < timeout {
-                        try? await Task.sleep(for: .milliseconds(pollInterval))
-                        elapsed += pollInterval
-                        if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
-                            break
-                        }
-                        if elapsed % 300 < pollInterval {
-                            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                            app.activate()
-                        }
-                    }
-
-                    let activated = NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
-
-                    if activated {
-                        let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste
-                            ? PasteService.saveClipboard()
-                            : nil
-
-                        let changeCountAfterPaste = PasteService.pasteToActiveApp(text)
-                        tier = .cgEvent
-
-                        if let snapshot {
-                            try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                            PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
-                        }
-                    } else {
-                        // Tier 2b: AppleScript Edit > Paste
-                        _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                        app.activate()
-                        try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-
-                        let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste
-                            ? PasteService.saveClipboard()
-                            : nil
-
-                        let changeCount = PasteService.copyToClipboardReturningChangeCount(text)
-
-                        if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
-                            tier = .appleScript
-                        }
-
-                        if let snapshot {
-                            try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                            PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
-                        }
-                    }
-                }
-
-                // Tier 3: Clipboard + fallback — text is never lost
-                if tier == .clipboardOnly {
-                    PasteService.copyToClipboard(text)
-                }
-
-                let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)
-                pasteTier = tier
-                pasteMs = durationMs
-                Task { await AppLogger.shared.log(
-                    "Pipeline paste: tier=\(tier.rawValue), app=\(bundleId), duration=\(durationMs)ms",
-                    level: .info, category: "PipelineTiming"
-                ) }
-
+                let result = await performPaste(text: text, pasteStart: pasteStart)
+                pasteTier = result.tier
+                pasteMs = result.durationMs
             } else if autoCopyToClipboard {
                 PasteService.copyToClipboard(transcript.displayText)
             }
@@ -1149,6 +1069,18 @@ public final class TranscriptionPipeline: DictationPipeline {
         )
 
         return result
+    }
+
+    // MARK: - Paste Cascade
+
+    private func performPaste(text: String, pasteStart: CFAbsoluteTime) async -> (tier: PasteTier, durationMs: Int) {
+        let result = await pasteExecutor.deliver(PasteDeliveryRequest(
+            text: text,
+            targetApp: targetApp,
+            targetElement: targetElement,
+            restoreClipboardAfterPaste: restoreClipboardAfterPaste
+        ))
+        return (result.tier, result.durationMs)
     }
 
     // MARK: - Text Processing

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -58,6 +58,9 @@ public final class WhisperKitPipeline: DictationPipeline {
     public var lastPolishError: String?
     public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
+    // Shared services
+    private let pasteExecutor = PasteCascadeExecutor()
+
     // Text processing steps (own instances — not shared with Parakeet)
     public let wordCorrectionStep = WordCorrectionStep()
     public let fillerRemovalStep = FillerRemovalStep()
@@ -975,79 +978,12 @@ public final class WhisperKitPipeline: DictationPipeline {
     // MARK: - Paste Cascade
 
     private func performPaste(text: String, pasteStart: CFAbsoluteTime) async -> (tier: PasteTier, durationMs: Int) {
-        let bundleId = targetApp?.bundleIdentifier ?? "unknown"
-        var tier: PasteTier = .clipboardOnly
-
-        // Tier 1: AX direct insertion
-        if let element = targetElement {
-            if PasteService.insertViaAccessibility(text, element: element) {
-                tier = .axDirect
-            }
-        }
-
-        // Tier 2: Activate target app + CGEvent Cmd+V
-        // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
-        // restrictions on background processes stealing focus.
-        if tier == .clipboardOnly, let app = targetApp, !app.isTerminated {
-            let pollInterval = TimingConstants.activationPollIntervalMs
-            let timeout = TimingConstants.activationTimeoutMs
-
-            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-            app.activate()
-            var elapsed = 0
-            while elapsed < timeout {
-                try? await Task.sleep(for: .milliseconds(pollInterval))
-                elapsed += pollInterval
-                if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
-                    break
-                }
-                if elapsed % 300 < pollInterval {
-                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                    app.activate()
-                }
-            }
-
-            let activated = NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
-
-            if activated {
-                let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste
-                    ? PasteService.saveClipboard()
-                    : nil
-                let changeCountAfterPaste = PasteService.pasteToActiveApp(text)
-                tier = .cgEvent
-                if let snapshot {
-                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
-                }
-            } else {
-                // Tier 2b: AppleScript Edit > Paste
-                _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                app.activate()
-                try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                let snapshot: ClipboardSnapshot? = restoreClipboardAfterPaste
-                    ? PasteService.saveClipboard()
-                    : nil
-                let changeCount = PasteService.copyToClipboardReturningChangeCount(text)
-                if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
-                    tier = .appleScript
-                }
-                if let snapshot {
-                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
-                }
-            }
-        }
-
-        // Tier 3: Clipboard fallback
-        if tier == .clipboardOnly {
-            PasteService.copyToClipboard(text)
-        }
-
-        let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)
-        Task { await AppLogger.shared.log(
-            "WhisperKit paste: tier=\(tier.rawValue), app=\(bundleId), duration=\(durationMs)ms",
-            level: .info, category: "WhisperKitPipeline"
-        ) }
-        return (tier, durationMs)
+        let result = await pasteExecutor.deliver(PasteDeliveryRequest(
+            text: text,
+            targetApp: targetApp,
+            targetElement: targetElement,
+            restoreClipboardAfterPaste: restoreClipboardAfterPaste
+        ))
+        return (result.tier, result.durationMs)
     }
 }


### PR DESCRIPTION
## Summary
- Phase 1 of pipeline deduplication refactor (#174)
- Extracts tiered paste cascade (AX -> CGEvent -> AppleScript -> clipboard) into shared `PasteCascadeExecutor`
- Both pipelines now delegate to single shared implementation via thin `performPaste()` wrappers
- ~160 lines of duplicated cascade code deleted from both pipelines
- Zero PasteService calls remain in either pipeline (all 6 in executor)

## Changes
- **New:** `PasteCascadeExecutor.swift` (108 lines) with `PasteDeliveryRequest` and `PasteDeliveryResult`
- **Modified:** `TranscriptionPipeline.swift` (-80 lines) and `WhisperKitPipeline.swift` (-80 lines)

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
- [x] App rebuilds, bundles, launches (11 processes)
- [x] PTT recording starts and stops correctly
- [x] Verified paste calls exist only in PasteCascadeExecutor (grep confirms 0 in pipelines)
