### PR TITLE
refactor(pipeline): Phase 2 - TextProcessingRunner extraction

### DIFF
--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -1,0 +1,96 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Result of running the text processing chain.
+@MainActor
+internal struct TextProcessingRunResult {
+    let context: TextProcessingContext
+    /// Error message from polish step failure, if any. Surfaced to user as lastPolishError.
+    let polishError: String?
+}
+
+/// Runs the post-ASR text processing chain: word correction -> filler removal -> LLM polish.
+///
+/// Does NOT own step instances. Steps are passed in by the pipeline, which retains
+/// ownership for PipelineSettingsSync mutation and polishExistingTranscript() access.
+/// The runner owns only the execution algorithm: ordering, timeout, cancellation,
+/// failure continuation (heart & limbs), and CORRECTION_DEBUG logging.
+@MainActor
+internal final class TextProcessingRunner {
+
+    func run(
+        rawText: String,
+        language: String?,
+        targetAppName: String?,
+        steps: [any TextProcessingStep]
+    ) async throws -> TextProcessingRunResult {
+        var context = TextProcessingContext(text: rawText, language: language)
+        context.targetAppName = targetAppName
+        var polishError: String?
+
+        Task {
+            await AppLogger.shared.log(
+                "CORRECTION_DEBUG [RAW ASR] \(rawText)",
+                level: .info, category: "CorrectionDebug"
+            )
+        }
+
+        for step in steps where step.isEnabled {
+            let stepName = step.name
+            let input = context
+            // nonisolated(unsafe) is safe: the task group inherits @MainActor isolation,
+            // so step.process() still runs on MainActor — no real isolation crossing.
+            nonisolated(unsafe) let unsafeStep = step
+            let stepStart = CFAbsoluteTimeGetCurrent()
+            let budgetSeconds = Double(unsafeStep.maxDuration.components.seconds)
+                              + Double(unsafeStep.maxDuration.components.attoseconds) / 1e18
+            do {
+                context = try await withThrowingTimeout(seconds: budgetSeconds) {
+                    try await unsafeStep.process(input)
+                }
+                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
+                let inputText = input.polishedText ?? input.text
+                let outputText = context.polishedText ?? context.text
+                let changed = inputText != outputText
+                Task {
+                    await AppLogger.shared.log(
+                        "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
+                        level: .info, category: "PipelineTiming"
+                    )
+                    if changed {
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] IN:  \(inputText)",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] OUT: \(outputText)",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                    } else {
+                        await AppLogger.shared.log(
+                            "CORRECTION_DEBUG [\(stepName)] no change",
+                            level: .info, category: "CorrectionDebug"
+                        )
+                    }
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
+                let reason = error is TimeoutError ? "timed out" : "failed: \(error.localizedDescription)"
+                if stepName == "LLM Polish" {
+                    polishError = error.localizedDescription
+                }
+                Task {
+                    await AppLogger.shared.log(
+                        "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping",
+                        level: .info, category: "TextProcessing"
+                    )
+                }
+                // Heart & Limbs: limb failed, continue with input text
+            }
+        }
+        return TextProcessingRunResult(context: context, polishError: polishError)
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -38,6 +38,7 @@ public final class TranscriptionPipeline: DictationPipeline {
 
     // Shared services
     private let pasteExecutor = PasteCascadeExecutor()
+    private let textProcessingRunner = TextProcessingRunner()
 
     // Text processing steps
     private let wordCorrectionStep = WordCorrectionStep()
@@ -1086,71 +1087,16 @@ public final class TranscriptionPipeline: DictationPipeline {
     // MARK: - Text Processing
 
     private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
-        var context = TextProcessingContext(
-            text: asrText,
-            language: language
+        let result = try await textProcessingRunner.run(
+            rawText: asrText,
+            language: language,
+            targetAppName: targetApp?.localizedName,
+            steps: textProcessingSteps
         )
-        context.targetAppName = targetApp?.localizedName
-        Task {
-            await AppLogger.shared.log(
-                "CORRECTION_DEBUG [RAW ASR] \(asrText)",
-                level: .info, category: "CorrectionDebug"
-            )
+        if let error = result.polishError {
+            lastPolishError = error
         }
-        for step in textProcessingSteps where step.isEnabled {
-            let stepName = step.name
-            let input = context
-            // nonisolated(unsafe) is safe: the task group inherits @MainActor isolation,
-            // so step.process() still runs on MainActor — no real isolation crossing.
-            nonisolated(unsafe) let unsafeStep = step
-            let stepStart = CFAbsoluteTimeGetCurrent()
-            let budgetSeconds = Double(unsafeStep.maxDuration.components.seconds)
-                              + Double(unsafeStep.maxDuration.components.attoseconds) / 1e18
-            do {
-                context = try await withThrowingTimeout(seconds: budgetSeconds) {
-                    try await unsafeStep.process(input)
-                }
-                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
-                let inputText = input.polishedText ?? input.text
-                let outputText = context.polishedText ?? context.text
-                let changed = inputText != outputText
-                Task {
-                    await AppLogger.shared.log(
-                        "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
-                        level: .info, category: "PipelineTiming"
-                    )
-                    // Debug: log text at each correction layer
-                    if changed {
-                        await AppLogger.shared.log(
-                            "CORRECTION_DEBUG [\(stepName)] IN:  \(inputText)",
-                            level: .info, category: "CorrectionDebug"
-                        )
-                        await AppLogger.shared.log(
-                            "CORRECTION_DEBUG [\(stepName)] OUT: \(outputText)",
-                            level: .info, category: "CorrectionDebug"
-                        )
-                    } else {
-                        await AppLogger.shared.log(
-                            "CORRECTION_DEBUG [\(stepName)] no change",
-                            level: .info, category: "CorrectionDebug"
-                        )
-                    }
-                }
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
-                let reason = error is TimeoutError ? "timed out" : "failed: \(error.localizedDescription)"
-                Task {
-                    await AppLogger.shared.log(
-                        "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping",
-                        level: .info, category: "TextProcessing"
-                    )
-                }
-                // Heart & Limbs: limb failed, continue with input text
-            }
-        }
-        return context
+        return result.context
     }
 
     // MARK: - DictationPipeline Conformance

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -60,6 +60,7 @@ public final class WhisperKitPipeline: DictationPipeline {
 
     // Shared services
     private let pasteExecutor = PasteCascadeExecutor()
+    private let textProcessingRunner = TextProcessingRunner()
 
     // Text processing steps (own instances — not shared with Parakeet)
     public let wordCorrectionStep = WordCorrectionStep()
@@ -933,46 +934,16 @@ public final class WhisperKitPipeline: DictationPipeline {
     // MARK: - Text Processing
 
     private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
-        var context = TextProcessingContext(
-            text: asrText,
-            language: language
+        let result = try await textProcessingRunner.run(
+            rawText: asrText,
+            language: language,
+            targetAppName: targetApp?.localizedName,
+            steps: textProcessingSteps
         )
-        context.targetAppName = targetApp?.localizedName
-        for step in textProcessingSteps where step.isEnabled {
-            let stepName = step.name
-            let input = context
-            // nonisolated(unsafe) is safe: the task group inherits @MainActor isolation,
-            // so step.process() still runs on MainActor — no real isolation crossing.
-            nonisolated(unsafe) let unsafeStep = step
-            let stepStart = CFAbsoluteTimeGetCurrent()
-            let budgetSeconds = Double(unsafeStep.maxDuration.components.seconds)
-                              + Double(unsafeStep.maxDuration.components.attoseconds) / 1e18
-            do {
-                context = try await withThrowingTimeout(seconds: budgetSeconds) {
-                    try await unsafeStep.process(input)
-                }
-                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
-                Task {
-                    await AppLogger.shared.log(
-                        "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
-                        level: .info, category: "PipelineTiming"
-                    )
-                }
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
-                let reason = error is TimeoutError ? "timed out" : "failed: \(error.localizedDescription)"
-                Task {
-                    await AppLogger.shared.log(
-                        "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping",
-                        level: .info, category: "TextProcessing"
-                    )
-                }
-                // Heart & Limbs: limb failed, continue with input text
-            }
+        if let error = result.polishError {
+            lastPolishError = error
         }
-        return context
+        return result.context
     }
 
     // MARK: - Paste Cascade


### PR DESCRIPTION
## Summary
- Phase 2 of pipeline deduplication refactor (#174)
- Extracts text processing chain algorithm into shared `TextProcessingRunner`
- Step instances stay on pipelines (PipelineSettingsSync, polishExistingTranscript depend on this)
- Runner receives steps as parameter, owns ordering/timeout/cancellation/logging
- WhisperKit gains CORRECTION_DEBUG logging, standardizing observability
- 101 lines deleted from both pipelines

## Runtime validation
- `record_tts("The quick brown fox jumps over the lazy dog")`
- RAW ASR confirmed in CORRECTION_DEBUG
- Paste cascade: tier=cgevent confirmed
- Pipeline timing: 1.043s (ASR=0.101s, polish=0.598s, paste=0.287s)
- Full chain: Word Correction -> Filler Removal -> LLM Polish all logged

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
- [x] record_tts() full pipeline validation passes
- [x] CORRECTION_DEBUG log entries verified
