### PR TITLE
refactor(pipeline): Phase 4a - SampleFilter extraction

### DIFF
--- a/Sources/EnviousWisprPipeline/SampleFilter.swift
+++ b/Sources/EnviousWisprPipeline/SampleFilter.swift
@@ -1,0 +1,50 @@
+import EnviousWisprAudio
+import Foundation
+
+/// Shared utilities extracted from both pipelines to eliminate duplication.
+internal enum SampleFilter {
+
+    /// Filter audio samples using VAD speech segments, with padding and segment merging.
+    /// Returns original samples if segments are empty or total voiced audio is below threshold.
+    ///
+    /// Extracted from TranscriptionPipeline.filterSamples() and WhisperKitPipeline.filterSamples()
+    /// which were character-for-character identical.
+    static func filter(
+        from allSamples: [Float],
+        segments: [SpeechSegment],
+        padding: Int = 1600
+    ) -> [Float] {
+        guard !segments.isEmpty else { return allSamples }
+
+        let totalVoiced = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) }
+        guard totalVoiced >= 4800 else { return allSamples }
+
+        var merged: [(start: Int, end: Int)] = []
+        for segment in segments {
+            let start = max(0, segment.startSample - padding)
+            let end = min(allSamples.count, segment.endSample + padding)
+            if let last = merged.last, start <= last.end {
+                merged[merged.count - 1].end = max(last.end, end)
+            } else {
+                merged.append((start, end))
+            }
+        }
+
+        var result: [Float] = []
+        for range in merged {
+            guard range.start < range.end else { continue }
+            result.append(contentsOf: allSamples[range.start..<range.end])
+        }
+        return result.isEmpty ? allSamples : result
+    }
+}
+
+/// Shared pipeline utilities.
+internal enum PipelineUtils {
+
+    /// Convert Duration to milliseconds for logging.
+    static func durationMs(_ d: Duration) -> Int {
+        let (seconds, attoseconds) = d.components
+        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -116,17 +116,11 @@ public final class TranscriptionPipeline: DictationPipeline {
         await audioCapture.preWarm()
         guard !Task.isCancelled else { return }
         isPreWarmed = true
-        let totalMs = Self.durationMs(ContinuousClock.now - start)
+        let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
         Task { await AppLogger.shared.log(
             "COLD-START [Parakeet] preWarmAudioInput total=\(totalMs)ms",
             level: .info, category: "Pipeline"
         ) }
-    }
-
-    /// Convert Duration to milliseconds for logging.
-    private static func durationMs(_ d: Duration) -> Int {
-        let (seconds, attoseconds) = d.components
-        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     /// Toggle recording: start if idle, stop if recording.
@@ -441,7 +435,7 @@ public final class TranscriptionPipeline: DictationPipeline {
             vadSegmentCount = segments.count
             vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             if !segments.isEmpty {
-                samples = Self.filterSamples(from: rawSamples, segments: segments)
+                samples = SampleFilter.filter(from: rawSamples, segments: segments)
             } else {
                 samples = rawSamples
             }
@@ -995,34 +989,6 @@ public final class TranscriptionPipeline: DictationPipeline {
         }
     }
 
-    // MARK: - VAD Segment Filtering
-
-    /// Filter samples using speech segments from service-side VAD (XPC mode).
-    /// Mirrors SilenceDetector.filterSamples logic — pad segments, merge overlaps, extract voiced audio.
-    private static func filterSamples(from allSamples: [Float], segments: [SpeechSegment], padding: Int = 1600) -> [Float] {
-        guard !segments.isEmpty else { return allSamples }
-
-        let totalVoiced = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) }
-        guard totalVoiced >= 4800 else { return allSamples }
-
-        var merged: [(start: Int, end: Int)] = []
-        for segment in segments {
-            let start = max(0, segment.startSample - padding)
-            let end = min(allSamples.count, segment.endSample + padding)
-            if let last = merged.last, start <= last.end {
-                merged[merged.count - 1].end = max(last.end, end)
-            } else {
-                merged.append((start, end))
-            }
-        }
-
-        var result: [Float] = []
-        for range in merged {
-            guard range.start < range.end else { continue }
-            result.append(contentsOf: allSamples[range.start..<range.end])
-        }
-        return result.isEmpty ? allSamples : result
-    }
 
     // MARK: - Streaming Rescue
 

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -194,7 +194,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         await audioCapture.preWarm()
         guard !Task.isCancelled else { return }
         isPreWarmed = true
-        let totalMs = Self.durationMs(ContinuousClock.now - start)
+        let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
         Task { await AppLogger.shared.log(
             "COLD-START [WhisperKit] preWarmAudioInput total=\(totalMs)ms",
             level: .info, category: "Pipeline"
@@ -202,12 +202,6 @@ public final class WhisperKitPipeline: DictationPipeline {
         // Defense-in-depth: ensure model is loaded from cache (no download).
         // If not cached, startRecording() handles the full load with user-visible UI.
         Task { _ = try? await backend.prepareIfCached() }
-    }
-
-    /// Convert Duration to milliseconds for logging.
-    private static func durationMs(_ d: Duration) -> Int {
-        let (seconds, attoseconds) = d.components
-        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
     }
 
     public func toggleRecording() async {
@@ -381,7 +375,7 @@ public final class WhisperKitPipeline: DictationPipeline {
             vadSegmentCount = segments.count
             vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
             if !segments.isEmpty {
-                samples = Self.filterSamples(from: rawSamples, segments: segments)
+                samples = SampleFilter.filter(from: rawSamples, segments: segments)
                 let pct = String(format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
                 Task { await AppLogger.shared.log(
                     "WhisperKit VAD (XPC) filtered to \(samples.count) samples (\(pct)% voiced)",
@@ -879,34 +873,6 @@ public final class WhisperKitPipeline: DictationPipeline {
         }
     }
 
-    // MARK: - VAD Segment Filtering
-
-    /// Filter samples using speech segments from service-side VAD (XPC mode).
-    /// Mirrors SilenceDetector.filterSamples logic — pad segments, merge overlaps, extract voiced audio.
-    private static func filterSamples(from allSamples: [Float], segments: [SpeechSegment], padding: Int = 1600) -> [Float] {
-        guard !segments.isEmpty else { return allSamples }
-
-        let totalVoiced = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) }
-        guard totalVoiced >= 4800 else { return allSamples }
-
-        var merged: [(start: Int, end: Int)] = []
-        for segment in segments {
-            let start = max(0, segment.startSample - padding)
-            let end = min(allSamples.count, segment.endSample + padding)
-            if let last = merged.last, start <= last.end {
-                merged[merged.count - 1].end = max(last.end, end)
-            } else {
-                merged.append((start, end))
-            }
-        }
-
-        var result: [Float] = []
-        for range in merged {
-            guard range.start < range.end else { continue }
-            result.append(contentsOf: allSamples[range.start..<range.end])
-        }
-        return result.isEmpty ? allSamples : result
-    }
 
     // MARK: - Model Lifecycle
 


### PR DESCRIPTION
## Summary
- Phase 4a of pipeline deduplication refactor (#174)
- Extracts `filterSamples()` into `SampleFilter.filter()` and `durationMs()` into `PipelineUtils.durationMs()`
- Character-for-character identical code moved to shared location
- 72 lines deleted from both pipelines

## Runtime validation
- `record_tts("The quick brown fox...")`: success=true
- Paste cascade: tier=cgevent, duration=271ms
- Pipeline timing: 1.060s (ASR=0.091s, polish=0.623s, paste=0.271s)

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
- [x] record_tts() full pipeline validation passes
