### PR TITLE
refactor(pipeline): Phase 3 - TranscriptFinalizer composition

### DIFF
--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -1,0 +1,139 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+
+/// Input for post-ASR finalization.
+@MainActor
+internal struct FinalizationRequest {
+    let asrText: String
+    let language: String?
+    let duration: TimeInterval
+    let processingTime: TimeInterval
+    let backendType: ASRBackendType
+    let targetApp: NSRunningApplication?
+    let targetElement: AXUIElement?
+    let autoCopyToClipboard: Bool
+    let autoPasteToActiveApp: Bool
+    let restoreClipboardAfterPaste: Bool
+    let steps: [any TextProcessingStep]
+}
+
+/// Output from post-ASR finalization.
+@MainActor
+internal struct FinalizationResult {
+    let transcript: Transcript
+    let pasteResult: PasteDeliveryResult?
+    /// Error message from polish step failure, if any.
+    let polishError: String?
+    /// Context from text processing, for LLM provider/model tracking.
+    let processingContext: TextProcessingContext
+    /// Time spent in text processing (for metrics).
+    let polishDurationSeconds: Double
+    /// Time spent in paste (for metrics).
+    let pasteDurationSeconds: Double
+}
+
+/// Typed errors so pipelines can decide the right fallback per category.
+/// GPT Desktop review: a single generic throw path blurs storage failures
+/// with polish failures, creating misleading Sentry data and wrong fallbacks.
+internal enum FinalizationError: Error {
+    /// Text processing ran but produced empty output
+    case emptyAfterProcessing
+    /// Transcript storage failed (disk full, permissions, etc.)
+    case storageFailed(underlying: Error)
+}
+
+/// Orchestrates the post-ASR delivery path: text processing -> store -> paste.
+///
+/// Does NOT own pipeline state transitions. Returns data; the pipeline decides
+/// .polishing, .complete, .error based on the result.
+/// Does NOT own step instances. Steps are passed in via the request.
+/// Does NOT emit pipeline-specific telemetry (ASR mode, backend, etc.).
+@MainActor
+internal final class TranscriptFinalizer {
+    private let transcriptStore: TranscriptStore
+    private let textProcessingRunner: TextProcessingRunner
+    private let pasteExecutor: PasteCascadeExecutor
+
+    init(
+        transcriptStore: TranscriptStore,
+        textProcessingRunner: TextProcessingRunner = TextProcessingRunner(),
+        pasteExecutor: PasteCascadeExecutor = PasteCascadeExecutor()
+    ) {
+        self.transcriptStore = transcriptStore
+        self.textProcessingRunner = textProcessingRunner
+        self.pasteExecutor = pasteExecutor
+    }
+
+    /// Finalize a transcription: process text, store transcript, paste to target.
+    ///
+    /// Throws `FinalizationError` for typed failures. Throws `CancellationError` if cancelled.
+    /// Text processing step failures are handled internally (heart & limbs) and reported
+    /// via `polishError` in the result, NOT as thrown errors.
+    func finalize(_ request: FinalizationRequest) async throws -> FinalizationResult {
+        // 1. Text processing (step failures handled internally by runner)
+        let polishStart = CFAbsoluteTimeGetCurrent()
+        let processingResult = try await textProcessingRunner.run(
+            rawText: request.asrText,
+            language: request.language,
+            targetAppName: request.targetApp?.localizedName,
+            steps: request.steps
+        )
+        let polishEnd = CFAbsoluteTimeGetCurrent()
+
+        Task { await AppLogger.shared.log(
+            "Pipeline timing: text processing completed in \(String(format: "%.3f", polishEnd - polishStart))s",
+            level: .info, category: "PipelineTiming"
+        ) }
+
+        let context = processingResult.context
+        let finalText = context.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !finalText.isEmpty else {
+            throw FinalizationError.emptyAfterProcessing
+        }
+
+        // 2. Create and store transcript
+        let transcript = Transcript(
+            text: context.text,
+            polishedText: context.polishedText,
+            language: request.language,
+            duration: request.duration,
+            processingTime: request.processingTime,
+            backendType: request.backendType,
+            llmProvider: context.llmProvider,
+            llmModel: context.llmModel
+        )
+        do {
+            try transcriptStore.save(transcript)
+        } catch {
+            throw FinalizationError.storageFailed(underlying: error)
+        }
+
+        // 3. Paste (never throws -- paste cascade always falls back to clipboard)
+        let pasteStart = CFAbsoluteTimeGetCurrent()
+        var pasteResult: PasteDeliveryResult?
+        if request.autoPasteToActiveApp {
+            let text = PasteService.appendTrailingSpace(transcript.displayText)
+            pasteResult = await pasteExecutor.deliver(PasteDeliveryRequest(
+                text: text,
+                targetApp: request.targetApp,
+                targetElement: request.targetElement,
+                restoreClipboardAfterPaste: request.restoreClipboardAfterPaste
+            ))
+        } else if request.autoCopyToClipboard {
+            PasteService.copyToClipboard(transcript.displayText)
+        }
+        let pasteEnd = CFAbsoluteTimeGetCurrent()
+
+        return FinalizationResult(
+            transcript: transcript,
+            pasteResult: pasteResult,
+            polishError: processingResult.polishError,
+            processingContext: context,
+            polishDurationSeconds: polishEnd - polishStart,
+            pasteDurationSeconds: pasteEnd - pasteStart
+        )
+    }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -37,8 +37,7 @@ public final class TranscriptionPipeline: DictationPipeline {
     public var lastPolishError: String?
 
     // Shared services
-    private let pasteExecutor = PasteCascadeExecutor()
-    private let textProcessingRunner = TextProcessingRunner()
+    private let transcriptFinalizer: TranscriptFinalizer
 
     // Text processing steps
     private let wordCorrectionStep = WordCorrectionStep()
@@ -91,6 +90,7 @@ public final class TranscriptionPipeline: DictationPipeline {
         self.asrManager = asrManager
         self.transcriptStore = transcriptStore
         self.keychainManager = keychainManager
+        self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
         self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
         llmPolishStep.onWillProcess = { [weak self] in
             self?.state = .polishing
@@ -577,94 +577,66 @@ public final class TranscriptionPipeline: DictationPipeline {
                 level: .info, category: "PipelineTiming"
             ) }
 
-            // Run pluggable text processing steps (word correction, LLM polish, etc.)
-            let polishStart = CFAbsoluteTimeGetCurrent()
-            var context: TextProcessingContext
+            // Post-ASR finalization: text processing -> store -> paste
+            let finalizationResult: FinalizationResult
             do {
-                context = try await runTextProcessing(asrText: asrText, language: result.language)
-            } catch {
-                SentryBreadcrumb.captureError(error, category: .generationFailed, stage: "polish", extra: [
-                    "provider": llmPolishStep.llmProvider.rawValue,
-                    "model": llmPolishStep.llmModel,
-                ])
-                // Fire-and-forget: AI diagnostics must not block paste path (up to 10s timeout)
-                if llmPolishStep.llmProvider == .appleIntelligence {
-                    let capturedStartTime = self.recordingStartTime
-                    Task { [weak self] in
-                        let aiReport = await AppleIntelligenceDiagnosticsService.runDiagnostics()
-                        guard self?.recordingStartTime == capturedStartTime else { return }
-                        SentryBreadcrumb.reportAIFailure(aiReport)
-                    }
-                }
-                Task { await AppLogger.shared.log(
-                    "Text processing failed: \(error.localizedDescription)",
-                    level: .info, category: "Pipeline"
-                ) }
-                lastPolishError = error.localizedDescription
-                context = TextProcessingContext(text: asrText, language: result.language)
-                context.targetAppName = targetApp?.localizedName
-            }
-            let polishEnd = CFAbsoluteTimeGetCurrent()
-
-            Task { await AppLogger.shared.log(
-                "Pipeline timing: text processing completed in \(String(format: "%.3f", polishEnd - polishStart))s",
-                level: .info, category: "PipelineTiming"
-            ) }
-
-            let finalText = context.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !finalText.isEmpty else {
-                state = .error("No text after processing")
+                finalizationResult = try await transcriptFinalizer.finalize(FinalizationRequest(
+                    asrText: asrText,
+                    language: result.language,
+                    duration: result.duration,
+                    processingTime: result.processingTime,
+                    backendType: result.backendType,
+                    targetApp: targetApp,
+                    targetElement: targetElement,
+                    autoCopyToClipboard: autoCopyToClipboard,
+                    autoPasteToActiveApp: autoPasteToActiveApp,
+                    restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+                    steps: textProcessingSteps
+                ))
+            } catch is CancellationError {
+                frozenSnapshot = nil
                 return
+            } catch let error as FinalizationError {
+                switch error {
+                case .emptyAfterProcessing:
+                    state = .error("No text after processing")
+                    frozenSnapshot = nil
+                    return
+                case .storageFailed(let underlying):
+                    SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
+                    state = .error("Failed to save transcript")
+                    frozenSnapshot = nil
+                    return
+                }
             }
 
-            var transcript = Transcript(
-                text: context.text,
-                polishedText: context.polishedText,
-                language: result.language,
-                duration: result.duration,
-                processingTime: result.processingTime,
-                backendType: result.backendType,
-                llmProvider: context.llmProvider,
-                llmModel: context.llmModel
-            )
-
-            // Save to store
-            try transcriptStore.save(transcript)
+            lastPolishError = finalizationResult.polishError
 
             // Notify ASR manager that transcription is done; schedules unload timer if configured.
             asrManager.noteTranscriptionComplete(policy: modelUnloadPolicy)
 
-            // Auto-copy/paste + auto-submit — tiered cascade
-            let pasteStart = CFAbsoluteTimeGetCurrent()
-            var pasteTier: PasteTier?
-            var pasteMs: Int?
+            // Build metrics (pipeline-specific: uses ASR timing, streaming mode)
             let pasteTargetApp = targetApp?.bundleIdentifier
-            if autoPasteToActiveApp {
-                let text = PasteService.appendTrailingSpace(transcript.displayText)
-                let result = await performPaste(text: text, pasteStart: pasteStart)
-                pasteTier = result.tier
-                pasteMs = result.durationMs
-            } else if autoCopyToClipboard {
-                PasteService.copyToClipboard(transcript.displayText)
-            }
-            let pasteEnd = CFAbsoluteTimeGetCurrent()
             targetApp = nil
             targetElement = nil
 
             let pipelineEnd = CFAbsoluteTimeGetCurrent()
+            let polishDuration = finalizationResult.polishDurationSeconds
+            let pasteDuration = finalizationResult.pasteDurationSeconds
             Task { await AppLogger.shared.log(
                 "Pipeline timing TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s " +
                 "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, " +
-                "polish=\(String(format: "%.3f", polishEnd - polishStart))s, " +
-                "paste=\(String(format: "%.3f", pasteEnd - pasteStart))s)",
+                "polish=\(String(format: "%.3f", polishDuration))s, " +
+                "paste=\(String(format: "%.3f", pasteDuration))s)",
                 level: .info, category: "PipelineTiming"
             ) }
 
+            var transcript = finalizationResult.transcript
             transcript.metrics = ExecutionMetrics(
                 asrLatencySeconds: asrEnd - asrStart,
-                llmLatencySeconds: polishEnd - polishStart,
-                pasteTier: pasteTier?.rawValue,
-                pasteLatencyMs: pasteMs,
+                llmLatencySeconds: polishDuration,
+                pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+                pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
                 targetApp: pasteTargetApp,
                 coldStart: false,
                 streamingMode: wasStreaming,
@@ -674,8 +646,8 @@ public final class TranscriptionPipeline: DictationPipeline {
             SentryBreadcrumb.add(stage: "pipeline", message: "Pipeline complete", data: [
                 "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
                 "asr_s": String(format: "%.3f", asrEnd - asrStart),
-                "polish_s": String(format: "%.3f", polishEnd - polishStart),
-                "paste_tier": pasteTier?.rawValue ?? "none",
+                "polish_s": String(format: "%.3f", polishDuration),
+                "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
                 "backend": asrManager.activeBackendType.rawValue,
             ])
             frozenSnapshot = nil
@@ -1036,33 +1008,6 @@ public final class TranscriptionPipeline: DictationPipeline {
         )
 
         return result
-    }
-
-    // MARK: - Paste Cascade
-
-    private func performPaste(text: String, pasteStart: CFAbsoluteTime) async -> (tier: PasteTier, durationMs: Int) {
-        let result = await pasteExecutor.deliver(PasteDeliveryRequest(
-            text: text,
-            targetApp: targetApp,
-            targetElement: targetElement,
-            restoreClipboardAfterPaste: restoreClipboardAfterPaste
-        ))
-        return (result.tier, result.durationMs)
-    }
-
-    // MARK: - Text Processing
-
-    private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
-        let result = try await textProcessingRunner.run(
-            rawText: asrText,
-            language: language,
-            targetAppName: targetApp?.localizedName,
-            steps: textProcessingSteps
-        )
-        if let error = result.polishError {
-            lastPolishError = error
-        }
-        return result.context
     }
 
     // MARK: - DictationPipeline Conformance

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -59,8 +59,7 @@ public final class WhisperKitPipeline: DictationPipeline {
     public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
     // Shared services
-    private let pasteExecutor = PasteCascadeExecutor()
-    private let textProcessingRunner = TextProcessingRunner()
+    private let transcriptFinalizer: TranscriptFinalizer
 
     // Text processing steps (own instances — not shared with Parakeet)
     public let wordCorrectionStep = WordCorrectionStep()
@@ -105,6 +104,7 @@ public final class WhisperKitPipeline: DictationPipeline {
         self.backend = backend
         self.transcriptStore = transcriptStore
         self.keychainManager = keychainManager
+        self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
         self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
 
         llmPolishStep.onWillProcess = { [weak self] in
@@ -550,80 +550,64 @@ public final class WhisperKitPipeline: DictationPipeline {
                 level: .info, category: "WhisperKitPipeline"
             ) }
 
-            // Run text processing (word correction, filler removal, LLM polish)
-            let polishStart = CFAbsoluteTimeGetCurrent()
-            var context: TextProcessingContext
-            do {
-                context = try await runTextProcessing(asrText: asrText, language: asrLanguage)
-            } catch {
-                SentryBreadcrumb.captureError(error, category: .generationFailed, stage: "polish", extra: [
-                    "provider": llmPolishStep.llmProvider.rawValue,
-                    "model": llmPolishStep.llmModel,
-                ])
-                // Fire-and-forget: AI diagnostics must not block paste path (up to 10s timeout)
-                if llmPolishStep.llmProvider == .appleIntelligence {
-                    let capturedStartTime = self.recordingStartTime
-                    Task { [weak self] in
-                        let aiReport = await AppleIntelligenceDiagnosticsService.runDiagnostics()
-                        guard self?.recordingStartTime == capturedStartTime else { return }
-                        SentryBreadcrumb.reportAIFailure(aiReport)
-                    }
-                }
-                lastPolishError = error.localizedDescription
-                context = TextProcessingContext(text: asrText, language: asrLanguage)
-                context.targetAppName = targetApp?.localizedName
-            }
-            let polishEnd = CFAbsoluteTimeGetCurrent()
-
-            let finalText = context.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !finalText.isEmpty else {
-                state = .error("No text after processing")
-                return
-            }
-
+            // Post-ASR finalization: text processing -> store -> paste
             let recordingDuration = Double(rawSamples.count) / 16000.0
-            var transcript = Transcript(
-                text: context.text,
-                polishedText: context.polishedText,
-                language: asrLanguage,
-                duration: recordingDuration,
-                processingTime: asrEnd - asrStart,
-                backendType: .whisperKit,
-                llmProvider: context.llmProvider,
-                llmModel: context.llmModel
-            )
-
-            try transcriptStore.save(transcript)
-
-            // Paste cascade (same tiered approach as TranscriptionPipeline)
-            let pasteStart = CFAbsoluteTimeGetCurrent()
-            let pasteTargetApp = targetApp?.bundleIdentifier
-            var pasteTier: PasteTier?
-            var pasteMs: Int?
-            if autoPasteToActiveApp {
-                let text = PasteService.appendTrailingSpace(transcript.displayText)
-                let result = await performPaste(text: text, pasteStart: pasteStart)
-                pasteTier = result.tier
-                pasteMs = result.durationMs
-            } else if autoCopyToClipboard {
-                PasteService.copyToClipboard(transcript.displayText)
+            let finalizationResult: FinalizationResult
+            do {
+                finalizationResult = try await transcriptFinalizer.finalize(FinalizationRequest(
+                    asrText: asrText,
+                    language: asrLanguage,
+                    duration: recordingDuration,
+                    processingTime: asrEnd - asrStart,
+                    backendType: .whisperKit,
+                    targetApp: targetApp,
+                    targetElement: targetElement,
+                    autoCopyToClipboard: autoCopyToClipboard,
+                    autoPasteToActiveApp: autoPasteToActiveApp,
+                    restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+                    steps: textProcessingSteps
+                ))
+            } catch is CancellationError {
+                frozenSnapshot = nil
+                return
+            } catch let error as FinalizationError {
+                switch error {
+                case .emptyAfterProcessing:
+                    state = .error("No text after processing")
+                    frozenSnapshot = nil
+                    return
+                case .storageFailed(let underlying):
+                    SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
+                    state = .error("Failed to save transcript")
+                    frozenSnapshot = nil
+                    return
+                }
             }
+
+            lastPolishError = finalizationResult.polishError
+
+            // Build metrics (pipeline-specific: uses ASR timing)
+            let pasteTargetApp = targetApp?.bundleIdentifier
             targetApp = nil
             targetElement = nil
 
             let pipelineEnd = CFAbsoluteTimeGetCurrent()
+            let polishDuration = finalizationResult.polishDurationSeconds
+            let pasteDuration = finalizationResult.pasteDurationSeconds
             Task { await AppLogger.shared.log(
                 "WhisperKit pipeline TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s " +
                 "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, " +
-                "polish=\(String(format: "%.3f", polishEnd - polishStart))s)",
+                "polish=\(String(format: "%.3f", polishDuration))s, " +
+                "paste=\(String(format: "%.3f", pasteDuration))s)",
                 level: .info, category: "WhisperKitPipeline"
             ) }
 
+            var transcript = finalizationResult.transcript
             transcript.metrics = ExecutionMetrics(
                 asrLatencySeconds: asrEnd - asrStart,
-                llmLatencySeconds: polishEnd - polishStart,
-                pasteTier: pasteTier?.rawValue,
-                pasteLatencyMs: pasteMs,
+                llmLatencySeconds: polishDuration,
+                pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+                pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
                 targetApp: pasteTargetApp,
                 coldStart: false,
                 streamingMode: false,
@@ -633,8 +617,8 @@ public final class WhisperKitPipeline: DictationPipeline {
             SentryBreadcrumb.add(stage: "pipeline", message: "WhisperKit pipeline complete", data: [
                 "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
                 "asr_s": String(format: "%.3f", asrEnd - asrStart),
-                "polish_s": String(format: "%.3f", polishEnd - polishStart),
-                "paste_tier": pasteTier?.rawValue ?? "none",
+                "polish_s": String(format: "%.3f", polishDuration),
+                "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
             ])
             frozenSnapshot = nil
             state = .complete
@@ -897,30 +881,4 @@ public final class WhisperKitPipeline: DictationPipeline {
         }
     }
 
-    // MARK: - Text Processing
-
-    private func runTextProcessing(asrText: String, language: String?) async throws -> TextProcessingContext {
-        let result = try await textProcessingRunner.run(
-            rawText: asrText,
-            language: language,
-            targetAppName: targetApp?.localizedName,
-            steps: textProcessingSteps
-        )
-        if let error = result.polishError {
-            lastPolishError = error
-        }
-        return result.context
-    }
-
-    // MARK: - Paste Cascade
-
-    private func performPaste(text: String, pasteStart: CFAbsoluteTime) async -> (tier: PasteTier, durationMs: Int) {
-        let result = await pasteExecutor.deliver(PasteDeliveryRequest(
-            text: text,
-            targetApp: targetApp,
-            targetElement: targetElement,
-            restoreClipboardAfterPaste: restoreClipboardAfterPaste
-        ))
-        return (result.tier, result.durationMs)
-    }
 }


### PR DESCRIPTION
## Summary
- Phase 3 of pipeline deduplication refactor (#174)
- Composes PasteCascadeExecutor + TextProcessingRunner + transcript storage into `TranscriptFinalizer`
- Typed error taxonomy: `.emptyAfterProcessing`, `.storageFailed(underlying:)`
- Both pipelines call `transcriptFinalizer.finalize()`, handle result, own state transitions
- Deleted `performPaste()` and `runTextProcessing()` wrappers from both pipelines
- 184 lines deleted from pipelines

## Runtime validation
- `record_tts("The quick brown fox...")`: success=true
- CORRECTION_DEBUG [RAW ASR]: confirmed
- Paste cascade: tier=cgevent, duration=276ms
- Pipeline timing TOTAL: 1.066s (ASR=0.094s, polish=0.618s, paste=0.276s)

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
- [x] record_tts() full pipeline validation passes
- [x] All three mandatory log entries confirmed
