### PR TITLE
refactor(pipeline): Phase 4b - VADMonitorLoop extraction

### DIFF
--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -877,32 +877,21 @@ public final class TranscriptionPipeline: DictationPipeline {
     }
 
     private func monitorVAD() async {
-        // Max-duration enforcement runs regardless of backend mode.
-        // VAD chunk processing only runs for in-process capture.
-        // XPC-mode VAD runs in the service and fires vadAutoStopTriggered callback.
-        //
-        // TEMPORARY DEBT: `is AudioCaptureProxy` leaks a concrete type into pipeline code.
-        // Step 7 (flag removal) should replace this with a capability query on the interface
-        // (e.g. `var supportsServiceSideVAD: Bool`) so the pipeline stays implementation-agnostic.
+        // Detector setup stays in pipeline (owns silenceDetector lifecycle)
         let isXPCMode = audioCapture is AudioCaptureProxy
+        var detector: SilenceDetector?
 
         if !isXPCMode {
-            // Build SmoothedVAD config from sensitivity setting
             let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
-
-            // Lazily create detector
             if silenceDetector == nil {
                 silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
             }
-            guard let detector = silenceDetector else { return }
-
-            await detector.reset()
-            await detector.updateConfig(config)
-
-            // Prepare VAD model if needed
-            if !(await detector.isReady) {
+            guard let det = silenceDetector else { return }
+            await det.reset()
+            await det.updateConfig(config)
+            if !(await det.isReady) {
                 do {
-                    try await detector.prepare()
+                    try await det.prepare()
                 } catch {
                     Task { await AppLogger.shared.log(
                         "VAD preparation failed: \(error)",
@@ -911,54 +900,23 @@ public final class TranscriptionPipeline: DictationPipeline {
                     return
                 }
             }
-
-            var processedSampleCount = 0
-            let chunkSize = SilenceDetector.chunkSize
-
-            while state == .recording && !Task.isCancelled {
-                // Graceful max duration check — auto-stop before AudioCaptureManager's hard limit.
-                if let startTime = recordingStartTime,
-                   Date().timeIntervalSince(startTime) >= TimingConstants.maxRecordingDuration {
-                    Task { [weak self] in await self?.stopAndTranscribe() }
-                    return
-                }
-
-                // Snapshot @MainActor-isolated data before any await suspension.
-                let currentCount = audioCapture.capturedSamples.count
-
-                while processedSampleCount + chunkSize <= currentCount && !Task.isCancelled {
-                    let endIdx = processedSampleCount + chunkSize
-                    // Snapshot the chunk on @MainActor before crossing into the detector actor.
-                    let chunk = Array(audioCapture.capturedSamples[processedSampleCount..<endIdx])
-                    let autoStop = vadAutoStop
-
-                    let shouldStop = await detector.processChunk(chunk)
-
-                    if shouldStop && autoStop && state == .recording {
-                        // Run in a new Task so cancelling vadMonitorTask
-                        // doesn't propagate CancellationError into transcription.
-                        Task { [weak self] in await self?.stopAndTranscribe() }
-                        return
-                    }
-
-                    processedSampleCount += chunkSize
-                    await Task.yield()
-                }
-
-                try? await Task.sleep(for: .milliseconds(100))
-            }
-        } else {
-            // XPC mode: service handles VAD, fires vadAutoStopTriggered callback.
-            // Only run max-duration enforcement here.
-            while state == .recording && !Task.isCancelled {
-                if let startTime = recordingStartTime,
-                   Date().timeIntervalSince(startTime) >= TimingConstants.maxRecordingDuration {
-                    Task { [weak self] in await self?.stopAndTranscribe() }
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(500))
-            }
+            detector = det
         }
+
+        let startTime = recordingStartTime ?? Date()
+        let capture = audioCapture
+
+        await VADMonitorLoop.run(
+            detector: detector,
+            vadAutoStop: vadAutoStop,
+            maxDuration: TimingConstants.maxRecordingDuration,
+            recordingStartTime: startTime,
+            sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
+            isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
+            onStop: { [weak self] _ in
+                Task { [weak self] in await self?.stopAndTranscribe() }
+            }
+        )
     }
 
 

--- a/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
+++ b/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
@@ -1,0 +1,86 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Reason the VAD monitor loop requests a recording stop.
+internal enum VADStopReason: Sendable {
+    case silenceTimeout
+    case maxDuration
+}
+
+/// Shared VAD monitoring loop used by both pipelines during recording.
+///
+/// Does not own the SilenceDetector, the monitoring task, or stop guards.
+/// Those stay on the pipeline. This is the loop algorithm only.
+@MainActor
+internal enum VADMonitorLoop {
+
+    /// Run the VAD monitoring loop. Returns when recording stops or auto-stop triggers.
+    ///
+    /// For in-process mode: pass the prepared detector. Processes audio chunks and triggers
+    /// auto-stop on silence detection.
+    /// For XPC mode: pass nil for detector. Only enforces max recording duration.
+    ///
+    /// - Parameters:
+    ///   - detector: Prepared SilenceDetector, or nil for XPC mode (service handles VAD)
+    ///   - vadAutoStop: Whether silence-triggered auto-stop is enabled
+    ///   - maxDuration: Maximum recording duration in seconds
+    ///   - recordingStartTime: When recording began (for max duration check)
+    ///   - sampleProvider: Returns current captured samples array (called on @MainActor)
+    ///   - isRecording: Returns whether recording is still active
+    ///   - onStop: Called when auto-stop should trigger. Runs in a new Task to avoid
+    ///     cancellation propagation from the monitor task into transcription.
+    static func run(
+        detector: SilenceDetector?,
+        vadAutoStop: Bool,
+        maxDuration: TimeInterval,
+        recordingStartTime: Date,
+        sampleProvider: @escaping @MainActor () -> [Float],
+        isRecording: @escaping @MainActor () -> Bool,
+        onStop: @escaping @MainActor (VADStopReason) -> Void
+    ) async {
+        if let detector {
+            // In-process mode: process chunks through SilenceDetector
+            var processedSampleCount = 0
+            let chunkSize = SilenceDetector.chunkSize
+
+            while isRecording() && !Task.isCancelled {
+                // Max duration check
+                if Date().timeIntervalSince(recordingStartTime) >= maxDuration {
+                    onStop(.maxDuration)
+                    return
+                }
+
+                let samples = sampleProvider()
+                let currentCount = samples.count
+
+                while processedSampleCount + chunkSize <= currentCount && !Task.isCancelled {
+                    let endIdx = processedSampleCount + chunkSize
+                    let chunk = Array(samples[processedSampleCount..<endIdx])
+
+                    let shouldStop = await detector.processChunk(chunk)
+
+                    if shouldStop && vadAutoStop && isRecording() {
+                        onStop(.silenceTimeout)
+                        return
+                    }
+
+                    processedSampleCount += chunkSize
+                    await Task.yield()
+                }
+
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        } else {
+            // XPC mode: service handles VAD. Only enforce max duration here.
+            while isRecording() && !Task.isCancelled {
+                if Date().timeIntervalSince(recordingStartTime) >= maxDuration {
+                    onStop(.maxDuration)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+    }
+}

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -781,80 +781,46 @@ public final class WhisperKitPipeline: DictationPipeline {
     }
 
     private func monitorVAD() async {
-        // Max-duration enforcement runs regardless of backend mode.
-        // VAD chunk processing only runs for in-process capture.
-        // XPC-mode VAD runs in the service and fires vadAutoStopTriggered callback.
-        //
-        // TEMPORARY DEBT: `is AudioCaptureProxy` — see TranscriptionPipeline.monitorVAD comment.
-        // Step 7 should replace with interface capability query.
+        // Detector setup stays in pipeline (owns silenceDetector lifecycle)
         let isXPCMode = audioCapture is AudioCaptureProxy
+        var detector: SilenceDetector?
 
         if !isXPCMode {
             let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
-
             if silenceDetector == nil {
                 silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
             }
-            guard let detector = silenceDetector else { return }
-
-            await detector.reset()
-            await detector.updateConfig(config)
-
-            if !(await detector.isReady) {
+            guard let det = silenceDetector else { return }
+            await det.reset()
+            await det.updateConfig(config)
+            if !(await det.isReady) {
                 do {
-                    try await detector.prepare()
+                    try await det.prepare()
                 } catch {
                     Task { await AppLogger.shared.log(
-                        "WhisperKit VAD preparation failed: \(error)",
-                        level: .info, category: "WhisperKitPipeline"
+                        "VAD preparation failed: \(error)",
+                        level: .info, category: "VAD"
                     ) }
                     return
                 }
             }
-
-            var processedSampleCount = 0
-            let chunkSize = SilenceDetector.chunkSize
-
-            while state == .recording && !Task.isCancelled {
-                // Graceful max duration check — auto-stop before AudioCaptureManager's hard limit.
-                if let startTime = recordingStartTime,
-                   Date().timeIntervalSince(startTime) >= TimingConstants.maxRecordingDuration {
-                    Task { [weak self] in await self?.stopAndTranscribe() }
-                    return
-                }
-
-                let currentCount = audioCapture.capturedSamples.count
-
-                while processedSampleCount + chunkSize <= currentCount && !Task.isCancelled {
-                    let endIdx = processedSampleCount + chunkSize
-                    let chunk = Array(audioCapture.capturedSamples[processedSampleCount..<endIdx])
-                    let autoStop = vadAutoStop
-
-                    let shouldStop = await detector.processChunk(chunk)
-
-                    if shouldStop && autoStop && state == .recording {
-                        Task { [weak self] in await self?.stopAndTranscribe() }
-                        return
-                    }
-
-                    processedSampleCount += chunkSize
-                    await Task.yield()
-                }
-
-                try? await Task.sleep(for: .milliseconds(100))
-            }
-        } else {
-            // XPC mode: service handles VAD, fires vadAutoStopTriggered callback.
-            // Only run max-duration enforcement here.
-            while state == .recording && !Task.isCancelled {
-                if let startTime = recordingStartTime,
-                   Date().timeIntervalSince(startTime) >= TimingConstants.maxRecordingDuration {
-                    Task { [weak self] in await self?.stopAndTranscribe() }
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(500))
-            }
+            detector = det
         }
+
+        let startTime = recordingStartTime ?? Date()
+        let capture = audioCapture
+
+        await VADMonitorLoop.run(
+            detector: detector,
+            vadAutoStop: vadAutoStop,
+            maxDuration: TimingConstants.maxRecordingDuration,
+            recordingStartTime: startTime,
+            sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
+            isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
+            onStop: { [weak self] _ in
+                Task { [weak self] in await self?.stopAndTranscribe() }
+            }
+        )
     }
 
 


### PR DESCRIPTION
## Summary
- Phase 4b (final phase) of pipeline deduplication refactor (#174)
- Extracts identical VAD monitoring loop into shared `VADMonitorLoop.run()`
- Pipelines keep detector setup, task ownership, stop guards
- Loop receives closures for sampleProvider, isRecording, onStop
- 121 lines deleted from both pipelines

## Runtime validation
- `record_tts()`: success=true (picked up live speech through headphones mic)
- RAW ASR: confirmed in CORRECTION_DEBUG
- Paste cascade: tier=cgevent, app=net.whatsapp.WhatsApp
- Pipeline timing TOTAL: 0.927s

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
- [x] record_tts() full pipeline validation passes
- [x] All three mandatory log entries confirmed
