### PR TITLE
chore(pipeline): remove dead code from dedup refactor

### DIFF
--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -1,5 +1,4 @@
 import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 /// Result of running the text processing chain.

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -27,8 +27,6 @@ internal struct FinalizationResult {
     let pasteResult: PasteDeliveryResult?
     /// Error message from polish step failure, if any.
     let polishError: String?
-    /// Context from text processing, for LLM provider/model tracking.
-    let processingContext: TextProcessingContext
     /// Time spent in text processing (for metrics).
     let polishDurationSeconds: Double
     /// Time spent in paste (for metrics).
@@ -131,7 +129,6 @@ internal final class TranscriptFinalizer {
             transcript: transcript,
             pasteResult: pasteResult,
             polishError: processingResult.polishError,
-            processingContext: context,
             polishDurationSeconds: polishEnd - polishStart,
             pasteDurationSeconds: pasteEnd - pasteStart
         )

--- a/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
+++ b/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
@@ -1,6 +1,4 @@
 import EnviousWisprAudio
-import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 /// Reason the VAD monitor loop requests a recording stop.

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -39,7 +39,6 @@ public enum WhisperKitPipelineState: Equatable, Sendable {
 public final class WhisperKitPipeline: DictationPipeline {
     private let audioCapture: any AudioCaptureInterface
     private let backend: WhisperKitBackend
-    private let transcriptStore: TranscriptStore
     private let keychainManager: KeychainManager
 
     public private(set) var state: WhisperKitPipelineState = .idle {
@@ -102,7 +101,6 @@ public final class WhisperKitPipeline: DictationPipeline {
     ) {
         self.audioCapture = audioCapture
         self.backend = backend
-        self.transcriptStore = transcriptStore
         self.keychainManager = keychainManager
         self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
         self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)


### PR DESCRIPTION
## Summary
Periphery scan cleanup after pipeline deduplication refactor (#174).
- 4 unused imports removed
- 1 unused property removed (processingContext in FinalizationResult)
- 1 assign-only property removed (transcriptStore in WhisperKitPipeline)
- 8 lines deleted, 0 added

## Test plan
- [x] `swift build -c release` passes
- [x] `scripts/swift-test.sh` passes (80 tests, 0 failures)
