### PR TITLE
Add Contact link to main navigation

### DIFF
--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -42,6 +42,7 @@ const { activePage = 'home' } = Astro.props;
       <li><a href="/how-it-works/" class:list={[{ active: activePage === 'how-it-works' }]}>How It Works</a></li>
       <li><a href="/compare/" class:list={[{ active: activePage === 'compare' }]}>Compare</a></li>
       <li><a href="/blog/">Blog</a></li>
+      <li><a href="/contact/" class:list={[{ active: activePage === 'contact' }]}>Contact</a></li>
       <li class="nav-gh-mobile"><a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true" style="vertical-align:middle;"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         <span>GitHub</span>


### PR DESCRIPTION
## Summary
- Adds Contact to the header nav bar (after Blog)
- Contact page already exists and is fully functional (Resend email backend verified E2E)
- Makes the contact form more discoverable for visitors

## Test plan
- [ ] Verify Contact link appears in desktop nav
- [ ] Verify Contact link appears in mobile hamburger menu
- [ ] Verify active state highlights when on /contact/ page
- [ ] Click through to confirm form still works
