### PR TITLE
Add Crisp chat widget for visitor support

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -106,5 +106,16 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
       });
     });
   </script>
+  <!-- Crisp Chat Widget -->
+  <script>
+    window.$crisp = [];
+    window.CRISP_WEBSITE_ID = '6cfca684-ab92-4927-a1a3-6bf97eac13f9';
+    (function() {
+      var d = document, s = d.createElement('script');
+      s.src = 'https://client.crisp.chat/l.js';
+      s.async = 1;
+      d.getElementsByTagName('head')[0].appendChild(s);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds Crisp live chat widget to all pages via BaseLayout.astro
- Visitors can message directly from the site
- Push notifications to Crisp mobile app when online
- Offline mode collects messages and emails them
- Crisp account: Envious Labs LLC

## Test plan
- [ ] Verify chat bubble appears on homepage
- [ ] Verify chat bubble appears on /contact/ page
- [ ] Send a test message and confirm it arrives in Crisp dashboard
- [ ] Verify offline message collection works
