### PR TITLE
feat(llm): dynamic Ollama model catalog and native API migration

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -24,6 +24,13 @@ struct AIPolishSettingsView: View {
         appState.settings.llmProvider != .none && appState.settings.llmProvider != .appleIntelligence
     }
 
+    private var ollamaShowsManageModels: Bool {
+        switch appState.ollamaSetup.setupState {
+        case .ready, .pullingModel: return true
+        default: return false
+        }
+    }
+
     private var showWritingStyleSection: Bool {
         appState.settings.llmProvider != .none
     }
@@ -159,9 +166,9 @@ struct AIPolishSettingsView: View {
                 }
             }
 
-            // Manage Models for Ollama (when ready)
+            // Manage Models for Ollama (when ready or pulling)
             if appState.settings.llmProvider == .ollama,
-               case .ready = appState.ollamaSetup.setupState {
+               ollamaShowsManageModels {
                 BrandedSection(header: "Manage Models") {
                     BrandedRow(showDivider: false) {
                         DisclosureGroup("Download / Remove Models", isExpanded: $showManageModels) {
@@ -768,8 +775,14 @@ struct AIPolishSettingsView: View {
 
     @ViewBuilder
     private var ollamaModelCatalogView: some View {
+        let catalog = appState.ollamaSetup.dynamicCatalog
+        let isPulling: Bool = {
+            if case .pullingModel = appState.ollamaSetup.setupState { return true }
+            return false
+        }()
+
         VStack(alignment: .leading, spacing: 6) {
-            ForEach(OllamaSetupService.modelCatalog) { entry in
+            ForEach(catalog) { entry in
                 HStack(spacing: 8) {
                     VStack(alignment: .leading, spacing: 1) {
                         HStack(spacing: 4) {
@@ -786,7 +799,7 @@ struct AIPolishSettingsView: View {
 
                     Spacer()
 
-                    if appState.ollamaSetup.downloadedModelNames.contains(entry.name) {
+                    if entry.isDownloaded {
                         Button {
                             appState.ollamaSetup.deleteModel(name: entry.name)
                         } label: {
@@ -795,6 +808,7 @@ struct AIPolishSettingsView: View {
                         }
                         .controlSize(.small)
                         .buttonStyle(.borderless)
+                        .disabled(isPulling)
                     } else {
                         Button {
                             appState.ollamaSetup.pullModel(entry.name)
@@ -803,11 +817,12 @@ struct AIPolishSettingsView: View {
                         }
                         .controlSize(.small)
                         .buttonStyle(.borderless)
+                        .disabled(isPulling)
                     }
                 }
                 .padding(.vertical, 2)
 
-                if entry.id != OllamaSetupService.modelCatalog.last?.id {
+                if entry.id != catalog.last?.id {
                     Divider()
                 }
             }

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -87,8 +87,8 @@ public enum LLMConstants {
     /// Thinking models (Gemini 2.5) consume output tokens for reasoning, so this must be generous.
     public static let defaultMaxTokens: Int = 8192
 
-    /// Max tokens for Ollama (local models).
-    public static let ollamaMaxTokens: Int = 2048
+    /// Max tokens for Ollama (local models). Polish output is short; 256 is plenty.
+    public static let ollamaMaxTokens: Int = 256
 
     /// Default thinking budget for extended thinking models (Gemini 2.5 Flash/Pro).
     public static let defaultThinkingBudget: Int = 8192

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -1,7 +1,8 @@
 import Foundation
 import EnviousWisprCore
 
-/// Ollama local LLM connector. Uses Ollama's OpenAI-compatible endpoint.
+/// Ollama local LLM connector. Uses Ollama's native /api/chat endpoint
+/// for access to `think`, `keep_alive`, and timing telemetry.
 /// Requires Ollama to be running: https://ollama.com
 public struct OllamaConnector: TranscriptPolisher {
     private let baseURL: String
@@ -19,7 +20,7 @@ public struct OllamaConnector: TranscriptPolisher {
         config: LLMProviderConfig,
         onToken: (@Sendable (String) -> Void)?
     ) async throws -> LLMResult {
-        let endpointURL = "\(baseURL)/v1/chat/completions"
+        let endpointURL = "\(baseURL)/api/chat"
         guard let url = URL(string: endpointURL) else {
             throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
         }
@@ -36,12 +37,16 @@ public struct OllamaConnector: TranscriptPolisher {
             messages.append(["role": "user", "content": text])
         }
 
-        let body: [String: Any] = [
-            "model":       config.model,
-            "messages":    messages,
-            "max_tokens":  config.maxTokens,
-            "temperature": config.temperature,
-            "stream":      false,
+        var body: [String: Any] = [
+            "model": config.model,
+            "messages": messages,
+            "stream": false,
+            "think": false,
+            "keep_alive": "15m",
+            "options": [
+                "num_predict": config.maxTokens,
+                "temperature": config.temperature,
+            ],
         ]
 
         var request = URLRequest(url: url)
@@ -53,17 +58,30 @@ public struct OllamaConnector: TranscriptPolisher {
         let (data, _) = try await performWithRetry(request: request, config: config)
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let choices = json?["choices"] as? [[String: Any]],
-              let message = choices.first?["message"] as? [String: Any],
+        guard let message = json?["message"] as? [String: Any],
               let content = message["content"] as? String,
               !content.isEmpty else {
             throw LLMError.emptyResponse
         }
 
-        if let finishReason = choices.first?["finish_reason"] as? String,
-           finishReason == "length" {
+        // Log timing telemetry for observability
+        if let loadNs = json?["load_duration"] as? Int64,
+           let promptNs = json?["prompt_eval_duration"] as? Int64,
+           let evalNs = json?["eval_duration"] as? Int64,
+           let evalCount = json?["eval_count"] as? Int {
+            let loadMs = Double(loadNs) / 1_000_000
+            let promptMs = Double(promptNs) / 1_000_000
+            let evalMs = Double(evalNs) / 1_000_000
             Task { await AppLogger.shared.log(
-                "WARNING: Ollama response truncated (finish_reason=length, model=\(config.model), max_tokens=\(config.maxTokens))",
+                "Ollama timing: load=\(String(format: "%.0f", loadMs))ms prompt=\(String(format: "%.0f", promptMs))ms eval=\(String(format: "%.0f", evalMs))ms tokens=\(evalCount) (model=\(config.model))",
+                level: .verbose, category: "LLM"
+            ) }
+        }
+
+        // Check for truncation via done_reason
+        if let doneReason = json?["done_reason"] as? String, doneReason != "stop" {
+            Task { await AppLogger.shared.log(
+                "WARNING: Ollama response truncated (done_reason=\(doneReason), model=\(config.model))",
                 level: .info, category: "LLM"
             ) }
         }

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -27,15 +27,42 @@ public enum OllamaQualityTier: String, Sendable {
     }
 }
 
-/// A model entry in the curated Ollama catalog.
+/// A model entry in the Ollama catalog (curated or dynamic).
 public struct OllamaModelCatalogEntry: Identifiable, Sendable {
     public let name: String
     public let displayName: String
     public let parameterCount: String
     public let qualityTier: OllamaQualityTier
     public let downloadSize: String
+    public let isDownloaded: Bool
 
     public var id: String { name }
+
+    public init(
+        name: String,
+        displayName: String,
+        parameterCount: String,
+        qualityTier: OllamaQualityTier,
+        downloadSize: String,
+        isDownloaded: Bool = false
+    ) {
+        self.name = name
+        self.displayName = displayName
+        self.parameterCount = parameterCount
+        self.qualityTier = qualityTier
+        self.downloadSize = downloadSize
+        self.isDownloaded = isDownloaded
+    }
+}
+
+/// A model parsed from Ollama's /api/tags response.
+public struct OllamaDownloadedModel: Sendable {
+    public let exactName: String
+    public let canonicalName: String
+    public let parameterSize: String?
+    public let parameterBillions: Double?
+    public let fileSizeBytes: Int64
+    public let displayName: String
 }
 
 /// Guides users through Ollama installation, server startup, and model pulling.
@@ -48,10 +75,16 @@ public final class OllamaSetupService {
     public private(set) var setupState: OllamaSetupState = .detecting
     public private(set) var pullProgress: Double = 0
     public private(set) var pullStatusText: String = ""
-    public private(set) var downloadedModelNames: Set<String> = []
+    public private(set) var downloadedModels: [OllamaDownloadedModel] = []
+
+    /// Canonical names of downloaded models. Backward-compatible with old Set<String> consumers.
+    public var downloadedModelNames: Set<String> {
+        Set(downloadedModels.map(\.canonicalName))
+    }
 
     // MARK: - Model Catalog
 
+    /// Curated suggestions for users who haven't downloaded models yet.
     public static let modelCatalog: [OllamaModelCatalogEntry] = [
         OllamaModelCatalogEntry(name: "llama3.2", displayName: "Llama 3.2", parameterCount: "3B", qualityTier: .best, downloadSize: "~2 GB"),
         OllamaModelCatalogEntry(name: "llama3.2:1b", displayName: "Llama 3.2 (1B)", parameterCount: "1B", qualityTier: .medium, downloadSize: "~800 MB"),
@@ -65,12 +98,109 @@ public final class OllamaSetupService {
         OllamaModelCatalogEntry(name: "phi-2", displayName: "Phi-2", parameterCount: "2.7B", qualityTier: .worst, downloadSize: "~1.7 GB"),
     ]
 
+    /// Dynamic catalog: downloaded models first (with real metadata), then undownloaded suggestions.
+    public var dynamicCatalog: [OllamaModelCatalogEntry] {
+        let canonicalDownloaded = Set(downloadedModels.map(\.canonicalName))
+
+        // Build catalog entries from downloaded models
+        let downloadedEntries: [OllamaModelCatalogEntry] = downloadedModels.map { model in
+            // Overlay curated metadata if we have a catalog match
+            if let curated = Self.modelCatalog.first(where: {
+                Self.canonicalModelName($0.name) == model.canonicalName
+            }) {
+                return OllamaModelCatalogEntry(
+                    name: model.exactName,
+                    displayName: curated.displayName,
+                    parameterCount: model.parameterSize ?? curated.parameterCount,
+                    qualityTier: curated.qualityTier,
+                    downloadSize: Self.formatFileSize(model.fileSizeBytes),
+                    isDownloaded: true
+                )
+            }
+
+            // Unknown/custom model: infer metadata
+            return OllamaModelCatalogEntry(
+                name: model.exactName,
+                displayName: Self.inferDisplayName(from: model.exactName),
+                parameterCount: model.parameterSize ?? "Unknown",
+                qualityTier: Self.inferQualityTier(parameterBillions: model.parameterBillions),
+                downloadSize: Self.formatFileSize(model.fileSizeBytes),
+                isDownloaded: true
+            )
+        }
+        .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+
+        // Undownloaded suggestions (preserve static catalog order)
+        let suggestions: [OllamaModelCatalogEntry] = Self.modelCatalog.compactMap { entry in
+            let canonical = Self.canonicalModelName(entry.name)
+            guard !canonicalDownloaded.contains(canonical) else { return nil }
+            return entry
+        }
+
+        return downloadedEntries + suggestions
+    }
+
+    // MARK: - Name Normalization
+
+    /// Canonical name: strips `:latest` suffix only. All other tags preserved.
+    public nonisolated static func canonicalModelName(_ name: String) -> String {
+        if name.hasSuffix(":latest") {
+            return String(name.dropLast(":latest".count))
+        }
+        return name
+    }
+
+    // MARK: - Parameter Size Parsing
+
+    /// Parse Ollama parameter size strings like "3B", "3.2B", "500M", "1T" into billions.
+    /// Returns nil if parsing fails.
+    public nonisolated static func parseParameterSize(_ raw: String) -> Double? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        let upper = trimmed.uppercased()
+        let multiplier: Double
+        let suffix: Character
+
+        if upper.hasSuffix("B") {
+            multiplier = 1.0
+            suffix = "B"
+        } else if upper.hasSuffix("M") {
+            multiplier = 0.001
+            suffix = "M"
+        } else if upper.hasSuffix("T") {
+            multiplier = 1000.0
+            suffix = "T"
+        } else {
+            return nil
+        }
+
+        let numberPart = String(upper.dropLast())
+        guard let value = Double(numberPart), value > 0 else { return nil }
+        _ = suffix  // used for clarity in the if-else chain above
+        return value * multiplier
+    }
+
     // MARK: - Weak Model Detection
 
-    public nonisolated static func isWeakModel(_ name: String) -> Bool {
-        let prefixes: [String] = ["tinyllama", "phi-2", "gemma2:2b"]
+    /// Hardcoded fallback prefixes for weak model detection when parameter size is unknown.
+    nonisolated private static let weakModelFallbackPrefixes: [String] = ["tinyllama", "phi-2", "gemma2:2b"]
+
+    /// Determine if a model should receive a simplified system prompt.
+    /// Uses parameter count when available, falls back to name-based heuristic.
+    public nonisolated static func isWeakModel(_ name: String, parameterBillions: Double? = nil) -> Bool {
+        if let billions = parameterBillions {
+            return billions <= 3.0
+        }
         let lower = name.lowercased()
-        return prefixes.contains(where: { lower.hasPrefix($0) })
+        return weakModelFallbackPrefixes.contains(where: { lower.hasPrefix($0) })
+    }
+
+    /// Convenience: check if a model name is weak using downloaded model metadata.
+    public func isWeakModel(_ name: String) -> Bool {
+        let canonical = Self.canonicalModelName(name)
+        let downloaded = downloadedModels.first(where: { $0.canonicalName == canonical })
+        return Self.isWeakModel(name, parameterBillions: downloaded?.parameterBillions)
     }
 
     // MARK: - Private
@@ -86,7 +216,7 @@ public final class OllamaSetupService {
 
     public init() {}
 
-    /// Run the full detection pipeline: binary → server → models.
+    /// Run the full detection pipeline: binary -> server -> models.
     public func detectState() async {
         setupState = .detecting
 
@@ -194,12 +324,12 @@ public final class OllamaSetupService {
     /// Check whether Ollama has at least one pulled model.
     public func hasAnyModels() async -> Bool {
         await refreshDownloadedModels()
-        return !downloadedModelNames.isEmpty
+        return !downloadedModels.isEmpty
     }
 
     // MARK: - Model Management
 
-    /// Refresh the set of downloaded model names from GET /api/tags.
+    /// Refresh the list of downloaded models from GET /api/tags, parsing full metadata.
     public func refreshDownloadedModels() async {
         guard let url = URL(string: "\(Self.baseURL)/api/tags") else { return }
         var request = URLRequest(url: url)
@@ -211,17 +341,38 @@ public final class OllamaSetupService {
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
             guard let models = json?["models"] as? [[String: Any]] else { return }
-            downloadedModelNames = Set(models.compactMap { model -> String? in
+            downloadedModels = models.compactMap { model -> OllamaDownloadedModel? in
                 guard let name = model["name"] as? String else { return nil }
-                // Ollama returns "llama3.2:latest" but catalog uses "llama3.2".
-                // Normalize by stripping the implicit ":latest" tag.
-                if name.hasSuffix(":latest") {
-                    return String(name.dropLast(":latest".count))
+                let canonical = Self.canonicalModelName(name)
+
+                // Parse details.parameter_size
+                let details = model["details"] as? [String: Any]
+                let parameterSize = details?["parameter_size"] as? String
+                let parameterBillions = parameterSize.flatMap { Self.parseParameterSize($0) }
+
+                // Parse file size (Int64 for large models)
+                let fileSizeBytes: Int64
+                if let size = model["size"] as? Int64 {
+                    fileSizeBytes = size
+                } else if let size = model["size"] as? Int {
+                    fileSizeBytes = Int64(size)
+                } else {
+                    fileSizeBytes = 0
                 }
-                return name
-            })
+
+                let displayName = Self.inferDisplayName(from: name)
+
+                return OllamaDownloadedModel(
+                    exactName: name,
+                    canonicalName: canonical,
+                    parameterSize: parameterSize,
+                    parameterBillions: parameterBillions,
+                    fileSizeBytes: fileSizeBytes,
+                    displayName: displayName
+                )
+            }
         } catch {
-            // Silently ignore — server may not be running
+            // Silently ignore -- server may not be running
         }
     }
 
@@ -239,15 +390,15 @@ public final class OllamaSetupService {
             do {
                 let (_, response) = try await URLSession.shared.data(for: request)
                 if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                    downloadedModelNames.remove(name)
+                    downloadedModels.removeAll(where: { $0.exactName == name })
                     // If current model was deleted, update setup state
-                    if downloadedModelNames.isEmpty {
+                    if downloadedModels.isEmpty {
                         setupState = .runningNoModels
                         UserDefaults.standard.set(false, forKey: Self.lastKnownStateKey)
                     }
                 }
             } catch {
-                // Silently ignore delete errors — user can try again
+                // Silently ignore delete errors -- user can try again
             }
         }
     }
@@ -337,7 +488,12 @@ public final class OllamaSetupService {
                 setupState = .ready
                 UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
             } catch is CancellationError {
-                setupState = .runningNoModels
+                // Bug fix: don't force .runningNoModels if models exist
+                if downloadedModels.isEmpty {
+                    setupState = .runningNoModels
+                } else {
+                    setupState = .ready
+                }
             } catch let urlError as URLError {
                 setupState = .error(friendlyMessage(for: urlError))
             } catch {
@@ -348,7 +504,7 @@ public final class OllamaSetupService {
                     )
                 } else {
                     setupState = .error(
-                        "Download failed — check your internet connection and try again."
+                        "Download failed. Check your internet connection and try again."
                     )
                 }
             }
@@ -359,7 +515,12 @@ public final class OllamaSetupService {
     public func cancelPull() {
         pullTask?.cancel()
         pullTask = nil
-        setupState = .runningNoModels
+        // Bug fix: don't force .runningNoModels if models exist
+        if downloadedModels.isEmpty {
+            setupState = .runningNoModels
+        } else {
+            setupState = .ready
+        }
     }
 
     // MARK: - Streaming Pull (Private)
@@ -421,16 +582,47 @@ public final class OllamaSetupService {
         }
     }
 
+    // MARK: - Display Helpers
+
+    /// Infer a display name from a raw Ollama model name.
+    nonisolated static func inferDisplayName(from name: String) -> String {
+        let base = name.components(separatedBy: ":").first ?? name
+        return base.replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: ".", with: " ")
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    /// Infer quality tier from parameter count.
+    nonisolated static func inferQualityTier(parameterBillions: Double?) -> OllamaQualityTier {
+        guard let billions = parameterBillions else { return .medium }
+        if billions >= 7.0 { return .best }
+        if billions <= 2.0 { return .worst }
+        return .medium
+    }
+
+    /// Format file size in bytes to human-readable string.
+    nonisolated static func formatFileSize(_ bytes: Int64) -> String {
+        guard bytes > 0 else { return "Unknown" }
+        let gb = Double(bytes) / 1_073_741_824.0
+        if gb >= 1.0 {
+            return String(format: "%.1f GB", gb)
+        }
+        let mb = Double(bytes) / 1_048_576.0
+        return String(format: "%.0f MB", mb)
+    }
+
     // MARK: - Error Mapping
 
     private func friendlyMessage(for urlError: URLError) -> String {
         switch urlError.code {
         case .notConnectedToInternet:
-            return "Download failed — check your internet connection and try again."
+            return "Download failed. Check your internet connection and try again."
         case .cancelled, .networkConnectionLost, .timedOut:
             return "Download was interrupted. Tap retry to resume where you left off."
         default:
-            return "Download failed — check your internet connection and try again."
+            return "Download failed. Check your internet connection and try again."
         }
     }
 }

--- a/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import EnviousWisprLLM
+
+@Suite("OllamaModelCatalog")
+struct OllamaModelCatalogTests {
+
+    // MARK: - Parameter Size Parsing
+
+    @Test("parses standard billion values")
+    func parsesBillions() {
+        #expect(OllamaSetupService.parseParameterSize("3B") == 3.0)
+        #expect(OllamaSetupService.parseParameterSize("7B") == 7.0)
+        #expect(OllamaSetupService.parseParameterSize("70B") == 70.0)
+    }
+
+    @Test("parses fractional billion values")
+    func parsesFractionalBillions() {
+        #expect(OllamaSetupService.parseParameterSize("3.2B") == 3.2)
+        #expect(OllamaSetupService.parseParameterSize("1.1B") == 1.1)
+        #expect(OllamaSetupService.parseParameterSize("3.8B") == 3.8)
+    }
+
+    @Test("parses million values as fractional billions")
+    func parsesMillions() {
+        let result = OllamaSetupService.parseParameterSize("500M")
+        #expect(result != nil)
+        #expect(abs(result! - 0.5) < 0.001)
+
+        let result2 = OllamaSetupService.parseParameterSize("125M")
+        #expect(result2 != nil)
+        #expect(abs(result2! - 0.125) < 0.001)
+    }
+
+    @Test("parses trillion values")
+    func parsesTrillion() {
+        #expect(OllamaSetupService.parseParameterSize("1T") == 1000.0)
+        #expect(OllamaSetupService.parseParameterSize("1.5T") == 1500.0)
+    }
+
+    @Test("returns nil for invalid input")
+    func parsesInvalid() {
+        #expect(OllamaSetupService.parseParameterSize("") == nil)
+        #expect(OllamaSetupService.parseParameterSize("abc") == nil)
+        #expect(OllamaSetupService.parseParameterSize("B") == nil)
+        #expect(OllamaSetupService.parseParameterSize("3X") == nil)
+    }
+
+    @Test("handles case insensitivity")
+    func parsesCaseInsensitive() {
+        #expect(OllamaSetupService.parseParameterSize("3b") == 3.0)
+        #expect(OllamaSetupService.parseParameterSize("500m") != nil)
+    }
+
+    // MARK: - Canonical Name
+
+    @Test("strips :latest suffix")
+    func canonicalStripsLatest() {
+        #expect(OllamaSetupService.canonicalModelName("llama3.2:latest") == "llama3.2")
+    }
+
+    @Test("preserves other tags")
+    func canonicalPreservesTags() {
+        #expect(OllamaSetupService.canonicalModelName("llama3.2:1b") == "llama3.2:1b")
+        #expect(OllamaSetupService.canonicalModelName("qwen2.5:7b") == "qwen2.5:7b")
+    }
+
+    @Test("bare name stays unchanged")
+    func canonicalBareName() {
+        #expect(OllamaSetupService.canonicalModelName("mistral") == "mistral")
+    }
+
+    // MARK: - Weak Model Detection
+
+    @Test("models under 3B are weak when parameter size is known")
+    func weakByParameterSize() {
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 1.1) == true)
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 2.0) == true)
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 2.9) == true)
+    }
+
+    @Test("3B models are weak (threshold is <=3)")
+    func weakAtThreshold() {
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 3.0) == true)
+    }
+
+    @Test("models above 3B are not weak")
+    func notWeakAboveThreshold() {
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 3.1) == false)
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 7.0) == false)
+        #expect(OllamaSetupService.isWeakModel("anything", parameterBillions: 70.0) == false)
+    }
+
+    @Test("falls back to hardcoded list when parameter size unknown")
+    func weakFallbackList() {
+        #expect(OllamaSetupService.isWeakModel("tinyllama", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("phi-2", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("gemma2:2b", parameterBillions: nil) == true)
+    }
+
+    @Test("defaults to not weak when unknown name and no parameter size")
+    func notWeakByDefault() {
+        #expect(OllamaSetupService.isWeakModel("some-custom-model", parameterBillions: nil) == false)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded 10-model Ollama catalog with dynamic discovery from `/api/tags`. New models (Gemma 4, etc.) appear automatically once downloaded.
- Migrate `OllamaConnector` from `/v1/chat/completions` to native `/api/chat` for access to `think`, `keep_alive`, and timing telemetry.
- Fix reasoning models (Gemma 4) randomly activating chain-of-thought and timing out by passing `think: false`.
- Send `keep_alive: 15m` to reduce cold model loads between requests.
- Fix cancel-pull state regression and show Manage Models during pull.

## Test plan

- [x] 94/94 unit tests pass (including new `OllamaModelCatalog` suite)
- [x] Release build passes
- [x] App launches and runs
- [x] Llama 3.2 polish: consistent sub-2s, zero timeouts
- [x] Gemma 4 polish: consistent sub-1.5s once warm, no thinking blowups
- [x] Dynamic catalog shows downloaded models with real metadata
- [ ] Verify Manage Models section shows during model pull
