### PR TITLE
feat(llm): Ollama warm-up indicator and UI cleanup

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -10,7 +10,6 @@ struct AIPolishSettingsView: View {
     @State private var openAIKey: String = ""
     @State private var geminiKey: String = ""
     @State private var validationStatus: String = ""
-    @State private var showManageModels = false
 
     private var isCloudProvider: Bool {
         appState.settings.llmProvider == .openAI || appState.settings.llmProvider == .gemini
@@ -26,7 +25,7 @@ struct AIPolishSettingsView: View {
 
     private var ollamaShowsManageModels: Bool {
         switch appState.ollamaSetup.setupState {
-        case .ready, .pullingModel: return true
+        case .ready, .pullingModel, .runningNoModels: return true
         default: return false
         }
     }
@@ -135,7 +134,9 @@ struct AIPolishSettingsView: View {
                                 }
                             }
 
-                            if appState.llmDiscovery.isDiscoveringModels {
+                            if appState.settings.llmProvider == .ollama {
+                                ollamaWarmupIndicator
+                            } else if appState.llmDiscovery.isDiscoveringModels {
                                 ProgressView()
                                     .controlSize(.small)
                             } else {
@@ -159,21 +160,21 @@ struct AIPolishSettingsView: View {
                         }
                     }
 
-                    // Model recommendation cards
-                    BrandedRow(showDivider: false) {
-                        modelRecommendationCards
+                    // Model recommendation cards (cloud providers only)
+                    if appState.settings.llmProvider != .ollama {
+                        BrandedRow(showDivider: false) {
+                            modelRecommendationCards
+                        }
                     }
                 }
             }
 
-            // Manage Models for Ollama (when ready or pulling)
+            // Manage Models for Ollama (always expanded)
             if appState.settings.llmProvider == .ollama,
                ollamaShowsManageModels {
                 BrandedSection(header: "Manage Models") {
                     BrandedRow(showDivider: false) {
-                        DisclosureGroup("Download / Remove Models", isExpanded: $showManageModels) {
-                            ollamaModelCatalogView
-                        }
+                        ollamaModelCatalogView
                     }
                 }
             }
@@ -216,22 +217,22 @@ struct AIPolishSettingsView: View {
             // Model canonicalization handled by SettingsManager.llmProvider didSet.
             // Discovery will refine the model async if needed.
 
+            // Clean up Ollama state when switching away
+            if newProvider != .ollama {
+                appState.ollamaSetup.cancelPull()
+                appState.ollamaSetup.resetWarmup()
+            }
+
             switch newProvider {
             case .none:
-                appState.ollamaSetup.cancelPull()
+                break
             case .ollama:
-                Task {
-                    await appState.ollamaSetup.detectState()
-                    if case .ready = appState.ollamaSetup.setupState {
-                        await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: .ollama, settings: appState.settings)
-                    }
-                }
+                // detectState() will set setupState, which triggers the onChange handler
+                // for discovery + warm-up. Don't duplicate that work here.
+                Task { await appState.ollamaSetup.detectState() }
             case .appleIntelligence:
-                appState.ollamaSetup.cancelPull()
-                // Model canonicalization handled by SettingsManager.llmProvider didSet
                 Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
             default:
-                appState.ollamaSetup.cancelPull()
                 appState.llmDiscovery.loadCachedModels(for: newProvider)
                 Task { await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: newProvider, settings: appState.settings) }
             }
@@ -239,11 +240,21 @@ struct AIPolishSettingsView: View {
         .onChange(of: appState.ollamaSetup.setupState) { _, newState in
             if case .ready = newState, appState.settings.llmProvider == .ollama {
                 Task { await appState.llmDiscovery.validateKeyAndDiscoverModels(provider: .ollama, settings: appState.settings) }
+                // Warm up the selected model when Ollama becomes ready
+                if !appState.settings.llmModel.isEmpty {
+                    appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+                }
+            } else if appState.settings.llmProvider == .ollama {
+                // Reset warmup when Ollama leaves .ready (server died, etc.)
+                appState.ollamaSetup.resetWarmup()
             }
         }
-        .onChange(of: showManageModels) { _, isOpen in
-            if isOpen {
-                Task { await appState.ollamaSetup.refreshDownloadedModels() }
+        .onChange(of: appState.settings.llmModel) { _, newModel in
+            // Warm up when user switches Ollama model
+            if appState.settings.llmProvider == .ollama,
+               case .ready = appState.ollamaSetup.setupState,
+               !newModel.isEmpty {
+                appState.ollamaSetup.warmUpModel(newModel)
             }
         }
     }
@@ -482,11 +493,7 @@ struct AIPolishSettingsView: View {
                 ModelCardInfo(name: "Gemini 2.0 Pro",   desc: "Slower · Higher cost",              badge: "Premium",    icon: "◈", iconBg: Color.primary.opacity(0.05), badgeBg: Color.primary.opacity(0.05), badgeBorder: Color.primary.opacity(0.09), badgeFg: Color.secondary),
             ]
         case .ollama:
-            return [
-                ModelCardInfo(name: "Llama 3.2",  desc: "Fast · Private · No internet needed",  badge: "Recommended", icon: "⚡", iconBg: Color.stSuccess.opacity(0.10),   badgeBg: Color.stSuccess.opacity(0.12),  badgeBorder: Color.stSuccess.opacity(0.22),  badgeFg: Color(hex: "007a4d")),
-                ModelCardInfo(name: "Llama 3.1",  desc: "Stable · Well tested",                 badge: "Also great",  icon: "✦", iconBg: Color.cyan.opacity(0.10),    badgeBg: Color.cyan.opacity(0.12),   badgeBorder: Color.cyan.opacity(0.22),   badgeFg: Color(hex: "006f7a")),
-                ModelCardInfo(name: "Phi-3 Mini", desc: "Smallest · Fastest on older Macs",     badge: "Lightweight", icon: "◇", iconBg: Color.primary.opacity(0.05), badgeBg: Color.primary.opacity(0.05), badgeBorder: Color.primary.opacity(0.09), badgeFg: Color.secondary),
-            ]
+            return []  // Ollama uses the dynamic Manage Models list instead
         default:
             return []
         }
@@ -889,5 +896,40 @@ struct AIPolishSettingsView: View {
         }
         .buttonStyle(.borderless)
         .help("Re-check Ollama status")
+    }
+
+    // MARK: - Ollama Warm-up Indicator
+
+    @ViewBuilder
+    private var ollamaWarmupIndicator: some View {
+        let currentModel = OllamaSetupService.canonicalModelName(appState.settings.llmModel)
+        switch appState.ollamaSetup.warmupState {
+        case .warming(let model) where model == currentModel:
+            ProgressView()
+                .controlSize(.small)
+                .help("Preparing model for faster responses...")
+        case .warm(let model, let expires) where model == currentModel && Date() < expires:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.stSuccess)
+                .help("Model is ready")
+        case .failed(let model) where model == currentModel:
+            Button {
+                appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+            } label: {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.stWarning)
+            }
+            .buttonStyle(.borderless)
+            .help("Couldn't prepare model. Click to retry.")
+        default:
+            Button {
+                guard !appState.settings.llmModel.isEmpty else { return }
+                appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .help("Prepare model")
+        }
     }
 }

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -42,7 +42,7 @@ public struct OllamaConnector: TranscriptPolisher {
             "messages": messages,
             "stream": false,
             "think": false,
-            "keep_alive": "15m",
+            "keep_alive": "60m",
             "options": [
                 "num_predict": config.maxTokens,
                 "temperature": config.temperature,

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -12,6 +12,22 @@ public enum OllamaSetupState: Equatable {
     case error(String)
 }
 
+/// Warm-up state for the currently selected Ollama model.
+public enum OllamaWarmupState: Equatable {
+    case idle
+    case warming(model: String)
+    case warm(model: String, expiresAt: Date)
+    case failed(model: String)
+
+    /// Whether the given model is currently warm (not expired).
+    public func isWarm(for model: String) -> Bool {
+        if case .warm(let m, let expires) = self, m == model {
+            return Date() < expires
+        }
+        return false
+    }
+}
+
 /// Quality tier for Ollama catalog models.
 public enum OllamaQualityTier: String, Sendable {
     case best = "best"
@@ -76,6 +92,7 @@ public final class OllamaSetupService {
     public private(set) var pullProgress: Double = 0
     public private(set) var pullStatusText: String = ""
     public private(set) var downloadedModels: [OllamaDownloadedModel] = []
+    public private(set) var warmupState: OllamaWarmupState = .idle
 
     /// Canonical names of downloaded models. Backward-compatible with old Set<String> consumers.
     public var downloadedModelNames: Set<String> {
@@ -160,24 +177,19 @@ public final class OllamaSetupService {
 
         let upper = trimmed.uppercased()
         let multiplier: Double
-        let suffix: Character
 
         if upper.hasSuffix("B") {
             multiplier = 1.0
-            suffix = "B"
         } else if upper.hasSuffix("M") {
             multiplier = 0.001
-            suffix = "M"
         } else if upper.hasSuffix("T") {
             multiplier = 1000.0
-            suffix = "T"
         } else {
             return nil
         }
 
         let numberPart = String(upper.dropLast())
         guard let value = Double(numberPart), value > 0 else { return nil }
-        _ = suffix  // used for clarity in the if-else chain above
         return value * multiplier
     }
 
@@ -207,6 +219,7 @@ public final class OllamaSetupService {
 
     private var ollamaProcess: Process?
     private var pullTask: Task<Void, Never>?
+    private var warmupTask: Task<Void, Never>?
 
     private static let binaryPaths = ["/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"]
     private static let baseURL = "http://localhost:11434"
@@ -391,6 +404,15 @@ public final class OllamaSetupService {
                 let (_, response) = try await URLSession.shared.data(for: request)
                 if let http = response as? HTTPURLResponse, http.statusCode == 200 {
                     downloadedModels.removeAll(where: { $0.exactName == name })
+                    // Reset warm-up if the deleted model was warmed or warming
+                    let canonical = Self.canonicalModelName(name)
+                    switch warmupState {
+                    case .warm(let m, _) where m == canonical,
+                         .warming(let m) where m == canonical:
+                        resetWarmup()
+                    default:
+                        break
+                    }
                     // If current model was deleted, update setup state
                     if downloadedModels.isEmpty {
                         setupState = .runningNoModels
@@ -521,6 +543,83 @@ public final class OllamaSetupService {
         } else {
             setupState = .ready
         }
+    }
+
+    // MARK: - Model Warm-up
+
+    /// Warm up a model by sending a minimal request to load it into GPU memory.
+    /// Cancels any in-flight warm-up for a different model.
+    public func warmUpModel(_ modelName: String) {
+        let canonical = Self.canonicalModelName(modelName)
+
+        // Skip if already warm for this model and not expired
+        if warmupState.isWarm(for: canonical) { return }
+
+        // Skip if already warming this model
+        if case .warming(let m) = warmupState, m == canonical { return }
+
+        // Cancel any in-flight warm-up for a different model
+        warmupTask?.cancel()
+        warmupTask = nil
+
+        warmupState = .warming(model: canonical)
+
+        warmupTask = Task { [weak self] in
+            defer { self?.warmupTask = nil }
+            do {
+                guard let url = URL(string: "\(Self.baseURL)/api/chat") else {
+                    self?.warmupState = .failed(model: canonical)
+                    return
+                }
+
+                let body: [String: Any] = [
+                    "model": modelName,
+                    "messages": [["role": "user", "content": "hi"]],
+                    "stream": false,
+                    "think": false,
+                    "keep_alive": "60m",
+                    "options": ["num_predict": 1],
+                ]
+
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                request.timeoutInterval = 30
+
+                let (_, response) = try await URLSession.shared.data(for: request)
+
+                try Task.checkCancellation()
+
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    self?.warmupState = .failed(model: canonical)
+                    return
+                }
+
+                let expirySeconds: TimeInterval = 55 * 60  // conservative vs 60m keep_alive
+                self?.warmupState = .warm(model: canonical, expiresAt: Date().addingTimeInterval(expirySeconds))
+
+                // Schedule state reset at expiry so the UI doesn't show a stale checkmark
+                try? await Task.sleep(nanoseconds: UInt64(expirySeconds * 1_000_000_000))
+                // Only reset if still warm for this model (not replaced by a newer warm-up)
+                if case .warm(let m, _) = self?.warmupState, m == canonical {
+                    self?.warmupState = .idle
+                }
+            } catch is CancellationError {
+                // Cancelled by a newer warm-up request; don't overwrite state
+            } catch let error as URLError where error.code == .cancelled {
+                // URLSession cancellation; same as above
+            } catch {
+                self?.warmupState = .failed(model: canonical)
+            }
+        }
+    }
+
+    /// Reset warm-up state (e.g., when provider changes away from Ollama).
+    public func resetWarmup() {
+        warmupTask?.cancel()
+        warmupTask = nil
+        warmupState = .idle
     }
 
     // MARK: - Streaming Pull (Private)


### PR DESCRIPTION
## Summary

- Add model warm-up on selection: spinner while loading, green checkmark when ready, warning on failure with retry
- Remove static Ollama recommendation cards (dynamic Manage Models list replaces them)
- Always expand Manage Models (no DisclosureGroup)
- Show Manage Models in `.runningNoModels` state for fresh installs
- Bump `keep_alive` from 15m to 60m to reduce cold loads
- Fix race conditions: catch URLError.cancelled, reset warmup on model deletion/server death, deduplicate post-ready handlers

## Test plan

- [x] 94/94 unit tests pass
- [x] Release build passes
- [x] App launches and runs (10 processes)
- [x] Gemma 4: green checkmark appears after selection, spinner visible during load
- [x] No recommendation cards for Ollama; cloud providers still have them
- [x] Manage Models expanded by default, shows downloaded + suggestions
- [x] Codex code review: all bugs fixed
- [x] Code simplifier: cleanup applied

Closes #203
