### PR TITLE
fix(website): make skip-nav target focusable

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -65,7 +65,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
   <a href="#main-content" class="skip-link">Skip to content</a>
   <div class="dot-grid" aria-hidden="true"></div>
   <Nav activePage={activePage} />
-  <main id="main-content">
+  <main id="main-content" tabindex="-1">
     <slot />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
- Add `tabindex="-1"` to `<main id="main-content">` so the skip-to-content link actually moves keyboard focus past the nav
- Without this, pressing Enter on the skip link only changes the URL hash but Tab continues into nav links

## Test plan
- [ ] Open site, Tab to "Skip to content" link, press Enter, then Tab again. Focus should land inside main content, not back in the nav.
