### PR TITLE
fix(website): add timeout to PostHog requestIdleCallback

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -83,7 +83,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
       });
     }
     if ('requestIdleCallback' in window) {
-      requestIdleCallback(loadPostHog);
+      requestIdleCallback(loadPostHog, { timeout: 3000 });
     } else {
       window.addEventListener('load', loadPostHog);
     }


### PR DESCRIPTION
## Summary
- Add `{ timeout: 3000 }` to `requestIdleCallback(loadPostHog)` so PostHog init is guaranteed within 3s even on busy pages
- Prevents dropped pageview/download telemetry on short sessions

## Test plan
- [ ] Verify PostHog events still fire on page load
- [ ] Check no visible performance regression (PostHog loads are async)
