### PR TITLE
chore(release): bump version to 1.9.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
Version bump for v1.9.0 release.

## What's in v1.9.0 (since v1.8.0)

### Context-Aware Structured Polish (#154)
- Provider-specific prompt builders: Gemini (plain-label blocks), OpenAI (prose + sandwich framing), Gemma (few-shot examples)
- TranscriptAnalyzer: deterministic mode routing (inline/message/structured) based on word count + list cues
- DefaultPromptPlanner replaces enrichedInstructions() with mode-aware, provider-specific prompts
- Mode-aware output validation with per-mode thresholds (inline=strict, structured=relaxed)
- PolishStyleConfig with CustomPromptMode detection for legacy ${transcript} templates

### Ollama Overhaul (#202, #204)
- Dynamic model catalog via native Ollama API (/api/tags)
- Warm-up indicator in UI during model load
- Model quality tier classification (weak model simplified prompts)

### Pipeline Architecture (#188-#192, #206)
- Extracted TextProcessingRunner, PasteCascadeExecutor, SampleFilter, PipelineUtils, TranscriptFinalizer
- Extracted VADMonitorLoop from both pipelines
- Extracted TranscriptPolishService from pipeline
- Behavioral freeze tests for pipeline deduplication

### Website + Content
- 11 competitor comparison pages with full SEO
- Crisp chat widget + 56 audited KB articles
- Contact page + navigation link
- Comprehensive SEO audit + blog factual accuracy sweep
- PostHog requestIdleCallback timeout fix
- Skip-nav keyboard accessibility fix

### Code Quality
- Dead code cleanup across all modules (139 to 56 Periphery findings)
- Dependency bumps: Sentry 9.9.0, PostHog 3.49.0, WhisperKit 0.18.0
- WERCalculator crash fix for empty hypothesis
- LLM connector defensive hardening

## Test plan
- [x] 202 tests passing
- [x] Release preflight (after merge)
- [x] Runtime validation: 7 dictation tests across 3 providers, 2 ASR backends
