### PR TITLE
fix(pipeline): clipboard fallback overlay when no text field focused

### DIFF
--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -177,7 +177,7 @@ final class RecordingOverlayPanel {
     func showClipboardFallback() {
         guard panel == nil else {
             // Transition from existing panel (recording/polishing) to clipboard notice
-            transitionToPolishing(label: "Paste failed \u{2014} \u{2318}V to paste")
+            transitionToPolishing(label: "Copied. Press \u{2318}V to paste")
             scheduleAutoDismiss()
             return
         }
@@ -189,7 +189,7 @@ final class RecordingOverlayPanel {
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.generation == token else { return }
             self.pendingCreateWork = nil
-            self.createPolishingPanel(label: "Paste failed \u{2014} \u{2318}V to paste")
+            self.createPolishingPanel(label: "Copied. Press \u{2318}V to paste")
             self.scheduleAutoDismiss()
         }
         pendingCreateWork = work

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -31,17 +31,25 @@ internal final class PasteCascadeExecutor {
         let bundleId = request.targetApp?.bundleIdentifier ?? "unknown"
         var tier: PasteTier = .clipboardOnly
 
-        // Tier 1: AX direct insertion
-        if let element = request.targetElement {
+        // Check if the focused element is a text field (AXTextField, AXTextArea, etc.).
+        // If not, Cmd+V won't land in a text input, so skip straight to clipboard-only.
+        let focusedElementIsTextField = request.targetElement.map {
+            PasteService.isTextFieldRole($0)
+        } ?? false
+
+        // Tier 1: AX direct insertion (only if a text field is focused)
+        if focusedElementIsTextField, let element = request.targetElement {
             if PasteService.insertViaAccessibility(request.text, element: element) {
                 tier = .axDirect
             }
         }
 
         // Tier 2: Activate target app + CGEvent Cmd+V
-        // Uses AX force-activate (kAXFrontmostAttribute) to bypass macOS 14+
-        // restrictions on background processes stealing focus.
-        if tier == .clipboardOnly, let app = request.targetApp, !app.isTerminated {
+        // Only attempt if a text field was focused but AX insert failed (e.g., Electron
+        // apps that reject kAXSelectedTextAttribute). If no text field was focused,
+        // Cmd+V goes nowhere -- skip to clipboard-only so the overlay can inform the user.
+        if tier == .clipboardOnly, focusedElementIsTextField,
+           let app = request.targetApp, !app.isTerminated {
             let pollInterval = TimingConstants.activationPollIntervalMs
             let timeout = TimingConstants.activationTimeoutMs
 
@@ -94,6 +102,12 @@ internal final class PasteCascadeExecutor {
         // Tier 3: Clipboard fallback
         if tier == .clipboardOnly {
             PasteService.copyToClipboard(request.text)
+            if !focusedElementIsTextField {
+                Task { await AppLogger.shared.log(
+                    "Paste cascade: no text field focused, falling back to clipboard-only",
+                    level: .info, category: "PipelineTiming"
+                ) }
+            }
         }
 
         let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -28,12 +28,22 @@ public enum PasteTier: String {
 public enum PasteService {
 
     /// AX roles that accept text insertion.
-    private static let textRoles: Set<String> = [
+    static let textRoles: Set<String> = [
         kAXTextFieldRole as String,
         kAXTextAreaRole as String,
         kAXComboBoxRole as String,
         "AXSearchField",
     ]
+
+    /// Check if an AX element has a text input role (AXTextField, AXTextArea, etc.).
+    public static func isTextFieldRole(_ element: AXUIElement) -> Bool {
+        var roleRef: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            element, kAXRoleAttribute as CFString, &roleRef
+        )
+        guard err == .success, let role = roleRef as? String else { return false }
+        return textRoles.contains(role)
+    }
 
     /// Copy text to the system clipboard.
     public static func copyToClipboard(_ text: String) {


### PR DESCRIPTION
## Summary

- When no text field is selected at recording time, skip Cmd+V (which goes nowhere) and fall back to clipboard-only
- Show "Copied. Press Cmd+V to paste" overlay so the user knows what happened
- Detection uses existing AX role check (AXTextField, AXTextArea, AXComboBox, AXSearchField)

Closes #219

## Changes

| File | Change |
|------|--------|
| `PasteService.swift` | Extract `isTextFieldRole()` from existing role-check logic |
| `PasteCascadeExecutor.swift` | Gate Tier 1+2 on `focusedElementIsTextField`, add skip log |
| `RecordingOverlayPanel.swift` | Update message: "Copied. Press Cmd+V to paste" |

## Test plan

- [ ] Focus a text field (Notes), record -> paste works as before (tier=ax_direct or cgevent)
- [ ] Open WhatsApp, click away from message box, record -> overlay shows "Copied. Press Cmd+V to paste", text on clipboard
- [ ] Heart smoke: normal dictation end-to-end
- [ ] Verify logs show "no text field focused, falling back to clipboard-only" for no-field case

Council reviewed (GPT + Gemini, 2 rounds). Both approved.
