### PR TITLE
feat(settings): add What's New tab with rainbow unread indicator

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Sidebar navigation sections for the unified window.
 enum SettingsSection: String, CaseIterable, Identifiable {
     case history
+    case whatsNew
     case speechEngine
     case audio
     case shortcuts
@@ -18,6 +19,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .history:        return "History"
+        case .whatsNew:       return "What's New"
         case .speechEngine:   return "Transcription"
         case .audio:          return "Microphone"
         case .shortcuts:      return "Shortcuts"
@@ -33,6 +35,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .history:        return "clock.arrow.circlepath"
+        case .whatsNew:       return "sparkle.magnifyingglass"
         case .speechEngine:   return "waveform"
         case .audio:          return "speaker.wave.2"
         case .shortcuts:      return "keyboard"
@@ -47,7 +50,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
     var group: SettingsGroup {
         switch self {
-        case .history:                              return .app
+        case .history, .whatsNew:                      return .app
         case .speechEngine, .audio, .shortcuts:     return .record
         case .aiPolish, .wordCorrection:            return .process
         case .clipboard:                            return .output

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -12,8 +12,13 @@ struct UnifiedWindowView: View {
                 ForEach(SettingsGroup.allCases, id: \.self) { group in
                     Section(group.rawValue) {
                         ForEach(group.sections) { section in
-                            Label(section.label, systemImage: section.icon)
-                                .tag(section)
+                            if section == .whatsNew {
+                                WhatsNewSidebarRow(isUnread: appState.settings.hasUnreadWhatsNew)
+                                    .tag(section)
+                            } else {
+                                Label(section.label, systemImage: section.icon)
+                                    .tag(section)
+                            }
                         }
                     }
                 }
@@ -53,6 +58,8 @@ struct UnifiedWindowView: View {
         switch selectedSection {
         case .history:
             HistoryContentView()
+        case .whatsNew:
+            WhatsNewSettingsView()
         case .speechEngine:
             SpeechEngineSettingsView()
         case .audio:

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -1,0 +1,128 @@
+import EnviousWisprCore
+import Foundation
+
+/// Static "What's New" content, decoupled from the view layer.
+/// Update WhatsNewConstants.currentContentVersion in Core whenever entries change.
+enum WhatsNewContent {
+    static let contentVersion = WhatsNewConstants.currentContentVersion
+
+    enum Category: String, CaseIterable, Identifiable {
+        case smarterAIPolish = "Smarter AI Polish"
+        case betterOllamaSupport = "Better Ollama Support"
+        case fasterAndMoreReliable = "Faster and More Reliable"
+        case qualityOfLife = "Quality of Life"
+
+        var id: String { rawValue }
+        var title: String { rawValue }
+    }
+
+    struct Entry: Identifiable, Hashable {
+        let id: String
+        let icon: String
+        let title: String
+        let description: String
+        let category: Category
+    }
+
+    static let entries: [Entry] = [
+        // Smarter AI Polish
+        Entry(
+            id: "apple-intelligence-guardrails",
+            icon: "sparkles",
+            title: "Apple Intelligence guardrails",
+            description: "AI polish no longer over-edits your text or answers questions instead of polishing them. Five protective rules keep your words intact.",
+            category: .smarterAIPolish
+        ),
+        Entry(
+            id: "context-aware-prompts",
+            icon: "brain.head.profile",
+            title: "Context-aware prompts",
+            description: "Each AI provider now gets prompts optimized for its strengths, producing better polish results.",
+            category: .smarterAIPolish
+        ),
+        Entry(
+            id: "repolish-from-history",
+            icon: "arrow.clockwise",
+            title: "Re-polish from History",
+            description: "The Enhance button on existing transcripts now works correctly for all speech engine types.",
+            category: .smarterAIPolish
+        ),
+
+        // Better Ollama Support
+        Entry(
+            id: "auto-discover-models",
+            icon: "server.rack",
+            title: "Auto-discover models",
+            description: "New Ollama models appear automatically once downloaded. No more hardcoded lists.",
+            category: .betterOllamaSupport
+        ),
+        Entry(
+            id: "warmup-indicator",
+            icon: "gauge.with.dots.needle.33percent",
+            title: "Warm-up indicator",
+            description: "See when your Ollama model is loading into GPU memory with a live status spinner.",
+            category: .betterOllamaSupport
+        ),
+        Entry(
+            id: "native-ollama-api",
+            icon: "bolt.horizontal",
+            title: "Native API",
+            description: "Switched to Ollama's native API for better compatibility with reasoning models like Gemma 4.",
+            category: .betterOllamaSupport
+        ),
+
+        // Faster and More Reliable
+        Entry(
+            id: "instant-first-press",
+            icon: "hare",
+            title: "Instant first press",
+            description: "Eliminated the delay on your very first recording. The speech engine warms up at launch.",
+            category: .fasterAndMoreReliable
+        ),
+        Entry(
+            id: "no-phantom-text",
+            icon: "waveform.slash",
+            title: "No more phantom text",
+            description: "Fixed the #1 reported issue: holding the record button in silence no longer produces hallucinated words.",
+            category: .fasterAndMoreReliable
+        ),
+        Entry(
+            id: "whispered-speech",
+            icon: "ear",
+            title: "Whispered speech captured",
+            description: "Quiet sensitivity mode now correctly captures whispered speech that was previously dropped.",
+            category: .fasterAndMoreReliable
+        ),
+        Entry(
+            id: "paste-back-fix",
+            icon: "doc.on.clipboard",
+            title: "Paste-back fix",
+            description: "Fixed a macOS 14+ issue where transcribed text sometimes failed to paste into the target app.",
+            category: .fasterAndMoreReliable
+        ),
+
+        // Quality of Life
+        Entry(
+            id: "configurable-engine-timeout",
+            icon: "timer",
+            title: "Configurable engine timeout",
+            description: "Choose how long to keep the microphone warm between recordings: 10s, 30s, 60s, or always.",
+            category: .qualityOfLife
+        ),
+        Entry(
+            id: "better-error-messages",
+            icon: "exclamationmark.bubble",
+            title: "Better error messages",
+            description: "Clearer notifications when something goes wrong, with distinct warnings for partial vs. complete failures.",
+            category: .qualityOfLife
+        ),
+    ]
+
+    /// Entries grouped by category, preserving display order.
+    static var groupedEntries: [(category: Category, entries: [Entry])] {
+        Category.allCases.compactMap { category in
+            let items = entries.filter { $0.category == category }
+            return items.isEmpty ? nil : (category, items)
+        }
+    }
+}

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
@@ -1,0 +1,98 @@
+import EnviousWisprCore
+import SwiftUI
+
+struct WhatsNewSettingsView: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        SettingsContentView {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("What's New in v\(AppConstants.appVersion)")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.stTextSecondary)
+                Text("Here's what improved since your last update.")
+                    .font(.stHelper)
+                    .foregroundStyle(.stTextTertiary)
+            }
+            .padding(.bottom, 4)
+
+            ForEach(WhatsNewContent.groupedEntries, id: \.category.id) { group in
+                BrandedSection(header: group.category.title) {
+                    ForEach(Array(group.entries.enumerated()), id: \.element.id) { index, entry in
+                        BrandedRow(showDivider: index < group.entries.count - 1) {
+                            HStack(alignment: .top, spacing: 12) {
+                                Image(systemName: entry.icon)
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(.stAccent)
+                                    .frame(width: 24, alignment: .center)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.title)
+                                        .font(.system(size: 13, weight: .semibold))
+                                    Text(entry.description)
+                                        .font(.stHelper)
+                                        .foregroundStyle(.stTextTertiary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            appState.settings.markWhatsNewSeen()
+        }
+    }
+}
+
+// MARK: - Sidebar Row
+
+/// Sidebar row for the "What's New" tab. Uses TimelineView + gradient mask
+/// for reliable animation inside a macOS NavigationSplitView List.
+struct WhatsNewSidebarRow: View {
+    let isUnread: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let rainbowColors: [Color] = [
+        Color(red: 1.0, green: 0.165, blue: 0.251),
+        Color(red: 1.0, green: 0.549, blue: 0.0),
+        Color(red: 1.0, green: 0.843, blue: 0.0),
+        Color(red: 0.0, green: 0.98, blue: 0.604),
+        Color(red: 0.118, green: 0.565, blue: 1.0),
+        Color(red: 0.541, green: 0.169, blue: 0.886),
+    ]
+
+    var body: some View {
+        Label {
+            Text("What's New")
+        } icon: {
+            icon
+                .frame(width: 16, height: 16)
+        }
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        if isUnread {
+            TimelineView(.animation(minimumInterval: reduceMotion ? 1.0 : (1.0 / 30.0))) { context in
+                let t = context.date.timeIntervalSinceReferenceDate
+                let phase = reduceMotion ? 0.25 : (t.truncatingRemainder(dividingBy: 3.0) / 3.0)
+
+                LinearGradient(
+                    colors: Self.rainbowColors,
+                    startPoint: UnitPoint(x: phase - 1.0, y: 0.0),
+                    endPoint: UnitPoint(x: phase, y: 1.0)
+                )
+                .mask(
+                    Image(systemName: "sparkle.magnifyingglass")
+                        .font(.system(size: 14, weight: .semibold))
+                )
+                .compositingGroup()
+            }
+        } else {
+            Image(systemName: "sparkle.magnifyingglass")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.primary)
+        }
+    }
+}

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Constants for the What's New feature. Lives in Core so both
+/// EnviousWisprServices (SettingsManager) and the app shell can reference it.
+public enum WhatsNewConstants {
+    /// Bump when bundled What's New content changes in a user-visible way.
+    public static let currentContentVersion = "1.9.1"
+
+    /// UserDefaults key for the last content version the user has viewed.
+    public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"
+}

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -322,6 +322,24 @@ public final class SettingsManager {
         }
     }
 
+    // MARK: - What's New
+
+    public var lastSeenWhatsNewVersion: String {
+        didSet {
+            UserDefaults.standard.set(lastSeenWhatsNewVersion, forKey: WhatsNewConstants.lastSeenVersionDefaultsKey)
+            hasUnreadWhatsNew = (lastSeenWhatsNewVersion != WhatsNewConstants.currentContentVersion)
+        }
+    }
+
+    public private(set) var hasUnreadWhatsNew: Bool
+
+    public func markWhatsNewSeen() {
+        guard hasUnreadWhatsNew else { return }
+        lastSeenWhatsNewVersion = WhatsNewConstants.currentContentVersion
+    }
+
+    // MARK: - Computed Configurations
+
     public var activePolishInstructions: PolishInstructions {
         switch writingStylePreset {
         case .formal:
@@ -433,6 +451,12 @@ public final class SettingsManager {
         warmEnginePolicy = WarmEnginePolicy(
             rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""
         ) ?? .seconds30
+
+        // What's New: fresh install (nil) defaults to current version so new users aren't badged.
+        let storedWhatsNew = defaults.string(forKey: WhatsNewConstants.lastSeenVersionDefaultsKey)
+            ?? WhatsNewConstants.currentContentVersion
+        lastSeenWhatsNewVersion = storedWhatsNew
+        hasUnreadWhatsNew = (storedWhatsNew != WhatsNewConstants.currentContentVersion)
 
         // Canonicalize provider-coupled model names after all properties are loaded.
         if llmProvider == .appleIntelligence {


### PR DESCRIPTION
## Summary
- Add "What's New" tab to Settings showing curated release notes (12 entries, 4 themes)
- Sidebar icon shimmers rainbow when unread, dismisses on first view
- Fresh installs see content but no shimmer (no false badge)

Closes #218

## Architecture
- Pure limb: zero interaction with audio/ASR/paste critical path
- `WhatsNewConstants` in Core (version + defaults key)
- Stored `hasUnreadWhatsNew` on SettingsManager (not computed, per Codex review)
- `TimelineView` + gradient mask for sidebar icon animation (per Codex review)
- Typed `Category` enum + stable semantic IDs (per Codex review)
- 3 new files, 3 modified. No changes to AppState, Pipeline, or any other module.

## Files
- `Sources/EnviousWisprCore/WhatsNewConstants.swift` (new)
- `Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift` (new)
- `Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift` (new)
- `Sources/EnviousWisprServices/SettingsManager.swift` (modified)
- `Sources/EnviousWispr/Views/Settings/SettingsSection.swift` (modified)
- `Sources/EnviousWispr/Views/Settings/SettingsView.swift` (modified)

## Reviewed by
GPT, Gemini, Codex (2026-04-08). 10 revisions incorporated.

## Test plan
- [x] `swift build` passes
- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] Release build + bundle-dev succeeds
- [x] "What's New" tab visible in sidebar below History
- [x] Rainbow icon animation visible when unread
- [x] Content displays 4 themed sections with 12 entries
- [x] Clicking tab dismisses rainbow via `markWhatsNewSeen()`
