### PR TITLE
feat(settings): version-grouped What's New with v1.9.1 entries

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -7,6 +7,7 @@ enum WhatsNewContent {
     static let contentVersion = WhatsNewConstants.currentContentVersion
 
     enum Category: String, CaseIterable, Identifiable {
+        case newFeatures = "New Features"
         case smarterAIPolish = "Smarter AI Polish"
         case betterOllamaSupport = "Better Ollama Support"
         case fasterAndMoreReliable = "Faster and More Reliable"
@@ -22,107 +23,154 @@ enum WhatsNewContent {
         let title: String
         let description: String
         let category: Category
+        let version: String
     }
 
     static let entries: [Entry] = [
-        // Smarter AI Polish
+        // MARK: - v1.9.1
+
         Entry(
-            id: "apple-intelligence-guardrails",
-            icon: "sparkles",
-            title: "Apple Intelligence guardrails",
-            description: "AI polish no longer over-edits your text or answers questions instead of polishing them. Five protective rules keep your words intact.",
-            category: .smarterAIPolish
+            id: "whats-new-tab",
+            icon: "sparkle.magnifyingglass",
+            title: "What's New tab",
+            description: "See what changed after every update, right here in Settings. The sidebar icon glows rainbow when there are unread notes.",
+            category: .newFeatures,
+            version: "1.9.1"
         ),
+        Entry(
+            id: "smarter-paste-detection",
+            icon: "doc.on.clipboard",
+            title: "Smarter paste detection",
+            description: "Transcribed text now pastes correctly into Slack, Discord, and other Electron apps that were previously missed.",
+            category: .qualityOfLife,
+            version: "1.9.1"
+        ),
+        Entry(
+            id: "clipboard-fallback-overlay",
+            icon: "rectangle.on.rectangle",
+            title: "Clipboard fallback overlay",
+            description: "When no text field is selected, your transcription is copied to the clipboard and a notification tells you to press Cmd+V.",
+            category: .qualityOfLife,
+            version: "1.9.1"
+        ),
+
+        // MARK: - v1.9.0
+
         Entry(
             id: "context-aware-prompts",
             icon: "brain.head.profile",
             title: "Context-aware prompts",
             description: "Each AI provider now gets prompts optimized for its strengths, producing better polish results.",
-            category: .smarterAIPolish
+            category: .smarterAIPolish,
+            version: "1.9.0"
+        ),
+        Entry(
+            id: "apple-intelligence-guardrails",
+            icon: "sparkles",
+            title: "Apple Intelligence guardrails",
+            description: "AI polish no longer over-edits your text or answers questions instead of polishing them. Five protective rules keep your words intact.",
+            category: .smarterAIPolish,
+            version: "1.9.0"
         ),
         Entry(
             id: "repolish-from-history",
             icon: "arrow.clockwise",
             title: "Re-polish from History",
             description: "The Enhance button on existing transcripts now works correctly for all speech engine types.",
-            category: .smarterAIPolish
+            category: .smarterAIPolish,
+            version: "1.9.0"
         ),
-
-        // Better Ollama Support
         Entry(
             id: "auto-discover-models",
             icon: "server.rack",
             title: "Auto-discover models",
             description: "New Ollama models appear automatically once downloaded. No more hardcoded lists.",
-            category: .betterOllamaSupport
+            category: .betterOllamaSupport,
+            version: "1.9.0"
         ),
         Entry(
             id: "warmup-indicator",
             icon: "gauge.with.dots.needle.33percent",
             title: "Warm-up indicator",
             description: "See when your Ollama model is loading into GPU memory with a live status spinner.",
-            category: .betterOllamaSupport
+            category: .betterOllamaSupport,
+            version: "1.9.0"
         ),
         Entry(
             id: "native-ollama-api",
             icon: "bolt.horizontal",
             title: "Native API",
             description: "Switched to Ollama's native API for better compatibility with reasoning models like Gemma 4.",
-            category: .betterOllamaSupport
+            category: .betterOllamaSupport,
+            version: "1.9.0"
         ),
-
-        // Faster and More Reliable
         Entry(
             id: "instant-first-press",
             icon: "hare",
             title: "Instant first press",
             description: "Eliminated the delay on your very first recording. The speech engine warms up at launch.",
-            category: .fasterAndMoreReliable
+            category: .fasterAndMoreReliable,
+            version: "1.9.0"
         ),
         Entry(
             id: "no-phantom-text",
             icon: "waveform.slash",
             title: "No more phantom text",
             description: "Fixed the #1 reported issue: holding the record button in silence no longer produces hallucinated words.",
-            category: .fasterAndMoreReliable
+            category: .fasterAndMoreReliable,
+            version: "1.9.0"
         ),
         Entry(
             id: "whispered-speech",
             icon: "ear",
             title: "Whispered speech captured",
             description: "Quiet sensitivity mode now correctly captures whispered speech that was previously dropped.",
-            category: .fasterAndMoreReliable
+            category: .fasterAndMoreReliable,
+            version: "1.9.0"
         ),
         Entry(
             id: "paste-back-fix",
             icon: "doc.on.clipboard",
             title: "Paste-back fix",
             description: "Fixed a macOS 14+ issue where transcribed text sometimes failed to paste into the target app.",
-            category: .fasterAndMoreReliable
+            category: .fasterAndMoreReliable,
+            version: "1.9.0"
         ),
-
-        // Quality of Life
         Entry(
             id: "configurable-engine-timeout",
             icon: "timer",
             title: "Configurable engine timeout",
             description: "Choose how long to keep the microphone warm between recordings: 10s, 30s, 60s, or always.",
-            category: .qualityOfLife
+            category: .qualityOfLife,
+            version: "1.9.0"
         ),
         Entry(
             id: "better-error-messages",
             icon: "exclamationmark.bubble",
             title: "Better error messages",
             description: "Clearer notifications when something goes wrong, with distinct warnings for partial vs. complete failures.",
-            category: .qualityOfLife
+            category: .qualityOfLife,
+            version: "1.9.0"
         ),
     ]
 
-    /// Entries grouped by category, preserving display order.
-    static var groupedEntries: [(category: Category, entries: [Entry])] {
-        Category.allCases.compactMap { category in
-            let items = entries.filter { $0.category == category }
-            return items.isEmpty ? nil : (category, items)
+    /// All distinct versions in the entries, sorted newest first.
+    static var versions: [String] {
+        let unique = Set(entries.map(\.version))
+        return unique.sorted { lhs, rhs in
+            lhs.compare(rhs, options: .numeric) == .orderedDescending
+        }
+    }
+
+    /// Entries grouped by version (newest first), then by category within each version.
+    static var groupedByVersion: [(version: String, sections: [(category: Category, entries: [Entry])])] {
+        versions.map { version in
+            let versionEntries = entries.filter { $0.version == version }
+            let sections = Category.allCases.compactMap { category -> (Category, [Entry])? in
+                let items = versionEntries.filter { $0.category == category }
+                return items.isEmpty ? nil : (category, items)
+            }
+            return (version, sections)
         }
     }
 }

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
@@ -7,30 +7,39 @@ struct WhatsNewSettingsView: View {
     var body: some View {
         SettingsContentView {
             VStack(alignment: .leading, spacing: 4) {
-                Text("What's New in v\(AppConstants.appVersion)")
+                Text("What's New")
                     .font(.system(size: 20, weight: .semibold))
                     .foregroundStyle(.stTextSecondary)
-                Text("Here's what improved since your last update.")
+                Text("Here's what improved in recent updates.")
                     .font(.stHelper)
                     .foregroundStyle(.stTextTertiary)
             }
             .padding(.bottom, 4)
 
-            ForEach(WhatsNewContent.groupedEntries, id: \.category.id) { group in
-                BrandedSection(header: group.category.title) {
-                    ForEach(Array(group.entries.enumerated()), id: \.element.id) { index, entry in
-                        BrandedRow(showDivider: index < group.entries.count - 1) {
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: entry.icon)
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(.stAccent)
-                                    .frame(width: 24, alignment: .center)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(entry.title)
-                                        .font(.system(size: 13, weight: .semibold))
-                                    Text(entry.description)
-                                        .font(.stHelper)
-                                        .foregroundStyle(.stTextTertiary)
+            ForEach(WhatsNewContent.groupedByVersion, id: \.version) { versionGroup in
+                // Version header
+                Text("v\(versionGroup.version)")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.stTextSecondary)
+                    .padding(.top, 8)
+
+                // Category sections within this version
+                ForEach(versionGroup.sections, id: \.category.id) { section in
+                    BrandedSection(header: section.category.title) {
+                        ForEach(Array(section.entries.enumerated()), id: \.element.id) { index, entry in
+                            BrandedRow(showDivider: index < section.entries.count - 1) {
+                                HStack(alignment: .top, spacing: 12) {
+                                    Image(systemName: entry.icon)
+                                        .font(.system(size: 16))
+                                        .foregroundStyle(.stAccent)
+                                        .frame(width: 24, alignment: .center)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(entry.title)
+                                            .font(.system(size: 13, weight: .semibold))
+                                        Text(entry.description)
+                                            .font(.stHelper)
+                                            .foregroundStyle(.stTextTertiary)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Group patch notes by version (newest first), then by category within each version
- Add v1.9.1 entries: What's New tab, smarter paste detection, clipboard fallback overlay
- Move existing 12 entries under v1.9.0 section
- Add `version` field to Entry, `groupedByVersion` computed property, version headers in view

## Test plan
- [x] `swift build` passes
- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] bundle-dev + visual verification: version sections render correctly
