### PR TITLE
chore(release): bump version to 1.9.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.9.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.9.0</string>
+	<string>1.9.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
- Version bump to 1.9.1 (CFBundleShortVersionString + CFBundleVersion)
- What's New content already updated in #222
