### PR TITLE
fix(pipeline): add isStarting guard to WhisperKitPipeline

### DIFF
--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -213,8 +213,14 @@ public final class WhisperKitPipeline: DictationPipeline {
         }
     }
 
+    /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
+    private var isStarting = false
+
     public func startRecording() async {
+        guard !isStarting else { return }
         guard !state.isActive || state == .complete || state == .ready else { return }
+        isStarting = true
+        defer { isStarting = false }
 
         // Cancel any pending model unload — keep model loaded during recording.
         modelUnloadTask?.cancel()


### PR DESCRIPTION
## Summary

- Adds `isStarting` guard to `WhisperKitPipeline.startRecording()`, matching the existing pattern in `TranscriptionPipeline`
- Prevents duplicate startup attempts when user rapidly retries after model load failure
- Eliminates duplicate Sentry `model_load_failed` events (ENVIOUSWISPR-C, 4 events from rapid retries)

## Context

Sentry issue ENVIOUSWISPR-C showed 4 `model_load_failed` events in rapid succession from the same user on an M1 MacBook Pro with low memory. Without `isStarting`, each hotkey press could enter `startRecording()` concurrently while the previous `backend.prepare()` was still failing.

Fixes #228

## Test plan

- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] `swift build` clean
- [ ] CI build-check
