### PR TITLE
fix(ui): load transcript history when History view appears

### DIFF
--- a/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
+++ b/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
@@ -27,5 +27,8 @@ struct HistoryContentView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task {
+            appState.transcriptCoordinator.load()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `.task` modifier to `HistoryContentView` to trigger `transcriptCoordinator.load()` when the view appears
- Ensures history is populated as soon as the user sees the History tab, not only after Settings renders or a dictation completes
- Fixes empty history on launch reported by user

## Context

`TranscriptCoordinator.load()` was only called from `SettingsView.task` and pipeline `.complete` callbacks. Since History is the default tab in `UnifiedWindowView`, it renders immediately, but `SettingsView.task` fires on the whole window (which is the same view). The `.task` on `HistoryContentView` provides a guaranteed load path tied to the view that actually needs the data.

Fixes #227
Related: #225

## Test plan

- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] `swift build` clean
- [ ] CI build-check
- [ ] Manual: quit app, relaunch, verify history loads without completing a dictation
