### PR TITLE
fix(audio): populate route telemetry on pre-warm + interruption cleanup

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -42,9 +42,6 @@ struct UnifiedWindowView: View {
             }
         }
         .preferredColorScheme(.light)
-        .task {
-            appState.transcriptCoordinator.load()
-        }
         .onChange(of: appState.pendingNavigationSection) { _, newSection in
             if let section = newSection {
                 selectedSection = section

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -190,6 +190,16 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
     public func preWarm() async {
         let proxyStart = ContinuousClock.now
+
+        // Derive route label so Sentry telemetry is populated even when
+        // startEnginePhase() is skipped on the next recording (warm engine reuse).
+        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
+           AudioDeviceEnumerator.isBluetoothDevice(outID) {
+            currentAudioRoute = "capture_session_bt"
+        } else {
+            currentAudioRoute = "built_in_mic"
+        }
+
         ensureConnection()
         resendConfigIfNeeded()
         let connMs = Self.ms(ContinuousClock.now - proxyStart)

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -710,6 +710,11 @@ public final class TranscriptionPipeline: DictationPipeline {
             }
         }
         deactivateStreamingForwarding()
+        // Reset capture state so isCapturing and warm engine timer are consistent.
+        // The engine is already dead, but stopCapture() clears client-side flags.
+        Task { [weak self] in
+            _ = await self?.audioCapture.stopCapture()
+        }
         targetApp = nil
         targetElement = nil
         recordingStartTime = nil

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -649,6 +649,10 @@ public final class WhisperKitPipeline: DictationPipeline {
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         silenceDetector = nil
+        // Reset capture state so isCapturing and warm engine timer are consistent.
+        Task { [weak self] in
+            _ = await self?.audioCapture.stopCapture()
+        }
         targetApp = nil
         targetElement = nil
         recordingStartTime = nil


### PR DESCRIPTION
## Summary

- Set `currentAudioRoute` in `AudioCaptureProxy.preWarm()` so Sentry reports the correct audio route when the engine is reused from pre-warm (previously reported "unknown")
- Add `stopCapture()` to both pipeline interruption handlers to reset `isCapturing` and cancel warm engine teardown timer after engine death
- Remove duplicate `transcriptCoordinator.load()` from `SettingsView` (now handled by `HistoryContentView.task` from #227, addressing Codex review feedback on #232)

## Context

Sentry issue ENVIOUSWISPR-A showed `audio.route=unknown` on 3 events because `preWarm()` didn't derive the route label. The route detection logic already existed in `startEnginePhase()` -- this copies it to `preWarm()`.

The interruption handlers reset pipeline state but didn't call `stopCapture()`, leaving `isCapturing=true` and the warm engine teardown timer potentially dangling after the engine was already dead.

Fixes #229

## Test plan

- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] `swift build` clean
- [ ] CI build-check
