### PR TITLE
fix(xpc): atomic VAD segment return from stopCapture

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -27,7 +27,7 @@ public protocol AudioCaptureInterface: AnyObject {
     func startEnginePhase() async throws
     func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer>
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> // periphery:ignore - convenience method combining engine + capture phases
-    func stopCapture() async -> [Float]
+    func stopCapture() async -> CaptureResult
     func rebuildEngine()
     func buildEngine(noiseSuppression: Bool)
     func preWarm() async

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -164,11 +164,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         return try await beginCapturePhase()
     }
 
-    public func stopCapture() async -> [Float] {
+    public func stopCapture() async -> CaptureResult {
         guard let source = activeSource else {
             let samples = capturedSamples
             capturedSamples = []
-            return samples
+            return CaptureResult(samples: samples)
         }
 
         isCapturing = false
@@ -188,10 +188,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         // dictation but doesn't run indefinitely.
         scheduleWarmEngineTeardown()
 
-        // Samples accumulated via onSamples callback → manager.capturedSamples
+        // Samples accumulated via onSamples callback -> manager.capturedSamples.
+        // In-process path returns empty vadSegments; pipeline owns its own SilenceDetector.
         let samples = capturedSamples
         capturedSamples = []
-        return samples
+        return CaptureResult(samples: samples)
     }
 
     public func rebuildEngine() {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -144,20 +144,22 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         return try await beginCapturePhase()
     }
 
-    public func stopCapture() async -> [Float] {
+    public func stopCapture() async -> CaptureResult {
         // Bump generation so stale callbacks from this session don't leak into the next.
         captureGeneration &+= 1
 
-        var result: [Float] = []
+        var result = CaptureResult(samples: [])
         do {
-            result = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<[Float], any Error>) in
+            result = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<CaptureResult, any Error>) in
                 let guard_ = OneShotContinuation(cont)
                 serviceProxy { proxy in
-                    proxy.stopCapture { data in
-                        guard_.resume(returning: Self.dataToFloats(data))
+                    proxy.stopCapture { sampleData, vadData in
+                        let samples = Self.dataToFloats(sampleData)
+                        let segments = Self.decodeVADSegments(vadData)
+                        guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
                     }
                 } onProxyError: {
-                    guard_.resume(returning: [])
+                    guard_.resume(returning: CaptureResult(samples: []))
                 }
             }
         } catch {

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -64,11 +64,6 @@ enum SmoothedVADPhase: Sendable {
     case hangover(chunksRemaining: Int)
 }
 
-public struct SpeechSegment: Sendable {
-    public let startSample: Int
-    public let endSample: Int
-}
-
 /// Monitors audio for speech activity and detects silence after speech for auto-stop.
 ///
 /// Uses FluidAudio's Silero VAD model for raw probability, then applies EMA smoothing

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -182,14 +182,33 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
         }
     }
 
-    func stopCapture(reply: @escaping (Data) -> Void) {
+    func stopCapture(reply: @escaping (Data, Data) -> Void) {
         nonisolated(unsafe) let safeReply = reply
         Task { @MainActor in
             self.cancelVADMonitoring()
-            let samples = await self.captureManager.stopCapture()
-            // Transport format: raw Float32 bytes, non-interleaved mono, 16kHz.
-            let data = samples.withUnsafeBytes { Data($0) }
-            safeReply(data)
+
+            // CRITICAL: finalize VAD segments BEFORE clearing the sample buffer.
+            // Previously, stopCapture() cleared capturedSamples first, then getVADSegments()
+            // read capturedSamples.count as 0 for finalization, producing endSample=0 on open
+            // segments and negative durations (-768ms). See #226.
+            var vadData = Data()
+            if let detector = self.silenceDetector {
+                let totalCount = self.captureManager.capturedSamples.count
+                await detector.finalizeSegments(totalSampleCount: totalCount)
+                let segments = await detector.speechSegments
+                vadData = Data(capacity: segments.count * MemoryLayout<Int32>.size * 2)
+                for seg in segments {
+                    var start = Int32(seg.startSample)
+                    var end = Int32(seg.endSample)
+                    vadData.append(Data(bytes: &start, count: MemoryLayout<Int32>.size))
+                    vadData.append(Data(bytes: &end, count: MemoryLayout<Int32>.size))
+                }
+            }
+
+            // NOW clear the sample buffer and return both atomically.
+            let captureResult = await self.captureManager.stopCapture()
+            let sampleData = captureResult.samples.withUnsafeBytes { Data($0) }
+            safeReply(sampleData, vadData)
         }
     }
 

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -48,8 +48,11 @@ import Foundation
     /// Phase 2: install audio tap and begin capture. Buffers flow back via audioBufferCaptured callback.
     func beginCapture(reply: @escaping (NSError?) -> Void)
 
-    /// Stop capture and return accumulated samples as raw Float32 bytes (Data).
-    func stopCapture(reply: @escaping (Data) -> Void)
+    /// Stop capture and return accumulated samples + finalized VAD segments atomically.
+    /// First Data = raw Float32 sample bytes. Second Data = packed [Int32 start, Int32 end] VAD segment pairs.
+    /// VAD segments are finalized BEFORE the sample buffer is cleared, preventing the call-order bug
+    /// where separate stopCapture/getVADSegments calls produced endSample=0 on open segments.
+    func stopCapture(reply: @escaping (Data, Data) -> Void)
 
     /// Cancel a pre-warmed engine that never began capture.
     func abortPreWarm()

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -27,6 +27,32 @@ public enum AppConstants {
     }
 }
 
+// MARK: - Speech Segment
+
+/// A contiguous range of audio samples identified as speech by VAD.
+public struct SpeechSegment: Sendable {
+    public let startSample: Int
+    public let endSample: Int
+    public init(startSample: Int, endSample: Int) {
+        self.startSample = startSample
+        self.endSample = endSample
+    }
+}
+
+// MARK: - Capture Result
+
+/// Atomic result from stopCapture(): audio samples + VAD speech segments.
+/// Bundling these together eliminates the ordering dependency between
+/// stopCapture() and getVADSegments() across the XPC boundary.
+public struct CaptureResult: Sendable {
+    public let samples: [Float]
+    public let vadSegments: [SpeechSegment]
+    public init(samples: [Float], vadSegments: [SpeechSegment] = []) {
+        self.samples = samples
+        self.vadSegments = vadSegments
+    }
+}
+
 // MARK: - Audio Constants
 
 public enum AudioConstants {

--- a/Sources/EnviousWisprPipeline/SampleFilter.swift
+++ b/Sources/EnviousWisprPipeline/SampleFilter.swift
@@ -1,4 +1,5 @@
 import EnviousWisprAudio
+import EnviousWisprCore
 import Foundation
 
 /// Shared utilities extracted from both pipelines to eliminate duplication.

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -368,7 +368,8 @@ public final class TranscriptionPipeline: DictationPipeline {
         // to the Parakeet actor before we deactivate forwarding.
         // Without this reorder, deactivateStreamingForwarding() sets the flag to false
         // and all queued tasks drop their buffers — losing ~250-500ms of trailing audio.
-        let rawSamples = await audioCapture.stopCapture()
+        let captureResult = await audioCapture.stopCapture()
+        let rawSamples = captureResult.samples
         SentryBreadcrumb.add(stage: "recording", message: "Recording stopped", data: ["sample_count": rawSamples.count])
         SentryBreadcrumb.updateRecordingState(active: false)
 
@@ -429,8 +430,10 @@ public final class TranscriptionPipeline: DictationPipeline {
         var vadSpeechDurationMs = 0
         let isXPCMode = audioCapture is AudioCaptureProxy
         if isXPCMode {
-            // XPC mode: get speech segments from service-side VAD.
-            let segments = await audioCapture.getVADSegments()
+            // XPC mode: VAD segments are returned atomically with samples from stopCapture().
+            // This eliminates the call-order bug where separate getVADSegments() read
+            // capturedSamples.count as 0 after stopCapture() cleared the buffer (#226).
+            let segments = captureResult.vadSegments
             hasSpeechEvidence = !segments.isEmpty
             vadSegmentCount = segments.count
             vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -350,7 +350,8 @@ public final class WhisperKitPipeline: DictationPipeline {
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
 
-        let rawSamples = await audioCapture.stopCapture()
+        let captureResult = await audioCapture.stopCapture()
+        let rawSamples = captureResult.samples
         SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording stopped", data: ["sample_count": rawSamples.count])
         SentryBreadcrumb.updateRecordingState(active: false)
 
@@ -373,8 +374,8 @@ public final class WhisperKitPipeline: DictationPipeline {
         var vadSpeechDurationMs = 0
         let isXPCMode = audioCapture is AudioCaptureProxy
         if isXPCMode {
-            // XPC mode: get speech segments from service-side VAD.
-            let segments = await audioCapture.getVADSegments()
+            // XPC mode: VAD segments returned atomically with samples from stopCapture() (#226).
+            let segments = captureResult.vadSegments
             hasSpeechEvidence = !segments.isEmpty
             vadSegmentCount = segments.count
             vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000


### PR DESCRIPTION
## Summary

- Eliminates the XPC call-order bug where `stopCapture()` cleared the sample buffer before `getVADSegments()` could finalize open speech segments, producing negative VAD durations (-768ms)
- `stopCapture()` now returns `CaptureResult(samples, vadSegments)` atomically: VAD segments are finalized BEFORE the buffer is cleared
- Moves `SpeechSegment` from Audio to Core for cross-module use
- Both pipelines use `captureResult.vadSegments` instead of a separate `getVADSegments()` call

## Root cause (mathematical proof)

Sentry value `vad_speech_duration_ms = -768` = `(0 - 12288) * 1000 / 16000`. A segment with `startSample=12288` (3 VAD chunks) and `endSample=0` (from `finalizeSegments(totalSampleCount: 0)` because `capturedSamples` was already cleared). Full analysis in #226.

## Files changed (10)

| File | Change |
|------|--------|
| `EnviousWisprCore/Constants.swift` | Add `SpeechSegment` + `CaptureResult` |
| `EnviousWisprAudio/SilenceDetector.swift` | Remove `SpeechSegment` (moved to Core) |
| `EnviousWisprAudio/AudioCaptureInterface.swift` | `stopCapture()` returns `CaptureResult` |
| `EnviousWisprAudio/AudioCaptureManager.swift` | Return `CaptureResult(samples:)` |
| `EnviousWisprAudio/AudioCaptureProxy.swift` | Decode both Data args from XPC |
| `EnviousWisprCore/AudioServiceProtocol.swift` | `stopCapture` reply: `(Data, Data)` |
| `EnviousWisprAudioService/AudioServiceHandler.swift` | Finalize VAD before clearing buffer |
| `EnviousWisprPipeline/TranscriptionPipeline.swift` | Use `captureResult.vadSegments` |
| `EnviousWisprPipeline/WhisperKitPipeline.swift` | Use `captureResult.vadSegments` |
| `EnviousWisprPipeline/SampleFilter.swift` | Add `import EnviousWisprCore` |

Fixes #226

## Test plan

- [x] `scripts/swift-test.sh` passes (202 tests)
- [x] `swift build` clean (debug)
- [ ] CI build-check
- [ ] Manual: short recording (< 1s), normal recording, verify no negative VAD durations in logs
