### PR TITLE
fix(website): correct enviouslabs.com to enviouslabs.co in JSON-LD

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -46,7 +46,7 @@ const articleJsonLd = JSON.stringify({
     "worksFor": {
       "@type": "Organization",
       "name": "Envious Labs",
-      "url": "https://enviouslabs.com",
+      "url": "https://enviouslabs.co",
     },
     "sameAs": [
       "https://github.com/saurabhav88",

--- a/website/src/pages/authors/saurabh-vaish.astro
+++ b/website/src/pages/authors/saurabh-vaish.astro
@@ -21,7 +21,7 @@ const personJsonLd = JSON.stringify({
   "worksFor": {
     "@type": "Organization",
     "name": "Envious Labs",
-    "url": "https://enviouslabs.com",
+    "url": "https://enviouslabs.co",
   },
   "sameAs": [
     "https://github.com/saurabhav88",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -21,7 +21,7 @@ const jsonLdOrg = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "Organization",
   "name": "Envious Labs",
-  "url": "https://enviouslabs.com",
+  "url": "https://enviouslabs.co",
   "logo": "https://enviouswispr.com/favicon.svg",
   "sameAs": [
     "https://x.com/EnviousLabs",


### PR DESCRIPTION
## Summary
- Fix `enviouslabs.com` → `enviouslabs.co` in JSON-LD structured data across 3 files
- We don't own enviouslabs.com; our actual domain is enviouslabs.co
- Affects BlogPost layout, author page, and homepage organization schema

## Test plan
- [ ] Verify deployed site JSON-LD contains `enviouslabs.co`
