### PR TITLE
fix(asr): WhisperKit tail truncation from prompt token decoder bias (#216)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -119,8 +119,9 @@ public actor WhisperKitIncrementalWorker {
             )
         }
 
-        // Tail has speech — async tail decode with silence padding
+        // Tail has speech — decode with standard silence padding.
         let paddedSamples = WhisperKitBackend.padAudioWithSilence(finalSamples)
+
         let tailStart = CFAbsoluteTimeGetCurrent()
         do {
             let overlapStartSeconds = max(0, Float(lastResultSampleCount) / 16000.0 - 1.0)
@@ -129,11 +130,11 @@ public actor WhisperKitIncrementalWorker {
             opts.clipTimestamps = [overlapStartSeconds]
             opts.windowClipTime = 0
 
-            if let tokenizer {
-                let suffix = String(candidateText!.suffix(200))
-                let allTokens = tokenizer.encode(text: " " + suffix.trimmingCharacters(in: .whitespaces))
-                opts.promptTokens = allTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
-            }
+            // Do NOT pass promptTokens for the tail decode. When the worker's last
+            // text ends a sentence (e.g., "finalize the vendor contract"), prompt
+            // tokens bias the decoder to emit end-of-text instead of transcribing
+            // the remaining short fragment (e.g., "by Friday"). This was the root
+            // cause of #216: tail decode returned empty despite speech being present.
 
             let results = try await whisperKit.transcribe(audioArray: paddedSamples, decodeOptions: opts)
             let tailText = results.map(\.text)
@@ -142,7 +143,6 @@ public actor WhisperKitIncrementalWorker {
 
             let tailMs = Int((CFAbsoluteTimeGetCurrent() - tailStart) * 1000)
 
-            // Diagnostic: log worker text, tail-only text, overlap window, and uncovered duration
             await AppLogger.shared.log(
                 "TAIL_DIAG: workerText=[\(candidateText?.suffix(60) ?? "nil")] " +
                 "tailText=[\(tailText.suffix(60))] " +
@@ -152,18 +152,29 @@ public actor WhisperKitIncrementalWorker {
                 level: .info, category: "WhisperKitWorker"
             )
 
-            let finalText: String
-            if tailText.isEmpty {
-                finalText = candidateText!
-            } else {
-                finalText = candidateText! + " " + tailText
+            if !tailText.isEmpty {
+                let finalText = candidateText! + " " + tailText
+                return IncrementalResult(
+                    text: finalText, samplesCovered: finalSamples.count,
+                    decodeCount: decodeCount, totalDecodeTimeMs: totalDecodeTimeMs,
+                    accepted: true, mode: baseMode + "+tail",
+                    strategy: "worker+tail", tailDecodeMs: tailMs
+                )
             }
 
+            // Tail decode returned empty despite speech evidence (RMS > 0.001).
+            // Do NOT silently accept the truncated worker result. Signal batch
+            // fallback so the pipeline re-transcribes the full audio.
+            await AppLogger.shared.log(
+                "TAIL_DIAG: empty tail despite speech evidence, triggering batch fallback " +
+                "(uncovered=\(String(format: "%.1f", tailDurationSeconds))s)",
+                level: .info, category: "WhisperKitWorker"
+            )
             return IncrementalResult(
-                text: finalText, samplesCovered: finalSamples.count,
+                text: nil, samplesCovered: lastResultSampleCount,
                 decodeCount: decodeCount, totalDecodeTimeMs: totalDecodeTimeMs,
-                accepted: true, mode: baseMode + "+tail",
-                strategy: "worker+tail", tailDecodeMs: tailMs
+                accepted: false, mode: baseMode,
+                strategy: "tail_empty_fallback", tailDecodeMs: tailMs
             )
         } catch {
             let tailMs = Int((CFAbsoluteTimeGetCurrent() - tailStart) * 1000)


### PR DESCRIPTION
## Summary
- Remove `promptTokens` from WhisperKit incremental worker tail decode, eliminating decoder bias that caused end-of-speech truncation
- When tail decode returns empty despite speech evidence, trigger batch fallback instead of silently accepting truncated text

Fixes #216.

## Root cause
The incremental worker passed the last 200 chars of already-transcribed text as `promptTokens` to WhisperKit's tail decode. When the worker text ended a complete sentence ("finalize the vendor contract"), the prompt biased Whisper's decoder into emitting `<|endoftext|>` instead of transcribing the remaining fragment ("by Friday").

TTS reproduction confirmed: Test 4 ("...finalize the vendor contract by Friday.") lost "by Friday" 100% of the time before the fix.

## What changed (1 file, 26 insertions, 15 deletions)
`WhisperKitIncrementalWorker.swift`:
1. Removed `promptTokens` from tail decode options (lines 132-136 deleted)
2. When `tailText.isEmpty` despite `needsTailDecode=true`, return `accepted: false` with strategy `tail_empty_fallback` instead of silently accepting truncated text

## Design rationale
- **Prompt tokens removal**: The tail segment is an independent decode. Passing context from the worker introduces a coupling where the decoder "thinks" the sentence is complete. Without prompts, the decoder transcribes what it hears without bias. The overlap region (`clipTimestamps` with 1s overlap) provides sufficient audio context.
- **Batch fallback on empty tail**: The pipeline already has a proven full-batch decode path (`backend.transcribe()`) with silence padding. If the tail decode fails for any reason, falling back to the full batch guarantees no content loss. This is a safety net, not a performance regression: it only fires when the fast path fails.

## Test plan
- [x] 204 unit tests pass
- [x] Release build clean
- [x] TTS reproduction: 4 test cases, all show FULL capture
  - Short (5 words): FULL via batch
  - Medium list (3 items ending with "go outside for a walk"): FULL via worker+tail
  - Long trailing ("quality assurance"): FULL via worker+tail
  - **Previously truncated** ("by Friday"): FULL via worker+tail (was TRUNCATED before fix)
- [x] Rebuilt, relaunched, and verified with live app

## Council review
GPT and Gemini both reviewed the investigation plan. Gemini flagged the tail concatenation overlap as a concern (visible as minor word duplication in some cases, cleaned by LLM polish). Both agreed on the batch fallback safety net approach.
