### PR TITLE
docs(ui): add What's New entries for v1.9.2

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -27,6 +27,25 @@ enum WhatsNewContent {
     }
 
     static let entries: [Entry] = [
+        // MARK: - v1.9.2
+
+        Entry(
+            id: "whisperkit-full-capture",
+            icon: "text.badge.checkmark",
+            title: "WhisperKit captures every word",
+            description: "Fixed an issue where the last few words of a dictation could be silently dropped when using WhisperKit. Every word now reaches your clipboard.",
+            category: .fasterAndMoreReliable,
+            version: "1.9.2"
+        ),
+        Entry(
+            id: "ollama-long-dictation",
+            icon: "timer",
+            title: "Ollama handles long dictations",
+            description: "Local AI polish with large models like Gemma 4 no longer times out on longer recordings. Timeout budgets now adapt to your provider.",
+            category: .betterOllamaSupport,
+            version: "1.9.2"
+        ),
+
         // MARK: - v1.9.1
 
         Entry(


### PR DESCRIPTION
## Summary
- Add two What's New entries for fixes shipping in v1.9.2
- WhisperKit full capture (#216): "Fixed an issue where the last few words of a dictation could be silently dropped"
- Ollama long dictation (#205): "Local AI polish with large models no longer times out on longer recordings"

`WhatsNewConstants.currentContentVersion` stays at `1.9.1` until the release checklist bumps it.

## Test plan
- [x] Debug build clean
- [ ] Visual check in Settings > What's New after next rebuild
