### PR TITLE
fix(llm): tighten Ollama max tokens and fix test title

### DIFF
--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -96,10 +96,10 @@ public final class LLMPolishStep: TextProcessingStep {
         let (thinkingBudget, reasoningEffort) = resolveThinkingConfig()
         let maxTokens: Int = {
             if llmProvider == .ollama {
-                // Scale with input length, same formula as cloud providers.
-                // For 921-char input this gives 921 tokens (~4x headroom over ~230 actual).
+                // Estimate tokens (~3 chars per token for English), add headroom.
+                // For 921-char input: 921/3 + 100 = 407 tokens (~2x actual output of ~195).
                 // The pipeline-level timeout (15s) caps runaway generation.
-                return max(context.text.count, LLMConstants.ollamaMaxTokens)
+                return max(context.text.count / 3 + 100, LLMConstants.ollamaMaxTokens)
             }
             // OpenAI reasoning models include reasoning in max_completion_tokens — keep generous.
             if reasoningEffort != nil { return LLMConstants.defaultMaxTokens }

--- a/Tests/EnviousWisprTests/PostASRTests.swift
+++ b/Tests/EnviousWisprTests/PostASRTests.swift
@@ -292,10 +292,10 @@ struct TextProcessingChainTests {
         #expect(result == "start-B")
     }
 
-    @Test("provider-aware timeout: 6s step passes with 15s budget but would fail with 5s")
-    func providerAwareTimeout() async throws {
-        // Simulates the Ollama scenario: a step that takes ~6s would timeout at 5s
-        // but succeeds with the 15s Ollama budget.
+    @Test("step with 15s budget completes within budget")
+    func largerBudgetCompletes() async throws {
+        // Verifies that a step with a generous budget (e.g., Ollama's 15s)
+        // completes successfully when the operation finishes within that budget.
         let ollamaStep = MockTextProcessingStep(
             name: "OllamaSim",
             maxDuration: .seconds(15),


### PR DESCRIPTION
## Summary
- Tighten Ollama `num_predict` from `text.count` (~4x headroom) to `text.count/3 + 100` (~2x headroom)
- Fix misleading test title: "6s step passes with 15s budget" renamed to "step with 15s budget completes within budget"

Addresses Codex review findings from PR #237. Council (GPT + Gemini) both recommended the token estimate tightening.

## Test plan
- [x] 204 tests pass
- [x] Release build clean
