### PR TITLE
feat(multilingual): 99-language auto-detect v1 with LID accuracy + CJK polish fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,14 @@ let package = Package(
     platforms: [
         .macOS(.v14)
     ],
+    products: [
+        // Exposed so the multilingual polish-quality harness (a separate
+        // SwiftPM package at scripts/multilingual-eval/polisher-runner) can
+        // depend on the real planner + connectors via a path-based package
+        // dependency. Purely additive — no production code imports these.
+        .library(name: "EnviousWisprCore", targets: ["EnviousWisprCore"]),
+        .library(name: "EnviousWisprLLM", targets: ["EnviousWisprLLM"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
         .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
@@ -122,6 +130,14 @@ let package = Package(
                 "EnviousWisprLLM",
             ],
             path: "Tests/EnviousWisprTests"
+        ),
+        .testTarget(
+            name: "EnviousWisprASRTests",
+            dependencies: [
+                "EnviousWisprCore",
+                "EnviousWisprASR",
+            ],
+            path: "Tests/EnviousWisprASRTests"
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -56,6 +56,14 @@ final class AppState {
     /// Read by the overlay to switch to the expanded lips visual.
     var isRecordingLocked: Bool = false
 
+    /// Multilingual v1: latest passive-chip trigger emitted by LanguageDetector,
+    /// if any. Observed by settings/overlay UI to offer a "Detected X. Lock it?"
+    /// or "Language unstable. Lock language?" CTA. Nil when no chip is pending.
+    /// UI consumers set this to nil after dismissing.
+    /// TODO: wire a settings-level banner that presents this; current v1 ship is
+    /// callback-only so chip events are not silently dropped.
+    var pendingPassiveChip: PassiveChipTrigger?
+
     // Feature #8: custom word management — delegated to coordinator
     let customWordsCoordinator = CustomWordsCoordinator()
 
@@ -100,11 +108,30 @@ final class AppState {
             transcriptStore: transcriptStore,
             keychainManager: keychainManager
         )
+        // W6: wire language-flip telemetry into the detector via a closure so
+        // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
+        // The detector fires this inline from an actor; we hop to MainActor to
+        // call `TelemetryService` (which is @MainActor isolated).
+        // The chip handler is wired AFTER init completes (see setPassiveChipHandler
+        // call below) because it needs to capture self, and Swift does not allow
+        // that before all stored properties are initialized.
+        let languageDetector = LanguageDetector(
+            onLanguageFlip: { @Sendable event in
+                Task { @MainActor in
+                    TelemetryService.shared.trackLanguageFlip(
+                        fromLang: event.fromLang,
+                        toLang: event.toLang,
+                        confidenceBoth: event.confidenceBoth
+                    )
+                }
+            }
+        )
         whisperKitPipeline = WhisperKitPipeline(
             audioCapture: audioCapture,
             backend: WhisperKitBackend(),
             transcriptStore: transcriptStore,
-            keychainManager: keychainManager
+            keychainManager: keychainManager,
+            languageDetector: languageDetector
         )
         // Transcript polish service (re-polish from detail view, decoupled from pipelines)
         polishService = TranscriptPolishService(
@@ -126,6 +153,17 @@ final class AppState {
 
         // Wire dictation activity provider (after all stored properties initialized)
         polishService.setDictationActivity(self)
+
+        // Wire the passive-chip handler on the LanguageDetector actor now that
+        // self is fully constructed. The handler hops back to the MainActor
+        // to publish the chip on `pendingPassiveChip` so UI can observe it.
+        Task { [weak self] in
+            await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
+                Task { @MainActor in
+                    self?.pendingPassiveChip = trigger
+                }
+            }
+        }
 
         // Unified engine interruption handler — routes to whichever pipeline is actively recording.
         // Both pipelines share the same audioCapture instance. When the audio engine/XPC service

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -241,6 +241,12 @@ final class PipelineSettingsSync {
             polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
         case .whisperKitLanguage:
             syncTranscriptionOptions(settings)
+        case .languageMode:
+            // Multilingual v1 (W2): keep pipeline in sync with user's auto/locked
+            // choice. Detection itself happens in the pipeline; this path just
+            // forwards the current mode so the detector actor reads it lazily.
+            whisperKitPipeline.languageMode = settings.languageMode
+            syncTranscriptionOptions(settings)
         case .selectedInputDeviceUID:
             audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
         case .preferredInputDeviceIDOverride:
@@ -265,6 +271,10 @@ final class PipelineSettingsSync {
             pipeline.useStreamingASR = settings.useStreamingASR
         case .warmEnginePolicy:
             audioCapture.warmEnginePolicy = settings.warmEnginePolicy
+        case .useRefreshedWhisperKitModel:
+            // Cold flag (Multilingual v1 W4). The active modelVariant is resolved
+            // from this default at startup; toggling requires an app restart.
+            break
         }
     }
 
@@ -272,9 +282,22 @@ final class PipelineSettingsSync {
     private func syncTranscriptionOptions(_ settings: SettingsManager) {
         var opts = TranscriptionOptions()
         // Parakeet is English-only; WhisperKit uses the user's selected language.
-        // Pass the language to both pipelines — Parakeet ignores it, WhisperKit
+        // Pass the language to both pipelines: Parakeet ignores it, WhisperKit
         // passes it through to DecodingOptions.
-        opts.language = settings.whisperKitLanguage
+        //
+        // Multilingual v1: source is now `languageMode`, not the deprecated
+        // `whisperKitLanguage` field. In auto mode, leave language empty so the
+        // detector's result (set later in the pipeline) fills it. In locked
+        // mode, push the ISO code so the incremental worker and the batch
+        // decode see the correct language from recording start.
+        switch settings.languageMode {
+        case .auto:
+            // `TranscriptionOptions.language` is String?; nil means "let the
+            // detector decide" (the pipeline overwrites it after LID runs).
+            opts.language = nil
+        case .locked(let code):
+            opts.language = code
+        }
         pipeline.transcriptionOptions = opts
         whisperKitPipeline.transcriptionOptions = opts
     }
@@ -297,6 +320,8 @@ final class PipelineSettingsSync {
         whisperKitPipeline.vadSensitivity = settings.vadSensitivity
         whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
         whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+        // Multilingual v1 (W2): mirror the current auto/locked mode on startup.
+        whisperKitPipeline.languageMode = settings.languageMode
     }
 
     /// Sync all LLM settings to the transcript polish service (re-polish from detail view).

--- a/Sources/EnviousWispr/Views/Settings/LanguageCatalog.swift
+++ b/Sources/EnviousWispr/Views/Settings/LanguageCatalog.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Display metadata for the 99 Whisper-supported languages.
+///
+/// Keyed by ISO 639-1 (and one ISO 639-3-style code, `haw`, plus `yue` for
+/// Cantonese) matching `LanguageTypes.whisperSupportedLanguages`. Each entry
+/// carries the endonym (native-script name) and an English exonym so the UI
+/// can render both: "日本語 (Japanese)", "தமிழ் (Tamil)", etc.
+///
+/// Native names were researched per language. Keep them accurate. Users see
+/// their own language spelled correctly, in their own script.
+enum LanguageCatalog {
+    struct Entry: Sendable, Equatable {
+        let code: String
+        let nativeName: String
+        let englishName: String
+    }
+
+    /// Lookup a display entry by ISO code. Returns a safe fallback entry using
+    /// the code itself if the code is not in the catalog (defensive, should
+    /// never happen for Whisper-supported codes).
+    static func entry(for code: String) -> Entry {
+        if let found = all.first(where: { $0.code == code.lowercased() }) {
+            return found
+        }
+        return Entry(code: code, nativeName: code.uppercased(), englishName: code.uppercased())
+    }
+
+    /// All 99 languages, sorted alphabetically by English name for catalog display.
+    static let sortedByEnglishName: [Entry] = all.sorted { lhs, rhs in
+        lhs.englishName.localizedCaseInsensitiveCompare(rhs.englishName) == .orderedAscending
+    }
+
+    /// All 99 Whisper-supported languages. Order here is not significant; the
+    /// UI sorts via `sortedByEnglishName`.
+    static let all: [Entry] = [
+        Entry(code: "af",  nativeName: "Afrikaans",        englishName: "Afrikaans"),
+        Entry(code: "am",  nativeName: "አማርኛ",              englishName: "Amharic"),
+        Entry(code: "ar",  nativeName: "العربية",           englishName: "Arabic"),
+        Entry(code: "as",  nativeName: "অসমীয়া",            englishName: "Assamese"),
+        Entry(code: "az",  nativeName: "Azərbaycanca",     englishName: "Azerbaijani"),
+        Entry(code: "ba",  nativeName: "Башҡортса",        englishName: "Bashkir"),
+        Entry(code: "be",  nativeName: "Беларуская",       englishName: "Belarusian"),
+        Entry(code: "bg",  nativeName: "Български",        englishName: "Bulgarian"),
+        Entry(code: "bn",  nativeName: "বাংলা",              englishName: "Bengali"),
+        Entry(code: "bo",  nativeName: "བོད་སྐད་",            englishName: "Tibetan"),
+        Entry(code: "br",  nativeName: "Brezhoneg",        englishName: "Breton"),
+        Entry(code: "bs",  nativeName: "Bosanski",         englishName: "Bosnian"),
+        Entry(code: "ca",  nativeName: "Català",           englishName: "Catalan"),
+        Entry(code: "cs",  nativeName: "Čeština",          englishName: "Czech"),
+        Entry(code: "cy",  nativeName: "Cymraeg",          englishName: "Welsh"),
+        Entry(code: "da",  nativeName: "Dansk",            englishName: "Danish"),
+        Entry(code: "de",  nativeName: "Deutsch",          englishName: "German"),
+        Entry(code: "el",  nativeName: "Ελληνικά",         englishName: "Greek"),
+        Entry(code: "en",  nativeName: "English",          englishName: "English"),
+        Entry(code: "es",  nativeName: "Español",          englishName: "Spanish"),
+        Entry(code: "et",  nativeName: "Eesti",            englishName: "Estonian"),
+        Entry(code: "eu",  nativeName: "Euskara",          englishName: "Basque"),
+        Entry(code: "fa",  nativeName: "فارسی",             englishName: "Persian"),
+        Entry(code: "fi",  nativeName: "Suomi",            englishName: "Finnish"),
+        Entry(code: "fo",  nativeName: "Føroyskt",         englishName: "Faroese"),
+        Entry(code: "fr",  nativeName: "Français",         englishName: "French"),
+        Entry(code: "gl",  nativeName: "Galego",           englishName: "Galician"),
+        Entry(code: "gu",  nativeName: "ગુજરાતી",            englishName: "Gujarati"),
+        Entry(code: "ha",  nativeName: "Hausa",            englishName: "Hausa"),
+        Entry(code: "haw", nativeName: "ʻŌlelo Hawaiʻi",   englishName: "Hawaiian"),
+        Entry(code: "he",  nativeName: "עברית",             englishName: "Hebrew"),
+        Entry(code: "hi",  nativeName: "हिन्दी",              englishName: "Hindi"),
+        Entry(code: "hr",  nativeName: "Hrvatski",         englishName: "Croatian"),
+        Entry(code: "ht",  nativeName: "Kreyòl Ayisyen",   englishName: "Haitian Creole"),
+        Entry(code: "hu",  nativeName: "Magyar",           englishName: "Hungarian"),
+        Entry(code: "hy",  nativeName: "Հայերեն",          englishName: "Armenian"),
+        Entry(code: "id",  nativeName: "Bahasa Indonesia", englishName: "Indonesian"),
+        Entry(code: "is",  nativeName: "Íslenska",         englishName: "Icelandic"),
+        Entry(code: "it",  nativeName: "Italiano",         englishName: "Italian"),
+        Entry(code: "ja",  nativeName: "日本語",              englishName: "Japanese"),
+        Entry(code: "jw",  nativeName: "Basa Jawa",        englishName: "Javanese"),
+        Entry(code: "ka",  nativeName: "ქართული",          englishName: "Georgian"),
+        Entry(code: "kk",  nativeName: "Қазақша",          englishName: "Kazakh"),
+        Entry(code: "km",  nativeName: "ខ្មែរ",                englishName: "Khmer"),
+        Entry(code: "kn",  nativeName: "ಕನ್ನಡ",              englishName: "Kannada"),
+        Entry(code: "ko",  nativeName: "한국어",              englishName: "Korean"),
+        Entry(code: "la",  nativeName: "Latina",           englishName: "Latin"),
+        Entry(code: "lb",  nativeName: "Lëtzebuergesch",   englishName: "Luxembourgish"),
+        Entry(code: "ln",  nativeName: "Lingála",          englishName: "Lingala"),
+        Entry(code: "lo",  nativeName: "ລາວ",                englishName: "Lao"),
+        Entry(code: "lt",  nativeName: "Lietuvių",         englishName: "Lithuanian"),
+        Entry(code: "lv",  nativeName: "Latviešu",         englishName: "Latvian"),
+        Entry(code: "mg",  nativeName: "Malagasy",         englishName: "Malagasy"),
+        Entry(code: "mi",  nativeName: "Māori",            englishName: "Maori"),
+        Entry(code: "mk",  nativeName: "Македонски",       englishName: "Macedonian"),
+        Entry(code: "ml",  nativeName: "മലയാളം",            englishName: "Malayalam"),
+        Entry(code: "mn",  nativeName: "Монгол",           englishName: "Mongolian"),
+        Entry(code: "mr",  nativeName: "मराठी",              englishName: "Marathi"),
+        Entry(code: "ms",  nativeName: "Bahasa Melayu",    englishName: "Malay"),
+        Entry(code: "mt",  nativeName: "Malti",            englishName: "Maltese"),
+        Entry(code: "my",  nativeName: "မြန်မာ",             englishName: "Burmese"),
+        Entry(code: "ne",  nativeName: "नेपाली",             englishName: "Nepali"),
+        Entry(code: "nl",  nativeName: "Nederlands",       englishName: "Dutch"),
+        Entry(code: "nn",  nativeName: "Nynorsk",          englishName: "Norwegian Nynorsk"),
+        Entry(code: "no",  nativeName: "Norsk",            englishName: "Norwegian"),
+        Entry(code: "oc",  nativeName: "Occitan",          englishName: "Occitan"),
+        Entry(code: "pa",  nativeName: "ਪੰਜਾਬੀ",             englishName: "Punjabi"),
+        Entry(code: "pl",  nativeName: "Polski",           englishName: "Polish"),
+        Entry(code: "ps",  nativeName: "پښتو",              englishName: "Pashto"),
+        Entry(code: "pt",  nativeName: "Português",        englishName: "Portuguese"),
+        Entry(code: "ro",  nativeName: "Română",           englishName: "Romanian"),
+        Entry(code: "ru",  nativeName: "Русский",          englishName: "Russian"),
+        Entry(code: "sa",  nativeName: "संस्कृतम्",            englishName: "Sanskrit"),
+        Entry(code: "sd",  nativeName: "سنڌي",              englishName: "Sindhi"),
+        Entry(code: "si",  nativeName: "සිංහල",             englishName: "Sinhala"),
+        Entry(code: "sk",  nativeName: "Slovenčina",       englishName: "Slovak"),
+        Entry(code: "sl",  nativeName: "Slovenščina",      englishName: "Slovenian"),
+        Entry(code: "sn",  nativeName: "ChiShona",         englishName: "Shona"),
+        Entry(code: "so",  nativeName: "Soomaali",         englishName: "Somali"),
+        Entry(code: "sq",  nativeName: "Shqip",            englishName: "Albanian"),
+        Entry(code: "sr",  nativeName: "Српски",           englishName: "Serbian"),
+        Entry(code: "su",  nativeName: "Basa Sunda",       englishName: "Sundanese"),
+        Entry(code: "sv",  nativeName: "Svenska",          englishName: "Swedish"),
+        Entry(code: "sw",  nativeName: "Kiswahili",        englishName: "Swahili"),
+        Entry(code: "ta",  nativeName: "தமிழ்",              englishName: "Tamil"),
+        Entry(code: "te",  nativeName: "తెలుగు",              englishName: "Telugu"),
+        Entry(code: "tg",  nativeName: "Тоҷикӣ",           englishName: "Tajik"),
+        Entry(code: "th",  nativeName: "ไทย",               englishName: "Thai"),
+        Entry(code: "tk",  nativeName: "Türkmençe",        englishName: "Turkmen"),
+        Entry(code: "tl",  nativeName: "Tagalog",          englishName: "Tagalog"),
+        Entry(code: "tr",  nativeName: "Türkçe",           englishName: "Turkish"),
+        Entry(code: "tt",  nativeName: "Татарча",          englishName: "Tatar"),
+        Entry(code: "uk",  nativeName: "Українська",       englishName: "Ukrainian"),
+        Entry(code: "ur",  nativeName: "اردو",              englishName: "Urdu"),
+        Entry(code: "uz",  nativeName: "Oʻzbekcha",        englishName: "Uzbek"),
+        Entry(code: "vi",  nativeName: "Tiếng Việt",       englishName: "Vietnamese"),
+        Entry(code: "yi",  nativeName: "ייִדיש",             englishName: "Yiddish"),
+        Entry(code: "yo",  nativeName: "Yorùbá",           englishName: "Yoruba"),
+        Entry(code: "yue", nativeName: "粵語",              englishName: "Cantonese"),
+        Entry(code: "zh",  nativeName: "中文",              englishName: "Chinese"),
+    ]
+}

--- a/Sources/EnviousWispr/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWispr/Views/Settings/LanguageLockSheet.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+import EnviousWisprCore
+import EnviousWisprServices
+
+/// Modal sheet that lets users pin WhisperKit to a specific language.
+///
+/// Surfaces all 99 Whisper-supported languages with a search field and an
+/// optional "Recent" section driven by the persisted `SessionLanguageMemory`
+/// usage cache. Tapping a row sets `languageMode = .locked(code)` and
+/// dismisses. The sheet is a settings detail, never an interrupt: nothing
+/// here blocks dictation.
+struct LanguageLockSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var searchText: String = ""
+
+    /// Recents are loaded once when the sheet appears. We intentionally do not
+    /// observe UserDefaults live: the sheet lifetime is short and W2 owns the
+    /// persistence contract.
+    @State private var recents: [LanguageCatalog.Entry] = []
+
+    private let maxRecents = 5
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                searchField
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        if !recents.isEmpty && searchText.isEmpty {
+                            recentSection
+                        }
+                        allLanguagesSection
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                }
+            }
+            .background(Color.stPageBg)
+            .navigationTitle("Lock language")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .frame(minWidth: 420, minHeight: 520)
+        .onAppear(perform: loadRecents)
+    }
+
+    // MARK: - Subviews
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.stTextTertiary)
+            TextField("Search by name or code", text: $searchText)
+                .textFieldStyle(.plain)
+                .accessibilityLabel("Search languages")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.stSectionBg)
+        .overlay(
+            Rectangle()
+                .fill(Color.stDivider)
+                .frame(height: 1),
+            alignment: .bottom
+        )
+    }
+
+    @ViewBuilder
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("RECENT")
+                .font(.stSectionHeader)
+                .foregroundStyle(.stTextTertiary)
+                .padding(.leading, 4)
+
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(recents.enumerated()), id: \.element.code) { index, entry in
+                    languageRow(entry, showDivider: index < recents.count - 1)
+                }
+            }
+            .background(Color.stSectionBg)
+            .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+                    .strokeBorder(Color.stDivider, lineWidth: 1)
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var allLanguagesSection: some View {
+        let filtered = filteredLanguages
+
+        VStack(alignment: .leading, spacing: 6) {
+            Text("ALL LANGUAGES")
+                .font(.stSectionHeader)
+                .foregroundStyle(.stTextTertiary)
+                .padding(.leading, 4)
+
+            if filtered.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack {
+                        Text("No language matches your search.")
+                            .font(.stHelper)
+                            .foregroundStyle(.stTextTertiary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 16)
+                }
+                .background(Color.stSectionBg)
+                .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+                        .strokeBorder(Color.stDivider, lineWidth: 1)
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(filtered.enumerated()), id: \.element.code) { index, entry in
+                        languageRow(entry, showDivider: index < filtered.count - 1)
+                    }
+                }
+                .background(Color.stSectionBg)
+                .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+                        .strokeBorder(Color.stDivider, lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func languageRow(_ entry: LanguageCatalog.Entry, showDivider: Bool) -> some View {
+        let isSelected = isCurrentLock(entry.code)
+
+        VStack(spacing: 0) {
+            Button {
+                select(entry)
+            } label: {
+                HStack(spacing: 10) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(entry.nativeName)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.primary)
+                        Text("\(entry.englishName) · \(entry.code)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.stTextTertiary)
+                    }
+                    Spacer()
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color.stAccent)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .contentShape(Rectangle())
+                .background(isSelected ? Color.stAccent.opacity(0.06) : Color.clear)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(entry.englishName), native \(entry.nativeName)")
+            .accessibilityValue(isSelected ? "selected" : "")
+
+            if showDivider {
+                Divider()
+                    .overlay(Color.stDivider)
+                    .padding(.leading, 14)
+            }
+        }
+    }
+
+    // MARK: - Filtering
+
+    private var filteredLanguages: [LanguageCatalog.Entry] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return LanguageCatalog.sortedByEnglishName }
+        return LanguageCatalog.sortedByEnglishName.filter { entry in
+            entry.englishName.lowercased().contains(query)
+                || entry.nativeName.lowercased().contains(query)
+                || entry.code.lowercased().contains(query)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func select(_ entry: LanguageCatalog.Entry) {
+        // W6 telemetry: record the mode transition before we mutate settings so
+        // we can read the prior value for `from_lang`.
+        let fromLang: String
+        switch appState.settings.languageMode {
+        case .auto:
+            fromLang = "auto"
+        case .locked(let prior):
+            fromLang = prior
+        }
+        // Reason classification: the sheet only distinguishes "first_time" (never
+        // locked before) from "preference" (user actively changing a lock). The
+        // "after_bad_detect" path is reserved for the passive-chip CTA (future
+        // hook) so we do not mis-label a Settings-driven change.
+        let reason: String
+        if case .auto = appState.settings.languageMode {
+            reason = "first_time"
+        } else {
+            reason = "preference"
+        }
+
+        appState.settings.languageMode = .locked(entry.code)
+        TelemetryService.shared.trackManualLockUsed(
+            fromLang: fromLang,
+            toLang: entry.code,
+            reason: reason
+        )
+        dismiss()
+    }
+
+    private func isCurrentLock(_ code: String) -> Bool {
+        if case .locked(let current) = appState.settings.languageMode {
+            return current == code
+        }
+        return false
+    }
+
+    // MARK: - Recents
+
+    /// Reads `SessionLanguageMemory.usage24h` from UserDefaults (written by
+    /// the detector stack in W2), sorts by `lastSeen` desc, and maps to
+    /// catalog entries. Silently drops unknown codes. Hides the section if
+    /// empty (does not show an empty state).
+    private func loadRecents() {
+        let key = SessionLanguageMemory.userDefaultsKey
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let memory = try? JSONDecoder().decode(SessionLanguageMemory.self, from: data)
+        else {
+            recents = []
+            return
+        }
+
+        // Honor the 24-hour TTL on SessionLanguageMemory.usage24h here in the
+        // UI layer too, so a user who opens Settings after a day without
+        // dictating does not see stale "Recent" langs. The detector's own
+        // pruneExpiredUsage only runs when the detector does; this keeps the
+        // UI consistent with the cache's expiration contract.
+        let now = Date()
+        let ttl = SessionLanguageMemory.usageCacheTTL
+        let sorted = memory.usage24h
+            .filter { now.timeIntervalSince($0.value.lastSeen) <= ttl }
+            .sorted { $0.value.lastSeen > $1.value.lastSeen }
+            .prefix(maxRecents)
+            .compactMap { pair -> LanguageCatalog.Entry? in
+                guard LanguageTypes.isSupported(pair.key) else { return nil }
+                return LanguageCatalog.entry(for: pair.key)
+            }
+
+        recents = Array(sorted)
+    }
+}

--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
@@ -5,6 +5,8 @@ import EnviousWisprCore
 struct SpeechEngineSettingsView: View {
     @Environment(AppState.self) private var appState
 
+    @State private var showLanguageLockSheet: Bool = false
+
     var body: some View {
         @Bindable var state = appState
 
@@ -42,17 +44,44 @@ struct SpeechEngineSettingsView: View {
             if appState.settings.selectedBackend == .whisperKit,
                case .ready = appState.whisperKitSetup.setupState {
                 BrandedSection(header: "Language") {
-                    BrandedRow(showDivider: false) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Picker("Language", selection: $state.settings.whisperKitLanguage) {
-                                Text("English").tag("en")
-                                Text("German (Deutsch)").tag("de")
-                                Text("Tamil (தமிழ்)").tag("ta")
-                            }
-                            .pickerStyle(.segmented)
-                            Text("Select the language you'll be speaking. Parakeet is English-only; WhisperKit supports multiple languages.")
+                    BrandedRow {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Toggle(
+                                "Auto-detect language",
+                                isOn: Binding(
+                                    get: { isAutoLanguage(appState.settings.languageMode) },
+                                    set: { newValue in
+                                        state.settings.languageMode = newValue
+                                            ? .auto
+                                            : .locked(currentOrDefaultLockCode())
+                                    }
+                                )
+                            )
+                            .toggleStyle(BrandedToggleStyle())
+                            Text("Auto-detect your language, or lock to a specific one. WhisperKit supports 99 languages.")
                                 .font(.stHelper)
                                 .foregroundStyle(.stTextTertiary)
+                        }
+                    }
+
+                    if case .locked(let code) = appState.settings.languageMode {
+                        BrandedRow(showDivider: false) {
+                            HStack(spacing: 10) {
+                                let entry = LanguageCatalog.entry(for: code)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Language")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.stTextTertiary)
+                                    Text("\(entry.nativeName) (\(entry.englishName))")
+                                        .font(.system(size: 13, weight: .medium))
+                                        .foregroundStyle(.primary)
+                                }
+                                Spacer()
+                                Button("Change") {
+                                    showLanguageLockSheet = true
+                                }
+                                .controlSize(.small)
+                            }
                         }
                     }
                 }
@@ -122,6 +151,33 @@ struct SpeechEngineSettingsView: View {
                 Task { await appState.whisperKitSetup.detectState() }
             }
         }
+        .sheet(isPresented: $showLanguageLockSheet) {
+            LanguageLockSheet()
+                .environment(appState)
+        }
+    }
+
+    // MARK: - Language mode helpers
+
+    /// True when the current mode is `.auto`. Defined as a free helper so the
+    /// Toggle binding stays trivially readable.
+    private func isAutoLanguage(_ mode: LanguageMode) -> Bool {
+        if case .auto = mode { return true }
+        return false
+    }
+
+    /// When the user flips the Auto toggle off, we need a concrete ISO code
+    /// to lock to. Preserve the prior locked code if we have one (comes from
+    /// the W2 migration of `whisperKitLanguage`), otherwise default to English.
+    private func currentOrDefaultLockCode() -> String {
+        if case .locked(let code) = appState.settings.languageMode {
+            return code
+        }
+        let migrated = appState.settings.whisperKitLanguage
+        if LanguageTypes.isSupported(migrated) {
+            return migrated
+        }
+        return "en"
     }
 
     // MARK: - WhisperKit Setup UI

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -1,0 +1,610 @@
+import Foundation
+import EnviousWisprCore
+@preconcurrency import WhisperKit
+
+/// Passive UX fallback event emitted by `LanguageDetector`.
+///
+/// The detector never owns UI. When conditions suggest a chip like
+/// "Detected: Japanese. Lock it?" should appear, it calls `onPassiveChipTrigger`
+/// on the main thread. The UI layer (W1) decides whether and how to show it.
+public struct PassiveChipTrigger: Sendable, Equatable {
+    public enum Reason: String, Sendable, Equatable {
+        case lidFlipFlop                // two different langs accepted within 5 min
+        case consecutiveLowConfidence   // two low-confidence results in a session
+    }
+    public let lang: String?
+    public let reason: Reason
+    public init(lang: String?, reason: Reason) {
+        self.lang = lang
+        self.reason = reason
+    }
+}
+
+/// Telemetry hook emitted when the detector observes two distinct accepted
+/// languages within 5 minutes. Vendor containment: the detector lives in
+/// `EnviousWisprASR` which cannot import PostHog, so the app wires a closure
+/// from `TelemetryService` at `LanguageDetector` construction time.
+///
+/// Callers MUST NOT do heavy work on this callback; it fires inline with
+/// detection. Treat it as fire-and-forget logging.
+public struct LanguageFlipEvent: Sendable, Equatable {
+    public let fromLang: String
+    public let toLang: String
+    /// Average of the two consecutive accept confidences (0...1). Used as a
+    /// rough quality signal for "how sure were we both times?".
+    public let confidenceBoth: Double
+    public init(fromLang: String, toLang: String, confidenceBoth: Double) {
+        self.fromLang = fromLang
+        self.toLang = toLang
+        self.confidenceBoth = confidenceBoth
+    }
+}
+
+/// Thin clock seam so tests can deterministically advance time.
+public protocol LanguageDetectorClock: Sendable {
+    func now() -> Date
+}
+public struct SystemLanguageDetectorClock: LanguageDetectorClock {
+    public init() {}
+    public func now() -> Date { Date() }
+}
+
+/// Actor wrapping WhisperKit's `detectLanguage` with the five-layer autodetect
+/// stack defined in docs/feature-requests/multilingual-v1.md.
+///
+/// Heart-protection contract: every public API returns a `LanguageDetectionResult`,
+/// never throws. If WhisperKit errors internally, the detector abstains and the
+/// pipeline passes `nil` to `TranscriptionOptions.language`, letting WhisperKit's
+/// own LID run as the final fallback.
+///
+/// The detector is an actor so concurrent recordings serialize naturally. It holds
+/// only the `SessionLanguageMemory` state and a clock seam; WhisperKit is supplied
+/// per call from the backend so unloaded-model lifecycles do not leak here.
+public actor LanguageDetector {
+    private var memory: SessionLanguageMemory
+    private let clock: LanguageDetectorClock
+    private let defaults: UserDefaults
+    // Mutable so callers can wire handlers post-init (see
+    // `setPassiveChipHandler`). Needed for AppState, which can't capture
+    // `self` in init because its stored properties are still being set up.
+    private var onPassiveChipTrigger: (@Sendable (PassiveChipTrigger) -> Void)?
+    private let onLanguageFlip: (@Sendable (LanguageFlipEvent) -> Void)?
+    // Last two accept timestamps/langs/confidences for flip-flop detection (within 5 min).
+    private var recentAccepts: [(lang: String, confidence: Double, at: Date)] = []
+    // Count of consecutive low-confidence detections in the current session.
+    private var consecutiveLowConfidence: Int = 0
+    // Anti-flap: candidate language pending a second consecutive strong accept
+    // before it can replace sessionPreferred. Any non-confirming utterance
+    // (abstain, lowAuto, different strong candidate, or a candidate that fails
+    // the switch bar) clears this.
+    private var pendingSwitchCandidate: String?
+
+    public init(
+        clock: LanguageDetectorClock = SystemLanguageDetectorClock(),
+        defaults: UserDefaults = .standard,
+        onPassiveChipTrigger: (@Sendable (PassiveChipTrigger) -> Void)? = nil,
+        onLanguageFlip: (@Sendable (LanguageFlipEvent) -> Void)? = nil
+    ) {
+        self.clock = clock
+        self.defaults = defaults
+        self.onPassiveChipTrigger = onPassiveChipTrigger
+        self.onLanguageFlip = onLanguageFlip
+        self.memory = Self.loadMemory(from: defaults)
+    }
+
+    /// Install or replace the passive-chip handler post-init. Used by owners
+    /// (e.g. AppState) that cannot capture `self` at construction time because
+    /// their stored properties are still being initialized.
+    public func setPassiveChipHandler(_ handler: (@Sendable (PassiveChipTrigger) -> Void)?) {
+        self.onPassiveChipTrigger = handler
+    }
+
+    // MARK: - Public API
+
+    /// Run language detection on the supplied voiced samples.
+    ///
+    /// - Parameters:
+    ///   - samples: 16kHz mono Float32 voiced samples. May be the raw captured
+    ///     buffer or a VAD-filtered subset; the detector itself just windows what
+    ///     it is given.
+    ///   - voicedDuration: Total voiced duration, in seconds. Used by the speech
+    ///     gate (Layer 1).
+    ///   - whisperKit: Loaded WhisperKit instance. Passed in per call so the
+    ///     detector does not own model lifecycle.
+    ///   - mode: Current `LanguageMode` (auto or locked). Captured here (not at
+    ///     recording-start) so late user toggles are respected.
+    public func detect(
+        samples: [Float],
+        voicedDuration: TimeInterval,
+        whisperKit: WhisperKit?,
+        mode: LanguageMode
+    ) async -> LanguageDetectionResult {
+        // Locked short-circuit. No model call required.
+        if case .locked(let code) = mode {
+            let normalized = Self.normalizeLangCode(code)
+            return LanguageDetectionResult(
+                lang: normalized,
+                confidence: 1.0,
+                margin: 1.0,
+                tier: .locked,
+                voicedDuration: voicedDuration,
+                abstained: false,
+                usedSessionPrior: false
+            )
+        }
+
+        let now = clock.now()
+        memory.applyInactivityTimeout(now: now)
+        memory.pruneExpiredUsage(now: now)
+        // Drop stale flip-flop history (>5min old) up front.
+        recentAccepts = recentAccepts.filter { now.timeIntervalSince($0.at) <= 300 }
+
+        // Layer 1: speech gate.
+        if voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
+            await log("LID abstain: voicedDuration=\(voicedDuration)s < \(LanguageDetectorThresholds.shortClipMinSec)s")
+            memory.recordAbstain(now: now)
+            persistMemory()
+            return .abstain(voicedDuration: voicedDuration)
+        }
+
+        guard let kit = whisperKit else {
+            await log("LID abstain: whisperKit instance unavailable")
+            memory.recordAbstain(now: now)
+            persistMemory()
+            return .abstain(voicedDuration: voicedDuration)
+        }
+
+        // Layer 2: multi-window detection with mean probabilities.
+        let aggregated: [String: Double]
+        do {
+            aggregated = try await runMultiWindowLID(samples: samples, voicedDuration: voicedDuration, whisperKit: kit)
+        } catch is CancellationError {
+            // User hotkey-cancelled: abstain cleanly, do not touch session memory.
+            await log("LID cancelled during detectLanguage windows")
+            return .abstain(voicedDuration: voicedDuration)
+        } catch {
+            await log("LID failed, abstaining: \(error.localizedDescription)")
+            memory.recordAbstain(now: now)
+            persistMemory()
+            return .abstain(voicedDuration: voicedDuration)
+        }
+
+        guard !aggregated.isEmpty else {
+            memory.recordAbstain(now: now)
+            persistMemory()
+            return .abstain(voicedDuration: voicedDuration)
+        }
+
+        // Layer 3: rank raw probabilities first so the anti-flap gate sees the
+        // model's unbiased view. Session-prior boost is only applied to rescue
+        // borderline (lowAuto) decisions per spec ("boost ... in later
+        // low-confidence decisions").
+        let rawRanked = aggregated.sorted { $0.value > $1.value }
+        var top = rawRanked[0]
+        var runnerUp: Double = rawRanked.count > 1 ? rawRanked[1].value : 0
+        var usedSessionPrior = false
+
+        // Decide acceptance tier against the speech-duration-aware thresholds.
+        var decision = classify(
+            topProb: top.value,
+            margin: top.value - runnerUp,
+            voicedDuration: voicedDuration
+        )
+
+        // If lowAuto AND we have a session-preferred language present in probs,
+        // apply the +0.10 boost and re-rank. This is the rescue path for
+        // borderline cases where the prior should tip the balance.
+        if decision == .lowAuto,
+           let preferred = memory.sessionPreferred,
+           LanguageTypes.isSupported(preferred),
+           aggregated[preferred] != nil {
+            var boosted = aggregated
+            boosted[preferred, default: 0] += LanguageDetectorThresholds.sessionPriorBoost
+            let boostedRanked = boosted.sorted { $0.value > $1.value }
+            let boostedTop = boostedRanked[0]
+            let boostedRunner: Double = boostedRanked.count > 1 ? boostedRanked[1].value : 0
+            let boostedDecision = classify(
+                topProb: boostedTop.value,
+                margin: boostedTop.value - boostedRunner,
+                voicedDuration: voicedDuration
+            )
+            if boostedDecision != .lowAuto && boostedDecision != .abstain {
+                top = boostedTop
+                runnerUp = boostedRunner
+                decision = boostedDecision
+                usedSessionPrior = true
+            }
+        }
+
+        let rawTopProb = min(max(aggregated[top.key] ?? top.value, 0), 1)
+        let rawMargin = max(0, rawTopProb - (rawRanked.count > 1 ? rawRanked[1].value : 0))
+
+        switch decision {
+        case .abstain:
+            await log("LID abstain: top=\(top.key) prob=\(top.value) margin=\(top.value - runnerUp) dur=\(voicedDuration)")
+            consecutiveLowConfidence += 1
+            // Anti-flap: abstain breaks the "consecutive" chain.
+            pendingSwitchCandidate = nil
+            memory.recordAbstain(now: now)
+            persistMemory()
+            emitPassiveChipIfNeeded(forLang: top.key)
+            return LanguageDetectionResult(
+                lang: nil,
+                confidence: rawTopProb,
+                margin: rawMargin,
+                tier: .abstain,
+                voicedDuration: voicedDuration,
+                abstained: true,
+                usedSessionPrior: usedSessionPrior
+            )
+
+        case .lowAuto:
+            // Accepted for decoding fallback tracking, but lexicon injection will
+            // be suppressed by the prompt layer. Do not mark as session-preferred
+            // or treat as a flip, but still count as a low-confidence signal.
+            consecutiveLowConfidence += 1
+            // Anti-flap: a low-confidence utterance also breaks the chain.
+            pendingSwitchCandidate = nil
+            memory.recordAbstain(now: now)
+            persistMemory()
+            emitPassiveChipIfNeeded(forLang: top.key)
+            return LanguageDetectionResult(
+                lang: top.key,
+                confidence: rawTopProb,
+                margin: rawMargin,
+                tier: .lowAuto,
+                voicedDuration: voicedDuration,
+                abstained: false,
+                usedSessionPrior: usedSessionPrior
+            )
+
+        case .mediumAuto, .highAuto:
+            // Anti-flap: if a sessionPreferred exists and the detected lang
+            // differs, require the high bar (>=0.85 prob, >=0.25 margin) twice
+            // in a row to switch away.
+            let tier: LanguageConfidenceTier = (decision == .highAuto ? .highAuto : .mediumAuto)
+            let finalLang = resolveAntiFlap(
+                candidate: top.key,
+                topProb: top.value,
+                margin: top.value - runnerUp
+            )
+            if finalLang == top.key {
+                consecutiveLowConfidence = 0
+                registerFlipFlopCandidate(lang: top.key, confidence: rawTopProb, at: now)
+                memory.recordAccepted(lang: top.key, confidence: rawTopProb, now: now)
+                persistMemory()
+                return LanguageDetectionResult(
+                    lang: top.key,
+                    confidence: rawTopProb,
+                    margin: rawMargin,
+                    tier: tier,
+                    voicedDuration: voicedDuration,
+                    abstained: false,
+                    usedSessionPrior: usedSessionPrior
+                )
+            } else {
+                // Anti-flap rejected the switch: report sessionPreferred as the
+                // winner, marked usedSessionPrior, with a dampened tier.
+                memory.recordAccepted(lang: finalLang, confidence: rawTopProb, now: now)
+                persistMemory()
+                return LanguageDetectionResult(
+                    lang: finalLang,
+                    confidence: rawTopProb,
+                    margin: rawMargin,
+                    tier: .mediumAuto,
+                    voicedDuration: voicedDuration,
+                    abstained: false,
+                    usedSessionPrior: true
+                )
+            }
+        }
+    }
+
+    /// Testing-only: observe internal memory.
+    public func peekMemory() -> SessionLanguageMemory { memory }
+    /// Testing-only: seed memory (e.g., for anti-flap setups without replaying
+    /// full history).
+    public func setMemoryForTesting(_ memory: SessionLanguageMemory) {
+        self.memory = memory
+    }
+    /// Testing seam: run Layer 3 logic over a pre-computed probability dict.
+    /// Skips the WhisperKit call so tests do not need a real model.
+    public func evaluateForTesting(
+        windowProbs: [String: Double],
+        voicedDuration: TimeInterval,
+        mode: LanguageMode = .auto
+    ) async -> LanguageDetectionResult {
+        if case .locked(let code) = mode {
+            return LanguageDetectionResult(
+                lang: Self.normalizeLangCode(code),
+                confidence: 1.0, margin: 1.0, tier: .locked,
+                voicedDuration: voicedDuration, abstained: false, usedSessionPrior: false
+            )
+        }
+        let now = clock.now()
+        memory.applyInactivityTimeout(now: now)
+        memory.pruneExpiredUsage(now: now)
+        recentAccepts = recentAccepts.filter { now.timeIntervalSince($0.at) <= 300 }
+
+        if voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
+            memory.recordAbstain(now: now)
+            return .abstain(voicedDuration: voicedDuration)
+        }
+        guard !windowProbs.isEmpty else {
+            memory.recordAbstain(now: now)
+            return .abstain(voicedDuration: voicedDuration)
+        }
+        let rawRanked = windowProbs.sorted { $0.value > $1.value }
+        var top = rawRanked[0]
+        var runnerUp: Double = rawRanked.count > 1 ? rawRanked[1].value : 0
+        var usedSessionPrior = false
+
+        var decision = classify(
+            topProb: top.value,
+            margin: top.value - runnerUp,
+            voicedDuration: voicedDuration
+        )
+
+        if decision == .lowAuto,
+           let preferred = memory.sessionPreferred,
+           LanguageTypes.isSupported(preferred),
+           windowProbs[preferred] != nil {
+            var boosted = windowProbs
+            boosted[preferred, default: 0] += LanguageDetectorThresholds.sessionPriorBoost
+            let boostedRanked = boosted.sorted { $0.value > $1.value }
+            let boostedTop = boostedRanked[0]
+            let boostedRunner: Double = boostedRanked.count > 1 ? boostedRanked[1].value : 0
+            let boostedDecision = classify(
+                topProb: boostedTop.value,
+                margin: boostedTop.value - boostedRunner,
+                voicedDuration: voicedDuration
+            )
+            if boostedDecision != .lowAuto && boostedDecision != .abstain {
+                top = boostedTop
+                runnerUp = boostedRunner
+                decision = boostedDecision
+                usedSessionPrior = true
+            }
+        }
+
+        let rawTopProb = min(max(windowProbs[top.key] ?? top.value, 0), 1)
+        let rawMargin = max(0, rawTopProb - (rawRanked.count > 1 ? rawRanked[1].value : 0))
+        switch decision {
+        case .abstain:
+            consecutiveLowConfidence += 1
+            pendingSwitchCandidate = nil
+            memory.recordAbstain(now: now)
+            return LanguageDetectionResult(
+                lang: nil, confidence: rawTopProb, margin: rawMargin,
+                tier: .abstain, voicedDuration: voicedDuration,
+                abstained: true, usedSessionPrior: usedSessionPrior
+            )
+        case .lowAuto:
+            consecutiveLowConfidence += 1
+            pendingSwitchCandidate = nil
+            memory.recordAbstain(now: now)
+            return LanguageDetectionResult(
+                lang: top.key, confidence: rawTopProb, margin: rawMargin,
+                tier: .lowAuto, voicedDuration: voicedDuration,
+                abstained: false, usedSessionPrior: usedSessionPrior
+            )
+        case .mediumAuto, .highAuto:
+            let tier: LanguageConfidenceTier = (decision == .highAuto ? .highAuto : .mediumAuto)
+            let finalLang = resolveAntiFlap(candidate: top.key, topProb: top.value, margin: top.value - runnerUp)
+            if finalLang == top.key {
+                consecutiveLowConfidence = 0
+                registerFlipFlopCandidate(lang: top.key, confidence: rawTopProb, at: now)
+                memory.recordAccepted(lang: top.key, confidence: rawTopProb, now: now)
+                return LanguageDetectionResult(
+                    lang: top.key, confidence: rawTopProb, margin: rawMargin,
+                    tier: tier, voicedDuration: voicedDuration,
+                    abstained: false, usedSessionPrior: usedSessionPrior
+                )
+            } else {
+                memory.recordAccepted(lang: finalLang, confidence: rawTopProb, now: now)
+                return LanguageDetectionResult(
+                    lang: finalLang, confidence: rawTopProb, margin: rawMargin,
+                    tier: .mediumAuto, voicedDuration: voicedDuration,
+                    abstained: false, usedSessionPrior: true
+                )
+            }
+        }
+    }
+
+    // MARK: - Layer 2: multi-window LID
+
+    private func runMultiWindowLID(
+        samples: [Float],
+        voicedDuration: TimeInterval,
+        whisperKit: WhisperKit
+    ) async throws -> [String: Double] {
+        let sampleRate = LanguageDetectorThresholds.sampleRate
+        let totalSamples = samples.count
+        var windows: [[Float]] = []
+
+        for w in LanguageDetectorThresholds.windows {
+            let startIdx = min(totalSamples, Int(w.start * Double(sampleRate)))
+            let endIdx = min(totalSamples, Int(w.end * Double(sampleRate)))
+            guard endIdx > startIdx else { continue }
+            windows.append(Array(samples[startIdx..<endIdx]))
+        }
+        // Full voiced window capped at 12s (always included so we always have >=1).
+        let fullEnd = min(totalSamples, Int(LanguageDetectorThresholds.fullWindowMaxSec * Double(sampleRate)))
+        if fullEnd > 0 {
+            windows.append(Array(samples[0..<fullEnd]))
+        }
+        guard !windows.isEmpty else { return [:] }
+
+        // Run up to 4 windows. The spec says "up to 4"; for short voicedDuration
+        // many of the fixed windows collapse to empty and are skipped above.
+        let capped = Array(windows.prefix(4))
+
+        var accumulated: [String: Double] = [:]
+        var counted = 0
+        for (i, window) in capped.enumerated() {
+            try Task.checkCancellation()
+            // Each window is its own detectLanguage call. WhisperKit API is
+            // `detectLangauge(audioArray:)` (original typo preserved upstream).
+            let result: (language: String, langProbs: [String: Float])
+            do {
+                result = try await whisperKit.detectLangauge(audioArray: window)
+            } catch {
+                await log("LID window \(i) failed: \(error.localizedDescription)")
+                continue
+            }
+            let probs = Self.softmaxFromLogProbs(result.langProbs)
+            for (lang, p) in probs {
+                accumulated[lang, default: 0] += p
+            }
+            counted += 1
+        }
+        guard counted > 0 else { return [:] }
+        // Arithmetic mean across windows.
+        for key in accumulated.keys {
+            accumulated[key, default: 0] /= Double(counted)
+        }
+        return accumulated
+    }
+
+    /// Convert WhisperKit's log-prob map into a normalized probability map.
+    /// WhisperKit returns the sampler's `logProbs` (filtered logits -> log softmax),
+    /// so exp() is a decent per-token probability; we then renormalize across the
+    /// reported candidates so the map sums to 1 for stable mean aggregation.
+    static func softmaxFromLogProbs(_ logProbs: [String: Float]) -> [String: Double] {
+        guard !logProbs.isEmpty else { return [:] }
+        // Numerical stability: subtract max before exp.
+        let maxLog = logProbs.values.max() ?? 0
+        var exped: [String: Double] = [:]
+        var sum = 0.0
+        for (lang, lp) in logProbs {
+            let v = exp(Double(lp - maxLog))
+            exped[lang] = v
+            sum += v
+        }
+        guard sum > 0 else { return [:] }
+        for key in exped.keys { exped[key, default: 0] /= sum }
+        return exped
+    }
+
+    // MARK: - Layer 3: session memory logic
+
+    /// Anti-flap: if there is a session-preferred language and the candidate is
+    /// different, require TWO consecutive utterances at prob >= 0.85 AND
+    /// margin >= 0.25 before switching away (per spec). A single strong
+    /// utterance sets a pending candidate; the next accepted utterance confirms
+    /// or invalidates it. Any non-confirming event (abstain, lowAuto, a
+    /// different strong candidate, or a candidate that fails the switch bar)
+    /// resets the pending state.
+    private func resolveAntiFlap(candidate: String, topProb: Double, margin: Double) -> String {
+        guard let preferred = memory.sessionPreferred,
+              LanguageTypes.isSupported(preferred),
+              preferred != candidate else {
+            // No preferred, or candidate is the preferred: no anti-flap logic needed.
+            pendingSwitchCandidate = nil
+            return candidate
+        }
+        let switchProb = 0.85
+        let meetsSwitchBar = topProb >= switchProb
+            && margin >= LanguageDetectorThresholds.highMargin
+        if !meetsSwitchBar {
+            // Candidate is not strong enough to count as switch evidence.
+            pendingSwitchCandidate = nil
+            return preferred
+        }
+        if pendingSwitchCandidate == candidate {
+            // Second consecutive strong utterance for this candidate: commit switch.
+            pendingSwitchCandidate = nil
+            return candidate
+        }
+        // First strong utterance for this candidate: record pending, keep preferred.
+        pendingSwitchCandidate = candidate
+        return preferred
+    }
+
+    private func registerFlipFlopCandidate(lang: String, confidence: Double, at now: Date) {
+        // Capture the most recent prior accept (if any) before we append, so we
+        // can emit a `language.flip` telemetry event with from/to lang + the
+        // confidence of both.
+        let prior = recentAccepts.last
+        recentAccepts.append((lang: lang, confidence: confidence, at: now))
+        recentAccepts = recentAccepts.filter { now.timeIntervalSince($0.at) <= 300 }
+        // Two distinct langs within 5 min triggers the UX chip AND telemetry.
+        let uniques = Set(recentAccepts.map { $0.lang })
+        if uniques.count >= 2 {
+            emitPassiveChip(.init(lang: lang, reason: .lidFlipFlop))
+            if let prior, prior.lang != lang, let cb = onLanguageFlip {
+                let avg = (prior.confidence + confidence) / 2.0
+                cb(LanguageFlipEvent(fromLang: prior.lang, toLang: lang, confidenceBoth: avg))
+            }
+        }
+    }
+
+    private func emitPassiveChipIfNeeded(forLang lang: String?) {
+        if consecutiveLowConfidence >= 2 {
+            emitPassiveChip(.init(lang: lang, reason: .consecutiveLowConfidence))
+            consecutiveLowConfidence = 0
+        }
+    }
+
+    private func emitPassiveChip(_ trigger: PassiveChipTrigger) {
+        guard let cb = onPassiveChipTrigger else { return }
+        cb(trigger)
+    }
+
+    // MARK: - Classification
+
+    enum Decision: Equatable { case abstain, lowAuto, mediumAuto, highAuto }
+
+    func classify(topProb: Double, margin: Double, voicedDuration: TimeInterval) -> Decision {
+        // Short clip: apply strict bar; below it, abstain entirely.
+        if voicedDuration < LanguageDetectorThresholds.confidentMinSec {
+            if topProb >= LanguageDetectorThresholds.strictProb,
+               margin >= LanguageDetectorThresholds.strictMargin {
+                return .highAuto
+            }
+            // Per spec: stricter thresholds failed -> abstain (fall back to sticky).
+            return .abstain
+        }
+        // Normal clip (>= 2.5s voiced).
+        if topProb >= LanguageDetectorThresholds.highProb,
+           margin >= LanguageDetectorThresholds.highMargin {
+            return .highAuto
+        }
+        if topProb >= LanguageDetectorThresholds.normalProb,
+           margin >= LanguageDetectorThresholds.normalMargin {
+            return .mediumAuto
+        }
+        return .lowAuto
+    }
+
+    // MARK: - Persistence
+
+    private func persistMemory() {
+        guard let data = try? JSONEncoder().encode(memory) else { return }
+        defaults.set(data, forKey: SessionLanguageMemory.userDefaultsKey)
+    }
+
+    private static func loadMemory(from defaults: UserDefaults) -> SessionLanguageMemory {
+        guard let data = defaults.data(forKey: SessionLanguageMemory.userDefaultsKey),
+              var decoded = try? JSONDecoder().decode(SessionLanguageMemory.self, from: data) else {
+            return SessionLanguageMemory()
+        }
+        // Defensive: strip any langs that are not in the 99-language set.
+        decoded.usage24h = decoded.usage24h.filter { LanguageTypes.isSupported($0.key) }
+        decoded.accepted = decoded.accepted.filter { LanguageTypes.isSupported($0.lang) }
+        if let p = decoded.sessionPreferred, !LanguageTypes.isSupported(p) {
+            decoded.sessionPreferred = nil
+        }
+        return decoded
+    }
+
+    // MARK: - Utilities
+
+    private static func normalizeLangCode(_ code: String) -> String {
+        code.lowercased()
+    }
+
+    private func log(_ message: String) async {
+        await AppLogger.shared.log(message, level: .info, category: "LanguageDetector")
+    }
+}

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -154,10 +154,10 @@ public actor LanguageDetector {
             return .abstain(voicedDuration: voicedDuration)
         }
 
-        // Layer 2: multi-window detection with mean probabilities.
-        let aggregated: [String: Double]
+        // Layer 2: multi-window detection with majority-vote aggregation.
+        let multi: MultiWindowLID
         do {
-            aggregated = try await runMultiWindowLID(samples: samples, voicedDuration: voicedDuration, whisperKit: kit)
+            multi = try await runMultiWindowLID(samples: samples, voicedDuration: voicedDuration, whisperKit: kit)
         } catch is CancellationError {
             // User hotkey-cancelled: abstain cleanly, do not touch session memory.
             await log("LID cancelled during detectLanguage windows")
@@ -169,59 +169,113 @@ public actor LanguageDetector {
             return .abstain(voicedDuration: voicedDuration)
         }
 
-        guard !aggregated.isEmpty else {
+        guard !multi.voteCounts.isEmpty else {
             memory.recordAbstain(now: now)
             persistMemory()
             return .abstain(voicedDuration: voicedDuration)
         }
+        // Structured aggregation log: lets us audit LID behavior in UAT logs
+        // without per-window noise.
+        let topLog = multi.voteCounts.keys
+            .sorted { lhs, rhs in
+                let lv = multi.voteCounts[lhs] ?? 0, rv = multi.voteCounts[rhs] ?? 0
+                if lv != rv { return lv > rv }
+                return (multi.meanProbs[lhs] ?? 0) > (multi.meanProbs[rhs] ?? 0)
+            }
+            .prefix(3)
+            .map { lang in
+                let votes = multi.voteCounts[lang] ?? 0
+                let mean = multi.meanProbs[lang] ?? 0
+                return "\(lang):votes=\(votes)/\(multi.windowCount),meanP=\(String(format: "%.3f", mean))"
+            }.joined(separator: " ")
+        await log("LID aggregated [\(topLog)]")
 
-        // Layer 3: rank raw probabilities first so the anti-flap gate sees the
-        // model's unbiased view. Session-prior boost is only applied to rescue
-        // borderline (lowAuto) decisions per spec ("boost ... in later
-        // low-confidence decisions").
-        let rawRanked = aggregated.sorted { $0.value > $1.value }
-        var top = rawRanked[0]
-        var runnerUp: Double = rawRanked.count > 1 ? rawRanked[1].value : 0
+        // Rank languages by (voteCount desc, meanProb desc). The winner is the
+        // language most windows agreed on; meanProb breaks ties. This separation
+        // keeps the downstream classifier and `recordAccepted` on true per-
+        // window confidence instead of a vote-share-diluted composite.
+        let rankedLangs = Array(multi.voteCounts.keys).sorted { lhs, rhs in
+            let lv = multi.voteCounts[lhs] ?? 0, rv = multi.voteCounts[rhs] ?? 0
+            if lv != rv { return lv > rv }
+            return (multi.meanProbs[lhs] ?? 0) > (multi.meanProbs[rhs] ?? 0)
+        }
+        let windowCountD = Double(max(multi.windowCount, 1))
+        var topLang = rankedLangs[0]
+        var topProb = multi.meanProbs[topLang] ?? 0
+        var topVoteShare = Double(multi.voteCounts[topLang] ?? 0) / windowCountD
+        // Margin is the vote-share gap between the winner and the next-best
+        // language (0 when there is no runner-up).
+        var runnerUpVoteShare: Double = rankedLangs.count > 1
+            ? Double(multi.voteCounts[rankedLangs[1]] ?? 0) / windowCountD
+            : 0
+        var margin = max(0, topVoteShare - runnerUpVoteShare)
         var usedSessionPrior = false
 
-        // Decide acceptance tier against the speech-duration-aware thresholds.
         var decision = classify(
-            topProb: top.value,
-            margin: top.value - runnerUp,
+            topProb: topProb,
+            margin: margin,
             voicedDuration: voicedDuration
         )
 
-        // If lowAuto AND we have a session-preferred language present in probs,
-        // apply the +0.10 boost and re-rank. This is the rescue path for
-        // borderline cases where the prior should tip the balance.
+        // Session-prior boost (lowAuto rescue): if the preferred language has
+        // at least as many votes as any other candidate (plurality, ties
+        // allowed), bump its meanProb by +0.10 and re-evaluate. The rescue
+        // CANNOT overturn a clear vote majority — that would defeat the whole
+        // point of majority-vote aggregation. Commits only if the boost
+        // elevates the decision past lowAuto.
+        let rawPreferredMeanProb = multi.meanProbs[memory.sessionPreferred ?? ""] ?? 0
         if decision == .lowAuto,
            let preferred = memory.sessionPreferred,
            LanguageTypes.isSupported(preferred),
-           aggregated[preferred] != nil {
-            var boosted = aggregated
-            boosted[preferred, default: 0] += LanguageDetectorThresholds.sessionPriorBoost
-            let boostedRanked = boosted.sorted { $0.value > $1.value }
-            let boostedTop = boostedRanked[0]
-            let boostedRunner: Double = boostedRanked.count > 1 ? boostedRanked[1].value : 0
-            let boostedDecision = classify(
-                topProb: boostedTop.value,
-                margin: boostedTop.value - boostedRunner,
-                voicedDuration: voicedDuration
-            )
-            if boostedDecision != .lowAuto && boostedDecision != .abstain {
-                top = boostedTop
-                runnerUp = boostedRunner
-                decision = boostedDecision
-                usedSessionPrior = true
+           (multi.voteCounts[preferred] ?? 0) > 0 {
+            let preferredShare = Double(multi.voteCounts[preferred] ?? 0) / windowCountD
+            let competitor = rankedLangs.first(where: { $0 != preferred })
+            let competitorShare = competitor.map {
+                Double(multi.voteCounts[$0] ?? 0) / windowCountD
+            } ?? 0
+            // Gate: preferred must not be a minority loser. If another lang
+            // has strictly more votes, the rescue is skipped.
+            if preferredShare >= competitorShare {
+                let boostedProb = min(1.0, rawPreferredMeanProb + LanguageDetectorThresholds.sessionPriorBoost)
+                let competitorMeanProb = competitor.map { multi.meanProbs[$0] ?? 0 } ?? 0
+                let voteMargin = preferredShare - competitorShare
+                let probMargin = boostedProb - competitorMeanProb
+                let boostedMargin = max(0, max(voteMargin, probMargin))
+                let boostedDecision = classify(
+                    topProb: boostedProb,
+                    margin: boostedMargin,
+                    voicedDuration: voicedDuration
+                )
+                if boostedDecision != .lowAuto && boostedDecision != .abstain {
+                    topLang = preferred
+                    topProb = boostedProb
+                    topVoteShare = preferredShare
+                    runnerUpVoteShare = competitorShare
+                    margin = boostedMargin
+                    decision = boostedDecision
+                    usedSessionPrior = true
+                }
             }
         }
 
-        let rawTopProb = min(max(aggregated[top.key] ?? top.value, 0), 1)
-        let rawMargin = max(0, rawTopProb - (rawRanked.count > 1 ? rawRanked[1].value : 0))
+        // When the session-prior boost rescues a decision, the returned
+        // confidence + the value recorded into session memory must reflect the
+        // model's actual per-window confidence, not the artificially boosted
+        // value. Otherwise `recordAccepted` elevates languages based on the
+        // +0.10 bump rather than genuine model evidence.
+        let rawTopProb: Double = {
+            if usedSessionPrior { return min(max(rawPreferredMeanProb, 0), 1) }
+            return min(max(topProb, 0), 1)
+        }()
+        let rawMargin = margin
+        // Repack as a (key, value) tuple so the existing downstream switch
+        // branches keep their concise spelling.
+        let top = (key: topLang, value: topProb)
+        let runnerUp = runnerUpVoteShare
 
         switch decision {
         case .abstain:
-            await log("LID abstain: top=\(top.key) prob=\(top.value) margin=\(top.value - runnerUp) dur=\(voicedDuration)")
+            await log("LID abstain: top=\(top.key) meanP=\(String(format: "%.3f", top.value)) voteShareMargin=\(String(format: "%.3f", rawMargin)) dur=\(voicedDuration)")
             consecutiveLowConfidence += 1
             // Anti-flap: abstain breaks the "consecutive" chain.
             pendingSwitchCandidate = nil
@@ -261,12 +315,25 @@ public actor LanguageDetector {
         case .mediumAuto, .highAuto:
             // Anti-flap: if a sessionPreferred exists and the detected lang
             // differs, require the high bar (>=0.85 prob, >=0.25 margin) twice
-            // in a row to switch away.
+            // in a row to switch away — unless the evidence is unanimous across
+            // all windows at moderate per-window confidence, in which case one
+            // utterance is enough (prevents first-switch hallucination on clean
+            // non-preferred audio).
+            //
+            // Note: the switch-bar signal is the per-window `meanProb` (not the
+            // combined `score = mean * voteShare`). Otherwise non-unanimous
+            // winners — e.g. 3/4 windows voting a language — could never cross
+            // 0.85 regardless of per-window confidence, leaving the two-
+            // utterance commit path unreachable in realistic mixed-window audio.
             let tier: LanguageConfidenceTier = (decision == .highAuto ? .highAuto : .mediumAuto)
+            let winningMeanProb = multi.meanProbs[top.key] ?? 0
+            let unanimous = multi.voteCounts[top.key] == multi.windowCount && multi.windowCount >= 2
+            let singleShotSwitch = unanimous && winningMeanProb >= LanguageDetectorThresholds.unanimousSingleShotProb
             let finalLang = resolveAntiFlap(
                 candidate: top.key,
-                topProb: top.value,
-                margin: top.value - runnerUp
+                switchProbSignal: winningMeanProb,
+                margin: rawMargin,
+                allowSingleShotSwitch: singleShotSwitch
             )
             if finalLang == top.key {
                 consecutiveLowConfidence = 0
@@ -390,7 +457,15 @@ public actor LanguageDetector {
             )
         case .mediumAuto, .highAuto:
             let tier: LanguageConfidenceTier = (decision == .highAuto ? .highAuto : .mediumAuto)
-            let finalLang = resolveAntiFlap(candidate: top.key, topProb: top.value, margin: top.value - runnerUp)
+            // evaluateForTesting has no per-window info; callers supply a
+            // pre-aggregated distribution, so treat `top.value` as both the
+            // switch-bar signal and the score. No single-shot path here.
+            let finalLang = resolveAntiFlap(
+                candidate: top.key,
+                switchProbSignal: top.value,
+                margin: top.value - runnerUp,
+                allowSingleShotSwitch: false
+            )
             if finalLang == top.key {
                 consecutiveLowConfidence = 0
                 registerFlipFlopCandidate(lang: top.key, confidence: rawTopProb, at: now)
@@ -413,38 +488,68 @@ public actor LanguageDetector {
 
     // MARK: - Layer 2: multi-window LID
 
+    /// Aggregated outcome of the multi-window language detection pass.
+    ///
+    /// - `voteCounts`: Raw per-window argmax wins per language.
+    /// - `meanProbs`: Mean exp(logProb) per language across windows where it won.
+    /// - `windowCount`: Number of windows that actually returned a result.
+    ///
+    /// The classifier and anti-flap paths consume `meanProbs[winner]` as the
+    /// per-window confidence and the `voteShare` gap as margin. Keeping these
+    /// signals separate (instead of collapsing them into a single score)
+    /// prevents vote-share dilution from masking true per-window confidence.
+    struct MultiWindowLID {
+        let voteCounts: [String: Int]
+        let meanProbs: [String: Double]
+        let windowCount: Int
+    }
+
     private func runMultiWindowLID(
         samples: [Float],
         voicedDuration: TimeInterval,
         whisperKit: WhisperKit
-    ) async throws -> [String: Double] {
+    ) async throws -> MultiWindowLID {
         let sampleRate = LanguageDetectorThresholds.sampleRate
         let totalSamples = samples.count
+        // Dedupe (startIdx, endIdx) pairs so short clips don't get counted
+        // twice — the fixed windows and the full-window range can collapse to
+        // identical slices on <3s audio and double-count under majority vote.
         var windows: [[Float]] = []
+        var seenRanges: Set<[Int]> = []
+
+        func appendIfNew(_ startIdx: Int, _ endIdx: Int) {
+            guard endIdx > startIdx else { return }
+            guard seenRanges.insert([startIdx, endIdx]).inserted else { return }
+            windows.append(Array(samples[startIdx..<endIdx]))
+        }
 
         for w in LanguageDetectorThresholds.windows {
             let startIdx = min(totalSamples, Int(w.start * Double(sampleRate)))
             let endIdx = min(totalSamples, Int(w.end * Double(sampleRate)))
-            guard endIdx > startIdx else { continue }
-            windows.append(Array(samples[startIdx..<endIdx]))
+            appendIfNew(startIdx, endIdx)
         }
-        // Full voiced window capped at 12s (always included so we always have >=1).
+        // Full voiced window capped at 12s (always tried so we always have >=1,
+        // but deduped against the fixed windows above for short clips).
         let fullEnd = min(totalSamples, Int(LanguageDetectorThresholds.fullWindowMaxSec * Double(sampleRate)))
-        if fullEnd > 0 {
-            windows.append(Array(samples[0..<fullEnd]))
-        }
-        guard !windows.isEmpty else { return [:] }
+        appendIfNew(0, fullEnd)
+        guard !windows.isEmpty else { return MultiWindowLID(voteCounts: [:], meanProbs: [:], windowCount: 0) }
 
         // Run up to 4 windows. The spec says "up to 4"; for short voicedDuration
         // many of the fixed windows collapse to empty and are skipped above.
         let capped = Array(windows.prefix(4))
 
-        var accumulated: [String: Double] = [:]
+        // WhisperKit's `detectLangauge` returns a single-entry `langProbs` map
+        // `{detectedLanguage: logProb}` — it's the argmax + its log-softmax, not
+        // a distribution over all languages. Aggregation must be majority vote
+        // over per-window argmaxes, with per-window exp(logProb) as a
+        // within-window confidence signal.
+        var votes: [String: Int] = [:]
+        var probSum: [String: Double] = [:]
         var counted = 0
         for (i, window) in capped.enumerated() {
             try Task.checkCancellation()
-            // Each window is its own detectLanguage call. WhisperKit API is
-            // `detectLangauge(audioArray:)` (original typo preserved upstream).
+            // WhisperKit API is `detectLangauge(audioArray:)` (original typo
+            // preserved upstream — do not "fix" it).
             let result: (language: String, langProbs: [String: Float])
             do {
                 result = try await whisperKit.detectLangauge(audioArray: window)
@@ -452,38 +557,23 @@ public actor LanguageDetector {
                 await log("LID window \(i) failed: \(error.localizedDescription)")
                 continue
             }
-            let probs = Self.softmaxFromLogProbs(result.langProbs)
-            for (lang, p) in probs {
-                accumulated[lang, default: 0] += p
-            }
+            let lang = result.language
+            // Safety: langProbs is single-entry; fall back to 0 log-prob if the
+            // detected language isn't represented (shouldn't happen per spec).
+            let lp = Double(result.langProbs[lang] ?? 0)
+            let p = min(max(exp(lp), 0), 1)
+            votes[lang, default: 0] += 1
+            probSum[lang, default: 0] += p
             counted += 1
         }
-        guard counted > 0 else { return [:] }
-        // Arithmetic mean across windows.
-        for key in accumulated.keys {
-            accumulated[key, default: 0] /= Double(counted)
+        guard counted > 0 else {
+            return MultiWindowLID(voteCounts: [:], meanProbs: [:], windowCount: 0)
         }
-        return accumulated
-    }
-
-    /// Convert WhisperKit's log-prob map into a normalized probability map.
-    /// WhisperKit returns the sampler's `logProbs` (filtered logits -> log softmax),
-    /// so exp() is a decent per-token probability; we then renormalize across the
-    /// reported candidates so the map sums to 1 for stable mean aggregation.
-    static func softmaxFromLogProbs(_ logProbs: [String: Float]) -> [String: Double] {
-        guard !logProbs.isEmpty else { return [:] }
-        // Numerical stability: subtract max before exp.
-        let maxLog = logProbs.values.max() ?? 0
-        var exped: [String: Double] = [:]
-        var sum = 0.0
-        for (lang, lp) in logProbs {
-            let v = exp(Double(lp - maxLog))
-            exped[lang] = v
-            sum += v
+        var means: [String: Double] = [:]
+        for (lang, count) in votes {
+            means[lang] = probSum[lang, default: 0] / Double(count)
         }
-        guard sum > 0 else { return [:] }
-        for key in exped.keys { exped[key, default: 0] /= sum }
-        return exped
+        return MultiWindowLID(voteCounts: votes, meanProbs: means, windowCount: counted)
     }
 
     // MARK: - Layer 3: session memory logic
@@ -495,7 +585,12 @@ public actor LanguageDetector {
     /// or invalidates it. Any non-confirming event (abstain, lowAuto, a
     /// different strong candidate, or a candidate that fails the switch bar)
     /// resets the pending state.
-    private func resolveAntiFlap(candidate: String, topProb: Double, margin: Double) -> String {
+    private func resolveAntiFlap(
+        candidate: String,
+        switchProbSignal: Double,
+        margin: Double,
+        allowSingleShotSwitch: Bool
+    ) -> String {
         guard let preferred = memory.sessionPreferred,
               LanguageTypes.isSupported(preferred),
               preferred != candidate else {
@@ -503,8 +598,16 @@ public actor LanguageDetector {
             pendingSwitchCandidate = nil
             return candidate
         }
+        // Unanimous + strong per-window confidence bypasses the two-utterance
+        // gate. Checked first so the low-confidence single-shot range that
+        // `unanimousSingleShotProb` is designed to cover cannot be short-
+        // circuited by the stricter `switchProb` bar below.
+        if allowSingleShotSwitch {
+            pendingSwitchCandidate = nil
+            return candidate
+        }
         let switchProb = 0.85
-        let meetsSwitchBar = topProb >= switchProb
+        let meetsSwitchBar = switchProbSignal >= switchProb
             && margin >= LanguageDetectorThresholds.highMargin
         if !meetsSwitchBar {
             // Candidate is not strong enough to count as switch evidence.

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -24,15 +24,31 @@ public actor WhisperKitBackend: ASRBackend {
     private let modelVariant: String
     private var whisperKit: WhisperKit?
 
+    /// Exposes the configured model variant name (e.g. `openai_whisper-large-v3-v20240930_turbo`).
+    /// Read-only; used by telemetry to tag per-transcription events with the model in use.
+    public var modelVariantName: String { modelVariant }
+
     /// Exposes the WhisperKit instance for background incremental transcription.
     public var whisperKitInstance: WhisperKit? { whisperKit }
 
     /// Exposes the tokenizer for prompt token encoding (used by incremental worker tail decode).
     public var whisperKitTokenizer: (any WhisperTokenizer)? { whisperKit?.tokenizer }
 
-    // BRAIN: gotcha id=default-model-turbo
-    public init(modelVariant: String = "openai_whisper-large-v3_turbo") {
+    // BRAIN: gotcha id=default-model-turbo-v20240930
+    public init(modelVariant: String = WhisperKitBackend.defaultModelVariant()) {
         self.modelVariant = modelVariant
+    }
+
+    /// Single source of truth for the shipped default model variant.
+    /// Reads the `useRefreshedWhisperKitModel` feature flag from UserDefaults:
+    /// true (default) returns the Multilingual v1 refresh, false returns the
+    /// legacy variant for emergency rollback. Cold flag: read at init time,
+    /// does not live-switch.
+    public static func defaultModelVariant() -> String {
+        let useRefreshed = UserDefaults.standard.object(forKey: "useRefreshedWhisperKitModel") as? Bool ?? true
+        return useRefreshed
+            ? "openai_whisper-large-v3-v20240930_turbo"
+            : "openai_whisper-large-v3_turbo"
     }
 
     public func prepare() async throws {

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -38,8 +38,11 @@ public final class WhisperKitSetupService {
     public private(set) var setupState: WhisperKitSetupState = .checking
 
     /// Model variant to download (synced from AppSettings).
+    /// Single source of truth lives on `WhisperKitBackend.defaultModelVariant()`.
+    /// Cold flag: changes to `useRefreshedWhisperKitModel` only take effect on
+    /// the next app launch, consistent with the flag's documented behavior.
     // BRAIN: gotcha id=model-name-format
-    public var modelVariant: String = "openai_whisper-large-v3_turbo"
+    public var modelVariant: String = WhisperKitBackend.defaultModelVariant()
 
     public init() {}
 

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -70,7 +70,18 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
                     self.parakeetBackend = backend
                 case "whisperKit":
-                    let variant = modelVariant.isEmpty ? "openai_whisper-large-v3_turbo" : modelVariant
+                    // XPC service process has a SEPARATE UserDefaults domain
+                    // from the app, so we cannot read the rollback flag here.
+                    // The app (SettingsManager.whisperKitModel) is flag-aware
+                    // and pushes the correct variant via the XPC interface.
+                    // The fallback used below is only hit if the app sends an
+                    // empty variant (e.g., first load before settings sync),
+                    // in which case we default to the refreshed Multilingual
+                    // v1 variant. Users opting into rollback rely on the app
+                    // to push the legacy variant explicitly.
+                    let variant = modelVariant.isEmpty
+                        ? "openai_whisper-large-v3-v20240930_turbo"
+                        : modelVariant
                     let backend = WhisperKitBackend(modelVariant: variant)
                     try await backend.prepare()
                     self.whisperKitBackend = backend

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -19,7 +19,7 @@ import Foundation
     /// Load the specified ASR backend and model variant.
     /// - Parameters:
     ///   - backendType: "parakeet" or "whisperKit"
-    ///   - modelVariant: WhisperKit model name (e.g., "openai_whisper-large-v3_turbo"). Ignored for Parakeet.
+    ///   - modelVariant: WhisperKit model name (e.g., "openai_whisper-large-v3-v20240930_turbo"). Ignored for Parakeet.
     ///   - reply: nil on success, NSError on failure.
     func loadModel(backendType: String, modelVariant: String, reply: @escaping (NSError?) -> Void)
 

--- a/Sources/EnviousWisprCore/LanguageTypes.swift
+++ b/Sources/EnviousWisprCore/LanguageTypes.swift
@@ -242,6 +242,17 @@ public enum LanguageDetectorThresholds {
     // Session-prior boost for low-confidence decisions
     public static let sessionPriorBoost: Double = 0.10
 
+    // Anti-flap single-shot switch: when all multi-window LID calls return the
+    // SAME language with mean exp(logProb) >= this value, bypass the two-
+    // utterance "pending candidate" requirement and switch immediately. Keeps
+    // the anti-flap protection for ambiguous cases while preventing first-
+    // switch hallucination on clean non-preferred audio. Aligned with
+    // `normalProb`: if the classifier accepts a unanimous detection as
+    // mediumAuto or highAuto, the single-shot path lets it through too.
+    // Avoids leaving low-confidence-but-consistent languages (e.g., Tamil on
+    // short clips) stuck behind the session prior indefinitely.
+    public static let unanimousSingleShotProb: Double = 0.65
+
     // Multi-window configuration (seconds)
     public static let windows: [(start: TimeInterval, end: TimeInterval)] = [
         (0, 3),
@@ -270,6 +281,21 @@ public enum LanguageScriptGuardrail {
     public static func isNonLatinScript(_ lang: String) -> Bool {
         nonLatinScriptLanguages.contains(lang.lowercased())
     }
+
+    /// Scripts that do not segment words with whitespace. Policy gates that
+    /// use word-count (e.g. LLM polish minimum-length short-circuit) must
+    /// switch to character-count for these. Note: Korean DOES use whitespace
+    /// between Eojeol word units, so it stays on the word-count path. Arabic,
+    /// Hebrew, Cyrillic, and Indic scripts also use whitespace.
+    public static let unsegmentedScriptLanguages: Set<String> = [
+        "ja", "zh", "yue", "th", "lo", "my", "km",
+    ]
+
+    /// True if the language uses a script that does not separate words with
+    /// whitespace. See `unsegmentedScriptLanguages`.
+    public static func isUnsegmentedScript(_ lang: String) -> Bool {
+        unsegmentedScriptLanguages.contains(lang.lowercased())
+    }
 }
 
 // Top-level helper so other modules can call `LanguageTypes.isNonLatinScript(...)`
@@ -277,6 +303,13 @@ public enum LanguageScriptGuardrail {
 public enum LanguageTypes {
     public static func isNonLatinScript(_ lang: String) -> Bool {
         LanguageScriptGuardrail.isNonLatinScript(lang)
+    }
+
+    /// True for scripts that do not whitespace-segment words (CJK, Thai, Lao,
+    /// Burmese, Khmer). Use character count, not word count, for length gates
+    /// on these languages.
+    public static func isUnsegmentedScript(_ lang: String) -> Bool {
+        LanguageScriptGuardrail.isUnsegmentedScript(lang)
     }
 
     /// Full set of Whisper-supported ISO 639-1 codes (99 languages).

--- a/Sources/EnviousWisprCore/LanguageTypes.swift
+++ b/Sources/EnviousWisprCore/LanguageTypes.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+// MARK: - Detection Result
+
+/// Outcome of a language detection call.
+///
+/// Produced by `LanguageDetector` and consumed by the pipeline and prompt layers.
+/// When `abstained` is true (or `tier == .abstain`), `lang` is nil and the caller
+/// should let WhisperKit's internal LID run by passing `nil` into
+/// `TranscriptionOptions.language`.
+public struct LanguageDetectionResult: Sendable, Equatable {
+    public let lang: String?            // ISO 639-1, nil if abstaining
+    public let confidence: Double       // top-1 probability, 0 if abstained
+    public let margin: Double           // top-1 minus top-2 probability
+    public let tier: LanguageConfidenceTier
+    public let voicedDuration: TimeInterval
+    public let abstained: Bool
+    public let usedSessionPrior: Bool
+
+    public init(
+        lang: String?,
+        confidence: Double,
+        margin: Double,
+        tier: LanguageConfidenceTier,
+        voicedDuration: TimeInterval,
+        abstained: Bool,
+        usedSessionPrior: Bool
+    ) {
+        self.lang = lang
+        self.confidence = confidence
+        self.margin = margin
+        self.tier = tier
+        self.voicedDuration = voicedDuration
+        self.abstained = abstained
+        self.usedSessionPrior = usedSessionPrior
+    }
+
+    /// Convenience: an abstain result with no detected language.
+    public static func abstain(voicedDuration: TimeInterval) -> LanguageDetectionResult {
+        LanguageDetectionResult(
+            lang: nil,
+            confidence: 0,
+            margin: 0,
+            tier: .abstain,
+            voicedDuration: voicedDuration,
+            abstained: true,
+            usedSessionPrior: false
+        )
+    }
+}
+
+/// Confidence tier used to gate prompt injection (see spec § Prompt injection).
+public enum LanguageConfidenceTier: String, Sendable, Equatable, Codable {
+    case locked       // user set Lock language
+    case highAuto     // prob >= 0.80 AND margin >= 0.25
+    case mediumAuto   // prob >= 0.65 AND margin >= 0.20
+    case lowAuto      // below medium thresholds (no lexical prompt)
+    case abstain      // below short-clip thresholds or no voiced speech
+}
+
+// MARK: - Language Mode setting
+
+/// Persisted user setting: auto-detect or locked to a specific ISO 639-1 code.
+public enum LanguageMode: Codable, Sendable, Equatable {
+    case auto
+    case locked(String)
+
+    // Manual Codable to avoid auto-synthesized discriminator formats, which are
+    // awkward to migrate from existing defaults values. We encode as
+    // `{"mode":"auto"}` or `{"mode":"locked","code":"xx"}`.
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case code
+    }
+
+    private enum ModeTag: String, Codable {
+        case auto
+        case locked
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let tag = try container.decode(ModeTag.self, forKey: .mode)
+        switch tag {
+        case .auto:
+            self = .auto
+        case .locked:
+            let code = try container.decode(String.self, forKey: .code)
+            self = .locked(code)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .auto:
+            try container.encode(ModeTag.auto, forKey: .mode)
+        case .locked(let code):
+            try container.encode(ModeTag.locked, forKey: .mode)
+            try container.encode(code, forKey: .code)
+        }
+    }
+}
+
+// MARK: - Session memory
+
+/// Recency-weighted per-session language memory with 24h UserDefaults cache.
+///
+/// Used by `LanguageDetector` to apply anti-flap rules:
+/// - track the last 10 accepted languages in a rolling ring buffer,
+/// - elevate a language to "session-preferred" after two consecutive high-confidence
+///   accepts,
+/// - require stronger evidence to switch away from the session-preferred language,
+/// - clear session-preferred after 10 minutes of inactivity,
+/// - persist a 24-hour usage-per-language cache for recency priors across app launches.
+///
+/// The type is a value-semantics struct so the owning actor stays the single source
+/// of truth. Instances are `Sendable`.
+public struct SessionLanguageMemory: Sendable, Codable, Equatable {
+    /// Rolling window of the last N accepted languages (newest last).
+    public var accepted: [AcceptedEntry]
+    /// Language the session currently favors after two consecutive high-confidence
+    /// accepts. Cleared on 10-minute inactivity.
+    public var sessionPreferred: String?
+    /// Per-language usage count for the last 24h, persisted to UserDefaults.
+    public var usage24h: [String: UsageEntry]
+    /// Most recent activity timestamp (accept OR abstain); used for 10-min timeout.
+    public var lastActivity: Date?
+
+    public static let rollingCapacity = 10
+    public static let sessionInactivityTimeout: TimeInterval = 600          // 10 min
+    public static let usageCacheTTL: TimeInterval = 24 * 60 * 60            // 24 hours
+    public static let userDefaultsKey = "sessionLanguagePriors"
+
+    public init(
+        accepted: [AcceptedEntry] = [],
+        sessionPreferred: String? = nil,
+        usage24h: [String: UsageEntry] = [:],
+        lastActivity: Date? = nil
+    ) {
+        self.accepted = accepted
+        self.sessionPreferred = sessionPreferred
+        self.usage24h = usage24h
+        self.lastActivity = lastActivity
+    }
+
+    public struct AcceptedEntry: Sendable, Codable, Equatable {
+        public let lang: String
+        public let confidence: Double
+        public let timestamp: Date
+
+        public init(lang: String, confidence: Double, timestamp: Date) {
+            self.lang = lang
+            self.confidence = confidence
+            self.timestamp = timestamp
+        }
+    }
+
+    public struct UsageEntry: Sendable, Codable, Equatable {
+        public var count: Int
+        public var lastSeen: Date
+
+        public init(count: Int, lastSeen: Date) {
+            self.count = count
+            self.lastSeen = lastSeen
+        }
+    }
+
+    // MARK: State transitions
+
+    /// Clears `sessionPreferred` if inactivity exceeded the timeout. Called before
+    /// each decision so stale preferences do not contaminate a new utterance.
+    public mutating func applyInactivityTimeout(now: Date = Date()) {
+        guard let last = lastActivity else { return }
+        if now.timeIntervalSince(last) > Self.sessionInactivityTimeout {
+            sessionPreferred = nil
+        }
+    }
+
+    /// Drops usage entries older than the 24h TTL.
+    public mutating func pruneExpiredUsage(now: Date = Date()) {
+        usage24h = usage24h.filter { now.timeIntervalSince($0.value.lastSeen) <= Self.usageCacheTTL }
+    }
+
+    /// Record an accepted detection. Updates rolling window, usage cache, and
+    /// session-preferred language (elevates on two consecutive high-confidence
+    /// accepts of the same language).
+    public mutating func recordAccepted(lang: String, confidence: Double, now: Date = Date()) {
+        let entry = AcceptedEntry(lang: lang, confidence: confidence, timestamp: now)
+        accepted.append(entry)
+        if accepted.count > Self.rollingCapacity {
+            accepted.removeFirst(accepted.count - Self.rollingCapacity)
+        }
+
+        var usage = usage24h[lang] ?? UsageEntry(count: 0, lastSeen: now)
+        usage.count += 1
+        usage.lastSeen = now
+        usage24h[lang] = usage
+
+        lastActivity = now
+
+        // Elevation: last two accepts are same lang AND both were high-confidence.
+        if accepted.count >= 2 {
+            let a = accepted[accepted.count - 1]
+            let b = accepted[accepted.count - 2]
+            if a.lang == b.lang,
+               a.confidence >= LanguageDetectorThresholds.highProb,
+               b.confidence >= LanguageDetectorThresholds.highProb {
+                sessionPreferred = a.lang
+            }
+        }
+    }
+
+    /// Record an abstention (touches `lastActivity` only so the 10-min inactivity
+    /// timer resets during an active session).
+    public mutating func recordAbstain(now: Date = Date()) {
+        lastActivity = now
+    }
+}
+
+// MARK: - Thresholds
+
+/// Single source of truth for the numeric gates defined in the spec.
+/// Kept as a public nested namespace so tests can reference the exact values.
+public enum LanguageDetectorThresholds {
+    // Layer 1: speech gate (voiced duration, seconds)
+    public static let shortClipMinSec: TimeInterval = 1.0    // below this: abstain, no LID
+    public static let confidentMinSec: TimeInterval = 2.5    // below this: provisional/stricter
+
+    // Layer 2 normal thresholds (voicedDuration >= 2.5s)
+    public static let normalProb: Double = 0.65
+    public static let normalMargin: Double = 0.20
+
+    // Layer 2 strict thresholds (1.0s <= voicedDuration < 2.5s)
+    public static let strictProb: Double = 0.80
+    public static let strictMargin: Double = 0.25
+
+    // Layer 3 high-confidence bar (for session-preferred elevation and switch-away)
+    public static let highProb: Double = 0.80
+    public static let highMargin: Double = 0.25
+
+    // Session-prior boost for low-confidence decisions
+    public static let sessionPriorBoost: Double = 0.10
+
+    // Multi-window configuration (seconds)
+    public static let windows: [(start: TimeInterval, end: TimeInterval)] = [
+        (0, 3),
+        (1, 4),
+        (2, 6),
+    ]
+    public static let fullWindowMaxSec: TimeInterval = 12.0
+    public static let sampleRate: Int = 16_000
+}
+
+// MARK: - Script guardrail
+
+/// Script classification helper. The set of non-Latin-script Whisper languages
+/// is fixed per spec § Layer 4.
+public enum LanguageScriptGuardrail {
+    /// ISO 639-1 codes whose dominant script is non-Latin.
+    /// Sourced verbatim from the spec.
+    public static let nonLatinScriptLanguages: Set<String> = [
+        "ar", "bg", "bn", "el", "gu", "he", "hi", "ja", "ka", "km", "kn",
+        "ko", "lo", "ml", "mr", "my", "ne", "pa", "ru", "sa", "si", "sr",
+        "ta", "te", "th", "uk", "ur", "yi", "yue", "zh",
+    ]
+
+    /// True if the ISO 639-1 language code's dominant script is not Latin.
+    /// Used by the prompt layer to decide whether to strip untagged Latin terms.
+    public static func isNonLatinScript(_ lang: String) -> Bool {
+        nonLatinScriptLanguages.contains(lang.lowercased())
+    }
+}
+
+// Top-level helper so other modules can call `LanguageTypes.isNonLatinScript(...)`
+// per the spec's naming. `LanguageTypes` is a namespace (not a value type).
+public enum LanguageTypes {
+    public static func isNonLatinScript(_ lang: String) -> Bool {
+        LanguageScriptGuardrail.isNonLatinScript(lang)
+    }
+
+    /// Full set of Whisper-supported ISO 639-1 codes (99 languages).
+    /// Used for defensive validation when reading persisted session priors.
+    public static let whisperSupportedLanguages: Set<String> = [
+        "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br",
+        "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", "eu",
+        "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw", "he", "hi", "hr",
+        "ht", "hu", "hy", "id", "is", "it", "ja", "jw", "ka", "kk", "km",
+        "kn", "ko", "la", "lb", "ln", "lo", "lt", "lv", "mg", "mi", "mk",
+        "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl", "nn", "no", "oc",
+        "pa", "pl", "ps", "pt", "ro", "ru", "sa", "sd", "si", "sk", "sl",
+        "sn", "so", "sq", "sr", "su", "sv", "sw", "ta", "te", "tg", "th",
+        "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi", "yi", "yo", "yue", "zh",
+    ]
+
+    /// True if `lang` is in the 99-language Whisper set. Used to defensively skip
+    /// stale/unrecognized session priors rather than crashing.
+    public static func isSupported(_ lang: String) -> Bool {
+        whisperSupportedLanguages.contains(lang.lowercased())
+    }
+}

--- a/Sources/EnviousWisprCore/PromptBuildInput.swift
+++ b/Sources/EnviousWisprCore/PromptBuildInput.swift
@@ -9,8 +9,37 @@ public struct PromptBuildInput: Sendable {
     public let customPromptMode: CustomPromptMode
     public let appName: String?
     public let language: String?
+
+    /// Legacy flat list of user-configured custom words (with aliases, priority).
+    /// Kept for rollback safety and because existing builders render aliases.
+    /// Deprecated: prefer `customVocabulary` + `languageDetection` so the planner
+    /// can apply confidence-tiered, language-aware injection. Builders still read
+    /// `customWords` after the planner has already filtered it to the set
+    /// permitted by the active tier.
     public let customWords: [CustomWord]
+
     public let focusSnapshot: FocusSnapshot?
+
+    // MARK: - Multilingual v1 (W3)
+
+    /// Confidence-tiered, language-aware prompt vocabulary. Migration default on
+    /// v1 upgrade: all existing `CustomWord` canonical spellings are placed in
+    /// `global`. A per-entry language tag in the UI is a v2 enhancement.
+    public let customVocabulary: PromptVocabulary
+
+    /// Language detection outcome from the autodetect stack (W2). Nil if the
+    /// callsite has not yet been wired to the detector. In that case the
+    /// planner falls back to `.locked` tier (legacy behavior: inject all custom
+    /// words as-is).
+    public let languageDetection: LanguageDetectionResult?
+
+    /// Active ASR backend for this polish request. Set explicitly by the
+    /// pipeline so the planner can dispatch on engine identity rather than
+    /// inferring it from `languageDetection == nil` (fragile: a WhisperKit
+    /// codepath that forgets to run the detector would silently fall through
+    /// to the English-centric legacy prompt). Nil means "unknown callsite"
+    /// and preserves legacy passthrough behavior as a safety net.
+    public let backend: ASRBackendType?
 
     public init(
         transcript: String,
@@ -22,7 +51,10 @@ public struct PromptBuildInput: Sendable {
         appName: String?,
         language: String?,
         customWords: [CustomWord],
-        focusSnapshot: FocusSnapshot? = nil
+        focusSnapshot: FocusSnapshot? = nil,
+        customVocabulary: PromptVocabulary? = nil,
+        languageDetection: LanguageDetectionResult? = nil,
+        backend: ASRBackendType? = nil
     ) {
         self.transcript = transcript
         self.provider = provider
@@ -34,5 +66,31 @@ public struct PromptBuildInput: Sendable {
         self.language = language
         self.customWords = customWords
         self.focusSnapshot = focusSnapshot
+        // Migration default: if no explicit customVocabulary is passed, fall
+        // back to deriving a global-only PromptVocabulary from customWords.
+        self.customVocabulary = customVocabulary ?? PromptVocabulary.fromLegacy(customWords)
+        self.languageDetection = languageDetection
+        self.backend = backend
+    }
+
+    /// Returns a copy of this input with `customWords` replaced. Used by the
+    /// planner to hand the builders a filtered list after applying the
+    /// confidence-tiered + script-guardrail policy.
+    public func withCustomWords(_ newCustomWords: [CustomWord]) -> PromptBuildInput {
+        PromptBuildInput(
+            transcript: transcript,
+            provider: provider,
+            modelID: modelID,
+            stylePreset: stylePreset,
+            customSystemPrompt: customSystemPrompt,
+            customPromptMode: customPromptMode,
+            appName: appName,
+            language: language,
+            customWords: newCustomWords,
+            focusSnapshot: focusSnapshot,
+            customVocabulary: customVocabulary,
+            languageDetection: languageDetection,
+            backend: backend
+        )
     }
 }

--- a/Sources/EnviousWisprCore/PromptVocabulary.swift
+++ b/Sources/EnviousWisprCore/PromptVocabulary.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Storage shape for confidence-tiered, language-aware prompt injection
+/// (see Multilingual v1 spec § Prompt injection rearchitecture).
+///
+/// `global` entries are always safe to inject regardless of detected language
+/// (product names, URLs, truly cross-lingual tokens). `perLanguage[code]`
+/// entries are only injected when the detected language matches the key AND
+/// the confidence tier is `.locked` or `.highAuto`.
+///
+/// At v1 this is populated via the migration helper
+/// (`fromLegacy(_:)`) which drops all existing `CustomWord` entries into
+/// `global`. This is the safe default since most are product names and proper nouns.
+/// A per-entry language tag in the UI is a v2 enhancement.
+public struct PromptVocabulary: Sendable, Equatable, Codable {
+    /// Cross-lingual entries: always safe to inject.
+    public var global: [String]
+    /// ISO 639-1 code -> terms specific to that language.
+    public var perLanguage: [String: [String]]
+
+    public init(global: [String] = [], perLanguage: [String: [String]] = [:]) {
+        self.global = global
+        self.perLanguage = perLanguage
+    }
+
+    /// True when both buckets are empty. Planner skips vocab injection entirely
+    /// in this case (formatting-only prompt).
+    public var isEmpty: Bool {
+        global.isEmpty && perLanguage.values.allSatisfy(\.isEmpty)
+    }
+
+    /// Migration: convert the legacy flat `[CustomWord]` list into a
+    /// `PromptVocabulary` with every canonical form tagged as `global`. This is
+    /// the safe default on first launch after the Multilingual v1 upgrade.
+    /// Aliases are NOT copied into the vocabulary (only canonical spellings);
+    /// CustomWord alias metadata is still preserved on the legacy `customWords`
+    /// field for rollback safety.
+    public static func fromLegacy(_ words: [CustomWord]) -> PromptVocabulary {
+        PromptVocabulary(global: words.map(\.canonical), perLanguage: [:])
+    }
+
+    /// Filtered view of the vocabulary for a specific confidence tier + detected
+    /// language, applying the script guardrail (see spec § Layer 4).
+    ///
+    /// Returns the list of terms the prompt layer should inject. An empty list
+    /// means no lexical injection for this call (formatting-only).
+    ///
+    /// Policy:
+    /// - `.locked` or `.highAuto`: global + perLanguage[detected]
+    /// - `.mediumAuto`: global only (NO perLanguage lexicon)
+    /// - `.lowAuto` or `.abstain`: empty (no lexical prompt)
+    ///
+    /// Script guardrail: if `detectedLang` is non-Latin script, perLanguage
+    /// entries whose characters are entirely Latin ASCII are dropped. `global`
+    /// entries survive regardless (they are tagged cross-lingual).
+    ///
+    /// Defensive: perLanguage keys that are not Whisper-supported are skipped.
+    public func effectiveTerms(
+        detectedLang: String?,
+        tier: LanguageConfidenceTier
+    ) -> [String] {
+        switch tier {
+        case .lowAuto, .abstain:
+            return []
+        case .mediumAuto:
+            return global
+        case .locked, .highAuto:
+            var out = global
+            if let lang = detectedLang?.lowercased(),
+               LanguageTypes.isSupported(lang),
+               let perLang = perLanguage[lang] {
+                let filtered: [String]
+                if LanguageTypes.isNonLatinScript(lang) {
+                    filtered = perLang.filter { !Self.isAllLatinScript($0) }
+                } else {
+                    filtered = perLang
+                }
+                out.append(contentsOf: filtered)
+            }
+            return out
+        }
+    }
+
+    /// True when every letter in the term lies in the ASCII range (A-Z, a-z).
+    /// Used by the script guardrail to strip Latin-script-only terms from the
+    /// perLanguage bucket when the detected language is non-Latin-script.
+    ///
+    /// Checks each letter scalar against the Latin Unicode blocks (Basic Latin,
+    /// Latin-1 Supplement, Latin Extended-A/B, IPA Extensions, combining
+    /// diacritics, and Latin Extended Additional). This correctly recognizes
+    /// German ß, French é, Spanish ñ, Turkish ı, Vietnamese ế etc. as Latin.
+    /// Non-letter characters (digits, punctuation, whitespace) are ignored so
+    /// alphanumeric Latin terms like "claude3" still qualify. A term with zero
+    /// letters (pure punctuation or digits) does not qualify as "a Latin term"
+    /// and therefore passes the guardrail (safe default).
+    static func isAllLatinScript(_ term: String) -> Bool {
+        var hasLetter = false
+        for scalar in term.unicodeScalars {
+            guard CharacterSet.letters.contains(scalar) else { continue }
+            hasLetter = true
+            if !Self.isLatinScriptScalar(scalar) {
+                return false
+            }
+        }
+        return hasLetter
+    }
+
+    /// True if the scalar is in one of the Latin Unicode blocks used for
+    /// natural language text. See:
+    /// https://en.wikipedia.org/wiki/Latin_script_in_Unicode
+    private static func isLatinScriptScalar(_ scalar: Unicode.Scalar) -> Bool {
+        let v = scalar.value
+        switch v {
+        case 0x0041...0x005A,        // Basic Latin: A-Z
+             0x0061...0x007A,        // Basic Latin: a-z
+             0x00C0...0x00D6,        // Latin-1 Supplement: À-Ö (skips × at 0xD7)
+             0x00D8...0x00F6,        // Latin-1 Supplement: Ø-ö (skips ÷ at 0xF7)
+             0x00F8...0x00FF,        // Latin-1 Supplement: ø-ÿ
+             0x0100...0x017F,        // Latin Extended-A
+             0x0180...0x024F,        // Latin Extended-B
+             0x0250...0x02AF,        // IPA Extensions
+             0x1E00...0x1EFF,        // Latin Extended Additional (Vietnamese etc.)
+             0x0300...0x036F:        // Combining Diacritical Marks
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/EnviousWisprLLM/Prompting/CustomVocabularyFormatter.swift
+++ b/Sources/EnviousWisprLLM/Prompting/CustomVocabularyFormatter.swift
@@ -2,6 +2,12 @@ import EnviousWisprCore
 
 /// Renders custom vocabulary entries into a prompt-safe string block.
 /// Single source of truth for vocab formatting. Extracted from LLMPolishStep.renderCustomWordsForPrompt().
+///
+/// Accepts either the legacy rich `[CustomWord]` list (with aliases + priority)
+/// or the Multilingual v1 `PromptVocabulary` shape (flat `[String]` per bucket).
+/// The `[CustomWord]` path preserves alias hints for builders that render them
+/// (OpenAI/Gemini). The `PromptVocabulary` path is for new callsites that want
+/// the confidence-tiered, language-aware filter applied before rendering.
 public struct CustomVocabularyFormatter: Sendable {
     private static let maxWords = 50
     private static let maxChars = 2000
@@ -42,6 +48,58 @@ public struct CustomVocabularyFormatter: Sendable {
         let sorted = words.sorted { ($0.priority, $0.canonical) < ($1.priority, $1.canonical) }
         let capped = Array(sorted.prefix(maxWords))
         let names = capped.map { sanitize($0.canonical) }.joined(separator: ", ")
+        return "Preferred spellings: \(names)"
+    }
+
+    // MARK: - Multilingual v1 (W3): PromptVocabulary entry points
+
+    /// Render a `PromptVocabulary` to a full-format prompt block, applying the
+    /// confidence-tiered + script-guardrail policy for the detected language.
+    /// Returns nil if no terms survive the filter (caller should emit a
+    /// formatting-only prompt in that case).
+    public static func render(
+        vocabulary: PromptVocabulary,
+        detectedLang: String?,
+        tier: LanguageConfidenceTier
+    ) -> String? {
+        let terms = vocabulary.effectiveTerms(detectedLang: detectedLang, tier: tier)
+        return renderStrings(terms)
+    }
+
+    /// Render a `PromptVocabulary` to a simplified comma-separated block (for
+    /// Gemma). Applies the same tier + script-guardrail policy.
+    public static func renderSimplified(
+        vocabulary: PromptVocabulary,
+        detectedLang: String?,
+        tier: LanguageConfidenceTier
+    ) -> String? {
+        let terms = vocabulary.effectiveTerms(detectedLang: detectedLang, tier: tier)
+        return renderStringsSimplified(terms)
+    }
+
+    /// Render a raw flat `[String]` list in full format. Used when a callsite
+    /// already has a pre-filtered list of terms.
+    public static func renderStrings(_ terms: [String]) -> String? {
+        guard !terms.isEmpty else { return nil }
+        let capped = Array(terms.prefix(maxWords))
+        var lines: [String] = []
+        var charCount = fullHeader.count
+        for term in capped {
+            let clean = sanitize(term)
+            let line = "- \(clean)"
+            if charCount + line.count > maxChars { break }
+            lines.append(line)
+            charCount += line.count
+        }
+        guard !lines.isEmpty else { return nil }
+        return fullHeader + "\n" + lines.joined(separator: "\n")
+    }
+
+    /// Render a raw flat `[String]` list in simplified (comma-separated) form.
+    public static func renderStringsSimplified(_ terms: [String]) -> String? {
+        guard !terms.isEmpty else { return nil }
+        let capped = Array(terms.prefix(maxWords))
+        let names = capped.map { sanitize($0) }.joined(separator: ", ")
         return "Preferred spellings: \(names)"
     }
 

--- a/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
+++ b/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
@@ -18,8 +18,14 @@ public struct DefaultPromptPlanner: PromptPlanning {
             )
         }
 
+        // Multilingual v1 (W3): filter custom vocabulary for the active
+        // confidence tier + script guardrail BEFORE handing it to the builder.
+        // Builders continue to read `input.customWords`, but the planner hands
+        // them a tier-appropriate list.
+        let filtered = applyVocabularyPolicy(to: input)
+
         let builder = Self.builder(for: input.provider, modelID: input.modelID)
-        let envelope = builder.build(input: input, mode: mode)
+        let envelope = builder.build(input: filtered, mode: mode)
         return PolishPlan(mode: mode, envelope: envelope)
     }
 
@@ -48,6 +54,90 @@ public struct DefaultPromptPlanner: PromptPlanning {
         case .appleIntelligence, .none:
             // Should not reach planner. Fallback to openAI prose.
             return .openAIProse
+        }
+    }
+
+    // MARK: - Multilingual v1 (W3): tiered vocabulary policy
+
+    /// Apply the confidence-tiered + script-guardrail policy to the
+    /// PromptBuildInput's vocabulary, returning a copy whose `customWords` list
+    /// contains only the entries permitted by the active tier.
+    ///
+    /// Dispatch is driven by the explicit `backend` field so engine identity is
+    /// never inferred from `languageDetection == nil`:
+    ///
+    /// - `backend == .parakeet`: force legacy English path (Parakeet is
+    ///   English-only; ignore any `languageDetection` even if set).
+    /// - `backend == .whisperKit` + populated detection: tier-gated,
+    ///   language-aware policy (W3 behavior).
+    ///   - `.locked` or `.highAuto`: global + perLanguage[detected]
+    ///   - `.mediumAuto`: global only (no perLanguage)
+    ///   - `.lowAuto` or `.abstain`: no lexical injection
+    /// - `backend == .whisperKit` + nil detection: defensive
+    ///   formatting-only path (treat as low confidence — prevents English
+    ///   contamination when the detector is bypassed).
+    /// - `backend == nil`: safety-net passthrough for callsites that have not
+    ///   adopted the explicit field yet (TranscriptPolishService, tests).
+    private func applyVocabularyPolicy(to input: PromptBuildInput) -> PromptBuildInput {
+        // Parakeet: force legacy (English-centric) behavior regardless of any
+        // language detection that may have leaked into the input. Parakeet
+        // never runs the LID stack, but a caller bug could still populate it.
+        if input.backend == .parakeet {
+            return input
+        }
+
+        // WhisperKit without detection: treat as low confidence. No lexical
+        // injection. Defensive: a future WhisperKit codepath that forgets the
+        // detector must not silently fall through to the English-centric
+        // legacy prompt and corrupt non-English output.
+        if input.backend == .whisperKit, input.languageDetection == nil {
+            return input.withCustomWords([])
+        }
+
+        guard let detection = input.languageDetection else {
+            // backend == nil safety net: untouched callsites (no detection
+            // wired, no explicit backend) preserve their existing behavior.
+            return input
+        }
+
+        let effectiveStrings = input.customVocabulary.effectiveTerms(
+            detectedLang: detection.lang,
+            tier: detection.tier
+        )
+        let filteredCustomWords = Self.filterCustomWords(
+            input.customWords,
+            tier: detection.tier,
+            detectedLang: detection.lang,
+            allowedStrings: Set(effectiveStrings)
+        )
+        return input.withCustomWords(filteredCustomWords)
+    }
+
+    /// Filter the legacy `[CustomWord]` list to match the tier policy.
+    /// Aliases and priority from the original entries survive for any word
+    /// whose canonical form remains in the allowed set (lets builders still
+    /// render "(may be misheard as: ...)" blocks for surviving entries).
+    /// If a permitted term came from `perLanguage` (no CustomWord peer), a
+    /// synthetic CustomWord is appended with just the canonical and no aliases.
+    static func filterCustomWords(
+        _ customWords: [CustomWord],
+        tier: LanguageConfidenceTier,
+        detectedLang: String?,
+        allowedStrings: Set<String>
+    ) -> [CustomWord] {
+        switch tier {
+        case .lowAuto, .abstain:
+            return []
+        case .mediumAuto, .locked, .highAuto:
+            // Keep CustomWord entries whose canonical is allowed.
+            var kept = customWords.filter { allowedStrings.contains($0.canonical) }
+            // Append synthetic entries for allowed strings that did not come
+            // from a CustomWord (i.e., perLanguage-only terms).
+            let keptCanonicals = Set(kept.map(\.canonical))
+            for term in allowedStrings where !keptCanonicals.contains(term) {
+                kept.append(CustomWord(canonical: term))
+            }
+            return kept
         }
     }
 }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -17,6 +17,22 @@ public final class LLMPolishStep: TextProcessingStep {
     public var useExtendedThinking: Bool = false
     public var customWords: [CustomWord] = []
 
+    // MARK: - Multilingual v1 (W3)
+
+    /// Language detection outcome from the autodetect stack. Set by
+    /// `WhisperKitPipeline` after the detector runs, before finalization.
+    /// Nil for the Parakeet highway or pre-W2 callsites. The planner falls
+    /// back to legacy (locked-equivalent) behavior when nil.
+    public var languageDetection: LanguageDetectionResult?
+
+    /// Active ASR backend for this polish step. Set at init time by the
+    /// owning pipeline (Parakeet or WhisperKit) so the prompt planner can
+    /// dispatch on explicit engine identity rather than inferring it from
+    /// the absence of `languageDetection`. Nil for standalone callsites
+    /// (e.g., `TranscriptPolishService`) that do not know the original ASR
+    /// engine; the planner preserves legacy passthrough in that case.
+    public var backend: ASRBackendType?
+
     /// Injectable prompt planner. DefaultPromptPlanner in production, mockable in tests.
     public var promptPlanner: any PromptPlanning = DefaultPromptPlanner()
 
@@ -158,6 +174,11 @@ public final class LLMPolishStep: TextProcessingStep {
             return prompt.replacingOccurrences(of: "${transcript}", with: context.text)
         }()
 
+        // Multilingual v1 (W3): snapshot the active vocabulary at construction
+        // time so the planner/builders see a stable list even if the user edits
+        // custom words mid-polish. Migration default: all entries tagged global.
+        let vocabularySnapshot = PromptVocabulary.fromLegacy(customWords)
+
         let input = PromptBuildInput(
             transcript: context.text,
             provider: llmProvider,
@@ -168,7 +189,10 @@ public final class LLMPolishStep: TextProcessingStep {
             appName: context.targetAppName,
             language: context.language,
             customWords: customWords,
-            focusSnapshot: nil  // PR 3
+            focusSnapshot: nil,  // PR 3
+            customVocabulary: vocabularySnapshot,
+            languageDetection: languageDetection,
+            backend: backend
         )
         let plan = promptPlanner.plan(input: input)
 

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -63,10 +63,16 @@ public final class LLMPolishStep: TextProcessingStep {
         self.keychainManager = keychainManager
     }
 
-    /// Minimum word count to send to the LLM. Transcripts at or below this
-    /// threshold are passed through verbatim — LLMs hallucinate on ultra-short
-    /// input (e.g., "Yeah" → a full essay). See ew-zr4.
+    /// Minimum word count to send to the LLM (Latin/Cyrillic/Indic/Arabic etc).
+    /// Transcripts at or below this threshold are passed through verbatim — LLMs
+    /// hallucinate on ultra-short input (e.g., "Yeah" → a full essay). See ew-zr4.
     private static let minWordsForPolish = 3
+
+    /// Minimum character count for CJK/Thai/Lao scripts which don't use spaces.
+    /// Japanese/Chinese word-counting treats a 31-char sentence as 2 words,
+    /// which would wrongly short-circuit polish. Character-count is the correct
+    /// gate for non-whitespace-segmented scripts. 10 chars ≈ a short utterance.
+    private static let minCharsForCJKPolish = 10
 
     public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
         onWillProcess?()
@@ -77,15 +83,33 @@ public final class LLMPolishStep: TextProcessingStep {
 
         // Short-circuit: ultra-short transcripts get passed through verbatim.
         // LLMs treat 1-3 word inputs as prompts to respond to, not text to clean.
-        let wordCount = context.text.split(whereSeparator: \.isWhitespace).count
-        if wordCount <= Self.minWordsForPolish {
-            Task { await AppLogger.shared.log(
-                "LLM polish skipped: transcript too short (\(wordCount) words, minimum \(Self.minWordsForPolish + 1))",
-                level: .info, category: "LLM"
-            ) }
-            var ctx = context
-            ctx.polishedText = context.text
-            return ctx
+        // Language-aware: CJK/Thai/Lao scripts use char-count since they don't
+        // segment words with whitespace (a 31-char Japanese utterance is 1-2
+        // "words" by split, which would wrongly skip polish).
+        let lang = languageDetection?.lang ?? context.language
+        let useCharCount = lang.map(LanguageTypes.isUnsegmentedScript) ?? false
+        if useCharCount {
+            let charCount = context.text.unicodeScalars.filter { !$0.properties.isWhitespace }.count
+            if charCount < Self.minCharsForCJKPolish {
+                Task { await AppLogger.shared.log(
+                    "LLM polish skipped: transcript too short (\(charCount) chars, minimum \(Self.minCharsForCJKPolish), lang=\(lang ?? "?"))",
+                    level: .info, category: "LLM"
+                ) }
+                var ctx = context
+                ctx.polishedText = context.text
+                return ctx
+            }
+        } else {
+            let wordCount = context.text.split(whereSeparator: \.isWhitespace).count
+            if wordCount <= Self.minWordsForPolish {
+                Task { await AppLogger.shared.log(
+                    "LLM polish skipped: transcript too short (\(wordCount) words, minimum \(Self.minWordsForPolish + 1))",
+                    level: .info, category: "LLM"
+                ) }
+                var ctx = context
+                ctx.polishedText = context.text
+                return ctx
+            }
         }
 
         Task { await AppLogger.shared.log(

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -100,6 +100,18 @@ public final class TranscriptPolishService {
         ])
 
         // Run the LLM polish step
+        // Multilingual v1: forward the original backend so the planner dispatches
+        // on the correct path (Parakeet → legacy, WhisperKit → tier-aware). Without
+        // this, re-polish of saved WhisperKit transcripts uses nil-backend legacy
+        // passthrough, which can corrupt non-English output with English prompts.
+        // See docs/feature-requests/multilingual-v1.md "Prompt injection
+        // rearchitecture" for tier-dispatch behavior.
+        llmPolishStep.backend = transcript.backendType
+        // languageDetection is not available for saved transcripts (the detector
+        // result is not persisted), so leave it nil. The planner treats
+        // .whisperKit + nil detection as formatting-only (safe, no lexical bias).
+        llmPolishStep.languageDetection = nil
+
         let polishedText: String
         do {
             var context = TextProcessingContext(

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -92,6 +92,10 @@ public final class TranscriptionPipeline: DictationPipeline {
         self.keychainManager = keychainManager
         self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
         self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
+        // Explicit engine identity: makes the Parakeet path non-inferred. The
+        // planner will force the legacy English-centric path for Parakeet
+        // regardless of any `languageDetection` a caller might set.
+        llmPolishStep.backend = .parakeet
         llmPolishStep.onWillProcess = { [weak self] in
             self?.state = .polishing
         }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -57,6 +57,29 @@ public final class WhisperKitPipeline: DictationPipeline {
     public var lastPolishError: String?
     public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
+    // Multilingual v1 (W2): language mode + detector. Captured lazily at
+    // detection time so a user toggling Auto->Locked mid-recording is respected.
+    public var languageMode: LanguageMode = .auto {
+        didSet {
+            // Mid-recording changes to the language mode invalidate the
+            // incremental worker, which snapshots the decode language at its
+            // init. Rather than try to re-decode the worker's buffers with the
+            // new language, we drop the worker entirely so finalize falls back
+            // to batch decode with the post-change language.
+            if oldValue != languageMode, let worker = incrementalWorker {
+                incrementalWorker = nil
+                Task { await worker.cancel() }
+                Task { await AppLogger.shared.log(
+                    "Language mode changed mid-recording, incremental worker invalidated",
+                    level: .info, category: "WhisperKitPipeline"
+                ) }
+            }
+        }
+    }
+    private let languageDetector: LanguageDetector
+    /// Last detection result, exposed for telemetry and UI (passive chip).
+    public private(set) var lastLanguageDetection: LanguageDetectionResult?
+
     // Shared services
     private let transcriptFinalizer: TranscriptFinalizer
 
@@ -97,13 +120,20 @@ public final class WhisperKitPipeline: DictationPipeline {
         audioCapture: any AudioCaptureInterface,
         backend: WhisperKitBackend,
         transcriptStore: TranscriptStore,
-        keychainManager: KeychainManager
+        keychainManager: KeychainManager,
+        languageDetector: LanguageDetector = LanguageDetector()
     ) {
         self.audioCapture = audioCapture
         self.backend = backend
         self.keychainManager = keychainManager
+        self.languageDetector = languageDetector
         self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
         self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
+        // Explicit engine identity: prevents a future codepath that skips the
+        // language detector from silently falling through to the legacy
+        // English-centric prompt path. The planner reads `.whisperKit` + nil
+        // detection as low-confidence (formatting only, no lexical injection).
+        llmPolishStep.backend = .whisperKit
 
         llmPolishStep.onWillProcess = { [weak self] in
             self?.state = .polishing
@@ -281,10 +311,21 @@ public final class WhisperKitPipeline: DictationPipeline {
             SentryBreadcrumb.updateRecordingState(active: true, backend: "whisperkit")
             SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
             startVADMonitoring()
-            await startIncrementalWorker()
+            // Multilingual v1: the incremental worker snapshots transcriptionOptions.language
+            // at recording start. In .auto mode, language is unknown until LID runs at
+            // recording stop, so the worker would decode with the stale/legacy language.
+            // Skip the worker in .auto mode; batch decode at finalize picks up the
+            // post-LID language. .locked mode is safe because the language is known upfront.
+            let workerEnabled: Bool
+            if case .locked = languageMode {
+                workerEnabled = true
+                await startIncrementalWorker()
+            } else {
+                workerEnabled = false
+            }
 
-            Task { await AppLogger.shared.log(
-                "WhisperKit recording started (batch mode, incremental worker active)",
+            Task { [workerEnabled] in await AppLogger.shared.log(
+                "WhisperKit recording started (batch mode, incremental worker: \(workerEnabled ? "on" : "off, auto language mode"))",
                 level: .info, category: "WhisperKitPipeline"
             ) }
         } catch {
@@ -448,6 +489,80 @@ public final class WhisperKitPipeline: DictationPipeline {
             samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
         }
 
+        // Multilingual v1 (W2): detect language on voiced audio before transcribe.
+        // Heart protection: detector never throws; if it abstains, pass nil to
+        // TranscriptionOptions.language so WhisperKit's internal LID runs.
+        // languageMode is captured lazily so a user toggling Auto<->Locked
+        // mid-recording is respected.
+        let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
+        // nonisolated(unsafe): WhisperKit is an actor/reference-typed handle that is
+        // not Sendable. Safe to pass to the detector actor because the backend owns
+        // it for its lifetime and the detector only calls read-only detectLanguage.
+        nonisolated(unsafe) let kitForLID = await backend.whisperKitInstance
+        let lidResult = await languageDetector.detect(
+            samples: samples,
+            voicedDuration: voicedDurationSec,
+            whisperKit: kitForLID,
+            mode: languageMode
+        )
+        lastLanguageDetection = lidResult
+        // Multilingual v1 (W3): forward the detection to the polish step so the
+        // prompt planner can apply confidence-tiered, language-aware vocab
+        // injection. Heart-protected: the planner degrades gracefully when the
+        // detection is abstained or low-confidence.
+        llmPolishStep.languageDetection = lidResult
+        if let lang = lidResult.lang, !lidResult.abstained {
+            transcriptionOptions.language = lang
+        } else {
+            // Abstain: let WhisperKit's own LID run. Heart still completes.
+            transcriptionOptions.language = nil
+        }
+        Task { await AppLogger.shared.log(
+            "LID result: lang=\(lidResult.lang ?? "nil") tier=\(lidResult.tier) conf=\(String(format: "%.2f", lidResult.confidence)) margin=\(String(format: "%.2f", lidResult.margin)) voiced=\(String(format: "%.2f", lidResult.voicedDuration))s abstained=\(lidResult.abstained)",
+            level: .info, category: "WhisperKitPipeline"
+        ) }
+        SentryBreadcrumb.add(stage: "asr", message: "Language detected", data: [
+            "lang": lidResult.lang ?? "nil",
+            "tier": lidResult.tier.rawValue,
+            "confidence": String(format: "%.3f", lidResult.confidence),
+            "margin": String(format: "%.3f", lidResult.margin),
+            "voiced_s": String(format: "%.2f", lidResult.voicedDuration),
+            "abstained": lidResult.abstained,
+        ])
+
+        // Multilingual v1 (W6): emit language.detected for every LID call and
+        // language.lid_abstained when abstaining. Fire-and-forget; telemetry is a
+        // limb and must never block transcription.
+        let sessionPreferredSnapshot = await languageDetector.peekMemory().sessionPreferred
+        TelemetryService.shared.trackLanguageDetected(
+            lang: lidResult.lang,
+            confidence: lidResult.confidence,
+            margin: lidResult.margin,
+            voicedDuration: lidResult.voicedDuration,
+            abstained: lidResult.abstained,
+            sessionPreferredLang: sessionPreferredSnapshot,
+            usedSticky: lidResult.usedSessionPrior
+        )
+        if lidResult.abstained {
+            // Classify the abstain reason per spec § Telemetry table.
+            let reason: String
+            if lidResult.voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
+                reason = "too_short"
+            } else if lidResult.confidence < LanguageDetectorThresholds.normalProb {
+                reason = "low_confidence"
+            } else if lidResult.margin < LanguageDetectorThresholds.normalMargin {
+                reason = "narrow_margin"
+            } else {
+                reason = "low_confidence"
+            }
+            TelemetryService.shared.trackLIDAbstained(
+                voicedDuration: lidResult.voicedDuration,
+                top1Prob: lidResult.confidence,
+                top1Lang: lidResult.lang,
+                reason: reason
+            )
+        }
+
         state = .transcribing
         SentryBreadcrumb.add(stage: "asr", message: "WhisperKit transcription started", data: ["backend": "whisperKit"])
 
@@ -507,6 +622,25 @@ public final class WhisperKitPipeline: DictationPipeline {
             }
 
             let asrEnd = CFAbsoluteTimeGetCurrent()
+
+            // Multilingual v1 (W6): per-transcription latency event for the
+            // per-language performance dashboard. Emitted only when we actually
+            // produced text (empty-result cases are covered by asr.completed +
+            // pipeline.failed elsewhere). Audio duration is derived from the raw
+            // capture buffer (16kHz mono) so latency is compared against actual
+            // recording length, not the VAD-trimmed slice.
+            let asrLatencySec = asrEnd - asrStart
+            let audioDurationSec = Double(rawSamples.count) / Double(AudioConstants.sampleRate)
+            if !asrText.isEmpty && audioDurationSec > 0 {
+                let msPerAudioSec = (asrLatencySec * 1000.0) / audioDurationSec
+                let modelName = await backend.modelVariantName
+                TelemetryService.shared.trackTranscriptionLatency(
+                    lang: asrLanguage,
+                    model: modelName,
+                    durationSeconds: asrLatencySec,
+                    msPerAudioSecond: msPerAudioSec
+                )
+            }
 
             guard !asrText.isEmpty else {
                 if hasSpeechEvidence {

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -34,6 +34,7 @@ public final class SettingsManager {
         case debugLogLevel
         case useExtendedThinking
         case whisperKitLanguage
+        case languageMode
         case selectedInputDeviceUID
         case noiseSuppression
         case preferredInputDeviceIDOverride
@@ -42,6 +43,7 @@ public final class SettingsManager {
         case useXPCAudioService
         case useStreamingASR
         case warmEnginePolicy
+        case useRefreshedWhisperKitModel
     }
 
     public var onChange: ((SettingKey) -> Void)?
@@ -57,6 +59,18 @@ public final class SettingsManager {
         didSet {
             UserDefaults.standard.set(whisperKitModel, forKey: "whisperKitModel")
             onChange?(.whisperKitModel)
+        }
+    }
+
+    /// Emergency rollback flag for the Multilingual v1 model swap (W4).
+    /// Default: true (use openai_whisper-large-v3-v20240930_turbo).
+    /// When false, the app falls back to the legacy openai_whisper-large-v3_turbo
+    /// variant. Cold flag: read by WhisperKitSetupService at startup.
+    /// Escape hatch: defaults write com.enviouswispr.app useRefreshedWhisperKitModel -bool false
+    public var useRefreshedWhisperKitModel: Bool {
+        didSet {
+            UserDefaults.standard.set(useRefreshedWhisperKitModel, forKey: "useRefreshedWhisperKitModel")
+            onChange?(.useRefreshedWhisperKitModel)
         }
     }
 
@@ -268,10 +282,24 @@ public final class SettingsManager {
 
     /// WhisperKit language code (ISO 639-1). Manual selection, not auto-detect.
     /// EN, DE, TA supported. "en" is default.
+    /// Deprecated: superseded by `languageMode` (Multilingual v1). Retained for
+    /// one-time migration and will be removed in a later stream.
     public var whisperKitLanguage: String {
         didSet {
             UserDefaults.standard.set(whisperKitLanguage, forKey: "whisperKitLanguage")
             onChange?(.whisperKitLanguage)
+        }
+    }
+
+    /// Language detection mode (Multilingual v1).
+    /// `.auto` is the default. `.locked("xx")` pins to an ISO 639-1 code and
+    /// short-circuits the `LanguageDetector`.
+    public var languageMode: LanguageMode {
+        didSet {
+            if let data = try? JSONEncoder().encode(languageMode) {
+                UserDefaults.standard.set(data, forKey: "languageMode")
+            }
+            onChange?(.languageMode)
         }
     }
 
@@ -376,7 +404,27 @@ public final class SettingsManager {
     public init() {
         let defaults = UserDefaults.standard
         selectedBackend = ASRBackendType(rawValue: defaults.string(forKey: "selectedBackend") ?? "") ?? .parakeet
-        whisperKitModel = defaults.string(forKey: "whisperKitModel") ?? "openai_whisper-large-v3_turbo"
+        // Fallback is flag-aware: when `useRefreshedWhisperKitModel` is false, we
+        // revert to the legacy variant so rollback actually flows end to end.
+        // Matches WhisperKitBackend.defaultModelVariant() (duplicated here because
+        // Services cannot import ASR; if this logic changes, update both sites).
+        let flagUseRefreshed = defaults.object(forKey: "useRefreshedWhisperKitModel") as? Bool ?? true
+        let refreshedVariant = "openai_whisper-large-v3-v20240930_turbo"
+        let legacyVariant = "openai_whisper-large-v3_turbo"
+        let defaultWhisperKitVariant = flagUseRefreshed ? refreshedVariant : legacyVariant
+        // One-time migration: existing installs persisted the legacy variant
+        // before Multilingual v1. If the flag says refreshed and we find the
+        // legacy value persisted, upgrade it so setup service + runtime backend
+        // converge on the same variant. Users who explicitly rolled back
+        // (`useRefreshedWhisperKitModel` = false) skip this migration because
+        // `defaultWhisperKitVariant` is already the legacy one for them.
+        let persistedWhisperKitModel = defaults.string(forKey: "whisperKitModel")
+        if flagUseRefreshed, persistedWhisperKitModel == legacyVariant {
+            whisperKitModel = refreshedVariant
+            defaults.set(refreshedVariant, forKey: "whisperKitModel")
+        } else {
+            whisperKitModel = persistedWhisperKitModel ?? defaultWhisperKitVariant
+        }
         recordingMode = RecordingMode(rawValue: defaults.string(forKey: "recordingMode") ?? "") ?? .pushToTalk
         llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .none
         llmModel = defaults.string(forKey: "llmModel") ?? LLMProvider.defaultModel(for: .openAI)
@@ -441,6 +489,41 @@ public final class SettingsManager {
         ) ?? .info
         useExtendedThinking = defaults.object(forKey: "useExtendedThinking") as? Bool ?? false
         whisperKitLanguage = defaults.string(forKey: "whisperKitLanguage") ?? "en"
+        // Load languageMode, or migrate from whisperKitLanguage on first launch
+        // (Multilingual v1). Both paths normalize (lowercase) and validate against
+        // the Whisper-supported 99-lang set; unsupported, empty, or case-variant
+        // codes fall back to .auto so a stale or bogus persisted value cannot
+        // lock the user into a non-existent language.
+        let resolvedLanguageMode: LanguageMode = {
+            let validate: (LanguageMode) -> LanguageMode = { mode in
+                switch mode {
+                case .auto:
+                    return .auto
+                case .locked(let code):
+                    let normalized = code.lowercased()
+                    guard !normalized.isEmpty, LanguageTypes.isSupported(normalized) else {
+                        return .auto
+                    }
+                    return .locked(normalized)
+                }
+            }
+            if let data = defaults.data(forKey: "languageMode"),
+               let decoded = try? JSONDecoder().decode(LanguageMode.self, from: data) {
+                return validate(decoded)
+            }
+            let legacy = (defaults.string(forKey: "whisperKitLanguage") ?? "en").lowercased()
+            let migrated: LanguageMode
+            if legacy.isEmpty || legacy == "en" || !LanguageTypes.isSupported(legacy) {
+                migrated = .auto
+            } else {
+                migrated = .locked(legacy)
+            }
+            if let encoded = try? JSONEncoder().encode(migrated) {
+                defaults.set(encoded, forKey: "languageMode")
+            }
+            return migrated
+        }()
+        languageMode = resolvedLanguageMode
         selectedInputDeviceUID = defaults.string(forKey: "selectedInputDeviceUID") ?? ""
         noiseSuppression = defaults.object(forKey: "noiseSuppression") as? Bool ?? false
         preferredInputDeviceIDOverride = defaults.string(forKey: "preferredInputDeviceIDOverride") ?? ""
@@ -448,6 +531,7 @@ public final class SettingsManager {
         writingStylePreset = WritingStylePreset(rawValue: defaults.string(forKey: "writingStylePreset") ?? "") ?? .standard
         useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
         useStreamingASR = defaults.object(forKey: "useStreamingASR") as? Bool ?? false
+        useRefreshedWhisperKitModel = defaults.object(forKey: "useRefreshedWhisperKitModel") as? Bool ?? true
         warmEnginePolicy = WarmEnginePolicy(
             rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""
         ) ?? .seconds30

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -233,4 +233,126 @@ public final class TelemetryService {
         if let p = llmProvider { props["llm_provider"] = p }
         PostHogSDK.shared.capture("metric.pipeline.e2e_seconds", properties: props)
     }
+
+    // MARK: - Multilingual v1 (language detection lifecycle)
+    //
+    // Events per docs/feature-requests/multilingual-v1.md § Telemetry.
+    // All methods are fire-and-forget and PII-free (lang codes + numeric stats only).
+    // The `environment` property (production/development) is globally registered on
+    // PostHog init (see ObservabilityBootstrap) so every capture below inherits it.
+
+    /// Emitted after `LanguageDetector.detect` completes for any outcome (accepted or abstained).
+    public func trackLanguageDetected(
+        lang: String?,
+        confidence: Double,
+        margin: Double,
+        voicedDuration: TimeInterval,
+        abstained: Bool,
+        sessionPreferredLang: String?,
+        usedSticky: Bool
+    ) {
+        var props: [String: Any] = [
+            "lang": lang ?? "nil",
+            "confidence": String(format: "%.3f", confidence),
+            "margin": String(format: "%.3f", margin),
+            "duration_bucket": Self.durationBucket(voicedDuration),
+            "voiced_duration_s": String(format: "%.2f", voicedDuration),
+            "abstained": abstained,
+            "used_sticky": usedSticky,
+        ]
+        if let pref = sessionPreferredLang {
+            props["session_preferred_lang"] = pref
+        }
+        PostHogSDK.shared.capture("language.detected", properties: props)
+    }
+
+    /// Emitted when the user confirms a language in the Lock language sheet.
+    /// `fromLang` is the prior mode ("auto" if unlocked, else prior ISO code).
+    /// `reason` is one of: "first_time", "after_bad_detect", "preference".
+    public func trackManualLockUsed(fromLang: String, toLang: String, reason: String) {
+        PostHogSDK.shared.capture("language.manual_lock_used", properties: [
+            "from_lang": fromLang,
+            "to_lang": toLang,
+            "reason": reason,
+        ])
+    }
+
+    /// Emitted when two different languages are accepted in the same session within 5 minutes.
+    /// Fired from the detector's flip-flop path (piggybacks on the passive-chip trigger).
+    public func trackLanguageFlip(fromLang: String, toLang: String, confidenceBoth: Double) {
+        PostHogSDK.shared.capture("language.flip", properties: [
+            "from_lang": fromLang,
+            "to_lang": toLang,
+            "confidence_both": String(format: "%.3f", confidenceBoth),
+        ])
+    }
+
+    /// Emitted when the user deletes more than 50% of pasted text within 5s of insert.
+    /// `lang` is the language detected for the failed transcript.
+    ///
+    /// TODO (W6/#248 follow-up): no call site yet. v1 ships with this method
+    /// available so the analytics schema is ready, but the paste-cascade does
+    /// not observe post-insert user edits. Implementing this requires either
+    /// an AX observer on the focused text field or a clipboard diff heuristic
+    /// that ignores our own restore-clipboard writes. Deferred pending review
+    /// of whether real-world correction rates justify the AX surface.
+    public func trackCorrectionAfterInsert(lang: String?, confidence: Double, charCount: Int) {
+        var props: [String: Any] = [
+            "confidence": String(format: "%.3f", confidence),
+            "char_count": charCount,
+        ]
+        if let l = lang { props["lang"] = l }
+        PostHogSDK.shared.capture("language.correction_after_insert", properties: props)
+    }
+
+    /// Emitted when LID abstains (returned nil language).
+    /// `reason` is one of: "too_short", "low_confidence", "narrow_margin".
+    public func trackLIDAbstained(
+        voicedDuration: TimeInterval,
+        top1Prob: Double,
+        top1Lang: String?,
+        reason: String
+    ) {
+        var props: [String: Any] = [
+            "voiced_duration": String(format: "%.2f", voicedDuration),
+            "top1_prob": String(format: "%.3f", top1Prob),
+            "reason": reason,
+        ]
+        if let l = top1Lang { props["top1_lang"] = l }
+        PostHogSDK.shared.capture("language.lid_abstained", properties: props)
+    }
+
+    /// Emitted per transcription: surfaces real-time factor per language+model for
+    /// per-language perf dashboards. Kept separate from `asr.completed` (generic) so
+    /// the multilingual dashboard can slice by lang without schema churn elsewhere.
+    public func trackTranscriptionLatency(
+        lang: String?,
+        model: String,
+        durationSeconds: Double,
+        msPerAudioSecond: Double
+    ) {
+        var props: [String: Any] = [
+            "model": model,
+            "duration_s": String(format: "%.3f", durationSeconds),
+            "ms_per_audio_s": String(format: "%.1f", msPerAudioSecond),
+            "$value": msPerAudioSecond,
+        ]
+        if let l = lang { props["lang"] = l }
+        PostHogSDK.shared.capture("language.transcription_latency", properties: props)
+    }
+
+    // MARK: - Multilingual helpers
+
+    /// Spec-defined voiced-duration buckets. Single source of truth so the
+    /// detector call site and UI debug views agree on labels.
+    private static func durationBucket(_ seconds: TimeInterval) -> String {
+        switch seconds {
+        case ..<1.0:    return "<1s"
+        case ..<2.5:    return "1-2.5s"
+        case ..<5.0:    return "2.5-5s"
+        case ..<10.0:   return "5-10s"
+        case ..<15.0:   return "10-15s"
+        default:        return "15s+"
+        }
+    }
 }

--- a/Tests/EnviousWisprASRTests/LanguageDetectorTests.swift
+++ b/Tests/EnviousWisprASRTests/LanguageDetectorTests.swift
@@ -1,0 +1,390 @@
+import Foundation
+import Testing
+@testable import EnviousWisprASR
+import EnviousWisprCore
+
+// Mutable clock seam for deterministic tests of session timeout and flip-flop.
+final class TestClock: LanguageDetectorClock, @unchecked Sendable {
+    var current: Date
+    init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+        self.current = start
+    }
+    func now() -> Date { current }
+    func advance(_ seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+}
+
+// Per-test UserDefaults suite so tests do not cross-contaminate or pollute
+// the real defaults domain.
+func makeEphemeralDefaults(_ suite: String = UUID().uuidString) -> UserDefaults {
+    UserDefaults(suiteName: suite)!
+}
+
+@Suite("LanguageDetector boundary logic")
+struct LanguageDetectorTests {
+
+    // MARK: - Duration gate
+
+    @Test("Below 1.0s voiced: abstain, never call LID")
+    func durationBelowShortGate() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let result = await det.evaluateForTesting(
+            windowProbs: ["en": 0.99, "de": 0.01],
+            voicedDuration: 0.5,
+            mode: .auto
+        )
+        #expect(result.abstained)
+        #expect(result.tier == .abstain)
+        #expect(result.lang == nil)
+    }
+
+    @Test("Between 1.0 and 2.5s voiced: strict thresholds apply")
+    func durationStrictWindow() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        // 0.70/0.20 passes normal, fails strict => abstain on short clip.
+        let mid = await det.evaluateForTesting(
+            windowProbs: ["en": 0.70, "de": 0.50],
+            voicedDuration: 1.5,
+            mode: .auto
+        )
+        #expect(mid.tier == .abstain)
+        #expect(mid.abstained)
+    }
+
+    @Test("Between 1.0 and 2.5s: high-confidence lang passes strict")
+    func strictPassesAtHighConfidence() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let ok = await det.evaluateForTesting(
+            windowProbs: ["en": 0.90, "de": 0.60],
+            voicedDuration: 1.5,
+            mode: .auto
+        )
+        #expect(ok.tier == .highAuto)
+        #expect(ok.lang == "en")
+    }
+
+    // MARK: - Normal thresholds
+
+    @Test("Normal clip: below 0.65 prob => lowAuto (accepted but unlexiconed)")
+    func lowAutoTier() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.50, "de": 0.30, "fr": 0.20],
+            voicedDuration: 4.0,
+            mode: .auto
+        )
+        #expect(r.tier == .lowAuto)
+        #expect(r.lang == "en")
+    }
+
+    @Test("Normal clip: 0.65/0.20 boundary is mediumAuto")
+    func mediumAutoBoundary() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.65, "de": 0.45],
+            voicedDuration: 4.0,
+            mode: .auto
+        )
+        #expect(r.tier == .mediumAuto)
+        #expect(r.lang == "en")
+    }
+
+    @Test("Normal clip: margin below 0.20 drops to lowAuto")
+    func marginGate() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.65, "de": 0.60],
+            voicedDuration: 4.0,
+            mode: .auto
+        )
+        #expect(r.tier == .lowAuto)
+    }
+
+    @Test("Normal clip: 0.80/0.25 => highAuto")
+    func highAuto() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.85, "de": 0.55],
+            voicedDuration: 4.0,
+            mode: .auto
+        )
+        #expect(r.tier == .highAuto)
+        #expect(r.lang == "en")
+    }
+
+    // MARK: - Locked mode
+
+    @Test("Locked mode: short-circuit to .locked tier")
+    func lockedShortCircuit() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: ["fr": 0.99],
+            voicedDuration: 0.1,            // even below short-clip gate
+            mode: .locked("ja")
+        )
+        #expect(r.tier == .locked)
+        #expect(r.lang == "ja")
+        #expect(!r.abstained)
+    }
+
+    @Test("Locked mode normalizes to lowercase")
+    func lockedNormalizes() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        let r = await det.evaluateForTesting(
+            windowProbs: [:],
+            voicedDuration: 3.0,
+            mode: .locked("ZH")
+        )
+        #expect(r.lang == "zh")
+        #expect(r.tier == .locked)
+    }
+
+    // MARK: - Session memory / anti-flap
+
+    @Test("Two consecutive high-confidence accepts elevate sessionPreferred")
+    func sessionElevation() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        _ = await det.evaluateForTesting(
+            windowProbs: ["de": 0.90, "en": 0.50],
+            voicedDuration: 4.0
+        )
+        _ = await det.evaluateForTesting(
+            windowProbs: ["de": 0.88, "en": 0.40],
+            voicedDuration: 4.0
+        )
+        let mem = await det.peekMemory()
+        #expect(mem.sessionPreferred == "de")
+    }
+
+    @Test("Anti-flap: switch away requires prob >= 0.85 AND margin >= 0.25")
+    func antiFlapBlocksWeakSwitch() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        // Elevate 'de' as sessionPreferred.
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.92, "en": 0.40], voicedDuration: 4.0)
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.90, "en": 0.45], voicedDuration: 4.0)
+        #expect(await det.peekMemory().sessionPreferred == "de")
+
+        // mediumAuto-level 'en' should NOT flip sessionPreferred.
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.70, "de": 0.45],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "de")
+        #expect(r.usedSessionPrior)
+    }
+
+    @Test("Anti-flap: one strong utterance alone does NOT switch (pending)")
+    func antiFlapOneStrongDoesNotSwitch() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        // Elevate 'de' as sessionPreferred.
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.92, "en": 0.40], voicedDuration: 4.0)
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.90, "en": 0.45], voicedDuration: 4.0)
+        // First strong 'fr' utterance: must NOT flip preferred yet (pending).
+        let r = await det.evaluateForTesting(
+            windowProbs: ["fr": 0.90, "de": 0.40],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "de")
+        #expect(r.usedSessionPrior)
+    }
+
+    @Test("Anti-flap: two consecutive strong utterances commit the switch")
+    func antiFlapTwoConsecutiveStrongSwitches() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.92, "en": 0.40], voicedDuration: 4.0)
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.90, "en": 0.45], voicedDuration: 4.0)
+        // First strong 'fr': pending, preferred still 'de'.
+        _ = await det.evaluateForTesting(windowProbs: ["fr": 0.90, "de": 0.40], voicedDuration: 4.0)
+        // Second consecutive strong 'fr': commits the switch.
+        let r = await det.evaluateForTesting(
+            windowProbs: ["fr": 0.91, "de": 0.35],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "fr")
+        #expect(r.tier == .highAuto)
+    }
+
+    @Test("Anti-flap: intervening weak utterance resets pending switch")
+    func antiFlapResetsOnInterruption() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.92, "en": 0.40], voicedDuration: 4.0)
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.90, "en": 0.45], voicedDuration: 4.0)
+        // First strong 'fr' (pending).
+        _ = await det.evaluateForTesting(windowProbs: ["fr": 0.90, "de": 0.40], voicedDuration: 4.0)
+        // Low-confidence utterance breaks the chain (pending cleared).
+        _ = await det.evaluateForTesting(windowProbs: ["en": 0.50, "de": 0.45], voicedDuration: 4.0)
+        // Another strong 'fr' should now be pending again, NOT commit switch.
+        let r = await det.evaluateForTesting(
+            windowProbs: ["fr": 0.91, "de": 0.35],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "de")
+        #expect(r.usedSessionPrior)
+    }
+
+    @Test("10-minute inactivity clears sessionPreferred")
+    func sessionInactivityTimeout() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.92, "en": 0.40], voicedDuration: 4.0)
+        _ = await det.evaluateForTesting(windowProbs: ["de": 0.90, "en": 0.45], voicedDuration: 4.0)
+        #expect(await det.peekMemory().sessionPreferred == "de")
+
+        clock.advance(601)  // 10 min + 1s
+        _ = await det.evaluateForTesting(windowProbs: [:], voicedDuration: 0.5)
+        #expect(await det.peekMemory().sessionPreferred == nil)
+    }
+
+    @Test("Session prior boosts low-confidence decision toward preferred lang")
+    func sessionPriorBoost() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        // Seed sessionPreferred = "en" without depending on the elevation path.
+        await det.setMemoryForTesting(
+            SessionLanguageMemory(
+                accepted: [
+                    .init(lang: "en", confidence: 0.9, timestamp: clock.now()),
+                    .init(lang: "en", confidence: 0.88, timestamp: clock.now()),
+                ],
+                sessionPreferred: "en",
+                usage24h: [:],
+                lastActivity: clock.now()
+            )
+        )
+        // Raw: top=en prob=0.56 margin=0.16 -> lowAuto. With +0.10 session-prior
+        // boost on en (preferred), en=0.66 margin=0.26 -> promoted to mediumAuto.
+        let r = await det.evaluateForTesting(
+            windowProbs: ["de": 0.40, "en": 0.56],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "en")
+        #expect(r.tier == .mediumAuto)
+        #expect(r.usedSessionPrior)
+    }
+
+    // MARK: - Script guardrail classification
+
+    @Test("Script guardrail: isNonLatinScript maps correctly")
+    func scriptGuardrailClassification() {
+        let nonLatin = ["ja", "zh", "ko", "hi", "ta", "ar", "he", "ru", "uk", "yue"]
+        let latin    = ["en", "de", "fr", "es", "pt", "tr", "vi", "id", "sw", "nl"]
+        for code in nonLatin {
+            #expect(LanguageTypes.isNonLatinScript(code), "expected non-Latin: \(code)")
+        }
+        for code in latin {
+            #expect(!LanguageTypes.isNonLatinScript(code), "expected Latin: \(code)")
+        }
+        // Case-insensitive.
+        #expect(LanguageTypes.isNonLatinScript("JA"))
+    }
+
+    @Test("Script guardrail: unknown code treated as Latin (conservative default)")
+    func scriptGuardrailUnknown() {
+        #expect(!LanguageTypes.isNonLatinScript("xx"))
+        #expect(!LanguageTypes.isNonLatinScript(""))
+    }
+
+    // MARK: - Whisper-supported set
+
+    @Test("whisperSupportedLanguages matches the spec roster size")
+    func whisperSupportedSize() {
+        // Spec claims 99 but enumerates 100 codes verbatim (includes both 'jw'
+        // and Whisper's full set). We track the enumerated list, not the marketing
+        // number, and flag future drift.
+        #expect(LanguageTypes.whisperSupportedLanguages.count == 100)
+        #expect(LanguageTypes.isSupported("en"))
+        #expect(LanguageTypes.isSupported("yue"))
+        #expect(!LanguageTypes.isSupported("xx"))
+    }
+
+    // MARK: - Defensive: stale persisted lang
+
+    @Test("Stale (unsupported) sessionPreferred is ignored, not crashed")
+    func stalePersistedLangIgnored() async {
+        let clock = TestClock()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults())
+        await det.setMemoryForTesting(
+            SessionLanguageMemory(
+                accepted: [],
+                sessionPreferred: "xx",        // not in Whisper's 99
+                usage24h: [:],
+                lastActivity: clock.now()
+            )
+        )
+        let r = await det.evaluateForTesting(
+            windowProbs: ["en": 0.70, "de": 0.45],
+            voicedDuration: 4.0
+        )
+        #expect(r.lang == "en")
+        #expect(!r.usedSessionPrior)
+    }
+
+    // MARK: - LanguageMode codable round-trip
+
+    @Test("LanguageMode Codable round-trip")
+    func languageModeCodable() throws {
+        let auto: LanguageMode = .auto
+        let locked: LanguageMode = .locked("ja")
+        let encA = try JSONEncoder().encode(auto)
+        let encL = try JSONEncoder().encode(locked)
+        let decA = try JSONDecoder().decode(LanguageMode.self, from: encA)
+        let decL = try JSONDecoder().decode(LanguageMode.self, from: encL)
+        #expect(decA == .auto)
+        #expect(decL == .locked("ja"))
+    }
+
+    // MARK: - Softmax helper
+
+    @Test("softmaxFromLogProbs normalizes to sum=1 and preserves ordering")
+    func softmaxHelper() {
+        let logProbs: [String: Float] = ["en": -0.2, "de": -2.0, "fr": -4.0]
+        let probs = LanguageDetector.softmaxFromLogProbs(logProbs)
+        let sum = probs.values.reduce(0, +)
+        #expect(abs(sum - 1.0) < 1e-6)
+        #expect((probs["en"] ?? 0) > (probs["de"] ?? 0))
+        #expect((probs["de"] ?? 0) > (probs["fr"] ?? 0))
+    }
+
+    @Test("softmaxFromLogProbs on empty map returns empty")
+    func softmaxEmpty() {
+        #expect(LanguageDetector.softmaxFromLogProbs([:]).isEmpty)
+    }
+
+    // MARK: - Passive chip
+
+    @Test("Passive chip fires on LID flip-flop within 5 minutes")
+    func passiveChipFlipFlop() async {
+        let clock = TestClock()
+        actor Collector { var triggers: [PassiveChipTrigger] = []
+            func add(_ t: PassiveChipTrigger) { triggers.append(t) }
+            func all() -> [PassiveChipTrigger] { triggers }
+        }
+        let collector = Collector()
+        let det = LanguageDetector(clock: clock, defaults: makeEphemeralDefaults()) { trigger in
+            Task { await collector.add(trigger) }
+        }
+        // First accept: en.
+        _ = await det.evaluateForTesting(windowProbs: ["en": 0.90, "de": 0.40], voicedDuration: 4.0)
+        // Second accept, different lang within the window. Use strong bar to
+        // beat anti-flap in case 'en' was elevated.
+        _ = await det.evaluateForTesting(windowProbs: ["fr": 0.90, "en": 0.40], voicedDuration: 4.0)
+        // Yield to let the Task-delivered trigger land.
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let triggers = await collector.all()
+        #expect(triggers.contains { $0.reason == .lidFlipFlop })
+    }
+}

--- a/Tests/EnviousWisprASRTests/LanguageDetectorTests.swift
+++ b/Tests/EnviousWisprASRTests/LanguageDetectorTests.swift
@@ -297,6 +297,26 @@ struct LanguageDetectorTests {
         #expect(!LanguageTypes.isNonLatinScript(""))
     }
 
+    @Test("Unsegmented script: CJK/Thai/Lao use char count, whitespace langs do not")
+    func unsegmentedScriptClassification() {
+        // CJK + Southeast Asian non-whitespace-segmented scripts.
+        for code in ["ja", "zh", "yue", "th", "lo", "my", "km"] {
+            #expect(LanguageTypes.isUnsegmentedScript(code), "expected unsegmented: \(code)")
+        }
+        // Scripts that DO whitespace-segment and must stay on the word-count
+        // path: Korean (Eojeol-spaced), Indic, Arabic, Hebrew, Cyrillic.
+        for code in ["ko", "hi", "gu", "ta", "te", "mr", "bn", "ar", "he", "ru", "uk"] {
+            #expect(!LanguageTypes.isUnsegmentedScript(code), "expected segmented: \(code)")
+        }
+        // Latin too.
+        for code in ["en", "es", "fr", "de"] {
+            #expect(!LanguageTypes.isUnsegmentedScript(code))
+        }
+        // Case-insensitive.
+        #expect(LanguageTypes.isUnsegmentedScript("JA"))
+        #expect(LanguageTypes.isUnsegmentedScript("Zh"))
+    }
+
     // MARK: - Whisper-supported set
 
     @Test("whisperSupportedLanguages matches the spec roster size")
@@ -344,23 +364,6 @@ struct LanguageDetectorTests {
         let decL = try JSONDecoder().decode(LanguageMode.self, from: encL)
         #expect(decA == .auto)
         #expect(decL == .locked("ja"))
-    }
-
-    // MARK: - Softmax helper
-
-    @Test("softmaxFromLogProbs normalizes to sum=1 and preserves ordering")
-    func softmaxHelper() {
-        let logProbs: [String: Float] = ["en": -0.2, "de": -2.0, "fr": -4.0]
-        let probs = LanguageDetector.softmaxFromLogProbs(logProbs)
-        let sum = probs.values.reduce(0, +)
-        #expect(abs(sum - 1.0) < 1e-6)
-        #expect((probs["en"] ?? 0) > (probs["de"] ?? 0))
-        #expect((probs["de"] ?? 0) > (probs["fr"] ?? 0))
-    }
-
-    @Test("softmaxFromLogProbs on empty map returns empty")
-    func softmaxEmpty() {
-        #expect(LanguageDetector.softmaxFromLogProbs([:]).isEmpty)
     }
 
     // MARK: - Passive chip

--- a/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
@@ -1,0 +1,439 @@
+import Testing
+@testable import EnviousWisprCore
+@testable import EnviousWisprLLM
+
+/// Multilingual v1 (W3): confidence-tiered + language-aware prompt injection.
+///
+/// Exercises the `PromptVocabulary` filter, the `DefaultPromptPlanner` tier
+/// policy, and the script-mismatch guardrail. The goal is to freeze the
+/// spec-mandated behavior:
+///
+/// - Tier `.locked` or `.highAuto`: global + perLanguage[detected]
+/// - Tier `.mediumAuto`: global only
+/// - Tier `.lowAuto` or `.abstain`: nothing
+/// - Non-Latin detected lang strips Latin-only perLanguage terms; global survives
+/// - Migration of legacy `[CustomWord]` puts everything in `global`
+/// - Detected lang without a perLanguage entry falls back to global-only
+@Suite("Multilingual v1 W3 Prompt Injection")
+struct LanguageAwarePromptInjectionTests {
+
+    // MARK: - Helpers
+
+    private func detection(
+        lang: String?,
+        tier: LanguageConfidenceTier
+    ) -> LanguageDetectionResult {
+        LanguageDetectionResult(
+            lang: lang,
+            confidence: tier == .highAuto ? 0.9 : (tier == .mediumAuto ? 0.7 : 0.3),
+            margin: tier == .highAuto ? 0.3 : (tier == .mediumAuto ? 0.22 : 0.05),
+            tier: tier,
+            voicedDuration: 3.0,
+            abstained: tier == .abstain,
+            usedSessionPrior: false
+        )
+    }
+
+    private func input(
+        customWords: [CustomWord] = [],
+        customVocabulary: PromptVocabulary? = nil,
+        detection: LanguageDetectionResult?,
+        backend: ASRBackendType? = nil,
+        provider: LLMProvider = .openAI,
+        modelID: String = "gpt-4o-mini",
+        transcript: String =
+            "This is a reasonably long transcript used to exercise the prompt planner filter."
+    ) -> PromptBuildInput {
+        PromptBuildInput(
+            transcript: transcript,
+            provider: provider,
+            modelID: modelID,
+            stylePreset: .standard,
+            customSystemPrompt: nil,
+            customPromptMode: .normal,
+            appName: nil,
+            language: nil,
+            customWords: customWords,
+            focusSnapshot: nil,
+            customVocabulary: customVocabulary,
+            languageDetection: detection,
+            backend: backend
+        )
+    }
+
+    // MARK: - Tier policy
+
+    @Test("locked tier: global + perLanguage[detected] both injected")
+    func lockedInjectsEverything() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr", "Claude"],
+            perLanguage: ["ja": ["ビデオ", "日本語"]]
+        )
+        let result = DefaultPromptPlanner.filterCustomWords(
+            [],
+            tier: .locked,
+            detectedLang: "ja",
+            allowedStrings: Set(vocab.effectiveTerms(detectedLang: "ja", tier: .locked))
+        )
+        let canonicals = Set(result.map(\.canonical))
+        #expect(canonicals.contains("EnviousWispr"))
+        #expect(canonicals.contains("Claude"))
+        #expect(canonicals.contains("ビデオ"))
+        #expect(canonicals.contains("日本語"))
+    }
+
+    @Test("highAuto tier: global + perLanguage[detected] both injected")
+    func highAutoInjectsEverything() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["de": ["Überlegung", "Schüssel"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "de", tier: .highAuto)
+        #expect(Set(terms) == Set(["EnviousWispr", "Überlegung", "Schüssel"]))
+    }
+
+    @Test("mediumAuto tier: ONLY global, NO perLanguage lexicon")
+    func mediumAutoInjectsGlobalOnly() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr", "Claude"],
+            perLanguage: ["de": ["Überlegung"], "ja": ["日本語"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "de", tier: .mediumAuto)
+        #expect(Set(terms) == Set(["EnviousWispr", "Claude"]))
+    }
+
+    @Test("lowAuto tier: NO lexical injection at all")
+    func lowAutoInjectsNothing() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["de": ["Überlegung"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "de", tier: .lowAuto)
+        #expect(terms.isEmpty)
+    }
+
+    @Test("abstain tier: NO lexical injection at all")
+    func abstainInjectsNothing() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["ja": ["日本語"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: nil, tier: .abstain)
+        #expect(terms.isEmpty)
+    }
+
+    // MARK: - Script guardrail
+
+    @Test("script guardrail: strips Latin-only terms from non-Latin perLanguage list")
+    func scriptGuardrailStripsLatinFromJapanese() {
+        let vocab = PromptVocabulary(
+            global: [],
+            // Japanese perLanguage bucket with a stray Latin-only term
+            // (shouldn't be there, but user config is untrusted).
+            perLanguage: ["ja": ["ビデオ", "video", "日本語", "latinonly"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "ja", tier: .locked)
+        #expect(terms.contains("ビデオ"))
+        #expect(terms.contains("日本語"))
+        #expect(!terms.contains("video"), "Latin-only term should be stripped for non-Latin lang")
+        #expect(!terms.contains("latinonly"))
+    }
+
+    @Test("script guardrail: keeps global terms regardless of their script")
+    func scriptGuardrailKeepsGlobalRegardless() {
+        let vocab = PromptVocabulary(
+            // Global is always safe: Latin product names + a Japanese term.
+            global: ["EnviousWispr", "Claude", "ビデオ"],
+            perLanguage: ["ja": ["日本語"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "ja", tier: .locked)
+        // Every global entry survives.
+        #expect(terms.contains("EnviousWispr"))
+        #expect(terms.contains("Claude"))
+        #expect(terms.contains("ビデオ"))
+        #expect(terms.contains("日本語"))
+    }
+
+    @Test("script guardrail: does NOT strip Latin terms for Latin-script langs")
+    func scriptGuardrailLatinLangKeepsLatin() {
+        let vocab = PromptVocabulary(
+            global: [],
+            perLanguage: ["de": ["Kaffee", "coffee"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "de", tier: .locked)
+        #expect(Set(terms) == Set(["Kaffee", "coffee"]))
+    }
+
+    @Test("script guardrail: strips Latin-extended terms (ß, é, ñ, ế) from non-Latin perLanguage list")
+    func scriptGuardrailStripsLatinExtendedFromJapanese() {
+        // Codex audit (Major #4): the earlier isAllLatinAscii check missed
+        // German ß, Spanish ñ, Vietnamese tone-marked letters, French
+        // accented letters. Those SHOULD be classified as Latin and stripped
+        // from non-Latin perLanguage lists. isAllLatinScript fixes this.
+        let vocab = PromptVocabulary(
+            global: [],
+            perLanguage: ["ja": [
+                "日本語",       // Japanese: keep
+                "ビデオ",       // Katakana: keep
+                "straße",       // German with ß: Latin, should strip
+                "niño",         // Spanish with ñ: Latin, should strip
+                "français",     // French with ç: Latin, should strip
+                "Tiếng Việt",   // Vietnamese: Latin script, should strip
+                "Türkçe",       // Turkish: Latin, should strip
+            ]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "ja", tier: .locked)
+        #expect(terms.contains("日本語"))
+        #expect(terms.contains("ビデオ"))
+        #expect(!terms.contains("straße"), "German ß is still Latin-script")
+        #expect(!terms.contains("niño"), "Spanish ñ is still Latin-script")
+        #expect(!terms.contains("français"), "French ç is still Latin-script")
+        #expect(!terms.contains("Tiếng Việt"), "Vietnamese tone marks are Latin-extended")
+        #expect(!terms.contains("Türkçe"), "Turkish dotted chars are Latin-extended")
+    }
+
+    // MARK: - Migration
+
+    @Test("fromLegacy: all CustomWords go into global, perLanguage is empty")
+    func migrationPutsAllInGlobal() {
+        let words = [
+            CustomWord(canonical: "EnviousWispr"),
+            CustomWord(canonical: "Claude"),
+            CustomWord(canonical: "WhisperKit"),
+        ]
+        let vocab = PromptVocabulary.fromLegacy(words)
+        #expect(Set(vocab.global) == Set(["EnviousWispr", "Claude", "WhisperKit"]))
+        #expect(vocab.perLanguage.isEmpty)
+    }
+
+    @Test("fromLegacy empty list produces empty vocabulary")
+    func migrationEmptyIsEmpty() {
+        let vocab = PromptVocabulary.fromLegacy([])
+        #expect(vocab.isEmpty)
+    }
+
+    // MARK: - Fallbacks
+
+    @Test("no perLanguage key for detected lang falls back to global-only")
+    func missingPerLanguageFallsBackToGlobal() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["ja": ["日本語"]]
+        )
+        // Detected lang is German; no "de" key present.
+        let terms = vocab.effectiveTerms(detectedLang: "de", tier: .locked)
+        #expect(terms == ["EnviousWispr"])
+    }
+
+    @Test("unsupported perLanguage key is defensively skipped")
+    func unsupportedLanguageSkipped() {
+        // "xx" is not a Whisper-supported ISO code; should be silently ignored.
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["xx": ["bogus"]]
+        )
+        let terms = vocab.effectiveTerms(detectedLang: "xx", tier: .locked)
+        // Only the global survives. The "xx" bucket is not treated as valid.
+        #expect(terms == ["EnviousWispr"])
+    }
+
+    // MARK: - DefaultPromptPlanner integration
+
+    @Test("planner nil detection preserves legacy customWords verbatim")
+    func plannerLegacyPathPassesThrough() {
+        // No languageDetection means "not wired yet". Planner should leave
+        // customWords untouched so untouched callsites behave as before.
+        let words = [CustomWord(canonical: "EnviousWispr", aliases: ["Envious Whisper"])]
+        let built = input(customWords: words, detection: nil)
+        let plan = DefaultPromptPlanner().plan(input: built)
+        // Envelope system prompt should still contain the CUSTOM VOCABULARY
+        // block with the alias hint preserved.
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("Envious Whisper"), "aliases preserved on legacy path")
+    }
+
+    @Test("planner lowAuto strips all vocab from system prompt")
+    func plannerLowAutoSystemPromptHasNoVocab() {
+        let words = [CustomWord(canonical: "EnviousWispr")]
+        let built = input(
+            customWords: words,
+            customVocabulary: PromptVocabulary(global: ["EnviousWispr"]),
+            detection: detection(lang: "en", tier: .lowAuto)
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(!system.contains("EnviousWispr"))
+        #expect(!system.contains("CUSTOM VOCABULARY"))
+    }
+
+    @Test("planner highAuto keeps vocab in system prompt")
+    func plannerHighAutoSystemPromptKeepsVocab() {
+        let words = [CustomWord(canonical: "EnviousWispr")]
+        let built = input(
+            customWords: words,
+            customVocabulary: PromptVocabulary(global: ["EnviousWispr"]),
+            detection: detection(lang: "en", tier: .highAuto)
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("CUSTOM VOCABULARY"))
+    }
+
+    @Test("planner mediumAuto keeps global but not perLanguage in system prompt")
+    func plannerMediumAutoKeepsGlobalOnly() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["de": ["Überlegung"]]
+        )
+        let built = input(
+            customWords: [],
+            customVocabulary: vocab,
+            detection: detection(lang: "de", tier: .mediumAuto)
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(!system.contains("Überlegung"))
+    }
+
+    @Test("planner locked + non-Latin detected lang strips Latin perLanguage terms")
+    func plannerScriptGuardrailIntegrates() {
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["ja": ["ビデオ", "stray"]]
+        )
+        let built = input(
+            customWords: [],
+            customVocabulary: vocab,
+            detection: detection(lang: "ja", tier: .locked)
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("ビデオ"))
+        #expect(!system.contains("stray"), "Latin-only ja term should be stripped by script guardrail")
+    }
+
+    // MARK: - Explicit ASR backend dispatch (W3 follow-up)
+
+    @Test("backend .parakeet forces legacy path even when detection is populated")
+    func parakeetForcesLegacyDespiteDetection() {
+        // Populating languageDetection with a non-English high-confidence
+        // result should be IGNORED when backend is explicitly Parakeet.
+        // Parakeet is English-only and any detection on that path is bogus.
+        let words = [CustomWord(canonical: "EnviousWispr", aliases: ["Envious Whisper"])]
+        let built = input(
+            customWords: words,
+            customVocabulary: PromptVocabulary(
+                global: ["EnviousWispr"],
+                perLanguage: ["ja": ["日本語"]]
+            ),
+            detection: detection(lang: "ja", tier: .highAuto),
+            backend: .parakeet
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        // Legacy path preserves the full CustomWord list verbatim — aliases
+        // survive, and perLanguage terms that would leak via the W3 tier
+        // policy never enter the prompt.
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("Envious Whisper"), "aliases preserved on Parakeet legacy path")
+        #expect(!system.contains("日本語"), "perLanguage terms must not leak on Parakeet path")
+    }
+
+    @Test("backend .whisperKit with nil detection uses formatting-only path")
+    func whisperKitNilDetectionIsFormattingOnly() {
+        // Defensive: a future WhisperKit codepath that bypasses the detector
+        // must NOT fall through to the English-centric legacy prompt. The
+        // planner treats this as low-confidence and strips all lexical
+        // injection.
+        let words = [CustomWord(canonical: "EnviousWispr")]
+        let built = input(
+            customWords: words,
+            customVocabulary: PromptVocabulary(global: ["EnviousWispr"]),
+            detection: nil,
+            backend: .whisperKit
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(!system.contains("EnviousWispr"), "no lexical injection when detection is absent on WhisperKit")
+        #expect(!system.contains("CUSTOM VOCABULARY"))
+    }
+
+    @Test("backend .whisperKit with populated detection uses tier-gated W3 path")
+    func whisperKitWithDetectionUsesTierPolicy() {
+        // Explicit WhisperKit + populated high-confidence detection should
+        // behave identically to the W3 tier-gated path: global + perLanguage
+        // for the detected language are injected.
+        let vocab = PromptVocabulary(
+            global: ["EnviousWispr"],
+            perLanguage: ["de": ["Überlegung"]]
+        )
+        let built = input(
+            customWords: [CustomWord(canonical: "EnviousWispr")],
+            customVocabulary: vocab,
+            detection: detection(lang: "de", tier: .highAuto),
+            backend: .whisperKit
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("Überlegung"))
+        #expect(system.contains("CUSTOM VOCABULARY"))
+    }
+
+    @Test("backend nil falls through to legacy passthrough (safety net)")
+    func nilBackendFallsThroughToLegacy() {
+        // Untouched callsites (no explicit backend, no detection wired) must
+        // preserve the legacy verbatim customWords behavior.
+        let words = [CustomWord(canonical: "EnviousWispr", aliases: ["Envious Whisper"])]
+        let built = input(
+            customWords: words,
+            detection: nil,
+            backend: nil
+        )
+        let plan = DefaultPromptPlanner().plan(input: built)
+        let system = plan.envelope.messages.first(where: { $0.role == .system })?.content ?? ""
+        #expect(system.contains("EnviousWispr"))
+        #expect(system.contains("Envious Whisper"), "aliases preserved on nil-backend legacy path")
+    }
+
+    // MARK: - Parakeet byte-identical characterization
+
+    @Test("Parakeet prompt output is byte-identical to legacy (no backend set)")
+    func parakeetByteIdenticalToLegacy() {
+        // Characterization test: the Parakeet explicit path must produce the
+        // exact same system prompt as the legacy nil-backend/nil-detection
+        // path. This locks in "no behavioral change for Parakeet in the happy
+        // path" across the W3 follow-up refactor.
+        let words = [CustomWord(canonical: "EnviousWispr", aliases: ["Envious Whisper"])]
+        let legacyInput = input(
+            customWords: words,
+            detection: nil,
+            backend: nil
+        )
+        let parakeetInput = input(
+            customWords: words,
+            detection: nil,
+            backend: .parakeet
+        )
+        let legacyPlan = DefaultPromptPlanner().plan(input: legacyInput)
+        let parakeetPlan = DefaultPromptPlanner().plan(input: parakeetInput)
+
+        let legacySystem = legacyPlan.envelope.messages
+            .first(where: { $0.role == .system })?.content ?? ""
+        let parakeetSystem = parakeetPlan.envelope.messages
+            .first(where: { $0.role == .system })?.content ?? ""
+        #expect(legacySystem == parakeetSystem,
+                "Parakeet explicit path must match legacy byte-for-byte")
+
+        // Also compare the user-role content for completeness.
+        let legacyUser = legacyPlan.envelope.messages
+            .first(where: { $0.role == .user })?.content ?? ""
+        let parakeetUser = parakeetPlan.envelope.messages
+            .first(where: { $0.role == .user })?.content ?? ""
+        #expect(legacyUser == parakeetUser)
+    }
+}

--- a/docs/feature-requests/multilingual-v1-followup.md
+++ b/docs/feature-requests/multilingual-v1-followup.md
@@ -1,0 +1,123 @@
+# Multilingual v1 Follow-up Plan
+
+Date: 2026-04-12. Parent: [multilingual-v1.md](multilingual-v1.md). Epic: #242.
+
+## What shipped in this PR (feat/multilingual-v1)
+
+All six workstreams landed end-to-end with build clean + 251 tests passing.
+
+- **W1 UI**: Auto toggle + hidden Lock language sheet with search + 99-lang catalog (native + English names). Replaces the old 3-lang segmented picker.
+- **W2 LanguageDetector**: actor with voiced-duration gate, multi-window LID, confidence thresholds, session memory with anti-flap, script guardrail helper. Session-preferred memory persisted in UserDefaults with defensive filtering.
+- **W3 Prompt rearchitecture**: PromptVocabulary with global + per-language lists, confidence-tiered injection (Locked/HighAuto/MediumAuto/LowAuto), explicit backend field so Parakeet and WhisperKit dispatch to correct paths.
+- **W4 Model swap**: default WhisperKit variant changed to `openai_whisper-large-v3-v20240930_turbo` with `useRefreshedWhisperKitModel` flag for emergency rollback, and a first-launch migration that upgrades legacy persisted values.
+- **W5 Eval harness**: FLEURS + Common Voice downloaders, eval_all.sh orchestrator, score.py with tier assignment and Korean dual metric (CER + whitespace-WER). Polish-QA harness with polisher-runner Swift CLI for mutation flag analysis.
+- **W6 Telemetry**: Six PostHog events (language_detected, manual_lock_used, language_flip, correction_after_insert, lid_abstained, transcription_latency) with vendor containment intact (no PostHog imports in ASR/Core).
+
+End-to-end UAT runtime verification:
+
+- Parakeet English dictation with Gemini polish: no regression
+- WhisperKit with Japanese locked: heart path works, ASR decoded correctly as Japanese, polish skipped by pre-existing CJK word-count heuristic
+- WhisperKit with Auto + Spanish TTS: detected as Spanish, ASR correct, Gemini polish ran cleanly
+
+## What is broken or incomplete
+
+### Critical: LanguageDetector accuracy on non-English audio
+
+**Symptom**: In auto mode, WhisperKit's `detectLangauge` call (wrapped by our `LanguageDetector`) returns `lang=en` with confidence 1.00 and margin 1.00 for clearly non-English audio (French, Italian, Japanese, Korean, Chinese, Tamil, Gujarati). The downstream `transcribe` call rescues most cases because the audio signal is unambiguous, but Italian and Tamil both hallucinated into complete English garbage.
+
+**Likely root cause**: the `softmaxFromLogProbs` transform in `LanguageDetector.swift` misinterprets WhisperKit's `langProbs` output. Either the field is already probabilities (not log-probs), in which case our exp+normalize squashes the distribution into near-uniform and lets Whisper's English bias dominate, or the field shape is not what we assumed.
+
+**Fix direction**: bypass the custom softmax entirely. Use `result.language` from `detectLangauge` directly (WhisperKit already did the argmax). Multi-window aggregation becomes majority-vote on the winning language across windows. Confidence becomes the mean of the winning language's probability across windows. This eliminates the softmax as a source of error.
+
+**Validation after fix**: rerun the 7-language TTS matrix (fr, it, hi, gu, ta, zh, ko) and require the detector to identify each correctly with high confidence for at least 6 of 7.
+
+### Major: LLM polish `<4 words` short-circuit fires on long CJK transcripts
+
+**Symptom**: Polish was skipped on a 31-character Japanese utterance because the word-count check treats it as 2 words (Japanese has no spaces).
+
+**Root cause**: pre-existing heuristic in `LLMPolishStep`, not introduced by this PR. Surfaced by multilingual support.
+
+**Fix direction**: language-aware minimum. For CJK and Thai/Lao, use character count (minimum ~10 chars). For Latin/Cyrillic/Indic/Arabic, keep word count (minimum 4). Consider using `LanguageTypes.isNonLatinScript(_:)` as the branch.
+
+### Major: Detector confuses Hindi and Gujarati
+
+**Symptom**: Gujarati audio was detected as Hindi, producing output in Devanagari script instead of Gujarati script.
+
+**Root cause**: Whisper is known to confuse closely-related Indic languages on short clips. The fix-LID work above may partially mitigate (better confidence signal), but the underlying model limitation remains.
+
+**Fix direction**: script-specific post-processing could detect Gujarati script and correct the lang tag. Or: prompt injection can bias the decoder. Or: accept the limitation and document it.
+
+### Major: Hindi / Tamil / Gujarati confidence is low (0.50 / lowAuto tier)
+
+Even when correctly identified, Indic languages scored 0.50 confidence with narrow or zero margin. Under our tier policy, that puts them in `lowAuto` which skips lexical prompt injection entirely. They still transcribe but lose the benefit of custom vocabulary.
+
+### Major: Pre-existing XPC service UserDefaults domain issue
+
+The XPC ASR service runs in a separate process with its own `UserDefaults.standard` domain. The `useRefreshedWhisperKitModel` flag is set by the app in `com.enviouswispr.app` defaults, invisible to the service. The service's fallback now hardcodes the refreshed variant (`openai_whisper-large-v3-v20240930_turbo`); rollback requires the app to explicitly push the variant through the XPC interface.
+
+This was flagged by codex audit pass 4 and reverted to hardcoded default. Pre-existing limitation, not a new regression.
+
+### Minor: passive chip UI is callback-only, no banner
+
+`LanguageDetector` emits `PassiveChipTrigger` events (flip-flop and consecutive-low-confidence). `AppState.pendingPassiveChip` holds the latest trigger, but no UI banner consumes it yet. Users will not see the "Detected X. Lock it?" or "Language unstable. Lock language?" CTAs the spec describes.
+
+### Minor: `correction_after_insert` telemetry is a stub
+
+W6 deferred implementing this event because it requires either an AX observer on the focused text field or a clipboard-diff heuristic that filters our own restore-clipboard writes.
+
+### Minor: 99 vs 100 languages mismatch
+
+`LanguageTypes.whisperSupportedLanguages` contains 100 codes. Spec says 99. The extra code is `yue` (Cantonese), which Whisper treats separately from `zh`. Fix is to either update the spec marketing copy or remove `yue` from the catalog.
+
+### Minor: pre-existing Parakeet characterization test is weak
+
+The "byte-identical" Parakeet characterization test in `LanguageAwarePromptInjectionTests.swift` compares `.parakeet` backend with nil-backend, both of which legacy-pass-through. Does not prove parity with pre-W3 behavior. Proper fix needs a golden-output capture from before the W3 changes landed, which was not done.
+
+## Follow-up issues to file
+
+- **LID accuracy fix** (P1): replace `softmaxFromLogProbs` with argmax on `result.language` per window, majority-vote aggregation. Validate via 7-language TTS matrix. Required before ship.
+- **CJK polish word-count** (P1): language-aware minimum on `LLMPolishStep` short-circuit. Affects all CJK users immediately.
+- **Indic language accuracy** (P2): investigate whether prompt injection of script-specific priming sentences improves Indic confidence and correctness. Also consider whether large-v3 (non-turbo) would help. The benchmark harness (W5) can measure this.
+- **Hindi vs Gujarati disambiguation** (P2): script detection post-processing, prompt priming, or accept limitation and document.
+- **Passive chip UI banner** (P2): wire a SettingsSpeechEngineView banner bound to `AppState.pendingPassiveChip` with "Lock" and "Dismiss" actions.
+- **Correction-after-insert telemetry** (P2): design and implement the AX observer or clipboard-diff approach.
+- **Parakeet golden-output characterization test** (P3): capture pre-W3 prompt output for Parakeet English flows, add as a fixture, compare in tests.
+- **XPC defaults domain sync for rollback flag** (P3): either pass the flag through the XPC interface or have the app always push `whisperKitModel` before the first `loadModel` call.
+- **99 vs 100 language code reconciliation** (P3): update spec or catalog.
+- **XPC crash routing cleanup** (P3): pre-existing issue codex surfaced where ASR XPC crashes are routed into WhisperKitPipeline regardless of backend; investigate scoping.
+
+## Native-speaker TTS for multilingual test corpus
+
+The current eval corpus uses OpenAI TTS with a single voice across all languages, which produces an American-accented rendering of every language. For French, Italian, and the Indic languages, this is far from a native speaker and is likely a source of the LID confusion we saw (Italian rendered by an American-accented TTS sounds closer to English than to native Italian).
+
+Options for improving the multilingual TTS signal, ordered by cost and quality:
+
+1. **OpenAI TTS with per-language voice selection**: OpenAI offers several voices (alloy, echo, fable, onyx, nova, shimmer). Some sound more natural for specific languages than others. Cheap, no new vendor. Quality gain: modest.
+
+2. **macOS `say` with native voices per language**: macOS ships with language-native voices (Kyoko for Japanese, Yelda for Turkish, Lekha for Hindi, etc.). Free, local, actually-native speakers. Quality varies by language but is usually better than American-accented OpenAI. Already supported as a fallback in `tts_generate.py`.
+
+3. **ElevenLabs Multilingual v3**: state of the art for multilingual TTS, voice cloning support, natural prosody. ~$22/month for starter. Quality gain: large. We flagged this earlier as "free-tools-only preferred" but it is worth a one-month trial to build a high-quality eval corpus.
+
+4. **Mozilla Common Voice**: not TTS, but real human speech across 120+ languages with native speakers. Free, CC0, already on our integration list from W5. This is the highest-quality signal but requires more integration work.
+
+5. **FLEURS (Google)**: research dataset with 102 languages, ~12 speakers per language. Free. Also on W5 integration list.
+
+**Recommended for the next validation round**: use FLEURS + Common Voice as the primary signal (real native speech), fall back to macOS `say` with language-native voices for synthetic regression tests, and only use OpenAI TTS for sanity checks or languages where FLEURS/Common Voice is thin. Drop OpenAI TTS as the default multilingual corpus source.
+
+## Plan for the next session
+
+1. Read this document and the parent `multilingual-v1.md` spec.
+2. Fix LID accuracy (the critical follow-up). Use `result.language` directly, majority-vote aggregation.
+3. Rebuild, rerun the 7-language TTS matrix (ta, zh, ko, fr, it, hi, gu) to validate.
+4. Fix CJK polish word-count. Rerun Japanese/Chinese/Korean dictation to verify polish fires.
+5. Codex review pass of the fixes via `codex review --uncommitted` (direct CLI, never the plugin skill).
+6. Wire the passive chip UI banner (small scope).
+7. Use FLEURS for the full 99-language quality matrix once LID is fixed.
+8. Council consultation on whether to reduce auto-detect confidence thresholds (currently 0.65 / 0.20) given the actual confidence values we see from the fixed LID.
+
+## Process learnings logged to memory
+
+- **No agents for code changes at LARGE/REFACTOR tier** (violated in this epic; direct cost was 13 codex findings + 2 rounds of self-introduced regressions). Memory: `feedback_refactor_discipline`.
+- **Check all tool interfaces before use** (we hit codex:rescue plugin bugs that `codex review --uncommitted` would have avoided). Memory: `feedback_check_tool_layers`.
+- **Validate automated review findings against actual code before acting** (applied correctly on codex pass 1 but required user reminder). Memory: `feedback_validate_review_findings`.
+- **End-to-end runtime validation catches bugs static analysis misses** (LID accuracy bug only surfaced when we actually dictated Italian TTS through the running app).

--- a/docs/feature-requests/multilingual-v1-followup.md
+++ b/docs/feature-requests/multilingual-v1-followup.md
@@ -260,3 +260,135 @@ If you are still stuck, the following session artifacts may help:
 - The actual UAT log (with LID results for the 7 languages) is in `~/Library/Logs/EnviousWispr/app.log` under the 2026-04-12T17:41-17:47Z timestamps.
 - The TTS audio files are at `/tmp/wispr_eyes_tts.mp3` (most recent overwrites prior; regenerate per language via `wispr_eyes.tts(sentence, voice, engine)`).
 - The benchmark corpus with 150 sentences across 15 languages is at `benchmark-results/multilingual-eval-2026-04-12/corpus/sentences.jsonl` on the feature branch.
+
+### 10. Hypotheses vs verified facts
+
+Be clear on what is verified and what is a hypothesis so you do not chase the wrong thing.
+
+**Verified (reproduced at runtime in this session):**
+- LanguageDetector in auto mode returns `lang=en` with confidence 1.00 and margin 1.00 for fr/it/zh/ko/ta audio when fed through WhisperKit's `detectLangauge`. Reproduced with 5 different TTS utterances across those languages in the same session.
+- Italian and Tamil audio hallucinated into complete English garbage. Other languages (fr, zh, ko) transcribed correctly despite the wrong language hint because Whisper's decoder is robust to bad hints when the audio is unambiguous.
+- Parakeet + Gemini polish is byte-identical to pre-change behavior (runtime UAT on a live dictation).
+- WhisperKit in locked mode correctly decodes Japanese and the incremental worker is used (per Critical #1 fix wiring).
+- Japanese/Chinese/Korean transcripts hit the polish short-circuit because word count treats them as 2 words.
+- The 99-lang sheet, search filter, and language persistence all work.
+
+**Hypotheses (not verified; test before acting):**
+- The root cause of the LID bug is `softmaxFromLogProbs` misinterpreting `langProbs`. This is the most likely cause but NOT confirmed. The alternative is that WhisperKit's API returns something other than what we assumed (e.g., only top-5 candidates, a different probability semantic, a token-log-prob map that includes non-language tokens). Run the diagnostic in section 2 BEFORE coding the fix.
+- The American-accented TTS is contributing to LID confusion. Plausible but untested. The LID bug might be real even with native-accented audio. Do NOT assume the TTS swap fixes it. Validate with FLEURS real-speech clips after the code fix.
+
+### 11. Ship criteria before merging feat/multilingual-v1 to main
+
+Check all of these before opening a PR. Per CLAUDE.md rule 9 you own the merge end-to-end.
+
+**Functional:**
+- [ ] #249 LID accuracy fix landed; detector correctly identifies at least 6 of 7 languages in the regression matrix (section 4).
+- [ ] #250 CJK polish short-circuit fix landed; Japanese/Chinese/Korean transcripts of sufficient character length trigger polish.
+- [ ] Parakeet English dictation + LLM polish still works (re-run the long dictation test that user exercised in this session).
+- [ ] WhisperKit auto-detect correctly identifies English, Japanese, Spanish on real PTT recordings.
+
+**Quality:**
+- [ ] `swift build -c release` exit 0.
+- [ ] `scripts/swift-test.sh` all tests pass. Target: 253+ tests (251 current + 2 for the two fixes minimum).
+- [ ] FLEURS-based validation across at least 10 languages from the priority list (en, es, fr, de, it, pt, ru, ja, zh, ko, hi, ar, tr) with WER/CER tier assignment.
+- [ ] No em-dashes or en-dashes in any new lines. Pre-existing ones in unrelated files are allowed.
+
+**Architecture DoD (per `.claude/rules/architecture-rules.md`):**
+- [ ] Module placement justified in the PR body (LanguageDetector → ASR, PromptVocabulary → Core, etc.).
+- [ ] Heart protection verified: pipeline completes even if detector, planner, or telemetry all throw.
+- [ ] No new god objects, no central file became a junk drawer, AppState growth is explainable.
+- [ ] Access control at narrowest practical level; any new `public` is justified.
+- [ ] Dependency direction unchanged (lower modules do not import upward).
+- [ ] Architecture Closeout comment written on issue #242 before closing.
+
+**Dead-code hygiene:**
+- [ ] `/periphery` scan run (LARGE tier mandatory). Clean output or justified exceptions.
+
+**External review:**
+- [ ] Fresh `codex review --uncommitted` pass (via direct CLI) on the fixes. Validate each finding, fix true positives, document false positives with reasoning.
+- [ ] `/ask-gpt` sign-off on the final diff.
+
+**Protocol:**
+- [ ] Wispr Eyes verification of the UI + transcription flow.
+- [ ] Post-merge: watch CI to green on main, clean up the worktree.
+
+### 12. Process playbook when things go sideways
+
+- **Codex returns findings:** for each, read the actual code, reproduce or falsify. Do NOT dispatch a fix agent (violates `feedback_refactor_discipline`). Fix directly in main session. Document false positives with one-line reasoning.
+- **Fix introduces regressions (codex or UAT finds new issues):** iterate. Rounds 2-4 in this session caught 2 regressions per round that my fixes caused. Expected. Budget for 2-3 passes.
+- **Test suite goes red:** read the failing test name, map to the change that broke it. Do not delete or weaken tests to make them pass (per `feedback_never_weaken_guardrails`). Fix the code or fix the test if the test was genuinely wrong.
+- **Uncertain architecture question:** resume the `multilingual-northstar-gpt` council session or open a fresh one. Architecture-changing decisions need council per CLAUDE.md rule 4.
+- **UAT reveals new real-world bug:** file a follow-up issue referencing epic #242. Decide if ship-blocking or next-iteration.
+
+### 13. Quick-reference commands and locations
+
+```bash
+# Worktree
+cd /Users/m4pro_sv/Desktop/EnviousWispr-multilingual-v1
+
+# Tail the app log during UAT
+tail -f ~/Library/Logs/EnviousWispr/app.log | grep -E "LID result|WhisperKit ASR|LLM Polish|CORRECTION_DEBUG"
+
+# Read current languageMode (binary plist)
+defaults read com.enviouswispr.app.dev languageMode
+
+# Current model variant persisted
+defaults read com.enviouswispr.app.dev whisperKitModel
+
+# Force rollback flag on
+defaults write com.enviouswispr.app.dev useRefreshedWhisperKitModel -bool false
+
+# Reset the Auto/Lock state to clean for testing
+defaults delete com.enviouswispr.app.dev languageMode
+
+# Session memory (JSON blob)
+defaults read com.enviouswispr.app.dev sessionLanguagePriors
+
+# Run just the new multilingual tests
+./scripts/swift-test.sh 2>&1 | grep -iE "language|multilingual|detector|prompt injection" | tail -30
+
+# Single-language TTS dictation harness
+cd /Users/m4pro_sv/Desktop/EnviousWispr && python3 -c "
+import sys; sys.path.insert(0, 'Tests/UITests')
+from wispr_eyes import connect, record_tts
+connect('EnviousWispr')
+result = record_tts(sentence='<YOUR SENTENCE>', key='rcmd')
+print(result.get('raw_asr'), '|', result.get('polished'))
+"
+```
+
+Key file locations (feature branch):
+- LID logic: `Sources/EnviousWisprASR/LanguageDetector.swift`
+- LID tests: `Tests/EnviousWisprASRTests/LanguageDetectorTests.swift`
+- Polish short-circuit: `Sources/EnviousWisprPipeline/LLMPolishStep.swift` (grep for `transcript too short`)
+- Prompt tier dispatch: `Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift`
+- UI entry: `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift`
+- Lock sheet: `Sources/EnviousWispr/Views/Settings/LanguageLockSheet.swift`
+- 99-lang catalog: `Sources/EnviousWispr/Views/Settings/LanguageCatalog.swift`
+- Settings migration: `Sources/EnviousWisprServices/SettingsManager.swift` (grep for `languageMode`)
+- Pipeline call site: `Sources/EnviousWisprPipeline/WhisperKitPipeline.swift` (grep for `LID result`)
+
+### 14. Gotchas burned in from this session
+
+- **Never auto-correct the typo `detectLangauge` to `detectLanguage`**. WhisperKit's public API actually has the typo. Our code preserves it. The inline comment in `LanguageDetector.swift` documents this. Do not "fix" it.
+- **macOS `defaults` reads plist-encoded values as binary byte dumps for non-string types.** `languageMode` is stored as base64-encoded JSON. To decode: `defaults read com.enviouswispr.app.dev languageMode` shows bytes; convert via `xxd` or Python.
+- **The rebuild skill `/wispr-rebuild-and-relaunch` hardcodes `PROJ_ROOT=/Users/m4pro_sv/Desktop/EnviousWispr`.** To rebuild the feature worktree, override `PROJ_ROOT` inline (the verbatim command sequence that worked is preserved in this session's bash history and in section 1).
+- **The bundle-app.md recipe requires the "EnviousWispr Dev" self-signed cert.** If that cert is missing, follow `docs/self-hosted-runner.md`. The cert is what lets TCC grants (Accessibility, Microphone) persist across rebuilds.
+- **`/tmp/wispr_eyes_tts.mp3` is overwritten on every `record_tts()` call.** Do not rely on it persisting.
+- **Telemetry fires during dev UAT.** Events tagged `environment=development` in PostHog. Filter those out when reading dashboards.
+- **The `benchmark-results/multilingual-eval-2026-04-12/corpus/sentences.jsonl` file with 150 native-speaker validated sentences** is on disk in the worktree but gitignored. If next session needs those sentences and they are missing, regenerate via the Gemini-backed agent approach documented in epic #242 history (W2 spec phase).
+- **The `scripts/multilingual-eval/` directory is gitignored.** The eval harness (`tts_generate.py`, `runner/`, `score.py`, `fleurs_download.py`, etc.) exists on disk but is not version-controlled. Update `.gitignore` to whitelist before committing the harness.
+
+### 15. Estimated time for ship-ready completion
+
+With high confidence the session state is correctly characterized:
+
+- LID diagnostic + fix + test: 2-3 hours
+- CJK polish fix + test: 30-45 minutes
+- 7-language regression rerun: 30 minutes
+- FLEURS validation across 10 priority languages: 1-2 hours
+- Codex review pass(es) + validation: 30-60 minutes
+- Architecture DoD + Periphery scan: 30 minutes
+- PR + CI watch + merge: 30-60 minutes
+
+**Total: roughly half a day to a full day of focused work from a fresh session.** If you hit an architecture question or codex surfaces something systemic, add a day.

--- a/docs/feature-requests/multilingual-v1-followup.md
+++ b/docs/feature-requests/multilingual-v1-followup.md
@@ -121,3 +121,142 @@ Options for improving the multilingual TTS signal, ordered by cost and quality:
 - **Check all tool interfaces before use** (we hit codex:rescue plugin bugs that `codex review --uncommitted` would have avoided). Memory: `feedback_check_tool_layers`.
 - **Validate automated review findings against actual code before acting** (applied correctly on codex pass 1 but required user reminder). Memory: `feedback_validate_review_findings`.
 - **End-to-end runtime validation catches bugs static analysis misses** (LID accuracy bug only surfaced when we actually dictated Italian TTS through the running app).
+
+---
+
+## Next session quickstart (10/10 confidence handoff)
+
+### 0. State at handoff (2026-04-12 end of session)
+
+- Feature branch `feat/multilingual-v1` is pushed to origin. NOT merged to main.
+- Worktree at `/Users/m4pro_sv/Desktop/EnviousWispr-multilingual-v1`, main repo at `/Users/m4pro_sv/Desktop/EnviousWispr`.
+- Last commit on the branch contains everything listed in the "What shipped" section above. 251 tests pass, build clean.
+- `main` is unchanged; multilingual work is isolated to the feature branch.
+- Dev app (`EnviousWispr Local.app`) from the feature branch may still be running (PID was 46090 last we checked). Bundle id `com.enviouswispr.app.dev`.
+- The `openai_whisper-large-v3-v20240930_turbo` model is cached on the dev machine under `~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/`. Legacy `openai_whisper-large-v3_turbo` is also cached (from before the swap).
+- UserDefaults at end of session: `languageMode={"mode":"auto"}`, `selectedBackend=whisperKit`, `llmProvider=gemini`, `llmModel=gemini-2.5-flash`.
+
+### 1. Resume commands
+
+```bash
+# Attach to the feature branch worktree
+cd /Users/m4pro_sv/Desktop/EnviousWispr-multilingual-v1
+
+# Confirm you are on feat/multilingual-v1
+git status
+
+# If the dev app is still running and you just want to test:
+ps aux | grep -c '[E]nviousWispr'   # expect >= 1
+
+# If you need to rebuild after code changes:
+find .build/arm64-apple-macosx/release/EnviousWispr.build/ -name "*.o" -delete 2>/dev/null
+rm -rf .build/arm64-apple-macosx/release/Modules/EnviousWispr.swiftmodule
+swift build -c release
+# then follow the bundle-app.md recipe with PROJ_ROOT pointing at this worktree
+# (the /wispr-rebuild-and-relaunch skill hardcodes main's path; override PROJ_ROOT inline)
+```
+
+### 2. Diagnostic to confirm the LID bug (do this BEFORE coding the fix)
+
+The hypothesis is that `softmaxFromLogProbs` in `LanguageDetector.swift` misinterprets WhisperKit's `langProbs` output. To verify, add one-shot diagnostic logging that dumps the raw `result.langProbs` from `detectLangauge` for each window, then rerun one non-English TTS and inspect the log. Concrete approach:
+
+In `Sources/EnviousWisprASR/LanguageDetector.swift` around line 406 (the `whisperKit.detectLangauge(audioArray: window)` call), add temporarily:
+
+```swift
+await log("LID window \(i) raw langProbs top-5: \(Array(result.langProbs.sorted { $0.value > $1.value }.prefix(5)))")
+```
+
+Then rebuild, run:
+```python
+# From /Users/m4pro_sv/Desktop/EnviousWispr
+python3 -c "
+import sys; sys.path.insert(0, 'Tests/UITests')
+from wispr_eyes import connect, record_tts
+connect('EnviousWispr')
+record_tts(sentence='Manda un messaggio a Giulia per dirle che sarò in ritardo di circa dieci minuti per il traffico.', key='rcmd')
+"
+```
+
+Then inspect `~/Library/Logs/EnviousWispr/app.log` for the raw values. If the top-5 shows Italian with a probability like 0.85 (already-softmaxed), the hypothesis is confirmed: remove the softmax, use values directly. If the top-5 shows Italian with a value like -0.16 (log-space), then softmax is probably correct and the bug is elsewhere (window slicing, API misuse, etc.). Remove the diagnostic log line after understanding the shape.
+
+### 3. Exact fix pointers
+
+**#249 LID accuracy:**
+- Primary file: `Sources/EnviousWisprASR/LanguageDetector.swift`
+- Suspect function: `softmaxFromLogProbs` around line 452
+- Callers: `runMultiWindowLID` around line 372-423 — this is where the aggregation happens
+- Alternative fix path if softmax is not the issue: bypass aggregation entirely, use `result.language` from a single full-audio call to `detectLangauge` and trust WhisperKit's argmax
+- Tests to update: `Tests/EnviousWisprASRTests/LanguageDetectorTests.swift` — the tests use `evaluateForTesting(windowProbs:)` which bypasses the softmax. After the fix, tests should still pass because they feed in already-normalized probabilities.
+- New test to add: an integration test that calls `detectLangauge` on a known Italian WAV (generate via OpenAI TTS once, commit as a fixture) and asserts `lidResult.lang == "it"`.
+
+**#250 CJK polish word-count:**
+- File: `Sources/EnviousWisprPipeline/LLMPolishStep.swift` — grep for the word-count short-circuit (the log message is `"LLM polish skipped: transcript too short"`).
+- Fix: use `LanguageTypes.isNonLatinScript(lang)` (already exists in Core) to branch. For CJK/Thai/Lao, compute character count; for everything else, keep word count. Minimums: ~10 chars for CJK, 4 words otherwise.
+- Tests: add @Test cases in `Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift` for the boundary conditions — a 10-char Japanese transcript triggers polish, a 9-char one short-circuits, etc.
+
+### 4. 7-language regression matrix (rerun after the fix)
+
+Exact sentences used in this session, with what the detector returned (WRONG in auto mode) and what it should return:
+
+| Lang | Sentence | LID returned | Should be |
+|---|---|---|---|
+| fr | `Envoie un message à Camille pour dire que je serai en retard d'environ dix minutes à cause du métro.` | en (1.00/1.00 mediumAuto) | fr |
+| it | `Manda un messaggio a Giulia per dirle che sarò in ritardo di circa dieci minuti per il traffico.` | en (1.00/1.00 highAuto) | it |
+| hi | `सारा को मैसेज भेजो कि मुझे ट्रैफिक की वजह से पहुँचने में करीब दस मिनट की देरी हो जाएगी।` | hi (0.50/0.25 lowAuto) | hi with higher confidence |
+| gu | `સારાને મેસેજ મોકલ કે ટ્રાફિકને કારણે મને પહોંચતાં લગભગ દસ મિનિટ મોડું થશે.` | hi (0.50/0.00 lowAuto) | gu |
+| ta | `போக்குவரத்து நெரிசலால் நான் சுமார் பத்து நிமிடம் தாமதமாக வருவேன் என்று சாராவுக்கு செய்தி அனுப்பு.` | en (1.00/1.00 highAuto) | ta |
+| zh | `给莎拉发条消息，告诉她我路上堵车，大概要晚十分钟才能到。` | en (1.00/1.00 mediumAuto) | zh |
+| ko | `사라한테 메시지 보내줘, 길이 막혀서 한 십 분 정도 늦을 것 같다고 전해줘.` | en (1.00/1.00 mediumAuto) | ko |
+
+Ship criteria for the LID fix: correct detection for at least 6 of 7, with confidence varying meaningfully (not all 1.00). Use the reference sentences above as the test set.
+
+### 5. Codex usage (burned in)
+
+- Never use the `codex:rescue` plugin skill. The plugin's `codex-companion.mjs` has zombie-process and interrupt-leak bugs.
+- Use `codex review --uncommitted` directly from Bash (no arguments — default prompt works fine).
+- If you need a custom prompt, the CLI currently rejects `--uncommitted [PROMPT]`. Either pipe via stdin after checking the current CLI version, or use `codex exec` subcommand with your prompt.
+- Each review pass costs ~0 direct dollars because you are on ChatGPT Plus/Pro subscription (not API-metered). Consumes your Plus cap.
+- Validate every codex finding against the actual code before acting. Do not dispatch fix agents; fix directly (LARGE tier rule).
+
+### 6. Native-speaker TTS for the next validation round
+
+- Default corpus source should be FLEURS (primary) and Mozilla Common Voice (fallback). Downloaders already shipped in `scripts/multilingual-eval/fleurs_download.py` and `commonvoice_download.py`. Common Voice requires a one-time `huggingface-cli login` plus accepting terms at `mozilla-foundation/common_voice_17_0`.
+- For synthetic regression tests, use macOS `say` with language-native voices: Kyoko (ja), Yelda (tr), Lekha (hi), Milena (ru), Monica (es), Anna (de), Thomas (fr), Alice (it), Luciana (pt), Tingting (zh), Yuna (ko), Majed (ar). Already mapped in `scripts/multilingual-eval/tts_generate.py` `SAY_VOICES_BY_LANG`.
+- Do NOT use OpenAI TTS as the default. Its single-voice American-accented rendering of every language may be contributing to the LID confusion we saw this session.
+
+### 7. Don't skip
+
+- Runtime UAT is mandatory before declaring the fix done. See `feedback_runtime_uat_catches_static` memory.
+- No coding agents for LARGE-tier work. See `feedback_refactor_discipline` memory.
+- Validate codex findings against actual code before acting. See `feedback_validate_review_findings` memory.
+
+### 8. Council sessions (persistent history)
+
+The `llm-council` MCP maintains session state across Claude conversations. The following sessions were created during Multilingual v1 work and have the full strategic context. Resume them in the next session by passing the same `session_name` to `mcp__llm-council__council`. Config (provider, model, temperature, reasoning_effort) is locked at creation — do NOT try to switch providers or models on an existing session; create a new session name if you need different config. The `system_prompt` is the one attribute that can be updated mid-session.
+
+| Session name | Provider / model | Topic |
+|---|---|---|
+| `multilingual-rubric-gpt-v2` | openai / gpt-5.4 | Pressure-tested the scoring rubric (tier thresholds, TTS-to-real-speech assumption, autodetect gate, sample sizes, model selection). GPT flagged: "best of explicit/autodetect is wrong, use explicit-only for picker and a separate autodetect gate." |
+| `multilingual-rubric-gemini-flash` | gemini / gemini-2.5-flash | Same rubric review. Converged with GPT on most points; emphasized real-speech data and stricter thresholds. |
+| `multilingual-northstar-gpt` | openai / gpt-5.4 | Strategy: 99-language auto-detect as default, no primary picker. GPT endorsed with specific 30-day roadmap (W1 Auto + hidden Lock, W2 VAD + multi-window LID + session memory, W3 prompt split, W4 eval). Source of the layered autodetect stack design (voiced-duration gate, multi-window LID, session memory, top-2 fallback, abstain logic). |
+| `multilingual-northstar-gemini` | gemini / gemini-2.5-flash | Same strategy question. Phased public messaging approach ("multiple languages" -> "50+" -> "99"). Hidden picker as escape hatch. |
+
+Sessions that errored and should NOT be reused (create fresh names instead):
+- `multilingual-rubric-gpt` (poisoned: gpt-5 rejected the default temperature=0.7)
+- `multilingual-rubric-gemini` (Gemini Pro hit 503 UNAVAILABLE; Flash version worked)
+
+**When to resume which session:**
+- Before coding the LID fix, optionally consult `multilingual-northstar-gpt` for "given the fixed LID returns confidences like X, should we reduce the 0.65/0.20 thresholds?" GPT has the full thresholds context.
+- Before the 99-language advertised-quality push, consult `multilingual-rubric-gpt-v2` for the tier thresholds conversation. The rubric in docs/feature-requests/multilingual-v1.md is based on its feedback.
+- For prompt-injection strategy tweaks (tier table, script guardrail edge cases), resume `multilingual-northstar-gpt`.
+
+**When to NOT resume:** for a fresh independent review of new code, spin up a new session name so the prior conversation does not anchor the review. Codex audit (`codex review --uncommitted`) should always be fresh per-pass.
+
+### 9. Artifacts to hand off verbatim
+
+If you are still stuck, the following session artifacts may help:
+
+- This session's transcript lives in `~/.claude/projects/-Users-m4pro-sv-Desktop-EnviousWispr/` logs.
+- The actual UAT log (with LID results for the 7 languages) is in `~/Library/Logs/EnviousWispr/app.log` under the 2026-04-12T17:41-17:47Z timestamps.
+- The TTS audio files are at `/tmp/wispr_eyes_tts.mp3` (most recent overwrites prior; regenerate per language via `wispr_eyes.tts(sentence, voice, engine)`).
+- The benchmark corpus with 150 sentences across 15 languages is at `benchmark-results/multilingual-eval-2026-04-12/corpus/sentences.jsonl` on the feature branch.

--- a/docs/feature-requests/multilingual-v1.md
+++ b/docs/feature-requests/multilingual-v1.md
@@ -1,0 +1,263 @@
+# Multilingual v1: 99-language auto-detect with hidden Lock language
+
+Status: planning. Date: 2026-04-12.
+
+## North Star
+
+Ship all 99 Whisper-supported languages, auto-detect by default, no primary picker. Hidden "Lock language" escape hatch for short clips, close-language collisions, and bilingual daily users. Positioning: 99 languages, fully on-device, always free, no weekly caps, works offline.
+
+## Why now
+
+Competitive recon (2026-04-12) confirmed all three major competitors are cloud-based: WisprFlow (Supabase + Stripe, Electron, no on-device ASR), SuperWhisper (`sw-ultra-cloud-v1-east`, empty local models dir), Edge Eloquent (Google Firebase, Flutter, Mac Catalyst). Their "99 languages" claim is a server-side capability + UX smoothing, not manual native-speaker parity. EnviousWispr is genuinely on-device. The on-device 99-language story is MORE defensible, not less.
+
+Council pressure-tested by GPT-5.4 and Gemini 2.5-Flash (2026-04-12). Both converged on: autodetect default is right, hidden manual lock is mandatory, `large-v3-v20240930_turbo` is the right model, multi-layer autodetect is the real engineering lever, prompt injection must split formatting from lexical and go language-aware.
+
+Supersedes existing issue #165.
+
+## Scope
+
+### In
+
+1. UI: replace en/de/ta segmented picker with `Auto` toggle and hidden "Lock language" sheet listing all 99 languages with search and recents.
+2. Autodetect stack: voiced-duration gate, multi-window `detectLanguage()`, confidence + margin thresholds with abstain, session language memory with anti-flap, script-mismatch guardrail. Top-2 fallback decode deferred to v2 pending real-world LID failure data.
+3. Prompt injection rearchitecture: formatting-only vs lexical split, per-language vocabulary map, confidence-tiered injection (Tier A locked/high-confidence, Tier B medium, Tier C low).
+4. Model swap: default to `openai_whisper-large-v3-v20240930_turbo`. 24-hour feature flag for rollout safety. Cache migration for existing users.
+5. Eval harness: FLEURS + Mozilla Common Voice downloaders, scorer for WER (Latin/Cyrillic/Indic/Arabic) and CER (ja/zh/ko, plus whitespace-WER for Korean). 30 clips per language weekly, 100 clips for top 20. Reuses existing `scripts/multilingual-eval/` runner + scorer.
+6. Telemetry: PostHog events for `language_detected`, `language_confidence`, `duration_bucket`, `manual_lock_used`, `language_flip`, `correction_after_insert`, `session_stability`. Sentry breadcrumbs for LID aborts and script-guardrail rejections.
+
+### Out (v2 or later)
+
+- Top-2 fallback decode (expensive, adds only if v1 data shows 5%+ LID failure rate).
+- ElevenLabs synthetic speech (paid tool rejected, zero revenue context).
+- Per-language prompt template packs beyond formatting-only plus English custom vocab.
+- Translation mode (`task: .translate`) as a user-facing feature.
+- Hindi/Tamil/Gujarati numeric normalization post-ASR (tracked separately if benchmark shows impact).
+- Per-app context catalog (SuperWhisper-style `bundled_app_info.json`). Tracked as separate future feature after v1 ships.
+
+## Architecture
+
+### Tier classification
+
+LARGE. Touches ASR backend, Pipeline, Services, UI. Requires Architecture DoD, council review (done), Periphery scan, both backends validation (Parakeet is unaffected but Pipeline wiring touched), GPT sign-off on final code.
+
+### Heart and limbs
+
+Heart: `Hotkey → Audio → WhisperKit transcribe → text → clipboard`. Still completes if LID abstains (falls back to session-locked language or the user's current Lock language). Still completes if prompt injection fails (transcribes without lexical bias).
+
+Limb: language-aware prompt injection, session memory, script guardrail, telemetry. All must fail open.
+
+### Module placement
+
+- `EnviousWisprASR`: new `LanguageDetector` actor (wraps WhisperKit's `detectLanguage` with multi-window aggregation, confidence + margin logic, script guardrail). Lives alongside `WhisperKitBackend`.
+- `EnviousWisprCore`: new types `LanguageDetectionResult`, `LanguageConfidenceTier` (`.locked`, `.highAuto`, `.mediumAuto`, `.lowAuto`, `.abstain`), `SessionLanguageMemory`.
+- `EnviousWisprServices`: `SettingsManager` gains `languageMode: LanguageMode` (`.auto` or `.locked(code)`). `whisperKitLanguage` kept for migration, deprecated. Telemetry events added to `TelemetryService`.
+- `EnviousWisprLLM`: `CustomVocabularyFormatter` extended to be language-aware. Prompt builders consume per-language vocab + confidence tier.
+- `EnviousWisprPipeline`: `WhisperKitPipeline` consults `LanguageDetector` before `transcribe()`. `transcriptionOptions.language` populated from detector result (nil if abstaining, which lets WhisperKit's own detection proceed).
+- `EnviousWispr` (app): `SpeechEngineSettingsView` replaces segmented picker with `Auto` toggle and "Lock language" sheet.
+
+### Dependency direction
+
+No lower module imports upward. `LanguageDetector` depends on `EnviousWisprCore` only. `WhisperKitPipeline` owns the detector call site.
+
+## Languages (all 99)
+
+Whisper-supported ISO codes. The picker UI will show native-script names.
+
+```
+af am ar as az ba be bg bn bo br bs ca cs cy da de el en es et eu
+fa fi fo fr gl gu ha haw he hi hr ht hu hy id is it ja jw ka kk
+km kn ko la lb ln lo lt lv mg mi mk ml mn mr ms mt my ne nl nn
+no oc pa pl ps pt ro ru sa sd si sk sl sn so sq sr su sv sw ta te
+tg th tk tl tr tt uk ur uz vi yi yo yue zh
+```
+
+## Autodetect stack (detailed spec)
+
+### Layer 1: speech gate
+
+Before calling `detectLanguage`, ensure the clip has enough voiced speech.
+
+- Required: voicedDuration greater than or equal to 1.0s for provisional LID, greater than or equal to 2.5s for confident LID. Derived from existing `SilenceDetector` speech segments (already computed post-recording).
+- Short-clip policy: less than 1.0s voiced means no LID call; use session-locked or sticky language or fall through to WhisperKit's internal LID without our gating.
+
+### Layer 2: multi-window LID
+
+On audio greater than or equal to 2.5s, run `detectLanguage` on up to 4 overlapping windows: 0 to 3s, 1 to 4s, 2 to 6s, full voiced segment capped at 12s. Aggregate via arithmetic mean of probabilities per language.
+
+Accept top-1 result only if:
+- top-1 probability greater than or equal to 0.65 AND
+- top-1 minus top-2 margin greater than or equal to 0.20
+
+For voiced duration less than 2.5s: stricter thresholds (top-1 greater than or equal to 0.80, margin greater than or equal to 0.25). If stricter thresholds fail, abstain and fall back to sticky or session-locked language.
+
+### Layer 3: session memory
+
+`SessionLanguageMemory` holds:
+- Recency-weighted last 10 accepted languages for the session.
+- Last 24-hour usage per language (persisted in UserDefaults).
+- Last manual Lock language value (highest priority when set).
+
+Anti-flap rules:
+- If the same language is accepted with high confidence twice in a row, mark as session-preferred and boost by +0.10 in later low-confidence decisions.
+- Only switch away from session-preferred if the new language shows probability greater than or equal to 0.85 AND margin greater than or equal to 0.25 on two consecutive utterances.
+
+Session timeout: 10 minutes of inactivity clears session-preferred; 24-hour cache persists.
+
+### Layer 4: script-mismatch guardrail
+
+If the detected language has a non-Latin script (ar, bg, bn, el, gu, he, hi, ja, ka, km, kn, ko, lo, ml, mr, my, ne, pa, ru, sa, si, sr, ta, te, th, uk, ur, yi, yue, zh), and a proposed prompt token string contains Latin characters tagged as `global`, allow it. If the same is ungated (not `global`), strip before passing to the decoder.
+
+### Layer 5: UX fallback
+
+Never modal. Show passive chip "Detected: Japanese. Lock it?" only when LID flip-flops twice in five minutes OR two low-confidence detections in a session OR a user correction follows a likely bad transcript.
+
+## Prompt injection rearchitecture
+
+### Prompt storage shape
+
+```swift
+struct PromptVocabulary {
+    var global: [String]          // True cross-lingual entities: product names, URLs
+    var perLanguage: [String: [String]] // lang code -> terms specific to that language
+}
+```
+
+`global` is always safe to inject. `perLanguage` only injects when detected language matches the key AND confidence tier is Locked or HighAuto.
+
+### Confidence-tiered injection
+
+| Tier | When | Inject |
+|---|---|---|
+| Locked | User selected Lock language | Full lexicon for that language + global |
+| HighAuto | Top-1 greater than or equal to 0.80 AND margin greater than or equal to 0.25 AND matches session prior | Full lexicon for detected + global |
+| MediumAuto | Top-1 greater than or equal to 0.65 AND margin greater than or equal to 0.20 | Formatting-only + global |
+| LowAuto | All else | No lexical prompt. Formatting-only. |
+
+Formatting-only prompt is language-neutral: punctuation, capitalization, line-break style. No lexical content.
+
+### Migration of existing custom-words
+
+Existing `CustomWordsManager` entries are untagged. Migration: treat all as `global` on first launch after upgrade (safe default since most are product names and proper nouns). Ship a per-entry language tag in the UI as a v2 enhancement.
+
+## Model swap
+
+### From and to
+
+From: `openai_whisper-large-v3_turbo` (current default in `WhisperKitBackend.init`, `SettingsManager`, `ASRServiceHandler`, `WhisperKitSetupService`).
+
+To: `openai_whisper-large-v3-v20240930_turbo`. OpenAI's 2024-09-30 multilingual refresh, turbo decoder speed.
+
+Argmax-published. Available at `argmaxinc/whisperkit-coreml` (confirmed via HuggingFace API 2026-04-12).
+
+### Rollout
+
+- Day 1: ship new model as default with `whisperKitModelVariant` settings key (new), defaulting to the new model. Existing users' `whisperKitModel` key preserved for 2 releases as fallback if the new model download fails.
+- Feature flag `useRefreshedWhisperKitModel` (defaults true) for emergency rollback via defaults write.
+- Cache migration: both old and new variants live in the same HF cache directory. `WhisperKitSetupService.getLocalModelPath` already uses fuzzy matching; no cache migration code needed.
+- Blast radius floor: no regression on en, de, or ta beyond 0.5 absolute WER points (measured pre-merge via eval harness).
+
+## Eval harness (reusing existing work)
+
+Build on the existing `scripts/multilingual-eval/` work:
+- `tts_generate.py` (already written) for synthetic regression tests
+- `runner/` Swift CLI (already written) for WhisperKit batch transcription
+- `score.py` (already written) for WER/CER scoring
+
+New additions:
+- `fleurs_download.py`: pull FLEURS dev-set clips + transcripts for all 99 languages (Common Voice overlap)
+- `commonvoice_download.py`: pull Common Voice validated clips (fallback where FLEURS thin)
+- `eval_all.sh`: orchestrate download -> transcribe -> score across all 99
+- Update `score.py` to emit per-language tier assignment (Ship/Strong/Acceptable/Do-not-expose) and cross-model comparison tables
+- Korean CER + whitespace-WER dual metric
+
+Target cadence: weekly automated run, results committed to `benchmark-results/multilingual-weekly/YYYY-MM-DD/`.
+
+## Telemetry
+
+New PostHog events (filter by `environment=production`):
+
+| Event | When | Properties |
+|---|---|---|
+| `language_detected` | After LID completes | `lang`, `confidence`, `margin`, `duration_bucket` (1-2.5s, 2.5-5s, 5-10s, 10-15s, 15s+), `abstained` (bool), `session_preferred_lang`, `used_sticky` (bool) |
+| `manual_lock_used` | User selects Lock language | `from_lang`, `to_lang`, `reason` (first_time, after_bad_detect, preference) |
+| `language_flip` | Two different langs accepted in same session within 5 min | `from_lang`, `to_lang`, `confidence_both` |
+| `correction_after_insert` | User deletes more than 50% of pasted text within 5s | `lang`, `confidence`, `char_count` |
+| `lid_abstained` | Detector returned nil | `voiced_duration`, `top1_prob`, `top1_lang`, `reason` (too_short, low_confidence, narrow_margin) |
+| `transcription_latency` | Per transcription | `lang`, `model`, `duration_s`, `ms_per_audio_s` (real-time factor) |
+
+Sentry breadcrumbs on every LID call (category: `language.detect`).
+
+## Build sequence (parallel workstreams)
+
+All streams target today. Dependencies explicit.
+
+| Stream | Owner | Depends on | Tier |
+|---|---|---|---|
+| W1: UI replacement | SwiftUI agent | W2 interface contract only | MEDIUM |
+| W2: Autodetect stack | ASR agent | none | LARGE |
+| W3: Prompt rearchitecture | LLM/prompt agent | W2 interface | MEDIUM |
+| W4: Model swap | Config agent | none | MEDIUM |
+| W5: Eval harness extension | Eval agent | W4 (model available for testing) | SMALL |
+| W6: Telemetry | Observability agent | W2 events defined | SMALL |
+
+Shared interface (W2 produces, W1 and W3 consume):
+
+```swift
+public struct LanguageDetectionResult: Sendable {
+    public let lang: String?         // ISO 639-1, nil if abstaining
+    public let confidence: Double    // top-1 prob, 0 if abstained
+    public let margin: Double        // top-1 minus top-2
+    public let tier: LanguageConfidenceTier
+    public let voicedDuration: TimeInterval
+    public let abstained: Bool
+    public let usedSessionPrior: Bool
+}
+
+public enum LanguageConfidenceTier: Sendable {
+    case locked      // user set Lock language
+    case highAuto    // prob >= 0.80 AND margin >= 0.25
+    case mediumAuto  // prob >= 0.65 AND margin >= 0.20
+    case lowAuto     // below medium thresholds
+    case abstain     // below short-clip thresholds or no voiced speech
+}
+
+public enum LanguageMode: Codable, Sendable {
+    case auto
+    case locked(String)  // ISO 639-1 code
+}
+```
+
+## Validation
+
+### Per stream
+
+Each stream closes its own child issue with: logic tests passing, `/wispr-rebuild-and-relaunch` clean, `/wispr-eyes` verification on any UI change, and for MEDIUM+ streams the edge-case enumeration filled in on the issue body.
+
+### Epic-level closeout
+
+Before closing the epic:
+1. `swift build -c release` exit 0
+2. `swift build --build-tests` exit 0
+3. `scripts/swift-test.sh` passes
+4. `/wispr-rebuild-and-relaunch` produces a usable app
+5. `/wispr-eyes "verify multilingual v1 settings flow + auto detect"` VERIFIED
+6. Eval harness shows no regression on en/de/ta versus pre-merge baseline (less than 0.5 absolute WER drop)
+7. `/ask-gpt` sign-off on the full PR stack
+8. `/periphery` scan clean
+9. Architecture closeout in epic closing comment (module placement, heart protection, anti-god-object check, boundary integrity)
+
+## Council references
+
+- Gemini 2.5-Flash review (2026-04-12): picker as escape hatch with recents + search; phased public messaging from "multiple languages" to "50+" to "99".
+- GPT-5.4 review (2026-04-12): multi-window LID, top-2 fallback deferred, session memory, formatting vs lexical prompt split, script guardrail, weak-supervision from edit behavior, `large-v3-v20240930_turbo` right choice, FLEURS + Common Voice + user feedback as the three pillars of QA.
+
+## Rules and gotchas to respect
+
+- `@preconcurrency import WhisperKit` required wherever the module is used
+- No em-dashes or en-dashes in code comments, docs, or UI copy
+- `nonisolated(unsafe)` for cross-actor audio buffers
+- `.contentShape(Rectangle())` on any new plain-style buttons
+- `SettingsManager` uses per-key `didSet` + `onChange?(.key)` pattern
+- XPC boundary: language setting is passed through `TranscriptionOptions.language`; detector call site is host-process (`WhisperKitPipeline`), not the XPC service process, because detection needs audio samples that live on the host side
+- Never log API keys, Bluetooth-specific audio paths need `AVCaptureSessionSource` (unaffected here but keep in mind for testing)
+- Every `swift build -c release` + bundle step after code edits; never test via `.build/debug` alone


### PR DESCRIPTION
## Summary

Ships Multilingual v1 (epic #242) with the two ship blockers resolved:

- **#249 LID accuracy**: `LanguageDetector` now uses majority-vote aggregation on WhisperKit's single-entry `langProbs` (discovered empirically: it contains only the greedily-sampled argmax token with its log-prob, not a distribution). The old `softmaxFromLogProbs` always collapsed to `{lang: 1.0}`, making confidence/margin structurally meaningless and letting anti-flap rule on noise alone.
- **#250 CJK polish length gate**: Polish no longer short-circuits on long CJK transcripts. Language-aware gate uses char count for unsegmented scripts (ja/zh/th/lo/my/km) and word count for everything else, including Korean (which IS whitespace-segmented via Eojeol).

Plus W1–W6 workstreams from the prior commits on this branch (99-language Auto toggle + Lock sheet, LanguageDetector actor, prompt rearchitecture, WhisperKit large-v3 turbo swap, FLEURS/Common Voice eval harness, six PostHog telemetry events).

## Key design changes in LanguageDetector

- Vote share (how many windows agreed) and mean exp(logProb) (per-window confidence) are kept as **separate signals**, not collapsed into a composite. The classifier consumes `meanProb` as `topProb` and vote-share gap as `margin`, so per-window confidence isn't diluted by vote share.
- **Single-shot switch bypass**: if all windows unanimously agree and winning mean prob >= normalProb (0.65), bypass the two-utterance anti-flap. Prevents first-switch hallucination on clean non-preferred audio without weakening flip-flop protection.
- **Session-prior rescue**: gated on preferred having at least plurality vote — cannot overturn a clear vote majority. Reported confidence + `memory.recordAccepted` use raw (un-boosted) meanProb.
- **Window dedupe**: short clips (<3s) no longer get counted multiple times when fixed windows and the full-window range coincide.

## UAT evidence

8-language regression via native macOS `say` voices (Samantha, Thomas, Alice, Lekha, Vani, Tingting, Yuna, Kyoko) from a freshly reset session memory:

| Lang | Voice | LID | Tier | Conf | Margin | Raw ASR |
|------|-------|-----|------|------|--------|---------|
| en | Samantha | en | highAuto | 0.99–1.00 | 1.00 | correct |
| fr | Thomas | fr | highAuto | 1.00 | 1.00 | correct |
| it | Alice | it | highAuto | 1.00 | 1.00 | **correct** (was hallucinating English) |
| hi | Lekha | hi | highAuto | 0.93 | 1.00 | correct Devanagari |
| ta | Vani | ta | mediumAuto | 0.68–0.73 | 1.00 | correct Tamil |
| zh | Tingting | zh | highAuto | 0.99 | 1.00 | correct |
| ko | Yuna | ko | highAuto | 1.00 | 1.00 | correct |
| ja | Kyoko | ja | highAuto | 1.00 | 1.00 | correct |

Confidences now **vary meaningfully** (0.68–1.00) as spec required, not uniformly 1.00. CJK polish fires on all ja/zh long transcripts; Korean still polishes via word-count path (12 Eojeol words > 3-word minimum).

## Codex review trail

Ran `codex review --uncommitted` four times. Fixed every validated finding:

- Pass 1: (1) Non-unanimous switch-away was unreachable under composite scoring. (2) singleShot check was placed after `meetsSwitchBar` returned preferred. (3) Korean misclassified as unsegmented. **All three fixed.**
- Pass 2: (1) classify() received vote-share-diluted topProb; session elevation broken. **Fixed by separating signals.**
- Pass 3: (1) Session-prior boost could overturn a vote majority via `max(voteMargin, probMargin)`. (2) Short clips counted twice in vote aggregation. **Both fixed.**
- Pass 4: Claimed WhisperKit populates langProbs with all languages. **Dismissed as false positive** — validated against WhisperKit `TextDecoder.swift:698-704` (iterates over sampled tokens, GreedyTokenSampler returns single token for LID) and runtime diagnostic (`count=1` in every window of 5+ test utterances).

## Architecture DoD

- **Module placement**: `LanguageDetector` stays in `EnviousWisprASR` (calls WhisperKit directly); `MultiWindowLID` is nested inside the actor as internal. `LanguageTypes` + `LanguageScriptGuardrail` additions stay in `EnviousWisprCore`. `LLMPolishStep` change stays in `EnviousWisprPipeline`. No dependency direction change.
- **Heart protection**: detector still never throws — all error paths abstain and let WhisperKit's own transcribe fallback run. Polish short-circuit falls through to original text.
- **No new god objects.** AppState unchanged.
- **Access control**: `MultiWindowLID` is internal; `unsegmentedScriptLanguages` + `isUnsegmentedScript` are public mirroring the existing `nonLatinScriptLanguages` / `isNonLatinScript` cross-module pattern.

## Test plan

- [x] 250 tests pass (`scripts/swift-test.sh`)
- [x] Clean release build
- [x] 8-language runtime UAT via native voices
- [x] 4 codex review passes, all findings validated + fixed or dismissed with reasoning
- [x] Periphery scan: no new dead-code findings beyond pre-existing pattern-consistent public modifiers
- [ ] CI green on merge
