### PR TITLE
docs(ui): What's New entries for v1.9.2 (multilingual + AI polish language gate)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -30,6 +30,22 @@ enum WhatsNewContent {
         // MARK: - v1.9.2
 
         Entry(
+            id: "multilingual-auto-detect",
+            icon: "globe",
+            title: "Dictate in 99 languages",
+            description: "EnviousWispr now auto-detects the language you are speaking and transcribes accordingly. German, Japanese, Arabic, Tamil, Mandarin and 95 others work out of the box with no setting change needed.",
+            category: .newFeatures,
+            version: "1.9.2"
+        ),
+        Entry(
+            id: "apple-intelligence-multilingual",
+            icon: "sparkles",
+            title: "Apple Intelligence polish stays in your language",
+            description: "AI polish with Apple Intelligence now preserves the language you spoke in. German stays German, Korean stays Korean. Languages Apple Intelligence cannot handle are quietly skipped so you always get your raw transcript instead of a silent failure.",
+            category: .smarterAIPolish,
+            version: "1.9.2"
+        ),
+        Entry(
             id: "whisperkit-full-capture",
             icon: "text.badge.checkmark",
             title: "WhisperKit captures every word",

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
     /// Bump when bundled What's New content changes in a user-visible way.
-    public static let currentContentVersion = "1.9.1"
+    public static let currentContentVersion = "1.9.2"
 
     /// UserDefaults key for the last content version the user has viewed.
     public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Two user-visible v1.9.2 entries plus WhatsNewConstants bump to 1.9.2 (per whats-new-protocol hard gate).

- **Multilingual dictation** (#257 follow-up): 99-language auto-detect user-facing description
- **Apple Intelligence language-aware polish** (#259 follow-up): describes the de/ko translation fix + silent-skip for unsupported languages

## Test plan

- [x] `swift build -c release` exit 0
- [x] Zero em-dashes / en-dashes
- [x] Content version (1.9.2) matches intended release tag
- [ ] Rebuild + launch + visual spot check of What's New tab (deferred to release checklist skill)
