### PR TITLE
chore(release): bump version to 1.9.2

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.1</string>
+	<string>1.9.2</string>
 	<key>CFBundleVersion</key>
-	<string>1.9.1</string>
+	<string>1.9.2</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary

Version bump for v1.9.2 tagged release. Info.plist CFBundleShortVersionString + CFBundleVersion → 1.9.2. Preceded by What's New content bump (#260, already merged).

## Shipped in 1.9.2

- #257 multilingual v1: 99-language auto-detect, LID accuracy, CJK polish
- #259 Apple Intelligence polish language gate: translation hallucinations eliminated on de/ko, clean preflight skip for ar/he/ru/uk/pl/th/ta
- #260 What's New entries

## Test plan

- [x] 270 tests pass
- [x] `swift build -c release` exit 0
- [x] WhatsNewConstants currentContentVersion = 1.9.2 (matches Info.plist)
- [ ] Tag v1.9.2 pushed from main post-merge (triggers release.yml)
