### PR TITLE
feat(website): Terms of Service page + accurate BSL licensing

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -24,6 +24,8 @@ const CORE_PAGE_DATES = {
   'https://enviouswispr.com/compare/notta/': '2026-04-04',
   'https://enviouswispr.com/compare/google-docs-voice-typing/': '2026-04-04',
   'https://enviouswispr.com/compare/otter-ai/': '2026-04-04',
+  'https://enviouswispr.com/privacy-policy/': '2026-04-10',
+  'https://enviouswispr.com/terms-of-service/': '2026-04-12',
 };
 
 // Build a URL→pubDate map by reading blog post frontmatter at config time.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,8 +12,10 @@
         "@astrojs/sitemap": "^3.7.1",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/plus-jakarta-sans": "^5.2.8",
-        "astro": "^6.0.2",
-        "wrangler": "^4.73.0"
+        "astro": "^6.0.2"
+      },
+      "devDependencies": {
+        "wrangler": "^4.81.1"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -75,12 +77,12 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.17.tgz",
-      "integrity": "sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "5.4.1",
+        "fast-xml-parser": "^5.5.7",
         "piccolore": "^0.1.3",
         "zod": "^4.3.6"
       }
@@ -195,15 +197,17 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -215,10 +219,96 @@
         }
       }
     },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260409.1.tgz",
+      "integrity": "sha512-h/bkaC0HJL63aqAGnV0oagqpBiTSstabODThkeMSbG8kctl0Jb4jlq1pNHJPmYGazFNtfyagrUZFb6HN22GX7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HTAC+B9uSYcm+GjN3UYJjuun19GqYtK1bAFJ0KECXyfsgIDwH1MTzxbTxzJpZUbWLw8s0jcwCU06MWZj6cgnxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260409.1.tgz",
+      "integrity": "sha512-QIoNq5cgmn1ko8qlngmgZLXQr2KglrjvIwVFOyJI3rbIpt8631n/YMzHPiOWgt38Cb6tcni8fXOzkcvIX2lBDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HJGBMTfPDb0GCjwdxWFx63wS20TYDVmtOuA5KVri/CiFnit71y++kmseVmemjsgLFFIzoEAuFG/xUh1FJLo6tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260409.1.tgz",
+      "integrity": "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -675,6 +765,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1140,6 +1231,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1155,6 +1247,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1171,6 +1264,7 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -1180,6 +1274,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -1191,6 +1286,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
@@ -1644,6 +1740,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1653,9 +1750,10 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
-      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/@types/debug": {
@@ -1893,6 +1991,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -2165,6 +2264,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2296,6 +2396,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2379,9 +2480,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
-      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -2390,13 +2491,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.2"
+        "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
+      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
       "funding": [
         {
           "type": "github",
@@ -2405,8 +2506,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.4.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2780,6 +2882,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3628,6 +3731,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/miniflare": {
+      "version": "4.20260409.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260409.0.tgz",
+      "integrity": "sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260409.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3840,9 +3964,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
-      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -3858,12 +3982,14 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/piccolore": {
@@ -4252,6 +4378,7 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4388,9 +4515,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -4403,6 +4530,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4542,12 +4670,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.3.tgz",
+      "integrity": "sha512-vTLEG/ceXgu/dMTQ8uNE2zgl7I7qEkx9l9tkz2H802AkgbBMvbmHMu4YqsrpGbUAMYKSQhCbmjsWMAeGu1dYXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -4560,6 +4689,7 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -4857,9 +4987,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -4968,144 +5098,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/wrangler": {
-      "version": "4.73.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.73.0.tgz",
-      "integrity": "sha512-VJXsqKDFCp6OtFEHXITSOR5kh95JOknwPY8m7RyQuWJQguSybJy43m4vhoCSt42prutTef7eeuw7L4V4xiynGw==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.15.0",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260312.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260312.1"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260312.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260312.1.tgz",
-      "integrity": "sha512-HUAtDWaqUduS6yasV6+NgsK7qBpP1qGU49ow/Wb117IHjYp+PZPUGReDYocpB4GOMRoQlvdd4L487iFxzdARpw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260312.1.tgz",
-      "integrity": "sha512-DOn7TPTHSxJYfi4m4NYga/j32wOTqvJf/pY4Txz5SDKWIZHSTXFyGz2K4B+thoPWLop/KZxGoyTv7db0mk/qyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260312.1.tgz",
-      "integrity": "sha512-TdkIh3WzPXYHuvz7phAtFEEvAxvFd30tHrm4gsgpw0R0F5b8PtoM3hfL2uY7EcBBWVYUBtkY2ahDYFfufnXw/g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260312.1.tgz",
-      "integrity": "sha512-kNauZhL569Iy94t844OMwa1zP6zKFiL3xiJ4tGLS+TFTEfZ3pZsRH6lWWOtkXkjTyCmBEOog0HSEKjIV4oAffw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260312.1.tgz",
-      "integrity": "sha512-5dBrlSK+nMsZy5bYQpj8t9iiQNvCRlkm9GGvswJa9vVU/1BNO4BhJMlqOLWT24EmFyApZ+kaBiPJMV8847NDTg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/miniflare": {
-      "version": "4.20260312.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.0.tgz",
-      "integrity": "sha512-pieP2rfXynPT6VRINYaiHe/tfMJ4c5OIhqRlIdLF6iZ9g5xgpEmvimvIgMpgAdDJuFlrLcwDUi8MfAo2R6dt/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.18.2",
-        "workerd": "1.20260312.1",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260312.1.tgz",
-      "integrity": "sha512-nNpPkw9jaqo79B+iBCOiksx+N62xC+ETIfyzofUEdY3cSOHJg6oNnVSHm7vHevzVblfV76c8Gr0cXHEapYMBEg==",
+    "node_modules/workerd": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260409.1.tgz",
+      "integrity": "sha512-kuWP20fAaqaLBqLbvUfY9nCF6c3C78L60G9lS6eVwBf+v8trVFIsAdLB/FtrnKm7vgVvpDzvFAfB80VIiVj95w==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5115,17 +5112,53 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260312.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260312.1",
-        "@cloudflare/workerd-linux-64": "1.20260312.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260312.1",
-        "@cloudflare/workerd-windows-64": "1.20260312.1"
+        "@cloudflare/workerd-darwin-64": "1.20260409.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260409.1",
+        "@cloudflare/workerd-linux-64": "1.20260409.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260409.1",
+        "@cloudflare/workerd-windows-64": "1.20260409.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.81.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.81.1.tgz",
+      "integrity": "sha512-fppPXi+W2KJ5bx1zxdUYe1e7CHj5cWPFVBPXy8hSMZhrHeIojMe3ozAktAOw1voVuQjXzbZJf/GVKyVeSjbF8w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260409.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260409.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260409.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5174,6 +5207,7 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -5187,6 +5221,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,9 @@
     "@astrojs/sitemap": "^3.7.1",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/plus-jakarta-sans": "^5.2.8",
-    "astro": "^6.0.2",
-    "wrangler": "^4.73.0"
+    "astro": "^6.0.2"
+  },
+  "devDependencies": {
+    "wrangler": "^4.81.1"
   }
 }

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -52,6 +52,7 @@ const year = new Date().getFullYear();
     <div class="footer-bottom">
       &copy; {year} Envious Labs. BSL Licensed. &nbsp;&middot;&nbsp;
       <a href="/privacy-policy/" style="color:inherit;text-decoration:none;border-bottom:1px solid rgba(138,43,226,0.15);">Privacy Policy</a> &nbsp;&middot;&nbsp;
+      <a href="/terms-of-service/" style="color:inherit;text-decoration:none;border-bottom:1px solid rgba(138,43,226,0.15);">Terms of Service</a> &nbsp;&middot;&nbsp;
       <a href="/contact/" style="color:inherit;text-decoration:none;border-bottom:1px solid rgba(138,43,226,0.15);">Contact</a>
     </div>
   </div>

--- a/website/src/pages/privacy-policy.astro
+++ b/website/src/pages/privacy-policy.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="Privacy Policy — EnviousWispr"
+  title="Privacy Policy: EnviousWispr"
   description="EnviousWispr privacy policy. All transcription happens on-device. No audio leaves your Mac."
   activePage="privacy-policy"
   canonicalPath="/privacy-policy/"

--- a/website/src/pages/terms-of-service.astro
+++ b/website/src/pages/terms-of-service.astro
@@ -1,0 +1,172 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Terms of Service: EnviousWispr",
+  "description": "EnviousWispr terms of service. License, warranty, liability, and acceptable use for the EnviousWispr macOS dictation app.",
+  "url": "https://enviouswispr.com/terms-of-service/",
+  "inLanguage": "en-US",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "EnviousWispr",
+    "url": "https://enviouswispr.com",
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs LLC",
+    "url": "https://enviouswispr.com",
+  },
+};
+---
+
+<BaseLayout
+  title="Terms of Service: EnviousWispr"
+  description="EnviousWispr terms of service. License, warranty, liability, and acceptable use for the EnviousWispr macOS dictation app."
+  activePage="terms-of-service"
+  canonicalPath="/terms-of-service/"
+>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+
+  <div class="legal-page">
+    <a href="/" class="back-link">&larr; Back to home</a>
+
+    <h1>Terms of Service</h1>
+    <p class="effective-date"><strong>Effective date: April 12, 2026</strong></p>
+
+    <p>Welcome to EnviousWispr. These Terms of Service (the "Terms") are a legal agreement between you and Envious Labs LLC, a New York limited liability company ("Envious Labs," "we," "us," or "our"). They govern your use of the EnviousWispr desktop application for macOS (the "App") and the website at enviouswispr.com (the "Site"). By downloading, installing, or using the App or the Site, you agree to these Terms.</p>
+
+    <p>If you do not agree to these Terms, do not download or use the App.</p>
+
+    <h2>1. The App</h2>
+    <p>EnviousWispr is a voice-to-text dictation application for Apple Silicon Macs running macOS 14 or later. The App performs speech-to-text processing on your device using Apple Silicon neural accelerators and third-party speech models. The App may provide additional features such as AI polish, dictation modes, a personal dictionary, and integrations with other apps.</p>
+    <p>We may change, add, or remove features over time. We may offer free and paid tiers. If we introduce a paid tier, we will not retroactively disable features or move features that were previously free into a paid tier for the specific version of the App you have already installed; new releases may change the set of features included in the free tier.</p>
+
+    <h2>2. License to Use the App</h2>
+    <p>Subject to these Terms, Envious Labs grants you a limited, non-exclusive, non-transferable, revocable license to download, install, and use the compiled, distributed binary of the App on Apple Silicon Macs that you own or control, for your personal use or your organization's internal business use. This license covers the distributed binary only. The underlying source code of EnviousWispr is made available under a separate source-available license (see Section 3).</p>
+    <p>You may not:</p>
+    <ul>
+      <li>Rent, lease, sell, sublicense, or transfer the App or these license rights,</li>
+      <li>Remove or alter any copyright, trademark, or proprietary notices in the App,</li>
+      <li>Use the App in a way that violates these Terms, applicable law, or the rights of any third party.</li>
+    </ul>
+
+    <h2>3. Source Code License</h2>
+    <p>The source code of EnviousWispr is published in the EnviousWispr repository on <a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener">GitHub</a> under a source-available license. The source code is licensed under the Business Source License 1.1 (the "BSL") as set out in the repository's LICENSE file. The BSL permits viewing, modifying, and non-commercial use of the source code under the terms specified in the LICENSE file; it is not an open-source license as defined by the Open Source Initiative. In the event of a conflict between these Terms and the BSL with respect to the source code, the BSL controls as to the source code.</p>
+    <p>These Terms continue to govern the distributed binary of the App, the EnviousWispr brand, name, and logos, the Site, and any services we offer in connection with the App.</p>
+
+    <h2>4. Your Content</h2>
+    <p>EnviousWispr processes your speech on your device and produces text output ("Your Content"). Your Content belongs to you. <strong>Envious Labs does not collect, upload, or store your audio or your transcripts on our servers, and does not use Your Content, your audio, or your transcripts to train any machine-learning model.</strong> The App may store transcription history locally on your device as a convenience to you; you can delete that history at any time through the App's settings.</p>
+
+    <h2>5. Privacy</h2>
+    <p>The App is designed to operate without user accounts, without requiring sign-in, and without sending your speech or transcripts to our servers. The App may make limited, outbound network requests for purposes such as checking for software updates, downloading or updating on-device models, or loading content on the Site. We describe these requests and any analytics the App may emit in our <a href="/privacy-policy/">Privacy Policy</a>.</p>
+
+    <h2>6. Third-Party Components</h2>
+    <p>The App is built on top of, and depends on, third-party frameworks and libraries, including Apple frameworks and open-source speech models. Those components are provided under their own licenses, which you can review in the App's About screen or in the source repository. You are responsible for complying with the terms of any third-party license that applies to any optional models, plugins, or components you choose to download, install, or use with the App. Envious Labs is not responsible for the performance, availability, or licensing of third-party components beyond our reasonable control.</p>
+
+    <h2>7. Acceptable Use</h2>
+    <p>You agree not to use the App or the Site to:</p>
+    <ul>
+      <li>Violate any applicable law, including laws governing recording, wiretapping, or consent to record,</li>
+      <li>Transcribe the speech of another person without that person's knowledge or consent where such consent is required by law,</li>
+      <li>Reverse engineer, decompile, or disassemble the distributed binary of the App, except to the extent (and only to the extent) that applicable law permits such activity,</li>
+      <li>Interfere with the normal operation of the App, the Site, or any services we offer, including by probing or testing them for vulnerabilities outside a published security program,</li>
+      <li>Misrepresent your affiliation with Envious Labs or claim to be an authorized distributor of the App.</li>
+    </ul>
+
+    <h2>8. Updates; Availability</h2>
+    <p>We may release updates to the App from time to time. Updates may add, change, or remove features, fix bugs, or address security issues. We are not obligated to support any specific version of the App or to keep any version available indefinitely. We may discontinue the App at any time.</p>
+
+    <h2>9. Warranty Disclaimer; AI Output Risks</h2>
+    <p>THE APP, THE SITE, AND ANY RELATED SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY LAW, ENVIOUS LABS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY WARRANTY ARISING FROM COURSE OF DEALING OR TRADE USAGE. WE DO NOT WARRANT THAT THE APP WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, ACCURATE, OR SUITABLE FOR ANY PARTICULAR PURPOSE, OR THAT TRANSCRIPTIONS WILL BE ACCURATE OR COMPLETE.</p>
+    <p>THE APP USES ARTIFICIAL INTELLIGENCE AND MACHINE LEARNING MODELS THAT MAY PRODUCE INACCURATE, INCOMPLETE, BIASED, OFFENSIVE, OR NONSENSICAL TRANSCRIPTIONS OR POLISH OUTPUTS, INCLUDING "HALLUCINATED" CONTENT NOT PRESENT IN YOUR SPEECH. YOU ARE SOLELY RESPONSIBLE FOR REVIEWING, VERIFYING, AND EDITING ALL OUTPUT BEFORE RELYING ON, FORWARDING, PUBLISHING, SUBMITTING, OR ACTING ON IT. THE APP IS NOT DESIGNED OR INTENDED FOR USE IN MEDICAL, LEGAL, FINANCIAL, REGULATORY, OR LIFE-SAFETY DICTATION OR RECORD-KEEPING, AND ENVIOUS LABS DISCLAIMS ALL RESPONSIBILITY FOR ANY SUCH USE.</p>
+
+    <h2>10. Limitation of Liability</h2>
+    <p>TO THE FULLEST EXTENT PERMITTED BY LAW, IN NO EVENT WILL ENVIOUS LABS, ITS MEMBERS, OFFICERS, EMPLOYEES, CONTRACTORS, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR RELATED TO YOUR USE OF THE APP OR THE SITE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+    <p>ENVIOUS LABS' TOTAL LIABILITY UNDER THESE TERMS, WHETHER IN CONTRACT, TORT, OR OTHERWISE, IS LIMITED TO THE GREATER OF (A) THE AMOUNT YOU PAID TO ENVIOUS LABS FOR THE APP OR THE APPLICABLE SERVICE IN THE TWELVE (12) MONTHS BEFORE THE CLAIM AROSE, OR (B) ONE HUNDRED U.S. DOLLARS ($100.00).</p>
+    <p>Some jurisdictions do not allow the exclusion or limitation of certain damages. In those jurisdictions, our liability is limited to the maximum extent permitted by law.</p>
+
+    <h2>11. Indemnification</h2>
+    <p>You agree to defend, indemnify, and hold harmless Envious Labs and its members, officers, employees, and contractors from any claims, damages, liabilities, costs, and expenses (including reasonable attorneys' fees) arising out of or related to (a) your use of the App or the Site, (b) your violation of these Terms, or (c) your violation of any law or third-party right, including in connection with your use of the App to record or transcribe the speech of others.</p>
+
+    <h2>12. Termination</h2>
+    <p>These Terms remain in effect while you use the App or the Site. You may stop using the App at any time; your license under these Terms terminates when you stop using the App. We may suspend or terminate your license if you materially breach these Terms. Sections 3 (open source carve-out), 4 (your content ownership), 9 (warranty disclaimer), 10 (limitation of liability), 11 (indemnification), and 14 (miscellaneous) survive termination.</p>
+
+    <h2>13. Changes to These Terms</h2>
+    <p>We may update these Terms from time to time. The effective date at the top of the Terms indicates when they were last revised. Material changes will be announced on the Site or in the App. Your continued use of the App or the Site after the effective date of revised Terms constitutes acceptance of the revised Terms.</p>
+
+    <h2>14. Miscellaneous</h2>
+    <p><strong>(a) Governing Law and Venue.</strong> These Terms are governed by the laws of the State of New York, without regard to its conflict of laws rules. Any dispute arising under these Terms will be brought exclusively in the state or federal courts located in New York County, New York, except that (i) either party may seek injunctive or equitable relief in any court of competent jurisdiction, and (ii) either party may bring a qualifying claim in any small claims court of competent jurisdiction.</p>
+    <p><strong>(b) Export Control.</strong> You agree not to export or re-export the App in violation of any applicable U.S. export control laws. You represent that you are not located in, and are not a resident or national of, any country subject to a U.S. Government embargo or designated by the U.S. Government as a "terrorist-supporting" country, and that you are not listed on any U.S. Government list of prohibited or restricted parties (including the Treasury Department's Specially Designated Nationals list and the Commerce Department's Denied Persons, Entity, or Unverified Lists).</p>
+    <p><strong>(c) Assignment.</strong> You may not assign these Terms without our prior written consent. We may assign these Terms freely, including to an affiliate or in connection with a merger, acquisition, or sale of substantially all of our assets.</p>
+    <p><strong>(d) Third-Party Beneficiaries; Apple.</strong> Except as provided in this Section 14(d), these Terms do not create any rights in any third party. If you obtain the App through the Apple App Store, you acknowledge that Apple Inc. and its subsidiaries are third-party beneficiaries of these Terms and have the right to enforce these Terms against you. Apple is not responsible for the App or these Terms, and Apple has no obligation to provide maintenance or support for the App.</p>
+    <p><strong>(e) Trademarks; DMCA.</strong> "Envious Labs," "EnviousWispr," and related names, logos, and marks are trademarks of Envious Labs LLC. No rights to these marks are granted except as necessary to identify the App. Copyright takedown notices under the Digital Millennium Copyright Act may be sent to hello@enviouslabs.co, Attn: DMCA Agent, Envious Labs LLC, 9 High Plains Rd, Shelton, CT 06484.</p>
+    <p><strong>(f) Severability.</strong> If any provision is found unenforceable, the remaining provisions will remain in full force and effect.</p>
+    <p><strong>(g) Entire Agreement.</strong> These Terms, together with the Privacy Policy and the BSL applicable to the source code, constitute the entire agreement between you and Envious Labs regarding the App and the Site, and supersede all prior agreements and understandings.</p>
+    <p><strong>(h) Contact.</strong> Questions about these Terms? Email <strong>hello@enviouswispr.com</strong>.</p>
+
+    <hr>
+
+    <p>
+      <strong>Envious Labs LLC</strong><br>
+      9 High Plains Rd, Shelton, CT 06484<br>
+      hello@enviouswispr.com
+    </p>
+  </div>
+
+  <style>
+    .legal-page {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 120px 24px 80px;
+      position: relative;
+      z-index: 1;
+      font-family: var(--font-body, system-ui, -apple-system, sans-serif);
+      color: var(--text, #1a1a1a);
+      line-height: 1.7;
+    }
+    .legal-page h1 {
+      font-family: var(--font-display, var(--font-body, system-ui));
+      font-size: 2.25rem;
+      margin: 0 0 0.5rem;
+      letter-spacing: -0.01em;
+    }
+    .legal-page h2 {
+      font-size: 1.25rem;
+      margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.005em;
+    }
+    .legal-page p,
+    .legal-page li {
+      font-size: 0.95rem;
+      margin-bottom: 0.9rem;
+    }
+    .legal-page ul {
+      margin: 0 0 1.1rem 1.5rem;
+    }
+    .legal-page a {
+      color: var(--accent, #8a2be2);
+    }
+    .legal-page .effective-date {
+      color: var(--muted, #666);
+      margin-bottom: 1.5rem;
+    }
+    .legal-page hr {
+      border: 0;
+      border-top: 1px solid rgba(0, 0, 0, 0.08);
+      margin: 2.5rem 0 1.5rem;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 32px;
+      color: var(--accent, #8a2be2);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+  </style>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Prior session drafted a Terms of Service page that incorrectly called EnviousWispr "open source" five times. Actual license is **Business Source License 1.1** (source-available, not open source). Shipping the page with accurate language.

## Changes

- **New page**: `/terms-of-service/` (license, warranty, liability, NY governing law, Apple App Store clause, DMCA agent, export control)
- **Accurate licensing language**: Section 3 renamed "Source Code License", BSL 1.1 cited with explicit note that it is not OSI-open-source. Sections 1, 2, 14(g) updated.
- **Footer**: Terms of Service link added alongside Privacy Policy
- **Sitemap**: both legal pages registered in astro.config.mjs CORE_PAGE_DATES with lastmod dates
- **Dep hygiene**: wrangler moved to devDependencies, bumped 4.73.0 → 4.81.1 (unrelated, ride-along)
- **Style**: em-dash in page titles replaced with colon (both legal pages), per project content rule

## Address

"9 High Plains Rd, Shelton, CT 06484" matches the existing privacy-policy.astro contact info. NY LLC formation with CT mailing address is a legitimate pattern; no change needed.

## Test plan

- [x] `npm run build` clean, 42 pages generated
- [x] `/terms-of-service/` and `/privacy-policy/` both build
- [x] Footer link renders
- [x] No em-dashes in new or modified content (legacy Termly-generated em-dashes in privacy-policy body are out of scope)
- [x] Zero `error:` in build output
