### PR TITLE
docs(readme): correct Envious Labs link to enviouslabs.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ EnviousWispr is built on a simple principle: **your voice is yours.**
 - **X:** [@EnviousLabs](https://x.com/EnviousLabs)
 - **Email:** hello@enviouswispr.com
 
-Built by [Envious Labs](https://enviouslabs.com)
+Built by [Envious Labs](https://enviouslabs.co)
 
 ## License
 


### PR DESCRIPTION
Small fix — README linked to enviouslabs.com which we do not own. Correcting to enviouslabs.co. Docs-only change, no impact on build or site.