### PR TITLE
feat(llm): diagnostic logging for cold-start polish timeouts (#266)

### DIFF
--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -59,11 +59,20 @@ public struct GeminiConnector: TranscriptPolisher {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         request.timeoutInterval = 60
 
+        // Allocate the call number once per logical polish. Retries reuse the
+        // same number so logs never mistake a retried polish for multiple
+        // independent calls (see Codex review finding P3).
+        let callNumber = LLMNetworkSession.shared.nextCallNumber()
+
         return try await performWithRetry(config: config) {
             if let onToken {
-                return try await self.polishStreaming(request: request, config: config, onToken: onToken)
+                return try await self.polishStreaming(
+                    request: request, config: config, callNumber: callNumber, onToken: onToken
+                )
             } else {
-                return try await self.polishBatch(request: request, config: config)
+                return try await self.polishBatch(
+                    request: request, config: config, callNumber: callNumber
+                )
             }
         }
     }
@@ -97,59 +106,94 @@ public struct GeminiConnector: TranscriptPolisher {
     private func polishStreaming(
         request: URLRequest,
         config: LLMProviderConfig,
+        callNumber: Int,
         onToken: @Sendable (String) -> Void
     ) async throws -> LLMResult {
         let session = LLMNetworkSession.shared.session
-        let (stream, response) = try await session.bytes(for: request)
+        let collector = LLMTaskMetricsCollector()
+        var statusForLog = "pending"
+        defer {
+            let line = LLMTaskMetricsCollector.format(
+                provider: "gemini", model: config.model, callNumber: callNumber,
+                status: statusForLog, metrics: collector.metrics
+            )
+            Task { await AppLogger.shared.log(line, level: .info, category: "LLM") }
+        }
+
+        let stream: URLSession.AsyncBytes
+        let response: URLResponse
+        do {
+            (stream, response) = try await session.bytes(for: request, delegate: collector)
+        } catch {
+            statusForLog = "error:\(Self.shortError(error))"
+            throw error
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
+            statusForLog = "error:non_http_response"
             throw LLMError.requestFailed("Invalid response")
         }
+        statusForLog = String(httpResponse.statusCode)
 
-        // For streaming, non-200 means the entire response is an error body
-        if httpResponse.statusCode != 200 {
-            var errorBody = ""
+        // From here on the stream may throw (mid-response timeout, disconnect,
+        // cancellation). Capture that outcome in statusForLog before the defer
+        // fires so the diagnostic does not record a mid-stream failure as a
+        // successful 200 (Codex review finding P2).
+        let fullText: String
+        let lastFinishReason: String?
+        do {
+            if httpResponse.statusCode != 200 {
+                var errorBody = ""
+                for try await line in stream.lines {
+                    errorBody += line
+                }
+                try handleHTTPError(statusCode: httpResponse.statusCode, body: errorBody)
+            }
+
+            var text = ""
+            var finishReason: String?
+
             for try await line in stream.lines {
-                errorBody += line
-            }
-            try handleHTTPError(statusCode: httpResponse.statusCode, body: errorBody)
-        }
+                // SSE format: lines prefixed with "data: " contain JSON
+                // Empty lines delimit events, lines starting with ":" are comments
+                guard line.hasPrefix("data: ") else { continue }
+                let jsonString = String(line.dropFirst(6))
 
-        var fullText = ""
-        var lastFinishReason: String?
+                guard let jsonData = jsonString.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                      let candidates = json["candidates"] as? [[String: Any]],
+                      let firstCandidate = candidates.first else {
+                    continue
+                }
 
-        for try await line in stream.lines {
-            // SSE format: lines prefixed with "data: " contain JSON
-            // Empty lines delimit events, lines starting with ":" are comments
-            guard line.hasPrefix("data: ") else { continue }
-            let jsonString = String(line.dropFirst(6))
-
-            guard let jsonData = jsonString.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-                  let candidates = json["candidates"] as? [[String: Any]],
-                  let firstCandidate = candidates.first else {
-                continue
-            }
-
-            // Extract text fragments from this chunk, skipping thought parts
-            if let content = firstCandidate["content"] as? [String: Any],
-               let parts = content["parts"] as? [[String: Any]] {
-                for part in parts {
-                    if part["thought"] as? Bool == true { continue }
-                    if let textFragment = part["text"] as? String {
-                        fullText += textFragment
-                        onToken(textFragment)
+                // Extract text fragments from this chunk, skipping thought parts
+                if let content = firstCandidate["content"] as? [String: Any],
+                   let parts = content["parts"] as? [[String: Any]] {
+                    for part in parts {
+                        if part["thought"] as? Bool == true { continue }
+                        if let textFragment = part["text"] as? String {
+                            text += textFragment
+                            onToken(textFragment)
+                        }
                     }
                 }
-            }
 
-            // Check finishReason — present only in the final chunk
-            if let finishReason = firstCandidate["finishReason"] as? String {
-                lastFinishReason = finishReason
+                // Check finishReason — present only in the final chunk
+                if let reason = firstCandidate["finishReason"] as? String {
+                    finishReason = reason
+                }
             }
+            fullText = text
+            lastFinishReason = finishReason
+        } catch {
+            // Record the mid-stream failure so the metrics line reflects reality.
+            // The HTTP status was 200 at headers, but the body did not complete.
+            statusForLog = "error_after_\(httpResponse.statusCode):\(Self.shortError(error))"
+            throw error
         }
 
         guard !fullText.isEmpty else {
+            statusForLog = "error_after_\(httpResponse.statusCode):empty_response"
             throw LLMError.emptyResponse
         }
 
@@ -165,26 +209,58 @@ public struct GeminiConnector: TranscriptPolisher {
 
     private func polishBatch(
         request: URLRequest,
-        config: LLMProviderConfig
+        config: LLMProviderConfig,
+        callNumber: Int
     ) async throws -> LLMResult {
         let session = LLMNetworkSession.shared.session
-        let (data, response) = try await session.data(for: request)
+        let collector = LLMTaskMetricsCollector()
+        var statusForLog = "pending"
+        defer {
+            let line = LLMTaskMetricsCollector.format(
+                provider: "gemini", model: config.model, callNumber: callNumber,
+                status: statusForLog, metrics: collector.metrics
+            )
+            Task { await AppLogger.shared.log(line, level: .info, category: "LLM") }
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request, delegate: collector)
+        } catch {
+            statusForLog = "error:\(Self.shortError(error))"
+            throw error
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
+            statusForLog = "error:non_http_response"
             throw LLMError.requestFailed("Invalid response")
         }
+        statusForLog = String(httpResponse.statusCode)
 
-        if httpResponse.statusCode != 200 {
-            let body = String(data: data, encoding: .utf8) ?? ""
-            try handleHTTPError(statusCode: httpResponse.statusCode, body: body)
-        }
+        // Post-header failures (non-200 body, malformed JSON, empty candidates)
+        // must be reflected in statusForLog so the defer never records a
+        // successful-looking line for a failed call (Codex review finding P2).
+        let firstCandidate: [String: Any]
+        let parts: [[String: Any]]
+        do {
+            if httpResponse.statusCode != 200 {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                try handleHTTPError(statusCode: httpResponse.statusCode, body: body)
+            }
 
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let candidates = json?["candidates"] as? [[String: Any]],
-              let firstCandidate = candidates.first,
-              let content = firstCandidate["content"] as? [String: Any],
-              let parts = content["parts"] as? [[String: Any]] else {
-            throw LLMError.emptyResponse
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            guard let candidates = json?["candidates"] as? [[String: Any]],
+                  let candidate = candidates.first,
+                  let content = candidate["content"] as? [String: Any],
+                  let candidateParts = content["parts"] as? [[String: Any]] else {
+                throw LLMError.emptyResponse
+            }
+            firstCandidate = candidate
+            parts = candidateParts
+        } catch {
+            statusForLog = "error_after_\(httpResponse.statusCode):\(Self.shortError(error))"
+            throw error
         }
 
         // Filter out thought parts and join remaining text
@@ -239,6 +315,19 @@ public struct GeminiConnector: TranscriptPolisher {
         default:
             throw LLMError.requestFailed(Self.friendlyMessage(for: statusCode))
         }
+    }
+
+    /// Short error token for diagnostic log lines. Prefers URLError.code.rawValue
+    /// for network errors (e.g. -1001 for timeout, -1009 for offline); falls back
+    /// to the Swift type name. Never a full localized message.
+    fileprivate static func shortError(_ error: Error) -> String {
+        if let urlError = error as? URLError {
+            return "urlerror_\(urlError.code.rawValue)"
+        }
+        if error is CancellationError {
+            return "cancelled"
+        }
+        return "\(type(of: error))"
     }
 
     private static func friendlyMessage(for statusCode: Int) -> String {

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import EnviousWisprCore
 
 /// Singleton URLSession for LLM API requests.
@@ -11,6 +12,11 @@ public final class LLMNetworkSession: Sendable {
 
     public let session: URLSession
 
+    /// Per-process monotonic counter for polish calls. Increments from 1. Lets
+    /// diagnostic log lines distinguish the very first call after launch from
+    /// subsequent calls without carrying extra state.
+    private let callCounter = OSAllocatedUnfairLock<Int>(initialState: 0)
+
     private init() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 60
@@ -18,6 +24,14 @@ public final class LLMNetworkSession: Sendable {
         config.waitsForConnectivity = false
         config.networkServiceType = .responsiveData
         session = URLSession(configuration: config)
+    }
+
+    /// Returns the next process-wide polish call number (starting at 1).
+    func nextCallNumber() -> Int {
+        callCounter.withLock { n in
+            n += 1
+            return n
+        }
     }
 
     /// Pre-warm the connection to the given URL by sending a lightweight HEAD request.
@@ -28,8 +42,24 @@ public final class LLMNetworkSession: Sendable {
         request.httpMethod = "HEAD"
         request.timeoutInterval = 5
 
-        Task.detached {
-            _ = try? await self.session.data(for: request)
+        Task.detached { [session] in
+            let start = CFAbsoluteTimeGetCurrent()
+            do {
+                let (_, response) = try await session.data(for: request)
+                let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+                let status = (response as? HTTPURLResponse)?.statusCode.description ?? "n/a"
+                await AppLogger.shared.log(
+                    "preWarm completed url=\(url.absoluteString) duration_ms=\(ms) status=\(status)",
+                    level: .info, category: "LLM"
+                )
+            } catch {
+                let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+                await AppLogger.shared.log(
+                    "preWarm failed url=\(url.absoluteString) duration_ms=\(ms) "
+                        + "error=\(String(describing: error))",
+                    level: .info, category: "LLM"
+                )
+            }
         }
     }
 

--- a/Sources/EnviousWisprLLM/LLMTaskMetricsCollector.swift
+++ b/Sources/EnviousWisprLLM/LLMTaskMetricsCollector.swift
@@ -1,0 +1,80 @@
+import Foundation
+import os
+
+/// Captures URLSessionTaskMetrics for a single polish request and formats them
+/// into a grep-friendly diagnostic log line. Lives in LLM module; no behavior
+/// impact on the polish pipeline.
+///
+/// See docs/plans/llm-cold-start-diagnostics.md for field semantics and why
+/// the earliest network-load transaction is preferred over `transactionMetrics.last`.
+final class LLMTaskMetricsCollector: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let storage = OSAllocatedUnfairLock<URLSessionTaskMetrics?>(initialState: nil)
+
+    var metrics: URLSessionTaskMetrics? { storage.withLock { $0 } }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        storage.withLock { $0 = metrics }
+    }
+
+    /// Select the transaction most likely to carry the meaningful connection phases.
+    /// A first-hop redirect on a cold call leaves the last transaction reading
+    /// `reused=true` with DNS/TCP/TLS unmeasured, masking the slow leg. Prefer the
+    /// first transaction whose phase dates are populated (or whose fetchType is
+    /// .networkLoad); fall back to `first` if none match.
+    static func select(
+        _ transactions: [URLSessionTaskTransactionMetrics]
+    ) -> URLSessionTaskTransactionMetrics? {
+        guard !transactions.isEmpty else { return nil }
+        let match = transactions.first { tx in
+            tx.resourceFetchType == .networkLoad
+                || tx.domainLookupStartDate != nil
+                || tx.connectStartDate != nil
+                || tx.secureConnectionStartDate != nil
+        }
+        return match ?? transactions.first
+    }
+
+    /// Format a single diagnostic log line. Always emits. Callers must pass
+    /// `metrics: nil` on failure/timeout so we still get one line per call.
+    static func format(
+        provider: String,
+        model: String,
+        callNumber: Int,
+        status: String,
+        metrics: URLSessionTaskMetrics?
+    ) -> String {
+        let head = "task_metrics provider=\(provider) model=\(model) call=\(callNumber)"
+        guard let metrics, let tx = select(metrics.transactionMetrics) else {
+            let total = metrics.map { ms($0.taskInterval.duration) } ?? "n/a"
+            return "\(head) metrics_available=false reused=n/a dns_ms=n/a tcp_ms=n/a "
+                + "tls_ms=n/a req_ms=n/a resp_ms=n/a ttfb_ms=n/a total_ms=\(total) "
+                + "proto=n/a status=\(status)"
+        }
+
+        let dns = delta(tx.domainLookupStartDate, tx.domainLookupEndDate)
+        let tcp = delta(tx.connectStartDate, tx.connectEndDate)
+        let tls = delta(tx.secureConnectionStartDate, tx.secureConnectionEndDate)
+        let req = delta(tx.requestStartDate, tx.requestEndDate)
+        let resp = delta(tx.responseStartDate, tx.responseEndDate)
+        let ttfb = delta(tx.requestStartDate, tx.responseStartDate)
+        let total = ms(metrics.taskInterval.duration)
+        let proto = tx.networkProtocolName ?? "n/a"
+
+        return "\(head) metrics_available=true reused=\(tx.isReusedConnection) "
+            + "dns_ms=\(dns) tcp_ms=\(tcp) tls_ms=\(tls) req_ms=\(req) resp_ms=\(resp) "
+            + "ttfb_ms=\(ttfb) total_ms=\(total) proto=\(proto) status=\(status)"
+    }
+
+    private static func delta(_ start: Date?, _ end: Date?) -> String {
+        guard let start, let end else { return "n/a" }
+        return ms(end.timeIntervalSince(start))
+    }
+
+    private static func ms(_ seconds: TimeInterval) -> String {
+        String(Int((seconds * 1000).rounded()))
+    }
+}

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -99,6 +99,10 @@ public struct OpenAIConnector: TranscriptPolisher {
         maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
         delays: [UInt64] = LLMRetryPolicy.defaultDelays
     ) async throws -> (Data, HTTPURLResponse) {
+        // Allocate the call number once per logical polish. Retries reuse the
+        // same number so logs never mistake a retried polish for multiple
+        // independent calls (Codex review finding P3).
+        let callNumber = LLMNetworkSession.shared.nextCallNumber()
         var lastError: Error?
         for attempt in 0...maxRetries {
             if attempt > 0 {
@@ -110,11 +114,31 @@ public struct OpenAIConnector: TranscriptPolisher {
                 try await Task.sleep(nanoseconds: delay)
             }
 
+            let collector = LLMTaskMetricsCollector()
+            var statusForLog = "pending"
             do {
-                let (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
+                defer {
+                    let line = LLMTaskMetricsCollector.format(
+                        provider: "openai", model: config.model, callNumber: callNumber,
+                        status: statusForLog, metrics: collector.metrics
+                    )
+                    Task { await AppLogger.shared.log(line, level: .info, category: "LLM") }
+                }
+                let data: Data
+                let response: URLResponse
+                do {
+                    (data, response) = try await LLMNetworkSession.shared.session.data(
+                        for: request, delegate: collector
+                    )
+                } catch {
+                    statusForLog = "error:\(Self.shortError(error))"
+                    throw error
+                }
                 guard let httpResponse = response as? HTTPURLResponse else {
+                    statusForLog = "error:non_http_response"
                     throw LLMError.requestFailed("Invalid response")
                 }
+                statusForLog = String(httpResponse.statusCode)
                 switch httpResponse.statusCode {
                 case 200:
                     return (data, httpResponse)
@@ -139,11 +163,25 @@ public struct OpenAIConnector: TranscriptPolisher {
                     throw LLMError.requestFailed(Self.friendlyMessage(for: httpResponse.statusCode))
                 }
             } catch {
+                if statusForLog == "pending" {
+                    statusForLog = "error:\(Self.shortError(error))"
+                }
                 lastError = error
                 if !LLMRetryPolicy.isRetryable(error) { throw error }
             }
         }
         throw lastError ?? LLMError.requestFailed("All retries exhausted")
+    }
+
+    /// Short error token for diagnostic log lines. Mirrors GeminiConnector.shortError.
+    fileprivate static func shortError(_ error: Error) -> String {
+        if let urlError = error as? URLError {
+            return "urlerror_\(urlError.code.rawValue)"
+        }
+        if error is CancellationError {
+            return "cancelled"
+        }
+        return "\(type(of: error))"
     }
 
     private static func friendlyMessage(for statusCode: Int) -> String {

--- a/Tests/EnviousWisprTests/LLM/LLMTaskMetricsCollectorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMTaskMetricsCollectorTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import EnviousWisprLLM
+
+/// URLSessionTaskMetrics and URLSessionTaskTransactionMetrics have no public
+/// initializers, so we cannot hand-construct a populated metrics object in
+/// tests. The happy-path field ordering and value extraction is verified via
+/// UAT log inspection after rebuild.
+///
+/// What we CAN and MUST test is the failure path: the format helper must emit
+/// a single, well-formed line even when metrics are nil. That guarantee is the
+/// entire reason we added defer-based logging. Without it, a 5s timeout gives
+/// us the same empty signal we have today.
+@Suite("LLMTaskMetricsCollector.format")
+struct LLMTaskMetricsCollectorTests {
+
+    @Test("metrics=nil emits a full line with metrics_available=false and n/a phases")
+    func nilMetricsFallback() {
+        let line = LLMTaskMetricsCollector.format(
+            provider: "gemini",
+            model: "gemini-2.5-flash",
+            callNumber: 1,
+            status: "error:urlerror_-1001",
+            metrics: nil
+        )
+
+        // Required header fields
+        #expect(line.contains("task_metrics"))
+        #expect(line.contains("provider=gemini"))
+        #expect(line.contains("model=gemini-2.5-flash"))
+        #expect(line.contains("call=1"))
+
+        // Failure path markers
+        #expect(line.contains("metrics_available=false"))
+        #expect(line.contains("status=error:urlerror_-1001"))
+        #expect(line.contains("total_ms=n/a"))
+
+        // Every phase field present as n/a so grep never misses a field
+        #expect(line.contains("reused=n/a"))
+        #expect(line.contains("dns_ms=n/a"))
+        #expect(line.contains("tcp_ms=n/a"))
+        #expect(line.contains("tls_ms=n/a"))
+        #expect(line.contains("req_ms=n/a"))
+        #expect(line.contains("resp_ms=n/a"))
+        #expect(line.contains("ttfb_ms=n/a"))
+        #expect(line.contains("proto=n/a"))
+
+        // Single line, no embedded newlines
+        #expect(!line.contains("\n"))
+    }
+
+    @Test("call number is echoed verbatim, no zero-padding")
+    func callNumberFormatting() {
+        let line = LLMTaskMetricsCollector.format(
+            provider: "openai", model: "gpt-4o-mini", callNumber: 42,
+            status: "200", metrics: nil
+        )
+        #expect(line.contains("call=42"))
+        #expect(!line.contains("call=042"))
+    }
+
+    @Test("empty-transaction-list case selects nothing and returns nil")
+    func emptyTransactionsSelect() {
+        let selected = LLMTaskMetricsCollector.select([])
+        #expect(selected == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds diagnostic logging for issue #266 (first Gemini polish call sometimes times out at 5s). Not a fix — instrumentation that captures hard data when the bug next fires naturally. The three candidate fixes (real-warmup ping, IPv4 force, streaming overlay) will be chosen once we have phase-level numbers from a real timeout.

## What landed

- **LLMTaskMetricsCollector**: per-request URLSessionTaskDelegate + formatter. Emits one grep-friendly line per Gemini/OpenAI polish call.
- **Pre-warm completion logging**: duration, URL, HTTP status, error. No longer silent.
- **Per-process call counter** (`call=N`) with retry correctness: one number per logical polish, not per attempt.
- **Defer-based always-emit**: a metrics line fires on every termination path, including timeout/cancel/error.
- **Transaction selection**: earliest `networkLoad` transaction, not `.last` — avoids redirect masking.
- **Mid-stream error capture (Gemini SSE)**: if the stream breaks after 200 headers, `statusForLog` reflects the real failure.

## Review notes

- GPT-5 reviewed the plan before implementation; caught the transaction-selection and always-emit bugs.
- Gemini 2.5 Pro reviewed the plan; validated scope.
- Codex reviewed the code after implementation; caught two more bugs (P2 mid-stream status preservation, P3 call counter per retry). Both fixed.
- Periphery clean on the 5 new/changed files.

## Scope

`EnviousWisprLLM` only. Heart path unchanged. No new persisted state, no UI signals, no PostHog/Sentry egress (file + OSLog only). 283 tests pass including 3 new formatter tests.

## Test plan

- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` full suite green
- [x] Live UAT: fresh launch + Gemini dictation produced expected `call=1 reused=true` line with phase timings
- [x] Re-bundled after P2/P3 fixes + second UAT: `call=1 status=200 ttfb_ms=504` — no regression on happy path
- [x] Periphery clean on new code (pre-existing warnings unchanged)
- [ ] CI `build-check` green
