### PR TITLE
fix(llm): capture post-200 parse failures in diagnostic status (#266)

### DIFF
--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -238,11 +238,14 @@ public struct GeminiConnector: TranscriptPolisher {
         }
         statusForLog = String(httpResponse.statusCode)
 
-        // Post-header failures (non-200 body, malformed JSON, empty candidates)
-        // must be reflected in statusForLog so the defer never records a
-        // successful-looking line for a failed call (Codex review finding P2).
+        // Post-header failures (non-200 body, malformed JSON, empty candidates,
+        // all-thought response with zero text) must be reflected in statusForLog
+        // so the defer never records a successful-looking line for a failed
+        // call. The responseText empty-check is inside this do block because
+        // an all-thought response still throws LLMError.emptyResponse and would
+        // otherwise leak through with status=200.
         let firstCandidate: [String: Any]
-        let parts: [[String: Any]]
+        let responseText: String
         do {
             if httpResponse.statusCode != 200 {
                 let body = String(data: data, encoding: .utf8) ?? ""
@@ -256,20 +259,18 @@ public struct GeminiConnector: TranscriptPolisher {
                   let candidateParts = content["parts"] as? [[String: Any]] else {
                 throw LLMError.emptyResponse
             }
+            let text = candidateParts
+                .filter { $0["thought"] as? Bool != true }
+                .compactMap { $0["text"] as? String }
+                .joined()
+            guard !text.isEmpty else {
+                throw LLMError.emptyResponse
+            }
             firstCandidate = candidate
-            parts = candidateParts
+            responseText = text
         } catch {
             statusForLog = "error_after_\(httpResponse.statusCode):\(Self.shortError(error))"
             throw error
-        }
-
-        // Filter out thought parts and join remaining text
-        let responseText = parts
-            .filter { $0["thought"] as? Bool != true }
-            .compactMap { $0["text"] as? String }
-            .joined()
-        guard !responseText.isEmpty else {
-            throw LLMError.emptyResponse
         }
 
         logTruncationIfNeeded(

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -43,28 +43,7 @@ public struct OpenAIConnector: TranscriptPolisher {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         request.timeoutInterval = 60
 
-        let (data, httpResponse) = try await performWithRetry(request: request, config: config)
-
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let choices = json?["choices"] as? [[String: Any]],
-              let message = choices.first?["message"] as? [String: Any],
-              let content = message["content"] as? String,
-              !content.isEmpty else {
-            throw LLMError.emptyResponse
-        }
-
-        if let finishReason = choices.first?["finish_reason"] as? String,
-           finishReason == "length" {
-            Task { await AppLogger.shared.log(
-                "WARNING: OpenAI response truncated (finish_reason=length, model=\(config.model), max_tokens=\(config.maxTokens))",
-                level: .info, category: "LLM"
-            ) }
-        }
-
-        return LLMResult(
-            polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
-                .strippingLLMPreamble()
-        )
+        return try await performWithRetry(request: request, config: config)
     }
 
     public func polish(
@@ -98,7 +77,7 @@ public struct OpenAIConnector: TranscriptPolisher {
         config: LLMProviderConfig,
         maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
         delays: [UInt64] = LLMRetryPolicy.defaultDelays
-    ) async throws -> (Data, HTTPURLResponse) {
+    ) async throws -> LLMResult {
         // Allocate the call number once per logical polish. Retries reuse the
         // same number so logs never mistake a retried polish for multiple
         // independent calls (Codex review finding P3).
@@ -141,7 +120,16 @@ public struct OpenAIConnector: TranscriptPolisher {
                 statusForLog = String(httpResponse.statusCode)
                 switch httpResponse.statusCode {
                 case 200:
-                    return (data, httpResponse)
+                    // Parse inside the defer scope so a malformed 200 payload
+                    // (e.g. content-moderation refusal, unexpected schema)
+                    // updates statusForLog to error_after_200 before the
+                    // metrics line is written (Codex GitHub review P2).
+                    do {
+                        return try Self.parseSuccess(data: data, config: config)
+                    } catch {
+                        statusForLog = "error_after_200:\(Self.shortError(error))"
+                        throw error
+                    }
                 case 401:
                     throw LLMError.invalidAPIKey
                 case 429:
@@ -171,6 +159,34 @@ public struct OpenAIConnector: TranscriptPolisher {
             }
         }
         throw lastError ?? LLMError.requestFailed("All retries exhausted")
+    }
+
+    /// Parse a successful OpenAI 200 response into an LLMResult.
+    /// Throws `LLMError.emptyResponse` on missing/empty content so the retry
+    /// caller can mark statusForLog as error_after_200.
+    private static func parseSuccess(
+        data: Data, config: LLMProviderConfig
+    ) throws -> LLMResult {
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let choices = json?["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any],
+              let content = message["content"] as? String,
+              !content.isEmpty else {
+            throw LLMError.emptyResponse
+        }
+
+        if let finishReason = choices.first?["finish_reason"] as? String,
+           finishReason == "length" {
+            Task { await AppLogger.shared.log(
+                "WARNING: OpenAI response truncated (finish_reason=length, model=\(config.model), max_tokens=\(config.maxTokens))",
+                level: .info, category: "LLM"
+            ) }
+        }
+
+        return LLMResult(
+            polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
+                .strippingLLMPreamble()
+        )
     }
 
     /// Short error token for diagnostic log lines. Mirrors GeminiConnector.shortError.


### PR DESCRIPTION
## Summary

Follow-up to PR #270. GitHub's auto-Codex review caught two post-200 failure paths where the diagnostic log line reported `status=200` for a polish call that actually failed after HTTP headers arrived.

- **Gemini batch**: an all-`thought=true` response (real scenario for thinking-enabled models) hit the empty-text guard *outside* the do-catch that maps errors into `statusForLog`. Moved the empty-text check inside the catch so the log reports `error_after_200:emptyResponse`.
- **OpenAI**: metrics `defer` lived inside `performWithRetry` and fired on a clean 200 return. The caller's parse could then throw (real case: content moderation refusal with empty content), but by then the log line was already written as 200. Moved the parse into `performWithRetry`'s 200 branch so parse failures update `statusForLog` to `error_after_200:<short>` before the defer fires. Extracted `parseSuccess()` helper.

No behavior change on the happy path.

## Review

CLI Codex review (pass 2) returned clean: _"The changes appear to be limited to improving post-response error accounting... I did not identify any introduced bugs that would break existing functionality or require follow-up."_

## Test plan

- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` 283 tests green
- [x] Codex CLI review clean
