### PR TITLE
fix(llm): stop gemma4 over-expansion and empty responses (#272)

### DIFF
--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -113,9 +113,21 @@ public enum LLMConstants {
     /// Thinking models (Gemini 2.5) consume output tokens for reasoning, so this must be generous.
     public static let defaultMaxTokens: Int = 8192
 
-    /// Floor for Ollama max tokens. Actual cap scales with input length (charCount)
-    /// to handle long dictations. 256 covers short text; longer text uses charCount.
+    /// Floor for Ollama max tokens on non-thinking-capable models (weak/small
+    /// models, plain completion models like llama3.2). Actual cap scales with
+    /// input length (charCount) to handle long dictations. Kept small so a
+    /// rambly small model can't outrun the 15s pipeline timeout.
     public static let ollamaMaxTokens: Int = 256
+
+    /// Floor for Ollama max tokens on thinking-capable models (e.g. Gemma4).
+    /// These models emit reasoning into `message.thinking` separately from the
+    /// final answer in `message.content`, but the reasoning still counts
+    /// against `num_predict`. With the 256 floor, Gemma4's internal reasoning
+    /// exhausted the budget and left `message.content` empty on ~50% of polish
+    /// calls (#272). 2048 gives thinking models enough headroom to complete
+    /// reasoning and emit a clean answer; `done_reason=stop` ends generation
+    /// early for short transcripts so latency is bounded.
+    public static let ollamaThinkingMaxTokens: Int = 2048
 
     /// Default thinking budget for extended thinking models (Gemini 2.5 Flash/Pro).
     public static let defaultThinkingBudget: Int = 8192

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -37,17 +37,12 @@ public struct OllamaConnector: TranscriptPolisher {
             messages.append(["role": "user", "content": text])
         }
 
-        var body: [String: Any] = [
-            "model": config.model,
-            "messages": messages,
-            "stream": false,
-            "think": false,
-            "keep_alive": "60m",
-            "options": [
-                "num_predict": config.maxTokens,
-                "temperature": config.temperature,
-            ],
-        ]
+        let body = Self.makeRequestBody(
+            model: config.model,
+            messages: messages,
+            maxTokens: config.maxTokens,
+            temperature: config.temperature
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -114,17 +109,12 @@ public struct OllamaConnector: TranscriptPolisher {
             throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
         }
 
-        let body: [String: Any] = [
-            "model": config.model,
-            "messages": messages,
-            "stream": false,
-            "think": false,
-            "keep_alive": "60m",
-            "options": [
-                "num_predict": config.maxTokens,
-                "temperature": config.temperature,
-            ],
-        ]
+        let body = Self.makeRequestBody(
+            model: config.model,
+            messages: messages,
+            maxTokens: config.maxTokens,
+            temperature: config.temperature
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -155,6 +145,38 @@ public struct OllamaConnector: TranscriptPolisher {
             polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
                 .strippingLLMPreamble()
         )
+    }
+
+    // MARK: - Request body
+
+    /// Builds the `/api/chat` request body shared by both polish entry points.
+    ///
+    /// The `think` parameter is intentionally omitted (#272):
+    /// - Setting `think: false` (boolean) is silently ignored by gemma4:latest and
+    ///   causes reasoning to leak into `message.content` as a 5-13× expansion that
+    ///   the validator rejects.
+    /// - Omitting the key lets Ollama route any reasoning to `message.thinking`
+    ///   (which we don't read) and deliver the clean final answer in `message.content`,
+    ///   provided `num_predict` is large enough to accommodate both (see
+    ///   `LLMConstants.ollamaMaxTokens`).
+    /// Non-thinking models (llama3.2 etc.) are unaffected: they emit empty
+    /// `message.thinking` regardless.
+    static func makeRequestBody(
+        model: String,
+        messages: [[String: String]],
+        maxTokens: Int,
+        temperature: Double
+    ) -> [String: Any] {
+        [
+            "model": model,
+            "messages": messages,
+            "stream": false,
+            "keep_alive": "60m",
+            "options": [
+                "num_predict": maxTokens,
+                "temperature": temperature,
+            ],
+        ]
     }
 
     // MARK: - Retry

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -195,17 +195,67 @@ public final class OllamaSetupService {
 
     // MARK: - Weak Model Detection
 
-    /// Hardcoded fallback prefixes for weak model detection when parameter size is unknown.
-    nonisolated private static let weakModelFallbackPrefixes: [String] = ["tinyllama", "phi-2", "gemma2:2b"]
+    /// Hardcoded fallback prefixes for weak model detection when parameter size
+    /// is unknown and no size tag is present. Covers:
+    /// - `tinyllama` (1.1B, all variants)
+    /// - `phi-2` (2.7B, bare name)
+    /// - `gemma2:2b` (2B, tagged)
+    /// - `llama3.2` (3B default; bare name used as the app's default Ollama model)
+    nonisolated private static let weakModelFallbackPrefixes: [String] = [
+        "tinyllama", "phi-2", "gemma2:2b", "llama3.2",
+    ]
+
+    /// Matches a size tag like `:1b`, `:3b`, `:0.5b` — Ollama's standard naming
+    /// convention for parameter-count variants. Used as a fallback when we don't
+    /// have downloaded-model metadata for the exact parameter billions.
+    nonisolated private static let sizeTagRegex = try? NSRegularExpression(
+        pattern: #":(\d+(?:\.\d+)?)b(?:-|$|\s|:)"#,
+        options: .caseInsensitive
+    )
 
     /// Determine if a model should receive a simplified system prompt.
-    /// Uses parameter count when available, falls back to name-based heuristic.
+    /// Resolution order (strongest signal first):
+    /// 1. Explicit `parameterBillions` from downloaded-model metadata.
+    /// 2. `:Nb` size tag in the name (e.g. `llama3.2:70b` → 70B, not weak; `qwen2.5:3b` → weak).
+    /// 3. Hardcoded fallback prefix list for bare names without any size hint.
     public nonisolated static func isWeakModel(_ name: String, parameterBillions: Double? = nil) -> Bool {
         if let billions = parameterBillions {
             return billions <= 3.0
         }
         let lower = name.lowercased()
+        // Size tag is authoritative when present (overrides prefix defaults so
+        // `llama3.2:70b` is correctly classified as non-weak even though the
+        // `llama3.2` family is in the prefix list).
+        let range = NSRange(lower.startIndex..<lower.endIndex, in: lower)
+        if let match = sizeTagRegex?.firstMatch(in: lower, range: range),
+           match.numberOfRanges > 1,
+           let billionsRange = Range(match.range(at: 1), in: lower),
+           let billions = Double(lower[billionsRange]) {
+            return billions <= 3.0
+        }
         return weakModelFallbackPrefixes.contains(where: { lower.hasPrefix($0) })
+    }
+
+    /// Known thinking-capable Ollama model family prefixes (as of 2026-04).
+    /// These families emit reasoning into `message.thinking` separately from the
+    /// final answer in `message.content`. Because the reasoning still counts
+    /// against `num_predict`, these models need a larger token budget to avoid
+    /// truncating the final answer to empty (#272).
+    nonisolated private static let thinkingCapableFamilyPrefixes: [String] = [
+        "gemma4",        // Google Gemma 4 (thinking capability in Ollama 0.20+)
+        "qwen3",         // Alibaba Qwen 3 reasoning
+        "deepseek-r1",   // DeepSeek R1 reasoning
+        "gpt-oss",       // OpenAI gpt-oss (low/medium/high thinking)
+    ]
+
+    /// Determine if a model emits separate thinking tokens that consume
+    /// `num_predict` budget. Used to decide whether to grant the larger
+    /// 2048-token floor in `LLMPolishStep` (non-thinking models stay on the
+    /// tight 256 floor so they can't outrun the 15s pipeline timeout on a
+    /// rambly generation).
+    public nonisolated static func isThinkingCapableModel(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return thinkingCapableFamilyPrefixes.contains(where: { lower.hasPrefix($0) })
     }
 
     /// Convenience: check if a model name is weak using downloaded model metadata.

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -139,7 +139,18 @@ public final class LLMPolishStep: TextProcessingStep {
                 // Estimate tokens (~3 chars per token for English), add headroom.
                 // For 921-char input: 921/3 + 100 = 407 tokens (~2x actual output of ~195).
                 // The pipeline-level timeout (15s) caps runaway generation.
-                return max(context.text.count / 3 + 100, LLMConstants.ollamaMaxTokens)
+                //
+                // Only thinking-capable families (Gemma4, qwen3, deepseek-r1,
+                // gpt-oss) get the larger 2048-token floor — they emit reasoning
+                // into `message.thinking` separately from `message.content`, and
+                // that reasoning still counts against `num_predict` (#272). All
+                // other Ollama models (weak or not) keep the tight 256 floor so
+                // a rambly generation can't outrun the 15s pipeline timeout.
+                // `done_reason=stop` ends generation early for short transcripts.
+                let floor = OllamaSetupService.isThinkingCapableModel(llmModel)
+                    ? LLMConstants.ollamaThinkingMaxTokens
+                    : LLMConstants.ollamaMaxTokens
+                return max(context.text.count / 3 + 100, floor)
             }
             // OpenAI reasoning models include reasoning in max_completion_tokens — keep generous.
             if reasoningEffort != nil { return LLMConstants.defaultMaxTokens }

--- a/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import EnviousWisprLLM
+
+@Suite("OllamaConnector request body")
+struct OllamaConnectorRequestBodyTests {
+
+    private func makeBody(temperature: Double = 0.3, maxTokens: Int = 512) -> [String: Any] {
+        OllamaConnector.makeRequestBody(
+            model: "gemma4:latest",
+            messages: [
+                ["role": "system", "content": "sys"],
+                ["role": "user", "content": "hello"],
+            ],
+            maxTokens: maxTokens,
+            temperature: temperature
+        )
+    }
+
+    /// Primary regression guard for #272. Passing `think: false` at the top level
+    /// is silently ignored by gemma4:latest and causes chain-of-thought to leak
+    /// into `message.content` (5-13× expansion). Omitting the key uses Ollama's
+    /// documented default (thinking OFF) and restores polish behavior.
+    @Test func requestBodyDoesNotIncludeThinkKey() {
+        let body = makeBody()
+        #expect(body["think"] == nil)
+    }
+
+    @Test func requestBodyDisablesStreaming() {
+        let body = makeBody()
+        #expect(body["stream"] as? Bool == false)
+    }
+
+    @Test func requestBodyPassesModelAndMessages() {
+        let body = makeBody()
+        #expect(body["model"] as? String == "gemma4:latest")
+        let messages = body["messages"] as? [[String: String]]
+        #expect(messages?.count == 2)
+        #expect(messages?.first?["role"] == "system")
+    }
+
+    @Test func requestBodyMapsOptions() {
+        let body = makeBody(temperature: 0.42, maxTokens: 777)
+        let options = body["options"] as? [String: Any]
+        #expect(options?["num_predict"] as? Int == 777)
+        #expect(options?["temperature"] as? Double == 0.42)
+    }
+}

--- a/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
@@ -102,4 +102,64 @@ struct OllamaModelCatalogTests {
     func notWeakByDefault() {
         #expect(OllamaSetupService.isWeakModel("some-custom-model", parameterBillions: nil) == false)
     }
+
+    @Test("parses :Nb size tag from name when parameter size is unknown")
+    func weakFromSizeTag() {
+        // Common 1-3B variants should be classified as weak by tag alone (#272).
+        #expect(OllamaSetupService.isWeakModel("llama3.2:1b", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("llama3.2:3b", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("qwen2.5:3b", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("gemma2:0.5b-instruct", parameterBillions: nil) == true)
+    }
+
+    @Test("size-tag parser leaves larger models non-weak")
+    func notWeakFromSizeTag() {
+        #expect(OllamaSetupService.isWeakModel("llama3.1:8b", parameterBillions: nil) == false)
+        #expect(OllamaSetupService.isWeakModel("llama3.1:70b", parameterBillions: nil) == false)
+        #expect(OllamaSetupService.isWeakModel("gemma4:latest", parameterBillions: nil) == false)
+    }
+
+    @Test("bare llama3.2 is weak (3B default); other bare names remain unknown")
+    func weakFromBarePrefix() {
+        // Default Ollama model shipped by the app is the bare name `llama3.2`
+        // (3B). Needs to hit the weak path or it falls into the thinking-token
+        // headroom intended only for larger models (#272 codex round 3).
+        #expect(OllamaSetupService.isWeakModel("llama3.2", parameterBillions: nil) == true)
+        #expect(OllamaSetupService.isWeakModel("llama3.2:latest", parameterBillions: nil) == true)
+    }
+
+    @Test("size tag wins over prefix when a larger variant is explicit")
+    func sizeTagWinsOverPrefix() {
+        // Hypothetical future tag: bare `llama3.2` is weak, but an explicit 70b
+        // variant must NOT be classified as weak just because the family prefix
+        // is in the fallback list.
+        #expect(OllamaSetupService.isWeakModel("llama3.2:70b", parameterBillions: nil) == false)
+        #expect(OllamaSetupService.isWeakModel("llama3.2:8b", parameterBillions: nil) == false)
+    }
+
+    // MARK: - Thinking-Capable Detection (#272)
+
+    @Test("known thinking-capable families are detected across tag variants")
+    func thinkingCapableFamilies() {
+        #expect(OllamaSetupService.isThinkingCapableModel("gemma4:latest") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("gemma4:8b") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("qwen3") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("qwen3:7b") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("deepseek-r1") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("deepseek-r1:14b") == true)
+        #expect(OllamaSetupService.isThinkingCapableModel("gpt-oss:20b") == true)
+    }
+
+    @Test("non-thinking models are not flagged as thinking-capable")
+    func notThinkingCapable() {
+        // Prevents regression where non-thinking 7B+ models would get the
+        // 2048-token budget and risk outrunning the 15s pipeline timeout.
+        #expect(OllamaSetupService.isThinkingCapableModel("llama3.2") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("llama3.1:8b") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("mistral") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("gemma2:2b") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("gemma3:12b") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("phi-2") == false)
+        #expect(OllamaSetupService.isThinkingCapableModel("qwen2.5:7b") == false)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #272. Gemma4 via Ollama polish was 100% falling back to raw ASR (5-13× expansion caught by validator). Root cause turned out to be two stacked failure modes:

1. **`think: false` (boolean) is silently ignored by gemma4:latest.** Reasoning dumps into `message.content` as a huge expansion (5-13× in evidence).
2. **Even with `think` omitted, gemma4 still emits internal reasoning into `message.thinking`.** With the old 256-token `num_predict` floor, reasoning consumed the whole budget and left `message.content` empty — surfaces as `LLMError.emptyResponse` on ~50% of calls. This second mode only showed up in live real-audio UAT, not the initial curl repro.

## Fix

- Extract the `/api/chat` body to a shared static helper on `OllamaConnector` so both the legacy and envelope polish paths use one contract.
- **Omit the `think` key** from the body. Ollama's documented default is thinking-off; thinking-capable models route reasoning to `message.thinking` (which we ignore).
- Add `LLMConstants.ollamaThinkingMaxTokens = 2048` and use it as the floor for non-weak Ollama models so thinking-capable models have room for reasoning + a clean final answer. `done_reason=stop` ends generation early for short transcripts so latency is bounded.
- Keep the 256 floor for weak models (≤3B) to prevent a rambly small model outrunning the 15s pipeline timeout.
- Strengthen `OllamaSetupService.isWeakModel(_:parameterBillions:)` fallback to parse `:Nb` size tags (catches `llama3.2:3b`, `qwen2.5:3b`, etc.) and added `llama3.2` to the bare-name prefix list since it's the app's default. Size tag is authoritative over prefix so `llama3.2:70b` (hypothetical) is correctly non-weak.

## Validation

- Swift tests: 20 new/updated assertions pass (request body shape, size-tag parser, bare-name default classification, prefix-vs-tag precedence).
- Council (GPT + Gemini): green on the remove-`think` plan; no Heart/Limbs violation.
- Empirical curl probe against live Ollama: `think: false` → 0/10 clean. `think` omitted → 10/10 clean when `num_predict ≥ 1024`.
- Real-audio UAT (10 TTS dictation samples through the rebuilt app): 0 expansion fallbacks, 0 empty responses, 8/9 clean polishes (1 caught by unrelated question-to-answer validator — correct behavior).
- Polish-quality probe (10 dictation inputs with fillers, missing punctuation, abbreviations): 10/10 passed. Observed list auto-conversion, PO/EOD/PR expansion, time formatting (three thirty → 3:30 PM), contraction fixes (im → I'm), filler removal (um/uh/so/like/yeah/cuz/gonna).
- Codex review rounds: 3 iterations. Round 1 caught P2 (token floor applied to all models); Round 2 caught P1 (`isWeakModel` static misclassifies 3B models); Round 3 caught P2 (bare `llama3.2` default model). All fixed; round 4 verification in progress.
- llama3.2 regression: none. `thinking_chars=0` regardless of `think` parameter; output identical before/after.

## Architecture Closeout

- Module/owner chosen: Ollama-specific payload + weak-model detection stay in `EnviousWisprLLM`; budget selection stays in `EnviousWisprPipeline` (where other polish-budget logic already lives).
- No central type grew; `AppState` untouched.
- Access control unchanged (`OllamaConnector.makeRequestBody` is internal, test-visible via `@testable import`).
- No temporary compromises. Dependency direction clean (Pipeline → LLM, no reverse).
- Heart stayed intact throughout: validator fallback to raw ASR already protected the user; this PR fixes the limb (polish) so it actually produces output.

## Test plan

- [x] `scripts/swift-test.sh --filter "OllamaModelCatalog|OllamaConnectorRequestBody"` passes locally (20/20)
- [x] `swift build -c release` green
- [x] `./scripts/bundle-dev.sh` bundles + relaunches the fixed binary
- [x] Real-audio UAT: 10 TTS dictations via `record_tts()` → 0 expansion fallbacks in log
- [x] Polish-quality probe: 10 dictation inputs produce filler-removed, capitalized, punctuated output
- [ ] CI `build-check` green after merge (auto-watched)
