### PR TITLE
chore(release): What's New entries for v1.9.3

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -27,6 +27,25 @@ enum WhatsNewContent {
     }
 
     static let entries: [Entry] = [
+        // MARK: - v1.9.3
+
+        Entry(
+            id: "gemma4-polish-fixed",
+            icon: "checkmark.seal",
+            title: "Gemma 4 polish works again",
+            description: "Local AI polish with Gemma 4 was quietly falling back to the raw transcript on every dictation. It now produces cleaned-up output reliably. Fillers are removed, punctuation is added, and lists are formatted, all running offline on your Mac.",
+            category: .betterOllamaSupport,
+            version: "1.9.3"
+        ),
+        Entry(
+            id: "thinking-models-supported",
+            icon: "brain",
+            title: "Better support for reasoning models",
+            description: "Thinking models like Gemma 4, Qwen 3, QwQ, DeepSeek R1, and gpt-oss now have enough room to finish reasoning and still produce a clean polished answer. Smaller local models still run on the tight budget that keeps them fast and reliable.",
+            category: .smarterAIPolish,
+            version: "1.9.3"
+        ),
+
         // MARK: - v1.9.2
 
         Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
     /// Bump when bundled What's New content changes in a user-visible way.
-    public static let currentContentVersion = "1.9.2"
+    public static let currentContentVersion = "1.9.3"
 
     /// UserDefaults key for the last content version the user has viewed.
     public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Adds What's New entries for the upcoming v1.9.3 release and bumps `WhatsNewConstants.currentContentVersion` so the sidebar dot announces the update.

Two entries, both user-benefit framed:
- **Gemma 4 polish works again** (covers #272). Plain-language description of the fix: local polish with Gemma 4 was silently falling back to raw; it now produces cleaned-up output reliably.
- **Better support for reasoning models**. Covers the generalized fix: Gemma 4, Qwen 3, QwQ, DeepSeek R1, and gpt-oss now get the token headroom needed to finish reasoning AND emit a clean answer. Smaller local models still get the tight 256-token budget so they stay fast.

Everything else since v1.9.2 is non-user-visible (cold-start diagnostic logging #266, dependabot bumps) so those get no What's New entry.

## Test plan

- [x] `swift build` green from release/v1.9.3 worktree
- [x] `currentContentVersion = "1.9.3"` matches the tag I am about to cut
- [ ] CI `build-check` green post-merge
- [ ] After merge: tag `v1.9.3` from main, CI handles build/sign/notarize/DMG/appcast/GitHub Release
