### PR TITLE
feat(llm): add Gemma 3 Nano (4B) to Ollama catalog

### DIFF
--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -103,6 +103,7 @@ public final class OllamaSetupService {
 
     /// Curated suggestions for users who haven't downloaded models yet.
     public static let modelCatalog: [OllamaModelCatalogEntry] = [
+        OllamaModelCatalogEntry(name: "gemma3n:e4b", displayName: "Gemma 3 Nano (4B)", parameterCount: "4B", qualityTier: .best, downloadSize: "~6 GB"),
         OllamaModelCatalogEntry(name: "llama3.2", displayName: "Llama 3.2", parameterCount: "3B", qualityTier: .best, downloadSize: "~2 GB"),
         OllamaModelCatalogEntry(name: "llama3.2:1b", displayName: "Llama 3.2 (1B)", parameterCount: "1B", qualityTier: .medium, downloadSize: "~800 MB"),
         OllamaModelCatalogEntry(name: "mistral", displayName: "Mistral", parameterCount: "7B", qualityTier: .best, downloadSize: "~4 GB"),


### PR DESCRIPTION
## Summary
- Add \`gemma3n:e4b\` (Gemma 3 Nano 4B) to the curated download catalog in \`OllamaSetupService.swift\`.

## Why
Per the binary analysis of Google's own Edge Eloquent app (\`docs/research/google-ai-edge-eloquent-2026-04-07.md\`), Google uses Gemma 3 Nano (\`MODEL_TYPE_GEMMA3N_E2B_IT\` / \`E4B_IT\`) for polish — not thinking-mode Gemma4. Our A/B bench in #276 (PR #280 data) shows Gemma4 polish is 5-9s cold and ~90-95% of that is thinking output, which Google themselves avoid for exactly this reason.

Adding Gemma 3 Nano 4B to the catalog lets users opt into the non-thinking speed-first path via the normal Settings → Models flow instead of pulling from the CLI.

## Tier
SMALL | Test: not required (data-only, one array entry, no logic) | Module: LLM

## Test plan
- [x] \`swift build -c release\` — PASS
- [x] Rebuild + relaunch — model appears at top of Manage Models → Downloads list
- [ ] User downloads via the UI and benches against gemma4:latest (tracked on #276)

Related: #276 #280