### PR TITLE
feat(telemetry): heart-path Sentry coverage (#285 PR 1 of 2)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -1,771 +1,926 @@
-import SwiftUI
-import EnviousWisprCore
-import EnviousWisprStorage
-import EnviousWisprAudio
-import EnviousWisprServices
 import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprPipeline
+import EnviousWisprServices
+import EnviousWisprStorage
+import SwiftUI
 
 /// Root observable state for the entire application.
 @MainActor
 @Observable
 final class AppState {
-    // Settings
-    var settings = SettingsManager()
+  // Settings
+  var settings = SettingsManager()
 
-    // Sub-systems
-    let permissions = PermissionsService()
-    let audioCapture: any AudioCaptureInterface
-    let asrManager: any ASRManagerInterface
-    let transcriptStore = TranscriptStore()
-    let keychainManager = KeychainManager()
-    let hotkeyService = HotkeyService()
-    let benchmark = BenchmarkSuite()
-    let recordingOverlay = RecordingOverlayPanel()
-    let ollamaSetup = OllamaSetupService()
-    let whisperKitSetup = WhisperKitSetupService()
-    let audioDeviceList = AudioDeviceList()
+  // Sub-systems
+  let permissions = PermissionsService()
+  let audioCapture: any AudioCaptureInterface
+  let asrManager: any ASRManagerInterface
+  let transcriptStore = TranscriptStore()
+  let keychainManager = KeychainManager()
+  let hotkeyService = HotkeyService()
+  let benchmark = BenchmarkSuite()
+  let recordingOverlay = RecordingOverlayPanel()
+  let ollamaSetup = OllamaSetupService()
+  let whisperKitSetup = WhisperKitSetupService()
+  let audioDeviceList = AudioDeviceList()
 
-    /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
-    private var whisperKitPreloadTask: Task<Void, Never>?
+  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
+  private var whisperKitPreloadTask: Task<Void, Never>?
 
-    /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
-    /// Cancelled when a new recording starts or a higher-priority notification is shown.
-    private var postCompletionWarningTask: Task<Void, Never>?
+  /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+  /// Cancelled when a new recording starts or a higher-priority notification is shown.
+  private var postCompletionWarningTask: Task<Void, Never>?
 
-    // Pipelines — initialized after sub-systems
-    let pipeline: TranscriptionPipeline
-    let whisperKitPipeline: WhisperKitPipeline
+  // Pipelines — initialized after sub-systems
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
 
-    /// Standalone service for re-polishing saved transcripts from the detail view.
-    /// Completely decoupled from pipeline state machines.
-    let polishService: TranscriptPolishService
+  /// Standalone service for re-polishing saved transcripts from the detail view.
+  /// Completely decoupled from pipeline state machines.
+  let polishService: TranscriptPolishService
 
-    /// Forwards settings changes to pipelines and subsystems.
-    private let settingsSync: PipelineSettingsSync
+  /// Forwards settings changes to pipelines and subsystems.
+  private let settingsSync: PipelineSettingsSync
 
-    /// Called when pipeline state changes — set by AppDelegate for icon updates.
-    var onPipelineStateChange: ((PipelineState) -> Void)?
+  /// Called when pipeline state changes — set by AppDelegate for icon updates.
+  var onPipelineStateChange: ((PipelineState) -> Void)?
 
-    // Transcript history — delegated to coordinator
-    let transcriptCoordinator: TranscriptCoordinator
-    var pendingNavigationSection: SettingsSection?
+  // Transcript history — delegated to coordinator
+  let transcriptCoordinator: TranscriptCoordinator
+  var pendingNavigationSection: SettingsSection?
 
-    /// True when recording is in hands-free (locked) mode via double-press.
-    /// Read by the overlay to switch to the expanded lips visual.
-    var isRecordingLocked: Bool = false
+  /// True when recording is in hands-free (locked) mode via double-press.
+  /// Read by the overlay to switch to the expanded lips visual.
+  var isRecordingLocked: Bool = false
 
-    /// Multilingual v1: latest passive-chip trigger emitted by LanguageDetector,
-    /// if any. Observed by settings/overlay UI to offer a "Detected X. Lock it?"
-    /// or "Language unstable. Lock language?" CTA. Nil when no chip is pending.
-    /// UI consumers set this to nil after dismissing.
-    /// TODO: wire a settings-level banner that presents this; current v1 ship is
-    /// callback-only so chip events are not silently dropped.
-    var pendingPassiveChip: PassiveChipTrigger?
+  /// Multilingual v1: latest passive-chip trigger emitted by LanguageDetector,
+  /// if any. Observed by settings/overlay UI to offer a "Detected X. Lock it?"
+  /// or "Language unstable. Lock language?" CTA. Nil when no chip is pending.
+  /// UI consumers set this to nil after dismissing.
+  /// TODO: wire a settings-level banner that presents this; current v1 ship is
+  /// callback-only so chip events are not silently dropped.
+  var pendingPassiveChip: PassiveChipTrigger?
 
-    // Feature #8: custom word management — delegated to coordinator
-    let customWordsCoordinator = CustomWordsCoordinator()
+  // Feature #8: custom word management — delegated to coordinator
+  let customWordsCoordinator = CustomWordsCoordinator()
 
-    // Model discovery — delegated to coordinator
-    let llmDiscovery: LLMModelDiscoveryCoordinator
+  // Model discovery — delegated to coordinator
+  let llmDiscovery: LLMModelDiscoveryCoordinator
 
-    // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
-    let aiAvailability = AIAvailabilityCoordinator()
+  // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
+  let aiAvailability = AIAvailabilityCoordinator()
 
-    init() {
-        // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
-        // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
-        // Read directly from UserDefaults because `settings` is not yet available (stored
-        // properties must all be initialized before `self` is accessible).
-        // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern
-        // so existing installs (no key written) get the new default.
-        let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
-        if useXPC {
-            audioCapture = AudioCaptureProxy()
-        } else {
-            audioCapture = AudioCaptureManager()
+  init() {
+    // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
+    // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
+    // Read directly from UserDefaults because `settings` is not yet available (stored
+    // properties must all be initialized before `self` is accessible).
+    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern
+    // so existing installs (no key written) get the new default.
+    let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
+    if useXPC {
+      audioCapture = AudioCaptureProxy()
+    } else {
+      audioCapture = AudioCaptureManager()
+    }
+
+    // Phase 5: XPC ASR service — default ON (Stage F). ASR inference runs in a separate
+    // XPC service process for memory isolation. Escape hatch: `defaults write ... useXPCASRService -bool false`
+    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern.
+    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
+    if useXPCASR {
+      asrManager = ASRManagerProxy()
+    } else {
+      asrManager = ASRManager()
+    }
+
+    transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
+
+    // Both pipeline properties must be initialized before `self` can be used.
+    // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
+    pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager
+    )
+    // W6: wire language-flip telemetry into the detector via a closure so
+    // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
+    // The detector fires this inline from an actor; we hop to MainActor to
+    // call `TelemetryService` (which is @MainActor isolated).
+    // The chip handler is wired AFTER init completes (see setPassiveChipHandler
+    // call below) because it needs to capture self, and Swift does not allow
+    // that before all stored properties are initialized.
+    let languageDetector = LanguageDetector(
+      onLanguageFlip: { @Sendable event in
+        Task { @MainActor in
+          TelemetryService.shared.trackLanguageFlip(
+            fromLang: event.fromLang,
+            toLang: event.toLang,
+            confidenceBoth: event.confidenceBoth
+          )
         }
+      }
+    )
+    whisperKitPipeline = WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      languageDetector: languageDetector
+    )
+    // Transcript polish service (re-polish from detail view, decoupled from pipelines)
+    polishService = TranscriptPolishService(
+      keychainManager: keychainManager,
+      transcriptStore: transcriptStore
+    )
 
-        // Phase 5: XPC ASR service — default ON (Stage F). ASR inference runs in a separate
-        // XPC service process for memory isolation. Escape hatch: `defaults write ... useXPCASRService -bool false`
-        // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern.
-        let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
-        if useXPCASR {
-            asrManager = ASRManagerProxy()
-        } else {
-            asrManager = ASRManager()
+    // Initialize settingsSync and apply initial settings to all targets
+    settingsSync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: hotkeyService,
+      whisperKitSetup: whisperKitSetup
+    )
+    settingsSync.applyInitialSettings(settings, customWords: customWordsCoordinator.customWords)
+
+    // Wire dictation activity provider (after all stored properties initialized)
+    polishService.setDictationActivity(self)
+
+    // Wire the passive-chip handler on the LanguageDetector actor now that
+    // self is fully constructed. The handler hops back to the MainActor
+    // to publish the chip on `pendingPassiveChip` so UI can observe it.
+    Task { [weak self] in
+      await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
+        Task { @MainActor in
+          self?.pendingPassiveChip = trigger
         }
+      }
+    }
 
-        transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
-        llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
-
-        // Both pipeline properties must be initialized before `self` can be used.
-        // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
-        pipeline = TranscriptionPipeline(
-            audioCapture: audioCapture,
-            asrManager: asrManager,
-            transcriptStore: transcriptStore,
-            keychainManager: keychainManager
+    // Unified engine interruption handler — routes to whichever pipeline is actively recording.
+    // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
+    // is interrupted, we must notify the pipeline that's currently recording, not the one
+    // that happened to set onEngineInterrupted last.
+    audioCapture.onEngineInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
         )
-        // W6: wire language-flip telemetry into the detector via a closure so
-        // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
-        // The detector fires this inline from an actor; we hop to MainActor to
-        // call `TelemetryService` (which is @MainActor isolated).
-        // The chip handler is wired AFTER init completes (see setPassiveChipHandler
-        // call below) because it needs to capture self, and Swift does not allow
-        // that before all stored properties are initialized.
-        let languageDetector = LanguageDetector(
-            onLanguageFlip: { @Sendable event in
-                Task { @MainActor in
-                    TelemetryService.shared.trackLanguageFlip(
-                        fromLang: event.fromLang,
-                        toLang: event.toLang,
-                        confidenceBoth: event.confidenceBoth
-                    )
-                }
-            }
+      }
+      SentryBreadcrumb.add(
+        stage: "audio", message: "Audio XPC interrupted", level: .error,
+        data: [
+          "parakeet_state": "\(pState)",
+          "whisperkit_state": "\(wkState)",
+        ])
+      // Issue #285 — route to the pipeline that owns the shared capture
+      // right now. Uses the same owner-selection as `activeTelemetryTarget()`
+      // so the two paths cannot drift when both pipelines are active
+      // (overlap during backend switch: one polishing while the other starts
+      // a new recording).
+      switch self.activeCaptureBackend() {
+      case .parakeet:
+        self.pipeline.handleEngineInterruption()
+      case .whisperKit:
+        self.whisperKitPipeline.handleEngineInterruption()
+      case nil:
+        break  // neither pipeline active — nothing to clean up
+      }
+      // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
+      // sets state = .error(...), which fires onStateChange and shows the error
+      // overlay. Calling hide() immediately after would dismiss it before the
+      // user can read it. The error overlay auto-dismisses after 3 seconds.
+    }
+
+    // Issue #285 — XPC transport telemetry. Proxy fires this from its
+    // interruption and invalidation handlers; idle interrupts stay silent.
+    // We emit a single captureError per channel with enough context for
+    // Sentry to classify and alert.
+    audioCapture.onXPCServiceError = { [weak self] ctx in
+      guard let self else { return }
+      let handlerKind: XPCHandlerKind = {
+        switch ctx.kind {
+        case .interruptCapturing: return .interrupt
+        case .invalidateCapturing, .invalidateIdle: return .invalidate
+        }
+      }()
+      let wasCapturing = ctx.kind != .invalidateIdle
+      let extras: [String: Any] = [
+        "xpc.handler": handlerKind.rawValue,
+        "xpc.was_capturing": wasCapturing,
+        "xpc.kind": ctx.kind.rawValue,
+        "capture_session_id": ctx.sessionID.map { Int($0) } ?? NSNull(),
+        "capture.route": self.audioCapture.currentAudioRoute,
+      ]
+      SentryBreadcrumb.captureError(
+        HeartPathError.audioXPCInterrupted(
+          handler: handlerKind, wasCapturing: wasCapturing),
+        category: .xpcServiceError,
+        stage: "audio",
+        extra: extras
+      )
+    }
+
+    // (see `activeTelemetryTarget()` at end of init for dispatch logic).
+    // Issue #285 — centralized routing for heart-path telemetry callbacks.
+    // `audioCapture` is a single instance shared by both pipelines, so these
+    // closure properties are single-owner — per-pipeline wiring would let the
+    // last-initialized pipeline silently steal the callbacks. Same pattern as
+    // `onEngineInterrupted` above: route to whichever pipeline is currently
+    // recording so the right backend's dedup flags get set.
+    audioCapture.onCaptureStalled = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.activeTelemetryTarget()?.handleCaptureStall(ctx)
+    }
+    audioCapture.onXPCReplyFailed = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.activeTelemetryTarget()?.handleXPCReplyFailed(ctx)
+    }
+    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.activeTelemetryTarget()?.handleCaptureSessionInterruption(ctx)
+    }
+
+    // Observe audio route changes for Sentry context enrichment.
+    // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
+    // recovery, but breadcrumbs live in EnviousWisprServices (unavailable in the audio module).
+    // AppState observes here to stay within module boundary rules.
+    NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
+    ) { [weak self] _ in
+      Task { @MainActor in
+        let route = self?.audioCapture.currentAudioRoute ?? "unknown"
+        SentryBreadcrumb.add(
+          stage: "audio", message: "Audio route changed", level: .warning,
+          data: [
+            "audio_route": route
+          ])
+        SentryBreadcrumb.updateAudioRoute(route)
+      }
+    }
+
+    // Unified ASR service crash handler — routes to whichever pipeline is active.
+    // Fires when the XPC ASR service dies mid-session (streaming or batch).
+    asrManager.onServiceInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[AppState] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
         )
-        whisperKitPipeline = WhisperKitPipeline(
-            audioCapture: audioCapture,
-            backend: WhisperKitBackend(),
-            transcriptStore: transcriptStore,
-            keychainManager: keychainManager,
-            languageDetector: languageDetector
-        )
-        // Transcript polish service (re-polish from detail view, decoupled from pipelines)
-        polishService = TranscriptPolishService(
-            keychainManager: keychainManager,
-            transcriptStore: transcriptStore
-        )
-
-        // Initialize settingsSync and apply initial settings to all targets
-        settingsSync = PipelineSettingsSync(
-            pipeline: pipeline,
-            whisperKitPipeline: whisperKitPipeline,
-            polishService: polishService,
-            audioCapture: audioCapture,
-            asrManager: asrManager,
-            hotkeyService: hotkeyService,
-            whisperKitSetup: whisperKitSetup
-        )
-        settingsSync.applyInitialSettings(settings, customWords: customWordsCoordinator.customWords)
-
-        // Wire dictation activity provider (after all stored properties initialized)
-        polishService.setDictationActivity(self)
-
-        // Wire the passive-chip handler on the LanguageDetector actor now that
-        // self is fully constructed. The handler hops back to the MainActor
-        // to publish the chip on `pendingPassiveChip` so UI can observe it.
-        Task { [weak self] in
-            await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
-                Task { @MainActor in
-                    self?.pendingPassiveChip = trigger
-                }
-            }
-        }
-
-        // Unified engine interruption handler — routes to whichever pipeline is actively recording.
-        // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
-        // is interrupted, we must notify the pipeline that's currently recording, not the one
-        // that happened to set onEngineInterrupted last.
-        audioCapture.onEngineInterrupted = { [weak self] in
-            guard let self else { return }
-            let pState = self.pipeline.state
-            let wkState = self.whisperKitPipeline.state
-            Task { await AppLogger.shared.log(
-                "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
-                level: .info, category: "XPC"
-            ) }
-            SentryBreadcrumb.add(stage: "audio", message: "Audio XPC interrupted", level: .error, data: [
-                "parakeet_state": "\(pState)",
-                "whisperkit_state": "\(wkState)",
-            ])
-            if pState == .recording {
-                self.pipeline.handleEngineInterruption()
-            } else if wkState == .recording {
-                self.whisperKitPipeline.handleEngineInterruption()
-            }
-            // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
-            // sets state = .error(...), which fires onStateChange and shows the error
-            // overlay. Calling hide() immediately after would dismiss it before the
-            // user can read it. The error overlay auto-dismisses after 3 seconds.
-        }
-
-        // Observe audio route changes for Sentry context enrichment.
-        // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
-        // recovery, but breadcrumbs live in EnviousWisprServices (unavailable in the audio module).
-        // AppState observes here to stay within module boundary rules.
-        NotificationCenter.default.addObserver(forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil) { [weak self] _ in
-            Task { @MainActor in
-                let route = self?.audioCapture.currentAudioRoute ?? "unknown"
-                SentryBreadcrumb.add(stage: "audio", message: "Audio route changed", level: .warning, data: [
-                    "audio_route": route,
-                ])
-                SentryBreadcrumb.updateAudioRoute(route)
-            }
-        }
-
-        // Unified ASR service crash handler — routes to whichever pipeline is active.
-        // Fires when the XPC ASR service dies mid-session (streaming or batch).
-        asrManager.onServiceInterrupted = { [weak self] in
-            guard let self else { return }
-            let pState = self.pipeline.state
-            let wkState = self.whisperKitPipeline.state
-            Task { await AppLogger.shared.log(
-                "[AppState] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
-                level: .info, category: "XPC"
-            ) }
-            if pState == .loadingModel || pState == .recording || pState == .transcribing {
-                self.pipeline.handleASRServiceInterruption()
-            } else if wkState == .recording || wkState == .transcribing {
-                self.whisperKitPipeline.handleASRServiceInterruption()
-            }
-            // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
-            // the pipeline sets .error(...) state which shows the error overlay via
-            // onStateChange. The error overlay auto-dismisses after 3 seconds.
-        }
-
-        // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
-        // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
-        audioCapture.onVADAutoStop = { [weak self] in
-            guard let self else { return }
-            if self.pipeline.state == .recording {
-                Task { await self.pipeline.stopAndTranscribe() }
-            } else if self.whisperKitPipeline.state == .recording {
-                Task { await self.whisperKitPipeline.stopAndTranscribe() }
-            }
-        }
-        settingsSync.onNeedsPreloadObservation = { [weak self] in
-            self?.startWhisperKitPreloadObservation()
-        }
-
-        // Wire custom words changes to pipeline sync
-        customWordsCoordinator.onWordsChanged = { [weak self] words in
-            guard let self else { return }
-            self.pipeline.wordCorrection.customWords = words
-            self.pipeline.llmPolish.customWords = words
-            self.whisperKitPipeline.wordCorrection.customWords = words
-            self.whisperKitPipeline.llmPolish.customWords = words
-            self.polishService.llmPolishStep.customWords = words
-        }
-
-        // Initialize logger
-        Task {
-            await AppLogger.shared.setLogLevel(settings.debugLogLevel)
-            await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
-        }
-
-        // Sync WhisperKit setup service model variant
-        whisperKitSetup.modelVariant = settings.whisperKitModel
-
-        // Restore persisted backend selection synchronously (no race with first record).
-        // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
-        asrManager.setInitialBackendType(settings.selectedBackend)
-        SentryBreadcrumb.updateASRBackend(settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
-
-        // Wire settings change handler
-        settings.onChange = { [weak self] key in
-            guard let self else { return }
-            self.settingsSync.handleSettingChanged(key, settings: self.settings)
-        }
-
-        // Wire pipeline state changes to overlay and icon
-        pipeline.onStateChange = { [weak self] newState in
-            guard let self else { return }
-            self.onPipelineStateChange?(newState)
-            // Hotkey management
-            switch newState {
-            case .recording:
-                self.hotkeyService.registerCancelHotkey()
-            case .loadingModel, .transcribing, .polishing, .error, .idle, .complete:
-                self.isRecordingLocked = false
-                self.hotkeyService.unregisterCancelHotkey()
-            }
-            // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label.
-            // On completion, compute a single post-completion notification by priority:
-            //   1. clipboardFallback (paste fell back to clipboard-only)
-            //   2. warning (polish failed but text was delivered)
-            //   3. hidden (success, no notification needed)
-            let overlayIntent: OverlayIntent
-            if newState == .complete {
-                let isClipboardFallback = self.pipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
-                let polishFailed = self.pipeline.lastPolishError != nil
-                if isClipboardFallback {
-                    overlayIntent = .clipboardFallback
-                } else if polishFailed {
-                    // Show polish warning after a brief delay so the completion
-                    // transition feels natural. Cancellable if a new recording starts.
-                    overlayIntent = self.pipeline.overlayIntent
-                    self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-                } else {
-                    overlayIntent = self.pipeline.overlayIntent
-                }
-            } else {
-                self.postCompletionWarningTask?.cancel()
-                overlayIntent = self.pipeline.overlayIntent
-            }
-            self.recordingOverlay.show(
-                intent: overlayIntent,
-                audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-                isRecordingLocked: self.isRecordingLocked
-            )
-            if newState == .complete {
-                self.transcriptCoordinator.load()
-                if let t = self.pipeline.currentTranscript {
-                    TelemetryService.shared.reportDictationCompleted(transcript: t, inputMode: self.settings.recordingMode.rawValue)
-                }
-            }
-            if case .error(let msg) = newState {
-                TelemetryService.shared.pipelineFailed(stage: "transcription", errorCategory: "pipeline_error", errorCode: msg, recoverable: false, backend: "parakeet")
-            }
-        }
-
-        // Wire WhisperKit pipeline state changes to overlay and icon
-        whisperKitPipeline.onStateChange = { [weak self] newState in
-            guard let self else { return }
-            self.onPipelineStateChange?(self.pipelineState)
-            // Hotkey management
-            switch newState {
-            case .recording:
-                self.hotkeyService.registerCancelHotkey()
-            case .startingUp, .loadingModel, .transcribing, .polishing, .error, .idle, .ready, .complete:
-                self.isRecordingLocked = false
-                self.hotkeyService.unregisterCancelHotkey()
-            }
-            // Intent-driven overlay — same post-completion priority logic as Parakeet above.
-            let wkOverlayIntent: OverlayIntent
-            if newState == .complete {
-                let isClipboardFallback = self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
-                let polishFailed = self.whisperKitPipeline.lastPolishError != nil
-                if isClipboardFallback {
-                    wkOverlayIntent = .clipboardFallback
-                } else if polishFailed {
-                    wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-                    self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-                } else {
-                    wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-                }
-            } else {
-                self.postCompletionWarningTask?.cancel()
-                wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-            }
-            self.recordingOverlay.show(
-                intent: wkOverlayIntent,
-                audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-                isRecordingLocked: self.isRecordingLocked
-            )
-            if newState == .complete {
-                self.transcriptCoordinator.load()
-                if let t = self.whisperKitPipeline.currentTranscript {
-                    TelemetryService.shared.reportDictationCompleted(transcript: t, inputMode: self.settings.recordingMode.rawValue)
-                }
-            }
-            if case .error(let msg) = newState {
-                TelemetryService.shared.pipelineFailed(stage: "transcription", errorCategory: "pipeline_error", errorCode: msg, recoverable: false, backend: "whisperKit")
-            }
-        }
-
-        // Wire hotkey callbacks
-        hotkeyService.recordingMode = settings.recordingMode
-        hotkeyService.cancelKeyCode = settings.cancelKeyCode
-        hotkeyService.cancelModifiers = settings.cancelModifiers
-        hotkeyService.toggleKeyCode = settings.toggleKeyCode
-        hotkeyService.toggleModifiers = settings.toggleModifiers
-        hotkeyService.onToggleRecording = { [weak self] in
-            guard let self else { return }
-            await self.toggleRecording()
-        }
-        hotkeyService.onStartRecording = { [weak self] in
-            guard let self else { return }
-            // Cancel any pending post-completion warning from the previous session
-            // before showing the new recording overlay.
-            self.postCompletionWarningTask?.cancel()
-            let isWhisperKit = self.asrManager.activeBackendType == .whisperKit
-            let active = self.activePipeline
-
-            if isWhisperKit {
-                guard !self.whisperKitPipeline.state.isActive else { return }
-                self.whisperKitPipeline.autoPasteToActiveApp = true
-                self.whisperKitPipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
-            } else {
-                guard !self.pipelineState.isActive else { return }
-                self.pipeline.autoPasteToActiveApp = true
-                self.pipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
-            }
-
-            self.permissions.refreshAccessibilityStatus()
-            if !self.permissions.hasAccessibilityPermission {
-                if isWhisperKit {
-                    self.whisperKitPipeline.autoPasteToActiveApp = false
-                } else {
-                    self.pipeline.autoPasteToActiveApp = false
-                }
-                self.permissions.restartMonitoringIfNeeded()
-            }
-
-            // Show recording overlay IMMEDIATELY for instant visual feedback.
-            // The pipeline hasn't started yet, but the user needs to see the
-            // overlay now — especially for double-press detection where they
-            // need visual confirmation before tapping again.
-            self.recordingOverlay.show(
-                intent: .recording(audioLevel: 0),
-                audioLevelProvider: { self.audioCapture.audioLevel },
-                isRecordingLocked: false
-            )
-
-            let pttStart = ContinuousClock.now
-            await active.handle(event: .preWarm)
-            guard !Task.isCancelled else {
-                // PTT release arrived during preWarm — stop the engine that preWarm started
-                self.audioCapture.abortPreWarm()
-                self.recordingOverlay.show(intent: .hidden)
-                return
-            }
-            let preWarmMs = {
-                let (s, a) = (ContinuousClock.now - pttStart).components
-                return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
-            }()
-            await active.handle(event: .toggleRecording)
-            let totalMs = {
-                let (s, a) = (ContinuousClock.now - pttStart).components
-                return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
-            }()
-            Task { await AppLogger.shared.log(
-                "COLD-START [AppState] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet")",
-                level: .info, category: "Pipeline"
-            ) }
-
-            if isWhisperKit {
-                if case .error = self.whisperKitPipeline.state {
-                    self.whisperKitPipeline.autoPasteToActiveApp = false
-                }
-            } else {
-                if case .error = self.pipeline.state {
-                    self.pipeline.autoPasteToActiveApp = false
-                }
-            }
-        }
-        hotkeyService.onStopRecording = { [weak self] in
-            guard let self else { return }
-            self.isRecordingLocked = false
-            await self.activePipeline.handle(event: .requestStop)
-            if self.asrManager.activeBackendType == .whisperKit {
-                self.whisperKitPipeline.autoPasteToActiveApp = false
-            } else {
-                self.pipeline.autoPasteToActiveApp = false
-            }
-        }
-
-        hotkeyService.onCancelRecording = { [weak self] in
-            self?.isRecordingLocked = false
-            await self?.cancelRecording()
-        }
-
-        hotkeyService.onIsProcessing = { [weak self] in
-            guard let self else { return false }
-            // Block during any state that means "still working on the last recording"
-            if self.asrManager.activeBackendType == .whisperKit {
-                let state = self.whisperKitPipeline.state
-                return state == .transcribing || state == .polishing
-            } else {
-                let state = self.pipeline.state
-                return state == .transcribing || state == .polishing
-            }
-        }
-
-        hotkeyService.onLocked = { [weak self] in
-            guard let self else { return }
-            self.isRecordingLocked = true
-            self.recordingOverlay.updateLockState(true)
-            Task { await AppLogger.shared.log(
-                "Hands-free mode activated — overlay expanding",
-                level: .info, category: "AppState"
-            ) }
-        }
-
-        // Pre-load the selected backend's model in the background to eliminate cold-start delay.
-        // Parakeet: direct silent load (model files already downloaded during onboarding).
-        // WhisperKit: observation-based (waits for setupState to become .ready first).
-        if settings.selectedBackend == .parakeet {
-            Task { [weak self] in
-                await self?.asrManager.loadModelSilently()
-            }
-        }
-        Task { [weak self] in
-            await self?.whisperKitSetup.detectState()
-            self?.startWhisperKitPreloadObservation()
-        }
-
-        // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
-        // called from applicationDidFinishLaunching. Carbon RegisterEventHotKey
-        // requires the NSApplication event loop to be running for event delivery.
+      }
+      if pState == .loadingModel || pState == .recording || pState == .transcribing {
+        self.pipeline.handleASRServiceInterruption()
+      } else if wkState == .recording || wkState == .transcribing {
+        self.whisperKitPipeline.handleASRServiceInterruption()
+      }
+      // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
+      // the pipeline sets .error(...) state which shows the error overlay via
+      // onStateChange. The error overlay auto-dismisses after 3 seconds.
     }
 
-    /// Start the hotkey service. Must be called after the NSApplication event loop
-    /// is running (e.g., from applicationDidFinishLaunching), because Carbon
-    /// RegisterEventHotKey events are only delivered once the run loop is active.
-    func startHotkeyServiceIfEnabled() {
-        if settings.hotkeyEnabled {
-            hotkeyService.start()
-        }
+    // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
+    // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
+    audioCapture.onVADAutoStop = { [weak self] in
+      guard let self else { return }
+      if self.pipeline.state == .recording {
+        Task { await self.pipeline.stopAndTranscribe() }
+      } else if self.whisperKitPipeline.state == .recording {
+        Task { await self.whisperKitPipeline.stopAndTranscribe() }
+      }
+    }
+    settingsSync.onNeedsPreloadObservation = { [weak self] in
+      self?.startWhisperKitPreloadObservation()
     }
 
-    /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
-    /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
-    private func startWhisperKitPreloadObservation() {
-        whisperKitPreloadTask?.cancel()
-        whisperKitPreloadTask = Task { [weak self] in
-            while !Task.isCancelled {
-                guard let self else { return }
-
-                // Check current state — if already .ready, trigger pre-load
-                let currentState = self.whisperKitSetup.setupState
-                if currentState == .ready {
-                    await self.whisperKitPipeline.prepareBackendSilently()
-                    return  // Model loaded — no need to keep observing
-                }
-
-                // Wait for the next change to setupState
-                await withCheckedContinuation { continuation in
-                    withObservationTracking {
-                        _ = self.whisperKitSetup.setupState
-                    } onChange: {
-                        continuation.resume()
-                    }
-                }
-            }
-        }
+    // Wire custom words changes to pipeline sync
+    customWordsCoordinator.onWordsChanged = { [weak self] words in
+      guard let self else { return }
+      self.pipeline.wordCorrection.customWords = words
+      self.pipeline.llmPolish.customWords = words
+      self.whisperKitPipeline.wordCorrection.customWords = words
+      self.whisperKitPipeline.llmPolish.customWords = words
+      self.polishService.llmPolishStep.customWords = words
     }
 
-    /// Active dictation pipeline — routes based on selected backend.
-    var activePipeline: any DictationPipeline {
-        asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
+    // Initialize logger
+    Task {
+      await AppLogger.shared.setLogLevel(settings.debugLogLevel)
+      await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
     }
 
-    /// Convenience: current pipeline state — routes through active backend.
-    var pipelineState: PipelineState {
-        if asrManager.activeBackendType == .whisperKit {
-            return whisperKitPipeline.state.asPipelineState
-        }
-        return pipeline.state
+    // Sync WhisperKit setup service model variant
+    whisperKitSetup.modelVariant = settings.whisperKitModel
+
+    // Restore persisted backend selection synchronously (no race with first record).
+    // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
+    asrManager.setInitialBackendType(settings.selectedBackend)
+    SentryBreadcrumb.updateASRBackend(
+      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+
+    // Wire settings change handler
+    settings.onChange = { [weak self] key in
+      guard let self else { return }
+      self.settingsSync.handleSettingChanged(key, settings: self.settings)
     }
 
-    /// Last polish error from the active pipeline.
-    var lastPolishError: String? {
-        if asrManager.activeBackendType == .whisperKit {
-            return whisperKitPipeline.lastPolishError
-        }
-        return pipeline.lastPolishError
-    }
-
-    /// Convenience: the transcript from the latest recording.
-    var activeTranscript: Transcript? {
-        if let selected = transcriptCoordinator.selectedTranscriptID {
-            return transcriptCoordinator.transcripts.first { $0.id == selected }
-        }
-        if asrManager.activeBackendType == .whisperKit {
-            return whisperKitPipeline.currentTranscript
-        }
-        return pipeline.currentTranscript
-    }
-
-    /// Schedule a deferred post-completion warning overlay. Cancellable and session-scoped:
-    /// cancelled if a new recording starts (any non-complete state change cancels it).
-    /// Uses the pipeline's current state as a guard to avoid showing stale warnings.
-    private func schedulePostCompletionWarning(message: String) {
-        postCompletionWarningTask?.cancel()
-        postCompletionWarningTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(400))
-            guard !Task.isCancelled, let self else { return }
-            // Only show if we're still in the completed state (no new recording started)
-            let parakeetComplete = self.pipeline.state == .complete
-            let whisperKitComplete = self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
-            guard parakeetComplete || whisperKitComplete else { return }
-            self.recordingOverlay.show(intent: .warning(message: message))
-        }
-    }
-
-    /// Reset the currently active pipeline to idle. Used by UI "dismiss" actions.
-    func resetActivePipeline() {
-        if asrManager.activeBackendType == .whisperKit {
-            whisperKitPipeline.reset()
+    // Wire pipeline state changes to overlay and icon
+    pipeline.onStateChange = { [weak self] newState in
+      guard let self else { return }
+      self.onPipelineStateChange?(newState)
+      // Hotkey management
+      switch newState {
+      case .recording:
+        self.hotkeyService.registerCancelHotkey()
+      case .loadingModel, .transcribing, .polishing, .error, .idle, .complete:
+        self.isRecordingLocked = false
+        self.hotkeyService.unregisterCancelHotkey()
+      }
+      // #285 — flip the telemetry tiebreaker ONLY on inactive→active
+      // transitions, so an active→active state change (e.g.
+      // `.transcribing → .polishing`) on this pipeline cannot steal ownership
+      // back from a different backend that already acquired the shared
+      // capture during the overlap window.
+      let nowActive = newState.isActive
+      if nowActive && !self.prevParakeetActive {
+        self.lastCapturingBackend = .parakeet
+      }
+      self.prevParakeetActive = nowActive
+      // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label.
+      // On completion, compute a single post-completion notification by priority:
+      //   1. clipboardFallback (paste fell back to clipboard-only)
+      //   2. warning (polish failed but text was delivered)
+      //   3. hidden (success, no notification needed)
+      let overlayIntent: OverlayIntent
+      if newState == .complete {
+        let isClipboardFallback =
+          self.pipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
+        let polishFailed = self.pipeline.lastPolishError != nil
+        if isClipboardFallback {
+          overlayIntent = .clipboardFallback
+        } else if polishFailed {
+          // Show polish warning after a brief delay so the completion
+          // transition feels natural. Cancellable if a new recording starts.
+          overlayIntent = self.pipeline.overlayIntent
+          self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
         } else {
-            pipeline.reset()
+          overlayIntent = self.pipeline.overlayIntent
         }
-    }
-
-    /// Convenience: audio level for UI visualization.
-    var audioLevel: Float {
-        audioCapture.audioLevel
-    }
-
-    /// Human-readable model name for display.
-    var activeModelName: String {
-        settings.selectedBackend == .parakeet ? "Parakeet v3" : "WhisperKit"
-    }
-
-    var activeLLMDisplayName: String {
-        guard settings.llmProvider != .none else { return "LLM Deactivated" }
-        let model = settings.llmProvider == .ollama ? settings.ollamaModel : settings.llmModel
-        if model.isEmpty { return settings.llmProvider.displayName }
-        // Use discoveredModels displayName if available, otherwise raw model ID
-        if let info = llmDiscovery.discoveredModels.first(where: { $0.id == model }) {
-            return info.displayName
+      } else {
+        self.postCompletionWarningTask?.cancel()
+        overlayIntent = self.pipeline.overlayIntent
+      }
+      self.recordingOverlay.show(
+        intent: overlayIntent,
+        audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+        isRecordingLocked: self.isRecordingLocked
+      )
+      if newState == .complete {
+        self.transcriptCoordinator.load()
+        if let t = self.pipeline.currentTranscript {
+          TelemetryService.shared.reportDictationCompleted(
+            transcript: t, inputMode: self.settings.recordingMode.rawValue)
         }
-        return model
+      }
+      if case .error(let msg) = newState {
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: "parakeet")
+      }
     }
 
-    /// Model status text for sidebar display.
-    var modelStatusText: String {
-        if asrManager.activeBackendType == .whisperKit {
-            switch whisperKitPipeline.state {
-            case .loadingModel: return "Loading Model"
-            case .recording: return "Recording"
-            case .transcribing: return "Transcribing"
-            case .polishing: return "Polishing"
-            case .error: return "Error"
-            default: break
-            }
+    // Wire WhisperKit pipeline state changes to overlay and icon
+    whisperKitPipeline.onStateChange = { [weak self] newState in
+      guard let self else { return }
+      self.onPipelineStateChange?(self.pipelineState)
+      // Hotkey management
+      switch newState {
+      case .recording:
+        self.hotkeyService.registerCancelHotkey()
+      case .startingUp, .loadingModel, .transcribing, .polishing, .error, .idle, .ready, .complete:
+        self.isRecordingLocked = false
+        self.hotkeyService.unregisterCancelHotkey()
+      }
+      // #285 — flip tiebreaker ONLY on inactive→active transitions so
+      // active→active state changes cannot steal capture ownership from the
+      // other backend.
+      let nowActive = newState.isActive
+      if nowActive && !self.prevWhisperKitActive {
+        self.lastCapturingBackend = .whisperKit
+      }
+      self.prevWhisperKitActive = nowActive
+      // Intent-driven overlay — same post-completion priority logic as Parakeet above.
+      let wkOverlayIntent: OverlayIntent
+      if newState == .complete {
+        let isClipboardFallback =
+          self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
+        let polishFailed = self.whisperKitPipeline.lastPolishError != nil
+        if isClipboardFallback {
+          wkOverlayIntent = .clipboardFallback
+        } else if polishFailed {
+          wkOverlayIntent = self.whisperKitPipeline.overlayIntent
+          self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
         } else {
-            if pipelineState == .recording { return "Recording" }
-            if pipelineState == .transcribing { return "Transcribing" }
-            if pipelineState == .polishing { return "Polishing" }
-            if case .error = pipelineState { return "Error" }
+          wkOverlayIntent = self.whisperKitPipeline.overlayIntent
         }
-        return asrManager.isModelLoaded ? "Loaded" : "Unloaded"
+      } else {
+        self.postCompletionWarningTask?.cancel()
+        wkOverlayIntent = self.whisperKitPipeline.overlayIntent
+      }
+      self.recordingOverlay.show(
+        intent: wkOverlayIntent,
+        audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+        isRecordingLocked: self.isRecordingLocked
+      )
+      if newState == .complete {
+        self.transcriptCoordinator.load()
+        if let t = self.whisperKitPipeline.currentTranscript {
+          TelemetryService.shared.reportDictationCompleted(
+            transcript: t, inputMode: self.settings.recordingMode.rawValue)
+        }
+      }
+      if case .error(let msg) = newState {
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: "whisperKit")
+      }
     }
 
-    /// Toggle recording on/off (plain, no forced LLM).
-    func toggleRecording() async {
-        postCompletionWarningTask?.cancel()
-        let active = activePipeline
-        // Set auto-paste before toggle
-        if active is WhisperKitPipeline {
-            switch whisperKitPipeline.state {
-            case .idle, .ready, .complete, .error:
-                whisperKitPipeline.autoPasteToActiveApp = true
-                permissions.refreshAccessibilityStatus()
-                if !permissions.hasAccessibilityPermission {
-                    whisperKitPipeline.autoPasteToActiveApp = false
-                    permissions.restartMonitoringIfNeeded()
-                }
-            default: break
-            }
-        } else {
-            switch pipeline.state {
-            case .idle, .complete, .error:
-                pipeline.autoPasteToActiveApp = true
-                permissions.refreshAccessibilityStatus()
-                if !permissions.hasAccessibilityPermission {
-                    pipeline.autoPasteToActiveApp = false
-                    permissions.restartMonitoringIfNeeded()
-                }
-            default: break
-            }
-        }
-
-        // Fire dictation.invoked telemetry when starting (not stopping).
-        // Intent event: captures user action before engine/ASR work begins.
-        // Check that the active pipeline is NOT already in a recording/processing state.
-        let alreadyActive: Bool
-        if active is WhisperKitPipeline {
-            let s = whisperKitPipeline.state
-            alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel || s == .startingUp
-        } else {
-            let s = pipeline.state
-            alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
-        }
-        if !alreadyActive {
-            let targetApp = NSWorkspace.shared.frontmostApplication?.localizedName
-            TelemetryService.shared.dictationInvoked(
-                triggerSource: settings.recordingMode.rawValue,
-                inputMode: settings.recordingMode.rawValue,
-                targetApp: targetApp
-            )
-        }
-
-        await active.handle(event: .toggleRecording)
-
-        // Clear auto-paste on completion/error
-        if active is WhisperKitPipeline {
-            if case .complete = whisperKitPipeline.state { whisperKitPipeline.autoPasteToActiveApp = false }
-            if case .error = whisperKitPipeline.state { whisperKitPipeline.autoPasteToActiveApp = false }
-        } else {
-            if pipeline.state == .complete { pipeline.autoPasteToActiveApp = false }
-            if case .error = pipeline.state { pipeline.autoPasteToActiveApp = false }
-        }
+    // Wire hotkey callbacks
+    hotkeyService.recordingMode = settings.recordingMode
+    hotkeyService.cancelKeyCode = settings.cancelKeyCode
+    hotkeyService.cancelModifiers = settings.cancelModifiers
+    hotkeyService.toggleKeyCode = settings.toggleKeyCode
+    hotkeyService.toggleModifiers = settings.toggleModifiers
+    hotkeyService.onToggleRecording = { [weak self] in
+      guard let self else { return }
+      await self.toggleRecording()
     }
+    hotkeyService.onStartRecording = { [weak self] in
+      guard let self else { return }
+      // Cancel any pending post-completion warning from the previous session
+      // before showing the new recording overlay.
+      self.postCompletionWarningTask?.cancel()
+      let isWhisperKit = self.asrManager.activeBackendType == .whisperKit
+      let active = self.activePipeline
 
-    /// Cancel an active recording, discarding all captured audio.
-    func cancelRecording() async {
-        TelemetryService.shared.dictationCanceled(stage: "recording", reason: "user_cancel", durationSeconds: nil)
-        isRecordingLocked = false
-        recordingOverlay.hide()
-        let isWhisperKit = asrManager.activeBackendType == .whisperKit
+      if isWhisperKit {
+        guard !self.whisperKitPipeline.state.isActive else { return }
+        self.whisperKitPipeline.autoPasteToActiveApp = true
+        self.whisperKitPipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
+      } else {
+        guard !self.pipelineState.isActive else { return }
+        self.pipeline.autoPasteToActiveApp = true
+        self.pipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
+      }
+
+      self.permissions.refreshAccessibilityStatus()
+      if !self.permissions.hasAccessibilityPermission {
         if isWhisperKit {
-            let wkState = whisperKitPipeline.state
-            guard wkState == .recording || wkState == .loadingModel || wkState == .startingUp else { return }
-            whisperKitPipeline.autoPasteToActiveApp = false
-            await whisperKitPipeline.handle(event: .cancelRecording)
+          self.whisperKitPipeline.autoPasteToActiveApp = false
         } else {
-            guard pipelineState == .recording || pipelineState == .loadingModel else { return }
-            pipeline.autoPasteToActiveApp = false
-            await pipeline.cancelRecording()
+          self.pipeline.autoPasteToActiveApp = false
         }
-    }
+        self.permissions.restartMonitoringIfNeeded()
+      }
 
-    /// Enhancement error from the transcript detail view's re-polish service.
-    /// Separate from `lastPolishError` which tracks live-dictation polish failures.
-    var lastEnhancementError: EnhancementError? {
-        polishService.lastEnhancementError
-    }
+      // Show recording overlay IMMEDIATELY for instant visual feedback.
+      // The pipeline hasn't started yet, but the user needs to see the
+      // overlay now — especially for double-press detection where they
+      // need visual confirmation before tapping again.
+      self.recordingOverlay.show(
+        intent: .recording(audioLevel: 0),
+        audioLevelProvider: { self.audioCapture.audioLevel },
+        isRecordingLocked: false
+      )
 
-    /// Re-polish an existing transcript via the standalone polish service.
-    /// Decoupled from pipeline state: does not touch pipeline.state, currentTranscript, or lastPolishError.
-    func polishTranscript(_ transcript: Transcript) async {
-        do {
-            let updated = try await polishService.polish(transcript)
-            if let idx = transcriptCoordinator.transcripts.firstIndex(where: { $0.id == updated.id }) {
-                transcriptCoordinator.transcripts[idx] = updated
-            }
-            // Ensure detail view refreshes even when activeTranscript falls back to pipeline.currentTranscript
-            transcriptCoordinator.selectedTranscriptID = updated.id
-        } catch {
-            // Error already captured in polishService.lastEnhancementError
-            Task { await AppLogger.shared.log(
-                "Transcript enhancement failed: \(error.localizedDescription)",
-                level: .info, category: "Enhancement"
-            ) }
+      let pttStart = ContinuousClock.now
+      await active.handle(event: .preWarm)
+      guard !Task.isCancelled else {
+        // PTT release arrived during preWarm — stop the engine that preWarm started
+        self.audioCapture.abortPreWarm()
+        self.recordingOverlay.show(intent: .hidden)
+        return
+      }
+      let preWarmMs = {
+        let (s, a) = (ContinuousClock.now - pttStart).components
+        return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+      }()
+      await active.handle(event: .toggleRecording)
+      let totalMs = {
+        let (s, a) = (ContinuousClock.now - pttStart).components
+        return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+      }()
+      Task {
+        await AppLogger.shared.log(
+          "COLD-START [AppState] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet")",
+          level: .info, category: "Pipeline"
+        )
+      }
+
+      if isWhisperKit {
+        if case .error = self.whisperKitPipeline.state {
+          self.whisperKitPipeline.autoPasteToActiveApp = false
         }
+      } else {
+        if case .error = self.pipeline.state {
+          self.pipeline.autoPasteToActiveApp = false
+        }
+      }
+    }
+    hotkeyService.onStopRecording = { [weak self] in
+      guard let self else { return }
+      self.isRecordingLocked = false
+      await self.activePipeline.handle(event: .requestStop)
+      if self.asrManager.activeBackendType == .whisperKit {
+        self.whisperKitPipeline.autoPasteToActiveApp = false
+      } else {
+        self.pipeline.autoPasteToActiveApp = false
+      }
     }
 
-    // Phase 5 B.1 validated 2026-03-16: batch round-trip 51-60ms across XPC.
-    // Cold model load: 13,966ms. 3 warm back-to-back runs stable.
-    // Test function in git history.
+    hotkeyService.onCancelRecording = { [weak self] in
+      self?.isRecordingLocked = false
+      await self?.cancelRecording()
+    }
+
+    hotkeyService.onIsProcessing = { [weak self] in
+      guard let self else { return false }
+      // Block during any state that means "still working on the last recording"
+      if self.asrManager.activeBackendType == .whisperKit {
+        let state = self.whisperKitPipeline.state
+        return state == .transcribing || state == .polishing
+      } else {
+        let state = self.pipeline.state
+        return state == .transcribing || state == .polishing
+      }
+    }
+
+    hotkeyService.onLocked = { [weak self] in
+      guard let self else { return }
+      self.isRecordingLocked = true
+      self.recordingOverlay.updateLockState(true)
+      Task {
+        await AppLogger.shared.log(
+          "Hands-free mode activated — overlay expanding",
+          level: .info, category: "AppState"
+        )
+      }
+    }
+
+    // Pre-load the selected backend's model in the background to eliminate cold-start delay.
+    // Parakeet: direct silent load (model files already downloaded during onboarding).
+    // WhisperKit: observation-based (waits for setupState to become .ready first).
+    if settings.selectedBackend == .parakeet {
+      Task { [weak self] in
+        await self?.asrManager.loadModelSilently()
+      }
+    }
+    Task { [weak self] in
+      await self?.whisperKitSetup.detectState()
+      self?.startWhisperKitPreloadObservation()
+    }
+
+    // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
+    // called from applicationDidFinishLaunching. Carbon RegisterEventHotKey
+    // requires the NSApplication event loop to be running for event delivery.
+  }
+
+  /// Start the hotkey service. Must be called after the NSApplication event loop
+  /// is running (e.g., from applicationDidFinishLaunching), because Carbon
+  /// RegisterEventHotKey events are only delivered once the run loop is active.
+  func startHotkeyServiceIfEnabled() {
+    if settings.hotkeyEnabled {
+      hotkeyService.start()
+    }
+  }
+
+  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
+  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
+  private func startWhisperKitPreloadObservation() {
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+
+        // Check current state — if already .ready, trigger pre-load
+        let currentState = self.whisperKitSetup.setupState
+        if currentState == .ready {
+          await self.whisperKitPipeline.prepareBackendSilently()
+          return  // Model loaded — no need to keep observing
+        }
+
+        // Wait for the next change to setupState
+        await withCheckedContinuation { continuation in
+          withObservationTracking {
+            _ = self.whisperKitSetup.setupState
+          } onChange: {
+            continuation.resume()
+          }
+        }
+      }
+    }
+  }
+
+  /// Active dictation pipeline — routes based on selected backend.
+  var activePipeline: any DictationPipeline {
+    asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
+  }
+
+  /// Convenience: current pipeline state — routes through active backend.
+  var pipelineState: PipelineState {
+    if asrManager.activeBackendType == .whisperKit {
+      return whisperKitPipeline.state.asPipelineState
+    }
+    return pipeline.state
+  }
+
+  /// Last polish error from the active pipeline.
+  var lastPolishError: String? {
+    if asrManager.activeBackendType == .whisperKit {
+      return whisperKitPipeline.lastPolishError
+    }
+    return pipeline.lastPolishError
+  }
+
+  /// Convenience: the transcript from the latest recording.
+  var activeTranscript: Transcript? {
+    if let selected = transcriptCoordinator.selectedTranscriptID {
+      return transcriptCoordinator.transcripts.first { $0.id == selected }
+    }
+    if asrManager.activeBackendType == .whisperKit {
+      return whisperKitPipeline.currentTranscript
+    }
+    return pipeline.currentTranscript
+  }
+
+  /// Schedule a deferred post-completion warning overlay. Cancellable and session-scoped:
+  /// cancelled if a new recording starts (any non-complete state change cancels it).
+  /// Uses the pipeline's current state as a guard to avoid showing stale warnings.
+  /// Issue #285 — which backend most recently entered an active state
+  /// (startup, loading, or recording). Used as a tiebreaker when both
+  /// pipelines are active simultaneously (e.g. one still polishing while the
+  /// other begins a new capture). Updated on any active-state entry, not just
+  /// `.recording`, so stall watchdog and interruption callbacks that fire
+  /// pre-recording resolve to the correct backend.
+  private enum LastCapturingBackend { case parakeet, whisperKit }
+  private var lastCapturingBackend: LastCapturingBackend = .parakeet
+  // Previous active-state of each pipeline, tracked so we flip
+  // `lastCapturingBackend` only on inactive→active transitions. Without this,
+  // `.transcribing → .polishing` (active → active) would re-steal ownership
+  // after a different backend acquired the shared capture.
+  private var prevParakeetActive: Bool = false
+  private var prevWhisperKitActive: Bool = false
+
+  /// Issue #285 — resolve which backend owns the shared audio capture right
+  /// now. Returns nil when both pipelines are fully idle. Shared helper for
+  /// both telemetry routing and engine-interrupt routing so the two paths
+  /// cannot drift.
+  private func activeCaptureBackend() -> LastCapturingBackend? {
+    let pActive = pipeline.state.isActive
+    let wkActive = whisperKitPipeline.state.isActive
+    if pActive && wkActive { return lastCapturingBackend }
+    if pActive { return .parakeet }
+    if wkActive { return .whisperKit }
+    return nil
+  }
+
+  /// Issue #285 — belt-and-suspenders filter for late callbacks that somehow
+  /// slip past the per-source `isCapturing` / observer-removal guards during a
+  /// backend switch. Dropping a stale callback is safer than misrouting it to
+  /// a new session's dedup state. Source-level guards normally catch this;
+  /// this is a second line of defense for the backend-overlap window.
+  private func isCurrentSession(_ sessionID: UInt64) -> Bool {
+    sessionID == audioCapture.currentCaptureSessionID
+  }
+
+  private func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
+    switch activeCaptureBackend() {
+    case .whisperKit: return whisperKitPipeline
+    case .parakeet: return pipeline
+    case nil:
+      // Idle → attribute to the backend that most recently owned a session.
+      return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
+    }
+  }
+
+  private func schedulePostCompletionWarning(message: String) {
+    postCompletionWarningTask?.cancel()
+    postCompletionWarningTask = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: .milliseconds(400))
+      guard !Task.isCancelled, let self else { return }
+      // Only show if we're still in the completed state (no new recording started)
+      let parakeetComplete = self.pipeline.state == .complete
+      let whisperKitComplete =
+        self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
+      guard parakeetComplete || whisperKitComplete else { return }
+      self.recordingOverlay.show(intent: .warning(message: message))
+    }
+  }
+
+  /// Reset the currently active pipeline to idle. Used by UI "dismiss" actions.
+  func resetActivePipeline() {
+    if asrManager.activeBackendType == .whisperKit {
+      whisperKitPipeline.reset()
+    } else {
+      pipeline.reset()
+    }
+  }
+
+  /// Convenience: audio level for UI visualization.
+  var audioLevel: Float {
+    audioCapture.audioLevel
+  }
+
+  /// Human-readable model name for display.
+  var activeModelName: String {
+    settings.selectedBackend == .parakeet ? "Parakeet v3" : "WhisperKit"
+  }
+
+  var activeLLMDisplayName: String {
+    guard settings.llmProvider != .none else { return "LLM Deactivated" }
+    let model = settings.llmProvider == .ollama ? settings.ollamaModel : settings.llmModel
+    if model.isEmpty { return settings.llmProvider.displayName }
+    // Use discoveredModels displayName if available, otherwise raw model ID
+    if let info = llmDiscovery.discoveredModels.first(where: { $0.id == model }) {
+      return info.displayName
+    }
+    return model
+  }
+
+  /// Model status text for sidebar display.
+  var modelStatusText: String {
+    if asrManager.activeBackendType == .whisperKit {
+      switch whisperKitPipeline.state {
+      case .loadingModel: return "Loading Model"
+      case .recording: return "Recording"
+      case .transcribing: return "Transcribing"
+      case .polishing: return "Polishing"
+      case .error: return "Error"
+      default: break
+      }
+    } else {
+      if pipelineState == .recording { return "Recording" }
+      if pipelineState == .transcribing { return "Transcribing" }
+      if pipelineState == .polishing { return "Polishing" }
+      if case .error = pipelineState { return "Error" }
+    }
+    return asrManager.isModelLoaded ? "Loaded" : "Unloaded"
+  }
+
+  /// Toggle recording on/off (plain, no forced LLM).
+  func toggleRecording() async {
+    postCompletionWarningTask?.cancel()
+    let active = activePipeline
+    // Set auto-paste before toggle
+    if active is WhisperKitPipeline {
+      switch whisperKitPipeline.state {
+      case .idle, .ready, .complete, .error:
+        whisperKitPipeline.autoPasteToActiveApp = true
+        permissions.refreshAccessibilityStatus()
+        if !permissions.hasAccessibilityPermission {
+          whisperKitPipeline.autoPasteToActiveApp = false
+          permissions.restartMonitoringIfNeeded()
+        }
+      default: break
+      }
+    } else {
+      switch pipeline.state {
+      case .idle, .complete, .error:
+        pipeline.autoPasteToActiveApp = true
+        permissions.refreshAccessibilityStatus()
+        if !permissions.hasAccessibilityPermission {
+          pipeline.autoPasteToActiveApp = false
+          permissions.restartMonitoringIfNeeded()
+        }
+      default: break
+      }
+    }
+
+    // Fire dictation.invoked telemetry when starting (not stopping).
+    // Intent event: captures user action before engine/ASR work begins.
+    // Check that the active pipeline is NOT already in a recording/processing state.
+    let alreadyActive: Bool
+    if active is WhisperKitPipeline {
+      let s = whisperKitPipeline.state
+      alreadyActive =
+        s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
+        || s == .startingUp
+    } else {
+      let s = pipeline.state
+      alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
+    }
+    if !alreadyActive {
+      let targetApp = NSWorkspace.shared.frontmostApplication?.localizedName
+      TelemetryService.shared.dictationInvoked(
+        triggerSource: settings.recordingMode.rawValue,
+        inputMode: settings.recordingMode.rawValue,
+        targetApp: targetApp
+      )
+    }
+
+    await active.handle(event: .toggleRecording)
+
+    // Clear auto-paste on completion/error
+    if active is WhisperKitPipeline {
+      if case .complete = whisperKitPipeline.state {
+        whisperKitPipeline.autoPasteToActiveApp = false
+      }
+      if case .error = whisperKitPipeline.state { whisperKitPipeline.autoPasteToActiveApp = false }
+    } else {
+      if pipeline.state == .complete { pipeline.autoPasteToActiveApp = false }
+      if case .error = pipeline.state { pipeline.autoPasteToActiveApp = false }
+    }
+  }
+
+  /// Cancel an active recording, discarding all captured audio.
+  func cancelRecording() async {
+    TelemetryService.shared.dictationCanceled(
+      stage: "recording", reason: "user_cancel", durationSeconds: nil)
+    isRecordingLocked = false
+    recordingOverlay.hide()
+    let isWhisperKit = asrManager.activeBackendType == .whisperKit
+    if isWhisperKit {
+      let wkState = whisperKitPipeline.state
+      guard wkState == .recording || wkState == .loadingModel || wkState == .startingUp else {
+        return
+      }
+      whisperKitPipeline.autoPasteToActiveApp = false
+      await whisperKitPipeline.handle(event: .cancelRecording)
+    } else {
+      guard pipelineState == .recording || pipelineState == .loadingModel else { return }
+      pipeline.autoPasteToActiveApp = false
+      await pipeline.cancelRecording()
+    }
+  }
+
+  /// Enhancement error from the transcript detail view's re-polish service.
+  /// Separate from `lastPolishError` which tracks live-dictation polish failures.
+  var lastEnhancementError: EnhancementError? {
+    polishService.lastEnhancementError
+  }
+
+  /// Re-polish an existing transcript via the standalone polish service.
+  /// Decoupled from pipeline state: does not touch pipeline.state, currentTranscript, or lastPolishError.
+  func polishTranscript(_ transcript: Transcript) async {
+    do {
+      let updated = try await polishService.polish(transcript)
+      if let idx = transcriptCoordinator.transcripts.firstIndex(where: { $0.id == updated.id }) {
+        transcriptCoordinator.transcripts[idx] = updated
+      }
+      // Ensure detail view refreshes even when activeTranscript falls back to pipeline.currentTranscript
+      transcriptCoordinator.selectedTranscriptID = updated.id
+    } catch {
+      // Error already captured in polishService.lastEnhancementError
+      Task {
+        await AppLogger.shared.log(
+          "Transcript enhancement failed: \(error.localizedDescription)",
+          level: .info, category: "Enhancement"
+        )
+      }
+    }
+  }
+
+  // Phase 5 B.1 validated 2026-03-16: batch round-trip 51-60ms across XPC.
+  // Cold model load: 13,966ms. 3 warm back-to-back runs stable.
+  // Test function in git history.
 }
 
 // MARK: - DictationActivityProviding
 
 extension AppState: DictationActivityProviding {
-    /// True when either pipeline is actively recording, transcribing, or polishing.
-    /// Used by TranscriptPolishService to prevent concurrent re-polish + live dictation.
-    var isDictationActive: Bool {
-        pipeline.state.isActive || whisperKitPipeline.state.isActive
-    }
+  /// True when either pipeline is actively recording, transcribing, or polishing.
+  /// Used by TranscriptPolishService to prevent concurrent re-polish + live dictation.
+  var isDictationActive: Bool {
+    pipeline.state.isActive || whisperKitPipeline.state.isActive
+  }
 }
 
 extension WhisperKitPipelineState {
-    /// One authoritative mapping from WhisperKit's 9-state enum to unified PipelineState.
-    var asPipelineState: PipelineState {
-        switch self {
-        case .idle, .ready:              return .idle
-        case .startingUp, .loadingModel: return .loadingModel
-        case .recording:                 return .recording
-        case .transcribing:              return .transcribing
-        case .polishing:                 return .polishing
-        case .complete:                  return .complete
-        case .error(let msg):            return .error(msg)
-        }
+  /// One authoritative mapping from WhisperKit's 9-state enum to unified PipelineState.
+  var asPipelineState: PipelineState {
+    switch self {
+    case .idle, .ready: return .idle
+    case .startingUp, .loadingModel: return .loadingModel
+    case .recording: return .recording
+    case .transcribing: return .transcribing
+    case .polishing: return .polishing
+    case .complete: return .complete
+    case .error(let msg): return .error(msg)
     }
+  }
 }

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -1,6 +1,6 @@
 @preconcurrency import AVFoundation
-import EnviousWisprCore
 import CoreAudio
+import EnviousWisprCore
 import os
 
 /// Diagnostic logger for BT crash investigation — safe from any thread including RT audio.
@@ -18,46 +18,66 @@ private let btCrashLogger = Logger(subsystem: "com.enviouswispr", category: "BTC
 /// Uses `os_unfair_lock` to guarantee visibility across the real-time audio
 /// thread and the main thread without priority inversion.
 private final class TapStoppedFlag: Sendable {
-    private struct State: Sendable {
-        var stopped = false
-        var configChangeTime: CFAbsoluteTime = 0
-    }
+  private struct State: Sendable {
+    var stopped = false
+    var configChangeTime: CFAbsoluteTime = 0
+  }
 
-    private let _lock = OSAllocatedUnfairLock(initialState: State())
+  private let _lock = OSAllocatedUnfairLock(initialState: State())
 
-    /// Mark as stopped (from main thread teardown paths).
-    func set() {
-        _lock.withLock { $0.stopped = true }
-    }
+  /// Mark as stopped (from main thread teardown paths).
+  func set() {
+    _lock.withLock { $0.stopped = true }
+  }
 
-    /// Mark as stopped from a config-change notification — records monotonic
-    /// timestamp for race-window measurement.
-    func setFromConfigChange() {
-        _lock.withLock {
-            $0.stopped = true
-            $0.configChangeTime = CFAbsoluteTimeGetCurrent()
-        }
+  /// Mark as stopped from a config-change notification — records monotonic
+  /// timestamp for race-window measurement.
+  func setFromConfigChange() {
+    _lock.withLock {
+      $0.stopped = true
+      $0.configChangeTime = CFAbsoluteTimeGetCurrent()
     }
+  }
 
-    func isSet() -> Bool {
-        _lock.withLock { $0.stopped }
-    }
+  func isSet() -> Bool {
+    _lock.withLock { $0.stopped }
+  }
 
-    /// Reset for reuse after codec-switch recovery rebuilds the tap.
-    func reset() {
-        _lock.withLock { $0 = State() }
-    }
+  /// Reset for reuse after codec-switch recovery rebuilds the tap.
+  func reset() {
+    _lock.withLock { $0 = State() }
+  }
 
-    /// Timestamp of the last config-change stop, or 0 if none.
-    func lastConfigChangeTime() -> CFAbsoluteTime {
-        _lock.withLock { $0.configChangeTime }
-    }
+  /// Timestamp of the last config-change stop, or 0 if none.
+  func lastConfigChangeTime() -> CFAbsoluteTime {
+    _lock.withLock { $0.configChangeTime }
+  }
+}
+
+/// Cross-thread set-once latch for "did any buffer reach the tap this session."
+/// Main actor reads at watchdog-fire time; the tap thread marks on first buffer.
+/// `OSAllocatedUnfairLock` avoids Swift Atomics dependency; the cost is trivial
+/// because the tap checks a tap-local cache first (see `TapLocalSeenCache`).
+private final class CaptureLivenessState: Sendable {
+  private let _lock = OSAllocatedUnfairLock(initialState: false)
+  func markReceived() { _lock.withLock { $0 = true } }
+  func wasReceived() -> Bool { _lock.withLock { $0 } }
+  func reset() { _lock.withLock { $0 = false } }
+}
+
+/// Tap-thread-local one-shot latch. Captured by the tap closure so the first
+/// buffer of a session takes the cross-thread lock exactly once; subsequent
+/// buffers skip it. Main actor resets before arming the watchdog so the next
+/// session rearms the latch. Races are benign — a stale `true` costs at most
+/// one missed mark, and the following buffer re-marks correctly.
+private final class TapLocalSeenCache: @unchecked Sendable {
+  var alreadyMarkedThisSession = false
 }
 
 /// Convert a Swift Duration to milliseconds as an Int for logging.
 private func ms(_ d: Duration) -> Int {
-    let (seconds, attoseconds) = d.components
-    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+  let (seconds, attoseconds) = d.components
+  return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
 }
 
 /// AVAudioEngine-based audio capture source. Supports voice processing (noise suppression)
@@ -68,582 +88,732 @@ private func ms(_ d: Duration) -> Int {
 @MainActor
 final class AVAudioEngineSource: AudioInputSource {
 
-    // MARK: - AudioInputSource callbacks
+  // MARK: - AudioInputSource callbacks
 
-    var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
-    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-    var onInterrupted: (() -> Void)?
+  var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onInterrupted: (() -> Void)?
 
-    // MARK: - State
+  // MARK: - Round-4 telemetry (issue #285) — capture liveness watchdog.
 
-    private(set) var isCapturing = false
-    var isRunning: Bool { engine.isRunning }
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  /// Direct engine source has no AVCaptureSession layer; callback stays nil.
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  private(set) var captureGeneration: UInt64 = 0
 
-    /// Whether noise suppression via Apple Voice Processing is enabled.
-    var noiseSuppressionEnabled = false
+  nonisolated let captureSourceType: String = "av_audio_engine"
 
-    /// Persistent UID of the selected input device. Empty string means system default.
-    var selectedInputDeviceUID: String = ""
+  /// Set-once latch the tap flips on first buffer; watchdog reads at fire time.
+  private let captureLiveness = CaptureLivenessState()
+  /// Tap-thread-local cache that lets the tap skip the cross-thread lock after
+  /// the first buffer of a session. Reset by `startCapture` before arming.
+  private let tapLocalSeen = TapLocalSeenCache()
+  /// Private serial queue for the stall-detection `DispatchWorkItem`.
+  private static let stallQueue = DispatchQueue(
+    label: "com.enviouswispr.audio.capture-stall"
+  )
+  /// Pending watchdog; cancelled on stop / deactivate / new session.
+  private var stallWorkItem: DispatchWorkItem?
+  /// Uptime nanoseconds captured when the current watchdog was armed —
+  /// passed into `CaptureStallContext` for latency diagnostics.
+  private var stallArmedAtUptimeNs: UInt64 = 0
 
-    /// User override for input device. Empty string means "Auto" (smart selection enabled).
-    var preferredInputDeviceIDOverride: String = ""
+  // MARK: - State
 
-    /// The CoreAudio device ID currently in use.
-    private(set) var currentInputDeviceID: AudioDeviceID?
+  private(set) var isCapturing = false
+  var isRunning: Bool { engine.isRunning }
 
-    // MARK: - Private state
+  /// Whether noise suppression via Apple Voice Processing is enabled.
+  var noiseSuppressionEnabled = false
 
-    private var engine = AVAudioEngine()
-    private var converter: AVAudioConverter? // periphery:ignore - retains converter to prevent deallocation while tap is active
-    private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
-    private var configChangeObserver: (any NSObjectProtocol)?
-    private var activeTasks: [Task<Void, Never>] = []
-    private var tapStoppedFlag: TapStoppedFlag?
-    private var isRecovering = false
-    private var forwarder: PreRollForwarder?
+  /// Persistent UID of the selected input device. Empty string means system default.
+  var selectedInputDeviceUID: String = ""
 
-    /// Called when an audio device operation fails.
-    var onDeviceError: ((String) -> Void)?
+  /// User override for input device. Empty string means "Auto" (smart selection enabled).
+  var preferredInputDeviceIDOverride: String = ""
 
-    // NOTE: onPartialSamples removed — manager owns capturedSamples and handles partial recovery.
+  /// The CoreAudio device ID currently in use.
+  private(set) var currentInputDeviceID: AudioDeviceID?
 
-    // MARK: - Constants
+  // MARK: - Private state
 
-    nonisolated static let targetSampleRate: Double = 16000
-    nonisolated static let targetChannels: AVAudioChannelCount = 1
+  private var engine = AVAudioEngine()
+  private var converter: AVAudioConverter?  // periphery:ignore - retains converter to prevent deallocation while tap is active
+  private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+  private var configChangeObserver: (any NSObjectProtocol)?
+  private var activeTasks: [Task<Void, Never>] = []
+  private var tapStoppedFlag: TapStoppedFlag?
+  private var isRecovering = false
+  private var forwarder: PreRollForwarder?
 
-    // MARK: - Lifecycle
+  /// Called when an audio device operation fails.
+  var onDeviceError: ((String) -> Void)?
 
-    func prepare() async throws {
-        guard !engine.isRunning else { return }
-        let prepareStart = ContinuousClock.now
+  // NOTE: onPartialSamples removed — manager owns capturedSamples and handles partial recovery.
 
-        activeTasks.removeAll()
+  // MARK: - Constants
 
-        // Step 1: Voice Processing FIRST — creates the final AudioUnit type (AUVPIO vs AUHAL).
-        // CRITICAL: Must happen before setInputDevice(). If setInputDevice() runs first, it
-        // instantiates an AUHAL. Then setVoiceProcessingEnabled(true) DESTROYS that AUHAL and
-        // creates an AUVPIO. CoreAudio's BT I/O thread still holds a reference to the destroyed
-        // AUHAL -> use-after-free -> heap corruption -> EXC_BAD_ACCESS.
-        //
-        // Split-route check: when input != output device (e.g., built-in mic + BT headphones),
-        // CoreAudio's AEC can't sync different hardware clocks. Disable VP in this case.
-        let vpStart = ContinuousClock.now
-        let inputDeviceID = AudioDeviceEnumerator.defaultInputDeviceID()
-        let outputDeviceID = AudioDeviceEnumerator.defaultOutputDeviceID()
-        let isSplitRoute = inputDeviceID != nil && outputDeviceID != nil && inputDeviceID != outputDeviceID
-        let effectiveNoiseSuppression = noiseSuppressionEnabled && !isSplitRoute
+  nonisolated static let targetSampleRate: Double = 16000
+  nonisolated static let targetChannels: AVAudioChannelCount = 1
 
-        if isSplitRoute && noiseSuppressionEnabled {
-            btCrashLogger.info("Split route detected (input=\(inputDeviceID ?? 0) output=\(outputDeviceID ?? 0)) — disabling VP (AEC can't sync different clocks)")
-        }
+  // MARK: - Lifecycle
 
-        if effectiveNoiseSuppression {
-            do {
-                try engine.inputNode.setVoiceProcessingEnabled(true)
-            } catch {
-                Task { await AppLogger.shared.log(
-                    "Voice processing unavailable: \(error.localizedDescription). Continuing without noise suppression.",
-                    level: .info, category: "Audio"
-                ) }
-            }
-        } else {
-            try? engine.inputNode.setVoiceProcessingEnabled(false)
-        }
-        let vpMs = ms(ContinuousClock.now - vpStart)
+  func prepare() async throws {
+    guard !engine.isRunning else { return }
+    let prepareStart = ContinuousClock.now
 
-        // Step 2: Resolve input device — smart selection when in Auto mode.
-        // SAFETY: Skip setInputDevice() entirely when BT output is active.
-        let deviceStart = ContinuousClock.now
-        let btOutputActive: Bool
-        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
-            btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
-        } else {
-            btOutputActive = false
-        }
+    activeTasks.removeAll()
 
-        let resolvedDeviceID: AudioDeviceID?
-        if btOutputActive {
-            // BT output active — skip device switch.
-            // Forcing built-in mic via setInputDevice crashes the XPC service.
-            // Root cause: CoreAudio creates corrupted CADefaultDeviceAggregate.
-            // Path forward: AVCaptureSessionSource handles BT case.
-            resolvedDeviceID = nil
-            btCrashLogger.info("BT output active — skipping setInputDevice (aggregate device crash prevention)")
-        } else if !preferredInputDeviceIDOverride.isEmpty {
-            resolvedDeviceID = AudioDeviceEnumerator.deviceID(forUID: preferredInputDeviceIDOverride)
-        } else if !selectedInputDeviceUID.isEmpty {
-            resolvedDeviceID = AudioDeviceEnumerator.deviceID(forUID: selectedInputDeviceUID)
-        } else if let recommended = AudioDeviceEnumerator.recommendedInputDevice() {
-            resolvedDeviceID = recommended
-            Task { await AppLogger.shared.log(
-                "Smart device selection: using built-in mic (BT output detected with active media)",
-                level: .info, category: "Audio"
-            ) }
-        } else {
-            resolvedDeviceID = nil
-        }
-        try setInputDevice(resolvedDeviceID)
-        currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
-        let deviceMs = ms(ContinuousClock.now - deviceStart)
+    // Step 1: Voice Processing FIRST — creates the final AudioUnit type (AUVPIO vs AUHAL).
+    // CRITICAL: Must happen before setInputDevice(). If setInputDevice() runs first, it
+    // instantiates an AUHAL. Then setVoiceProcessingEnabled(true) DESTROYS that AUHAL and
+    // creates an AUVPIO. CoreAudio's BT I/O thread still holds a reference to the destroyed
+    // AUHAL -> use-after-free -> heap corruption -> EXC_BAD_ACCESS.
+    //
+    // Split-route check: when input != output device (e.g., built-in mic + BT headphones),
+    // CoreAudio's AEC can't sync different hardware clocks. Disable VP in this case.
+    let vpStart = ContinuousClock.now
+    let inputDeviceID = AudioDeviceEnumerator.defaultInputDeviceID()
+    let outputDeviceID = AudioDeviceEnumerator.defaultOutputDeviceID()
+    let isSplitRoute =
+      inputDeviceID != nil && outputDeviceID != nil && inputDeviceID != outputDeviceID
+    let effectiveNoiseSuppression = noiseSuppressionEnabled && !isSplitRoute
 
-        // Create the capture stop token for this session
-        let stopToken = TapStoppedFlag()
-        self.tapStoppedFlag = stopToken
-
-        // Register for engine configuration changes
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        configChangeObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: engine,
-            queue: nil
-        ) { [weak self] _ in
-            stopToken.setFromConfigChange()
-            btCrashLogger.info("Config change notification — stop token flipped immediately")
-
-            Task { @MainActor in
-                await self?.handleEngineConfigurationChange()
-            }
-        }
-
-        let engineStartTime = ContinuousClock.now
-        btCrashLogger.info("Engine starting — stop token created, observer registered (queue: nil)")
-        try engine.start()
-        let engineMs = ms(ContinuousClock.now - engineStartTime)
-        btCrashLogger.info("Engine started successfully")
-
-        // Install pre-roll tap immediately after engine start.
-        // Format is stable for built-in mic (BT uses AVCaptureSessionSource).
-        // The tap routes through a PreRollForwarder that buffers audio until
-        // startCapture() activates live forwarding.
-        let tapStart = ContinuousClock.now
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-
-        guard let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Self.targetSampleRate,
-            channels: Self.targetChannels,
-            interleaved: false
-        ) else {
-            btCrashLogger.error("Pre-roll: failed to create target format — tap not installed")
-            return
-        }
-
-        guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            btCrashLogger.error("Pre-roll: failed to create converter from \(inputFormat) — tap not installed")
-            return
-        }
-        self.converter = audioConverter
-
-        let fwd = PreRollForwarder()
-        self.forwarder = fwd
-
-        let tapHandler = Self.makeTapHandler(
-            audioConverter: audioConverter,
-            targetFormat: targetFormat,
-            inputFormat: inputFormat,
-            forwarder: fwd,
-            stoppedFlag: stopToken
-        )
-        inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
-        let tapMs = ms(ContinuousClock.now - tapStart)
-        let totalMs = ms(ContinuousClock.now - prepareStart)
-        AudioCaptureManager.btRouteLog("COLD-START prepare(): total=\(totalMs)ms | vp=\(vpMs)ms device=\(deviceMs)ms engine.start=\(engineMs)ms tap=\(tapMs)ms | vp=\(effectiveNoiseSuppression) bt=\(btOutputActive)")
+    if isSplitRoute && noiseSuppressionEnabled {
+      btCrashLogger.info(
+        "Split route detected (input=\(inputDeviceID ?? 0) output=\(outputDeviceID ?? 0)) — disabling VP (AEC can't sync different clocks)"
+      )
     }
 
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard let fwd = forwarder else {
-            throw AudioError.formatCreationFailed
-        }
-
-        // Reset stoppedFlag in case a config change happened during pre-roll
-        tapStoppedFlag?.reset()
-
-        let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
-            self.bufferContinuation = continuation
-        }
-
-        // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
-        _ = fwd.activate(
-            onSamples: self.onSamples,
-            onBuffer: self.onBufferCaptured,
-            continuation: self.bufferContinuation,
-            logPrefix: "Pre-roll"
-        )
-
-        isCapturing = true
-        return stream
-    }
-
-    func deactivateCapture() {
-        forwarder?.returnToPreRoll()
-        isCapturing = false
-        bufferContinuation = nil
-        AudioCaptureManager.btRouteLog("Engine deactivated — tap stays warm, pre-roll capturing")
-    }
-
-    func stop() async -> [Float] {
-        for task in activeTasks { task.cancel() }
-        activeTasks.removeAll()
-
-        forwarder?.stop()
-        forwarder = nil
-
-        tapStoppedFlag?.set()
-        tapStoppedFlag = nil
-
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
-        try? engine.inputNode.setVoiceProcessingEnabled(false)
-        isCapturing = false
-        currentInputDeviceID = nil
-        isRecovering = false
-        bufferContinuation = nil
-        converter = nil
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
-        // Source does not own samples — manager accumulates via onSamples callback.
-        return []
-    }
-
-    func waitForFormatStabilization(
-        maxWait: TimeInterval = 1.5,
-        pollInterval: TimeInterval = 0.2
-    ) async -> Bool {
-        let stabStart = ContinuousClock.now
-        let deadline = Date().addingTimeInterval(maxWait)
-        var lastFormat = engine.inputNode.outputFormat(forBus: 0)
-        try? await Task.sleep(for: .milliseconds(10))
-        let recheck = engine.inputNode.outputFormat(forBus: 0)
-        if recheck == lastFormat {
-            AudioCaptureManager.btRouteLog("COLD-START formatStab: stable on fast path (\(ms(ContinuousClock.now - stabStart))ms, 0 polls)")
-            return true
-        }
-        lastFormat = recheck
-        var polls = 0
-        while Date() < deadline {
-            try? await Task.sleep(for: .seconds(pollInterval))
-            polls += 1
-            let format = engine.inputNode.outputFormat(forBus: 0)
-            if format == lastFormat {
-                AudioCaptureManager.btRouteLog("COLD-START formatStab: stable after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)")
-                return true
-            }
-            lastFormat = format
-        }
-        AudioCaptureManager.btRouteLog("COLD-START formatStab: TIMED OUT after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)")
-        return false
-    }
-
-    func abortPrepare() {
-        guard engine.isRunning, !isCapturing else { return }
-        teardownEngine()
-        try? engine.inputNode.setVoiceProcessingEnabled(false)
-    }
-
-    func rebuild() {
-        teardownEngine()
-        engine.reset()
-        engine = AVAudioEngine()
-    }
-
-    /// Build (or rebuild) the AVAudioEngine with voice-processing configuration.
-    func buildEngine(noiseSuppression: Bool) {
-        teardownEngine()
-        engine = AVAudioEngine()
-
-        if noiseSuppression {
-            do {
-                try engine.inputNode.setVoiceProcessingEnabled(true)
-                if #available(macOS 14.0, *) {
-                    let duckingConfig = AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
-                        enableAdvancedDucking: false,
-                        duckingLevel: .min
-                    )
-                    engine.inputNode.voiceProcessingOtherAudioDuckingConfiguration = duckingConfig
-                }
-            } catch {
-                Task { await AppLogger.shared.log(
-                    "Voice processing unavailable during engine build: \(error.localizedDescription)",
-                    level: .info, category: "Audio"
-                ) }
-            }
-        }
-        noiseSuppressionEnabled = noiseSuppression
-    }
-
-    // MARK: - Private: Engine Teardown
-
-    /// Shared teardown: stop forwarder, stop engine, remove tap, remove config observer.
-    /// Does NOT reset or replace the engine (caller decides whether to do that).
-    private func teardownEngine() {
-        forwarder?.stop()
-        forwarder = nil
-        if engine.isRunning { engine.stop() }
-        engine.inputNode.removeTap(onBus: 0)
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
-    }
-
-    // MARK: - Private: Input Device
-
-    private func setInputDevice(_ deviceID: AudioDeviceID?) throws {
-        guard let deviceID, deviceID != 0 else { return }
-
-        let audioUnit = engine.inputNode.audioUnit
-        guard let au = audioUnit else { return }
-
-        var devID = deviceID
-        let status = AudioUnitSetProperty(
-            au,
-            kAudioOutputUnitProperty_CurrentDevice,
-            kAudioUnitScope_Global,
-            0,
-            &devID,
-            UInt32(MemoryLayout<AudioDeviceID>.size)
-        )
-        if status != noErr {
-            Task { await AppLogger.shared.log(
-                "Failed to set input device \(deviceID): OSStatus \(status)",
-                level: .info, category: "Audio"
-            ) }
-            onDeviceError?("Audio device switch failed for device \(deviceID)")
-        }
-    }
-
-    // MARK: - Private: Bluetooth Codec Switch Recovery
-
-    private func handleEngineConfigurationChange() async {
-        btCrashLogger.info("handleEngineConfigurationChange on MainActor — isCapturing=\(self.isCapturing), isRecovering=\(self.isRecovering)")
-        guard isCapturing, !isRecovering else { return }
-
-        guard let deviceID = currentInputDeviceID else {
-            await AppLogger.shared.log(
-                "Audio engine config changed — no device ID, performing emergency teardown",
-                level: .info, category: "Audio"
-            )
-            emergencyTeardown()
-            onInterrupted?()
-            return
-        }
-
-        var isAlive: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        var addr = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceIsAlive,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
-
-        if isAlive == 0 {
-            await AppLogger.shared.log(
-                "Audio device \(deviceID) is dead — performing emergency teardown",
-                level: .info, category: "Audio"
-            )
-            emergencyTeardown()
-            onInterrupted?()
-            return
-        }
-
-        await AppLogger.shared.log(
-            "Audio engine config changed — device \(deviceID) still alive (Bluetooth codec switch), attempting graceful recovery",
+    if effectiveNoiseSuppression {
+      do {
+        try engine.inputNode.setVoiceProcessingEnabled(true)
+      } catch {
+        Task {
+          await AppLogger.shared.log(
+            "Voice processing unavailable: \(error.localizedDescription). Continuing without noise suppression.",
             level: .info, category: "Audio"
-        )
-        await recoverFromCodecSwitch()
+          )
+        }
+      }
+    } else {
+      try? engine.inputNode.setVoiceProcessingEnabled(false)
+    }
+    let vpMs = ms(ContinuousClock.now - vpStart)
+
+    // Step 2: Resolve input device — smart selection when in Auto mode.
+    // SAFETY: Skip setInputDevice() entirely when BT output is active.
+    let deviceStart = ContinuousClock.now
+    let btOutputActive: Bool
+    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
+      btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
+    } else {
+      btOutputActive = false
     }
 
-    private func recoverFromCodecSwitch() async {
-        isRecovering = true
-        defer { isRecovering = false }
-
-        let configTime = tapStoppedFlag?.lastConfigChangeTime() ?? 0
-        let recoveryStart = CFAbsoluteTimeGetCurrent()
-        let gapMs = configTime > 0 ? (recoveryStart - configTime) * 1000 : -1
-        btCrashLogger.info("Recovery started — config→recovery gap: \(gapMs, format: .fixed(precision: 1))ms")
-
-        tapStoppedFlag?.set()
-
-        engine.inputNode.removeTap(onBus: 0)
-        btCrashLogger.info("Recovery: tap removed")
-
-        engine.stop()
-        btCrashLogger.info("Recovery: engine stopped")
-
-        let stabilized = await waitForFormatStabilization(
-            maxWait: 1.5,
-            pollInterval: 0.2
+    let resolvedDeviceID: AudioDeviceID?
+    if btOutputActive {
+      // BT output active — skip device switch.
+      // Forcing built-in mic via setInputDevice crashes the XPC service.
+      // Root cause: CoreAudio creates corrupted CADefaultDeviceAggregate.
+      // Path forward: AVCaptureSessionSource handles BT case.
+      resolvedDeviceID = nil
+      btCrashLogger.info(
+        "BT output active — skipping setInputDevice (aggregate device crash prevention)")
+    } else if !preferredInputDeviceIDOverride.isEmpty {
+      resolvedDeviceID = AudioDeviceEnumerator.deviceID(forUID: preferredInputDeviceIDOverride)
+    } else if !selectedInputDeviceUID.isEmpty {
+      resolvedDeviceID = AudioDeviceEnumerator.deviceID(forUID: selectedInputDeviceUID)
+    } else if let recommended = AudioDeviceEnumerator.recommendedInputDevice() {
+      resolvedDeviceID = recommended
+      Task {
+        await AppLogger.shared.log(
+          "Smart device selection: using built-in mic (BT output detected with active media)",
+          level: .info, category: "Audio"
         )
-        guard stabilized else {
-            btCrashLogger.error("Recovery: format stabilization timed out — emergency teardown")
-            emergencyTeardown()
-            onInterrupted?()
-            return
-        }
+      }
+    } else {
+      resolvedDeviceID = nil
+    }
+    try setInputDevice(resolvedDeviceID)
+    currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
+    let deviceMs = ms(ContinuousClock.now - deviceStart)
 
-        do {
-            let inputNode = engine.inputNode
-            let inputFormat = inputNode.outputFormat(forBus: 0)
+    // Create the capture stop token for this session
+    let stopToken = TapStoppedFlag()
+    self.tapStoppedFlag = stopToken
 
-            guard let targetFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: Self.targetSampleRate,
-                channels: Self.targetChannels,
-                interleaved: false
-            ) else {
-                throw AudioError.formatCreationFailed
-            }
+    // Register for engine configuration changes
+    if let observer = configChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    configChangeObserver = NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange,
+      object: engine,
+      queue: nil
+    ) { [weak self] _ in
+      stopToken.setFromConfigChange()
+      btCrashLogger.info("Config change notification — stop token flipped immediately")
 
-            guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-                throw AudioError.formatCreationFailed
-            }
-            self.converter = audioConverter
-
-            guard let stoppedFlag = tapStoppedFlag else {
-                throw AudioError.formatCreationFailed
-            }
-            stoppedFlag.reset()
-            btCrashLogger.info("Recovery: stop token reset for new tap")
-
-            guard let fwd = forwarder else {
-                throw AudioError.formatCreationFailed
-            }
-
-            // Validate format before reinstalling tap.
-            // After codec switch, format may be zero/invalid.
-            guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-                btCrashLogger.error("Recovery: invalid input format \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch — emergency teardown")
-                throw AudioError.formatCreationFailed
-            }
-
-            // Safety: remove tap again before reinstalling.
-            // AVAudioEngine may not fully clear tap state after engine.stop().
-            inputNode.removeTap(onBus: 0)
-
-            let bufferSize: AVAudioFrameCount = 2048
-            let tapHandler = Self.makeTapHandler(
-                audioConverter: audioConverter,
-                targetFormat: targetFormat,
-                inputFormat: inputFormat,
-                forwarder: fwd,
-                stoppedFlag: stoppedFlag
-            )
-            inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat, block: tapHandler)
-
-            do {
-                try engine.start()
-            } catch {
-                stoppedFlag.set()
-                tapStoppedFlag = nil
-                inputNode.removeTap(onBus: 0)
-                throw error
-            }
-
-            let totalMs = (CFAbsoluteTimeGetCurrent() - recoveryStart) * 1000
-            btCrashLogger.info("Recovery succeeded — total: \(totalMs, format: .fixed(precision: 1))ms, recording continues")
-        } catch {
-            btCrashLogger.error("Recovery failed: \(error.localizedDescription) — emergency teardown")
-            emergencyTeardown()
-            onInterrupted?()
-        }
+      Task { @MainActor in
+        await self?.handleEngineConfigurationChange()
+      }
     }
 
-    private func emergencyTeardown() {
-        guard isCapturing else { return }
+    let engineStartTime = ContinuousClock.now
+    btCrashLogger.info("Engine starting — stop token created, observer registered (queue: nil)")
+    try engine.start()
+    let engineMs = ms(ContinuousClock.now - engineStartTime)
+    btCrashLogger.info("Engine started successfully")
 
-        for task in activeTasks { task.cancel() }
-        activeTasks.removeAll()
+    // Install pre-roll tap immediately after engine start.
+    // Format is stable for built-in mic (BT uses AVCaptureSessionSource).
+    // The tap routes through a PreRollForwarder that buffers audio until
+    // startCapture() activates live forwarding.
+    let tapStart = ContinuousClock.now
+    let inputNode = engine.inputNode
+    let inputFormat = inputNode.outputFormat(forBus: 0)
 
-        forwarder?.stop()
-        forwarder = nil
+    guard
+      let targetFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: Self.targetSampleRate,
+        channels: Self.targetChannels,
+        interleaved: false
+      )
+    else {
+      btCrashLogger.error("Pre-roll: failed to create target format — tap not installed")
+      return
+    }
 
-        tapStoppedFlag?.set()
+    guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+      btCrashLogger.error(
+        "Pre-roll: failed to create converter from \(inputFormat) — tap not installed")
+      return
+    }
+    self.converter = audioConverter
+
+    let fwd = PreRollForwarder()
+    self.forwarder = fwd
+
+    let tapHandler = Self.makeTapHandler(
+      audioConverter: audioConverter,
+      targetFormat: targetFormat,
+      inputFormat: inputFormat,
+      forwarder: fwd,
+      stoppedFlag: stopToken,
+      liveness: captureLiveness,
+      tapLocal: tapLocalSeen
+    )
+    inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
+    let tapMs = ms(ContinuousClock.now - tapStart)
+    let totalMs = ms(ContinuousClock.now - prepareStart)
+    AudioCaptureManager.btRouteLog(
+      "COLD-START prepare(): total=\(totalMs)ms | vp=\(vpMs)ms device=\(deviceMs)ms engine.start=\(engineMs)ms tap=\(tapMs)ms | vp=\(effectiveNoiseSuppression) bt=\(btOutputActive)"
+    )
+  }
+
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard let fwd = forwarder else {
+      throw AudioError.formatCreationFailed
+    }
+
+    // Reset stoppedFlag in case a config change happened during pre-roll
+    tapStoppedFlag?.reset()
+
+    let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
+      self.bufferContinuation = continuation
+    }
+
+    // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
+    _ = fwd.activate(
+      onSamples: self.onSamples,
+      onBuffer: self.onBufferCaptured,
+      continuation: self.bufferContinuation,
+      logPrefix: "Pre-roll"
+    )
+
+    captureGeneration &+= 1
+    captureLiveness.reset()
+    tapLocalSeen.alreadyMarkedThisSession = false
+    armCaptureStallWatchdog()
+
+    isCapturing = true
+    return stream
+  }
+
+  /// Schedule a one-shot stall watchdog for the current `captureGeneration`.
+  /// Cancels any prior pending item so stale sessions cannot fire.
+  private func armCaptureStallWatchdog() {
+    stallWorkItem?.cancel()
+    let armedSession = captureGeneration
+    let armedAtNs = DispatchTime.now().uptimeNanoseconds
+    stallArmedAtUptimeNs = armedAtNs
+    let item = Self.makeStallWorkItem(
+      armedSession: armedSession, armedAtNs: armedAtNs, source: self)
+    stallWorkItem = item
+    Self.stallQueue.asyncAfter(
+      deadline: .now() + .milliseconds(TimingConstants.audioCaptureStallWindowMs),
+      execute: item
+    )
+  }
+
+  /// Build the watchdog closure in a nonisolated context so it does NOT inherit
+  /// the enclosing `@MainActor` isolation. Without this escape hatch, Swift 6
+  /// inserts an executor check that fires `dispatch_assert_queue_fail` when
+  /// the work item runs on `stallQueue`.
+  nonisolated private static func makeStallWorkItem(
+    armedSession: UInt64,
+    armedAtNs: UInt64,
+    source: AVAudioEngineSource
+  ) -> DispatchWorkItem {
+    return DispatchWorkItem { [weak source] in
+      Task { @MainActor [weak source] in
+        source?.captureStallWatchdogFired(
+          armedSession: armedSession, armedAtNs: armedAtNs)
+      }
+    }
+  }
+
+  private func captureStallWatchdogFired(armedSession: UInt64, armedAtNs: UInt64) {
+    // Guard: session still the one we armed for, still capturing, no buffers.
+    guard captureGeneration == armedSession else { return }
+    guard isCapturing else { return }
+    guard !captureLiveness.wasReceived() else { return }
+
+    let ctx = CaptureStallContext(
+      sessionID: armedSession,
+      armedAtUptimeNs: armedAtNs,
+      firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      engineStartedSuccessfully: engine.isRunning,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
+        ? nil : preferredInputDeviceIDOverride,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+    )
+    onCaptureStalled?(ctx)
+  }
+
+  func deactivateCapture() {
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    forwarder?.returnToPreRoll()
+    isCapturing = false
+    bufferContinuation = nil
+    AudioCaptureManager.btRouteLog("Engine deactivated — tap stays warm, pre-roll capturing")
+  }
+
+  func stop() async -> [Float] {
+    // Cancel the stall watchdog; do NOT bump `captureGeneration`. The pipeline
+    // reads `audioCapture.currentCaptureSessionID` after stop to dedup the
+    // final `no_audio_captured` against the earlier stall event for the same
+    // session (#285). Staleness protection for a late-fired watchdog is
+    // already provided by `isCapturing == false` in `captureStallWatchdogFired`.
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+
+    for task in activeTasks { task.cancel() }
+    activeTasks.removeAll()
+
+    forwarder?.stop()
+    forwarder = nil
+
+    tapStoppedFlag?.set()
+    tapStoppedFlag = nil
+
+    engine.inputNode.removeTap(onBus: 0)
+    engine.stop()
+    try? engine.inputNode.setVoiceProcessingEnabled(false)
+    isCapturing = false
+    currentInputDeviceID = nil
+    isRecovering = false
+    bufferContinuation = nil
+    converter = nil
+    if let observer = configChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      configChangeObserver = nil
+    }
+    // Source does not own samples — manager accumulates via onSamples callback.
+    return []
+  }
+
+  func waitForFormatStabilization(
+    maxWait: TimeInterval = 1.5,
+    pollInterval: TimeInterval = 0.2
+  ) async -> Bool {
+    let stabStart = ContinuousClock.now
+    let deadline = Date().addingTimeInterval(maxWait)
+    var lastFormat = engine.inputNode.outputFormat(forBus: 0)
+    try? await Task.sleep(for: .milliseconds(10))
+    let recheck = engine.inputNode.outputFormat(forBus: 0)
+    if recheck == lastFormat {
+      AudioCaptureManager.btRouteLog(
+        "COLD-START formatStab: stable on fast path (\(ms(ContinuousClock.now - stabStart))ms, 0 polls)"
+      )
+      return true
+    }
+    lastFormat = recheck
+    var polls = 0
+    while Date() < deadline {
+      try? await Task.sleep(for: .seconds(pollInterval))
+      polls += 1
+      let format = engine.inputNode.outputFormat(forBus: 0)
+      if format == lastFormat {
+        AudioCaptureManager.btRouteLog(
+          "COLD-START formatStab: stable after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)"
+        )
+        return true
+      }
+      lastFormat = format
+    }
+    AudioCaptureManager.btRouteLog(
+      "COLD-START formatStab: TIMED OUT after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)"
+    )
+    return false
+  }
+
+  func abortPrepare() {
+    guard engine.isRunning, !isCapturing else { return }
+    teardownEngine()
+    try? engine.inputNode.setVoiceProcessingEnabled(false)
+  }
+
+  func rebuild() {
+    teardownEngine()
+    engine.reset()
+    engine = AVAudioEngine()
+  }
+
+  /// Build (or rebuild) the AVAudioEngine with voice-processing configuration.
+  func buildEngine(noiseSuppression: Bool) {
+    teardownEngine()
+    engine = AVAudioEngine()
+
+    if noiseSuppression {
+      do {
+        try engine.inputNode.setVoiceProcessingEnabled(true)
+        if #available(macOS 14.0, *) {
+          let duckingConfig = AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
+            enableAdvancedDucking: false,
+            duckingLevel: .min
+          )
+          engine.inputNode.voiceProcessingOtherAudioDuckingConfiguration = duckingConfig
+        }
+      } catch {
+        Task {
+          await AppLogger.shared.log(
+            "Voice processing unavailable during engine build: \(error.localizedDescription)",
+            level: .info, category: "Audio"
+          )
+        }
+      }
+    }
+    noiseSuppressionEnabled = noiseSuppression
+  }
+
+  // MARK: - Private: Engine Teardown
+
+  /// Shared teardown: stop forwarder, stop engine, remove tap, remove config observer.
+  /// Does NOT reset or replace the engine (caller decides whether to do that).
+  private func teardownEngine() {
+    forwarder?.stop()
+    forwarder = nil
+    if engine.isRunning { engine.stop() }
+    engine.inputNode.removeTap(onBus: 0)
+    if let observer = configChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      configChangeObserver = nil
+    }
+  }
+
+  // MARK: - Private: Input Device
+
+  private func setInputDevice(_ deviceID: AudioDeviceID?) throws {
+    guard let deviceID, deviceID != 0 else { return }
+
+    let audioUnit = engine.inputNode.audioUnit
+    guard let au = audioUnit else { return }
+
+    var devID = deviceID
+    let status = AudioUnitSetProperty(
+      au,
+      kAudioOutputUnitProperty_CurrentDevice,
+      kAudioUnitScope_Global,
+      0,
+      &devID,
+      UInt32(MemoryLayout<AudioDeviceID>.size)
+    )
+    if status != noErr {
+      Task {
+        await AppLogger.shared.log(
+          "Failed to set input device \(deviceID): OSStatus \(status)",
+          level: .info, category: "Audio"
+        )
+      }
+      onDeviceError?("Audio device switch failed for device \(deviceID)")
+    }
+  }
+
+  // MARK: - Private: Bluetooth Codec Switch Recovery
+
+  private func handleEngineConfigurationChange() async {
+    btCrashLogger.info(
+      "handleEngineConfigurationChange on MainActor — isCapturing=\(self.isCapturing), isRecovering=\(self.isRecovering)"
+    )
+    guard isCapturing, !isRecovering else { return }
+
+    guard let deviceID = currentInputDeviceID else {
+      await AppLogger.shared.log(
+        "Audio engine config changed — no device ID, performing emergency teardown",
+        level: .info, category: "Audio"
+      )
+      emergencyTeardown()
+      onInterrupted?()
+      return
+    }
+
+    var isAlive: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsAlive,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
+
+    if isAlive == 0 {
+      await AppLogger.shared.log(
+        "Audio device \(deviceID) is dead — performing emergency teardown",
+        level: .info, category: "Audio"
+      )
+      emergencyTeardown()
+      onInterrupted?()
+      return
+    }
+
+    await AppLogger.shared.log(
+      "Audio engine config changed — device \(deviceID) still alive (Bluetooth codec switch), attempting graceful recovery",
+      level: .info, category: "Audio"
+    )
+    await recoverFromCodecSwitch()
+  }
+
+  private func recoverFromCodecSwitch() async {
+    isRecovering = true
+    defer { isRecovering = false }
+
+    let configTime = tapStoppedFlag?.lastConfigChangeTime() ?? 0
+    let recoveryStart = CFAbsoluteTimeGetCurrent()
+    let gapMs = configTime > 0 ? (recoveryStart - configTime) * 1000 : -1
+    btCrashLogger.info(
+      "Recovery started — config→recovery gap: \(gapMs, format: .fixed(precision: 1))ms")
+
+    tapStoppedFlag?.set()
+
+    engine.inputNode.removeTap(onBus: 0)
+    btCrashLogger.info("Recovery: tap removed")
+
+    engine.stop()
+    btCrashLogger.info("Recovery: engine stopped")
+
+    let stabilized = await waitForFormatStabilization(
+      maxWait: 1.5,
+      pollInterval: 0.2
+    )
+    guard stabilized else {
+      btCrashLogger.error("Recovery: format stabilization timed out — emergency teardown")
+      emergencyTeardown()
+      onInterrupted?()
+      return
+    }
+
+    do {
+      let inputNode = engine.inputNode
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+
+      guard
+        let targetFormat = AVAudioFormat(
+          commonFormat: .pcmFormatFloat32,
+          sampleRate: Self.targetSampleRate,
+          channels: Self.targetChannels,
+          interleaved: false
+        )
+      else {
+        throw AudioError.formatCreationFailed
+      }
+
+      guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+        throw AudioError.formatCreationFailed
+      }
+      self.converter = audioConverter
+
+      guard let stoppedFlag = tapStoppedFlag else {
+        throw AudioError.formatCreationFailed
+      }
+      stoppedFlag.reset()
+      btCrashLogger.info("Recovery: stop token reset for new tap")
+
+      guard let fwd = forwarder else {
+        throw AudioError.formatCreationFailed
+      }
+
+      // Validate format before reinstalling tap.
+      // After codec switch, format may be zero/invalid.
+      guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+        btCrashLogger.error(
+          "Recovery: invalid input format \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch — emergency teardown"
+        )
+        throw AudioError.formatCreationFailed
+      }
+
+      // Safety: remove tap again before reinstalling.
+      // AVAudioEngine may not fully clear tap state after engine.stop().
+      inputNode.removeTap(onBus: 0)
+
+      let bufferSize: AVAudioFrameCount = 2048
+      let tapHandler = Self.makeTapHandler(
+        audioConverter: audioConverter,
+        targetFormat: targetFormat,
+        inputFormat: inputFormat,
+        forwarder: fwd,
+        stoppedFlag: stoppedFlag,
+        liveness: captureLiveness,
+        tapLocal: tapLocalSeen
+      )
+      inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat, block: tapHandler)
+
+      do {
+        try engine.start()
+      } catch {
+        stoppedFlag.set()
         tapStoppedFlag = nil
+        inputNode.removeTap(onBus: 0)
+        throw error
+      }
 
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
-        engine.reset()
-
-        isCapturing = false
-        currentInputDeviceID = nil
-        isRecovering = false
-        bufferContinuation = nil
-        converter = nil
-
-        // Source does not own samples — manager handles partial sample recovery.
-
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
+      let totalMs = (CFAbsoluteTimeGetCurrent() - recoveryStart) * 1000
+      btCrashLogger.info(
+        "Recovery succeeded — total: \(totalMs, format: .fixed(precision: 1))ms, recording continues"
+      )
+    } catch {
+      btCrashLogger.error("Recovery failed: \(error.localizedDescription) — emergency teardown")
+      emergencyTeardown()
+      onInterrupted?()
     }
+  }
 
-    // MARK: - Private: Tap Handler (nonisolated)
+  private func emergencyTeardown() {
+    guard isCapturing else { return }
 
-    nonisolated private static func makeTapHandler(
-        audioConverter: AVAudioConverter,
-        targetFormat: AVAudioFormat,
-        inputFormat: AVAudioFormat,
-        forwarder: PreRollForwarder,
-        stoppedFlag: TapStoppedFlag
-    ) -> (AVAudioPCMBuffer, AVAudioTime) -> Void {
-        return { buffer, _ in
-            guard !stoppedFlag.isSet() else {
-                btCrashLogger.debug("Tap: bailing — stop flag set")
-                return
-            }
+    // No captureGeneration bump — see rationale in `stop()`. `isCapturing`
+    // flips false below, which guards a late-fired watchdog.
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
 
-            let bufferFormat = buffer.format
-            guard bufferFormat.sampleRate == inputFormat.sampleRate,
-                  bufferFormat.channelCount == inputFormat.channelCount else {
-                btCrashLogger.info("Tap: format mismatch — \(bufferFormat.sampleRate)Hz/\(bufferFormat.channelCount)ch vs expected \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch")
-                return
-            }
+    for task in activeTasks { task.cancel() }
+    activeTasks.removeAll()
 
-            let ratio = targetFormat.sampleRate / inputFormat.sampleRate
-            let outputFrameCount = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
-            guard outputFrameCount > 0, outputFrameCount <= 65536 else { return }
-            guard let convertedBuffer = AVAudioPCMBuffer(
-                pcmFormat: targetFormat,
-                frameCapacity: outputFrameCount
-            ) else { return }
+    forwarder?.stop()
+    forwarder = nil
 
-            var error: NSError?
-            nonisolated(unsafe) var inputConsumed = false
-            audioConverter.convert(to: convertedBuffer, error: &error) { _, outStatus in
-                if inputConsumed {
-                    outStatus.pointee = .noDataNow
-                    return nil
-                }
-                inputConsumed = true
-                outStatus.pointee = .haveData
-                return buffer
-            }
+    tapStoppedFlag?.set()
+    tapStoppedFlag = nil
 
-            guard error == nil, convertedBuffer.frameLength > 0 else { return }
+    engine.inputNode.removeTap(onBus: 0)
+    engine.stop()
+    engine.reset()
 
-            guard !stoppedFlag.isSet() else {
-                btCrashLogger.debug("Tap: bailing post-convert — stop flag set during conversion")
-                return
-            }
+    isCapturing = false
+    currentInputDeviceID = nil
+    isRecovering = false
+    bufferContinuation = nil
+    converter = nil
 
-            let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
+    // Source does not own samples — manager handles partial sample recovery.
 
-            if let channelData = convertedBuffer.floatChannelData {
-                let frameCount = Int(convertedBuffer.frameLength)
-                let samples = Array(UnsafeBufferPointer(
-                    start: channelData[0],
-                    count: frameCount
-                ))
-                forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
-            }
-        }
+    if let observer = configChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      configChangeObserver = nil
     }
+  }
+
+  // MARK: - Private: Tap Handler (nonisolated)
+
+  nonisolated private static func makeTapHandler(
+    audioConverter: AVAudioConverter,
+    targetFormat: AVAudioFormat,
+    inputFormat: AVAudioFormat,
+    forwarder: PreRollForwarder,
+    stoppedFlag: TapStoppedFlag,
+    liveness: CaptureLivenessState,
+    tapLocal: TapLocalSeenCache
+  ) -> (AVAudioPCMBuffer, AVAudioTime) -> Void {
+    return { buffer, _ in
+      guard !stoppedFlag.isSet() else {
+        btCrashLogger.debug("Tap: bailing — stop flag set")
+        return
+      }
+
+      let bufferFormat = buffer.format
+      guard bufferFormat.sampleRate == inputFormat.sampleRate,
+        bufferFormat.channelCount == inputFormat.channelCount
+      else {
+        btCrashLogger.info(
+          "Tap: format mismatch — \(bufferFormat.sampleRate)Hz/\(bufferFormat.channelCount)ch vs expected \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch"
+        )
+        return
+      }
+
+      let ratio = targetFormat.sampleRate / inputFormat.sampleRate
+      let outputFrameCount = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+      guard outputFrameCount > 0, outputFrameCount <= 65536 else { return }
+      guard
+        let convertedBuffer = AVAudioPCMBuffer(
+          pcmFormat: targetFormat,
+          frameCapacity: outputFrameCount
+        )
+      else { return }
+
+      var error: NSError?
+      nonisolated(unsafe) var inputConsumed = false
+      audioConverter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+        if inputConsumed {
+          outStatus.pointee = .noDataNow
+          return nil
+        }
+        inputConsumed = true
+        outStatus.pointee = .haveData
+        return buffer
+      }
+
+      guard error == nil, convertedBuffer.frameLength > 0 else { return }
+
+      guard !stoppedFlag.isSet() else {
+        btCrashLogger.debug("Tap: bailing post-convert — stop flag set during conversion")
+        return
+      }
+
+      // Capture-liveness watchdog: mark on first buffer of the session.
+      // Tap-local cache lets us skip the cross-thread lock after the first hit.
+      if !tapLocal.alreadyMarkedThisSession {
+        liveness.markReceived()
+        tapLocal.alreadyMarkedThisSession = true
+      }
+
+      let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
+
+      if let channelData = convertedBuffer.floatChannelData {
+        let frameCount = Int(convertedBuffer.frameLength)
+        let samples = Array(
+          UnsafeBufferPointer(
+            start: channelData[0],
+            count: frameCount
+          ))
+        forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
+      }
+    }
+  }
 }

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -1,6 +1,18 @@
 @preconcurrency import AVFoundation
-import EnviousWisprCore
 import CoreAudio
+import EnviousWisprCore
+import os
+
+/// Cross-thread set-once latch for "did any buffer reach the delegate this
+/// session." The `CaptureDelegate` marks from its callback queue; the
+/// MainActor watchdog reads at fire time. `OSAllocatedUnfairLock` keeps the
+/// write cost negligible.
+private final class CaptureLivenessFlag: Sendable {
+  private let _lock = OSAllocatedUnfairLock(initialState: false)
+  func markReceived() { _lock.withLock { $0 = true } }
+  func wasReceived() -> Bool { _lock.withLock { $0 } }
+  func reset() { _lock.withLock { $0 = false } }
+}
 
 /// AVCaptureSession-based audio capture source. Avoids BT A2DP→SCO codec switch by
 /// capturing from the built-in microphone via AVCaptureSession, which on macOS does NOT
@@ -14,363 +26,506 @@ import CoreAudio
 @MainActor
 final class AVCaptureSessionSource: AudioInputSource {
 
-    // MARK: - AudioInputSource callbacks
+  // MARK: - AudioInputSource callbacks
 
-    var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
-    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-    var onInterrupted: (() -> Void)?
+  var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onInterrupted: (() -> Void)?
 
-    // MARK: - State
+  // MARK: - Round-4 telemetry (issue #285) — stall watchdog + interruption ctx.
 
-    private(set) var isCapturing = false
-    var isRunning: Bool { session?.isRunning ?? false }
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  private(set) var captureGeneration: UInt64 = 0
 
-    // MARK: - Private state
+  nonisolated let captureSourceType: String = "av_capture_session"
 
-    private var session: AVCaptureSession?
-    private var audioOutput: AVCaptureAudioDataOutput?
-    private var delegate: CaptureDelegate?
-    private var interruptionObservers: [NSObjectProtocol] = []
-    private var forwarder: PreRollForwarder?
+  /// Set-once latch the delegate flips on first buffer; watchdog reads at fire time.
+  private let captureLiveness = CaptureLivenessFlag()
+  private static let stallQueue = DispatchQueue(
+    label: "com.enviouswispr.audio.capture-stall.session"
+  )
+  private var stallWorkItem: DispatchWorkItem?
 
-    /// Dedicated serial queue for AVCaptureSession start/stop operations.
-    /// Apple recommends session lifecycle on a serial queue to avoid race conditions.
-    /// IMPORTANT: This is separate from callbackQueue to avoid ordering bugs — lifecycle
-    /// work (start/stop) and sample delivery (captureOutput) never share a queue.
-    private let sessionQueue = DispatchQueue(label: "com.enviouswispr.capture-session-lifecycle")
+  // MARK: - State
 
-    /// Serial queue for sample buffer delivery. Separate from sessionQueue.
-    private let callbackQueue = DispatchQueue(label: "com.enviouswispr.capture-session-callback", qos: .userInteractive)
+  private(set) var isCapturing = false
+  var isRunning: Bool { session?.isRunning ?? false }
 
-    /// 16kHz mono Float32 format — matches ASR backend requirements.
-    private static let targetFormat = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: 16000,
-        channels: 1,
-        interleaved: false
-    )!
+  // MARK: - Private state
 
-    // MARK: - Lifecycle
+  private var session: AVCaptureSession?
+  private var audioOutput: AVCaptureAudioDataOutput?
+  private var delegate: CaptureDelegate?
+  private var interruptionObservers: [NSObjectProtocol] = []
+  private var forwarder: PreRollForwarder?
 
-    func prepare() async throws {
-        // Double-start protection
-        guard session == nil || session?.isRunning == false else { return }
+  /// Dedicated serial queue for AVCaptureSession start/stop operations.
+  /// Apple recommends session lifecycle on a serial queue to avoid race conditions.
+  /// IMPORTANT: This is separate from callbackQueue to avoid ordering bugs — lifecycle
+  /// work (start/stop) and sample delivery (captureOutput) never share a queue.
+  private let sessionQueue = DispatchQueue(label: "com.enviouswispr.capture-session-lifecycle")
 
-        // Find the built-in microphone by transport type — NOT AVCaptureDevice.default(for: .audio)
-        // which follows the system default and may return a BT device.
-        let builtInMic = findBuiltInMicrophone()
-        guard let mic = builtInMic else {
-            throw AudioError.noBuiltInMicrophoneFound
-        }
+  /// Serial queue for sample buffer delivery. Separate from sessionQueue.
+  private let callbackQueue = DispatchQueue(
+    label: "com.enviouswispr.capture-session-callback", qos: .userInteractive)
 
-        let captureSession = AVCaptureSession()
+  /// 16kHz mono Float32 format — matches ASR backend requirements.
+  private static let targetFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32,
+    sampleRate: 16000,
+    channels: 1,
+    interleaved: false
+  )!
 
-        let input = try AVCaptureDeviceInput(device: mic)
-        guard captureSession.canAddInput(input) else {
-            throw AudioError.formatCreationFailed
-        }
-        captureSession.addInput(input)
+  // MARK: - Lifecycle
 
-        let output = AVCaptureAudioDataOutput()
-        // Request 16kHz mono Float32 directly — macOS-only API.
-        // The framework handles sample rate conversion internally.
-        output.audioSettings = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: 16000.0,
-            AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 32,
-            AVLinearPCMIsFloatKey: true,
-            AVLinearPCMIsBigEndianKey: false,
-            AVLinearPCMIsNonInterleaved: true
-        ]
+  func prepare() async throws {
+    // Double-start protection
+    guard session == nil || session?.isRunning == false else { return }
 
-        guard captureSession.canAddOutput(output) else {
-            throw AudioError.formatCreationFailed
-        }
-        captureSession.addOutput(output)
-
-        self.session = captureSession
-        self.audioOutput = output
-
-        // Install pre-roll delegate to capture audio during setup latency.
-        // CaptureDelegate routes through PreRollForwarder, which buffers until
-        // startCapture() activates live forwarding.
-        let fwd = PreRollForwarder()
-        self.forwarder = fwd
-        let preRollDelegate = CaptureDelegate(
-            targetFormat: Self.targetFormat,
-            forwarder: fwd
-        )
-        self.delegate = preRollDelegate
-        output.setSampleBufferDelegate(preRollDelegate, queue: callbackQueue)
-
-        // Register interruption observers
-        registerInterruptionObservers(for: captureSession)
-
-        // Start the session — this does NOT trigger BT route changes on macOS.
-        // IMPORTANT: startRunning() is a blocking call that Apple says must not run on main thread.
-        // Dispatch to background and await completion.
-        let sessionQ = sessionQueue
-        let started = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-            sessionQ.async {
-                captureSession.startRunning()
-                cont.resume(returning: captureSession.isRunning)
-            }
-        }
-
-        guard started else {
-            throw AudioError.formatCreationFailed
-        }
-
-        AudioCaptureManager.btRouteLog("AVCaptureSessionSource: prepared with \(mic.localizedName) (uid=\(mic.uniqueID))")
+    // Find the built-in microphone by transport type — NOT AVCaptureDevice.default(for: .audio)
+    // which follows the system default and may return a BT device.
+    let builtInMic = findBuiltInMicrophone()
+    guard let mic = builtInMic else {
+      throw AudioError.noBuiltInMicrophoneFound
     }
 
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard !isCapturing else {
-            throw AudioError.alreadyCapturing
-        }
-        guard let fwd = forwarder else {
-            throw AudioError.formatCreationFailed
-        }
+    let captureSession = AVCaptureSession()
 
-        let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
-            self.delegate?.continuation = continuation
-        }
+    let input = try AVCaptureDeviceInput(device: mic)
+    guard captureSession.canAddInput(input) else {
+      throw AudioError.formatCreationFailed
+    }
+    captureSession.addInput(input)
 
-        // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
-        _ = fwd.activate(
-            onSamples: self.onSamples,
-            onBuffer: self.onBufferCaptured,
-            continuation: self.delegate?.continuation,
-            logPrefix: "AVCaptureSessionSource"
-        )
+    let output = AVCaptureAudioDataOutput()
+    // Request 16kHz mono Float32 directly — macOS-only API.
+    // The framework handles sample rate conversion internally.
+    output.audioSettings = [
+      AVFormatIDKey: kAudioFormatLinearPCM,
+      AVSampleRateKey: 16000.0,
+      AVNumberOfChannelsKey: 1,
+      AVLinearPCMBitDepthKey: 32,
+      AVLinearPCMIsFloatKey: true,
+      AVLinearPCMIsBigEndianKey: false,
+      AVLinearPCMIsNonInterleaved: true,
+    ]
 
-        isCapturing = true
-        return stream
+    guard captureSession.canAddOutput(output) else {
+      throw AudioError.formatCreationFailed
+    }
+    captureSession.addOutput(output)
+
+    self.session = captureSession
+    self.audioOutput = output
+
+    // Install pre-roll delegate to capture audio during setup latency.
+    // CaptureDelegate routes through PreRollForwarder, which buffers until
+    // startCapture() activates live forwarding.
+    let fwd = PreRollForwarder()
+    self.forwarder = fwd
+    let preRollDelegate = CaptureDelegate(
+      targetFormat: Self.targetFormat,
+      forwarder: fwd,
+      liveness: captureLiveness
+    )
+    self.delegate = preRollDelegate
+    output.setSampleBufferDelegate(preRollDelegate, queue: callbackQueue)
+
+    // Register interruption observers
+    registerInterruptionObservers(for: captureSession)
+
+    // Start the session — this does NOT trigger BT route changes on macOS.
+    // IMPORTANT: startRunning() is a blocking call that Apple says must not run on main thread.
+    // Dispatch to background and await completion.
+    let sessionQ = sessionQueue
+    let started = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+      sessionQ.async {
+        captureSession.startRunning()
+        cont.resume(returning: captureSession.isRunning)
+      }
     }
 
-    func deactivateCapture() {
-        forwarder?.returnToPreRoll()
-        isCapturing = false
-        delegate?.continuation = nil
-        AudioCaptureManager.btRouteLog("AVCaptureSession deactivated — session stays warm, pre-roll capturing")
+    guard started else {
+      throw AudioError.formatCreationFailed
     }
 
-    func stop() async -> [Float] {
-        forwarder?.stop()
-        forwarder = nil
+    AudioCaptureManager.btRouteLog(
+      "AVCaptureSessionSource: prepared with \(mic.localizedName) (uid=\(mic.uniqueID))")
+  }
 
-        // Stop session FIRST — stopRunning() is synchronous per Apple docs, blocks until
-        // the session stops and no new frames are delivered to callbackQueue.
-        // RULE: Do NOT touch delegate, callback queue, or continuation state until
-        // stopRunning() has returned. No "cleanup optimization" before the session stops.
-        if let captureSession = session {
-            let sessionQ = sessionQueue
-            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                sessionQ.async {
-                    captureSession.stopRunning()
-                    cont.resume()
-                }
-            }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard !isCapturing else {
+      throw AudioError.alreadyCapturing
+    }
+    guard let fwd = forwarder else {
+      throw AudioError.formatCreationFailed
+    }
+
+    let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
+      self.delegate?.continuation = continuation
+    }
+
+    // Two-step activation: snapshot ring, feed pre-roll, commit, feed delta.
+    _ = fwd.activate(
+      onSamples: self.onSamples,
+      onBuffer: self.onBufferCaptured,
+      continuation: self.delegate?.continuation,
+      logPrefix: "AVCaptureSessionSource"
+    )
+
+    captureGeneration &+= 1
+    captureLiveness.reset()
+    delegate?.resetBufferSeen()
+    armCaptureStallWatchdog()
+
+    isCapturing = true
+    return stream
+  }
+
+  /// Issue #285 — arm one-shot stall watchdog for the current capture session.
+  private func armCaptureStallWatchdog() {
+    stallWorkItem?.cancel()
+    let armedSession = captureGeneration
+    let armedAtNs = DispatchTime.now().uptimeNanoseconds
+    let item = Self.makeStallWorkItem(
+      armedSession: armedSession, armedAtNs: armedAtNs, source: self)
+    stallWorkItem = item
+    Self.stallQueue.asyncAfter(
+      deadline: .now() + .milliseconds(TimingConstants.audioCaptureStallWindowMs),
+      execute: item
+    )
+  }
+
+  /// Build the watchdog closure in a nonisolated context so it does NOT inherit
+  /// the enclosing `@MainActor` isolation. Without this escape hatch, Swift 6
+  /// inserts an executor check that fires `dispatch_assert_queue_fail` when
+  /// the work item runs on the stall queue.
+  nonisolated private static func makeStallWorkItem(
+    armedSession: UInt64,
+    armedAtNs: UInt64,
+    source: AVCaptureSessionSource
+  ) -> DispatchWorkItem {
+    return DispatchWorkItem { [weak source] in
+      Task { @MainActor [weak source] in
+        source?.captureStallWatchdogFired(
+          armedSession: armedSession, armedAtNs: armedAtNs)
+      }
+    }
+  }
+
+  private func captureStallWatchdogFired(armedSession: UInt64, armedAtNs: UInt64) {
+    guard captureGeneration == armedSession else { return }
+    guard isCapturing else { return }
+    guard !captureLiveness.wasReceived() else { return }
+
+    let ctx = CaptureStallContext(
+      sessionID: armedSession,
+      armedAtUptimeNs: armedAtNs,
+      firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+      route: "capture_session_bt",
+      sourceType: "av_capture_session",
+      engineStartedSuccessfully: session?.isRunning ?? false,
+      tapInstalled: true,
+      formatMismatchObserved: delegate?.didObserveFormatMismatch ?? false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+    )
+    onCaptureStalled?(ctx)
+  }
+
+  func deactivateCapture() {
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    forwarder?.returnToPreRoll()
+    isCapturing = false
+    delegate?.continuation = nil
+    AudioCaptureManager.btRouteLog(
+      "AVCaptureSession deactivated — session stays warm, pre-roll capturing")
+  }
+
+  func stop() async -> [Float] {
+    // Do NOT bump `captureGeneration` — it must stay stable across stop so the
+    // pipeline's stall→no-audio dedup keys the same session (#285). Watchdog
+    // staleness is covered by `stallWorkItem?.cancel()` + the `isCapturing`
+    // guard in `captureStallWatchdogFired`.
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    forwarder?.stop()
+    forwarder = nil
+
+    // Stop session FIRST — stopRunning() is synchronous per Apple docs, blocks until
+    // the session stops and no new frames are delivered to callbackQueue.
+    // RULE: Do NOT touch delegate, callback queue, or continuation state until
+    // stopRunning() has returned. No "cleanup optimization" before the session stops.
+    if let captureSession = session {
+      let sessionQ = sessionQueue
+      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        sessionQ.async {
+          captureSession.stopRunning()
+          cont.resume()
         }
-
-        // NOW safe to clear delegate — session is stopped, no more buffers arriving.
-        audioOutput?.setSampleBufferDelegate(nil, queue: nil)
-
-        isCapturing = false
-        removeInterruptionObservers()
-
-        delegate?.continuation = nil
-        delegate = nil
-
-        // Source does not own samples — manager accumulates via onSamples callback.
-        return []
+      }
     }
 
-    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-        // AVCaptureSession has no codec-switch problem — format is immediately stable.
-        return true
-    }
+    // NOW safe to clear delegate — session is stopped, no more buffers arriving.
+    audioOutput?.setSampleBufferDelegate(nil, queue: nil)
 
-    func abortPrepare() {
-        guard session?.isRunning == true, !isCapturing else { return }
-        teardownSession(clearDelegate: false)
-    }
+    isCapturing = false
+    removeInterruptionObservers()
 
-    func rebuild() {
-        teardownSession(clearDelegate: true)
-        session = nil
-        audioOutput = nil
-    }
+    delegate?.continuation = nil
+    delegate = nil
 
-    /// Shared teardown: stop forwarder, fire-and-forget session stop, remove observers.
-    /// `clearDelegate` controls whether delegate/continuation are nil'd (rebuild needs it,
-    /// abortPrepare does not because session stop handles it).
-    private func teardownSession(clearDelegate: Bool) {
-        forwarder?.stop()
-        forwarder = nil
-        if clearDelegate {
-            audioOutput?.setSampleBufferDelegate(nil, queue: nil)
-            delegate?.continuation?.finish()
-            delegate = nil
+    // Source does not own samples — manager accumulates via onSamples callback.
+    return []
+  }
+
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    // AVCaptureSession has no codec-switch problem — format is immediately stable.
+    return true
+  }
+
+  func abortPrepare() {
+    guard session?.isRunning == true, !isCapturing else { return }
+    teardownSession(clearDelegate: false)
+  }
+
+  func rebuild() {
+    teardownSession(clearDelegate: true)
+    session = nil
+    audioOutput = nil
+  }
+
+  /// Shared teardown: stop forwarder, fire-and-forget session stop, remove observers.
+  /// `clearDelegate` controls whether delegate/continuation are nil'd (rebuild needs it,
+  /// abortPrepare does not because session stop handles it).
+  private func teardownSession(clearDelegate: Bool) {
+    forwarder?.stop()
+    forwarder = nil
+    if clearDelegate {
+      audioOutput?.setSampleBufferDelegate(nil, queue: nil)
+      delegate?.continuation?.finish()
+      delegate = nil
+    }
+    // Fire-and-forget stop — synchronous protocol methods can't await.
+    // Using async avoids serial-queue self-deadlock risk.
+    let captureSession = session
+    sessionQueue.async {
+      captureSession?.stopRunning()
+    }
+    removeInterruptionObservers()
+  }
+
+  // MARK: - Private: Device Discovery
+
+  /// Find the built-in microphone via CoreAudio transport type.
+  /// Does NOT use AVCaptureDevice.default(for: .audio) which follows system default
+  /// and may return BT devices.
+  private func findBuiltInMicrophone() -> AVCaptureDevice? {
+    let discovery = AVCaptureDevice.DiscoverySession(
+      deviceTypes: [.microphone],
+      mediaType: .audio,
+      position: .unspecified
+    )
+
+    // Match by CoreAudio transport type — the most reliable way to identify built-in mic.
+    for device in discovery.devices {
+      if let audioDeviceID = AudioDeviceEnumerator.deviceID(forUID: device.uniqueID) {
+        let transport = AudioDeviceEnumerator.transportType(for: audioDeviceID)
+        if transport == kAudioDeviceTransportTypeBuiltIn {
+          return device
         }
-        // Fire-and-forget stop — synchronous protocol methods can't await.
-        // Using async avoids serial-queue self-deadlock risk.
-        let captureSession = session
-        sessionQueue.async {
-            captureSession?.stopRunning()
-        }
-        removeInterruptionObservers()
+      }
     }
 
-    // MARK: - Private: Device Discovery
-
-    /// Find the built-in microphone via CoreAudio transport type.
-    /// Does NOT use AVCaptureDevice.default(for: .audio) which follows system default
-    /// and may return BT devices.
-    private func findBuiltInMicrophone() -> AVCaptureDevice? {
-        let discovery = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.microphone],
-            mediaType: .audio,
-            position: .unspecified
-        )
-
-        // Match by CoreAudio transport type — the most reliable way to identify built-in mic.
-        for device in discovery.devices {
-            if let audioDeviceID = AudioDeviceEnumerator.deviceID(forUID: device.uniqueID) {
-                let transport = AudioDeviceEnumerator.transportType(for: audioDeviceID)
-                if transport == kAudioDeviceTransportTypeBuiltIn {
-                    return device
-                }
-            }
-        }
-
-        // Fallback: match by name (less reliable but covers edge cases)
-        AudioCaptureManager.btRouteLog("findBuiltInMicrophone: CoreAudio transport lookup found no built-in device, trying name fallback")
-        for device in discovery.devices {
-            let name = device.localizedName.lowercased()
-            if name.contains("built-in") || name.contains("macbook") {
-                return device
-            }
-        }
-
-        return nil
+    // Fallback: match by name (less reliable but covers edge cases)
+    AudioCaptureManager.btRouteLog(
+      "findBuiltInMicrophone: CoreAudio transport lookup found no built-in device, trying name fallback"
+    )
+    for device in discovery.devices {
+      let name = device.localizedName.lowercased()
+      if name.contains("built-in") || name.contains("macbook") {
+        return device
+      }
     }
 
-    // MARK: - Private: Interruption Handling
+    return nil
+  }
 
-    private func registerInterruptionObservers(for session: AVCaptureSession) {
-        let wasInterrupted = NotificationCenter.default.addObserver(
-            forName: .AVCaptureSessionWasInterrupted,
-            object: session,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.onInterrupted?()
-            }
-        }
+  // MARK: - Private: Interruption Handling
 
-        let runtimeError = NotificationCenter.default.addObserver(
-            forName: .AVCaptureSessionRuntimeError,
-            object: session,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.onInterrupted?()
-            }
-        }
-
-        interruptionObservers = [wasInterrupted, runtimeError]
+  private func registerInterruptionObservers(for session: AVCaptureSession) {
+    let wasInterrupted = NotificationCenter.default.addObserver(
+      forName: .AVCaptureSessionWasInterrupted,
+      object: session,
+      queue: .main
+    ) { [weak self] notification in
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        self.emitCaptureSessionInterruption(kind: .wasInterrupted, notification: notification)
+        self.onInterrupted?()
+      }
     }
 
-    private func removeInterruptionObservers() {
-        for observer in interruptionObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        interruptionObservers = []
+    let runtimeError = NotificationCenter.default.addObserver(
+      forName: .AVCaptureSessionRuntimeError,
+      object: session,
+      queue: .main
+    ) { [weak self] notification in
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        self.emitCaptureSessionInterruption(kind: .runtimeError, notification: notification)
+        self.onInterrupted?()
+      }
     }
+
+    interruptionObservers = [wasInterrupted, runtimeError]
+  }
+
+  /// Issue #285 — build `CaptureSessionInterruptionContext` from the
+  /// notification userInfo and invoke `onCaptureSessionInterruption`. Kept
+  /// defensive: userInfo keys are optional on macOS and any shape may be nil.
+  private func emitCaptureSessionInterruption(
+    kind: CaptureSessionInterruptionContext.Kind,
+    notification: Notification
+  ) {
+    // macOS: `AVCaptureSessionInterruptionReasonKey` is iOS-only. The
+    // wasInterrupted notification has no reason userInfo; only runtimeError
+    // carries an `AVCaptureSessionErrorKey` NSError.
+    let userInfo = notification.userInfo
+    let reasonCode: Int? = nil
+    let reasonLabel: String? = nil
+    let error = userInfo?[AVCaptureSessionErrorKey] as? NSError
+    let ctx = CaptureSessionInterruptionContext(
+      kind: kind,
+      reasonCode: reasonCode,
+      reasonLabel: reasonLabel,
+      errorDomain: error?.domain,
+      errorCode: error.map { $0.code },
+      errorDescription: error?.localizedDescription,
+      sessionID: captureGeneration,
+      isActivelyCapturing: isCapturing
+    )
+    onCaptureSessionInterruption?(ctx)
+  }
+
+  private func removeInterruptionObservers() {
+    for observer in interruptionObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    interruptionObservers = []
+  }
 }
 
 // MARK: - Capture Delegate
 
 /// Handles AVCaptureAudioDataOutput sample buffer delivery on a serial dispatch queue.
 /// Extracts Float32 samples from CMSampleBuffer and forwards via callbacks.
-private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate, @unchecked Sendable {
+private final class CaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate,
+  @unchecked Sendable
+{
 
-    /// Set after init by the AsyncStream closure.
-    var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
-    private let forwarder: PreRollForwarder
+  /// Set after init by the AsyncStream closure.
+  var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+  private let forwarder: PreRollForwarder
+  private let liveness: CaptureLivenessFlag
+  /// Callback-queue-local latch so we only mark once per session.
+  private var bufferSeenThisSession = false
 
-    /// Track whether first buffer format has been validated.
-    private var formatValidated = false
-    /// If true, format was wrong — drop all subsequent buffers.
-    private var formatMismatch = false
+  /// Track whether first buffer format has been validated.
+  private var formatValidated = false
+  /// If true, format was wrong — drop all subsequent buffers.
+  private var formatMismatch = false
 
-    init(targetFormat: AVAudioFormat, forwarder: PreRollForwarder) {
-        _ = targetFormat // validated at init site; format checking done in captureOutput
-        self.forwarder = forwarder
-    }
+  /// Readable by the source for `CaptureStallContext.formatMismatchObserved`.
+  var didObserveFormatMismatch: Bool { formatMismatch }
 
-    func captureOutput(
-        _ output: AVCaptureOutput,
-        didOutput sampleBuffer: CMSampleBuffer,
-        from connection: AVCaptureConnection
-    ) {
-        guard !formatMismatch else { return }  // Format was wrong — drop all buffers
-        guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer) else { return }
-        let numSamples = CMSampleBufferGetNumSamples(sampleBuffer)
-        guard numSamples > 0 else { return }
+  /// Called from the source on `startCapture` to rearm the per-session latch.
+  func resetBufferSeen() { bufferSeenThisSession = false }
 
-        // Format validation gate — debug assert, release log + fail safe
-        let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)!.pointee
-        if !formatValidated {
-            let actualRate = asbd.mSampleRate
-            let actualChannels = asbd.mChannelsPerFrame
-            AudioCaptureManager.btRouteLog("AVCaptureSessionSource first buffer: \(actualRate)Hz/\(actualChannels)ch, bits=\(asbd.mBitsPerChannel), float=\(asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0)")
+  init(targetFormat: AVAudioFormat, forwarder: PreRollForwarder, liveness: CaptureLivenessFlag) {
+    _ = targetFormat  // validated at init site; format checking done in captureOutput
+    self.forwarder = forwarder
+    self.liveness = liveness
+  }
 
-            #if DEBUG
-            assert(actualRate == 16000 && actualChannels == 1,
-                   "AVCaptureSession format mismatch: \(actualRate)Hz/\(actualChannels)ch — expected 16000Hz/1ch")
-            #endif
+  func captureOutput(
+    _ output: AVCaptureOutput,
+    didOutput sampleBuffer: CMSampleBuffer,
+    from connection: AVCaptureConnection
+  ) {
+    guard !formatMismatch else { return }  // Format was wrong — drop all buffers
+    guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer) else { return }
+    let numSamples = CMSampleBufferGetNumSamples(sampleBuffer)
+    guard numSamples > 0 else { return }
 
-            formatValidated = true  // Set regardless of match — log once, not on every buffer
-            if actualRate != 16000 || actualChannels != 1 {
-                AudioCaptureManager.btRouteLog("FORMAT MISMATCH: expected 16000Hz/1ch, got \(actualRate)Hz/\(actualChannels)ch — dropping all buffers")
-                formatMismatch = true
-                return
-            }
-        }
+    // Format validation gate — debug assert, release log + fail safe
+    let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)!.pointee
+    if !formatValidated {
+      let actualRate = asbd.mSampleRate
+      let actualChannels = asbd.mChannelsPerFrame
+      AudioCaptureManager.btRouteLog(
+        "AVCaptureSessionSource first buffer: \(actualRate)Hz/\(actualChannels)ch, bits=\(asbd.mBitsPerChannel), float=\(asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0)"
+      )
 
-        // Extract Float32 samples from CMSampleBuffer
-        let frameCount = numSamples
-
-        let audioFormat = AVAudioFormat(cmAudioFormatDescription: formatDesc)
-        guard let pcmBuffer = AVAudioPCMBuffer(
-            pcmFormat: audioFormat,
-            frameCapacity: AVAudioFrameCount(frameCount)
-        ) else { return }
-
-        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
-
-        // Copy PCM data from CMSampleBuffer into AVAudioPCMBuffer
-        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
-            sampleBuffer,
-            at: 0,
-            frameCount: Int32(frameCount),
-            into: pcmBuffer.mutableAudioBufferList
+      #if DEBUG
+        assert(
+          actualRate == 16000 && actualChannels == 1,
+          "AVCaptureSession format mismatch: \(actualRate)Hz/\(actualChannels)ch — expected 16000Hz/1ch"
         )
-        guard status == noErr else { return }
+      #endif
 
-        // Calculate audio level (RMS)
-        let level = AudioBufferProcessor.calculateRMS(pcmBuffer)
-
-        // Route through forwarder (pre-roll ring or live callbacks)
-        if let channelData = pcmBuffer.floatChannelData {
-            let samples = Array(UnsafeBufferPointer(
-                start: channelData[0],
-                count: frameCount
-            ))
-            forwarder.route(samples: samples, level: level, buffer: pcmBuffer)
-        }
+      formatValidated = true  // Set regardless of match — log once, not on every buffer
+      if actualRate != 16000 || actualChannels != 1 {
+        AudioCaptureManager.btRouteLog(
+          "FORMAT MISMATCH: expected 16000Hz/1ch, got \(actualRate)Hz/\(actualChannels)ch — dropping all buffers"
+        )
+        formatMismatch = true
+        return
+      }
     }
+
+    // Extract Float32 samples from CMSampleBuffer
+    let frameCount = numSamples
+
+    let audioFormat = AVAudioFormat(cmAudioFormatDescription: formatDesc)
+    guard
+      let pcmBuffer = AVAudioPCMBuffer(
+        pcmFormat: audioFormat,
+        frameCapacity: AVAudioFrameCount(frameCount)
+      )
+    else { return }
+
+    pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+    // Copy PCM data from CMSampleBuffer into AVAudioPCMBuffer
+    let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+      sampleBuffer,
+      at: 0,
+      frameCount: Int32(frameCount),
+      into: pcmBuffer.mutableAudioBufferList
+    )
+    guard status == noErr else { return }
+
+    // Capture-liveness watchdog: mark on first buffer of the session.
+    if !bufferSeenThisSession {
+      liveness.markReceived()
+      bufferSeenThisSession = true
+    }
+
+    // Calculate audio level (RMS)
+    let level = AudioBufferProcessor.calculateRMS(pcmBuffer)
+
+    // Route through forwarder (pre-roll ring or live callbacks)
+    if let channelData = pcmBuffer.floatChannelData {
+      let samples = Array(
+        UnsafeBufferPointer(
+          start: channelData[0],
+          count: frameCount
+        ))
+      forwarder.route(samples: samples, level: level, buffer: pcmBuffer)
+    }
+  }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -5,37 +5,93 @@ import EnviousWisprCore
 /// Abstraction over audio capture — enables swapping between in-process and XPC implementations.
 @MainActor
 public protocol AudioCaptureInterface: AnyObject {
-    // Observable state (read-only externally)
-    var isCapturing: Bool { get }
-    var audioLevel: Float { get }
-    var capturedSamples: [Float] { get }
-    /// Low-cardinality audio route label for Sentry. Set after route resolution.
-    var currentAudioRoute: String { get }
+  // Observable state (read-only externally)
+  var isCapturing: Bool { get }
+  var audioLevel: Float { get }
+  var capturedSamples: [Float] { get }
+  /// Low-cardinality audio route label for Sentry. Set after route resolution.
+  var currentAudioRoute: String { get }
 
-    // Callback properties (read-write)
-    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
-    var onEngineInterrupted: (() -> Void)? { get set }
-    var onVADAutoStop: (() -> Void)? { get set }
+  // Callback properties (read-write)
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
+  var onEngineInterrupted: (() -> Void)? { get set }
+  var onVADAutoStop: (() -> Void)? { get set }
 
-    // Configuration properties (read-write)
-    var noiseSuppressionEnabled: Bool { get set }
-    var selectedInputDeviceUID: String { get set }
-    var preferredInputDeviceIDOverride: String { get set }
-    var warmEnginePolicy: WarmEnginePolicy { get set }
+  // Telemetry callbacks (round-4 additions for #285 heart-path Sentry coverage).
+  // Producers: source backends (`AVAudioEngineSource`, `AVCaptureSessionSource`,
+  //            `AudioCaptureProxy`). Consumers: pipeline layer + `AppState`.
+  // All callbacks fire on the MainActor. Conformers that don't produce a given
+  // signal leave the closure nil (e.g. direct sources leave XPC callbacks nil).
 
-    // Core lifecycle
-    func startEnginePhase() async throws
-    func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer>
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> // periphery:ignore - convenience method combining engine + capture phases
-    func stopCapture() async -> CaptureResult
-    func rebuildEngine()
-    func buildEngine(noiseSuppression: Bool)
-    func preWarm() async
-    func abortPreWarm()
-    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
+  /// Fires once per capture session when the liveness watchdog observes zero
+  /// audio buffers within `Constants.audioCaptureStallWindowMs` of tap install.
+  /// At most one call per `currentCaptureSessionID`. Never called after a
+  /// subsequent `stopCapture` for that session. Telemetry-only: consumers
+  /// must not treat this as a control-flow signal.
+  var onCaptureStalled: ((CaptureStallContext) -> Void)? { get set }
 
-    // VAD (Step 5)
-    func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)
-    func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int)
-    func getVADSegments() async -> [SpeechSegment]
+  /// Fires on `AVCaptureSessionWasInterrupted` / `AVCaptureSessionRuntimeError`
+  /// notifications from `AVCaptureSessionSource`. Carries the diagnostic
+  /// payload (interruption reason, runtime NSError) that the notification
+  /// userInfo would otherwise drop. Non-BT sources leave nil.
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)? { get set }
+
+  /// Fires from the proxy's XPC interruption / invalidation handlers.
+  /// Direct sources have no XPC layer and leave nil. Consumer emits
+  /// `captureError(.xpcServiceError)`. Idle interrupts do NOT invoke (silent
+  /// end-to-end per §3.5 Channel 2 in the round-4 plan).
+  var onXPCServiceError: ((XPCErrorContext) -> Void)? { get set }
+
+  /// Fires when a non-throwing XPC call (`stopCapture`, `getSamplesSnapshot`,
+  /// `getSpeechSegments`) swallowed a transport error in its internal catch
+  /// block. The proxy invokes the callback BEFORE returning its empty default
+  /// so the pipeline can emit the correct root cause instead of misrouting
+  /// into "no_audio_captured".
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)? { get set }
+
+  /// Fires on the first route resolution and on every subsequent resolution
+  /// where sourceType or reason differs from the prior call. No-op on
+  /// warm-reuse resolutions that produce the same decision.
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)? { get set }
+
+  /// Monotonic per-source identifier for the active capture session.
+  /// Increments on every `startCapture` / `beginCapturePhase`. Zero if no
+  /// session has started yet. Pipeline uses for correlation extras +
+  /// dedup-claim keying. Never persisted; not meaningful across launches.
+  var currentCaptureSessionID: UInt64 { get }
+
+  /// Authoritative "is a capture session in-flight right now." Backed by
+  /// source/proxy internal state (not pipeline UI state which lags at
+  /// start/stop boundaries). Used as the telemetry gate for XPC interrupt
+  /// classification.
+  var isActivelyCapturing: Bool { get }
+
+  /// Low-cardinality string identifying the concrete capture backend driving
+  /// the current session. Values: `"av_audio_engine"`, `"av_capture_session"`,
+  /// `"xpc_proxy"`. Used by pipeline-layer Sentry extras so BT-direct sessions
+  /// (AVCaptureSession) are not mislabeled as AVAudioEngine. Delegates to the
+  /// active source in direct mode; constant for the proxy.
+  var captureSourceType: String { get }
+
+  // Configuration properties (read-write)
+  var noiseSuppressionEnabled: Bool { get set }
+  var selectedInputDeviceUID: String { get set }
+  var preferredInputDeviceIDOverride: String { get set }
+  var warmEnginePolicy: WarmEnginePolicy { get set }
+
+  // Core lifecycle
+  func startEnginePhase() async throws
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer>
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>  // periphery:ignore - convenience method combining engine + capture phases
+  func stopCapture() async -> CaptureResult
+  func rebuildEngine()
+  func buildEngine(noiseSuppression: Bool)
+  func preWarm() async
+  func abortPreWarm()
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
+
+  // VAD (Step 5)
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int)
+  func getVADSegments() async -> [SpeechSegment]
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -1,6 +1,6 @@
 @preconcurrency import AVFoundation
-import EnviousWisprCore
 import CoreAudio
+import EnviousWisprCore
 import os
 
 /// Manages audio capture from the microphone — thin coordinator over AudioInputSource backends.
@@ -16,466 +16,558 @@ import os
 @MainActor
 @Observable
 public final class AudioCaptureManager: AudioCaptureInterface {
-    /// Current recording state.
-    public private(set) var isCapturing = false
+  /// Current recording state.
+  public private(set) var isCapturing = false
 
-    /// Current audio level (0.0 - 1.0) for waveform visualization.
-    public private(set) var audioLevel: Float = 0.0
+  /// Current audio level (0.0 - 1.0) for waveform visualization.
+  public private(set) var audioLevel: Float = 0.0
 
-    /// Accumulated audio samples from the current recording.
-    public private(set) var capturedSamples: [Float] = []
+  /// Accumulated audio samples from the current recording.
+  public private(set) var capturedSamples: [Float] = []
 
-    /// Optional callback to forward converted audio buffers (e.g., to streaming ASR).
-    /// Called on the audio thread — must be @Sendable.
-    public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  /// Optional callback to forward converted audio buffers (e.g., to streaming ASR).
+  /// Called on the audio thread — must be @Sendable.
+  public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
 
-    /// Called on the main actor when the audio engine is interrupted (e.g., device disconnect).
-    /// The pipeline should transition to an error state when this fires.
-    public var onEngineInterrupted: (() -> Void)?
+  /// Called on the main actor when the audio engine is interrupted (e.g., device disconnect).
+  /// The pipeline should transition to an error state when this fires.
+  public var onEngineInterrupted: (() -> Void)?
 
-    /// Called when service-side VAD detects sustained silence after speech.
-    /// No-op for in-process capture — VAD runs in the pipeline's monitorVAD() loop instead.
-    public var onVADAutoStop: (() -> Void)?
+  /// Called when service-side VAD detects sustained silence after speech.
+  /// No-op for in-process capture — VAD runs in the pipeline's monitorVAD() loop instead.
+  public var onVADAutoStop: (() -> Void)?
 
-    /// Whether noise suppression via Apple Voice Processing is enabled.
-    public var noiseSuppressionEnabled = false
+  // MARK: - Round-4 telemetry callbacks (issue #285)
 
-    /// Persistent UID of the selected input device. Empty string means system default.
-    public var selectedInputDeviceUID: String = ""
+  /// Stall watchdog callback (forwarded to active source in Phase B implementation).
+  public var onCaptureStalled: ((CaptureStallContext) -> Void)?
 
-    /// User override for input device. Empty string means "Auto" (smart selection enabled).
-    public var preferredInputDeviceIDOverride: String = ""
+  /// AVCaptureSession interruption context (forwarded from `AVCaptureSessionSource`).
+  public var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
 
-    /// Maximum recording duration in seconds. Prevents unbounded memory growth.
-    public nonisolated static let maxRecordingDurationSeconds: Double = 600
-    /// Maximum sample count derived from maxRecordingDurationSeconds at 16kHz.
-    public nonisolated static let maxRecordingSamples: Int = Int(maxRecordingDurationSeconds * targetSampleRate)
+  /// Only the XPC proxy invokes this; direct-mode manager leaves nil.
+  public var onXPCServiceError: ((XPCErrorContext) -> Void)?
 
-    /// Target format: 16kHz, mono, Float32 — required by both Parakeet and WhisperKit.
-    public nonisolated static let targetSampleRate: Double = 16000
+  /// Only the XPC proxy invokes this; direct-mode manager leaves nil.
+  public var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
 
-    /// The active capture source. Created on buildEngine/startEnginePhase.
-    /// Either AVAudioEngineSource (no BT) or AVCaptureSessionSource (BT output active).
-    private var activeSource: (any AudioInputSource)?
+  /// Fired by `resolveSource()` — initial resolution + changed-only afterwards.
+  public var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
 
-    /// Route resolver — decides which source to use based on BT state + user preference.
-    private var routeResolver = CaptureRouteResolver()
+  /// Monotonic counter, increments on each begin/start-capture.
+  /// Delegates to the active source's session counter so dedup and correlation
+  /// extras at the pipeline layer always read the live value. Returns 0 when
+  /// no source has been resolved yet.
+  public var currentCaptureSessionID: UInt64 {
+    activeSource?.captureGeneration ?? cachedCaptureGeneration
+  }
 
-    /// Idle teardown timer: shuts down the warm engine after inactivity.
-    private var warmEngineTeardownTask: Task<Void, Never>?
+  /// Delegates to the active source so the pipeline can attribute Sentry
+  /// events to the concrete backend (AVAudioEngine vs AVCaptureSession).
+  /// Falls back to the cached last-known value after stopCapture tears the
+  /// source down (see `cachedSourceType` rationale at field declaration).
+  public var captureSourceType: String {
+    activeSource?.captureSourceType ?? cachedSourceType
+  }
 
-    /// How long to keep the engine warm after recording stops.
-    /// Setting this property automatically reconciles with the current engine state.
-    public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
-        didSet {
-            guard oldValue != warmEnginePolicy else { return }
-            reconcileWarmEnginePolicy()
-        }
+  /// Authoritative capture-active predicate.
+  public var isActivelyCapturing: Bool { isCapturing }
+
+  /// Whether noise suppression via Apple Voice Processing is enabled.
+  public var noiseSuppressionEnabled = false
+
+  /// Persistent UID of the selected input device. Empty string means system default.
+  public var selectedInputDeviceUID: String = ""
+
+  /// User override for input device. Empty string means "Auto" (smart selection enabled).
+  public var preferredInputDeviceIDOverride: String = ""
+
+  /// Maximum recording duration in seconds. Prevents unbounded memory growth.
+  public nonisolated static let maxRecordingDurationSeconds: Double = 600
+  /// Maximum sample count derived from maxRecordingDurationSeconds at 16kHz.
+  public nonisolated static let maxRecordingSamples: Int = Int(
+    maxRecordingDurationSeconds * targetSampleRate)
+
+  /// Target format: 16kHz, mono, Float32 — required by both Parakeet and WhisperKit.
+  public nonisolated static let targetSampleRate: Double = 16000
+
+  /// The active capture source. Created on buildEngine/startEnginePhase.
+  /// Either AVAudioEngineSource (no BT) or AVCaptureSessionSource (BT output active).
+  private var activeSource: (any AudioInputSource)?
+
+  /// Issue #285 — mirror of `activeSource.captureGeneration` / `captureSourceType`
+  /// captured at session start, so pipeline Sentry extras still resolve a real
+  /// session id + backend tag after `stopCapture()` synchronously tears down
+  /// the source (warmEnginePolicy == .off). Without this cache, post-stop
+  /// reads fall back to `0` / `"unknown"` and break stall-vs-no-audio dedup.
+  private var cachedCaptureGeneration: UInt64 = 0
+  private var cachedSourceType: String = "unknown"
+
+  /// Route resolver — decides which source to use based on BT state + user preference.
+  private var routeResolver = CaptureRouteResolver()
+
+  /// Idle teardown timer: shuts down the warm engine after inactivity.
+  private var warmEngineTeardownTask: Task<Void, Never>?
+
+  /// How long to keep the engine warm after recording stops.
+  /// Setting this property automatically reconciles with the current engine state.
+  public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
+    didSet {
+      guard oldValue != warmEnginePolicy else { return }
+      reconcileWarmEnginePolicy()
+    }
+  }
+
+  /// When the engine entered idle-warm state. Used to recalculate remaining
+  /// timeout when the policy changes mid-idle.
+  private var idleSince: ContinuousClock.Instant?
+  private let clock = ContinuousClock()
+
+  /// The last route decision — for telemetry and debugging.
+  private var lastRouteDecision: CaptureRouteDecision?
+
+  /// Low-cardinality audio route label derived from the last route decision.
+  public var currentAudioRoute: String {
+    guard let decision = lastRouteDecision else { return "unknown" }
+    switch decision.reason {
+    case .noBTAutoInput, .noBTUserSelectedDevice:
+      return "built_in_mic"
+    case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
+      .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
+      return "capture_session_bt"
+    case .forcedEngine, .fallbackToEngine:
+      return "audio_engine"
+    case .forcedCaptureSession:
+      return "capture_session"
+    case .failedNoFallback:
+      return "failed"
+    }
+  }
+
+  public init() {}
+
+  // MARK: - AudioCaptureInterface
+
+  public func startEnginePhase() async throws {
+    // Re-evaluate route on every recording start — BT state may have changed.
+    let source = resolveSource()
+    try await source.prepare()
+  }
+
+  public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard let source = activeSource else {
+      throw AudioError.formatCreationFailed
     }
 
-    /// When the engine entered idle-warm state. Used to recalculate remaining
-    /// timeout when the policy changes mid-idle.
-    private var idleSince: ContinuousClock.Instant?
-    private let clock = ContinuousClock()
+    // Pre-allocate sample buffer
+    capturedSamples = []
+    capturedSamples.reserveCapacity(16000 * 30)
+    audioLevel = 0.0
 
-    /// The last route decision — for telemetry and debugging.
-    private var lastRouteDecision: CaptureRouteDecision?
-
-    /// Low-cardinality audio route label derived from the last route decision.
-    public var currentAudioRoute: String {
-        guard let decision = lastRouteDecision else { return "unknown" }
-        switch decision.reason {
-        case .noBTAutoInput, .noBTUserSelectedDevice:
-            return "built_in_mic"
-        case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
-             .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
-            return "capture_session_bt"
-        case .forcedEngine, .fallbackToEngine:
-            return "audio_engine"
-        case .forcedCaptureSession:
-            return "capture_session"
-        case .failedNoFallback:
-            return "failed"
-        }
-    }
-
-    public init() {}
-
-    // MARK: - AudioCaptureInterface
-
-    public func startEnginePhase() async throws {
-        // Re-evaluate route on every recording start — BT state may have changed.
-        let source = resolveSource()
-        try await source.prepare()
-    }
-
-    public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard let source = activeSource else {
-            throw AudioError.formatCreationFailed
-        }
-
-        // Pre-allocate sample buffer
-        capturedSamples = []
-        capturedSamples.reserveCapacity(16000 * 30)
-        audioLevel = 0.0
-
-        // Wire source callbacks → manager state.
-        // Source identity check prevents stale callbacks from a replaced source
-        // (e.g., pre-warm source replaced by startEnginePhase) from modifying state.
-        let sourceID = ObjectIdentifier(source)
-        let maxSamples = Self.maxRecordingSamples
-        source.onSamples = { [weak self] samples, level in
-            Task { @MainActor in
-                guard let self, self.isCapturing,
-                      self.activeSource.map({ ObjectIdentifier($0) }) == sourceID else { return }
-                self.audioLevel = level
-                self.capturedSamples.append(contentsOf: samples)
-                if self.capturedSamples.count >= maxSamples {
-                    await AppLogger.shared.log(
-                        "Max recording duration reached (\(Self.maxRecordingDurationSeconds)s) — auto-stopping",
-                        level: .info, category: "Audio"
-                    )
-                    self.isCapturing = false
-                    self.audioLevel = 0.0
-                    self.onEngineInterrupted?()
-                }
-            }
-        }
-        source.onBufferCaptured = onBufferCaptured
-        source.onInterrupted = { [weak self] in
-            guard let self,
-                  self.activeSource.map({ ObjectIdentifier($0) }) == sourceID else { return }
-            self.isCapturing = false
-            self.audioLevel = 0.0
-            self.onEngineInterrupted?()
-        }
-
-        let stream = try await source.startCapture()
-        isCapturing = true
-        return stream
-    }
-
-    // periphery:ignore - protocol conformance (AudioCaptureInterface); convenience for single-phase callers
-    public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard !isCapturing else {
-            return AsyncStream { $0.finish() }
-        }
-        try await startEnginePhase()
-        return try await beginCapturePhase()
-    }
-
-    public func stopCapture() async -> CaptureResult {
-        guard let source = activeSource else {
-            let samples = capturedSamples
-            capturedSamples = []
-            return CaptureResult(samples: samples)
-        }
-
-        isCapturing = false
-        audioLevel = 0.0
-
-        // Deactivate capture but keep engine warm. The tap stays installed and the
-        // pre-roll ring buffer continues capturing audio. On the next recording,
-        // prepare() sees the engine is already running and skips startup.
-        // This eliminates first-word clipping by ensuring the ring buffer has
-        // audio from before the user pressed the key.
-        source.deactivateCapture()
-
-        // Keep activeSource alive — resolveSource() will reuse it if still running.
-        // BT state changes are handled by resolveSource() re-evaluating the route.
-
-        // Schedule full teardown after idle period. Engine stays warm for rapid-fire
-        // dictation but doesn't run indefinitely.
-        scheduleWarmEngineTeardown()
-
-        // Samples accumulated via onSamples callback -> manager.capturedSamples.
-        // In-process path returns empty vadSegments; pipeline owns its own SilenceDetector.
-        let samples = capturedSamples
-        capturedSamples = []
-        return CaptureResult(samples: samples)
-    }
-
-    public func rebuildEngine() {
-        activeSource?.rebuild()
-    }
-
-    public func buildEngine(noiseSuppression: Bool) {
-        noiseSuppressionEnabled = noiseSuppression
-        // buildEngine is called at app startup for VP config. Create an engine source
-        // for now — startEnginePhase will re-resolve if BT state requires capture session.
-        // If re-resolved to capture session, this engine source is discarded (no resources held —
-        // buildEngine only creates an AVAudioEngine object, doesn't start it or install taps).
-        if let engineSource = activeSource as? AVAudioEngineSource {
-            engineSource.buildEngine(noiseSuppression: noiseSuppression)
-        } else {
-            // Tear down any existing non-engine source before replacing
-            activeSource?.rebuild()
-            let engineSource = AVAudioEngineSource()
-            engineSource.buildEngine(noiseSuppression: noiseSuppression)
-            activeSource = engineSource
-        }
-    }
-
-    public func preWarm() async {
-        let preWarmStart = ContinuousClock.now
-        let source = resolveSource()
-        let resolveMs = Self.ms(ContinuousClock.now - preWarmStart)
-        guard !source.isRunning else {
-            Self.btRouteLog("COLD-START preWarm(): engine already running (warm hit) resolveSource=\(resolveMs)ms")
-            return
-        }
-        do {
-            try await source.prepare()
-        } catch {
-            Task { await AppLogger.shared.log(
-                "Audio pre-warm failed: \(error.localizedDescription)",
-                level: .info, category: "Audio"
-            ) }
-            return
-        }
-        let prepareMs = Self.ms(ContinuousClock.now - preWarmStart)
-        let stabStart = ContinuousClock.now
-        let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
-        let stabMs = Self.ms(ContinuousClock.now - stabStart)
-        let totalMs = Self.ms(ContinuousClock.now - preWarmStart)
-        Self.btRouteLog("COLD-START preWarm(): total=\(totalMs)ms | resolve=\(resolveMs)ms prepare=\(prepareMs)ms formatStab=\(stabMs)ms stabilized=\(stabilized)")
-    }
-
-    /// Convert Duration to milliseconds for logging.
-    nonisolated private static func ms(_ d: Duration) -> Int {
-        let (seconds, attoseconds) = d.components
-        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
-    }
-
-    public func abortPreWarm() {
-        activeSource?.abortPrepare()
-    }
-
-    public func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-        guard let source = activeSource else { return true }
-        return await source.waitForFormatStabilization(maxWait: maxWait, pollInterval: pollInterval)
-    }
-
-    // MARK: - Warm Engine Management
-
-    /// Schedule engine teardown based on the current warm engine policy.
-    /// Called after every recording stops. Cancelled if a new recording starts.
-    private func scheduleWarmEngineTeardown() {
-        warmEngineTeardownTask?.cancel()
-        warmEngineTeardownTask = nil
-
-        switch warmEnginePolicy {
-        case .off:
-            performEngineTeardown()
-            return
-        case .always:
-            idleSince = clock.now
-            return
-        case .seconds10, .seconds30, .seconds60:
-            break
-        }
-
-        let timeout = policyTimeout(warmEnginePolicy)
-        idleSince = clock.now
-        warmEngineTeardownTask = Task { [weak self] in
-            try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled, let self, !self.isCapturing else { return }
-            self.performEngineTeardown()
-        }
-    }
-
-    /// In-flight engine stop task. Stored so resolveSource() can cancel it
-    /// if a new recording starts before the stop completes, preventing two
-    /// engines from running simultaneously on the same hardware.
-    private var engineStopTask: Task<Void, Never>?
-
-    /// Tear down the warm engine. Clears activeSource synchronously before
-    /// awaiting stop to prevent stale async completions from clobbering new state.
-    private func performEngineTeardown() {
-        idleSince = nil
-        guard let source = activeSource else { return }
-        activeSource = nil
-        Self.btRouteLog("Warm engine teardown")
-        engineStopTask = Task { [weak self] in
-            _ = await source.stop()
-            self?.engineStopTask = nil
-        }
-    }
-
-    /// Reconcile engine state when the policy changes while idle.
-    /// Called automatically by the warmEnginePolicy setter.
-    private func reconcileWarmEnginePolicy() {
-        // If capturing, new policy applies on next stopCapture.
-        guard !isCapturing else { return }
-        // If engine is not warm, nothing to reconcile.
-        guard activeSource != nil else { return }
-
-        warmEngineTeardownTask?.cancel()
-        warmEngineTeardownTask = nil
-
-        switch warmEnginePolicy {
-        case .off:
-            performEngineTeardown()
-        case .always:
-            // Keep warm indefinitely, preserve idleSince.
-            break
-        case .seconds10, .seconds30, .seconds60:
-            let timeout = policyTimeout(warmEnginePolicy)
-            let elapsed = idleSince.map { clock.now - $0 } ?? .zero
-            if elapsed >= timeout {
-                performEngineTeardown()
-            } else {
-                let remaining = timeout - elapsed
-                warmEngineTeardownTask = Task { [weak self] in
-                    try? await Task.sleep(for: remaining)
-                    guard !Task.isCancelled, let self, !self.isCapturing else { return }
-                    self.performEngineTeardown()
-                }
-            }
-        }
-    }
-
-    /// Map a timed policy case to a Duration.
-    private func policyTimeout(_ policy: WarmEnginePolicy) -> Duration {
-        switch policy {
-        case .seconds10: .seconds(10)
-        case .seconds30: .seconds(30)
-        case .seconds60: .seconds(60)
-        default: .seconds(30)
-        }
-    }
-
-    // MARK: - Source Management
-
-    /// Resolve and create the appropriate capture source based on BT state and user preference.
-    /// Re-evaluates on every call — BT state may change between recordings.
-    private func resolveSource() -> any AudioInputSource {
-        // Cancel idle teardown — we're about to record
-        warmEngineTeardownTask?.cancel()
-        warmEngineTeardownTask = nil
-        // Cancel any in-flight engine stop from a previous teardown.
-        engineStopTask?.cancel()
-        engineStopTask = nil
-
-        // If a source is already running (warm engine), check route compatibility
-        if let existing = activeSource, existing.isRunning {
-            let decision = routeResolver.resolve(
-                preferredInputDeviceUID: preferredInputDeviceIDOverride,
-                noiseSuppression: noiseSuppressionEnabled
-            )
-            let existingIsEngine = existing is AVAudioEngineSource
-            let wantsEngine = decision.sourceType == .audioEngine
-
-            // Check full config signature, not just source type.
-            // Device/VP changes between recordings must trigger rebuild.
-            var configMatch = existingIsEngine == wantsEngine
-            if configMatch, let engineSource = existing as? AVAudioEngineSource {
-                // Compare effective device selection: preferredInputDeviceIDOverride
-                // takes priority, fall back to selectedInputDeviceUID when empty.
-                let oldEffective = engineSource.preferredInputDeviceIDOverride.isEmpty
-                    ? engineSource.selectedInputDeviceUID
-                    : engineSource.preferredInputDeviceIDOverride
-                let newEffective = preferredInputDeviceIDOverride.isEmpty
-                    ? selectedInputDeviceUID
-                    : preferredInputDeviceIDOverride
-                let deviceMatch = oldEffective == newEffective
-                let vpMatch = engineSource.noiseSuppressionEnabled == noiseSuppressionEnabled
-                configMatch = deviceMatch && vpMatch
-            }
-
-            if configMatch {
-                // Route and config unchanged, reuse warm source
-                lastRouteDecision = decision
-                Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
-                return existing
-            }
-            // Route changed (e.g., BT connected/disconnected) — synchronous teardown.
-            // Must be synchronous to avoid racing with new source's prepare() on same hardware.
-            Self.btRouteLog("Route changed while warm — tearing down old source")
-            existing.rebuild()
-            activeSource = nil
-        }
-
-        let decision = routeResolver.resolve(
-            preferredInputDeviceUID: preferredInputDeviceIDOverride,
-            noiseSuppression: noiseSuppressionEnabled
-        )
-        lastRouteDecision = decision
-
-        // Structured telemetry log
-        Self.btRouteLog("Route decision: source=\(decision.sourceType), reason=\(decision.reason.rawValue), vp=\(decision.vpAvailable), fallback=\(decision.fallbackAllowed) — \(decision.rationale)")
-        Task { await AppLogger.shared.log(
-            "Capture route: \(decision.reason.rawValue) → \(decision.sourceType == .captureSession ? "AVCaptureSession" : "AVAudioEngine"), VP=\(decision.vpAvailable)",
+    // Wire source callbacks → manager state.
+    // Source identity check prevents stale callbacks from a replaced source
+    // (e.g., pre-warm source replaced by startEnginePhase) from modifying state.
+    let sourceID = ObjectIdentifier(source)
+    let maxSamples = Self.maxRecordingSamples
+    source.onSamples = { [weak self] samples, level in
+      Task { @MainActor in
+        guard let self, self.isCapturing,
+          self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
+        else { return }
+        self.audioLevel = level
+        self.capturedSamples.append(contentsOf: samples)
+        if self.capturedSamples.count >= maxSamples {
+          await AppLogger.shared.log(
+            "Max recording duration reached (\(Self.maxRecordingDurationSeconds)s) — auto-stopping",
             level: .info, category: "Audio"
-        ) }
-
-        let source: any AudioInputSource
-        switch decision.sourceType {
-        case .captureSession:
-            if decision.vpAvailable == false && noiseSuppressionEnabled {
-                Self.btRouteLog("Noise suppression unavailable on AVCaptureSession path — VP requires AVAudioEngine to own input")
-            }
-            source = AVCaptureSessionSource()
-        case .audioEngine:
-            let engineSource = AVAudioEngineSource()
-            engineSource.noiseSuppressionEnabled = noiseSuppressionEnabled
-            engineSource.selectedInputDeviceUID = selectedInputDeviceUID
-            engineSource.preferredInputDeviceIDOverride = preferredInputDeviceIDOverride
-            source = engineSource
+          )
+          self.isCapturing = false
+          self.audioLevel = 0.0
+          self.onEngineInterrupted?()
         }
-
-        activeSource = source
-        return source
+      }
+    }
+    source.onBufferCaptured = onBufferCaptured
+    source.onInterrupted = { [weak self] in
+      guard let self,
+        self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
+      else { return }
+      self.isCapturing = false
+      self.audioLevel = 0.0
+      self.onEngineInterrupted?()
     }
 
-    // MARK: - BT Route Logging (Step 6 instrumentation)
+    // Forward heart-path telemetry callbacks (issue #285) — direct capture
+    // mode must surface the same stall / AVCaptureSession interruption signals
+    // the XPC proxy already exposes. Stale callbacks from a replaced source
+    // are rejected via the sourceID guard.
+    source.onCaptureStalled = { [weak self] ctx in
+      guard let self,
+        self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
+      else { return }
+      self.onCaptureStalled?(ctx)
+    }
+    source.onCaptureSessionInterruption = { [weak self] ctx in
+      guard let self,
+        self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
+      else { return }
+      self.onCaptureSessionInterruption?(ctx)
+    }
 
-    /// Direct file write for BT route diagnostics. os_log info level is suppressed on macOS 26 beta,
-    /// and AppLogger.shared is process-local (XPC service has its own instance).
-    nonisolated static func btRouteLog(_ message: String) {
-        let timestamp = ISO8601DateFormatter().string(from: Date())
-        let line = "[\(timestamp)] [BTRoute] \(message)\n"
-        let url = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/EnviousWispr/bt-route.log")
-        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-        if let data = line.data(using: .utf8) {
-            if FileManager.default.fileExists(atPath: url.path) {
-                if let handle = try? FileHandle(forWritingTo: url) {
-                    handle.seekToEndOfFile()
-                    handle.write(data)
-                    handle.closeFile()
-                }
-            } else {
-                try? data.write(to: url)
-            }
+    let stream = try await source.startCapture()
+    isCapturing = true
+    // Mirror source identity so pipeline-layer Sentry extras still resolve
+    // after stopCapture tears `activeSource` down synchronously.
+    cachedCaptureGeneration = source.captureGeneration
+    cachedSourceType = source.captureSourceType
+    return stream
+  }
+
+  // periphery:ignore - protocol conformance (AudioCaptureInterface); convenience for single-phase callers
+  public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard !isCapturing else {
+      return AsyncStream { $0.finish() }
+    }
+    try await startEnginePhase()
+    return try await beginCapturePhase()
+  }
+
+  public func stopCapture() async -> CaptureResult {
+    guard let source = activeSource else {
+      let samples = capturedSamples
+      capturedSamples = []
+      return CaptureResult(samples: samples)
+    }
+
+    // Snapshot identity BEFORE any teardown path so the pipeline's post-stop
+    // Sentry extras still resolve when warmEnginePolicy == .off nils activeSource
+    // synchronously (#285).
+    cachedCaptureGeneration = source.captureGeneration
+    cachedSourceType = source.captureSourceType
+
+    isCapturing = false
+    audioLevel = 0.0
+
+    // Deactivate capture but keep engine warm. The tap stays installed and the
+    // pre-roll ring buffer continues capturing audio. On the next recording,
+    // prepare() sees the engine is already running and skips startup.
+    // This eliminates first-word clipping by ensuring the ring buffer has
+    // audio from before the user pressed the key.
+    source.deactivateCapture()
+
+    // Keep activeSource alive — resolveSource() will reuse it if still running.
+    // BT state changes are handled by resolveSource() re-evaluating the route.
+
+    // Schedule full teardown after idle period. Engine stays warm for rapid-fire
+    // dictation but doesn't run indefinitely.
+    scheduleWarmEngineTeardown()
+
+    // Samples accumulated via onSamples callback -> manager.capturedSamples.
+    // In-process path returns empty vadSegments; pipeline owns its own SilenceDetector.
+    let samples = capturedSamples
+    capturedSamples = []
+    return CaptureResult(samples: samples)
+  }
+
+  public func rebuildEngine() {
+    activeSource?.rebuild()
+  }
+
+  public func buildEngine(noiseSuppression: Bool) {
+    noiseSuppressionEnabled = noiseSuppression
+    // buildEngine is called at app startup for VP config. Create an engine source
+    // for now — startEnginePhase will re-resolve if BT state requires capture session.
+    // If re-resolved to capture session, this engine source is discarded (no resources held —
+    // buildEngine only creates an AVAudioEngine object, doesn't start it or install taps).
+    if let engineSource = activeSource as? AVAudioEngineSource {
+      engineSource.buildEngine(noiseSuppression: noiseSuppression)
+    } else {
+      // Tear down any existing non-engine source before replacing
+      activeSource?.rebuild()
+      let engineSource = AVAudioEngineSource()
+      engineSource.buildEngine(noiseSuppression: noiseSuppression)
+      activeSource = engineSource
+    }
+  }
+
+  public func preWarm() async {
+    let preWarmStart = ContinuousClock.now
+    let source = resolveSource()
+    let resolveMs = Self.ms(ContinuousClock.now - preWarmStart)
+    guard !source.isRunning else {
+      Self.btRouteLog(
+        "COLD-START preWarm(): engine already running (warm hit) resolveSource=\(resolveMs)ms")
+      return
+    }
+    do {
+      try await source.prepare()
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "Audio pre-warm failed: \(error.localizedDescription)",
+          level: .info, category: "Audio"
+        )
+      }
+      return
+    }
+    let prepareMs = Self.ms(ContinuousClock.now - preWarmStart)
+    let stabStart = ContinuousClock.now
+    let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+    let stabMs = Self.ms(ContinuousClock.now - stabStart)
+    let totalMs = Self.ms(ContinuousClock.now - preWarmStart)
+    Self.btRouteLog(
+      "COLD-START preWarm(): total=\(totalMs)ms | resolve=\(resolveMs)ms prepare=\(prepareMs)ms formatStab=\(stabMs)ms stabilized=\(stabilized)"
+    )
+  }
+
+  /// Convert Duration to milliseconds for logging.
+  nonisolated private static func ms(_ d: Duration) -> Int {
+    let (seconds, attoseconds) = d.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+  }
+
+  public func abortPreWarm() {
+    activeSource?.abortPrepare()
+  }
+
+  public func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+    -> Bool
+  {
+    guard let source = activeSource else { return true }
+    return await source.waitForFormatStabilization(maxWait: maxWait, pollInterval: pollInterval)
+  }
+
+  // MARK: - Warm Engine Management
+
+  /// Schedule engine teardown based on the current warm engine policy.
+  /// Called after every recording stops. Cancelled if a new recording starts.
+  private func scheduleWarmEngineTeardown() {
+    warmEngineTeardownTask?.cancel()
+    warmEngineTeardownTask = nil
+
+    switch warmEnginePolicy {
+    case .off:
+      performEngineTeardown()
+      return
+    case .always:
+      idleSince = clock.now
+      return
+    case .seconds10, .seconds30, .seconds60:
+      break
+    }
+
+    let timeout = policyTimeout(warmEnginePolicy)
+    idleSince = clock.now
+    warmEngineTeardownTask = Task { [weak self] in
+      try? await Task.sleep(for: timeout)
+      guard !Task.isCancelled, let self, !self.isCapturing else { return }
+      self.performEngineTeardown()
+    }
+  }
+
+  /// In-flight engine stop task. Stored so resolveSource() can cancel it
+  /// if a new recording starts before the stop completes, preventing two
+  /// engines from running simultaneously on the same hardware.
+  private var engineStopTask: Task<Void, Never>?
+
+  /// Tear down the warm engine. Clears activeSource synchronously before
+  /// awaiting stop to prevent stale async completions from clobbering new state.
+  private func performEngineTeardown() {
+    idleSince = nil
+    guard let source = activeSource else { return }
+    activeSource = nil
+    Self.btRouteLog("Warm engine teardown")
+    engineStopTask = Task { [weak self] in
+      _ = await source.stop()
+      self?.engineStopTask = nil
+    }
+  }
+
+  /// Reconcile engine state when the policy changes while idle.
+  /// Called automatically by the warmEnginePolicy setter.
+  private func reconcileWarmEnginePolicy() {
+    // If capturing, new policy applies on next stopCapture.
+    guard !isCapturing else { return }
+    // If engine is not warm, nothing to reconcile.
+    guard activeSource != nil else { return }
+
+    warmEngineTeardownTask?.cancel()
+    warmEngineTeardownTask = nil
+
+    switch warmEnginePolicy {
+    case .off:
+      performEngineTeardown()
+    case .always:
+      // Keep warm indefinitely, preserve idleSince.
+      break
+    case .seconds10, .seconds30, .seconds60:
+      let timeout = policyTimeout(warmEnginePolicy)
+      let elapsed = idleSince.map { clock.now - $0 } ?? .zero
+      if elapsed >= timeout {
+        performEngineTeardown()
+      } else {
+        let remaining = timeout - elapsed
+        warmEngineTeardownTask = Task { [weak self] in
+          try? await Task.sleep(for: remaining)
+          guard !Task.isCancelled, let self, !self.isCapturing else { return }
+          self.performEngineTeardown()
         }
+      }
+    }
+  }
+
+  /// Map a timed policy case to a Duration.
+  private func policyTimeout(_ policy: WarmEnginePolicy) -> Duration {
+    switch policy {
+    case .seconds10: .seconds(10)
+    case .seconds30: .seconds(30)
+    case .seconds60: .seconds(60)
+    default: .seconds(30)
+    }
+  }
+
+  // MARK: - Source Management
+
+  /// Resolve and create the appropriate capture source based on BT state and user preference.
+  /// Re-evaluates on every call — BT state may change between recordings.
+  private func resolveSource() -> any AudioInputSource {
+    // Cancel idle teardown — we're about to record
+    warmEngineTeardownTask?.cancel()
+    warmEngineTeardownTask = nil
+    // Cancel any in-flight engine stop from a previous teardown.
+    engineStopTask?.cancel()
+    engineStopTask = nil
+
+    // If a source is already running (warm engine), check route compatibility
+    if let existing = activeSource, existing.isRunning {
+      let decision = routeResolver.resolve(
+        preferredInputDeviceUID: preferredInputDeviceIDOverride,
+        noiseSuppression: noiseSuppressionEnabled
+      )
+      let existingIsEngine = existing is AVAudioEngineSource
+      let wantsEngine = decision.sourceType == .audioEngine
+
+      // Check full config signature, not just source type.
+      // Device/VP changes between recordings must trigger rebuild.
+      var configMatch = existingIsEngine == wantsEngine
+      if configMatch, let engineSource = existing as? AVAudioEngineSource {
+        // Compare effective device selection: preferredInputDeviceIDOverride
+        // takes priority, fall back to selectedInputDeviceUID when empty.
+        let oldEffective =
+          engineSource.preferredInputDeviceIDOverride.isEmpty
+          ? engineSource.selectedInputDeviceUID
+          : engineSource.preferredInputDeviceIDOverride
+        let newEffective =
+          preferredInputDeviceIDOverride.isEmpty
+          ? selectedInputDeviceUID
+          : preferredInputDeviceIDOverride
+        let deviceMatch = oldEffective == newEffective
+        let vpMatch = engineSource.noiseSuppressionEnabled == noiseSuppressionEnabled
+        configMatch = deviceMatch && vpMatch
+      }
+
+      if configMatch {
+        // Route and config unchanged, reuse warm source
+        lastRouteDecision = decision
+        Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
+        return existing
+      }
+      // Route changed (e.g., BT connected/disconnected) — synchronous teardown.
+      // Must be synchronous to avoid racing with new source's prepare() on same hardware.
+      Self.btRouteLog("Route changed while warm — tearing down old source")
+      existing.rebuild()
+      activeSource = nil
     }
 
-    // MARK: - VAD Interface (Step 5)
+    let decision = routeResolver.resolve(
+      preferredInputDeviceUID: preferredInputDeviceIDOverride,
+      noiseSuppression: noiseSuppressionEnabled
+    )
+    lastRouteDecision = decision
 
-    /// No-op for in-process capture. The in-process path manages VAD entirely through
-    /// pipeline-owned properties (vadAutoStop, vadSensitivity, etc.) and the pipeline's
-    /// monitorVAD() loop. The capture manager never runs VAD itself.
-    /// Exists solely for AudioCaptureInterface protocol conformance.
-    public func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {
-        // Intentional no-op — see comment above.
+    // Structured telemetry log
+    Self.btRouteLog(
+      "Route decision: source=\(decision.sourceType), reason=\(decision.reason.rawValue), vp=\(decision.vpAvailable), fallback=\(decision.fallbackAllowed) — \(decision.rationale)"
+    )
+    Task {
+      await AppLogger.shared.log(
+        "Capture route: \(decision.reason.rawValue) → \(decision.sourceType == .captureSession ? "AVCaptureSession" : "AVAudioEngine"), VP=\(decision.vpAvailable)",
+        level: .info, category: "Audio"
+      )
     }
 
-    /// Returns a slice of capturedSamples starting at fromIndex plus the current total count.
-    /// Both values are from the same snapshot moment for consistency.
-    public func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
-        let totalCount = capturedSamples.count
-        let clampedIndex = max(0, min(fromIndex, totalCount))
-        if clampedIndex >= totalCount {
-            return (samples: [], totalCount: totalCount)
+    let source: any AudioInputSource
+    switch decision.sourceType {
+    case .captureSession:
+      if decision.vpAvailable == false && noiseSuppressionEnabled {
+        Self.btRouteLog(
+          "Noise suppression unavailable on AVCaptureSession path — VP requires AVAudioEngine to own input"
+        )
+      }
+      source = AVCaptureSessionSource()
+    case .audioEngine:
+      let engineSource = AVAudioEngineSource()
+      engineSource.noiseSuppressionEnabled = noiseSuppressionEnabled
+      engineSource.selectedInputDeviceUID = selectedInputDeviceUID
+      engineSource.preferredInputDeviceIDOverride = preferredInputDeviceIDOverride
+      source = engineSource
+    }
+
+    activeSource = source
+    return source
+  }
+
+  // MARK: - BT Route Logging (Step 6 instrumentation)
+
+  /// Direct file write for BT route diagnostics. os_log info level is suppressed on macOS 26 beta,
+  /// and AppLogger.shared is process-local (XPC service has its own instance).
+  nonisolated static func btRouteLog(_ message: String) {
+    let timestamp = ISO8601DateFormatter().string(from: Date())
+    let line = "[\(timestamp)] [BTRoute] \(message)\n"
+    let url = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/Logs/EnviousWispr/bt-route.log")
+    try? FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    if let data = line.data(using: .utf8) {
+      if FileManager.default.fileExists(atPath: url.path) {
+        if let handle = try? FileHandle(forWritingTo: url) {
+          handle.seekToEndOfFile()
+          handle.write(data)
+          handle.closeFile()
         }
-        let slice = Array(capturedSamples[clampedIndex..<totalCount])
-        return (samples: slice, totalCount: totalCount)
+      } else {
+        try? data.write(to: url)
+      }
     }
+  }
 
-    /// Returns empty — in-process VAD segments are owned by the pipeline's SilenceDetector,
-    /// not by the capture manager. Only meaningful for the XPC path.
-    public func getVADSegments() async -> [SpeechSegment] {
-        return []
+  // MARK: - VAD Interface (Step 5)
+
+  /// No-op for in-process capture. The in-process path manages VAD entirely through
+  /// pipeline-owned properties (vadAutoStop, vadSensitivity, etc.) and the pipeline's
+  /// monitorVAD() loop. The capture manager never runs VAD itself.
+  /// Exists solely for AudioCaptureInterface protocol conformance.
+  public func configureVAD(
+    autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool
+  ) {
+    // Intentional no-op — see comment above.
+  }
+
+  /// Returns a slice of capturedSamples starting at fromIndex plus the current total count.
+  /// Both values are from the same snapshot moment for consistency.
+  public func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    let totalCount = capturedSamples.count
+    let clampedIndex = max(0, min(fromIndex, totalCount))
+    if clampedIndex >= totalCount {
+      return (samples: [], totalCount: totalCount)
     }
+    let slice = Array(capturedSamples[clampedIndex..<totalCount])
+    return (samples: slice, totalCount: totalCount)
+  }
+
+  /// Returns empty — in-process VAD segments are owned by the pipeline's SilenceDetector,
+  /// not by the capture manager. Only meaningful for the XPC path.
+  public func getVADSegments() async -> [SpeechSegment] {
+    return []
+  }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -16,468 +16,641 @@ import Foundation
 @Observable
 public final class AudioCaptureProxy: AudioCaptureInterface {
 
-    // MARK: - Observable state
+  // MARK: - Observable state
 
-    public private(set) var isCapturing = false
-    public private(set) var audioLevel: Float = 0.0
+  public private(set) var isCapturing = false
+  public private(set) var audioLevel: Float = 0.0
 
-    /// Step 3: returns [] — samples accumulate in the service process.
-    /// Step 5 will add getSamplesSnapshot XPC method for incremental access.
-    public private(set) var capturedSamples: [Float] = []
+  /// Step 3: returns [] — samples accumulate in the service process.
+  /// Step 5 will add getSamplesSnapshot XPC method for incremental access.
+  public private(set) var capturedSamples: [Float] = []
 
-    // MARK: - Callbacks
+  // MARK: - Callbacks
 
-    public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-    public var onEngineInterrupted: (() -> Void)?
-    public var onVADAutoStop: (() -> Void)?
+  public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  public var onEngineInterrupted: (() -> Void)?
+  public var onVADAutoStop: (() -> Void)?
 
-    // MARK: - Configuration (stored locally, forwarded to service)
+  // MARK: - Round-4 telemetry callbacks (issue #285)
 
-    public var noiseSuppressionEnabled = false
-    public var selectedInputDeviceUID: String = ""
-    public var preferredInputDeviceIDOverride: String = ""
+  public var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  public var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  public var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  public var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  public var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
 
-    /// Cached warm engine policy -- forwarded to service, replayed after crash.
-    public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
-        didSet {
-            guard oldValue != warmEnginePolicy else { return }
-            serviceProxy { [self] proxy in
-                proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
-            }
+  /// Monotonic capture-session counter — returns `activeCaptureGeneration` so
+  /// the id stays stable across the `stopCapture` bump (which flips
+  /// `captureGeneration` early to reject stale XPC callbacks). The pipeline's
+  /// dedup flag relies on this stability; using `captureGeneration` would
+  /// produce two distinct sessions for a single stall-then-empty incident.
+  public var currentCaptureSessionID: UInt64 { activeCaptureGeneration }
+
+  /// Authoritative capture-active predicate.
+  public var isActivelyCapturing: Bool { isCapturing }
+
+  /// Concrete capture backend tag for Sentry attribution. Always "xpc_proxy"
+  /// — actual sample capture happens service-side and is not visible here.
+  public let captureSourceType: String = "xpc_proxy"
+
+  // MARK: - Configuration (stored locally, forwarded to service)
+
+  public var noiseSuppressionEnabled = false
+  public var selectedInputDeviceUID: String = ""
+  public var preferredInputDeviceIDOverride: String = ""
+
+  /// Cached warm engine policy -- forwarded to service, replayed after crash.
+  public var warmEnginePolicy: WarmEnginePolicy = .seconds30 {
+    didSet {
+      guard oldValue != warmEnginePolicy else { return }
+      serviceProxy { [self] proxy in
+        proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
+      }
+    }
+  }
+
+  // MARK: - XPC connection state
+
+  private var connection: NSXPCConnection?
+  private var needsReinit = false
+
+  /// AsyncStream continuation for buffer delivery from service → pipeline.
+  private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+  /// Generation counter to reject stale callbacks from previous capture sessions.
+  /// Incremented on beginCapturePhase, stopCapture, and interruption.
+  /// Checked in audioBufferCaptured (inside @MainActor Task) before yielding.
+  private var captureGeneration: UInt64 = 0
+
+  /// The generation that was active when the current capture session began.
+  /// Set in beginCapturePhase, compared in audioBufferCaptured.
+  private var activeCaptureGeneration: UInt64 = 0
+
+  // MARK: - Capture-liveness watchdog (issue #285)
+
+  /// Private serial queue that fires the stall `DispatchWorkItem`.
+  private static let stallQueue = DispatchQueue(
+    label: "com.enviouswispr.audio.capture-stall.proxy"
+  )
+  /// Pending stall watchdog. Cancelled on stop / interrupt / invalidate /
+  /// on every new session's arm. Fires on MainActor via Task hop.
+  private var stallWorkItem: DispatchWorkItem?
+  /// Flips true on the MainActor inside `audioBufferCaptured` when any buffer
+  /// for the active session reaches us. Reset to false when arming.
+  private var hasReceivedBufferThisSession: Bool = false
+  /// Uptime-ns captured when the current watchdog armed; threaded into
+  /// `CaptureStallContext` for latency diagnostics.
+  private var stallArmedAtUptimeNs: UInt64 = 0
+
+  /// 16kHz mono Float32 format used for buffer reconstruction.
+  /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
+  nonisolated(unsafe) private static let targetFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32,
+    sampleRate: 16000,
+    channels: 1,
+    interleaved: false
+  )!
+
+  /// Derived at startEnginePhase time from the same BT detection logic as CaptureRouteResolver.
+  public private(set) var currentAudioRoute: String = "unknown"
+
+  public init() {}
+
+  // MARK: - Core lifecycle
+
+  public func startEnginePhase() async throws {
+    // Derive route label app-side (same BT check as CaptureRouteResolver).
+    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
+      AudioDeviceEnumerator.isBluetoothDevice(outID)
+    {
+      currentAudioRoute = "capture_session_bt"
+    } else {
+      currentAudioRoute = "built_in_mic"
+    }
+
+    ensureConnection()
+    resendConfigIfNeeded()
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+      let guard_ = OneShotContinuation(cont)
+      serviceProxy { proxy in
+        proxy.startEnginePhase(
+          preferredDeviceUID: self.preferredInputDeviceIDOverride,
+          selectedDeviceUID: self.selectedInputDeviceUID
+        ) { nsError in
+          if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
         }
+      } onProxyError: {
+        guard_.resume(throwing: XPCTransportError.serviceUnreachable)
+      }
+    }
+  }
+
+  public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    ensureConnection()
+
+    // Finish any stale continuation from a previous session.
+    bufferContinuation?.finish()
+    bufferContinuation = nil
+
+    captureGeneration &+= 1
+    activeCaptureGeneration = captureGeneration
+
+    let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
+      self.bufferContinuation = continuation
     }
 
-    // MARK: - XPC connection state
-
-    private var connection: NSXPCConnection?
-    private var needsReinit = false
-
-    /// AsyncStream continuation for buffer delivery from service → pipeline.
-    private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
-
-    /// Generation counter to reject stale callbacks from previous capture sessions.
-    /// Incremented on beginCapturePhase, stopCapture, and interruption.
-    /// Checked in audioBufferCaptured (inside @MainActor Task) before yielding.
-    private var captureGeneration: UInt64 = 0
-
-    /// The generation that was active when the current capture session began.
-    /// Set in beginCapturePhase, compared in audioBufferCaptured.
-    private var activeCaptureGeneration: UInt64 = 0
-
-    /// 16kHz mono Float32 format used for buffer reconstruction.
-    /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
-    nonisolated(unsafe) private static let targetFormat = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: 16000,
-        channels: 1,
-        interleaved: false
-    )!
-
-    /// Derived at startEnginePhase time from the same BT detection logic as CaptureRouteResolver.
-    public private(set) var currentAudioRoute: String = "unknown"
-
-    public init() {}
-
-    // MARK: - Core lifecycle
-
-    public func startEnginePhase() async throws {
-        // Derive route label app-side (same BT check as CaptureRouteResolver).
-        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
-           AudioDeviceEnumerator.isBluetoothDevice(outID) {
-            currentAudioRoute = "capture_session_bt"
-        } else {
-            currentAudioRoute = "built_in_mic"
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+      let guard_ = OneShotContinuation(cont)
+      serviceProxy { proxy in
+        proxy.beginCapture { nsError in
+          if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
         }
-
-        ensureConnection()
-        resendConfigIfNeeded()
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-            let guard_ = OneShotContinuation(cont)
-            serviceProxy { proxy in
-                proxy.startEnginePhase(
-                    preferredDeviceUID: self.preferredInputDeviceIDOverride,
-                    selectedDeviceUID: self.selectedInputDeviceUID
-                ) { nsError in
-                    if let error = nsError { guard_.resume(throwing: error) }
-                    else { guard_.resume() }
-                }
-            } onProxyError: {
-                guard_.resume(throwing: XPCTransportError.serviceUnreachable)
-            }
-        }
+      } onProxyError: {
+        guard_.resume(throwing: XPCTransportError.serviceUnreachable)
+      }
     }
 
-    public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        ensureConnection()
+    isCapturing = true
+    hasReceivedBufferThisSession = false
+    armCaptureStallWatchdog()
+    return stream
+  }
 
-        // Finish any stale continuation from a previous session.
-        bufferContinuation?.finish()
-        bufferContinuation = nil
+  /// Arm the one-shot stall watchdog for the current `activeCaptureGeneration`.
+  private func armCaptureStallWatchdog() {
+    stallWorkItem?.cancel()
+    let armedSession = activeCaptureGeneration
+    let armedAtNs = DispatchTime.now().uptimeNanoseconds
+    stallArmedAtUptimeNs = armedAtNs
+    let item = Self.makeStallWorkItem(
+      armedSession: armedSession, armedAtNs: armedAtNs, proxy: self)
+    stallWorkItem = item
+    Self.stallQueue.asyncAfter(
+      deadline: .now() + .milliseconds(TimingConstants.audioCaptureStallWindowMs),
+      execute: item
+    )
+  }
 
-        captureGeneration &+= 1
-        activeCaptureGeneration = captureGeneration
-
-        let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
-            self.bufferContinuation = continuation
-        }
-
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-            let guard_ = OneShotContinuation(cont)
-            serviceProxy { proxy in
-                proxy.beginCapture { nsError in
-                    if let error = nsError { guard_.resume(throwing: error) }
-                    else { guard_.resume() }
-                }
-            } onProxyError: {
-                guard_.resume(throwing: XPCTransportError.serviceUnreachable)
-            }
-        }
-
-        isCapturing = true
-        return stream
+  /// Build the watchdog closure in a nonisolated context so it does NOT inherit
+  /// the enclosing `@MainActor` isolation. Swift 6 otherwise inserts executor
+  /// checks that fire `dispatch_assert_queue_fail` when the work item runs on
+  /// the stall queue. Same escape-hatch pattern as `makeInterruptionHandler`.
+  nonisolated private static func makeStallWorkItem(
+    armedSession: UInt64,
+    armedAtNs: UInt64,
+    proxy: AudioCaptureProxy
+  ) -> DispatchWorkItem {
+    return DispatchWorkItem { [weak proxy] in
+      Task { @MainActor [weak proxy] in
+        proxy?.captureStallWatchdogFired(
+          armedSession: armedSession, armedAtNs: armedAtNs)
+      }
     }
+  }
 
-    // periphery:ignore - protocol conformance (AudioCaptureInterface)
-    public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-        guard !isCapturing else { return AsyncStream { $0.finish() } }
-        try await startEnginePhase()
-        return try await beginCapturePhase()
-    }
+  private func captureStallWatchdogFired(armedSession: UInt64, armedAtNs: UInt64) {
+    guard activeCaptureGeneration == armedSession else { return }
+    guard isCapturing else { return }
+    guard !hasReceivedBufferThisSession else { return }
 
-    public func stopCapture() async -> CaptureResult {
-        // Bump generation so stale callbacks from this session don't leak into the next.
-        captureGeneration &+= 1
+    let ctx = CaptureStallContext(
+      sessionID: armedSession,
+      armedAtUptimeNs: armedAtNs,
+      firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+      route: currentAudioRoute,
+      sourceType: "xpc_proxy",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
+        ? nil : preferredInputDeviceIDOverride,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+    )
+    onCaptureStalled?(ctx)
+  }
 
-        var result = CaptureResult(samples: [])
-        do {
-            result = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<CaptureResult, any Error>) in
-                let guard_ = OneShotContinuation(cont)
-                serviceProxy { proxy in
-                    proxy.stopCapture { sampleData, vadData in
-                        let samples = Self.dataToFloats(sampleData)
-                        let segments = Self.decodeVADSegments(vadData)
-                        guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
-                    }
-                } onProxyError: {
-                    guard_.resume(returning: CaptureResult(samples: []))
-                }
-            }
-        } catch {
-            // XPC error — service crashed during stopCapture. Samples are lost.
-            // The interruptionHandler fires independently and handles pipeline notification.
-            // Do NOT call onEngineInterrupted here to avoid double-firing.
-            Task { await AppLogger.shared.log(
-                "[AudioCaptureProxy] stopCapture failed — service unreachable, samples lost: \(error)",
-                level: .info, category: "XPC"
-            ) }
-        }
+  // periphery:ignore - protocol conformance (AudioCaptureInterface)
+  public func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard !isCapturing else { return AsyncStream { $0.finish() } }
+    try await startEnginePhase()
+    return try await beginCapturePhase()
+  }
 
-        isCapturing = false
-        audioLevel = 0
-        bufferContinuation?.finish()
-        bufferContinuation = nil
-        return result
-    }
+  public func stopCapture() async -> CaptureResult {
+    // Cancel any pending stall watchdog before the session id rolls.
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    // Snapshot the session id BEFORE the generation bump so reply-path
+    // failures report the session the caller was actually stopping.
+    let endingSession = activeCaptureGeneration
+    // Bump generation so stale callbacks from this session don't leak into the next.
+    captureGeneration &+= 1
 
-    public func rebuildEngine() {
-        serviceProxy { proxy in proxy.rebuildEngine() }
-    }
-
-    public func buildEngine(noiseSuppression: Bool) {
-        noiseSuppressionEnabled = noiseSuppression
-        ensureConnection()
-        resendConfigIfNeeded()
-        serviceProxy { proxy in proxy.buildEngine(noiseSuppression: noiseSuppression) }
-    }
-
-    public func preWarm() async {
-        let proxyStart = ContinuousClock.now
-
-        // Derive route label so Sentry telemetry is populated even when
-        // startEnginePhase() is skipped on the next recording (warm engine reuse).
-        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
-           AudioDeviceEnumerator.isBluetoothDevice(outID) {
-            currentAudioRoute = "capture_session_bt"
-        } else {
-            currentAudioRoute = "built_in_mic"
-        }
-
-        ensureConnection()
-        resendConfigIfNeeded()
-        let connMs = Self.ms(ContinuousClock.now - proxyStart)
-        // Phase 1: start engine
-        let enginePhaseStart = ContinuousClock.now
-        do {
-            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-                let guard_ = OneShotContinuation(cont)
-                serviceProxy { proxy in
-                    proxy.startEnginePhase(
-                        preferredDeviceUID: self.preferredInputDeviceIDOverride,
-                        selectedDeviceUID: self.selectedInputDeviceUID
-                    ) { nsError in
-                        if let error = nsError { guard_.resume(throwing: error) }
-                        else { guard_.resume() }
-                    }
-                } onProxyError: {
-                    guard_.resume(throwing: XPCTransportError.serviceUnreachable)
-                }
-            }
-        } catch {
-            Task { await AppLogger.shared.log(
-                "[AudioCaptureProxy] preWarm failed: \(error)",
-                level: .info, category: "XPC"
-            ) }
-            return
-        }
-        let enginePhaseMs = Self.ms(ContinuousClock.now - enginePhaseStart)
-        // Phase 2: wait for format stabilization
-        let stabStart = ContinuousClock.now
-        _ = await waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
-        let stabMs = Self.ms(ContinuousClock.now - stabStart)
-        let totalMs = Self.ms(ContinuousClock.now - proxyStart)
-        Task { await AppLogger.shared.log(
-            "COLD-START [XPC proxy] preWarm: total=\(totalMs)ms | conn=\(connMs)ms enginePhase=\(enginePhaseMs)ms formatStab=\(stabMs)ms",
-            level: .info, category: "XPC"
-        ) }
-    }
-
-    /// Convert Duration to milliseconds for logging.
-    private static func ms(_ d: Duration) -> Int {
-        let (seconds, attoseconds) = d.components
-        return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
-    }
-
-    public func abortPreWarm() {
-        serviceProxy { proxy in proxy.abortPreWarm() }
-    }
-
-    public func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-        await withCheckedContinuation { cont in
-            serviceProxy { proxy in
-                proxy.waitForFormatStabilization(maxWait: maxWait, pollInterval: pollInterval) { result in
-                    cont.resume(returning: result)
-                }
-            } onProxyError: {
-                cont.resume(returning: false)
-            }
-        }
-    }
-
-    // MARK: - Config re-send after crash
-
-    /// Replays configuration to the service after a crash/relaunch.
-    /// Clears needsReinit after the XPC call is dispatched. Note: buildEngine is fire-and-forget
-    /// (no reply handler), so we cannot detect if the service actually processed the config.
-    /// If the service crashes during replay, the next interruptionHandler will re-set needsReinit.
-    /// This is acceptable because buildEngine is idempotent — replay on next attempt is safe.
-    private func resendConfigIfNeeded() {
-        guard needsReinit else { return }
-        serviceProxy { [self] proxy in
-            proxy.buildEngine(noiseSuppression: noiseSuppressionEnabled)
-            // Replay VAD config so service rebuilds its SilenceDetector after crash.
-            if let vad = vadConfig {
-                proxy.configureVAD(autoStop: vad.autoStop, silenceTimeout: vad.silenceTimeout,
-                                   sensitivity: vad.sensitivity, energyGate: vad.energyGate)
-            }
-            // Replay warm engine policy so service uses correct idle timeout.
-            proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
-            needsReinit = false
-        }
-    }
-
-    // MARK: - XPC connection management
-
-    private func ensureConnection() {
-        guard connection == nil else { return }
-
-        let conn = NSXPCConnection(serviceName: XPCServiceName.audioService)
-        conn.remoteObjectInterface = NSXPCInterface(with: AudioServiceProtocol.self)
-        conn.exportedInterface = NSXPCInterface(with: AudioServiceClientProtocol.self)
-        conn.exportedObject = self
-
-        // DESIGN RULE: Interruption while isCapturing == true is a user-visible capture failure.
-        // Interruption while idle is transient — just set needsReinit.
-        //
-        // IMPORTANT(Step 3+): Step 1.5 proved kill -9 fires interruptionHandler for embedded
-        // XPC services. During active capture, this IS the crash signal. The connection stays
-        // valid — the next XPC call auto-relaunches the service via launchd.
-        // CRITICAL: interruptionHandler and invalidationHandler run on XPC dispatch queues,
-        // NOT MainActor. Closures defined inside @MainActor methods inherit that isolation in
-        // Swift 6, causing dispatch_assert_queue_fail when XPC calls them. Extract to
-        // nonisolated static to break the isolation inheritance.
-        conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
-        conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
-
-        conn.resume()
-        connection = conn
-
-        // Verify service is alive — this ping triggers launchd to spawn the service.
-        serviceProxy { proxy in proxy.ping { _ in } }
-    }
-
-    /// Gets the remote proxy with error handling.
-    /// `onProxyError` is called if the proxy can't be obtained (connection nil or cast fails)
-    /// AND if the XPC framework delivers a per-call error (service crashed mid-call).
-    /// This is critical: when the service dies after a call is dispatched but before it replies,
-    /// the XPC error handler fires but the reply handler does NOT. Without routing the error
-    /// to `onProxyError`, any pending continuation hangs forever.
-    private func serviceProxy(
-        _ work: (any AudioServiceProtocol) -> Void,
-        onProxyError: (() -> Void)? = nil
-    ) {
-        guard let conn = connection else { onProxyError?(); return }
-        let proxy = conn.remoteObjectProxyWithErrorHandler(Self.makeXPCErrorHandler(onProxyError: onProxyError))
-        guard let service = proxy as? AudioServiceProtocol else { onProxyError?(); return }
-        work(service)
-    }
-
-    /// Build the XPC error handler in a nonisolated context.
-    /// Critical: closures defined inside @MainActor methods inherit that isolation.
-    /// When XPC calls the error handler on its dispatch queue, Swift 6 asserts
-    /// dispatch_assert_queue(main) and traps with EXC_BREAKPOINT. By constructing
-    /// the handler in a nonisolated static method, the closure is free of @MainActor.
-    /// Build the XPC per-call error handler in a nonisolated context.
-    /// This handler fires when the service crashes after a call is dispatched but before it replies.
-    /// It MUST call onProxyError to resume any pending continuation — otherwise the caller hangs forever.
-    /// The error handler is the primary recovery signal; interruption/invalidation are secondary cleanup.
-    nonisolated private static func makeXPCErrorHandler(onProxyError: (() -> Void)? = nil) -> @Sendable (any Error) -> Void {
-        // Capture onProxyError as nonisolated(unsafe) — it may reference @MainActor closures
-        // but we dispatch it via Task { @MainActor } so the actual call is safe.
-        nonisolated(unsafe) let proxyError = onProxyError
-        return { error in
-            Task { @MainActor in
-                await AppLogger.shared.log(
-                    "[AudioCaptureProxy] XPC error: \(error.localizedDescription)",
-                    level: .info, category: "XPC"
-                )
-                proxyError?()
-            }
-        }
-    }
-
-    /// Build the XPC interruptionHandler in a nonisolated context.
-    /// Same isolation-escape pattern as makeXPCErrorHandler.
-    nonisolated private static func makeInterruptionHandler(proxy: AudioCaptureProxy) -> @Sendable () -> Void {
-        return { [weak proxy] in
-
-            Task { @MainActor [weak proxy] in
-                guard let proxy else { return }
-                let wasCapturing = proxy.isCapturing
-                await AppLogger.shared.log(
-                    "[AudioCaptureProxy] XPC interruptionHandler fired — wasCapturing=\(wasCapturing)",
-                    level: .info, category: "XPC"
-                )
-                if wasCapturing {
-                    proxy.isCapturing = false
-                    proxy.audioLevel = 0
-                    proxy.captureGeneration &+= 1
-                    proxy.bufferContinuation?.finish()
-                    proxy.bufferContinuation = nil
-                    proxy.onEngineInterrupted?()
-                }
-                proxy.needsReinit = true
-            }
-        }
-    }
-
-    /// Build the XPC invalidationHandler in a nonisolated context.
-    nonisolated private static func makeInvalidationHandler(proxy: AudioCaptureProxy) -> @Sendable () -> Void {
-        return { [weak proxy] in
-
-            Task { @MainActor [weak proxy] in
-                guard let proxy else { return }
-
-                proxy.connection = nil
-                if proxy.isCapturing {
-                    proxy.isCapturing = false
-                    proxy.audioLevel = 0
-                    proxy.captureGeneration &+= 1
-                    proxy.bufferContinuation?.finish()
-                    proxy.bufferContinuation = nil
-                    proxy.onEngineInterrupted?()
-                }
-                proxy.needsReinit = true
-            }
-        }
-    }
-
-    // MARK: - VAD Interface (Step 5)
-
-    /// Stored VAD config — forwarded to service, replayed after crash via resendConfigIfNeeded().
-    private var vadConfig: (autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)?
-
-    public func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {
-        vadConfig = (autoStop, silenceTimeout, sensitivity, energyGate)
+    var result = CaptureResult(samples: [])
+    do {
+      result = try await withCheckedThrowingContinuation {
+        (cont: CheckedContinuation<CaptureResult, any Error>) in
+        let guard_ = OneShotContinuation(cont)
         serviceProxy { proxy in
-            proxy.configureVAD(autoStop: autoStop, silenceTimeout: silenceTimeout, sensitivity: sensitivity, energyGate: energyGate)
+          proxy.stopCapture { sampleData, vadData in
+            let samples = Self.dataToFloats(sampleData)
+            let segments = Self.decodeVADSegments(vadData)
+            guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
+          }
+        } onProxyError: { [weak self] in
+          self?.reportXPCReplyFailure(stage: "stop_capture", sessionID: endingSession)
+          guard_.resume(returning: CaptureResult(samples: []))
         }
+      }
+    } catch {
+      // XPC error — service crashed during stopCapture. Samples are lost.
+      // The interruptionHandler fires independently and handles pipeline notification.
+      // Do NOT call onEngineInterrupted here to avoid double-firing.
+      Task {
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] stopCapture failed — service unreachable, samples lost: \(error)",
+          level: .info, category: "XPC"
+        )
+      }
     }
 
-    public func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
-        // Use OneShotContinuation to guarantee exactly one resume — XPC error handler and
-        // reply handler can race, and double-resume is undefined behavior.
-        do {
-            return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<(samples: [Float], totalCount: Int), any Error>) in
-                let guard_ = OneShotContinuation(cont)
-                serviceProxy { proxy in
-                    proxy.getSamplesSnapshot(fromIndex: fromIndex) { data, totalCount in
-                        let floats = Self.dataToFloats(data)
-                        guard_.resume(returning: (samples: floats, totalCount: totalCount))
-                    }
-                } onProxyError: {
-                    guard_.resume(returning: (samples: [], totalCount: 0))
-                }
-            }
-        } catch {
-            return (samples: [], totalCount: 0)
+    isCapturing = false
+    audioLevel = 0
+    bufferContinuation?.finish()
+    bufferContinuation = nil
+    return result
+  }
+
+  public func rebuildEngine() {
+    serviceProxy { proxy in proxy.rebuildEngine() }
+  }
+
+  public func buildEngine(noiseSuppression: Bool) {
+    noiseSuppressionEnabled = noiseSuppression
+    ensureConnection()
+    resendConfigIfNeeded()
+    serviceProxy { proxy in proxy.buildEngine(noiseSuppression: noiseSuppression) }
+  }
+
+  public func preWarm() async {
+    let proxyStart = ContinuousClock.now
+
+    // Derive route label so Sentry telemetry is populated even when
+    // startEnginePhase() is skipped on the next recording (warm engine reuse).
+    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
+      AudioDeviceEnumerator.isBluetoothDevice(outID)
+    {
+      currentAudioRoute = "capture_session_bt"
+    } else {
+      currentAudioRoute = "built_in_mic"
+    }
+
+    ensureConnection()
+    resendConfigIfNeeded()
+    let connMs = Self.ms(ContinuousClock.now - proxyStart)
+    // Phase 1: start engine
+    let enginePhaseStart = ContinuousClock.now
+    do {
+      try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+        let guard_ = OneShotContinuation(cont)
+        serviceProxy { proxy in
+          proxy.startEnginePhase(
+            preferredDeviceUID: self.preferredInputDeviceIDOverride,
+            selectedDeviceUID: self.selectedInputDeviceUID
+          ) { nsError in
+            if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
+          }
+        } onProxyError: {
+          guard_.resume(throwing: XPCTransportError.serviceUnreachable)
         }
+      }
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] preWarm failed: \(error)",
+          level: .info, category: "XPC"
+        )
+      }
+      return
     }
+    let enginePhaseMs = Self.ms(ContinuousClock.now - enginePhaseStart)
+    // Phase 2: wait for format stabilization
+    let stabStart = ContinuousClock.now
+    _ = await waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+    let stabMs = Self.ms(ContinuousClock.now - stabStart)
+    let totalMs = Self.ms(ContinuousClock.now - proxyStart)
+    Task {
+      await AppLogger.shared.log(
+        "COLD-START [XPC proxy] preWarm: total=\(totalMs)ms | conn=\(connMs)ms enginePhase=\(enginePhaseMs)ms formatStab=\(stabMs)ms",
+        level: .info, category: "XPC"
+      )
+    }
+  }
 
-    public func getVADSegments() async -> [SpeechSegment] {
-        // Use OneShotContinuation to guarantee exactly one resume.
-        do {
-            return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<[SpeechSegment], any Error>) in
-                let guard_ = OneShotContinuation(cont)
-                serviceProxy { proxy in
-                    proxy.getVADSegments { data in
-                        guard_.resume(returning: Self.decodeVADSegments(data))
-                    }
-                } onProxyError: {
-                    guard_.resume(returning: [])
-                }
-            }
-        } catch {
-            return []
+  /// Convert Duration to milliseconds for logging.
+  private static func ms(_ d: Duration) -> Int {
+    let (seconds, attoseconds) = d.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+  }
+
+  public func abortPreWarm() {
+    serviceProxy { proxy in proxy.abortPreWarm() }
+  }
+
+  public func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+    -> Bool
+  {
+    await withCheckedContinuation { cont in
+      serviceProxy { proxy in
+        proxy.waitForFormatStabilization(maxWait: maxWait, pollInterval: pollInterval) { result in
+          cont.resume(returning: result)
         }
+      } onProxyError: {
+        cont.resume(returning: false)
+      }
     }
+  }
 
-    // MARK: - Data conversion
+  // MARK: - Config re-send after crash
 
-    /// Convert raw Data to [Float]. Transport format: Float32 PCM, non-interleaved mono, 16kHz.
-    /// Data is raw bytes — no header, no metadata.
-    /// nonisolated: called from XPC reply callbacks which run on XPC dispatch queues, not MainActor.
-    nonisolated private static func dataToFloats(_ data: Data) -> [Float] {
-        guard !data.isEmpty, data.count.isMultiple(of: MemoryLayout<Float>.size) else { return [] }
-        return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+  /// Replays configuration to the service after a crash/relaunch.
+  /// Clears needsReinit after the XPC call is dispatched. Note: buildEngine is fire-and-forget
+  /// (no reply handler), so we cannot detect if the service actually processed the config.
+  /// If the service crashes during replay, the next interruptionHandler will re-set needsReinit.
+  /// This is acceptable because buildEngine is idempotent — replay on next attempt is safe.
+  private func resendConfigIfNeeded() {
+    guard needsReinit else { return }
+    serviceProxy { [self] proxy in
+      proxy.buildEngine(noiseSuppression: noiseSuppressionEnabled)
+      // Replay VAD config so service rebuilds its SilenceDetector after crash.
+      if let vad = vadConfig {
+        proxy.configureVAD(
+          autoStop: vad.autoStop, silenceTimeout: vad.silenceTimeout,
+          sensitivity: vad.sensitivity, energyGate: vad.energyGate)
+      }
+      // Replay warm engine policy so service uses correct idle timeout.
+      proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
+      needsReinit = false
     }
+  }
 
-    /// Decode packed [Int32 start, Int32 end] pairs into SpeechSegment array.
-    nonisolated private static func decodeVADSegments(_ data: Data) -> [SpeechSegment] {
-        let pairSize = MemoryLayout<Int32>.size * 2
-        guard !data.isEmpty, data.count.isMultiple(of: pairSize) else { return [] }
-        return data.withUnsafeBytes { raw in
-            let int32s = raw.bindMemory(to: Int32.self)
-            var segments: [SpeechSegment] = []
-            segments.reserveCapacity(int32s.count / 2)
-            for i in stride(from: 0, to: int32s.count, by: 2) {
-                segments.append(SpeechSegment(
-                    startSample: Int(int32s[i]),
-                    endSample: Int(int32s[i + 1])
-                ))
-            }
-            return segments
+  // MARK: - XPC connection management
+
+  private func ensureConnection() {
+    guard connection == nil else { return }
+
+    let conn = NSXPCConnection(serviceName: XPCServiceName.audioService)
+    conn.remoteObjectInterface = NSXPCInterface(with: AudioServiceProtocol.self)
+    conn.exportedInterface = NSXPCInterface(with: AudioServiceClientProtocol.self)
+    conn.exportedObject = self
+
+    // DESIGN RULE: Interruption while isCapturing == true is a user-visible capture failure.
+    // Interruption while idle is transient — just set needsReinit.
+    //
+    // IMPORTANT(Step 3+): Step 1.5 proved kill -9 fires interruptionHandler for embedded
+    // XPC services. During active capture, this IS the crash signal. The connection stays
+    // valid — the next XPC call auto-relaunches the service via launchd.
+    // CRITICAL: interruptionHandler and invalidationHandler run on XPC dispatch queues,
+    // NOT MainActor. Closures defined inside @MainActor methods inherit that isolation in
+    // Swift 6, causing dispatch_assert_queue_fail when XPC calls them. Extract to
+    // nonisolated static to break the isolation inheritance.
+    conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
+    conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
+
+    conn.resume()
+    connection = conn
+
+    // Verify service is alive — this ping triggers launchd to spawn the service.
+    serviceProxy { proxy in proxy.ping { _ in } }
+  }
+
+  /// Gets the remote proxy with error handling.
+  /// `onProxyError` is called if the proxy can't be obtained (connection nil or cast fails)
+  /// AND if the XPC framework delivers a per-call error (service crashed mid-call).
+  /// This is critical: when the service dies after a call is dispatched but before it replies,
+  /// the XPC error handler fires but the reply handler does NOT. Without routing the error
+  /// to `onProxyError`, any pending continuation hangs forever.
+  private func serviceProxy(
+    _ work: (any AudioServiceProtocol) -> Void,
+    onProxyError: (() -> Void)? = nil
+  ) {
+    guard let conn = connection else {
+      onProxyError?()
+      return
+    }
+    let proxy = conn.remoteObjectProxyWithErrorHandler(
+      Self.makeXPCErrorHandler(onProxyError: onProxyError))
+    guard let service = proxy as? AudioServiceProtocol else {
+      onProxyError?()
+      return
+    }
+    work(service)
+  }
+
+  /// Build the XPC error handler in a nonisolated context.
+  /// Critical: closures defined inside @MainActor methods inherit that isolation.
+  /// When XPC calls the error handler on its dispatch queue, Swift 6 asserts
+  /// dispatch_assert_queue(main) and traps with EXC_BREAKPOINT. By constructing
+  /// the handler in a nonisolated static method, the closure is free of @MainActor.
+  /// Build the XPC per-call error handler in a nonisolated context.
+  /// This handler fires when the service crashes after a call is dispatched but before it replies.
+  /// It MUST call onProxyError to resume any pending continuation — otherwise the caller hangs forever.
+  /// The error handler is the primary recovery signal; interruption/invalidation are secondary cleanup.
+  nonisolated private static func makeXPCErrorHandler(onProxyError: (() -> Void)? = nil)
+    -> @Sendable (any Error) -> Void
+  {
+    // Capture onProxyError as nonisolated(unsafe) — it may reference @MainActor closures
+    // but we dispatch it via Task { @MainActor } so the actual call is safe.
+    nonisolated(unsafe) let proxyError = onProxyError
+    return { error in
+      Task { @MainActor in
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] XPC error: \(error.localizedDescription)",
+          level: .info, category: "XPC"
+        )
+        proxyError?()
+      }
+    }
+  }
+
+  /// Build the XPC interruptionHandler in a nonisolated context.
+  /// Same isolation-escape pattern as makeXPCErrorHandler.
+  nonisolated private static func makeInterruptionHandler(proxy: AudioCaptureProxy) -> @Sendable ()
+    -> Void
+  {
+    return { [weak proxy] in
+
+      Task { @MainActor [weak proxy] in
+        guard let proxy else { return }
+        let wasCapturing = proxy.isCapturing
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] XPC interruptionHandler fired — wasCapturing=\(wasCapturing)",
+          level: .info, category: "XPC"
+        )
+        if wasCapturing {
+          // Cancel pending stall watchdog before the session ends.
+          proxy.stallWorkItem?.cancel()
+          proxy.stallWorkItem = nil
+          let endingSession = proxy.activeCaptureGeneration
+          proxy.isCapturing = false
+          proxy.audioLevel = 0
+          proxy.captureGeneration &+= 1
+          proxy.bufferContinuation?.finish()
+          proxy.bufferContinuation = nil
+          proxy.onEngineInterrupted?()
+          // Fire telemetry callback — idle interruptions stay silent (§3.4 row 2).
+          proxy.onXPCServiceError?(
+            XPCErrorContext(
+              kind: .interruptCapturing,
+              sessionID: endingSession,
+              timestampNs: DispatchTime.now().uptimeNanoseconds
+            )
+          )
         }
+        proxy.needsReinit = true
+      }
     }
+  }
+
+  /// Build the XPC invalidationHandler in a nonisolated context.
+  nonisolated private static func makeInvalidationHandler(proxy: AudioCaptureProxy) -> @Sendable ()
+    -> Void
+  {
+    return { [weak proxy] in
+
+      Task { @MainActor [weak proxy] in
+        guard let proxy else { return }
+
+        proxy.connection = nil
+        let wasCapturing = proxy.isCapturing
+        let endingSession = proxy.activeCaptureGeneration
+        if wasCapturing {
+          proxy.stallWorkItem?.cancel()
+          proxy.stallWorkItem = nil
+          proxy.isCapturing = false
+          proxy.audioLevel = 0
+          proxy.captureGeneration &+= 1
+          proxy.bufferContinuation?.finish()
+          proxy.bufferContinuation = nil
+          proxy.onEngineInterrupted?()
+        }
+        proxy.needsReinit = true
+        // Invalidation is always a telemetry signal — connection is gone.
+        proxy.onXPCServiceError?(
+          XPCErrorContext(
+            kind: wasCapturing ? .invalidateCapturing : .invalidateIdle,
+            sessionID: wasCapturing ? endingSession : nil,
+            timestampNs: DispatchTime.now().uptimeNanoseconds
+          )
+        )
+      }
+    }
+  }
+
+  // MARK: - VAD Interface (Step 5)
+
+  /// Stored VAD config — forwarded to service, replayed after crash via resendConfigIfNeeded().
+  private var vadConfig:
+    (autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)?
+
+  public func configureVAD(
+    autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool
+  ) {
+    vadConfig = (autoStop, silenceTimeout, sensitivity, energyGate)
+    serviceProxy { proxy in
+      proxy.configureVAD(
+        autoStop: autoStop, silenceTimeout: silenceTimeout, sensitivity: sensitivity,
+        energyGate: energyGate)
+    }
+  }
+
+  public func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    // Use OneShotContinuation to guarantee exactly one resume — XPC error handler and
+    // reply handler can race, and double-resume is undefined behavior.
+    let sessionID = activeCaptureGeneration
+    do {
+      return try await withCheckedThrowingContinuation {
+        (cont: CheckedContinuation<(samples: [Float], totalCount: Int), any Error>) in
+        let guard_ = OneShotContinuation(cont)
+        serviceProxy { proxy in
+          proxy.getSamplesSnapshot(fromIndex: fromIndex) { data, totalCount in
+            let floats = Self.dataToFloats(data)
+            guard_.resume(returning: (samples: floats, totalCount: totalCount))
+          }
+        } onProxyError: { [weak self] in
+          self?.reportXPCReplyFailure(stage: "get_samples", sessionID: sessionID)
+          guard_.resume(returning: (samples: [], totalCount: 0))
+        }
+      }
+    } catch {
+      return (samples: [], totalCount: 0)
+    }
+  }
+
+  public func getVADSegments() async -> [SpeechSegment] {
+    // Use OneShotContinuation to guarantee exactly one resume.
+    let sessionID = activeCaptureGeneration
+    do {
+      return try await withCheckedThrowingContinuation {
+        (cont: CheckedContinuation<[SpeechSegment], any Error>) in
+        let guard_ = OneShotContinuation(cont)
+        serviceProxy { proxy in
+          proxy.getVADSegments { data in
+            guard_.resume(returning: Self.decodeVADSegments(data))
+          }
+        } onProxyError: { [weak self] in
+          self?.reportXPCReplyFailure(stage: "get_speech_segments", sessionID: sessionID)
+          guard_.resume(returning: [])
+        }
+      }
+    } catch {
+      return []
+    }
+  }
+
+  /// Invoke `onXPCReplyFailed` before a reply-path swallowed empty default
+  /// surfaces to callers, so the pipeline can emit the correct root cause
+  /// instead of mis-classifying as `no_audio_captured`.
+  private func reportXPCReplyFailure(stage: String, sessionID: UInt64) {
+    onXPCReplyFailed?(
+      XPCReplyFailureContext(
+        replyStage: stage,
+        errorDomain: "com.enviouswispr.xpc",
+        errorCode: -1,
+        errorDescription: "XPC reply failed — service unreachable",
+        sessionID: sessionID
+      )
+    )
+  }
+
+  // MARK: - Data conversion
+
+  /// Convert raw Data to [Float]. Transport format: Float32 PCM, non-interleaved mono, 16kHz.
+  /// Data is raw bytes — no header, no metadata.
+  /// nonisolated: called from XPC reply callbacks which run on XPC dispatch queues, not MainActor.
+  nonisolated private static func dataToFloats(_ data: Data) -> [Float] {
+    guard !data.isEmpty, data.count.isMultiple(of: MemoryLayout<Float>.size) else { return [] }
+    return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+  }
+
+  /// Decode packed [Int32 start, Int32 end] pairs into SpeechSegment array.
+  nonisolated private static func decodeVADSegments(_ data: Data) -> [SpeechSegment] {
+    let pairSize = MemoryLayout<Int32>.size * 2
+    guard !data.isEmpty, data.count.isMultiple(of: pairSize) else { return [] }
+    return data.withUnsafeBytes { raw in
+      let int32s = raw.bindMemory(to: Int32.self)
+      var segments: [SpeechSegment] = []
+      segments.reserveCapacity(int32s.count / 2)
+      for i in stride(from: 0, to: int32s.count, by: 2) {
+        segments.append(
+          SpeechSegment(
+            startSample: Int(int32s[i]),
+            endSample: Int(int32s[i + 1])
+          ))
+      }
+      return segments
+    }
+  }
 }
 
 // MARK: - AudioServiceClientProtocol (service → host callbacks)
@@ -486,65 +659,72 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 /// Each hops to @MainActor via Task before updating observable state.
 extension AudioCaptureProxy: AudioServiceClientProtocol {
 
-    /// Received audio buffer from service — reconstruct AVAudioPCMBuffer and deliver.
-    nonisolated public func audioBufferCaptured(_ data: Data, frameCount: Int, audioLevel: Float) {
-        // Validation guards before memcpy.
-        guard frameCount > 0, frameCount <= 65536 else { return }
-        guard data.count == frameCount * MemoryLayout<Float>.size else { return }
-        guard let buffer = AVAudioPCMBuffer(
-            pcmFormat: Self.targetFormat,
-            frameCapacity: AVAudioFrameCount(frameCount)
-        ) else { return }
+  /// Received audio buffer from service — reconstruct AVAudioPCMBuffer and deliver.
+  nonisolated public func audioBufferCaptured(_ data: Data, frameCount: Int, audioLevel: Float) {
+    // Validation guards before memcpy.
+    guard frameCount > 0, frameCount <= 65536 else { return }
+    guard data.count == frameCount * MemoryLayout<Float>.size else { return }
+    guard
+      let buffer = AVAudioPCMBuffer(
+        pcmFormat: Self.targetFormat,
+        frameCapacity: AVAudioFrameCount(frameCount)
+      )
+    else { return }
 
-        buffer.frameLength = AVAudioFrameCount(frameCount)
-        data.withUnsafeBytes { raw in
-            guard let src = raw.baseAddress, let dst = buffer.floatChannelData?[0] else { return }
-            memcpy(dst, src, data.count)
-        }
-
-        nonisolated(unsafe) let safeBuffer = buffer
-        // Snapshot frameCount for generation check inside the MainActor Task.
-        // captureGeneration is read inside the Task (MainActor-isolated), not here.
-
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            // Reject stale callbacks from previous capture sessions.
-            guard self.isCapturing,
-                  self.captureGeneration == self.activeCaptureGeneration else { return }
-            self.audioLevel = audioLevel
-            self.bufferContinuation?.yield(safeBuffer)
-            self.onBufferCaptured?(safeBuffer)
-        }
+    buffer.frameLength = AVAudioFrameCount(frameCount)
+    data.withUnsafeBytes { raw in
+      guard let src = raw.baseAddress, let dst = buffer.floatChannelData?[0] else { return }
+      memcpy(dst, src, data.count)
     }
 
-    /// Service's audio engine was interrupted (device disconnect, emergency teardown).
-    /// Matches interruptionHandler contract: only fires onEngineInterrupted during active capture.
-    /// Idle interruptions are transient — just set needsReinit.
-    nonisolated public func engineInterrupted() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            if self.isCapturing {
-                self.isCapturing = false
-                self.audioLevel = 0
-                self.captureGeneration &+= 1
-                self.bufferContinuation?.finish()
-                self.bufferContinuation = nil
-                self.onEngineInterrupted?()
-            }
-            self.needsReinit = true
-        }
-    }
+    nonisolated(unsafe) let safeBuffer = buffer
+    // Snapshot frameCount for generation check inside the MainActor Task.
+    // captureGeneration is read inside the Task (MainActor-isolated), not here.
 
-    /// Service-side VAD detected sustained silence after speech — auto-stop should trigger.
-    /// Stale-fire protection: generation check + pipeline state guard (in AppState handler).
-    nonisolated public func vadAutoStopTriggered() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            guard self.isCapturing,
-                  self.captureGeneration == self.activeCaptureGeneration else { return }
-            self.onVADAutoStop?()
-        }
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      // Reject stale callbacks from previous capture sessions.
+      guard self.isCapturing,
+        self.captureGeneration == self.activeCaptureGeneration
+      else { return }
+      self.hasReceivedBufferThisSession = true
+      self.audioLevel = audioLevel
+      self.bufferContinuation?.yield(safeBuffer)
+      self.onBufferCaptured?(safeBuffer)
     }
+  }
+
+  /// Service's audio engine was interrupted (device disconnect, emergency teardown).
+  /// Matches interruptionHandler contract: only fires onEngineInterrupted during active capture.
+  /// Idle interruptions are transient — just set needsReinit.
+  nonisolated public func engineInterrupted() {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      if self.isCapturing {
+        self.stallWorkItem?.cancel()
+        self.stallWorkItem = nil
+        self.isCapturing = false
+        self.audioLevel = 0
+        self.captureGeneration &+= 1
+        self.bufferContinuation?.finish()
+        self.bufferContinuation = nil
+        self.onEngineInterrupted?()
+      }
+      self.needsReinit = true
+    }
+  }
+
+  /// Service-side VAD detected sustained silence after speech — auto-stop should trigger.
+  /// Stale-fire protection: generation check + pipeline state guard (in AppState handler).
+  nonisolated public func vadAutoStopTriggered() {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      guard self.isCapturing,
+        self.captureGeneration == self.activeCaptureGeneration
+      else { return }
+      self.onVADAutoStop?()
+    }
+  }
 }
 
 // MARK: - Helpers
@@ -552,44 +732,44 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
 /// Thread-safe one-shot continuation guard. Ensures exactly one resume,
 /// preventing crashes from double-resume when XPC reply and error handler race.
 private final class OneShotContinuation<T: Sendable>: @unchecked Sendable {
-    private var continuation: CheckedContinuation<T, any Error>?
-    private let lock = NSLock()
+  private var continuation: CheckedContinuation<T, any Error>?
+  private let lock = NSLock()
 
-    init(_ continuation: CheckedContinuation<T, any Error>) {
-        self.continuation = continuation
-    }
+  init(_ continuation: CheckedContinuation<T, any Error>) {
+    self.continuation = continuation
+  }
 
-    func resume(returning value: T) {
-        lock.lock()
-        let cont = continuation
-        continuation = nil
-        lock.unlock()
-        cont?.resume(returning: value)
-    }
+  func resume(returning value: T) {
+    lock.lock()
+    let cont = continuation
+    continuation = nil
+    lock.unlock()
+    cont?.resume(returning: value)
+  }
 
-    func resume(throwing error: any Error) {
-        lock.lock()
-        let cont = continuation
-        continuation = nil
-        lock.unlock()
-        cont?.resume(throwing: error)
-    }
+  func resume(throwing error: any Error) {
+    lock.lock()
+    let cont = continuation
+    continuation = nil
+    lock.unlock()
+    cont?.resume(throwing: error)
+  }
 }
 
 /// Convenience overload for Void continuations.
 extension OneShotContinuation where T == Void {
-    func resume() {
-        resume(returning: ())
-    }
+  func resume() {
+    resume(returning: ())
+  }
 }
 
 /// XPC transport errors surfaced by the proxy.
 enum XPCTransportError: LocalizedError {
-    case serviceUnreachable
+  case serviceUnreachable
 
-    var errorDescription: String? {
-        switch self {
-        case .serviceUnreachable: return "XPC audio service is unreachable."
-        }
+  var errorDescription: String? {
+    switch self {
+    case .serviceUnreachable: return "XPC audio service is unreachable."
     }
+  }
 }

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -3,265 +3,277 @@ import Foundation
 
 /// Represents an audio input device discovered via CoreAudio.
 public struct AudioInputDevice: Sendable, Identifiable, Hashable {
-    public let id: AudioDeviceID
-    public let name: String
-    public let uid: String
+  public let id: AudioDeviceID
+  public let name: String
+  public let uid: String
 }
 
 /// Enumerates audio input devices using CoreAudio HAL.
 public enum AudioDeviceEnumerator {
-    /// Returns all audio input devices currently connected.
-    public static func allInputDevices() -> [AudioInputDevice] {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
+  /// Returns all audio input devices currently connected.
+  public static func allInputDevices() -> [AudioInputDevice] {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
 
-        var dataSize: UInt32 = 0
-        var status = AudioObjectGetPropertyDataSize(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0,
-            nil,
-            &dataSize
-        )
-        guard status == noErr, dataSize > 0 else { return [] }
+    var dataSize: UInt32 = 0
+    var status = AudioObjectGetPropertyDataSize(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize
+    )
+    guard status == noErr, dataSize > 0 else { return [] }
 
-        let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
-        var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
+    let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+    var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
 
-        status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0,
-            nil,
-            &dataSize,
-            &deviceIDs
-        )
-        guard status == noErr else { return [] }
+    status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize,
+      &deviceIDs
+    )
+    guard status == noErr else { return [] }
 
-        return deviceIDs.compactMap { deviceID -> AudioInputDevice? in
-            let channelCount = inputChannelCount(for: deviceID)
-            guard channelCount > 0 else { return nil }
+    return deviceIDs.compactMap { deviceID -> AudioInputDevice? in
+      let channelCount = inputChannelCount(for: deviceID)
+      guard channelCount > 0 else { return nil }
 
-            let name = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceNameCFString) ?? "Unknown"
-            let uid = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID) ?? ""
+      let name =
+        stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceNameCFString) ?? "Unknown"
+      let uid = stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID) ?? ""
 
-            return AudioInputDevice(
-                id: deviceID,
-                name: name,
-                uid: uid
-            )
-        }
+      return AudioInputDevice(
+        id: deviceID,
+        name: name,
+        uid: uid
+      )
     }
+  }
 
-    /// Returns the default system input device ID, or nil if unavailable.
-    public static func defaultInputDeviceID() -> AudioDeviceID? {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
+  /// Returns the default system input device ID, or nil if unavailable.
+  public static func defaultInputDeviceID() -> AudioDeviceID? {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultInputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
 
-        var deviceID: AudioDeviceID = 0
-        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+    var deviceID: AudioDeviceID = 0
+    var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
 
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0,
-            nil,
-            &dataSize,
-            &deviceID
-        )
+    let status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize,
+      &deviceID
+    )
 
-        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
-        return deviceID
+    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return deviceID
+  }
+
+  /// Finds a device ID by its persistent UID string.
+  public static func deviceID(forUID uid: String) -> AudioDeviceID? {
+    let devices = allInputDevices()
+    return devices.first(where: { $0.uid == uid })?.id
+  }
+
+  /// Returns the UID of the current system-default input device, or nil if
+  /// none. Used by Sentry extras (`capture.input_device_uid_system_default`)
+  /// so divergence vs the preferred device is measured correctly.
+  public static func defaultInputDeviceUID() -> String? {
+    guard let id = defaultInputDeviceID() else { return nil }
+    return stringProperty(for: id, selector: kAudioDevicePropertyDeviceUID)
+  }
+
+  // MARK: - Bluetooth & Smart Device Selection
+
+  /// Returns true if the given device uses Bluetooth transport (Classic or LE).
+  public static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+    let transport = transportType(for: deviceID)
+    return transport == kAudioDeviceTransportTypeBluetooth
+      || transport == kAudioDeviceTransportTypeBluetoothLE
+  }
+
+  /// Returns the AudioDeviceID of the built-in microphone, if one exists.
+  public static func builtInMicrophoneDeviceID() -> AudioDeviceID? {
+    let devices = allInputDevices()
+    return devices.first { transportType(for: $0.id) == kAudioDeviceTransportTypeBuiltIn }?.id
+  }
+
+  /// Returns the default system output device ID, or nil if unavailable.
+  public static func defaultOutputDeviceID() -> AudioDeviceID? {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    var deviceID: AudioDeviceID = 0
+    var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+
+    let status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize,
+      &deviceID
+    )
+
+    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return deviceID
+  }
+
+  /// Returns true if the device's I/O cycle is active (audio is flowing somewhere).
+  public static func isDeviceRunningSomewhere(_ deviceID: AudioDeviceID) -> Bool {
+    var isRunning: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isRunning)
+    return isRunning != 0
+  }
+
+  /// Recommended input device given current output device and media-playing state.
+  /// Returns the built-in mic if Bluetooth output is active and media is playing;
+  /// nil otherwise (meaning "use whatever is currently selected").
+  public static func recommendedInputDevice() -> AudioDeviceID? {
+    guard let outputDeviceID = defaultOutputDeviceID() else { return nil }
+    guard isBluetoothDevice(outputDeviceID) else { return nil }
+    guard isDeviceRunningSomewhere(outputDeviceID) else { return nil }
+    return builtInMicrophoneDeviceID()
+  }
+
+  // MARK: - Private Helpers
+
+  static func transportType(for deviceID: AudioDeviceID) -> UInt32 {
+    var transport: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyTransportType,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &transport)
+    return transport
+  }
+
+  private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyStreamConfiguration,
+      mScope: kAudioObjectPropertyScopeInput,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    var dataSize: UInt32 = 0
+    let status = AudioObjectGetPropertyDataSize(deviceID, &propertyAddress, 0, nil, &dataSize)
+    guard status == noErr, dataSize > 0 else { return 0 }
+
+    // AudioBufferList has a variable-length trailing array of AudioBuffer entries.
+    // Allocate the exact byte count reported by CoreAudio to avoid heap corruption
+    // on multi-stream devices where dataSize > MemoryLayout<AudioBufferList>.size.
+    let rawPointer = UnsafeMutableRawPointer.allocate(
+      byteCount: Int(dataSize),
+      alignment: MemoryLayout<AudioBufferList>.alignment
+    )
+    defer { rawPointer.deallocate() }
+
+    let bufferListPointer = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
+
+    let getStatus = AudioObjectGetPropertyData(
+      deviceID, &propertyAddress, 0, nil, &dataSize, bufferListPointer)
+    guard getStatus == noErr else { return 0 }
+
+    let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
+    return bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
+  }
+
+  private static func stringProperty(
+    for deviceID: AudioDeviceID, selector: AudioObjectPropertySelector
+  ) -> String? {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: selector,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    // CoreAudio string properties return CFStringRef — use withUnsafeMutablePointer
+    // to avoid the warning about forming UnsafeMutableRawPointer to a reference type.
+    var dataSize = UInt32(MemoryLayout<CFString>.size)
+    var result: CFString? = nil
+
+    let status = withUnsafeMutablePointer(to: &result) { ptr in
+      AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &dataSize, ptr)
     }
-
-    /// Finds a device ID by its persistent UID string.
-    public static func deviceID(forUID uid: String) -> AudioDeviceID? {
-        let devices = allInputDevices()
-        return devices.first(where: { $0.uid == uid })?.id
-    }
-
-    // MARK: - Bluetooth & Smart Device Selection
-
-    /// Returns true if the given device uses Bluetooth transport (Classic or LE).
-    public static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
-        let transport = transportType(for: deviceID)
-        return transport == kAudioDeviceTransportTypeBluetooth
-            || transport == kAudioDeviceTransportTypeBluetoothLE
-    }
-
-    /// Returns the AudioDeviceID of the built-in microphone, if one exists.
-    public static func builtInMicrophoneDeviceID() -> AudioDeviceID? {
-        let devices = allInputDevices()
-        return devices.first { transportType(for: $0.id) == kAudioDeviceTransportTypeBuiltIn }?.id
-    }
-
-    /// Returns the default system output device ID, or nil if unavailable.
-    public static func defaultOutputDeviceID() -> AudioDeviceID? {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var deviceID: AudioDeviceID = 0
-        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
-
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0,
-            nil,
-            &dataSize,
-            &deviceID
-        )
-
-        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
-        return deviceID
-    }
-
-    /// Returns true if the device's I/O cycle is active (audio is flowing somewhere).
-    public static func isDeviceRunningSomewhere(_ deviceID: AudioDeviceID) -> Bool {
-        var isRunning: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        var addr = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isRunning)
-        return isRunning != 0
-    }
-
-    /// Recommended input device given current output device and media-playing state.
-    /// Returns the built-in mic if Bluetooth output is active and media is playing;
-    /// nil otherwise (meaning "use whatever is currently selected").
-    public static func recommendedInputDevice() -> AudioDeviceID? {
-        guard let outputDeviceID = defaultOutputDeviceID() else { return nil }
-        guard isBluetoothDevice(outputDeviceID) else { return nil }
-        guard isDeviceRunningSomewhere(outputDeviceID) else { return nil }
-        return builtInMicrophoneDeviceID()
-    }
-
-    // MARK: - Private Helpers
-
-    static func transportType(for deviceID: AudioDeviceID) -> UInt32 {
-        var transport: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        var addr = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyTransportType,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &transport)
-        return transport
-    }
-
-    private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyStreamConfiguration,
-            mScope: kAudioObjectPropertyScopeInput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var dataSize: UInt32 = 0
-        let status = AudioObjectGetPropertyDataSize(deviceID, &propertyAddress, 0, nil, &dataSize)
-        guard status == noErr, dataSize > 0 else { return 0 }
-
-        // AudioBufferList has a variable-length trailing array of AudioBuffer entries.
-        // Allocate the exact byte count reported by CoreAudio to avoid heap corruption
-        // on multi-stream devices where dataSize > MemoryLayout<AudioBufferList>.size.
-        let rawPointer = UnsafeMutableRawPointer.allocate(
-            byteCount: Int(dataSize),
-            alignment: MemoryLayout<AudioBufferList>.alignment
-        )
-        defer { rawPointer.deallocate() }
-
-        let bufferListPointer = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
-
-        let getStatus = AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &dataSize, bufferListPointer)
-        guard getStatus == noErr else { return 0 }
-
-        let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
-        return bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
-    }
-
-    private static func stringProperty(for deviceID: AudioDeviceID, selector: AudioObjectPropertySelector) -> String? {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: selector,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        // CoreAudio string properties return CFStringRef — use withUnsafeMutablePointer
-        // to avoid the warning about forming UnsafeMutableRawPointer to a reference type.
-        var dataSize = UInt32(MemoryLayout<CFString>.size)
-        var result: CFString? = nil
-
-        let status = withUnsafeMutablePointer(to: &result) { ptr in
-            AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &dataSize, ptr)
-        }
-        guard status == noErr, let name = result else { return nil }
-        return name as String
-    }
+    guard status == noErr, let name = result else { return nil }
+    return name as String
+  }
 }
 
 /// Monitors audio device connect/disconnect events via CoreAudio property listener.
 public final class AudioDeviceMonitor: Sendable {
-    private let onDevicesChanged: @Sendable () -> Void
-    /// Stored listener block — CoreAudio requires the same reference for removal.
-    nonisolated(unsafe) private var listenerBlock: AudioObjectPropertyListenerBlock?
+  private let onDevicesChanged: @Sendable () -> Void
+  /// Stored listener block — CoreAudio requires the same reference for removal.
+  nonisolated(unsafe) private var listenerBlock: AudioObjectPropertyListenerBlock?
 
-    public init(onDevicesChanged: @escaping @Sendable () -> Void) {
-        self.onDevicesChanged = onDevicesChanged
-        startListening()
+  public init(onDevicesChanged: @escaping @Sendable () -> Void) {
+    self.onDevicesChanged = onDevicesChanged
+    startListening()
+  }
+
+  deinit {
+    stopListening()
+  }
+
+  private func startListening() {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    let callback = self.onDevicesChanged
+    let block: AudioObjectPropertyListenerBlock = { _, _ in
+      callback()
     }
+    self.listenerBlock = block
 
-    deinit {
-        stopListening()
-    }
+    AudioObjectAddPropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      nil,
+      block
+    )
+  }
 
-    private func startListening() {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
+  private func stopListening() {
+    guard let block = listenerBlock else { return }
 
-        let callback = self.onDevicesChanged
-        let block: AudioObjectPropertyListenerBlock = { _, _ in
-            callback()
-        }
-        self.listenerBlock = block
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
 
-        AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            nil,
-            block
-        )
-    }
-
-    private func stopListening() {
-        guard let block = listenerBlock else { return }
-
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            nil,
-            block
-        )
-        listenerBlock = nil
-    }
+    AudioObjectRemovePropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      nil,
+      block
+    )
+    listenerBlock = nil
+  }
 }

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import EnviousWisprCore
 
 /// Internal abstraction over audio capture sources.
 ///
@@ -11,28 +12,49 @@
 /// audioLevel, isCapturing); sources own hardware/session/engine lifecycle.
 @MainActor
 protocol AudioInputSource: AnyObject {
-    // Callbacks — set by AudioCaptureManager before start
-    var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)? { get set }
-    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
-    var onInterrupted: (() -> Void)? { get set }
+  // Callbacks — set by AudioCaptureManager before start
+  var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)? { get set }
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
+  var onInterrupted: (() -> Void)? { get set }
 
-    // Lifecycle (mirrors AudioCaptureManager's two-phase start)
-    func prepare() async throws
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>
-    func stop() async -> [Float]
+  /// Liveness-watchdog callback — fires once per capture session if zero
+  /// buffers are delivered within `Constants.audioCaptureStallWindowMs` of
+  /// tap install. Set by `AudioCaptureManager` on every `resolveSource()`.
+  /// Source must cancel any pending watchdog on `stop()` / `deactivateCapture()`.
+  var onCaptureStalled: ((CaptureStallContext) -> Void)? { get set }
 
-    /// Deactivate live capture but keep engine/session and tap warm.
-    /// The forwarder returns to preRolling mode so the ring buffer continues
-    /// capturing audio for instant first-word capture on next recording.
-    /// Call stop() for full teardown.
-    func deactivateCapture()
+  /// AVCaptureSession-specific: interruption / runtime-error telemetry.
+  /// `AVAudioEngineSource` leaves nil (no AVCaptureSession layer).
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)? { get set }
 
-    // State
-    var isCapturing: Bool { get } // periphery:ignore - used by conformers for internal guards
-    var isRunning: Bool { get }
+  /// Monotonic capture-session id. Increments inside `startCapture`.
+  /// Zero if no session has started. Used for watchdog generation check +
+  /// dedup correlation at the pipeline layer.
+  var captureGeneration: UInt64 { get }
 
-    // Engine-specific (no-op for AVCaptureSessionSource)
-    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
-    func abortPrepare()
-    func rebuild()
+  /// Low-cardinality tag naming the concrete capture backend
+  /// (`"av_audio_engine"` vs `"av_capture_session"`). Surfaced via
+  /// `AudioCaptureManager.captureSourceType` so pipeline Sentry extras
+  /// distinguish BT-direct (AVCaptureSession) from AVAudioEngine paths.
+  var captureSourceType: String { get }
+
+  // Lifecycle (mirrors AudioCaptureManager's two-phase start)
+  func prepare() async throws
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>
+  func stop() async -> [Float]
+
+  /// Deactivate live capture but keep engine/session and tap warm.
+  /// The forwarder returns to preRolling mode so the ring buffer continues
+  /// capturing audio for instant first-word capture on next recording.
+  /// Call stop() for full teardown.
+  func deactivateCapture()
+
+  // State
+  var isCapturing: Bool { get }  // periphery:ignore - used by conformers for internal guards
+  var isRunning: Bool { get }
+
+  // Engine-specific (no-op for AVCaptureSessionSource)
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
+  func abortPrepare()
+  func rebuild()
 }

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -3,39 +3,53 @@ import CoreAudio
 /// Policy for selecting the audio capture source.
 /// `.automatic` decides based on output route + input intent.
 /// `.forceEngine` / `.forceCaptureSession` are for debugging/testing.
-enum CaptureSourcePolicy {
-    case automatic
-    case forceEngine
-    case forceCaptureSession
+public enum CaptureSourcePolicy: Sendable {
+  case automatic
+  case forceEngine
+  case forceCaptureSession
 }
 
 /// Which capture backend to use.
-enum CaptureSourceType {
-    case audioEngine
-    case captureSession
+public enum CaptureSourceType: Sendable {
+  case audioEngine
+  case captureSession
 }
 
 /// Machine-readable reason for the route decision. Used for telemetry.
-enum CaptureRouteReason: String {
-    case btOutputAutoInput
-    case btOutputUserSelectedBTMic
-    case btOutputUserSelectedBuiltIn
-    case btOutputUserSelectedWired
-    case noBTAutoInput
-    case noBTUserSelectedDevice
-    case forcedEngine
-    case forcedCaptureSession
-    case fallbackToEngine
-    case failedNoFallback
+public enum CaptureRouteReason: String, Sendable {
+  case btOutputAutoInput
+  case btOutputUserSelectedBTMic
+  case btOutputUserSelectedBuiltIn
+  case btOutputUserSelectedWired
+  case noBTAutoInput
+  case noBTUserSelectedDevice
+  case forcedEngine
+  case forcedCaptureSession
+  case fallbackToEngine
+  case failedNoFallback
 }
 
 /// The result of route resolution — tells AudioCaptureManager which source to create and why.
-struct CaptureRouteDecision {
-    let sourceType: CaptureSourceType
-    let reason: CaptureRouteReason
-    let rationale: String
-    let vpAvailable: Bool
-    let fallbackAllowed: Bool
+public struct CaptureRouteDecision: Sendable {
+  public let sourceType: CaptureSourceType
+  public let reason: CaptureRouteReason
+  public let rationale: String
+  public let vpAvailable: Bool
+  public let fallbackAllowed: Bool
+
+  public init(
+    sourceType: CaptureSourceType,
+    reason: CaptureRouteReason,
+    rationale: String,
+    vpAvailable: Bool,
+    fallbackAllowed: Bool
+  ) {
+    self.sourceType = sourceType
+    self.reason = reason
+    self.rationale = rationale
+    self.vpAvailable = vpAvailable
+    self.fallbackAllowed = fallbackAllowed
+  }
 }
 
 /// Decides which `AudioInputSource` to use based on output route, user input preference, and policy.
@@ -45,96 +59,104 @@ struct CaptureRouteDecision {
 @MainActor
 struct CaptureRouteResolver {
 
-    var policy: CaptureSourcePolicy = .automatic
+  var policy: CaptureSourcePolicy = .automatic
 
-    /// Resolve which capture source to use.
-    ///
-    /// - Parameters:
-    ///   - preferredInputDeviceUID: User's explicit device choice. Empty = Auto.
-    ///   - noiseSuppression: Whether noise suppression is requested (only available on engine path).
-    func resolve(preferredInputDeviceUID: String, noiseSuppression: Bool) -> CaptureRouteDecision {
-        switch policy {
-        case .forceEngine:
-            return CaptureRouteDecision(
-                sourceType: .audioEngine,
-                reason: .forcedEngine,
-                rationale: "Policy override: forced engine",
-                vpAvailable: true,
-                fallbackAllowed: false
-            )
-        case .forceCaptureSession:
-            return CaptureRouteDecision(
-                sourceType: .captureSession,
-                reason: .forcedCaptureSession,
-                rationale: "Policy override: forced capture session",
-                vpAvailable: false,
-                fallbackAllowed: false
-            )
-        case .automatic:
-            return resolveAutomatic(preferredInputDeviceUID: preferredInputDeviceUID, noiseSuppression: noiseSuppression)
-        }
+  /// Resolve which capture source to use.
+  ///
+  /// - Parameters:
+  ///   - preferredInputDeviceUID: User's explicit device choice. Empty = Auto.
+  ///   - noiseSuppression: Whether noise suppression is requested (only available on engine path).
+  func resolve(preferredInputDeviceUID: String, noiseSuppression: Bool) -> CaptureRouteDecision {
+    switch policy {
+    case .forceEngine:
+      return CaptureRouteDecision(
+        sourceType: .audioEngine,
+        reason: .forcedEngine,
+        rationale: "Policy override: forced engine",
+        vpAvailable: true,
+        fallbackAllowed: false
+      )
+    case .forceCaptureSession:
+      return CaptureRouteDecision(
+        sourceType: .captureSession,
+        reason: .forcedCaptureSession,
+        rationale: "Policy override: forced capture session",
+        vpAvailable: false,
+        fallbackAllowed: false
+      )
+    case .automatic:
+      return resolveAutomatic(
+        preferredInputDeviceUID: preferredInputDeviceUID, noiseSuppression: noiseSuppression)
+    }
+  }
+
+  // periphery:ignore:parameters noiseSuppression - reserved for future VP-aware routing decisions
+  private func resolveAutomatic(preferredInputDeviceUID: String, noiseSuppression: Bool)
+    -> CaptureRouteDecision
+  {
+    let btOutputActive: Bool
+    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
+      btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
+    } else {
+      btOutputActive = false
     }
 
-    // periphery:ignore:parameters noiseSuppression - reserved for future VP-aware routing decisions
-    private func resolveAutomatic(preferredInputDeviceUID: String, noiseSuppression: Bool) -> CaptureRouteDecision {
-        let btOutputActive: Bool
-        if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
-            btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
-        } else {
-            btOutputActive = false
-        }
-
-        // No BT output — safe to use AVAudioEngine for everything
-        guard btOutputActive else {
-            if preferredInputDeviceUID.isEmpty {
-                return CaptureRouteDecision(
-                    sourceType: .audioEngine,
-                    reason: .noBTAutoInput,
-                    rationale: "No BT output — engine with system default input",
-                    vpAvailable: true,
-                    fallbackAllowed: false
-                )
-            } else {
-                return CaptureRouteDecision(
-                    sourceType: .audioEngine,
-                    reason: .noBTUserSelectedDevice,
-                    rationale: "No BT output — engine with user device \(preferredInputDeviceUID)",
-                    vpAvailable: true,
-                    fallbackAllowed: false
-                )
-            }
-        }
-
-        // BT output active — use AVCaptureSession to avoid A2DP→SCO switch.
-        // Do NOT re-enter AVAudioEngine path under BT output regardless of user preference.
-        let reason: CaptureRouteReason
-        let rationale: String
-
-        if preferredInputDeviceUID.isEmpty {
-            reason = .btOutputAutoInput
-            rationale = "BT output active, auto input — capture session with built-in mic"
-        } else {
-            // Check if user's preferred device is BT
-            let prefDeviceID = AudioDeviceEnumerator.deviceID(forUID: preferredInputDeviceUID)
-            let prefIsBT = prefDeviceID.map { AudioDeviceEnumerator.isBluetoothDevice($0) } ?? false
-
-            if prefIsBT {
-                reason = .btOutputUserSelectedBTMic
-                rationale = "BT output active, user selected BT mic — override to capture session with built-in mic (crash prevention)"
-            } else {
-                // User selected built-in or wired — still use capture session under BT output
-                let isBuiltIn = prefDeviceID.map { AudioDeviceEnumerator.transportType(for: $0) == kAudioDeviceTransportTypeBuiltIn } ?? false
-                reason = isBuiltIn ? .btOutputUserSelectedBuiltIn : .btOutputUserSelectedWired
-                rationale = "BT output active, user selected \(isBuiltIn ? "built-in" : "wired") device — capture session"
-            }
-        }
-
+    // No BT output — safe to use AVAudioEngine for everything
+    guard btOutputActive else {
+      if preferredInputDeviceUID.isEmpty {
         return CaptureRouteDecision(
-            sourceType: .captureSession,
-            reason: reason,
-            rationale: rationale,
-            vpAvailable: false,
-            fallbackAllowed: !btOutputActive  // Only fall back if BT is not active
+          sourceType: .audioEngine,
+          reason: .noBTAutoInput,
+          rationale: "No BT output — engine with system default input",
+          vpAvailable: true,
+          fallbackAllowed: false
         )
+      } else {
+        return CaptureRouteDecision(
+          sourceType: .audioEngine,
+          reason: .noBTUserSelectedDevice,
+          rationale: "No BT output — engine with user device \(preferredInputDeviceUID)",
+          vpAvailable: true,
+          fallbackAllowed: false
+        )
+      }
     }
+
+    // BT output active — use AVCaptureSession to avoid A2DP→SCO switch.
+    // Do NOT re-enter AVAudioEngine path under BT output regardless of user preference.
+    let reason: CaptureRouteReason
+    let rationale: String
+
+    if preferredInputDeviceUID.isEmpty {
+      reason = .btOutputAutoInput
+      rationale = "BT output active, auto input — capture session with built-in mic"
+    } else {
+      // Check if user's preferred device is BT
+      let prefDeviceID = AudioDeviceEnumerator.deviceID(forUID: preferredInputDeviceUID)
+      let prefIsBT = prefDeviceID.map { AudioDeviceEnumerator.isBluetoothDevice($0) } ?? false
+
+      if prefIsBT {
+        reason = .btOutputUserSelectedBTMic
+        rationale =
+          "BT output active, user selected BT mic — override to capture session with built-in mic (crash prevention)"
+      } else {
+        // User selected built-in or wired — still use capture session under BT output
+        let isBuiltIn =
+          prefDeviceID.map {
+            AudioDeviceEnumerator.transportType(for: $0) == kAudioDeviceTransportTypeBuiltIn
+          } ?? false
+        reason = isBuiltIn ? .btOutputUserSelectedBuiltIn : .btOutputUserSelectedWired
+        rationale =
+          "BT output active, user selected \(isBuiltIn ? "built-in" : "wired") device — capture session"
+      }
+    }
+
+    return CaptureRouteDecision(
+      sourceType: .captureSession,
+      reason: reason,
+      rationale: rationale,
+      vpAvailable: false,
+      fallbackAllowed: !btOutputActive  // Only fall back if BT is not active
+    )
+  }
 }

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Context attached to a stalled-capture telemetry event. Built by an audio
+/// source (`AVAudioEngineSource`, `AVCaptureSessionSource`, or `AudioCaptureProxy`)
+/// at watchdog-fire time and consumed by the pipeline's emission site.
+///
+/// All fields are Sendable and safe to carry across actor boundaries. No PII:
+/// device UIDs are opaque CoreAudio identifiers, not human-visible strings.
+public struct CaptureStallContext: Sendable {
+  public let sessionID: UInt64
+  public let armedAtUptimeNs: UInt64
+  public let firedAtUptimeNs: UInt64
+  public let route: String
+  public let sourceType: String
+  public let engineStartedSuccessfully: Bool
+  public let tapInstalled: Bool
+  public let formatMismatchObserved: Bool
+  public let inputDeviceUIDPreferred: String?
+  public let inputDeviceUIDSystemDefault: String?
+
+  public init(
+    sessionID: UInt64,
+    armedAtUptimeNs: UInt64,
+    firedAtUptimeNs: UInt64,
+    route: String,
+    sourceType: String,
+    engineStartedSuccessfully: Bool,
+    tapInstalled: Bool,
+    formatMismatchObserved: Bool,
+    inputDeviceUIDPreferred: String?,
+    inputDeviceUIDSystemDefault: String?
+  ) {
+    self.sessionID = sessionID
+    self.armedAtUptimeNs = armedAtUptimeNs
+    self.firedAtUptimeNs = firedAtUptimeNs
+    self.route = route
+    self.sourceType = sourceType
+    self.engineStartedSuccessfully = engineStartedSuccessfully
+    self.tapInstalled = tapInstalled
+    self.formatMismatchObserved = formatMismatchObserved
+    self.inputDeviceUIDPreferred = inputDeviceUIDPreferred
+    self.inputDeviceUIDSystemDefault = inputDeviceUIDSystemDefault
+  }
+}
+
+/// Context for `AVCaptureSessionSource` interruption / runtime-error notifications.
+/// Carries the diagnostic payload (reason code, runtime NSError fields) that the
+/// underlying notification userInfo would otherwise drop on the floor.
+public struct CaptureSessionInterruptionContext: Sendable {
+  public enum Kind: String, Sendable {
+    case wasInterrupted
+    case runtimeError
+  }
+
+  public let kind: Kind
+  public let reasonCode: Int?
+  public let reasonLabel: String?
+  public let errorDomain: String?
+  public let errorCode: Int?
+  public let errorDescription: String?
+  public let sessionID: UInt64
+  public let isActivelyCapturing: Bool
+
+  public init(
+    kind: Kind,
+    reasonCode: Int?,
+    reasonLabel: String?,
+    errorDomain: String?,
+    errorCode: Int?,
+    errorDescription: String?,
+    sessionID: UInt64,
+    isActivelyCapturing: Bool
+  ) {
+    self.kind = kind
+    self.reasonCode = reasonCode
+    self.reasonLabel = reasonLabel
+    self.errorDomain = errorDomain
+    self.errorCode = errorCode
+    self.errorDescription = errorDescription
+    self.sessionID = sessionID
+    self.isActivelyCapturing = isActivelyCapturing
+  }
+}
+
+/// Context for a swallowed XPC reply-path error on a non-throwing proxy call
+/// (stopCapture / getSamplesSnapshot / getSpeechSegments). Reported via
+/// `onXPCReplyFailed` before the proxy returns its empty default, so the
+/// pipeline can emit the correct root cause instead of misrouting into
+/// "no_audio_captured".
+public struct XPCReplyFailureContext: Sendable {
+  public let replyStage: String
+  public let errorDomain: String
+  public let errorCode: Int
+  public let errorDescription: String
+  public let sessionID: UInt64
+
+  public init(
+    replyStage: String,
+    errorDomain: String,
+    errorCode: Int,
+    errorDescription: String,
+    sessionID: UInt64
+  ) {
+    self.replyStage = replyStage
+    self.errorDomain = errorDomain
+    self.errorCode = errorCode
+    self.errorDescription = errorDescription
+    self.sessionID = sessionID
+  }
+}
+
+/// Classifies XPC interruption / invalidation events for the `onXPCServiceError`
+/// callback on `AudioCaptureInterface`. Exhaustive: any new XPC channel
+/// requires adding a case, which the compiler enforces at every consumer
+/// switch site.
+public enum XPCErrorKind: String, Sendable {
+  case interruptCapturing
+  case invalidateCapturing
+  case invalidateIdle
+}
+
+/// Context for XPC interrupt / invalidate handler fires. Consumed by
+/// `AppState.onXPCServiceError` which emits the captureError.
+public struct XPCErrorContext: Sendable {
+  public let kind: XPCErrorKind
+  public let sessionID: UInt64?
+  public let timestampNs: UInt64
+
+  public init(kind: XPCErrorKind, sessionID: UInt64?, timestampNs: UInt64) {
+    self.kind = kind
+    self.sessionID = sessionID
+    self.timestampNs = timestampNs
+  }
+}

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -1,42 +1,47 @@
 import Foundation
 
 public enum AppConstants {
-    public static let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "EnviousWispr"
-    public static let appVersion: String = {
-        let raw = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        // Strip leading "v" and git metadata (e.g. "v1.0.6-1-gabcdef-dev" → "1.0.6")
-        let stripped = raw.hasPrefix("v") ? String(raw.dropFirst()) : raw
-        return stripped.split(separator: "-").first.map(String.init) ?? stripped
-    }()
-    public static let appSupportDir = "EnviousWispr"
-    public static let transcriptsDir = "transcripts"
-    public static let onboardingWindowTitle = "Setup"
+  public static let appName =
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "EnviousWispr"
+  public static let appVersion: String = {
+    let raw =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+    // Strip leading "v" and git metadata (e.g. "v1.0.6-1-gabcdef-dev" → "1.0.6")
+    let stripped = raw.hasPrefix("v") ? String(raw.dropFirst()) : raw
+    return stripped.split(separator: "-").first.map(String.init) ?? stripped
+  }()
+  public static let appSupportDir = "EnviousWispr"
+  public static let transcriptsDir = "transcripts"
+  public static let onboardingWindowTitle = "Setup"
 
-    /// Application Support directory for EnviousWispr.
-    /// Falls back to a temporary directory if Application Support is unavailable.
-    public static var appSupportURL: URL {
-        if let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first {
-            return appSupport.appendingPathComponent(appSupportDir, isDirectory: true)
-        }
-        let fallback = FileManager.default.temporaryDirectory.appendingPathComponent(appSupportDir, isDirectory: true)
-        NSLog("[EnviousWispr] WARNING: Application Support directory unavailable, using fallback: \(fallback.path)")
-        return fallback
+  /// Application Support directory for EnviousWispr.
+  /// Falls back to a temporary directory if Application Support is unavailable.
+  public static var appSupportURL: URL {
+    if let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first {
+      return appSupport.appendingPathComponent(appSupportDir, isDirectory: true)
     }
+    let fallback = FileManager.default.temporaryDirectory.appendingPathComponent(
+      appSupportDir, isDirectory: true)
+    NSLog(
+      "[EnviousWispr] WARNING: Application Support directory unavailable, using fallback: \(fallback.path)"
+    )
+    return fallback
+  }
 }
 
 // MARK: - Speech Segment
 
 /// A contiguous range of audio samples identified as speech by VAD.
 public struct SpeechSegment: Sendable {
-    public let startSample: Int
-    public let endSample: Int
-    public init(startSample: Int, endSample: Int) {
-        self.startSample = startSample
-        self.endSample = endSample
-    }
+  public let startSample: Int
+  public let endSample: Int
+  public init(startSample: Int, endSample: Int) {
+    self.startSample = startSample
+    self.endSample = endSample
+  }
 }
 
 // MARK: - Capture Result
@@ -45,102 +50,108 @@ public struct SpeechSegment: Sendable {
 /// Bundling these together eliminates the ordering dependency between
 /// stopCapture() and getVADSegments() across the XPC boundary.
 public struct CaptureResult: Sendable {
-    public let samples: [Float]
-    public let vadSegments: [SpeechSegment]
-    public init(samples: [Float], vadSegments: [SpeechSegment] = []) {
-        self.samples = samples
-        self.vadSegments = vadSegments
-    }
+  public let samples: [Float]
+  public let vadSegments: [SpeechSegment]
+  public init(samples: [Float], vadSegments: [SpeechSegment] = []) {
+    self.samples = samples
+    self.vadSegments = vadSegments
+  }
 }
 
 // MARK: - Audio Constants
 
 public enum AudioConstants {
-    /// Target sample rate for ASR processing (16kHz mono).
-    public static let sampleRate: Double = 16000.0
+  /// Target sample rate for ASR processing (16kHz mono).
+  public static let sampleRate: Double = 16000.0
 
-    /// Audio channels for recording (mono).
-    public static let channels: Int = 1
+  /// Audio channels for recording (mono).
+  public static let channels: Int = 1
 
-    /// Audio buffer size for capture tap (256ms at 16kHz).
-    public static let captureBufferSize: Int = 4096
+  /// Audio buffer size for capture tap (256ms at 16kHz).
+  public static let captureBufferSize: Int = 4096
 
-    /// Minimum samples required for valid transcription (1 second).
-    public static let minimumTranscriptionSamples: Int = 16000
+  /// Minimum samples required for valid transcription (1 second).
+  public static let minimumTranscriptionSamples: Int = 16000
 
 }
 
 // MARK: - Timing Constants
 
 public enum TimingConstants {
-    /// Delay before clipboard restoration after paste.
-    public static let clipboardRestoreDelayMs: Int = 200
+  /// Delay before clipboard restoration after paste.
+  public static let clipboardRestoreDelayMs: Int = 200
 
-    /// Delay after hiding the app before simulating paste (ms).
-    public static let appHideBeforePasteDelayMs: Int = 300
+  /// Delay after hiding the app before simulating paste (ms).
+  public static let appHideBeforePasteDelayMs: Int = 300
 
-    /// Interval between activation-check polls (ms).
-    public static let activationPollIntervalMs: Int = 50
+  /// Interval between activation-check polls (ms).
+  public static let activationPollIntervalMs: Int = 50
 
-    /// Maximum time to wait for target app activation before pasting anyway (ms).
-    public static let activationTimeoutMs: Int = 1000
+  /// Maximum time to wait for target app activation before pasting anyway (ms).
+  public static let activationTimeoutMs: Int = 1000
 
-    /// Accessibility permission polling interval (seconds).
-    public static let accessibilityPollIntervalSec: Double = 5.0
+  /// Accessibility permission polling interval (seconds).
+  public static let accessibilityPollIntervalSec: Double = 5.0
 
-    /// Minimum recording duration before transcription (seconds).
-    /// Recordings shorter than this are silently discarded (accidental taps).
-    public static let minimumRecordingDuration: TimeInterval = 0.5
+  /// Minimum recording duration before transcription (seconds).
+  /// Recordings shorter than this are silently discarded (accidental taps).
+  public static let minimumRecordingDuration: TimeInterval = 0.5
 
-    /// Maximum recording duration before graceful auto-stop (seconds).
-    /// Prevents runaway recordings from consuming unbounded memory/CPU.
-    /// AudioCaptureManager has a hard emergency limit at 600s; this fires earlier and gracefully.
-    public static let maxRecordingDuration: TimeInterval = 300
+  /// Maximum recording duration before graceful auto-stop (seconds).
+  /// Prevents runaway recordings from consuming unbounded memory/CPU.
+  /// AudioCaptureManager has a hard emergency limit at 600s; this fires earlier and gracefully.
+  public static let maxRecordingDuration: TimeInterval = 300
 
-    /// Double-press detection window for hands-free recording mode (milliseconds).
-    /// Release within this window starts a debounce timer; second press within
-    /// this window locks recording. Matches Wispr Flow's proven 500ms constant.
-    public static let handsFreeDebounceDelayMs: UInt64 = 500
+  /// Double-press detection window for hands-free recording mode (milliseconds).
+  /// Release within this window starts a debounce timer; second press within
+  /// this window locks recording. Matches Wispr Flow's proven 500ms constant.
+  public static let handsFreeDebounceDelayMs: UInt64 = 500
+
+  /// Audio capture stall-detection window (milliseconds). A capture session that
+  /// reports `engine.start` success and installs a tap but delivers zero buffers
+  /// within this window fires `onCaptureStalled`. Pre-roll ringbuffer is 1.5s;
+  /// healthy cold-start delivers first buffer ~200ms; 800ms is a 4x margin.
+  public static let audioCaptureStallWindowMs: Int = 800
 }
 
 // MARK: - LLM Constants
 
 public enum LLMConstants {
-    /// Maximum concurrent model probes to avoid rate limiting.
-    public static let maxConcurrentProbes: Int = 5
+  /// Maximum concurrent model probes to avoid rate limiting.
+  public static let maxConcurrentProbes: Int = 5
 
-    /// Default max tokens for cloud LLM providers (supports ~5 min dictations with safe headroom).
-    /// Thinking models (Gemini 2.5) consume output tokens for reasoning, so this must be generous.
-    public static let defaultMaxTokens: Int = 8192
+  /// Default max tokens for cloud LLM providers (supports ~5 min dictations with safe headroom).
+  /// Thinking models (Gemini 2.5) consume output tokens for reasoning, so this must be generous.
+  public static let defaultMaxTokens: Int = 8192
 
-    /// Floor for Ollama max tokens on non-thinking-capable models (weak/small
-    /// models, plain completion models like llama3.2). Actual cap scales with
-    /// input length (charCount) to handle long dictations. Kept small so a
-    /// rambly small model can't outrun the 15s pipeline timeout.
-    public static let ollamaMaxTokens: Int = 256
+  /// Floor for Ollama max tokens on non-thinking-capable models (weak/small
+  /// models, plain completion models like llama3.2). Actual cap scales with
+  /// input length (charCount) to handle long dictations. Kept small so a
+  /// rambly small model can't outrun the 15s pipeline timeout.
+  public static let ollamaMaxTokens: Int = 256
 
-    /// Floor for Ollama max tokens on thinking-capable models (e.g. Gemma4).
-    /// These models emit reasoning into `message.thinking` separately from the
-    /// final answer in `message.content`, but the reasoning still counts
-    /// against `num_predict`. With the 256 floor, Gemma4's internal reasoning
-    /// exhausted the budget and left `message.content` empty on ~50% of polish
-    /// calls (#272). 2048 gives thinking models enough headroom to complete
-    /// reasoning and emit a clean answer; `done_reason=stop` ends generation
-    /// early for short transcripts so latency is bounded.
-    public static let ollamaThinkingMaxTokens: Int = 2048
+  /// Floor for Ollama max tokens on thinking-capable models (e.g. Gemma4).
+  /// These models emit reasoning into `message.thinking` separately from the
+  /// final answer in `message.content`, but the reasoning still counts
+  /// against `num_predict`. With the 256 floor, Gemma4's internal reasoning
+  /// exhausted the budget and left `message.content` empty on ~50% of polish
+  /// calls (#272). 2048 gives thinking models enough headroom to complete
+  /// reasoning and emit a clean answer; `done_reason=stop` ends generation
+  /// early for short transcripts so latency is bounded.
+  public static let ollamaThinkingMaxTokens: Int = 2048
 
-    /// Default thinking budget for extended thinking models (Gemini 2.5 Flash/Pro).
-    public static let defaultThinkingBudget: Int = 8192
+  /// Default thinking budget for extended thinking models (Gemini 2.5 Flash/Pro).
+  public static let defaultThinkingBudget: Int = 8192
 
-    /// Floor for dynamic output token cap. Ensures short transcripts have room to expand.
-    public static let polishMaxTokensFloor: Int = 512
+  /// Floor for dynamic output token cap. Ensures short transcripts have room to expand.
+  public static let polishMaxTokensFloor: Int = 512
 }
 
 public enum FormattingConstants {
-    /// Format a duration in seconds as "m:ss".
-    public static func formatDuration(_ seconds: TimeInterval) -> String {
-        let mins = Int(seconds) / 60
-        let secs = Int(seconds) % 60
-        return String(format: "%d:%02d", mins, secs)
-    }
+  /// Format a duration in seconds as "m:ss".
+  public static func formatDuration(_ seconds: TimeInterval) -> String {
+    let mins = Int(seconds) / 60
+    let secs = Int(seconds) % 60
+    return String(format: "%d:%02d", mins, secs)
+  }
 }

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -1,42 +1,54 @@
+import EnviousWisprCore
 import Foundation
 
 /// Known interruption message strings used to route .error state to .interruption overlay intent.
 public enum InterruptionMessages {
-    public static let micDisconnected = "Microphone disconnected"
+  public static let micDisconnected = "Microphone disconnected"
 }
 
 /// Events that any dictation pipeline must handle.
 public enum PipelineEvent: Sendable {
-    case preWarm
-    case toggleRecording
-    case requestStop
-    case cancelRecording
-    case reset
+  case preWarm
+  case toggleRecording
+  case requestStop
+  case cancelRecording
+  case reset
 }
 
 /// What the overlay should display — decoupled from internal pipeline state.
 public enum OverlayIntent: Equatable, Sendable {
-    case hidden
-    case recording(audioLevel: Float)
-    case processing(label: String)
-    /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
-    /// Auto-dismissed by the overlay panel after a short delay.
-    case clipboardFallback
-    /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
-    /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
-    case warning(message: String)
-    /// Transient error notice shown when ASR fails despite speech evidence.
-    /// Auto-dismissed by the overlay panel after 3 seconds.
-    case error(message: String)
-    /// Transient interruption notice shown when the recording device disconnects.
-    /// Distress lips (red pulse) with reason text, auto-dismissed after 2 seconds.
-    case interruption(message: String)
+  case hidden
+  case recording(audioLevel: Float)
+  case processing(label: String)
+  /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
+  /// Auto-dismissed by the overlay panel after a short delay.
+  case clipboardFallback
+  /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
+  /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
+  case warning(message: String)
+  /// Transient error notice shown when ASR fails despite speech evidence.
+  /// Auto-dismissed by the overlay panel after 3 seconds.
+  case error(message: String)
+  /// Transient interruption notice shown when the recording device disconnects.
+  /// Distress lips (red pulse) with reason text, auto-dismissed after 2 seconds.
+  case interruption(message: String)
 }
 
 /// Abstraction over dictation pipelines (Parakeet streaming, WhisperKit batch, etc.).
 /// Each pipeline owns its own state machine and emits `OverlayIntent` for UI.
 @MainActor
 public protocol DictationPipeline: AnyObject {
-    var overlayIntent: OverlayIntent { get }
-    func handle(event: PipelineEvent) async
+  var overlayIntent: OverlayIntent { get }
+  func handle(event: PipelineEvent) async
+}
+
+/// Issue #285 — heart-path telemetry callbacks that AppState routes to
+/// whichever pipeline is currently recording. The underlying `AudioCapture*`
+/// callback properties are single-owner on the shared capture instance, so
+/// per-pipeline wiring would let the second-initialized pipeline steal them.
+@MainActor
+public protocol HeartPathTelemetryTarget: AnyObject {
+  func handleCaptureStall(_ ctx: CaptureStallContext)
+  func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext)
+  func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext)
 }

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -6,46 +6,62 @@ import Foundation
 /// Input for a paste delivery operation. Captures session-scoped target info.
 @MainActor
 internal struct PasteDeliveryRequest {
-    let text: String
-    let targetApp: NSRunningApplication?
-    let targetElement: AXUIElement?
-    let restoreClipboardAfterPaste: Bool
+  let text: String
+  let targetApp: NSRunningApplication?
+  let targetElement: AXUIElement?
+  let restoreClipboardAfterPaste: Bool
+}
+
+/// Typed outcome of a paste delivery operation. Authoritative input for both
+/// UI overlay decisions and Sentry telemetry — decouples the two from the
+/// stringly-typed `pasteTier` metric (issue #285).
+internal enum PasteDeliveryOutcome: Equatable, Sendable {
+  case delivered(tier: PasteTier, durationMs: Int)
+  case clipboardOnly(
+    tiersAttempted: [PasteTier],
+    focus: PasteFocusClassification,
+    targetBundleID: String?
+  )
+  case cgEventCreationFailed(accessibilityTrusted: Bool)
 }
 
 /// Result of a paste delivery operation.
 internal struct PasteDeliveryResult {
-    let tier: PasteTier
-    let durationMs: Int
+  let tier: PasteTier
+  let durationMs: Int
+  let outcome: PasteDeliveryOutcome
 }
 
 /// Three-way classification of the focused AX element at paste time.
 internal enum PasteFocusClassification: Equatable {
-    /// Element present with a known text-input role. Full cascade applies.
-    case textField
-    /// No focused element reported (Chromium/Electron lazy-AX tree).
-    /// Skip Tier 1 but still attempt Tier 2 Cmd+V.
-    case missing
-    /// Element present but role not in textRoles. Skip Tier 1 and Tier 2 —
-    /// firing Cmd+V would go nowhere. Falls through to clipboard-only overlay.
-    case nonText
+  /// Element present with a known text-input role. Full cascade applies.
+  case textField
+  /// No focused element reported (Chromium/Electron lazy-AX tree).
+  /// Skip Tier 1 but still attempt Tier 2 Cmd+V.
+  case missing
+  /// Element present but role not in textRoles. Skip Tier 1 and Tier 2 —
+  /// firing Cmd+V would go nowhere. Falls through to clipboard-only overlay.
+  case nonText
 }
 
 /// Pure classification helper. Extracted for unit testing — the live cascade
 /// provides the two inputs from `request.targetElement` and `isTextFieldRole`.
-internal func classifyPasteFocus(elementPresent: Bool, roleIsTextField: Bool) -> PasteFocusClassification {
-    guard elementPresent else { return .missing }
-    return roleIsTextField ? .textField : .nonText
+internal func classifyPasteFocus(elementPresent: Bool, roleIsTextField: Bool)
+  -> PasteFocusClassification
+{
+  guard elementPresent else { return .missing }
+  return roleIsTextField ? .textField : .nonText
 }
 
 extension PasteFocusClassification {
-    /// Whether a key-based paste (Tier 2 Cmd+V / Tier 2b AppleScript) should be
-    /// attempted. True for `.textField` and `.missing`; false for `.nonText`.
-    var canAttemptKeyPaste: Bool {
-        switch self {
-        case .textField, .missing: return true
-        case .nonText: return false
-        }
+  /// Whether a key-based paste (Tier 2 Cmd+V / Tier 2b AppleScript) should be
+  /// attempted. True for `.textField` and `.missing`; false for `.nonText`.
+  var canAttemptKeyPaste: Bool {
+    switch self {
+    case .textField, .missing: return true
+    case .nonText: return false
     }
+  }
 }
 
 /// Executes the tiered paste cascade: AX direct -> CGEvent Cmd+V -> AppleScript -> clipboard.
@@ -56,123 +72,213 @@ extension PasteFocusClassification {
 @MainActor
 internal final class PasteCascadeExecutor {
 
-    func deliver(_ request: PasteDeliveryRequest) async -> PasteDeliveryResult {
-        let pasteStart = CFAbsoluteTimeGetCurrent()
-        let bundleId = request.targetApp?.bundleIdentifier ?? "unknown"
-        var tier: PasteTier = .clipboardOnly
+  func deliver(_ request: PasteDeliveryRequest) async -> PasteDeliveryResult {
+    let pasteStart = CFAbsoluteTimeGetCurrent()
+    let bundleId = request.targetApp?.bundleIdentifier ?? "unknown"
+    var tier: PasteTier = .clipboardOnly
+    // Tracked for `.clipboardOnly` outcome construction.
+    var tiersAttempted: [PasteTier] = []
+    var cgEventFailureAccessibilityTrusted: Bool? = nil
 
-        // Three-way classification of the focused element (PR #220 design intent,
-        // restored for Chromium/Electron contenteditable inputs — see #277).
-        //
-        // - textField: element present with a known text input role. Run full cascade.
-        // - missing:   captureFocusedElement returned nil. Common when Chromium /
-        //              Electron apps lazy-init their AX tree (systemWide focus query
-        //              returns kAXErrorNoValue even though a DOM contenteditable is
-        //              focused). Skip Tier 1 (no element to write to), but STILL
-        //              attempt Tier 2 Cmd+V — the target usually accepts it.
-        // - nonText:   element present but role not in textRoles (button, page body).
-        //              Cmd+V would fire into a void; fall straight to clipboard-only
-        //              with the "Copied. Press Cmd+V" overlay (PR #220's protection).
-        // If Accessibility is not trusted, CGEvent Cmd+V can't paste anyway
-        // (see gotchas.md § CGEvent Paste Requires Accessibility). Fall back
-        // to clipboard-only + overlay so the user can press Cmd+V themselves,
-        // matching PR #220's behavior rather than silently synthesizing
-        // keystrokes that go nowhere.
-        let axTrusted = AXIsProcessTrusted()
-        let classification: PasteFocusClassification
-        if !axTrusted {
-            classification = classifyPasteFocus(elementPresent: true, roleIsTextField: false)
-        } else if let element = request.targetElement {
-            classification = classifyPasteFocus(
-                elementPresent: true,
-                roleIsTextField: PasteService.isTextFieldRole(element)
-            )
-        } else {
-            classification = classifyPasteFocus(elementPresent: false, roleIsTextField: false)
-        }
-        let canAttemptKeyPaste = classification.canAttemptKeyPaste
-
-        // Tier 1: AX direct insertion (only with a confirmed text field element).
-        if classification == .textField, let element = request.targetElement {
-            if PasteService.insertViaAccessibility(request.text, element: element) {
-                tier = .axDirect
-            }
-        }
-
-        // Tier 2: Activate target app + CGEvent Cmd+V. Attempted when a text field
-        // was focused OR when no element was reported at all (Chromium/Electron
-        // lazy-AX fallback). Skipped when a non-text element was focused so Cmd+V
-        // doesn't fire into a void.
-        if tier == .clipboardOnly, canAttemptKeyPaste,
-           let app = request.targetApp, !app.isTerminated {
-            let pollInterval = TimingConstants.activationPollIntervalMs
-            let timeout = TimingConstants.activationTimeoutMs
-
-            _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-            app.activate()
-            var elapsed = 0
-            while elapsed < timeout {
-                try? await Task.sleep(for: .milliseconds(pollInterval))
-                elapsed += pollInterval
-                if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
-                    break
-                }
-                if elapsed % 300 < pollInterval {
-                    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                    app.activate()
-                }
-            }
-
-            let activated = NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
-
-            if activated {
-                let snapshot: ClipboardSnapshot? = request.restoreClipboardAfterPaste
-                    ? PasteService.saveClipboard()
-                    : nil
-                let changeCountAfterPaste = PasteService.pasteToActiveApp(request.text)
-                tier = .cgEvent
-                if let snapshot {
-                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
-                }
-            } else {
-                // Tier 2b: AppleScript Edit > Paste
-                _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-                app.activate()
-                try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                let snapshot: ClipboardSnapshot? = request.restoreClipboardAfterPaste
-                    ? PasteService.saveClipboard()
-                    : nil
-                let changeCount = PasteService.copyToClipboardReturningChangeCount(request.text)
-                if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
-                    tier = .appleScript
-                }
-                if let snapshot {
-                    try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
-                    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
-                }
-            }
-        }
-
-        // Tier 3: Clipboard fallback.
-        // The "non-text element focused" log fires only when we deliberately skipped
-        // Tier 2 because a non-text element was focused (PR #220's void-protection
-        // path). Nil-element paths reach Tier 2 and log their own tier=cgevent.
-        if tier == .clipboardOnly {
-            PasteService.copyToClipboard(request.text)
-            if !canAttemptKeyPaste {
-                Task { await AppLogger.shared.log(
-                    "Paste cascade: non-text element focused, falling back to clipboard-only",
-                    level: .info, category: "PipelineTiming"
-                ) }
-            }
-        }
-
-        let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)
-        Task { await AppLogger.shared.log(
-            "Paste cascade: tier=\(tier.rawValue), app=\(bundleId), duration=\(durationMs)ms",
-            level: .info, category: "PipelineTiming"
-        ) }
-        return PasteDeliveryResult(tier: tier, durationMs: durationMs)
+    // Three-way classification of the focused element (PR #220 design intent,
+    // restored for Chromium/Electron contenteditable inputs — see #277).
+    //
+    // - textField: element present with a known text input role. Run full cascade.
+    // - missing:   captureFocusedElement returned nil. Common when Chromium /
+    //              Electron apps lazy-init their AX tree (systemWide focus query
+    //              returns kAXErrorNoValue even though a DOM contenteditable is
+    //              focused). Skip Tier 1 (no element to write to), but STILL
+    //              attempt Tier 2 Cmd+V — the target usually accepts it.
+    // - nonText:   element present but role not in textRoles (button, page body).
+    //              Cmd+V would fire into a void; fall straight to clipboard-only
+    //              with the "Copied. Press Cmd+V" overlay (PR #220's protection).
+    // If Accessibility is not trusted, CGEvent Cmd+V can't paste anyway
+    // (see gotchas.md § CGEvent Paste Requires Accessibility). Fall back
+    // to clipboard-only + overlay so the user can press Cmd+V themselves,
+    // matching PR #220's behavior rather than silently synthesizing
+    // keystrokes that go nowhere.
+    let axTrusted = AXIsProcessTrusted()
+    let classification: PasteFocusClassification
+    if !axTrusted {
+      classification = classifyPasteFocus(elementPresent: true, roleIsTextField: false)
+    } else if let element = request.targetElement {
+      classification = classifyPasteFocus(
+        elementPresent: true,
+        roleIsTextField: PasteService.isTextFieldRole(element)
+      )
+    } else {
+      classification = classifyPasteFocus(elementPresent: false, roleIsTextField: false)
     }
+    let canAttemptKeyPaste = classification.canAttemptKeyPaste
+
+    // Tier 1: AX direct insertion (only with a confirmed text field element).
+    if classification == .textField, let element = request.targetElement {
+      tiersAttempted.append(.axDirect)
+      if PasteService.insertViaAccessibility(request.text, element: element) {
+        tier = .axDirect
+      }
+    }
+
+    // Tier 2: Activate target app + CGEvent Cmd+V. Attempted when a text field
+    // was focused OR when no element was reported at all (Chromium/Electron
+    // lazy-AX fallback). Skipped when a non-text element was focused so Cmd+V
+    // doesn't fire into a void.
+    if tier == .clipboardOnly, canAttemptKeyPaste,
+      let app = request.targetApp, !app.isTerminated
+    {
+      let pollInterval = TimingConstants.activationPollIntervalMs
+      let timeout = TimingConstants.activationTimeoutMs
+
+      _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+      app.activate()
+      var elapsed = 0
+      while elapsed < timeout {
+        try? await Task.sleep(for: .milliseconds(pollInterval))
+        elapsed += pollInterval
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
+          break
+        }
+        if elapsed % 300 < pollInterval {
+          _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+          app.activate()
+        }
+      }
+
+      let activated =
+        NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+
+      if activated {
+        tiersAttempted.append(.cgEvent)
+        let snapshot: ClipboardSnapshot? =
+          request.restoreClipboardAfterPaste
+          ? PasteService.saveClipboard()
+          : nil
+        let dispatchResult = PasteService.pasteToActiveApp(request.text)
+        switch dispatchResult {
+        case .dispatched:
+          tier = .cgEvent
+        case .cgEventCreationFailed(let accessibilityTrusted, _):
+          cgEventFailureAccessibilityTrusted = accessibilityTrusted
+        }
+        if let snapshot {
+          try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+          PasteService.restoreClipboard(
+            snapshot, changeCountAfterPaste: dispatchResult.changeCount)
+        }
+      } else {
+        // Tier 2b: AppleScript Edit > Paste
+        tiersAttempted.append(.appleScript)
+        _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+        app.activate()
+        try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+        let snapshot: ClipboardSnapshot? =
+          request.restoreClipboardAfterPaste
+          ? PasteService.saveClipboard()
+          : nil
+        let changeCount = PasteService.copyToClipboardReturningChangeCount(request.text)
+        if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
+          tier = .appleScript
+        }
+        if let snapshot {
+          try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+          PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
+        }
+      }
+    }
+
+    // Tier 3: Clipboard fallback.
+    // The "non-text element focused" log fires only when we deliberately skipped
+    // Tier 2 because a non-text element was focused (PR #220's void-protection
+    // path). Nil-element paths reach Tier 2 and log their own tier=cgevent.
+    if tier == .clipboardOnly {
+      PasteService.copyToClipboard(request.text)
+      if !canAttemptKeyPaste {
+        Task {
+          await AppLogger.shared.log(
+            "Paste cascade: non-text element focused, falling back to clipboard-only",
+            level: .info, category: "PipelineTiming"
+          )
+        }
+      }
+    }
+
+    let durationMs = Int((CFAbsoluteTimeGetCurrent() - pasteStart) * 1000)
+    Task {
+      await AppLogger.shared.log(
+        "Paste cascade: tier=\(tier.rawValue), app=\(bundleId), duration=\(durationMs)ms",
+        level: .info, category: "PipelineTiming"
+      )
+    }
+
+    // Construct typed outcome. `cgEventCreationFailed` takes priority over
+    // `clipboardOnly` when both would be true — CGEvent failure is a more
+    // specific diagnosis than generic fallback.
+    let outcome: PasteDeliveryOutcome
+    if tier != .clipboardOnly {
+      outcome = .delivered(tier: tier, durationMs: durationMs)
+    } else if let accessibilityTrusted = cgEventFailureAccessibilityTrusted {
+      outcome = .cgEventCreationFailed(accessibilityTrusted: accessibilityTrusted)
+    } else {
+      outcome = .clipboardOnly(
+        tiersAttempted: tiersAttempted,
+        focus: classification,
+        targetBundleID: request.targetApp?.bundleIdentifier
+      )
+    }
+
+    emitPasteTelemetry(outcome: outcome)
+
+    return PasteDeliveryResult(tier: tier, durationMs: durationMs, outcome: outcome)
+  }
+
+  /// Fires Sentry captureError for non-delivered outcomes. Owned by the cascade
+  /// so overlay UI and telemetry both derive from the same typed outcome.
+  private func emitPasteTelemetry(outcome: PasteDeliveryOutcome) {
+    switch outcome {
+    case .delivered:
+      return
+    case .clipboardOnly(let tiers, let focus, let bundle):
+      let tierStrings = tiers.map(\.rawValue)
+      let err = HeartPathError.pasteCascadeClipboardFallback(
+        tiersAttempted: tierStrings,
+        focusClassification: focus.telemetryLabel,
+        targetBundleID: bundle
+      )
+      SentryBreadcrumb.captureError(
+        err,
+        category: .pasteFailed,
+        stage: "paste",
+        extra: [
+          "paste.tiers_attempted": tierStrings,
+          "paste.focus_classification": focus.telemetryLabel,
+          "paste.target_bundle_id": bundle ?? NSNull(),
+          "paste.outcome": "clipboard_only",
+        ]
+      )
+    case .cgEventCreationFailed(let accessibilityTrusted):
+      let err = HeartPathError.pasteCGEventCreationFailed(
+        accessibilityTrusted: accessibilityTrusted)
+      SentryBreadcrumb.captureError(
+        err,
+        category: .pasteFailed,
+        stage: "paste",
+        extra: [
+          "paste.outcome": "cgevent_creation_failed",
+          "paste.accessibility_trusted": accessibilityTrusted,
+          "paste.cgevent_failed": true,
+        ]
+      )
+    }
+  }
+}
+
+extension PasteFocusClassification {
+  /// Stable string label for Sentry tags.
+  fileprivate var telemetryLabel: String {
+    switch self {
+    case .textField: return "text_field"
+    case .missing: return "missing"
+    case .nonText: return "non_text"
+    }
+  }
 }

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -1,965 +1,1182 @@
 import AppKit
-import EnviousWisprCore
-import EnviousWisprStorage
-import EnviousWisprAudio
-import EnviousWisprServices
 import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprServices
+import EnviousWisprStorage
 import Foundation
 
 /// Orchestrates the full dictation pipeline: record → transcribe → (correct) → (polish) → store → copy/paste.
 @MainActor
 @Observable
-public final class TranscriptionPipeline: DictationPipeline {
-    private let audioCapture: any AudioCaptureInterface
-    private let asrManager: any ASRManagerInterface
-    private let transcriptStore: TranscriptStore
-    private let keychainManager: KeychainManager
+public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryTarget {
+  private let audioCapture: any AudioCaptureInterface
+  private let asrManager: any ASRManagerInterface
+  private let transcriptStore: TranscriptStore
+  private let keychainManager: KeychainManager
 
-    public private(set) var state: PipelineState = .idle {
-        didSet {
-            if state != oldValue {
-                onStateChange?(state)
-            }
-        }
+  public private(set) var state: PipelineState = .idle {
+    didSet {
+      if state != oldValue {
+        onStateChange?(state)
+      }
     }
-    public var onStateChange: ((PipelineState) -> Void)?
-    public private(set) var currentTranscript: Transcript?
-    public var autoCopyToClipboard: Bool = true
-    public var autoPasteToActiveApp: Bool = false
-    public var vadAutoStop: Bool = false
-    public var vadSilenceTimeout: Double = 1.5
-    public var vadSensitivity: Float = 0.5
-    public var vadEnergyGate: Bool = false
-    public var modelUnloadPolicy: ModelUnloadPolicy = .never
-    public var restoreClipboardAfterPaste: Bool = false
-    public var transcriptionOptions: TranscriptionOptions = .default
-    public var lastPolishError: String?
+  }
+  public var onStateChange: ((PipelineState) -> Void)?
+  public private(set) var currentTranscript: Transcript?
+  public var autoCopyToClipboard: Bool = true
+  public var autoPasteToActiveApp: Bool = false
+  public var vadAutoStop: Bool = false
+  public var vadSilenceTimeout: Double = 1.5
+  public var vadSensitivity: Float = 0.5
+  public var vadEnergyGate: Bool = false
+  public var modelUnloadPolicy: ModelUnloadPolicy = .never
+  public var restoreClipboardAfterPaste: Bool = false
+  public var transcriptionOptions: TranscriptionOptions = .default
+  public var lastPolishError: String?
 
-    // Shared services
-    private let transcriptFinalizer: TranscriptFinalizer
+  // Shared services
+  private let transcriptFinalizer: TranscriptFinalizer
 
-    // Text processing steps
-    private let wordCorrectionStep = WordCorrectionStep()
-    private let fillerRemovalStep = FillerRemovalStep()
-    private let llmPolishStep: LLMPolishStep
-    private var textProcessingSteps: [any TextProcessingStep] = []
+  // Text processing steps
+  private let wordCorrectionStep = WordCorrectionStep()
+  private let fillerRemovalStep = FillerRemovalStep()
+  private let llmPolishStep: LLMPolishStep
+  private var textProcessingSteps: [any TextProcessingStep] = []
 
-    /// Access word correction step for configuration.
-    public var wordCorrection: WordCorrectionStep { wordCorrectionStep }
-    /// Access filler removal step for configuration.
-    public var fillerRemoval: FillerRemovalStep { fillerRemovalStep }
-    /// Access LLM polish step for configuration.
-    public var llmPolish: LLMPolishStep { llmPolishStep }
+  /// Access word correction step for configuration.
+  public var wordCorrection: WordCorrectionStep { wordCorrectionStep }
+  /// Access filler removal step for configuration.
+  public var fillerRemoval: FillerRemovalStep { fillerRemovalStep }
+  /// Access LLM polish step for configuration.
+  public var llmPolish: LLMPolishStep { llmPolishStep }
 
-    /// The app that was frontmost when recording started — re-activated before pasting.
-    private var targetApp: NSRunningApplication?
-    /// The specific text field that was focused when recording started — used for AX direct insertion.
-    private var targetElement: AXUIElement?
-    private var silenceDetector: SilenceDetector?
-    private var vadMonitorTask: Task<Void, Never>?
-    private var recordingStartTime: Date?
-    /// User preference: use streaming ASR during recording (lower latency) or batch after stop (cleaner text).
-    public var useStreamingASR: Bool = true
-    /// Whether streaming ASR was successfully started for the current recording.
-    private var streamingASRActive = false
-    /// Counters for diagnosing streaming buffer delivery (tail-cutoff instrumentation).
-    private var streamingBuffersDispatched = 0
-    private var streamingBuffersFed = 0
-    /// Guards against concurrent stopAndTranscribe calls (e.g., VAD auto-stop racing PTT release).
-    private var isStopping = false
-    /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
-    private var isStarting = false
-    /// Set by key-up when startRecording() is still in-flight; checked after .recording is entered.
-    private var stopRequested = false
-    /// Whether audio input has been pre-warmed (engine started) by PTT key-down.
-    private var isPreWarmed = false
-    /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
-    private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
-    /// Cancellable model load task. Cancelled by cancelRecording() during .loadingModel.
-    /// Late completion after cancel is guarded by checking state == .loadingModel before proceeding.
-    private var modelLoadTask: Task<Void, any Error>?
+  /// The app that was frontmost when recording started — re-activated before pasting.
+  private var targetApp: NSRunningApplication?
+  /// The specific text field that was focused when recording started — used for AX direct insertion.
+  private var targetElement: AXUIElement?
+  private var silenceDetector: SilenceDetector?
+  private var vadMonitorTask: Task<Void, Never>?
+  private var recordingStartTime: Date?
+  /// User preference: use streaming ASR during recording (lower latency) or batch after stop (cleaner text).
+  public var useStreamingASR: Bool = true
+  /// Whether streaming ASR was successfully started for the current recording.
+  private var streamingASRActive = false
+  /// Counters for diagnosing streaming buffer delivery (tail-cutoff instrumentation).
+  private var streamingBuffersDispatched = 0
+  private var streamingBuffersFed = 0
+  /// Guards against concurrent stopAndTranscribe calls (e.g., VAD auto-stop racing PTT release).
+  private var isStopping = false
+  /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
+  private var isStarting = false
+  /// Set by key-up when startRecording() is still in-flight; checked after .recording is entered.
+  private var stopRequested = false
+  /// Whether audio input has been pre-warmed (engine started) by PTT key-down.
+  private var isPreWarmed = false
+  /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
+  private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
+  /// Cancellable model load task. Cancelled by cancelRecording() during .loadingModel.
+  /// Late completion after cancel is guarded by checking state == .loadingModel before proceeding.
+  private var modelLoadTask: Task<Void, any Error>?
 
-    public init(
-        audioCapture: any AudioCaptureInterface,
-        asrManager: any ASRManagerInterface,
-        transcriptStore: TranscriptStore,
-        keychainManager: KeychainManager = KeychainManager()
-    ) {
-        self.audioCapture = audioCapture
-        self.asrManager = asrManager
-        self.transcriptStore = transcriptStore
-        self.keychainManager = keychainManager
-        self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
-        self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
-        // Explicit engine identity: makes the Parakeet path non-inferred. The
-        // planner will force the legacy English-centric path for Parakeet
-        // regardless of any `languageDetection` a caller might set.
-        llmPolishStep.backend = .parakeet
-        llmPolishStep.onWillProcess = { [weak self] in
-            self?.state = .polishing
-        }
+  // Issue #285 — stall vs final no-audio dedup. One Sentry event per wedge
+  // incident even though the stall watchdog and the `rawSamples.isEmpty`
+  // branch both observe the same session. Reset on session-id change.
+  private var stallEventAlreadyCaptured: Bool = false
+  private var lastObservedCaptureSession: UInt64 = 0
+  /// Set when the proxy's reply-path swallowed an XPC failure. The
+  /// rawSamples-empty branch dedups against this so we emit `xpc_service_error`
+  /// instead of also firing `no_audio_captured` for the same incident.
+  private var xpcReplyFailedThisSession: Bool = false
 
-        // Engine interruption cleanup is wired by AppState.onEngineInterrupted
-        // (unified handler that routes to the active pipeline). The pipeline exposes
-        // handleEngineInterruption() for AppState to call.
-        // Activate SSE streaming for Gemini — a non-nil onToken causes GeminiConnector
-        // to use streamGenerateContent instead of batch generateContent.
-        // No-op callback is correct; live token display in overlay is a future follow-up.
-        llmPolishStep.onToken = { _ in }
-        textProcessingSteps = [wordCorrectionStep, fillerRemovalStep, llmPolishStep]
+  public init(
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    transcriptStore: TranscriptStore,
+    keychainManager: KeychainManager = KeychainManager()
+  ) {
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.transcriptStore = transcriptStore
+    self.keychainManager = keychainManager
+    self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
+    self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
+    // Explicit engine identity: makes the Parakeet path non-inferred. The
+    // planner will force the legacy English-centric path for Parakeet
+    // regardless of any `languageDetection` a caller might set.
+    llmPolishStep.backend = .parakeet
+    llmPolishStep.onWillProcess = { [weak self] in
+      self?.state = .polishing
     }
 
-    /// Pre-warm the audio input to trigger any Bluetooth codec switch before recording.
-    /// Called on PTT key-down to hide the 0.5-2s Bluetooth negotiation latency.
-    /// Sets `isPreWarmed` so `startRecording()` skips engine phase 1.
-    public func preWarmAudioInput() async {
-        guard !state.isActive, state != .recording else { return }
+    // Engine interruption cleanup is wired by AppState.onEngineInterrupted
+    // (unified handler that routes to the active pipeline). The pipeline exposes
+    // handleEngineInterruption() for AppState to call.
+    // Activate SSE streaming for Gemini — a non-nil onToken causes GeminiConnector
+    // to use streamGenerateContent instead of batch generateContent.
+    // No-op callback is correct; live token display in overlay is a future follow-up.
+    llmPolishStep.onToken = { _ in }
+    textProcessingSteps = [wordCorrectionStep, fillerRemovalStep, llmPolishStep]
+
+    // Issue #285 — telemetry callbacks on `audioCapture` are single-owner
+    // properties and both pipelines share the same instance. `AppState`
+    // centralizes routing to the active pipeline (same pattern as
+    // `onEngineInterrupted`) and calls into our public `handleCaptureStall` /
+    // `handleXPCReplyFailed` / `handleCaptureSessionInterruption` methods.
+  }
+
+  public func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
+    SentryBreadcrumb.captureError(
+      HeartPathError.captureSessionInterrupted(ctx: ctx),
+      category: .audioCaptureFailed,
+      stage: "audio",
+      extra: [
+        "capture_session.kind": ctx.kind.rawValue,
+        "capture_session.reason_code": ctx.reasonCode.map { $0 } ?? NSNull(),
+        "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
+        "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
+        "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
+        "capture_session.error_description": ctx.errorDescription ?? NSNull(),
+        "capture.is_actively_capturing": ctx.isActivelyCapturing,
+        "capture_session_id": Int(ctx.sessionID),
+      ]
+    )
+  }
+
+  public func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
+    resetStallFlagIfNewSession(ctx.sessionID)
+    xpcReplyFailedThisSession = true
+    SentryBreadcrumb.captureError(
+      HeartPathError.xpcReplyFailed(ctx: ctx),
+      category: .xpcServiceError,
+      stage: "audio",
+      extra: [
+        "xpc.reply_stage": ctx.replyStage,
+        "xpc.error_domain": ctx.errorDomain,
+        "xpc.error_code": ctx.errorCode,
+        "capture_session_id": Int(ctx.sessionID),
+      ]
+    )
+  }
+
+  public func handleCaptureStall(_ ctx: CaptureStallContext) {
+    resetStallFlagIfNewSession(ctx.sessionID)
+    guard !stallEventAlreadyCaptured else { return }
+    stallEventAlreadyCaptured = true
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.sourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: audioCapture.isActivelyCapturing,
+      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+      failureMode: "stall_window_elapsed",
+      stallContext: ctx
+    )
+    SentryBreadcrumb.captureError(
+      HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
+      category: .audioCaptureStalled,
+      stage: "recording",
+      extra: extras
+    )
+  }
+
+  private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
+    guard sessionID != lastObservedCaptureSession else { return }
+    lastObservedCaptureSession = sessionID
+    stallEventAlreadyCaptured = false
+    xpcReplyFailedThisSession = false
+  }
+
+  /// Emit either a dedup breadcrumb (stall already fired for this session) or a
+  /// terminal `audioCaptureFailed` captureError. Called from the rawSamples-empty
+  /// branch after stopCapture.
+  private func emitNoAudioCapturedEvent(wasStreaming: Bool) {
+    let sessionID = audioCapture.currentCaptureSessionID
+    resetStallFlagIfNewSession(sessionID)
+    let durationMs: Int = {
+      guard let start = recordingStartTime else { return 0 }
+      return Int(Date().timeIntervalSince(start) * 1000)
+    }()
+    let route = audioCapture.currentAudioRoute
+    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
+      let dedupedFrom =
+        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
+      SentryBreadcrumb.add(
+        stage: "recording",
+        message: "No audio captured (deduped)",
+        level: .warning,
+        data: [
+          "deduped_from": dedupedFrom,
+          "capture_session_id": Int(sessionID),
+        ]
+      )
+      return
+    }
+    let err = HeartPathError.noAudioCaptured(
+      sessionID: sessionID,
+      durationMs: durationMs,
+      wasStreaming: wasStreaming,
+      route: route
+    )
+    SentryBreadcrumb.captureError(
+      err,
+      category: .audioCaptureFailed,
+      stage: "recording",
+      extra: SentryAudioExtras.buildCaptureExtras(
+        route: route,
+        sourceType: audioCapture.captureSourceType,
+        sessionID: sessionID,
+        isActivelyCapturing: audioCapture.isActivelyCapturing,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: "no_audio_captured"
+      )
+    )
+  }
+
+  /// Pre-warm the audio input to trigger any Bluetooth codec switch before recording.
+  /// Called on PTT key-down to hide the 0.5-2s Bluetooth negotiation latency.
+  /// Sets `isPreWarmed` so `startRecording()` skips engine phase 1.
+  public func preWarmAudioInput() async {
+    guard !state.isActive, state != .recording else { return }
+    stopRequested = false
+    let start = ContinuousClock.now
+    await audioCapture.preWarm()
+    guard !Task.isCancelled else { return }
+    isPreWarmed = true
+    let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
+    Task {
+      await AppLogger.shared.log(
+        "COLD-START [Parakeet] preWarmAudioInput total=\(totalMs)ms",
+        level: .info, category: "Pipeline"
+      )
+    }
+  }
+
+  /// Toggle recording: start if idle, stop if recording.
+  public func toggleRecording() async {
+    switch state {
+    case .idle, .complete, .error:
+      await startRecording()
+    case .recording:
+      await stopAndTranscribe()
+    case .loadingModel, .transcribing, .polishing:
+      break  // Don't interrupt processing
+    }
+  }
+
+  /// Start recording audio from the microphone.
+  public func startRecording() async {
+    guard !Task.isCancelled else { return }
+    guard !isStarting else { return }
+    guard !state.isActive || state == .complete else { return }
+    isStarting = true
+    defer { isStarting = false }
+
+    lastPolishError = nil
+    deactivateStreamingForwarding()
+
+    // Cancel idle timer so model stays loaded during recording.
+    asrManager.cancelIdleTimer()
+
+    // Ensure model is loaded (model should already be warm from launch-time preload).
+    // Wrap in a cancellable task so cancelRecording() can abort a cold-start load.
+    if !asrManager.isModelLoaded {
+      state = .loadingModel
+      SentryBreadcrumb.add(
+        stage: "asr", message: "Model loading",
+        data: ["backend": asrManager.activeBackendType.rawValue])
+      let loadTask = Task {
+        try await asrManager.loadModel()
+      }
+      modelLoadTask = loadTask
+      do {
+        try await loadTask.value
+      } catch is CancellationError {
+        // User cancelled during model load. Return to idle.
         stopRequested = false
-        let start = ContinuousClock.now
-        await audioCapture.preWarm()
-        guard !Task.isCancelled else { return }
-        isPreWarmed = true
-        let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
-        Task { await AppLogger.shared.log(
-            "COLD-START [Parakeet] preWarmAudioInput total=\(totalMs)ms",
+        modelLoadTask = nil
+        state = .idle
+        return
+      } catch {
+        SentryBreadcrumb.captureError(
+          error, category: .modelLoadFailed, stage: "asr",
+          extra: ["backend": asrManager.activeBackendType.rawValue])
+        stopRequested = false
+        modelLoadTask = nil
+        state = .error("Model load failed: \(error.localizedDescription)")
+        return
+      }
+      modelLoadTask = nil
+      // Late-completion guard: if state changed while we were loading (e.g., cancel),
+      // do not proceed. The cancel handler already set state to .idle.
+      guard state == .loadingModel else { return }
+      guard !Task.isCancelled else { return }
+    }
+
+    // Remember the frontmost app and focused text field so we can paste back
+    // (LLM polishing can take seconds, during which focus may shift)
+    targetApp = NSWorkspace.shared.frontmostApplication
+    targetElement = PasteService.captureFocusedElement()
+
+    // BRAIN: gotcha id=pipeline-timing-misconception
+    // Start streaming ASR if the backend supports it — feed audio buffers
+    // to the ASR model during recording so transcription overlaps with capture.
+    var streamingSetupSucceeded = false
+    defer { if !streamingSetupSucceeded { deactivateStreamingForwarding() } }
+
+    let supportsStreaming = await asrManager.activeBackendSupportsStreaming
+    if supportsStreaming && useStreamingASR {
+      do {
+        try await asrManager.startStreaming(options: transcriptionOptions)
+        streamingASRActive = true
+        streamingBuffersDispatched = 0
+        streamingBuffersFed = 0
+        SentryBreadcrumb.add(
+          stage: "asr", message: "Streaming ASR started",
+          data: ["backend": asrManager.activeBackendType.rawValue])
+
+        // Wire audio buffer forwarding: each converted buffer goes to streaming ASR.
+        // The streamingASRActive flag gates delivery — deactivateStreamingForwarding()
+        // sets it to false and nils onBufferCaptured, so in-flight tasks exit quickly.
+        //
+        // NOTE: This callback runs on the real-time audio thread. The TapStoppedFlag
+        // in AudioCaptureManager prevents this from being called after teardown starts.
+        // The nonisolated(unsafe) is safe because the buffer is created on the audio
+        // thread, transferred to the main thread via Task, and never accessed from
+        // both threads simultaneously.
+        audioCapture.onBufferCaptured = { [weak self] buffer in
+          guard let self else { return }
+          nonisolated(unsafe) let safeBuffer = buffer
+          Task { @MainActor in
+            self.streamingBuffersDispatched += 1
+            guard self.streamingASRActive, self.state == .recording else { return }
+            try? await self.asrManager.feedAudio(safeBuffer)
+            self.streamingBuffersFed += 1
+          }
+        }
+
+        Task {
+          await AppLogger.shared.log(
+            "Streaming ASR started during recording",
             level: .info, category: "Pipeline"
-        ) }
-    }
-
-    /// Toggle recording: start if idle, stop if recording.
-    public func toggleRecording() async {
-        switch state {
-        case .idle, .complete, .error:
-            await startRecording()
-        case .recording:
-            await stopAndTranscribe()
-        case .loadingModel, .transcribing, .polishing:
-            break // Don't interrupt processing
+          )
         }
-    }
-
-    /// Start recording audio from the microphone.
-    public func startRecording() async {
-        guard !Task.isCancelled else { return }
-        guard !isStarting else { return }
-        guard !state.isActive || state == .complete else { return }
-        isStarting = true
-        defer { isStarting = false }
-
-        lastPolishError = nil
+      } catch {
+        // Streaming init failed — fall back to batch after recording
         deactivateStreamingForwarding()
-
-        // Cancel idle timer so model stays loaded during recording.
-        asrManager.cancelIdleTimer()
-
-        // Ensure model is loaded (model should already be warm from launch-time preload).
-        // Wrap in a cancellable task so cancelRecording() can abort a cold-start load.
-        if !asrManager.isModelLoaded {
-            state = .loadingModel
-            SentryBreadcrumb.add(stage: "asr", message: "Model loading", data: ["backend": asrManager.activeBackendType.rawValue])
-            let loadTask = Task {
-                try await asrManager.loadModel()
-            }
-            modelLoadTask = loadTask
-            do {
-                try await loadTask.value
-            } catch is CancellationError {
-                // User cancelled during model load. Return to idle.
-                stopRequested = false
-                modelLoadTask = nil
-                state = .idle
-                return
-            } catch {
-                SentryBreadcrumb.captureError(error, category: .modelLoadFailed, stage: "asr", extra: ["backend": asrManager.activeBackendType.rawValue])
-                stopRequested = false
-                modelLoadTask = nil
-                state = .error("Model load failed: \(error.localizedDescription)")
-                return
-            }
-            modelLoadTask = nil
-            // Late-completion guard: if state changed while we were loading (e.g., cancel),
-            // do not proceed. The cancel handler already set state to .idle.
-            guard state == .loadingModel else { return }
-            guard !Task.isCancelled else { return }
+        SentryBreadcrumb.add(
+          stage: "asr", message: "Streaming start failed, will use batch", level: .warning)
+        Task {
+          await AppLogger.shared.log(
+            "Streaming ASR failed to start, will use batch: \(error.localizedDescription)",
+            level: .info, category: "Pipeline"
+          )
         }
-
-        // Remember the frontmost app and focused text field so we can paste back
-        // (LLM polishing can take seconds, during which focus may shift)
-        targetApp = NSWorkspace.shared.frontmostApplication
-        targetElement = PasteService.captureFocusedElement()
-
-        // BRAIN: gotcha id=pipeline-timing-misconception
-        // Start streaming ASR if the backend supports it — feed audio buffers
-        // to the ASR model during recording so transcription overlaps with capture.
-        var streamingSetupSucceeded = false
-        defer { if !streamingSetupSucceeded { deactivateStreamingForwarding() } }
-
-        let supportsStreaming = await asrManager.activeBackendSupportsStreaming
-        if supportsStreaming && useStreamingASR {
-            do {
-                try await asrManager.startStreaming(options: transcriptionOptions)
-                streamingASRActive = true
-                streamingBuffersDispatched = 0
-                streamingBuffersFed = 0
-                SentryBreadcrumb.add(stage: "asr", message: "Streaming ASR started", data: ["backend": asrManager.activeBackendType.rawValue])
-
-                // Wire audio buffer forwarding: each converted buffer goes to streaming ASR.
-                // The streamingASRActive flag gates delivery — deactivateStreamingForwarding()
-                // sets it to false and nils onBufferCaptured, so in-flight tasks exit quickly.
-                //
-                // NOTE: This callback runs on the real-time audio thread. The TapStoppedFlag
-                // in AudioCaptureManager prevents this from being called after teardown starts.
-                // The nonisolated(unsafe) is safe because the buffer is created on the audio
-                // thread, transferred to the main thread via Task, and never accessed from
-                // both threads simultaneously.
-                audioCapture.onBufferCaptured = { [weak self] buffer in
-                    guard let self else { return }
-                    nonisolated(unsafe) let safeBuffer = buffer
-                    Task { @MainActor in
-                        self.streamingBuffersDispatched += 1
-                        guard self.streamingASRActive, self.state == .recording else { return }
-                        try? await self.asrManager.feedAudio(safeBuffer)
-                        self.streamingBuffersFed += 1
-                    }
-                }
-
-                Task { await AppLogger.shared.log(
-                    "Streaming ASR started during recording",
-                    level: .info, category: "Pipeline"
-                ) }
-            } catch {
-                // Streaming init failed — fall back to batch after recording
-                deactivateStreamingForwarding()
-                SentryBreadcrumb.add(stage: "asr", message: "Streaming start failed, will use batch", level: .warning)
-                Task { await AppLogger.shared.log(
-                    "Streaming ASR failed to start, will use batch: \(error.localizedDescription)",
-                    level: .info, category: "Pipeline"
-                ) }
-            }
-        }
-
-        do {
-            // Two-phase start: phase 1 triggers any Bluetooth codec switch
-            if !isPreWarmed {
-                try await audioCapture.startEnginePhase()
-
-                // Wait for format to stabilize (Bluetooth) or pass immediately (built-in mic)
-                let stabilized = await audioCapture.waitForFormatStabilization(
-                    maxWait: 1.5,
-                    pollInterval: 0.2
-                )
-                guard !Task.isCancelled else { isPreWarmed = false; return }
-
-                // If format never settled, rebuild engine once and retry
-                if !stabilized {
-                    audioCapture.rebuildEngine()
-                    try await audioCapture.startEnginePhase()
-                }
-            }
-            isPreWarmed = false
-
-            // Phase 2: install tap and start capture
-            _ = try await audioCapture.beginCapturePhase()
-            streamingSetupSucceeded = true
-            state = .recording
-            recordingStartTime = Date()
-            currentTranscript = nil
-            SentryBreadcrumb.add(stage: "recording", message: "Recording started", data: [
-                "backend": asrManager.activeBackendType.rawValue,
-                "streaming": streamingASRActive,
-            ])
-            SentryBreadcrumb.updateRecordingState(active: true, backend: "parakeet", isStreaming: streamingASRActive)
-            SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
-
-            if stopRequested {
-                stopRequested = false
-                await stopAndTranscribe()
-                return
-            }
-
-            Task { await AppLogger.shared.log(
-                "Recording started. Backend: \(asrManager.activeBackendType.rawValue), streaming=\(streamingASRActive)",
-                level: .info, category: "Pipeline"
-            ) }
-
-            // Always start VAD monitoring for silence removal
-            startVADMonitoring()
-        } catch {
-            // startCapture() failed — cancel any streaming session we started
-            if streamingASRActive {
-                await asrManager.cancelStreaming()
-            }
-            deactivateStreamingForwarding()
-            SentryBreadcrumb.captureError(error, category: .audioCaptureFailed, stage: "recording")
-            stopRequested = false
-            state = .error("Recording failed: \(error.localizedDescription)")
-        }
+      }
     }
 
-    /// Stop recording, or set a flag if startRecording() is still in-flight.
-    /// Handles the pre-warm phase (.idle) as well as model loading (.transcribing).
-    public func requestStop() async {
-        switch state {
-        case .recording:
-            await stopAndTranscribe()
-        case .idle, .loadingModel, .transcribing:
-            // .idle: startRecording is in-flight (pre-warm/engine setup) → will check after entering .recording.
-            // .loadingModel/.transcribing: model load or ASR in progress → startRecording will check and stop.
-            stopRequested = true
-            // PTT release before recording started — clean up pre-warmed audio engine
-            if state == .idle, isPreWarmed {
-                isPreWarmed = false
-                audioCapture.abortPreWarm()
-            }
-        case .polishing, .complete, .error:
-            // Pipeline is past the point of no return or already finished — ignore.
-            break
-        }
-    }
+    do {
+      // Two-phase start: phase 1 triggers any Bluetooth codec switch
+      if !isPreWarmed {
+        try await audioCapture.startEnginePhase()
 
-    /// Stop recording and transcribe the captured audio.
-    public func stopAndTranscribe() async {
-        guard state == .recording, !isStopping else { return }
-        isStopping = true
-        defer { isStopping = false }
-
-        let pipelineStart = CFAbsoluteTimeGetCurrent()
-
-        // Silently discard recordings shorter than minimum duration (accidental taps)
-        if let startTime = recordingStartTime {
-            let elapsed = Date().timeIntervalSince(startTime)
-            if elapsed < TimingConstants.minimumRecordingDuration {
-                vadMonitorTask?.cancel()
-                vadMonitorTask = nil
-                if streamingASRActive {
-                    await asrManager.cancelStreaming()
-                }
-                deactivateStreamingForwarding()
-                _ = await audioCapture.stopCapture()
-                recordingStartTime = nil
-                state = .idle
-                Task { await AppLogger.shared.log(
-                    "Recording too short (\(String(format: "%.2f", elapsed))s), discarded silently",
-                    level: .info, category: "Pipeline"
-                ) }
-                return
-            }
-        }
-        // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
-        let snapshotStartTime = recordingStartTime ?? Date()
-        let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
-        frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
-            backend: "parakeet",
-            audioRoute: audioCapture.currentAudioRoute,
-            wasStreaming: streamingASRActive,
-            startTime: snapshotStartTime,
-            durationMs: durationMs,
-            targetAppBundleID: targetApp?.bundleIdentifier
+        // Wait for format to stabilize (Bluetooth) or pass immediately (built-in mic)
+        let stabilized = await audioCapture.waitForFormatStabilization(
+          maxWait: 1.5,
+          pollInterval: 0.2
         )
-
-        recordingStartTime = nil
-
-        // Cancel VAD monitoring
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-
-        let wasStreaming = streamingASRActive
-
-        // Stop the audio tap FIRST — prevents new buffer-feed tasks from being dispatched.
-        // Then yield to drain any in-flight feed tasks already queued on @MainActor.
-        // These tasks check streamingASRActive (still true) and deliver their buffers
-        // to the Parakeet actor before we deactivate forwarding.
-        // Without this reorder, deactivateStreamingForwarding() sets the flag to false
-        // and all queued tasks drop their buffers — losing ~250-500ms of trailing audio.
-        let captureResult = await audioCapture.stopCapture()
-        let rawSamples = captureResult.samples
-        SentryBreadcrumb.add(stage: "recording", message: "Recording stopped", data: ["sample_count": rawSamples.count])
-        SentryBreadcrumb.updateRecordingState(active: false)
-
-        if wasStreaming {
-            // Deterministic drain: freeze the dispatch count after stopCapture (no new buffers
-            // will be dispatched since the tap/session is stopped). Wait for all queued buffer-feed
-            // tasks to complete before deactivating forwarding. Bounded by 500ms deadline.
-            let targetDispatched = streamingBuffersDispatched
-            let drainDeadline = ContinuousClock.now + .milliseconds(500)
-            while streamingBuffersFed < targetDispatched,
-                  ContinuousClock.now < drainDeadline {
-                await Task.yield()
-            }
-            if streamingBuffersFed >= targetDispatched {
-                Task { await AppLogger.shared.log(
-                    "Streaming drain: clean (\(self.streamingBuffersFed)/\(targetDispatched) fed)",
-                    level: .info, category: "PipelineTiming"
-                ) }
-            } else {
-                Task { await AppLogger.shared.log(
-                    "Streaming drain: TIMEOUT (\(self.streamingBuffersFed)/\(targetDispatched) fed — \(targetDispatched - self.streamingBuffersFed) lost)",
-                    level: .info, category: "PipelineTiming"
-                ) }
-            }
+        guard !Task.isCancelled else {
+          isPreWarmed = false
+          return
         }
 
-        deactivateStreamingForwarding()
-
-        // Defense: if cancelRecording() ran during yield, bail out
-        guard state == .recording else { return }
-
-        // Pre-warm the LLM connection while ASR is still running (fire-and-forget).
-        // Establishes TLS + HTTP/2 so the polish request skips the handshake.
-        LLMNetworkSession.shared.preWarmIfConfigured(
-            provider: llmPolishStep.llmProvider,
-            keychainManager: keychainManager
-        )
-
-        guard !rawSamples.isEmpty else {
-            // Cancel streaming if it was active — empty samples means no useful audio
-            if wasStreaming {
-                await asrManager.cancelStreaming()
-            }
-            SentryBreadcrumb.add(stage: "recording", message: "No audio captured", level: .warning)
-            state = .error("No audio captured")
-            return
+        // If format never settled, rebuild engine once and retry
+        if !stabilized {
+          audioCapture.rebuildEngine()
+          try await audioCapture.startEnginePhase()
         }
+      }
+      isPreWarmed = false
 
-        Task { await AppLogger.shared.log(
-            "Captured \(rawSamples.count) samples (\(String(format: "%.2f", Double(rawSamples.count)/16000))s)",
-            level: .verbose, category: "Pipeline"
-        ) }
-
-        // Filter silence using VAD speech segments (used for batch fallback and logging).
-        var samples: [Float]
-        var hasSpeechEvidence = false
-        var vadSegmentCount = 0
-        var vadSpeechDurationMs = 0
-        let isXPCMode = audioCapture is AudioCaptureProxy
-        if isXPCMode {
-            // XPC mode: VAD segments are returned atomically with samples from stopCapture().
-            // This eliminates the call-order bug where separate getVADSegments() read
-            // capturedSamples.count as 0 after stopCapture() cleared the buffer (#226).
-            let segments = captureResult.vadSegments
-            hasSpeechEvidence = !segments.isEmpty
-            vadSegmentCount = segments.count
-            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
-            if !segments.isEmpty {
-                samples = SampleFilter.filter(from: rawSamples, segments: segments)
-            } else {
-                samples = rawSamples
-            }
-        } else if let detector = silenceDetector {
-            await detector.finalizeSegments(totalSampleCount: rawSamples.count)
-            let segments = await detector.speechSegments
-            hasSpeechEvidence = !segments.isEmpty
-            vadSegmentCount = segments.count
-            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
-            samples = await detector.filterSamples(from: rawSamples)
-        } else {
-            samples = rawSamples
-            // No VAD detector available -- cannot determine speech presence.
-            // Default to true so that empty ASR results still fire Sentry errors
-            // (fail toward visibility rather than silently swallowing failures).
-            hasSpeechEvidence = true
-        }
-        let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
-
-        Task { await AppLogger.shared.log(
-            "VAD filtered to \(samples.count) samples (\(String(format: "%.1f", Double(samples.count)/Double(max(rawSamples.count, 1))*100))% voiced)",
-            level: .verbose, category: "Pipeline"
-        ) }
-
-        // VAD gate: if no speech was detected, skip ASR entirely.
-        // Prevents noise-induced hallucinations ("Okay", "Yeah") from ambient sounds.
-        // The decoder hallucinates filler words from low-information audio; not
-        // invoking it eliminates the problem at the source.
-        if !hasSpeechEvidence {
-            if wasStreaming {
-                await asrManager.cancelStreaming()
-            }
-            SentryBreadcrumb.add(
-                stage: "asr", message: "VAD gate: no speech detected, skipping ASR",
-                level: .info,
-                data: [
-                    "backend": asrManager.activeBackendType.rawValue,
-                    "mode": wasStreaming ? "streaming" : "batch",
-                    "raw_sample_count": rawSamples.count,
-                    "peak_audio_level": peakAudioLevel,
-                ]
-            )
-            frozenSnapshot = nil
-            state = .idle
-            Task { await AppLogger.shared.log(
-                "VAD gate: no speech, skipping ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
-                level: .info, category: "Pipeline"
-            ) }
-            return
-        }
-
-        // ASR backends require >= 1 second of audio.
-        // If VAD filtering was too aggressive, fall back to raw samples.
-        let minimumSamples = AudioConstants.minimumTranscriptionSamples
-        if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
-            samples = rawSamples
-        }
-
-        // Pad short recordings with silence so single-word inputs ("hey", "hi") work.
-        if samples.count > 0 && samples.count < minimumSamples {
-            samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
-        }
-
-        state = .transcribing
-        SentryBreadcrumb.add(stage: "asr", message: "Transcription started", data: [
-            "mode": wasStreaming ? "streaming" : "batch",
-            "backend": asrManager.activeBackendType.rawValue,
+      // Phase 2: install tap and start capture
+      _ = try await audioCapture.beginCapturePhase()
+      streamingSetupSucceeded = true
+      state = .recording
+      recordingStartTime = Date()
+      currentTranscript = nil
+      SentryBreadcrumb.add(
+        stage: "recording", message: "Recording started",
+        data: [
+          "backend": asrManager.activeBackendType.rawValue,
+          "streaming": streamingASRActive,
         ])
+      SentryBreadcrumb.updateRecordingState(
+        active: true, backend: "parakeet", isStreaming: streamingASRActive)
+      SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
 
-        do {
-            let asrStart = CFAbsoluteTimeGetCurrent()
-
-            // Use streaming finalize when available for lowest latency.
-            // FluidAudio fork uses fresh decoder state per chunk + chunk-aware text assembly
-            // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
-            // Streaming mode includes batch rescue: if finalize fails or returns empty
-            // despite VAD speech evidence, retry with batch decode using captured samples.
-            let result: ASRResult
-            if wasStreaming {
-                result = try await transcribeWithStreamingRescue(
-                    samples: samples,
-                    hasSpeechEvidence: hasSpeechEvidence
-                )
-            } else {
-                result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
-            }
-
-            let asrEnd = CFAbsoluteTimeGetCurrent()
-
-            let asrText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !asrText.isEmpty else {
-                if hasSpeechEvidence {
-                    // Real ASR failure: VAD detected speech but decoder returned nothing
-                    SentryBreadcrumb.captureError(
-                        NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"]),
-                        category: .asrEmptyResult, stage: "asr",
-                        extra: [
-                            "backend": asrManager.activeBackendType.rawValue,
-                            "mode": wasStreaming ? "streaming" : "batch",
-                            "has_speech_evidence": true,
-                            "raw_sample_count": rawSamples.count,
-                            "vad_segment_count": vadSegmentCount,
-                            "vad_speech_duration_ms": vadSpeechDurationMs,
-                            "peak_audio_level": peakAudioLevel,
-                        ],
-                        snapshot: frozenSnapshot
-                    )
-                    state = .error("Couldn't catch that -- try again")
-                    Task { await AppLogger.shared.log(
-                        "ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
-                        level: .info, category: "Pipeline"
-                    ) }
-                } else {
-                    // Expected: user held button without speaking
-                    SentryBreadcrumb.add(
-                        stage: "asr", message: "ASR empty (no speech detected)",
-                        level: .info,
-                        data: ["backend": asrManager.activeBackendType.rawValue, "mode": wasStreaming ? "streaming" : "batch"]
-                    )
-                    state = .idle
-                    Task { await AppLogger.shared.log(
-                        "No speech detected, returning to idle",
-                        level: .info, category: "Pipeline"
-                    ) }
-                }
-                frozenSnapshot = nil
-                return
-            }
-
-            SentryBreadcrumb.add(stage: "asr", message: "ASR completed", data: [
-                "mode": wasStreaming ? "streaming" : "batch",
-                "backend": asrManager.activeBackendType.rawValue,
-                "duration_s": String(format: "%.3f", asrEnd - asrStart),
-                "char_count": asrText.count,
-            ])
-            Task { await AppLogger.shared.log(
-                "Pipeline timing: ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s " +
-                "(mode=\(wasStreaming ? "streaming" : "batch"), \(asrText.count) chars, lang=\(result.language ?? "?"))",
-                level: .info, category: "PipelineTiming"
-            ) }
-
-            // Post-ASR finalization: text processing -> store -> paste
-            let finalizationResult: FinalizationResult
-            do {
-                finalizationResult = try await transcriptFinalizer.finalize(FinalizationRequest(
-                    asrText: asrText,
-                    language: result.language,
-                    duration: result.duration,
-                    processingTime: result.processingTime,
-                    backendType: result.backendType,
-                    targetApp: targetApp,
-                    targetElement: targetElement,
-                    autoCopyToClipboard: autoCopyToClipboard,
-                    autoPasteToActiveApp: autoPasteToActiveApp,
-                    restoreClipboardAfterPaste: restoreClipboardAfterPaste,
-                    steps: textProcessingSteps
-                ))
-            } catch is CancellationError {
-                frozenSnapshot = nil
-                return
-            } catch let error as FinalizationError {
-                switch error {
-                case .emptyAfterProcessing:
-                    state = .error("No text after processing")
-                    frozenSnapshot = nil
-                    return
-                case .storageFailed(let underlying):
-                    SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
-                    state = .error("Failed to save transcript")
-                    frozenSnapshot = nil
-                    return
-                }
-            }
-
-            lastPolishError = finalizationResult.polishError
-
-            // Notify ASR manager that transcription is done; schedules unload timer if configured.
-            asrManager.noteTranscriptionComplete(policy: modelUnloadPolicy)
-
-            // Build metrics (pipeline-specific: uses ASR timing, streaming mode)
-            let pasteTargetApp = targetApp?.bundleIdentifier
-            targetApp = nil
-            targetElement = nil
-
-            let pipelineEnd = CFAbsoluteTimeGetCurrent()
-            let polishDuration = finalizationResult.polishDurationSeconds
-            let pasteDuration = finalizationResult.pasteDurationSeconds
-            Task { await AppLogger.shared.log(
-                "Pipeline timing TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s " +
-                "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, " +
-                "polish=\(String(format: "%.3f", polishDuration))s, " +
-                "paste=\(String(format: "%.3f", pasteDuration))s)",
-                level: .info, category: "PipelineTiming"
-            ) }
-
-            var transcript = finalizationResult.transcript
-            transcript.metrics = ExecutionMetrics(
-                asrLatencySeconds: asrEnd - asrStart,
-                llmLatencySeconds: polishDuration,
-                pasteTier: finalizationResult.pasteResult?.tier.rawValue,
-                pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
-                targetApp: pasteTargetApp,
-                coldStart: false,
-                streamingMode: wasStreaming,
-                e2eSeconds: pipelineEnd - pipelineStart
-            )
-            currentTranscript = transcript
-            SentryBreadcrumb.add(stage: "pipeline", message: "Pipeline complete", data: [
-                "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
-                "asr_s": String(format: "%.3f", asrEnd - asrStart),
-                "polish_s": String(format: "%.3f", polishDuration),
-                "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
-                "backend": asrManager.activeBackendType.rawValue,
-            ])
-            frozenSnapshot = nil
-            state = .complete
-        } catch {
-            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: [
-                "backend": asrManager.activeBackendType.rawValue,
-            ], snapshot: frozenSnapshot)
-            frozenSnapshot = nil
-            state = .error("Transcription failed: \(error.localizedDescription)")
-        }
-    }
-
-    // polishExistingTranscript() removed — re-polish is now handled by TranscriptPolishService,
-    // which is decoupled from pipeline state. See #206.
-
-    /// Reset pipeline to idle state.
-    public func reset() {
-        guard !isStopping, !isStarting else { return }
+      if stopRequested {
         stopRequested = false
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        // Cancel any active streaming ASR session to prevent orphaned sessions.
-        let wasStreaming = streamingASRActive
-        deactivateStreamingForwarding()
-        if wasStreaming {
-            Task { [weak self] in
-                await self?.asrManager.cancelStreaming()
-            }
-        }
-        if audioCapture.isCapturing {
-            let capture = audioCapture
-            Task { _ = await capture.stopCapture() }
-        }
-        silenceDetector = nil
-        recordingStartTime = nil
-        state = .idle
-        currentTranscript = nil
-    }
+        await stopAndTranscribe()
+        return
+      }
 
-    /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
-    /// Called by AppState's unified interruption handler, not set directly on audioCapture.
-    public func handleEngineInterruption() {
-        // Build snapshot at interruption time — recording_state may be cleared before captureError runs.
-        let snapshot = buildInterruptionSnapshot()
-        SentryBreadcrumb.captureError(
-            NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted"]),
-            category: .xpcServiceError, stage: "audio",
-            extra: ["was_recording": state == .recording],
-            snapshot: snapshot
+      Task {
+        await AppLogger.shared.log(
+          "Recording started. Backend: \(asrManager.activeBackendType.rawValue), streaming=\(streamingASRActive)",
+          level: .info, category: "Pipeline"
         )
-        SentryBreadcrumb.updateRecordingState(active: false)
-        frozenSnapshot = nil
+      }
+
+      // Always start VAD monitoring for silence removal
+      startVADMonitoring()
+    } catch {
+      // startCapture() failed — cancel any streaming session we started
+      if streamingASRActive {
+        await asrManager.cancelStreaming()
+      }
+      deactivateStreamingForwarding()
+      SentryBreadcrumb.captureError(
+        error,
+        category: .audioCaptureFailed,
+        stage: "recording",
+        extra: SentryAudioExtras.buildCaptureExtras(
+          route: audioCapture.currentAudioRoute,
+          sourceType: audioCapture.captureSourceType,
+          sessionID: audioCapture.currentCaptureSessionID,
+          isActivelyCapturing: audioCapture.isActivelyCapturing,
+          inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+            ? nil : audioCapture.preferredInputDeviceIDOverride,
+          inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+          failureMode: "thrown_start"
+        )
+      )
+      stopRequested = false
+      state = .error("Recording failed: \(error.localizedDescription)")
+    }
+  }
+
+  /// Stop recording, or set a flag if startRecording() is still in-flight.
+  /// Handles the pre-warm phase (.idle) as well as model loading (.transcribing).
+  public func requestStop() async {
+    switch state {
+    case .recording:
+      await stopAndTranscribe()
+    case .idle, .loadingModel, .transcribing:
+      // .idle: startRecording is in-flight (pre-warm/engine setup) → will check after entering .recording.
+      // .loadingModel/.transcribing: model load or ASR in progress → startRecording will check and stop.
+      stopRequested = true
+      // PTT release before recording started — clean up pre-warmed audio engine
+      if state == .idle, isPreWarmed {
+        isPreWarmed = false
+        audioCapture.abortPreWarm()
+      }
+    case .polishing, .complete, .error:
+      // Pipeline is past the point of no return or already finished — ignore.
+      break
+    }
+  }
+
+  /// Stop recording and transcribe the captured audio.
+  public func stopAndTranscribe() async {
+    guard state == .recording, !isStopping else { return }
+    isStopping = true
+    defer { isStopping = false }
+
+    let pipelineStart = CFAbsoluteTimeGetCurrent()
+
+    // Silently discard recordings shorter than minimum duration (accidental taps)
+    if let startTime = recordingStartTime {
+      let elapsed = Date().timeIntervalSince(startTime)
+      if elapsed < TimingConstants.minimumRecordingDuration {
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
-        silenceDetector = nil
         if streamingASRActive {
-            Task { [weak self] in
-                await self?.asrManager.cancelStreaming()
-            }
+          await asrManager.cancelStreaming()
         }
         deactivateStreamingForwarding()
-        // Reset capture state so isCapturing and warm engine timer are consistent.
-        // The engine is already dead, but stopCapture() clears client-side flags.
-        Task { [weak self] in
-            _ = await self?.audioCapture.stopCapture()
-        }
-        targetApp = nil
-        targetElement = nil
-        recordingStartTime = nil
-        state = .error("Microphone disconnected")
-    }
-
-    /// Handle ASR XPC service crash during active session.
-    /// Called by AppState's unified ASR interruption handler when this pipeline is active.
-    /// Must stop audio capture (still running — only ASR died) and clean up fully.
-    public func handleASRServiceInterruption() {
-        let snapshot = buildInterruptionSnapshot()
-        SentryBreadcrumb.captureError(
-            NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed"]),
-            category: .xpcServiceError, stage: "asr",
-            extra: ["was_recording": state == .recording],
-            snapshot: snapshot
-        )
-        SentryBreadcrumb.updateRecordingState(active: false)
-        frozenSnapshot = nil
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        silenceDetector = nil
-        if streamingASRActive {
-            deactivateStreamingForwarding()
-        }
-        // Stop audio capture — it's still running since only the ASR service died
-        Task { [weak self] in
-            await self?.audioCapture.stopCapture()
-        }
-        targetApp = nil
-        targetElement = nil
-        recordingStartTime = nil
-        state = .error("Transcription service crashed — please try again")
-    }
-
-    /// Build a snapshot at interruption time when no frozen snapshot exists yet
-    /// (e.g., XPC crash during recording before stopAndTranscribe is reached).
-    private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
-        if let existing = frozenSnapshot { return existing }
-        let start = recordingStartTime ?? Date()
-        return SentryBreadcrumb.RecordingSnapshot(
-            backend: "parakeet",
-            audioRoute: audioCapture.currentAudioRoute,
-            wasStreaming: streamingASRActive,
-            startTime: start,
-            durationMs: Int(Date().timeIntervalSince(start) * 1000),
-            targetAppBundleID: targetApp?.bundleIdentifier
-        )
-    }
-
-    /// Cancel an active recording immediately without transcribing.
-    /// Guards on `.recording` state — safe to call from any other state.
-    public func cancelRecording() async {
-        stopRequested = false
-
-        // Cancel during model loading: abort the load task and return to idle.
-        if state == .loadingModel {
-            modelLoadTask?.cancel()
-            modelLoadTask = nil
-            targetApp = nil
-            targetElement = nil
-            state = .idle
-            return
-        }
-
-        guard state == .recording else { return }
-
-        // Stop VAD monitoring task immediately
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        silenceDetector = nil
-
-        // Deactivate streaming forwarding FIRST to prevent new buffer dispatches
-        let wasStreaming = streamingASRActive
-        deactivateStreamingForwarding()
-
-        // Stop the audio engine and discard samples BEFORE awaiting cancelStreaming().
-        // This is critical: stopCapture() sets the TapStoppedFlag which prevents
-        // the real-time audio thread from creating any new Task allocations. If we
-        // await cancelStreaming() first (which suspends), the audio engine continues
-        // firing tap callbacks during the suspension, creating Tasks that race with
-        // teardown and corrupt the heap.
         _ = await audioCapture.stopCapture()
-
-        // Now cancel streaming ASR session (safe to await — engine is stopped)
-        if wasStreaming {
-            await asrManager.cancelStreaming()
-        }
-
-        // Clear target app/element reference — nothing will be pasted
-        targetApp = nil
-        targetElement = nil
         recordingStartTime = nil
-
-        // Transition to idle without saving any transcript
         state = .idle
-    }
-
-    /// Deactivate streaming ASR buffer forwarding. Does not cancel the backend session.
-    private func deactivateStreamingForwarding() {
-        streamingASRActive = false
-        audioCapture.onBufferCaptured = nil
-    }
-
-    // MARK: - VAD Monitoring
-
-    private func startVADMonitoring() {
-        vadMonitorTask = Task { [weak self] in
-            await self?.monitorVAD()
+        Task {
+          await AppLogger.shared.log(
+            "Recording too short (\(String(format: "%.2f", elapsed))s), discarded silently",
+            level: .info, category: "Pipeline"
+          )
         }
+        return
+      }
+    }
+    // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
+    let snapshotStartTime = recordingStartTime ?? Date()
+    let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
+    frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
+      backend: "parakeet",
+      audioRoute: audioCapture.currentAudioRoute,
+      wasStreaming: streamingASRActive,
+      startTime: snapshotStartTime,
+      durationMs: durationMs,
+      targetAppBundleID: targetApp?.bundleIdentifier
+    )
+
+    recordingStartTime = nil
+
+    // Cancel VAD monitoring
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+
+    let wasStreaming = streamingASRActive
+
+    // Stop the audio tap FIRST — prevents new buffer-feed tasks from being dispatched.
+    // Then yield to drain any in-flight feed tasks already queued on @MainActor.
+    // These tasks check streamingASRActive (still true) and deliver their buffers
+    // to the Parakeet actor before we deactivate forwarding.
+    // Without this reorder, deactivateStreamingForwarding() sets the flag to false
+    // and all queued tasks drop their buffers — losing ~250-500ms of trailing audio.
+    let captureResult = await audioCapture.stopCapture()
+    let rawSamples = captureResult.samples
+    SentryBreadcrumb.add(
+      stage: "recording", message: "Recording stopped", data: ["sample_count": rawSamples.count])
+    SentryBreadcrumb.updateRecordingState(active: false)
+
+    if wasStreaming {
+      // Deterministic drain: freeze the dispatch count after stopCapture (no new buffers
+      // will be dispatched since the tap/session is stopped). Wait for all queued buffer-feed
+      // tasks to complete before deactivating forwarding. Bounded by 500ms deadline.
+      let targetDispatched = streamingBuffersDispatched
+      let drainDeadline = ContinuousClock.now + .milliseconds(500)
+      while streamingBuffersFed < targetDispatched,
+        ContinuousClock.now < drainDeadline
+      {
+        await Task.yield()
+      }
+      if streamingBuffersFed >= targetDispatched {
+        Task {
+          await AppLogger.shared.log(
+            "Streaming drain: clean (\(self.streamingBuffersFed)/\(targetDispatched) fed)",
+            level: .info, category: "PipelineTiming"
+          )
+        }
+      } else {
+        Task {
+          await AppLogger.shared.log(
+            "Streaming drain: TIMEOUT (\(self.streamingBuffersFed)/\(targetDispatched) fed — \(targetDispatched - self.streamingBuffersFed) lost)",
+            level: .info, category: "PipelineTiming"
+          )
+        }
+      }
     }
 
-    private func monitorVAD() async {
-        // Detector setup stays in pipeline (owns silenceDetector lifecycle)
-        let isXPCMode = audioCapture is AudioCaptureProxy
-        var detector: SilenceDetector?
+    deactivateStreamingForwarding()
 
-        if !isXPCMode {
-            let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
-            if silenceDetector == nil {
-                silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
-            }
-            guard let det = silenceDetector else { return }
-            await det.reset()
-            await det.updateConfig(config)
-            if !(await det.isReady) {
-                do {
-                    try await det.prepare()
-                } catch {
-                    Task { await AppLogger.shared.log(
-                        "VAD preparation failed: \(error)",
-                        level: .info, category: "VAD"
-                    ) }
-                    return
-                }
-            }
-            detector = det
-        }
+    // Defense: if cancelRecording() ran during yield, bail out
+    guard state == .recording else { return }
 
-        let startTime = recordingStartTime ?? Date()
-        let capture = audioCapture
+    // Pre-warm the LLM connection while ASR is still running (fire-and-forget).
+    // Establishes TLS + HTTP/2 so the polish request skips the handshake.
+    LLMNetworkSession.shared.preWarmIfConfigured(
+      provider: llmPolishStep.llmProvider,
+      keychainManager: keychainManager
+    )
 
-        await VADMonitorLoop.run(
-            detector: detector,
-            vadAutoStop: vadAutoStop,
-            maxDuration: TimingConstants.maxRecordingDuration,
-            recordingStartTime: startTime,
-            sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
-            isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
-            onStop: { [weak self] _ in
-                Task { [weak self] in await self?.stopAndTranscribe() }
-            }
+    guard !rawSamples.isEmpty else {
+      // Cancel streaming if it was active — empty samples means no useful audio
+      if wasStreaming {
+        await asrManager.cancelStreaming()
+      }
+      emitNoAudioCapturedEvent(wasStreaming: wasStreaming)
+      state = .error("No audio captured")
+      return
+    }
+
+    Task {
+      await AppLogger.shared.log(
+        "Captured \(rawSamples.count) samples (\(String(format: "%.2f", Double(rawSamples.count)/16000))s)",
+        level: .verbose, category: "Pipeline"
+      )
+    }
+
+    // Filter silence using VAD speech segments (used for batch fallback and logging).
+    var samples: [Float]
+    var hasSpeechEvidence = false
+    var vadSegmentCount = 0
+    var vadSpeechDurationMs = 0
+    let isXPCMode = audioCapture is AudioCaptureProxy
+    if isXPCMode {
+      // XPC mode: VAD segments are returned atomically with samples from stopCapture().
+      // This eliminates the call-order bug where separate getVADSegments() read
+      // capturedSamples.count as 0 after stopCapture() cleared the buffer (#226).
+      let segments = captureResult.vadSegments
+      hasSpeechEvidence = !segments.isEmpty
+      vadSegmentCount = segments.count
+      vadSpeechDurationMs =
+        segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
+      if !segments.isEmpty {
+        samples = SampleFilter.filter(from: rawSamples, segments: segments)
+      } else {
+        samples = rawSamples
+      }
+    } else if let detector = silenceDetector {
+      await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+      let segments = await detector.speechSegments
+      hasSpeechEvidence = !segments.isEmpty
+      vadSegmentCount = segments.count
+      vadSpeechDurationMs =
+        segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
+      samples = await detector.filterSamples(from: rawSamples)
+    } else {
+      samples = rawSamples
+      // No VAD detector available -- cannot determine speech presence.
+      // Default to true so that empty ASR results still fire Sentry errors
+      // (fail toward visibility rather than silently swallowing failures).
+      hasSpeechEvidence = true
+    }
+    let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
+
+    Task {
+      await AppLogger.shared.log(
+        "VAD filtered to \(samples.count) samples (\(String(format: "%.1f", Double(samples.count)/Double(max(rawSamples.count, 1))*100))% voiced)",
+        level: .verbose, category: "Pipeline"
+      )
+    }
+
+    // VAD gate: if no speech was detected, skip ASR entirely.
+    // Prevents noise-induced hallucinations ("Okay", "Yeah") from ambient sounds.
+    // The decoder hallucinates filler words from low-information audio; not
+    // invoking it eliminates the problem at the source.
+    if !hasSpeechEvidence {
+      if wasStreaming {
+        await asrManager.cancelStreaming()
+      }
+      SentryBreadcrumb.add(
+        stage: "asr", message: "VAD gate: no speech detected, skipping ASR",
+        level: .info,
+        data: [
+          "backend": asrManager.activeBackendType.rawValue,
+          "mode": wasStreaming ? "streaming" : "batch",
+          "raw_sample_count": rawSamples.count,
+          "peak_audio_level": peakAudioLevel,
+        ]
+      )
+      frozenSnapshot = nil
+      state = .idle
+      Task {
+        await AppLogger.shared.log(
+          "VAD gate: no speech, skipping ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
+          level: .info, category: "Pipeline"
         )
+      }
+      return
     }
 
+    // ASR backends require >= 1 second of audio.
+    // If VAD filtering was too aggressive, fall back to raw samples.
+    let minimumSamples = AudioConstants.minimumTranscriptionSamples
+    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
+      samples = rawSamples
+    }
 
-    // MARK: - Streaming Rescue
+    // Pad short recordings with silence so single-word inputs ("hey", "hi") work.
+    if samples.count > 0 && samples.count < minimumSamples {
+      samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
+    }
 
-    /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
-    /// and VAD detected speech. Heart-level rescue: captured samples are already available,
-    /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
-    private func transcribeWithStreamingRescue(
-        samples: [Float],
-        hasSpeechEvidence: Bool
-    ) async throws -> ASRResult {
-        // 1. Try streaming finalize (happy path)
-        do {
-            let result = try await asrManager.finalizeStreaming()
-            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !text.isEmpty {
-                return result
-            }
-            // Streaming returned empty -- check rescue eligibility below
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
+    state = .transcribing
+    SentryBreadcrumb.add(
+      stage: "asr", message: "Transcription started",
+      data: [
+        "mode": wasStreaming ? "streaming" : "batch",
+        "backend": asrManager.activeBackendType.rawValue,
+      ])
+
+    do {
+      let asrStart = CFAbsoluteTimeGetCurrent()
+
+      // Use streaming finalize when available for lowest latency.
+      // FluidAudio fork uses fresh decoder state per chunk + chunk-aware text assembly
+      // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
+      // Streaming mode includes batch rescue: if finalize fails or returns empty
+      // despite VAD speech evidence, retry with batch decode using captured samples.
+      let result: ASRResult
+      if wasStreaming {
+        result = try await transcribeWithStreamingRescue(
+          samples: samples,
+          hasSpeechEvidence: hasSpeechEvidence
+        )
+      } else {
+        result = try await asrManager.transcribe(
+          audioSamples: samples, options: transcriptionOptions)
+      }
+
+      let asrEnd = CFAbsoluteTimeGetCurrent()
+
+      let asrText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !asrText.isEmpty else {
+        if hasSpeechEvidence {
+          // Real ASR failure: VAD detected speech but decoder returned nothing
+          SentryBreadcrumb.captureError(
+            NSError(
+              domain: "EnviousWispr", code: -1,
+              userInfo: [
+                NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"
+              ]),
+            category: .asrEmptyResult, stage: "asr",
+            extra: [
+              "backend": asrManager.activeBackendType.rawValue,
+              "mode": wasStreaming ? "streaming" : "batch",
+              "has_speech_evidence": true,
+              "raw_sample_count": rawSamples.count,
+              "vad_segment_count": vadSegmentCount,
+              "vad_speech_duration_ms": vadSpeechDurationMs,
+              "peak_audio_level": peakAudioLevel,
+            ],
+            snapshot: frozenSnapshot
+          )
+          state = .error("Couldn't catch that -- try again")
+          Task {
             await AppLogger.shared.log(
-                "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
-                level: .info, category: "Pipeline"
+              "ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
+              level: .info, category: "Pipeline"
             )
+          }
+        } else {
+          // Expected: user held button without speaking
+          SentryBreadcrumb.add(
+            stage: "asr", message: "ASR empty (no speech detected)",
+            level: .info,
+            data: [
+              "backend": asrManager.activeBackendType.rawValue,
+              "mode": wasStreaming ? "streaming" : "batch",
+            ]
+          )
+          state = .idle
+          Task {
+            await AppLogger.shared.log(
+              "No speech detected, returning to idle",
+              level: .info, category: "Pipeline"
+            )
+          }
         }
+        frozenSnapshot = nil
+        return
+      }
 
-        // 2. No speech evidence means genuine silence, not a rescue candidate.
-        // Return an empty result so the caller handles it with the appropriate message.
-        guard hasSpeechEvidence else {
-            return ASRResult(text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+      SentryBreadcrumb.add(
+        stage: "asr", message: "ASR completed",
+        data: [
+          "mode": wasStreaming ? "streaming" : "batch",
+          "backend": asrManager.activeBackendType.rawValue,
+          "duration_s": String(format: "%.3f", asrEnd - asrStart),
+          "char_count": asrText.count,
+        ])
+      Task {
+        await AppLogger.shared.log(
+          "Pipeline timing: ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s "
+            + "(mode=\(wasStreaming ? "streaming" : "batch"), \(asrText.count) chars, lang=\(result.language ?? "?"))",
+          level: .info, category: "PipelineTiming"
+        )
+      }
+
+      // Post-ASR finalization: text processing -> store -> paste
+      let finalizationResult: FinalizationResult
+      do {
+        finalizationResult = try await transcriptFinalizer.finalize(
+          FinalizationRequest(
+            asrText: asrText,
+            language: result.language,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            backendType: result.backendType,
+            targetApp: targetApp,
+            targetElement: targetElement,
+            autoCopyToClipboard: autoCopyToClipboard,
+            autoPasteToActiveApp: autoPasteToActiveApp,
+            restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+            steps: textProcessingSteps
+          ))
+      } catch is CancellationError {
+        frozenSnapshot = nil
+        return
+      } catch let error as FinalizationError {
+        switch error {
+        case .emptyAfterProcessing:
+          SentryBreadcrumb.captureError(
+            HeartPathError.emptyAfterProcessing(
+              route: audioCapture.currentAudioRoute,
+              wasPolishEnabled: llmPolishStep.isEnabled
+            ),
+            category: .heartPathFinalization,
+            stage: "processing",
+            extra: [
+              "capture.route": audioCapture.currentAudioRoute,
+              "polish.enabled": llmPolishStep.isEnabled,
+              "backend": "parakeet",
+              "capture_session_id": Int(audioCapture.currentCaptureSessionID),
+            ]
+          )
+          state = .error("No text after processing")
+          frozenSnapshot = nil
+          return
+        case .storageFailed(let underlying):
+          SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
+          state = .error("Failed to save transcript")
+          frozenSnapshot = nil
+          return
         }
+      }
 
-        // 3. Batch rescue: speech was detected but streaming failed to decode it.
+      lastPolishError = finalizationResult.polishError
+
+      // Notify ASR manager that transcription is done; schedules unload timer if configured.
+      asrManager.noteTranscriptionComplete(policy: modelUnloadPolicy)
+
+      // Build metrics (pipeline-specific: uses ASR timing, streaming mode)
+      let pasteTargetApp = targetApp?.bundleIdentifier
+      targetApp = nil
+      targetElement = nil
+
+      let pipelineEnd = CFAbsoluteTimeGetCurrent()
+      let polishDuration = finalizationResult.polishDurationSeconds
+      let pasteDuration = finalizationResult.pasteDurationSeconds
+      Task {
         await AppLogger.shared.log(
-            "Streaming rescue: speech evidence found, retrying batch (\(samples.count) samples)",
-            level: .info, category: "Pipeline"
+          "Pipeline timing TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s "
+            + "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, "
+            + "polish=\(String(format: "%.3f", polishDuration))s, "
+            + "paste=\(String(format: "%.3f", pasteDuration))s)",
+          level: .info, category: "PipelineTiming"
         )
+      }
 
-        let result = try await asrManager.transcribe(audioSamples: samples, options: transcriptionOptions)
+      var transcript = finalizationResult.transcript
+      transcript.metrics = ExecutionMetrics(
+        asrLatencySeconds: asrEnd - asrStart,
+        llmLatencySeconds: polishDuration,
+        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+        pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
+        targetApp: pasteTargetApp,
+        coldStart: false,
+        streamingMode: wasStreaming,
+        e2eSeconds: pipelineEnd - pipelineStart
+      )
+      currentTranscript = transcript
+      SentryBreadcrumb.add(
+        stage: "pipeline", message: "Pipeline complete",
+        data: [
+          "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
+          "asr_s": String(format: "%.3f", asrEnd - asrStart),
+          "polish_s": String(format: "%.3f", polishDuration),
+          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+          "backend": asrManager.activeBackendType.rawValue,
+        ])
+      frozenSnapshot = nil
+      state = .complete
+    } catch {
+      SentryBreadcrumb.captureError(
+        error, category: .asrFailed, stage: "transcription",
+        extra: [
+          "backend": asrManager.activeBackendType.rawValue
+        ], snapshot: frozenSnapshot)
+      frozenSnapshot = nil
+      state = .error("Transcription failed: \(error.localizedDescription)")
+    }
+  }
 
-        await AppLogger.shared.log(
-            "Streaming rescue: batch produced \(result.text.count) chars",
-            level: .info, category: "Pipeline"
-        )
+  // polishExistingTranscript() removed — re-polish is now handled by TranscriptPolishService,
+  // which is decoupled from pipeline state. See #206.
 
+  /// Reset pipeline to idle state.
+  public func reset() {
+    guard !isStopping, !isStarting else { return }
+    stopRequested = false
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    // Cancel any active streaming ASR session to prevent orphaned sessions.
+    let wasStreaming = streamingASRActive
+    deactivateStreamingForwarding()
+    if wasStreaming {
+      Task { [weak self] in
+        await self?.asrManager.cancelStreaming()
+      }
+    }
+    if audioCapture.isCapturing {
+      let capture = audioCapture
+      Task { _ = await capture.stopCapture() }
+    }
+    silenceDetector = nil
+    recordingStartTime = nil
+    state = .idle
+    currentTranscript = nil
+  }
+
+  /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
+  /// Called by AppState's unified interruption handler, not set directly on audioCapture.
+  public func handleEngineInterruption() {
+    // Issue #285 — Sentry emission for audio/XPC interruptions is owned by
+    // AppState.onXPCServiceError (single-owner per plan §3.4a). This handler
+    // is control-flow only: clean up pipeline state + transition UI.
+    SentryBreadcrumb.updateRecordingState(active: false)
+    frozenSnapshot = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    silenceDetector = nil
+    if streamingASRActive {
+      Task { [weak self] in
+        await self?.asrManager.cancelStreaming()
+      }
+    }
+    deactivateStreamingForwarding()
+    // Reset capture state so isCapturing and warm engine timer are consistent.
+    // The engine is already dead, but stopCapture() clears client-side flags.
+    Task { [weak self] in
+      _ = await self?.audioCapture.stopCapture()
+    }
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+    state = .error("Microphone disconnected")
+  }
+
+  /// Handle ASR XPC service crash during active session.
+  /// Called by AppState's unified ASR interruption handler when this pipeline is active.
+  /// Must stop audio capture (still running — only ASR died) and clean up fully.
+  public func handleASRServiceInterruption() {
+    let snapshot = buildInterruptionSnapshot()
+    SentryBreadcrumb.captureError(
+      NSError(
+        domain: "EnviousWispr", code: -3,
+        userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed"]),
+      category: .xpcServiceError, stage: "asr",
+      extra: ["was_recording": state == .recording],
+      snapshot: snapshot
+    )
+    SentryBreadcrumb.updateRecordingState(active: false)
+    frozenSnapshot = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    silenceDetector = nil
+    if streamingASRActive {
+      deactivateStreamingForwarding()
+    }
+    // Stop audio capture — it's still running since only the ASR service died
+    Task { [weak self] in
+      await self?.audioCapture.stopCapture()
+    }
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+    state = .error("Transcription service crashed — please try again")
+  }
+
+  /// Build a snapshot at interruption time when no frozen snapshot exists yet
+  /// (e.g., XPC crash during recording before stopAndTranscribe is reached).
+  private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
+    if let existing = frozenSnapshot { return existing }
+    let start = recordingStartTime ?? Date()
+    return SentryBreadcrumb.RecordingSnapshot(
+      backend: "parakeet",
+      audioRoute: audioCapture.currentAudioRoute,
+      wasStreaming: streamingASRActive,
+      startTime: start,
+      durationMs: Int(Date().timeIntervalSince(start) * 1000),
+      targetAppBundleID: targetApp?.bundleIdentifier
+    )
+  }
+
+  /// Cancel an active recording immediately without transcribing.
+  /// Guards on `.recording` state — safe to call from any other state.
+  public func cancelRecording() async {
+    stopRequested = false
+
+    // Cancel during model loading: abort the load task and return to idle.
+    if state == .loadingModel {
+      modelLoadTask?.cancel()
+      modelLoadTask = nil
+      targetApp = nil
+      targetElement = nil
+      state = .idle
+      return
+    }
+
+    guard state == .recording else { return }
+
+    // Stop VAD monitoring task immediately
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    silenceDetector = nil
+
+    // Deactivate streaming forwarding FIRST to prevent new buffer dispatches
+    let wasStreaming = streamingASRActive
+    deactivateStreamingForwarding()
+
+    // Stop the audio engine and discard samples BEFORE awaiting cancelStreaming().
+    // This is critical: stopCapture() sets the TapStoppedFlag which prevents
+    // the real-time audio thread from creating any new Task allocations. If we
+    // await cancelStreaming() first (which suspends), the audio engine continues
+    // firing tap callbacks during the suspension, creating Tasks that race with
+    // teardown and corrupt the heap.
+    _ = await audioCapture.stopCapture()
+
+    // Now cancel streaming ASR session (safe to await — engine is stopped)
+    if wasStreaming {
+      await asrManager.cancelStreaming()
+    }
+
+    // Clear target app/element reference — nothing will be pasted
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+
+    // Transition to idle without saving any transcript
+    state = .idle
+  }
+
+  /// Deactivate streaming ASR buffer forwarding. Does not cancel the backend session.
+  private func deactivateStreamingForwarding() {
+    streamingASRActive = false
+    audioCapture.onBufferCaptured = nil
+  }
+
+  // MARK: - VAD Monitoring
+
+  private func startVADMonitoring() {
+    vadMonitorTask = Task { [weak self] in
+      await self?.monitorVAD()
+    }
+  }
+
+  private func monitorVAD() async {
+    // Detector setup stays in pipeline (owns silenceDetector lifecycle)
+    let isXPCMode = audioCapture is AudioCaptureProxy
+    var detector: SilenceDetector?
+
+    if !isXPCMode {
+      let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
+      if silenceDetector == nil {
+        silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
+      }
+      guard let det = silenceDetector else { return }
+      await det.reset()
+      await det.updateConfig(config)
+      if !(await det.isReady) {
+        do {
+          try await det.prepare()
+        } catch {
+          Task {
+            await AppLogger.shared.log(
+              "VAD preparation failed: \(error)",
+              level: .info, category: "VAD"
+            )
+          }
+          return
+        }
+      }
+      detector = det
+    }
+
+    let startTime = recordingStartTime ?? Date()
+    let capture = audioCapture
+
+    await VADMonitorLoop.run(
+      detector: detector,
+      vadAutoStop: vadAutoStop,
+      maxDuration: TimingConstants.maxRecordingDuration,
+      recordingStartTime: startTime,
+      sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
+      isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
+      onStop: { [weak self] _ in
+        Task { [weak self] in await self?.stopAndTranscribe() }
+      }
+    )
+  }
+
+  // MARK: - Streaming Rescue
+
+  /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
+  /// and VAD detected speech. Heart-level rescue: captured samples are already available,
+  /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
+  private func transcribeWithStreamingRescue(
+    samples: [Float],
+    hasSpeechEvidence: Bool
+  ) async throws -> ASRResult {
+    // 1. Try streaming finalize (happy path)
+    do {
+      let result = try await asrManager.finalizeStreaming()
+      let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !text.isEmpty {
         return result
+      }
+      // Streaming returned empty -- check rescue eligibility below
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      await AppLogger.shared.log(
+        "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
+        level: .info, category: "Pipeline"
+      )
     }
 
-    // MARK: - DictationPipeline Conformance
-
-    public var overlayIntent: OverlayIntent {
-        switch state {
-        case .loadingModel:
-            return .processing(label: "Loading model...")
-        case .recording:
-            return .recording(audioLevel: 0) // actual level provided by AudioCaptureManager
-        case .transcribing:
-            return .processing(label: "Transcribing...")
-        case .polishing:
-            return .processing(label: "Polishing...")
-        case .idle, .complete:
-            return .hidden
-        case .error(let msg):
-            if msg == InterruptionMessages.micDisconnected {
-                return .interruption(message: msg)
-            }
-            return .error(message: msg)
-        }
+    // 2. No speech evidence means genuine silence, not a rescue candidate.
+    // Return an empty result so the caller handles it with the appropriate message.
+    guard hasSpeechEvidence else {
+      return ASRResult(
+        text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
     }
 
-    public func handle(event: PipelineEvent) async {
-        switch event {
-        case .preWarm:
-            await preWarmAudioInput()
-        case .toggleRecording:
-            await toggleRecording()
-        case .requestStop:
-            await requestStop()
-        case .cancelRecording:
-            await cancelRecording()
-        case .reset:
-            reset()
-        }
+    // 3. Batch rescue: speech was detected but streaming failed to decode it.
+    await AppLogger.shared.log(
+      "Streaming rescue: speech evidence found, retrying batch (\(samples.count) samples)",
+      level: .info, category: "Pipeline"
+    )
+
+    let result = try await asrManager.transcribe(
+      audioSamples: samples, options: transcriptionOptions)
+
+    await AppLogger.shared.log(
+      "Streaming rescue: batch produced \(result.text.count) chars",
+      level: .info, category: "Pipeline"
+    )
+
+    return result
+  }
+
+  // MARK: - DictationPipeline Conformance
+
+  public var overlayIntent: OverlayIntent {
+    switch state {
+    case .loadingModel:
+      return .processing(label: "Loading model...")
+    case .recording:
+      return .recording(audioLevel: 0)  // actual level provided by AudioCaptureManager
+    case .transcribing:
+      return .processing(label: "Transcribing...")
+    case .polishing:
+      return .processing(label: "Polishing...")
+    case .idle, .complete:
+      return .hidden
+    case .error(let msg):
+      if msg == InterruptionMessages.micDisconnected {
+        return .interruption(message: msg)
+      }
+      return .error(message: msg)
     }
+  }
+
+  public func handle(event: PipelineEvent) async {
+    switch event {
+    case .preWarm:
+      await preWarmAudioInput()
+    case .toggleRecording:
+      await toggleRecording()
+    case .requestStop:
+      await requestStop()
+    case .cancelRecording:
+      await cancelRecording()
+    case .reset:
+      reset()
+    }
+  }
 }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -1,33 +1,33 @@
 import AppKit
-import EnviousWisprCore
-import EnviousWisprStorage
-import EnviousWisprAudio
-import EnviousWisprServices
 import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprServices
+import EnviousWisprStorage
 import Foundation
 @preconcurrency import WhisperKit
 
 /// Internal state machine for the WhisperKit highway — independent of PipelineState.
 public enum WhisperKitPipelineState: Equatable, Sendable {
-    case idle
-    case startingUp       // engine warm-up / pre-capture setup
-    case loadingModel
-    case ready
-    case recording
-    case transcribing
-    case polishing
-    case complete
-    case error(String)
+  case idle
+  case startingUp  // engine warm-up / pre-capture setup
+  case loadingModel
+  case ready
+  case recording
+  case transcribing
+  case polishing
+  case complete
+  case error(String)
 
-    public var isActive: Bool {
-        switch self {
-        case .startingUp, .recording, .transcribing, .polishing, .loadingModel:
-            return true
-        default:
-            return false
-        }
+  public var isActive: Bool {
+    switch self {
+    case .startingUp, .recording, .transcribing, .polishing, .loadingModel:
+      return true
+    default:
+      return false
     }
+  }
 }
 
 /// Independent WhisperKit dictation pipeline — batch record → transcribe → polish → paste.
@@ -36,961 +36,1164 @@ public enum WhisperKitPipelineState: Equatable, Sendable {
 /// with the Parakeet highway (TranscriptionPipeline). No streaming — batch only.
 @MainActor
 @Observable
-public final class WhisperKitPipeline: DictationPipeline {
-    private let audioCapture: any AudioCaptureInterface
-    private let backend: WhisperKitBackend
-    private let keychainManager: KeychainManager
+public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarget {
+  private let audioCapture: any AudioCaptureInterface
+  private let backend: WhisperKitBackend
+  private let keychainManager: KeychainManager
 
-    public private(set) var state: WhisperKitPipelineState = .idle {
-        didSet {
-            if state != oldValue {
-                onStateChange?(state)
-            }
-        }
+  public private(set) var state: WhisperKitPipelineState = .idle {
+    didSet {
+      if state != oldValue {
+        onStateChange?(state)
+      }
     }
-    public var onStateChange: ((WhisperKitPipelineState) -> Void)?
-    public private(set) var currentTranscript: Transcript?
-    public var autoCopyToClipboard: Bool = true
-    public var autoPasteToActiveApp: Bool = false
-    public var restoreClipboardAfterPaste: Bool = false
-    public var transcriptionOptions: TranscriptionOptions = .default
-    public var lastPolishError: String?
-    public var modelUnloadPolicy: ModelUnloadPolicy = .never
+  }
+  public var onStateChange: ((WhisperKitPipelineState) -> Void)?
+  public private(set) var currentTranscript: Transcript?
+  public var autoCopyToClipboard: Bool = true
+  public var autoPasteToActiveApp: Bool = false
+  public var restoreClipboardAfterPaste: Bool = false
+  public var transcriptionOptions: TranscriptionOptions = .default
+  public var lastPolishError: String?
+  public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
-    // Multilingual v1 (W2): language mode + detector. Captured lazily at
-    // detection time so a user toggling Auto->Locked mid-recording is respected.
-    public var languageMode: LanguageMode = .auto {
-        didSet {
-            // Mid-recording changes to the language mode invalidate the
-            // incremental worker, which snapshots the decode language at its
-            // init. Rather than try to re-decode the worker's buffers with the
-            // new language, we drop the worker entirely so finalize falls back
-            // to batch decode with the post-change language.
-            if oldValue != languageMode, let worker = incrementalWorker {
-                incrementalWorker = nil
-                Task { await worker.cancel() }
-                Task { await AppLogger.shared.log(
-                    "Language mode changed mid-recording, incremental worker invalidated",
-                    level: .info, category: "WhisperKitPipeline"
-                ) }
-            }
-        }
-    }
-    private let languageDetector: LanguageDetector
-    /// Last detection result, exposed for telemetry and UI (passive chip).
-    public private(set) var lastLanguageDetection: LanguageDetectionResult?
-
-    // Shared services
-    private let transcriptFinalizer: TranscriptFinalizer
-
-    // Text processing steps (own instances — not shared with Parakeet)
-    public let wordCorrectionStep = WordCorrectionStep()
-    public let fillerRemovalStep = FillerRemovalStep()
-    public let llmPolishStep: LLMPolishStep
-    private var textProcessingSteps: [any TextProcessingStep] = []
-
-    /// Access for configuration
-    public var wordCorrection: WordCorrectionStep { wordCorrectionStep }
-    public var fillerRemoval: FillerRemovalStep { fillerRemovalStep }
-    public var llmPolish: LLMPolishStep { llmPolishStep }
-
-    /// The app that was frontmost when recording started.
-    private var targetApp: NSRunningApplication?
-    private var targetElement: AXUIElement?
-    private var recordingStartTime: Date?
-    /// Guards against concurrent stopAndTranscribe calls.
-    private var isStopping = false
-    /// Whether audio input has been pre-warmed by PTT key-down.
-    private var isPreWarmed = false
-
-    // VAD properties
-    public var vadAutoStop: Bool = false
-    public var vadSilenceTimeout: Double = 1.5
-    public var vadSensitivity: Float = 0.5
-    public var vadEnergyGate: Bool = false
-
-    private var silenceDetector: SilenceDetector?
-    private var vadMonitorTask: Task<Void, Never>?
-    /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
-    private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
-    private var incrementalWorker: WhisperKitIncrementalWorker?
-    private var modelUnloadTask: Task<Void, Never>?
-
-    public init(
-        audioCapture: any AudioCaptureInterface,
-        backend: WhisperKitBackend,
-        transcriptStore: TranscriptStore,
-        keychainManager: KeychainManager,
-        languageDetector: LanguageDetector = LanguageDetector()
-    ) {
-        self.audioCapture = audioCapture
-        self.backend = backend
-        self.keychainManager = keychainManager
-        self.languageDetector = languageDetector
-        self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
-        self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
-        // Explicit engine identity: prevents a future codepath that skips the
-        // language detector from silently falling through to the legacy
-        // English-centric prompt path. The planner reads `.whisperKit` + nil
-        // detection as low-confidence (formatting only, no lexical injection).
-        llmPolishStep.backend = .whisperKit
-
-        llmPolishStep.onWillProcess = { [weak self] in
-            self?.state = .polishing
-        }
-
-        // Engine interruption cleanup is wired by AppState.onEngineInterrupted
-        // (unified handler that routes to the active pipeline). The pipeline exposes
-        // handleEngineInterruption() for AppState to call.
-
-        // Activate SSE streaming for Gemini
-        llmPolishStep.onToken = { _ in }
-        textProcessingSteps = [wordCorrectionStep, fillerRemovalStep, llmPolishStep]
-    }
-
-    // MARK: - DictationPipeline Conformance
-
-    public var overlayIntent: OverlayIntent {
-        switch state {
-        case .startingUp:
-            return .processing(label: "Starting...")
-        case .loadingModel:
-            return .processing(label: "Loading model...")
-        case .recording:
-            return .recording(audioLevel: 0)
-        case .transcribing:
-            return .processing(label: "Transcribing...")
-        case .polishing:
-            return .processing(label: "Polishing...")
-        case .idle, .ready, .complete:
-            return .hidden
-        case .error(let msg):
-            if msg == InterruptionMessages.micDisconnected {
-                return .interruption(message: msg)
-            }
-            return .error(message: msg)
-        }
-    }
-
-    public func handle(event: PipelineEvent) async {
-        switch event {
-        case .preWarm:
-            await preWarmAudioInput()
-        case .toggleRecording:
-            await toggleRecording()
-        case .requestStop:
-            await requestStop()
-        case .cancelRecording:
-            await cancelRecording()
-        case .reset:
-            reset()
-        }
-    }
-
-    // MARK: - Background Pre-load
-
-    /// Silently load the WhisperKit model into RAM without changing pipeline state.
-    /// Called after model download completes or on launch if model is already cached.
-    /// Uses prepareIfCached() to avoid triggering a silent network download.
-    /// If user presses record before this finishes, startRecording() handles it with its own .loadingModel flow.
-    public func prepareBackendSilently() async {
-        let isBackendReady = await backend.isReady
-        guard !isBackendReady else { return }
-        do {
-            let loaded = try await backend.prepareIfCached()
-            if loaded {
-                Task { await AppLogger.shared.log(
-                    "WhisperKit model pre-loaded successfully (background)",
-                    level: .info, category: "WhisperKitPipeline"
-                ) }
-            } else {
-                Task { await AppLogger.shared.log(
-                    "WhisperKit model not cached, skipping silent pre-load",
-                    level: .info, category: "WhisperKitPipeline"
-                ) }
-            }
-        } catch {
-            Task { await AppLogger.shared.log(
-                "WhisperKit model pre-load failed: \(error.localizedDescription)",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-        }
-    }
-
-    // MARK: - Recording Lifecycle
-
-    public func preWarmAudioInput() async {
-        guard !state.isActive, state != .recording else { return }
-        let start = ContinuousClock.now
-        await audioCapture.preWarm()
-        guard !Task.isCancelled else { return }
-        isPreWarmed = true
-        let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
-        Task { await AppLogger.shared.log(
-            "COLD-START [WhisperKit] preWarmAudioInput total=\(totalMs)ms",
-            level: .info, category: "Pipeline"
-        ) }
-        // Defense-in-depth: ensure model is loaded from cache (no download).
-        // If not cached, startRecording() handles the full load with user-visible UI.
-        Task { _ = try? await backend.prepareIfCached() }
-    }
-
-    public func toggleRecording() async {
-        switch state {
-        case .idle, .ready, .complete, .error:
-            await startRecording()
-        case .recording:
-            await stopAndTranscribe()
-        case .loadingModel, .startingUp, .transcribing, .polishing:
-            break
-        }
-    }
-
-    /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
-    private var isStarting = false
-
-    public func startRecording() async {
-        guard !isStarting else { return }
-        guard !state.isActive || state == .complete || state == .ready else { return }
-        isStarting = true
-        defer { isStarting = false }
-
-        // Cancel any pending model unload — keep model loaded during recording.
-        modelUnloadTask?.cancel()
-        modelUnloadTask = nil
-
-        state = .startingUp
-        lastPolishError = nil
-        SentryBreadcrumb.add(stage: "whisperkit", message: "Pipeline starting up")
-
-        // Load model if not ready
-        let isBackendReady = await backend.isReady
-        guard state == .startingUp else { return }  // cancelled during await
-
-        if !isBackendReady {
-            state = .loadingModel
-            SentryBreadcrumb.add(stage: "asr", message: "WhisperKit model loading")
-            do {
-                try await backend.prepare()
-            } catch {
-                SentryBreadcrumb.captureError(error, category: .modelLoadFailed, stage: "asr", extra: ["backend": "whisperKit"])
-                state = .error("Model load failed: \(error.localizedDescription)")
-                return
-            }
-            guard state == .loadingModel else { return }  // cancelled during model load
-            state = .startingUp  // back to startingUp for engine setup
-        }
-
-        // Capture target app for paste-back
-        targetApp = NSWorkspace.shared.frontmostApplication
-        targetElement = PasteService.captureFocusedElement()
-
-        // No streaming buffer forwarding for batch mode
-        audioCapture.onBufferCaptured = nil
-
-        do {
-            if !isPreWarmed {
-                try await audioCapture.startEnginePhase()
-                let stabilized = await audioCapture.waitForFormatStabilization(
-                    maxWait: 1.5,
-                    pollInterval: 0.2
-                )
-                guard state == .startingUp else { return }  // cancelled during stabilization
-                if !stabilized {
-                    audioCapture.rebuildEngine()
-                    try await audioCapture.startEnginePhase()
-                }
-            }
-            isPreWarmed = false
-
-            _ = try await audioCapture.beginCapturePhase()
-            state = .recording
-            recordingStartTime = Date()
-            currentTranscript = nil
-            SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording started", data: ["backend": "whisperKit"])
-            SentryBreadcrumb.updateRecordingState(active: true, backend: "whisperkit")
-            SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
-            startVADMonitoring()
-            // Multilingual v1: the incremental worker snapshots transcriptionOptions.language
-            // at recording start. In .auto mode, language is unknown until LID runs at
-            // recording stop, so the worker would decode with the stale/legacy language.
-            // Skip the worker in .auto mode; batch decode at finalize picks up the
-            // post-LID language. .locked mode is safe because the language is known upfront.
-            let workerEnabled: Bool
-            if case .locked = languageMode {
-                workerEnabled = true
-                await startIncrementalWorker()
-            } else {
-                workerEnabled = false
-            }
-
-            Task { [workerEnabled] in await AppLogger.shared.log(
-                "WhisperKit recording started (batch mode, incremental worker: \(workerEnabled ? "on" : "off, auto language mode"))",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-        } catch {
-            SentryBreadcrumb.captureError(error, category: .audioCaptureFailed, stage: "recording", extra: ["backend": "whisperKit"])
-            state = .error("Recording failed: \(error.localizedDescription)")
-        }
-    }
-
-    public func requestStop() async {
-        switch state {
-        case .recording:
-            await stopAndTranscribe()
-        case .startingUp, .loadingModel:
-            // Clean abort — startRecording() checks state after each await suspension point.
-            state = .idle
-        case .idle, .ready, .complete, .error:
-            // PTT release before recording started — clean up pre-warmed audio engine
-            if isPreWarmed {
-                isPreWarmed = false
-                audioCapture.abortPreWarm()
-            }
-        case .transcribing, .polishing:
-            // Pipeline is past the point of no return — ignore.
-            break
-        }
-    }
-
-    public func stopAndTranscribe() async {
-        guard state == .recording, !isStopping else { return }
-        isStopping = true
-        defer { isStopping = false }
-
-        let pipelineStart = CFAbsoluteTimeGetCurrent()
-
-        // Discard accidental short recordings
-        if let startTime = recordingStartTime {
-            let elapsed = Date().timeIntervalSince(startTime)
-            if elapsed < TimingConstants.minimumRecordingDuration {
-                vadMonitorTask?.cancel()
-                vadMonitorTask = nil
-                await incrementalWorker?.cancel()
-                incrementalWorker = nil
-                _ = await audioCapture.stopCapture()
-                recordingStartTime = nil
-                state = .idle
-                Task { await AppLogger.shared.log(
-                    "WhisperKit recording too short (\(String(format: "%.2f", elapsed))s), discarded",
-                    level: .info, category: "WhisperKitPipeline"
-                ) }
-                return
-            }
-        }
-        // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
-        let snapshotStartTime = recordingStartTime ?? Date()
-        let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
-        frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
-            backend: "whisperkit",
-            audioRoute: audioCapture.currentAudioRoute,
-            wasStreaming: false,
-            startTime: snapshotStartTime,
-            durationMs: durationMs,
-            targetAppBundleID: targetApp?.bundleIdentifier
-        )
-
-        recordingStartTime = nil
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-
-        let captureResult = await audioCapture.stopCapture()
-        let rawSamples = captureResult.samples
-        SentryBreadcrumb.add(stage: "recording", message: "WhisperKit recording stopped", data: ["sample_count": rawSamples.count])
-        SentryBreadcrumb.updateRecordingState(active: false)
-
-        // Pre-warm LLM connection while ASR runs
-        LLMNetworkSession.shared.preWarmIfConfigured(
-            provider: llmPolishStep.llmProvider,
-            keychainManager: keychainManager
-        )
-
-        guard !rawSamples.isEmpty else {
-            SentryBreadcrumb.add(stage: "recording", message: "No audio captured (WhisperKit)", level: .warning)
-            state = .error("No audio captured")
-            return
-        }
-
-        // Post-capture VAD filtering — remove silence segments
-        var samples: [Float]
-        var hasSpeechEvidence = false
-        var vadSegmentCount = 0
-        var vadSpeechDurationMs = 0
-        let isXPCMode = audioCapture is AudioCaptureProxy
-        if isXPCMode {
-            // XPC mode: VAD segments returned atomically with samples from stopCapture() (#226).
-            let segments = captureResult.vadSegments
-            hasSpeechEvidence = !segments.isEmpty
-            vadSegmentCount = segments.count
-            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
-            if !segments.isEmpty {
-                samples = SampleFilter.filter(from: rawSamples, segments: segments)
-                let pct = String(format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
-                Task { await AppLogger.shared.log(
-                    "WhisperKit VAD (XPC) filtered to \(samples.count) samples (\(pct)% voiced)",
-                    level: .info, category: "WhisperKitPipeline"
-                ) }
-            } else {
-                samples = rawSamples
-            }
-        } else if let detector = silenceDetector {
-            await detector.finalizeSegments(totalSampleCount: rawSamples.count)
-            let segments = await detector.speechSegments
-            hasSpeechEvidence = !segments.isEmpty
-            vadSegmentCount = segments.count
-            vadSpeechDurationMs = segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
-            samples = await detector.filterSamples(from: rawSamples)
-            let pct = String(format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
-            Task { await AppLogger.shared.log(
-                "WhisperKit VAD filtered to \(samples.count) samples (\(pct)% voiced)",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-        } else {
-            samples = rawSamples
-            // No VAD detector available -- default to true so empty ASR results
-            // still fire Sentry errors (fail toward visibility).
-            hasSpeechEvidence = true
-        }
-        let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
-
-        // VAD gate: if no speech was detected, skip ASR entirely.
-        // Prevents noise-induced hallucinations from ambient sounds.
-        if !hasSpeechEvidence {
-            if let worker = incrementalWorker {
-                await worker.cancel()
-                incrementalWorker = nil
-            }
-            SentryBreadcrumb.add(
-                stage: "asr", message: "VAD gate: no speech detected, skipping WhisperKit ASR",
-                level: .info,
-                data: [
-                    "backend": "whisperKit",
-                    "raw_sample_count": rawSamples.count,
-                    "peak_audio_level": peakAudioLevel,
-                ]
-            )
-            frozenSnapshot = nil
-            state = .idle
-            Task { await AppLogger.shared.log(
-                "VAD gate: no speech, skipping WhisperKit ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-            return
-        }
-
-        // Fallback: if VAD was too aggressive, use raw
-        let minimumSamples = AudioConstants.minimumTranscriptionSamples
-        if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
-            samples = rawSamples
-        }
-
-        // Pad short recordings
-        if samples.count > 0 && samples.count < minimumSamples {
-            samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
-        }
-
-        // Multilingual v1 (W2): detect language on voiced audio before transcribe.
-        // Heart protection: detector never throws; if it abstains, pass nil to
-        // TranscriptionOptions.language so WhisperKit's internal LID runs.
-        // languageMode is captured lazily so a user toggling Auto<->Locked
-        // mid-recording is respected.
-        let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
-        // nonisolated(unsafe): WhisperKit is an actor/reference-typed handle that is
-        // not Sendable. Safe to pass to the detector actor because the backend owns
-        // it for its lifetime and the detector only calls read-only detectLanguage.
-        nonisolated(unsafe) let kitForLID = await backend.whisperKitInstance
-        let lidResult = await languageDetector.detect(
-            samples: samples,
-            voicedDuration: voicedDurationSec,
-            whisperKit: kitForLID,
-            mode: languageMode
-        )
-        lastLanguageDetection = lidResult
-        // Multilingual v1 (W3): forward the detection to the polish step so the
-        // prompt planner can apply confidence-tiered, language-aware vocab
-        // injection. Heart-protected: the planner degrades gracefully when the
-        // detection is abstained or low-confidence.
-        llmPolishStep.languageDetection = lidResult
-        if let lang = lidResult.lang, !lidResult.abstained {
-            transcriptionOptions.language = lang
-        } else {
-            // Abstain: let WhisperKit's own LID run. Heart still completes.
-            transcriptionOptions.language = nil
-        }
-        Task { await AppLogger.shared.log(
-            "LID result: lang=\(lidResult.lang ?? "nil") tier=\(lidResult.tier) conf=\(String(format: "%.2f", lidResult.confidence)) margin=\(String(format: "%.2f", lidResult.margin)) voiced=\(String(format: "%.2f", lidResult.voicedDuration))s abstained=\(lidResult.abstained)",
+  // Multilingual v1 (W2): language mode + detector. Captured lazily at
+  // detection time so a user toggling Auto->Locked mid-recording is respected.
+  public var languageMode: LanguageMode = .auto {
+    didSet {
+      // Mid-recording changes to the language mode invalidate the
+      // incremental worker, which snapshots the decode language at its
+      // init. Rather than try to re-decode the worker's buffers with the
+      // new language, we drop the worker entirely so finalize falls back
+      // to batch decode with the post-change language.
+      if oldValue != languageMode, let worker = incrementalWorker {
+        incrementalWorker = nil
+        Task { await worker.cancel() }
+        Task {
+          await AppLogger.shared.log(
+            "Language mode changed mid-recording, incremental worker invalidated",
             level: .info, category: "WhisperKitPipeline"
-        ) }
-        SentryBreadcrumb.add(stage: "asr", message: "Language detected", data: [
-            "lang": lidResult.lang ?? "nil",
-            "tier": lidResult.tier.rawValue,
-            "confidence": String(format: "%.3f", lidResult.confidence),
-            "margin": String(format: "%.3f", lidResult.margin),
-            "voiced_s": String(format: "%.2f", lidResult.voicedDuration),
-            "abstained": lidResult.abstained,
-        ])
-
-        // Multilingual v1 (W6): emit language.detected for every LID call and
-        // language.lid_abstained when abstaining. Fire-and-forget; telemetry is a
-        // limb and must never block transcription.
-        let sessionPreferredSnapshot = await languageDetector.peekMemory().sessionPreferred
-        TelemetryService.shared.trackLanguageDetected(
-            lang: lidResult.lang,
-            confidence: lidResult.confidence,
-            margin: lidResult.margin,
-            voicedDuration: lidResult.voicedDuration,
-            abstained: lidResult.abstained,
-            sessionPreferredLang: sessionPreferredSnapshot,
-            usedSticky: lidResult.usedSessionPrior
-        )
-        if lidResult.abstained {
-            // Classify the abstain reason per spec § Telemetry table.
-            let reason: String
-            if lidResult.voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
-                reason = "too_short"
-            } else if lidResult.confidence < LanguageDetectorThresholds.normalProb {
-                reason = "low_confidence"
-            } else if lidResult.margin < LanguageDetectorThresholds.normalMargin {
-                reason = "narrow_margin"
-            } else {
-                reason = "low_confidence"
-            }
-            TelemetryService.shared.trackLIDAbstained(
-                voicedDuration: lidResult.voicedDuration,
-                top1Prob: lidResult.confidence,
-                top1Lang: lidResult.lang,
-                reason: reason
-            )
+          )
         }
+      }
+    }
+  }
+  private let languageDetector: LanguageDetector
+  /// Last detection result, exposed for telemetry and UI (passive chip).
+  public private(set) var lastLanguageDetection: LanguageDetectionResult?
 
-        state = .transcribing
-        SentryBreadcrumb.add(stage: "asr", message: "WhisperKit transcription started", data: ["backend": "whisperKit"])
+  // Shared services
+  private let transcriptFinalizer: TranscriptFinalizer
 
-        do {
-            let asrStart = CFAbsoluteTimeGetCurrent()
+  // Text processing steps (own instances — not shared with Parakeet)
+  public let wordCorrectionStep = WordCorrectionStep()
+  public let fillerRemovalStep = FillerRemovalStep()
+  public let llmPolishStep: LLMPolishStep
+  private var textProcessingSteps: [any TextProcessingStep] = []
 
-            // Try background worker result first, batch fallback if stale/empty
-            let asrText: String
-            let asrLanguage: String?
-            var usedIncremental = false
+  /// Access for configuration
+  public var wordCorrection: WordCorrectionStep { wordCorrectionStep }
+  public var fillerRemoval: FillerRemovalStep { fillerRemovalStep }
+  public var llmPolish: LLMPolishStep { llmPolishStep }
 
-            if let worker = incrementalWorker {
-                let segments = await silenceDetector?.speechSegments ?? []
-                let result = await worker.finalize(finalSamples: rawSamples, speechSegments: segments)
-                incrementalWorker = nil
+  /// The app that was frontmost when recording started.
+  private var targetApp: NSRunningApplication?
+  private var targetElement: AXUIElement?
+  private var recordingStartTime: Date?
+  /// Guards against concurrent stopAndTranscribe calls.
+  private var isStopping = false
+  /// Whether audio input has been pre-warmed by PTT key-down.
+  private var isPreWarmed = false
 
-                let coveragePct = rawSamples.count > 0
-                    ? String(format: "%.1f", Double(result.samplesCovered) / Double(rawSamples.count) * 100)
-                    : "0"
+  // VAD properties
+  public var vadAutoStop: Bool = false
+  public var vadSilenceTimeout: Double = 1.5
+  public var vadSensitivity: Float = 0.5
+  public var vadEnergyGate: Bool = false
 
-                if result.accepted, let text = result.text,
-                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    asrText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                    asrLanguage = transcriptionOptions.language
-                    usedIncremental = true
+  private var silenceDetector: SilenceDetector?
+  private var vadMonitorTask: Task<Void, Never>?
+  /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
+  private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
+  private var incrementalWorker: WhisperKitIncrementalWorker?
+  private var modelUnloadTask: Task<Void, Never>?
 
-                    Task { await AppLogger.shared.log(
-                        "WhisperKit finalize: strategy=\(result.strategy), mode=\(result.mode), " +
-                        "decodes=\(result.decodeCount), tailDecodeMs=\(result.tailDecodeMs), " +
-                        "coverage=\(result.samplesCovered)/\(rawSamples.count) (\(coveragePct)%)",
-                        level: .info, category: "WhisperKitPipeline"
-                    ) }
-                } else {
-                    Task { await AppLogger.shared.log(
-                        "WhisperKit finalize: strategy=\(result.strategy), " +
-                        "workerDecodes=\(result.decodeCount), workerCoverage=\(coveragePct)%, " +
-                        "falling back to batch",
-                        level: .info, category: "WhisperKitPipeline"
-                    ) }
+  public init(
+    audioCapture: any AudioCaptureInterface,
+    backend: WhisperKitBackend,
+    transcriptStore: TranscriptStore,
+    keychainManager: KeychainManager,
+    languageDetector: LanguageDetector = LanguageDetector()
+  ) {
+    self.audioCapture = audioCapture
+    self.backend = backend
+    self.keychainManager = keychainManager
+    self.languageDetector = languageDetector
+    self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
+    self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
+    // Explicit engine identity: prevents a future codepath that skips the
+    // language detector from silently falling through to the legacy
+    // English-centric prompt path. The planner reads `.whisperKit` + nil
+    // detection as low-confidence (formatting only, no lexical injection).
+    llmPolishStep.backend = .whisperKit
 
-                    let batchStart = CFAbsoluteTimeGetCurrent()
-                    let batchResult = try await backend.transcribe(audioSamples: samples, options: transcriptionOptions)
-                    let batchMs = Int((CFAbsoluteTimeGetCurrent() - batchStart) * 1000)
-                    asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                    asrLanguage = batchResult.language
-
-                    Task { await AppLogger.shared.log(
-                        "WhisperKit finalize: strategy=\(result.strategy), batchMs=\(batchMs), " +
-                        "workerDecodes=\(result.decodeCount), workerCoverage=\(coveragePct)%",
-                        level: .info, category: "WhisperKitPipeline"
-                    ) }
-                }
-            } else {
-                let batchResult = try await backend.transcribe(audioSamples: samples, options: transcriptionOptions)
-                asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                asrLanguage = batchResult.language
-            }
-
-            let asrEnd = CFAbsoluteTimeGetCurrent()
-
-            // Multilingual v1 (W6): per-transcription latency event for the
-            // per-language performance dashboard. Emitted only when we actually
-            // produced text (empty-result cases are covered by asr.completed +
-            // pipeline.failed elsewhere). Audio duration is derived from the raw
-            // capture buffer (16kHz mono) so latency is compared against actual
-            // recording length, not the VAD-trimmed slice.
-            let asrLatencySec = asrEnd - asrStart
-            let audioDurationSec = Double(rawSamples.count) / Double(AudioConstants.sampleRate)
-            if !asrText.isEmpty && audioDurationSec > 0 {
-                let msPerAudioSec = (asrLatencySec * 1000.0) / audioDurationSec
-                let modelName = await backend.modelVariantName
-                TelemetryService.shared.trackTranscriptionLatency(
-                    lang: asrLanguage,
-                    model: modelName,
-                    durationSeconds: asrLatencySec,
-                    msPerAudioSecond: msPerAudioSec
-                )
-            }
-
-            guard !asrText.isEmpty else {
-                if hasSpeechEvidence {
-                    // Real ASR failure: VAD detected speech but decoder returned nothing
-                    SentryBreadcrumb.captureError(
-                        NSError(domain: "EnviousWispr", code: -1, userInfo: [NSLocalizedDescriptionKey: "WhisperKit ASR returned empty text despite speech evidence"]),
-                        category: .asrEmptyResult, stage: "asr",
-                        extra: [
-                            "backend": "whisperKit",
-                            "incremental": usedIncremental,
-                            "has_speech_evidence": true,
-                            "raw_sample_count": rawSamples.count,
-                            "vad_segment_count": vadSegmentCount,
-                            "vad_speech_duration_ms": vadSpeechDurationMs,
-                            "peak_audio_level": peakAudioLevel,
-                        ],
-                        snapshot: frozenSnapshot
-                    )
-                    state = .error("Couldn't catch that -- try again")
-                    Task { await AppLogger.shared.log(
-                        "WhisperKit ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
-                        level: .info, category: "WhisperKitPipeline"
-                    ) }
-                } else {
-                    // Expected: user held button without speaking
-                    SentryBreadcrumb.add(
-                        stage: "asr", message: "WhisperKit ASR empty (no speech detected)",
-                        level: .info,
-                        data: ["backend": "whisperKit", "incremental": usedIncremental]
-                    )
-                    state = .idle
-                    Task { await AppLogger.shared.log(
-                        "WhisperKit: no speech detected, returning to idle",
-                        level: .info, category: "WhisperKitPipeline"
-                    ) }
-                }
-                frozenSnapshot = nil
-                return
-            }
-
-            SentryBreadcrumb.add(stage: "asr", message: "WhisperKit ASR completed", data: [
-                "duration_s": String(format: "%.3f", asrEnd - asrStart),
-                "char_count": asrText.count,
-                "incremental": usedIncremental,
-            ])
-            Task { await AppLogger.shared.log(
-                "WhisperKit ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s " +
-                "(\(asrText.count) chars, lang=\(asrLanguage ?? "?"), incremental=\(usedIncremental))",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-
-            // Post-ASR finalization: text processing -> store -> paste
-            let recordingDuration = Double(rawSamples.count) / 16000.0
-            let finalizationResult: FinalizationResult
-            do {
-                finalizationResult = try await transcriptFinalizer.finalize(FinalizationRequest(
-                    asrText: asrText,
-                    language: asrLanguage,
-                    duration: recordingDuration,
-                    processingTime: asrEnd - asrStart,
-                    backendType: .whisperKit,
-                    targetApp: targetApp,
-                    targetElement: targetElement,
-                    autoCopyToClipboard: autoCopyToClipboard,
-                    autoPasteToActiveApp: autoPasteToActiveApp,
-                    restoreClipboardAfterPaste: restoreClipboardAfterPaste,
-                    steps: textProcessingSteps
-                ))
-            } catch is CancellationError {
-                frozenSnapshot = nil
-                return
-            } catch let error as FinalizationError {
-                switch error {
-                case .emptyAfterProcessing:
-                    state = .error("No text after processing")
-                    frozenSnapshot = nil
-                    return
-                case .storageFailed(let underlying):
-                    SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
-                    state = .error("Failed to save transcript")
-                    frozenSnapshot = nil
-                    return
-                }
-            }
-
-            lastPolishError = finalizationResult.polishError
-
-            // Build metrics (pipeline-specific: uses ASR timing)
-            let pasteTargetApp = targetApp?.bundleIdentifier
-            targetApp = nil
-            targetElement = nil
-
-            let pipelineEnd = CFAbsoluteTimeGetCurrent()
-            let polishDuration = finalizationResult.polishDurationSeconds
-            let pasteDuration = finalizationResult.pasteDurationSeconds
-            Task { await AppLogger.shared.log(
-                "WhisperKit pipeline TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s " +
-                "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, " +
-                "polish=\(String(format: "%.3f", polishDuration))s, " +
-                "paste=\(String(format: "%.3f", pasteDuration))s)",
-                level: .info, category: "WhisperKitPipeline"
-            ) }
-
-            var transcript = finalizationResult.transcript
-            transcript.metrics = ExecutionMetrics(
-                asrLatencySeconds: asrEnd - asrStart,
-                llmLatencySeconds: polishDuration,
-                pasteTier: finalizationResult.pasteResult?.tier.rawValue,
-                pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
-                targetApp: pasteTargetApp,
-                coldStart: false,
-                streamingMode: false,
-                e2eSeconds: pipelineEnd - pipelineStart
-            )
-            currentTranscript = transcript
-            SentryBreadcrumb.add(stage: "pipeline", message: "WhisperKit pipeline complete", data: [
-                "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
-                "asr_s": String(format: "%.3f", asrEnd - asrStart),
-                "polish_s": String(format: "%.3f", polishDuration),
-                "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
-            ])
-            frozenSnapshot = nil
-            state = .complete
-            scheduleModelUnloadIfNeeded()
-        } catch {
-            SentryBreadcrumb.captureError(error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"], snapshot: frozenSnapshot)
-            frozenSnapshot = nil
-            state = .error("Transcription failed: \(error.localizedDescription)")
-        }
+    llmPolishStep.onWillProcess = { [weak self] in
+      self?.state = .polishing
     }
 
-    /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
-    /// Called by AppState's unified interruption handler, not set directly on audioCapture.
-    public func handleEngineInterruption() {
-        let snapshot = buildInterruptionSnapshot()
+    // Engine interruption cleanup is wired by AppState.onEngineInterrupted
+    // (unified handler that routes to the active pipeline). The pipeline exposes
+    // handleEngineInterruption() for AppState to call.
+
+    // Activate SSE streaming for Gemini
+    llmPolishStep.onToken = { _ in }
+    textProcessingSteps = [wordCorrectionStep, fillerRemovalStep, llmPolishStep]
+
+    // Issue #285 — telemetry callbacks on `audioCapture` are single-owner
+    // properties and both pipelines share the same instance. `AppState`
+    // centralizes routing to the active pipeline.
+  }
+
+  public func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
+    SentryBreadcrumb.captureError(
+      HeartPathError.captureSessionInterrupted(ctx: ctx),
+      category: .audioCaptureFailed,
+      stage: "audio",
+      extra: [
+        "capture_session.kind": ctx.kind.rawValue,
+        "capture_session.reason_code": ctx.reasonCode.map { $0 } ?? NSNull(),
+        "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
+        "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
+        "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
+        "capture_session.error_description": ctx.errorDescription ?? NSNull(),
+        "capture.is_actively_capturing": ctx.isActivelyCapturing,
+        "capture_session_id": Int(ctx.sessionID),
+        "backend": "whisperKit",
+      ]
+    )
+  }
+
+  // Issue #285 dedup — stall vs rawSamples-empty for a single session.
+  private var stallEventAlreadyCaptured: Bool = false
+  private var lastObservedCaptureSession: UInt64 = 0
+  private var xpcReplyFailedThisSession: Bool = false
+
+  public func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
+    resetStallFlagIfNewSession(ctx.sessionID)
+    xpcReplyFailedThisSession = true
+    SentryBreadcrumb.captureError(
+      HeartPathError.xpcReplyFailed(ctx: ctx),
+      category: .xpcServiceError,
+      stage: "audio",
+      extra: [
+        "xpc.reply_stage": ctx.replyStage,
+        "xpc.error_domain": ctx.errorDomain,
+        "xpc.error_code": ctx.errorCode,
+        "capture_session_id": Int(ctx.sessionID),
+      ]
+    )
+  }
+
+  public func handleCaptureStall(_ ctx: CaptureStallContext) {
+    resetStallFlagIfNewSession(ctx.sessionID)
+    guard !stallEventAlreadyCaptured else { return }
+    stallEventAlreadyCaptured = true
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.sourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: audioCapture.isActivelyCapturing,
+      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+      failureMode: "stall_window_elapsed",
+      stallContext: ctx
+    )
+    SentryBreadcrumb.captureError(
+      HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
+      category: .audioCaptureStalled,
+      stage: "recording",
+      extra: extras
+    )
+  }
+
+  private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
+    guard sessionID != lastObservedCaptureSession else { return }
+    lastObservedCaptureSession = sessionID
+    stallEventAlreadyCaptured = false
+    xpcReplyFailedThisSession = false
+  }
+
+  private func emitNoAudioCapturedEvent() {
+    let sessionID = audioCapture.currentCaptureSessionID
+    resetStallFlagIfNewSession(sessionID)
+    let durationMs: Int = {
+      guard let start = recordingStartTime else { return 0 }
+      return Int(Date().timeIntervalSince(start) * 1000)
+    }()
+    let route = audioCapture.currentAudioRoute
+    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
+      let dedupedFrom =
+        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
+      SentryBreadcrumb.add(
+        stage: "recording",
+        message: "No audio captured (WhisperKit, deduped)",
+        level: .warning,
+        data: [
+          "deduped_from": dedupedFrom,
+          "capture_session_id": Int(sessionID),
+        ]
+      )
+      return
+    }
+    SentryBreadcrumb.captureError(
+      HeartPathError.noAudioCaptured(
+        sessionID: sessionID, durationMs: durationMs, wasStreaming: false, route: route),
+      category: .audioCaptureFailed,
+      stage: "recording",
+      extra: SentryAudioExtras.buildCaptureExtras(
+        route: route,
+        sourceType: audioCapture.captureSourceType,
+        sessionID: sessionID,
+        isActivelyCapturing: audioCapture.isActivelyCapturing,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: "no_audio_captured"
+      )
+    )
+  }
+
+  // MARK: - DictationPipeline Conformance
+
+  public var overlayIntent: OverlayIntent {
+    switch state {
+    case .startingUp:
+      return .processing(label: "Starting...")
+    case .loadingModel:
+      return .processing(label: "Loading model...")
+    case .recording:
+      return .recording(audioLevel: 0)
+    case .transcribing:
+      return .processing(label: "Transcribing...")
+    case .polishing:
+      return .processing(label: "Polishing...")
+    case .idle, .ready, .complete:
+      return .hidden
+    case .error(let msg):
+      if msg == InterruptionMessages.micDisconnected {
+        return .interruption(message: msg)
+      }
+      return .error(message: msg)
+    }
+  }
+
+  public func handle(event: PipelineEvent) async {
+    switch event {
+    case .preWarm:
+      await preWarmAudioInput()
+    case .toggleRecording:
+      await toggleRecording()
+    case .requestStop:
+      await requestStop()
+    case .cancelRecording:
+      await cancelRecording()
+    case .reset:
+      reset()
+    }
+  }
+
+  // MARK: - Background Pre-load
+
+  /// Silently load the WhisperKit model into RAM without changing pipeline state.
+  /// Called after model download completes or on launch if model is already cached.
+  /// Uses prepareIfCached() to avoid triggering a silent network download.
+  /// If user presses record before this finishes, startRecording() handles it with its own .loadingModel flow.
+  public func prepareBackendSilently() async {
+    let isBackendReady = await backend.isReady
+    guard !isBackendReady else { return }
+    do {
+      let loaded = try await backend.prepareIfCached()
+      if loaded {
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit model pre-loaded successfully (background)",
+            level: .info, category: "WhisperKitPipeline"
+          )
+        }
+      } else {
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit model not cached, skipping silent pre-load",
+            level: .info, category: "WhisperKitPipeline"
+          )
+        }
+      }
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit model pre-load failed: \(error.localizedDescription)",
+          level: .info, category: "WhisperKitPipeline"
+        )
+      }
+    }
+  }
+
+  // MARK: - Recording Lifecycle
+
+  public func preWarmAudioInput() async {
+    guard !state.isActive, state != .recording else { return }
+    let start = ContinuousClock.now
+    await audioCapture.preWarm()
+    guard !Task.isCancelled else { return }
+    isPreWarmed = true
+    let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
+    Task {
+      await AppLogger.shared.log(
+        "COLD-START [WhisperKit] preWarmAudioInput total=\(totalMs)ms",
+        level: .info, category: "Pipeline"
+      )
+    }
+    // Defense-in-depth: ensure model is loaded from cache (no download).
+    // If not cached, startRecording() handles the full load with user-visible UI.
+    Task { _ = try? await backend.prepareIfCached() }
+  }
+
+  public func toggleRecording() async {
+    switch state {
+    case .idle, .ready, .complete, .error:
+      await startRecording()
+    case .recording:
+      await stopAndTranscribe()
+    case .loadingModel, .startingUp, .transcribing, .polishing:
+      break
+    }
+  }
+
+  /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
+  private var isStarting = false
+
+  public func startRecording() async {
+    guard !isStarting else { return }
+    guard !state.isActive || state == .complete || state == .ready else { return }
+    isStarting = true
+    defer { isStarting = false }
+
+    // Cancel any pending model unload — keep model loaded during recording.
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+
+    state = .startingUp
+    lastPolishError = nil
+    SentryBreadcrumb.add(stage: "whisperkit", message: "Pipeline starting up")
+
+    // Load model if not ready
+    let isBackendReady = await backend.isReady
+    guard state == .startingUp else { return }  // cancelled during await
+
+    if !isBackendReady {
+      state = .loadingModel
+      SentryBreadcrumb.add(stage: "asr", message: "WhisperKit model loading")
+      do {
+        try await backend.prepare()
+      } catch {
         SentryBreadcrumb.captureError(
-            NSError(domain: "EnviousWispr", code: -2, userInfo: [NSLocalizedDescriptionKey: "Audio engine interrupted (WhisperKit)"]),
-            category: .xpcServiceError, stage: "audio",
-            extra: ["was_recording": state == .recording, "backend": "whisperKit"],
-            snapshot: snapshot
+          error, category: .modelLoadFailed, stage: "asr", extra: ["backend": "whisperKit"])
+        state = .error("Model load failed: \(error.localizedDescription)")
+        return
+      }
+      guard state == .loadingModel else { return }  // cancelled during model load
+      state = .startingUp  // back to startingUp for engine setup
+    }
+
+    // Capture target app for paste-back
+    targetApp = NSWorkspace.shared.frontmostApplication
+    targetElement = PasteService.captureFocusedElement()
+
+    // No streaming buffer forwarding for batch mode
+    audioCapture.onBufferCaptured = nil
+
+    do {
+      if !isPreWarmed {
+        try await audioCapture.startEnginePhase()
+        let stabilized = await audioCapture.waitForFormatStabilization(
+          maxWait: 1.5,
+          pollInterval: 0.2
         )
-        SentryBreadcrumb.updateRecordingState(active: false)
-        frozenSnapshot = nil
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        silenceDetector = nil
-        // Reset capture state so isCapturing and warm engine timer are consistent.
-        Task { [weak self] in
-            _ = await self?.audioCapture.stopCapture()
+        guard state == .startingUp else { return }  // cancelled during stabilization
+        if !stabilized {
+          audioCapture.rebuildEngine()
+          try await audioCapture.startEnginePhase()
         }
-        targetApp = nil
-        targetElement = nil
-        recordingStartTime = nil
-        isStopping = false
+      }
+      isPreWarmed = false
+
+      _ = try await audioCapture.beginCapturePhase()
+      state = .recording
+      recordingStartTime = Date()
+      currentTranscript = nil
+      SentryBreadcrumb.add(
+        stage: "recording", message: "WhisperKit recording started", data: ["backend": "whisperKit"]
+      )
+      SentryBreadcrumb.updateRecordingState(active: true, backend: "whisperkit")
+      SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
+      startVADMonitoring()
+      // Multilingual v1: the incremental worker snapshots transcriptionOptions.language
+      // at recording start. In .auto mode, language is unknown until LID runs at
+      // recording stop, so the worker would decode with the stale/legacy language.
+      // Skip the worker in .auto mode; batch decode at finalize picks up the
+      // post-LID language. .locked mode is safe because the language is known upfront.
+      let workerEnabled: Bool
+      if case .locked = languageMode {
+        workerEnabled = true
+        await startIncrementalWorker()
+      } else {
+        workerEnabled = false
+      }
+
+      Task { [workerEnabled] in
+        await AppLogger.shared.log(
+          "WhisperKit recording started (batch mode, incremental worker: \(workerEnabled ? "on" : "off, auto language mode"))",
+          level: .info, category: "WhisperKitPipeline"
+        )
+      }
+    } catch {
+      var extras = SentryAudioExtras.buildCaptureExtras(
+        route: audioCapture.currentAudioRoute,
+        sourceType: audioCapture.captureSourceType,
+        sessionID: audioCapture.currentCaptureSessionID,
+        isActivelyCapturing: audioCapture.isActivelyCapturing,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: "thrown_start"
+      )
+      extras["backend"] = "whisperKit"
+      SentryBreadcrumb.captureError(
+        error, category: .audioCaptureFailed, stage: "recording", extra: extras)
+      state = .error("Recording failed: \(error.localizedDescription)")
+    }
+  }
+
+  public func requestStop() async {
+    switch state {
+    case .recording:
+      await stopAndTranscribe()
+    case .startingUp, .loadingModel:
+      // Clean abort — startRecording() checks state after each await suspension point.
+      state = .idle
+    case .idle, .ready, .complete, .error:
+      // PTT release before recording started — clean up pre-warmed audio engine
+      if isPreWarmed {
         isPreWarmed = false
-        state = .error("Microphone disconnected")
+        audioCapture.abortPreWarm()
+      }
+    case .transcribing, .polishing:
+      // Pipeline is past the point of no return — ignore.
+      break
     }
+  }
 
-    /// Handle ASR XPC service crash during active session.
-    /// Called by AppState's unified ASR interruption handler when this pipeline is active.
-    /// Must stop audio capture (still running — only ASR died) and clean up fully.
-    public func handleASRServiceInterruption() {
-        let snapshot = buildInterruptionSnapshot()
-        SentryBreadcrumb.captureError(
-            NSError(domain: "EnviousWispr", code: -3, userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed (WhisperKit)"]),
-            category: .xpcServiceError, stage: "asr",
-            extra: ["was_recording": state == .recording, "backend": "whisperKit"],
-            snapshot: snapshot
-        )
-        SentryBreadcrumb.updateRecordingState(active: false)
-        frozenSnapshot = nil
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        silenceDetector = nil
-        Task { [weak self] in
-            await self?.audioCapture.stopCapture()
-        }
-        targetApp = nil
-        targetElement = nil
-        recordingStartTime = nil
-        isStopping = false
-        isPreWarmed = false
-        state = .error("Transcription service crashed — please try again")
-    }
+  public func stopAndTranscribe() async {
+    guard state == .recording, !isStopping else { return }
+    isStopping = true
+    defer { isStopping = false }
 
-    private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
-        if let existing = frozenSnapshot { return existing }
-        let start = recordingStartTime ?? Date()
-        return SentryBreadcrumb.RecordingSnapshot(
-            backend: "whisperkit",
-            audioRoute: audioCapture.currentAudioRoute,
-            wasStreaming: false,
-            startTime: start,
-            durationMs: Int(Date().timeIntervalSince(start) * 1000),
-            targetAppBundleID: targetApp?.bundleIdentifier
-        )
-    }
+    let pipelineStart = CFAbsoluteTimeGetCurrent()
 
-    public func cancelRecording() async {
-        if state == .startingUp || state == .loadingModel {
-            // Cancel during startup or model load — transition to idle
-            state = .idle
-            return
-        }
-
-        guard state == .recording else { return }
+    // Discard accidental short recordings
+    if let startTime = recordingStartTime {
+      let elapsed = Date().timeIntervalSince(startTime)
+      if elapsed < TimingConstants.minimumRecordingDuration {
         vadMonitorTask?.cancel()
         vadMonitorTask = nil
         await incrementalWorker?.cancel()
         incrementalWorker = nil
-        silenceDetector = nil
         _ = await audioCapture.stopCapture()
-        targetApp = nil
-        targetElement = nil
         recordingStartTime = nil
         state = .idle
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit recording too short (\(String(format: "%.2f", elapsed))s), discarded",
+            level: .info, category: "WhisperKitPipeline"
+          )
+        }
+        return
+      }
+    }
+    // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
+    let snapshotStartTime = recordingStartTime ?? Date()
+    let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
+    frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
+      backend: "whisperkit",
+      audioRoute: audioCapture.currentAudioRoute,
+      wasStreaming: false,
+      startTime: snapshotStartTime,
+      durationMs: durationMs,
+      targetAppBundleID: targetApp?.bundleIdentifier
+    )
+
+    recordingStartTime = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+
+    let captureResult = await audioCapture.stopCapture()
+    let rawSamples = captureResult.samples
+    SentryBreadcrumb.add(
+      stage: "recording", message: "WhisperKit recording stopped",
+      data: ["sample_count": rawSamples.count])
+    SentryBreadcrumb.updateRecordingState(active: false)
+
+    // Pre-warm LLM connection while ASR runs
+    LLMNetworkSession.shared.preWarmIfConfigured(
+      provider: llmPolishStep.llmProvider,
+      keychainManager: keychainManager
+    )
+
+    guard !rawSamples.isEmpty else {
+      emitNoAudioCapturedEvent()
+      state = .error("No audio captured")
+      return
     }
 
-    public func reset() {
-        vadMonitorTask?.cancel()
-        vadMonitorTask = nil
-        // Fire-and-forget cancel — reset() is synchronous, worker cancel is safe to defer
-        if let worker = incrementalWorker {
-            incrementalWorker = nil
-            Task { await worker.cancel() }
+    // Post-capture VAD filtering — remove silence segments
+    var samples: [Float]
+    var hasSpeechEvidence = false
+    var vadSegmentCount = 0
+    var vadSpeechDurationMs = 0
+    let isXPCMode = audioCapture is AudioCaptureProxy
+    if isXPCMode {
+      // XPC mode: VAD segments returned atomically with samples from stopCapture() (#226).
+      let segments = captureResult.vadSegments
+      hasSpeechEvidence = !segments.isEmpty
+      vadSegmentCount = segments.count
+      vadSpeechDurationMs =
+        segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
+      if !segments.isEmpty {
+        samples = SampleFilter.filter(from: rawSamples, segments: segments)
+        let pct = String(
+          format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit VAD (XPC) filtered to \(samples.count) samples (\(pct)% voiced)",
+            level: .info, category: "WhisperKitPipeline"
+          )
         }
-        silenceDetector = nil
-        if audioCapture.isCapturing {
-            let capture = audioCapture
-            Task { _ = await capture.stopCapture() }
-        }
-        audioCapture.onBufferCaptured = nil
-        recordingStartTime = nil
-        state = .idle
-        currentTranscript = nil
-    }
-
-    // MARK: - Incremental Worker
-
-    private func startIncrementalWorker() async {
-        guard let kit = await backend.whisperKitInstance else { return }
-        let opts = await backend.makeDecodeOptions(from: transcriptionOptions, sampleCount: 0)
-        // BRAIN: gotcha id=nonisolated-unsafe-tokenizer
-        // nonisolated(unsafe): WhisperTokenizer is not Sendable but is safe to transfer —
-        // the backend is the sole owner and we pass it to a single actor that holds it for its lifetime.
-        nonisolated(unsafe) let tokenizer = await backend.whisperKitTokenizer
-        let worker = WhisperKitIncrementalWorker(whisperKit: kit, decodingOptions: opts, tokenizer: tokenizer)
-        self.incrementalWorker = worker
-
-        let isXPCMode = audioCapture is AudioCaptureProxy
-        let capture = audioCapture
-
-        if isXPCMode {
-            // XPC mode: use getSamplesSnapshot for incremental sample access.
-            // Tracks fromIndex locally — each call fetches only new samples since last snapshot.
-            //
-            // Memory: `accumulated` grows linearly with recording duration, mirroring the
-            // in-process path where capturedSamples grows the same way. The worker expects
-            // full audio history for re-transcription. At 16kHz Float32, 2 min = ~7.7MB,
-            // 5 min (max recording) = ~19MB. Bounded by TimingConstants.maxRecordingDuration.
-            var nextIndex = 0
-            var accumulated: [Float] = []
-            await worker.start(audioSamplesProvider: { @MainActor in
-                let (newSamples, totalCount) = await capture.getSamplesSnapshot(fromIndex: nextIndex)
-                accumulated.append(contentsOf: newSamples)
-                nextIndex = totalCount
-                return (samples: accumulated, count: accumulated.count)
-            })
-        } else {
-            // In-process mode: read directly from MainActor-isolated capturedSamples.
-            await worker.start(audioSamplesProvider: { @MainActor in
-                let samples = capture.capturedSamples
-                return (samples: samples, count: samples.count)
-            })
-        }
-    }
-
-    // MARK: - VAD Monitoring
-
-    private func startVADMonitoring() {
-        vadMonitorTask = Task { [weak self] in
-            await self?.monitorVAD()
-        }
-    }
-
-    private func monitorVAD() async {
-        // Detector setup stays in pipeline (owns silenceDetector lifecycle)
-        let isXPCMode = audioCapture is AudioCaptureProxy
-        var detector: SilenceDetector?
-
-        if !isXPCMode {
-            let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
-            if silenceDetector == nil {
-                silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
-            }
-            guard let det = silenceDetector else { return }
-            await det.reset()
-            await det.updateConfig(config)
-            if !(await det.isReady) {
-                do {
-                    try await det.prepare()
-                } catch {
-                    Task { await AppLogger.shared.log(
-                        "VAD preparation failed: \(error)",
-                        level: .info, category: "VAD"
-                    ) }
-                    return
-                }
-            }
-            detector = det
-        }
-
-        let startTime = recordingStartTime ?? Date()
-        let capture = audioCapture
-
-        await VADMonitorLoop.run(
-            detector: detector,
-            vadAutoStop: vadAutoStop,
-            maxDuration: TimingConstants.maxRecordingDuration,
-            recordingStartTime: startTime,
-            sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
-            isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
-            onStop: { [weak self] _ in
-                Task { [weak self] in await self?.stopAndTranscribe() }
-            }
+      } else {
+        samples = rawSamples
+      }
+    } else if let detector = silenceDetector {
+      await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+      let segments = await detector.speechSegments
+      hasSpeechEvidence = !segments.isEmpty
+      vadSegmentCount = segments.count
+      vadSpeechDurationMs =
+        segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
+      samples = await detector.filterSamples(from: rawSamples)
+      let pct = String(
+        format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit VAD filtered to \(samples.count) samples (\(pct)% voiced)",
+          level: .info, category: "WhisperKitPipeline"
         )
+      }
+    } else {
+      samples = rawSamples
+      // No VAD detector available -- default to true so empty ASR results
+      // still fire Sentry errors (fail toward visibility).
+      hasSpeechEvidence = true
+    }
+    let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
+
+    // VAD gate: if no speech was detected, skip ASR entirely.
+    // Prevents noise-induced hallucinations from ambient sounds.
+    if !hasSpeechEvidence {
+      if let worker = incrementalWorker {
+        await worker.cancel()
+        incrementalWorker = nil
+      }
+      SentryBreadcrumb.add(
+        stage: "asr", message: "VAD gate: no speech detected, skipping WhisperKit ASR",
+        level: .info,
+        data: [
+          "backend": "whisperKit",
+          "raw_sample_count": rawSamples.count,
+          "peak_audio_level": peakAudioLevel,
+        ]
+      )
+      frozenSnapshot = nil
+      state = .idle
+      Task {
+        await AppLogger.shared.log(
+          "VAD gate: no speech, skipping WhisperKit ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
+          level: .info, category: "WhisperKitPipeline"
+        )
+      }
+      return
     }
 
+    // Fallback: if VAD was too aggressive, use raw
+    let minimumSamples = AudioConstants.minimumTranscriptionSamples
+    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
+      samples = rawSamples
+    }
 
-    // MARK: - Model Lifecycle
+    // Pad short recordings
+    if samples.count > 0 && samples.count < minimumSamples {
+      samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
+    }
 
-    private func scheduleModelUnloadIfNeeded() {
-        modelUnloadTask?.cancel()
-        modelUnloadTask = nil
+    // Multilingual v1 (W2): detect language on voiced audio before transcribe.
+    // Heart protection: detector never throws; if it abstains, pass nil to
+    // TranscriptionOptions.language so WhisperKit's internal LID runs.
+    // languageMode is captured lazily so a user toggling Auto<->Locked
+    // mid-recording is respected.
+    let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
+    // nonisolated(unsafe): WhisperKit is an actor/reference-typed handle that is
+    // not Sendable. Safe to pass to the detector actor because the backend owns
+    // it for its lifetime and the detector only calls read-only detectLanguage.
+    nonisolated(unsafe) let kitForLID = await backend.whisperKitInstance
+    let lidResult = await languageDetector.detect(
+      samples: samples,
+      voicedDuration: voicedDurationSec,
+      whisperKit: kitForLID,
+      mode: languageMode
+    )
+    lastLanguageDetection = lidResult
+    // Multilingual v1 (W3): forward the detection to the polish step so the
+    // prompt planner can apply confidence-tiered, language-aware vocab
+    // injection. Heart-protected: the planner degrades gracefully when the
+    // detection is abstained or low-confidence.
+    llmPolishStep.languageDetection = lidResult
+    if let lang = lidResult.lang, !lidResult.abstained {
+      transcriptionOptions.language = lang
+    } else {
+      // Abstain: let WhisperKit's own LID run. Heart still completes.
+      transcriptionOptions.language = nil
+    }
+    Task {
+      await AppLogger.shared.log(
+        "LID result: lang=\(lidResult.lang ?? "nil") tier=\(lidResult.tier) conf=\(String(format: "%.2f", lidResult.confidence)) margin=\(String(format: "%.2f", lidResult.margin)) voiced=\(String(format: "%.2f", lidResult.voicedDuration))s abstained=\(lidResult.abstained)",
+        level: .info, category: "WhisperKitPipeline"
+      )
+    }
+    SentryBreadcrumb.add(
+      stage: "asr", message: "Language detected",
+      data: [
+        "lang": lidResult.lang ?? "nil",
+        "tier": lidResult.tier.rawValue,
+        "confidence": String(format: "%.3f", lidResult.confidence),
+        "margin": String(format: "%.3f", lidResult.margin),
+        "voiced_s": String(format: "%.2f", lidResult.voicedDuration),
+        "abstained": lidResult.abstained,
+      ])
 
-        switch modelUnloadPolicy {
-        case .never:
-            return
-        case .immediately:
-            modelUnloadTask = Task { [weak self] in
-                await self?.backend.unload()
-            }
-        default:
-            guard let interval = modelUnloadPolicy.interval else { return }
-            modelUnloadTask = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(interval))
-                guard !Task.isCancelled else { return }
-                await self?.backend.unload()
-            }
+    // Multilingual v1 (W6): emit language.detected for every LID call and
+    // language.lid_abstained when abstaining. Fire-and-forget; telemetry is a
+    // limb and must never block transcription.
+    let sessionPreferredSnapshot = await languageDetector.peekMemory().sessionPreferred
+    TelemetryService.shared.trackLanguageDetected(
+      lang: lidResult.lang,
+      confidence: lidResult.confidence,
+      margin: lidResult.margin,
+      voicedDuration: lidResult.voicedDuration,
+      abstained: lidResult.abstained,
+      sessionPreferredLang: sessionPreferredSnapshot,
+      usedSticky: lidResult.usedSessionPrior
+    )
+    if lidResult.abstained {
+      // Classify the abstain reason per spec § Telemetry table.
+      let reason: String
+      if lidResult.voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
+        reason = "too_short"
+      } else if lidResult.confidence < LanguageDetectorThresholds.normalProb {
+        reason = "low_confidence"
+      } else if lidResult.margin < LanguageDetectorThresholds.normalMargin {
+        reason = "narrow_margin"
+      } else {
+        reason = "low_confidence"
+      }
+      TelemetryService.shared.trackLIDAbstained(
+        voicedDuration: lidResult.voicedDuration,
+        top1Prob: lidResult.confidence,
+        top1Lang: lidResult.lang,
+        reason: reason
+      )
+    }
+
+    state = .transcribing
+    SentryBreadcrumb.add(
+      stage: "asr", message: "WhisperKit transcription started", data: ["backend": "whisperKit"])
+
+    do {
+      let asrStart = CFAbsoluteTimeGetCurrent()
+
+      // Try background worker result first, batch fallback if stale/empty
+      let asrText: String
+      let asrLanguage: String?
+      var usedIncremental = false
+
+      if let worker = incrementalWorker {
+        let segments = await silenceDetector?.speechSegments ?? []
+        let result = await worker.finalize(finalSamples: rawSamples, speechSegments: segments)
+        incrementalWorker = nil
+
+        let coveragePct =
+          rawSamples.count > 0
+          ? String(format: "%.1f", Double(result.samplesCovered) / Double(rawSamples.count) * 100)
+          : "0"
+
+        if result.accepted, let text = result.text,
+          !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+          asrText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+          asrLanguage = transcriptionOptions.language
+          usedIncremental = true
+
+          Task {
+            await AppLogger.shared.log(
+              "WhisperKit finalize: strategy=\(result.strategy), mode=\(result.mode), "
+                + "decodes=\(result.decodeCount), tailDecodeMs=\(result.tailDecodeMs), "
+                + "coverage=\(result.samplesCovered)/\(rawSamples.count) (\(coveragePct)%)",
+              level: .info, category: "WhisperKitPipeline"
+            )
+          }
+        } else {
+          Task {
+            await AppLogger.shared.log(
+              "WhisperKit finalize: strategy=\(result.strategy), "
+                + "workerDecodes=\(result.decodeCount), workerCoverage=\(coveragePct)%, "
+                + "falling back to batch",
+              level: .info, category: "WhisperKitPipeline"
+            )
+          }
+
+          let batchStart = CFAbsoluteTimeGetCurrent()
+          let batchResult = try await backend.transcribe(
+            audioSamples: samples, options: transcriptionOptions)
+          let batchMs = Int((CFAbsoluteTimeGetCurrent() - batchStart) * 1000)
+          asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+          asrLanguage = batchResult.language
+
+          Task {
+            await AppLogger.shared.log(
+              "WhisperKit finalize: strategy=\(result.strategy), batchMs=\(batchMs), "
+                + "workerDecodes=\(result.decodeCount), workerCoverage=\(coveragePct)%",
+              level: .info, category: "WhisperKitPipeline"
+            )
+          }
         }
+      } else {
+        let batchResult = try await backend.transcribe(
+          audioSamples: samples, options: transcriptionOptions)
+        asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        asrLanguage = batchResult.language
+      }
+
+      let asrEnd = CFAbsoluteTimeGetCurrent()
+
+      // Multilingual v1 (W6): per-transcription latency event for the
+      // per-language performance dashboard. Emitted only when we actually
+      // produced text (empty-result cases are covered by asr.completed +
+      // pipeline.failed elsewhere). Audio duration is derived from the raw
+      // capture buffer (16kHz mono) so latency is compared against actual
+      // recording length, not the VAD-trimmed slice.
+      let asrLatencySec = asrEnd - asrStart
+      let audioDurationSec = Double(rawSamples.count) / Double(AudioConstants.sampleRate)
+      if !asrText.isEmpty && audioDurationSec > 0 {
+        let msPerAudioSec = (asrLatencySec * 1000.0) / audioDurationSec
+        let modelName = await backend.modelVariantName
+        TelemetryService.shared.trackTranscriptionLatency(
+          lang: asrLanguage,
+          model: modelName,
+          durationSeconds: asrLatencySec,
+          msPerAudioSecond: msPerAudioSec
+        )
+      }
+
+      guard !asrText.isEmpty else {
+        if hasSpeechEvidence {
+          // Real ASR failure: VAD detected speech but decoder returned nothing
+          SentryBreadcrumb.captureError(
+            NSError(
+              domain: "EnviousWispr", code: -1,
+              userInfo: [
+                NSLocalizedDescriptionKey:
+                  "WhisperKit ASR returned empty text despite speech evidence"
+              ]),
+            category: .asrEmptyResult, stage: "asr",
+            extra: [
+              "backend": "whisperKit",
+              "incremental": usedIncremental,
+              "has_speech_evidence": true,
+              "raw_sample_count": rawSamples.count,
+              "vad_segment_count": vadSegmentCount,
+              "vad_speech_duration_ms": vadSpeechDurationMs,
+              "peak_audio_level": peakAudioLevel,
+            ],
+            snapshot: frozenSnapshot
+          )
+          state = .error("Couldn't catch that -- try again")
+          Task {
+            await AppLogger.shared.log(
+              "WhisperKit ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
+              level: .info, category: "WhisperKitPipeline"
+            )
+          }
+        } else {
+          // Expected: user held button without speaking
+          SentryBreadcrumb.add(
+            stage: "asr", message: "WhisperKit ASR empty (no speech detected)",
+            level: .info,
+            data: ["backend": "whisperKit", "incremental": usedIncremental]
+          )
+          state = .idle
+          Task {
+            await AppLogger.shared.log(
+              "WhisperKit: no speech detected, returning to idle",
+              level: .info, category: "WhisperKitPipeline"
+            )
+          }
+        }
+        frozenSnapshot = nil
+        return
+      }
+
+      SentryBreadcrumb.add(
+        stage: "asr", message: "WhisperKit ASR completed",
+        data: [
+          "duration_s": String(format: "%.3f", asrEnd - asrStart),
+          "char_count": asrText.count,
+          "incremental": usedIncremental,
+        ])
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s "
+            + "(\(asrText.count) chars, lang=\(asrLanguage ?? "?"), incremental=\(usedIncremental))",
+          level: .info, category: "WhisperKitPipeline"
+        )
+      }
+
+      // Post-ASR finalization: text processing -> store -> paste
+      let recordingDuration = Double(rawSamples.count) / 16000.0
+      let finalizationResult: FinalizationResult
+      do {
+        finalizationResult = try await transcriptFinalizer.finalize(
+          FinalizationRequest(
+            asrText: asrText,
+            language: asrLanguage,
+            duration: recordingDuration,
+            processingTime: asrEnd - asrStart,
+            backendType: .whisperKit,
+            targetApp: targetApp,
+            targetElement: targetElement,
+            autoCopyToClipboard: autoCopyToClipboard,
+            autoPasteToActiveApp: autoPasteToActiveApp,
+            restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+            steps: textProcessingSteps
+          ))
+      } catch is CancellationError {
+        frozenSnapshot = nil
+        return
+      } catch let error as FinalizationError {
+        switch error {
+        case .emptyAfterProcessing:
+          SentryBreadcrumb.captureError(
+            HeartPathError.emptyAfterProcessing(
+              route: audioCapture.currentAudioRoute,
+              wasPolishEnabled: llmPolishStep.isEnabled
+            ),
+            category: .heartPathFinalization,
+            stage: "processing",
+            extra: [
+              "capture.route": audioCapture.currentAudioRoute,
+              "polish.enabled": llmPolishStep.isEnabled,
+              "backend": "whisperKit",
+              "capture_session_id": Int(audioCapture.currentCaptureSessionID),
+            ]
+          )
+          state = .error("No text after processing")
+          frozenSnapshot = nil
+          return
+        case .storageFailed(let underlying):
+          SentryBreadcrumb.captureError(underlying, category: .asrFailed, stage: "storage")
+          state = .error("Failed to save transcript")
+          frozenSnapshot = nil
+          return
+        }
+      }
+
+      lastPolishError = finalizationResult.polishError
+
+      // Build metrics (pipeline-specific: uses ASR timing)
+      let pasteTargetApp = targetApp?.bundleIdentifier
+      targetApp = nil
+      targetElement = nil
+
+      let pipelineEnd = CFAbsoluteTimeGetCurrent()
+      let polishDuration = finalizationResult.polishDurationSeconds
+      let pasteDuration = finalizationResult.pasteDurationSeconds
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit pipeline TOTAL: \(String(format: "%.3f", pipelineEnd - pipelineStart))s "
+            + "(ASR=\(String(format: "%.3f", asrEnd - asrStart))s, "
+            + "polish=\(String(format: "%.3f", polishDuration))s, "
+            + "paste=\(String(format: "%.3f", pasteDuration))s)",
+          level: .info, category: "WhisperKitPipeline"
+        )
+      }
+
+      var transcript = finalizationResult.transcript
+      transcript.metrics = ExecutionMetrics(
+        asrLatencySeconds: asrEnd - asrStart,
+        llmLatencySeconds: polishDuration,
+        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+        pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
+        targetApp: pasteTargetApp,
+        coldStart: false,
+        streamingMode: false,
+        e2eSeconds: pipelineEnd - pipelineStart
+      )
+      currentTranscript = transcript
+      SentryBreadcrumb.add(
+        stage: "pipeline", message: "WhisperKit pipeline complete",
+        data: [
+          "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
+          "asr_s": String(format: "%.3f", asrEnd - asrStart),
+          "polish_s": String(format: "%.3f", polishDuration),
+          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+        ])
+      frozenSnapshot = nil
+      state = .complete
+      scheduleModelUnloadIfNeeded()
+    } catch {
+      SentryBreadcrumb.captureError(
+        error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"],
+        snapshot: frozenSnapshot)
+      frozenSnapshot = nil
+      state = .error("Transcription failed: \(error.localizedDescription)")
     }
+  }
+
+  /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
+  /// Called by AppState's unified interruption handler, not set directly on audioCapture.
+  public func handleEngineInterruption() {
+    // Issue #285 — Sentry emission for audio/XPC interruptions is owned by
+    // AppState.onXPCServiceError (single-owner per plan §3.4a). Control-flow
+    // cleanup only.
+    SentryBreadcrumb.updateRecordingState(active: false)
+    frozenSnapshot = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    silenceDetector = nil
+    // Reset capture state so isCapturing and warm engine timer are consistent.
+    Task { [weak self] in
+      _ = await self?.audioCapture.stopCapture()
+    }
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+    isStopping = false
+    isPreWarmed = false
+    state = .error("Microphone disconnected")
+  }
+
+  /// Handle ASR XPC service crash during active session.
+  /// Called by AppState's unified ASR interruption handler when this pipeline is active.
+  /// Must stop audio capture (still running — only ASR died) and clean up fully.
+  public func handleASRServiceInterruption() {
+    let snapshot = buildInterruptionSnapshot()
+    SentryBreadcrumb.captureError(
+      NSError(
+        domain: "EnviousWispr", code: -3,
+        userInfo: [NSLocalizedDescriptionKey: "ASR XPC service crashed (WhisperKit)"]),
+      category: .xpcServiceError, stage: "asr",
+      extra: ["was_recording": state == .recording, "backend": "whisperKit"],
+      snapshot: snapshot
+    )
+    SentryBreadcrumb.updateRecordingState(active: false)
+    frozenSnapshot = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    silenceDetector = nil
+    Task { [weak self] in
+      await self?.audioCapture.stopCapture()
+    }
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+    isStopping = false
+    isPreWarmed = false
+    state = .error("Transcription service crashed — please try again")
+  }
+
+  private func buildInterruptionSnapshot() -> SentryBreadcrumb.RecordingSnapshot {
+    if let existing = frozenSnapshot { return existing }
+    let start = recordingStartTime ?? Date()
+    return SentryBreadcrumb.RecordingSnapshot(
+      backend: "whisperkit",
+      audioRoute: audioCapture.currentAudioRoute,
+      wasStreaming: false,
+      startTime: start,
+      durationMs: Int(Date().timeIntervalSince(start) * 1000),
+      targetAppBundleID: targetApp?.bundleIdentifier
+    )
+  }
+
+  public func cancelRecording() async {
+    if state == .startingUp || state == .loadingModel {
+      // Cancel during startup or model load — transition to idle
+      state = .idle
+      return
+    }
+
+    guard state == .recording else { return }
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    await incrementalWorker?.cancel()
+    incrementalWorker = nil
+    silenceDetector = nil
+    _ = await audioCapture.stopCapture()
+    targetApp = nil
+    targetElement = nil
+    recordingStartTime = nil
+    state = .idle
+  }
+
+  public func reset() {
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    // Fire-and-forget cancel — reset() is synchronous, worker cancel is safe to defer
+    if let worker = incrementalWorker {
+      incrementalWorker = nil
+      Task { await worker.cancel() }
+    }
+    silenceDetector = nil
+    if audioCapture.isCapturing {
+      let capture = audioCapture
+      Task { _ = await capture.stopCapture() }
+    }
+    audioCapture.onBufferCaptured = nil
+    recordingStartTime = nil
+    state = .idle
+    currentTranscript = nil
+  }
+
+  // MARK: - Incremental Worker
+
+  private func startIncrementalWorker() async {
+    guard let kit = await backend.whisperKitInstance else { return }
+    let opts = await backend.makeDecodeOptions(from: transcriptionOptions, sampleCount: 0)
+    // BRAIN: gotcha id=nonisolated-unsafe-tokenizer
+    // nonisolated(unsafe): WhisperTokenizer is not Sendable but is safe to transfer —
+    // the backend is the sole owner and we pass it to a single actor that holds it for its lifetime.
+    nonisolated(unsafe) let tokenizer = await backend.whisperKitTokenizer
+    let worker = WhisperKitIncrementalWorker(
+      whisperKit: kit, decodingOptions: opts, tokenizer: tokenizer)
+    self.incrementalWorker = worker
+
+    let isXPCMode = audioCapture is AudioCaptureProxy
+    let capture = audioCapture
+
+    if isXPCMode {
+      // XPC mode: use getSamplesSnapshot for incremental sample access.
+      // Tracks fromIndex locally — each call fetches only new samples since last snapshot.
+      //
+      // Memory: `accumulated` grows linearly with recording duration, mirroring the
+      // in-process path where capturedSamples grows the same way. The worker expects
+      // full audio history for re-transcription. At 16kHz Float32, 2 min = ~7.7MB,
+      // 5 min (max recording) = ~19MB. Bounded by TimingConstants.maxRecordingDuration.
+      var nextIndex = 0
+      var accumulated: [Float] = []
+      await worker.start(audioSamplesProvider: { @MainActor in
+        let (newSamples, totalCount) = await capture.getSamplesSnapshot(fromIndex: nextIndex)
+        accumulated.append(contentsOf: newSamples)
+        nextIndex = totalCount
+        return (samples: accumulated, count: accumulated.count)
+      })
+    } else {
+      // In-process mode: read directly from MainActor-isolated capturedSamples.
+      await worker.start(audioSamplesProvider: { @MainActor in
+        let samples = capture.capturedSamples
+        return (samples: samples, count: samples.count)
+      })
+    }
+  }
+
+  // MARK: - VAD Monitoring
+
+  private func startVADMonitoring() {
+    vadMonitorTask = Task { [weak self] in
+      await self?.monitorVAD()
+    }
+  }
+
+  private func monitorVAD() async {
+    // Detector setup stays in pipeline (owns silenceDetector lifecycle)
+    let isXPCMode = audioCapture is AudioCaptureProxy
+    var detector: SilenceDetector?
+
+    if !isXPCMode {
+      let config = SmoothedVADConfig.fromSensitivity(vadSensitivity, energyGate: vadEnergyGate)
+      if silenceDetector == nil {
+        silenceDetector = SilenceDetector(silenceTimeout: vadSilenceTimeout, vadConfig: config)
+      }
+      guard let det = silenceDetector else { return }
+      await det.reset()
+      await det.updateConfig(config)
+      if !(await det.isReady) {
+        do {
+          try await det.prepare()
+        } catch {
+          Task {
+            await AppLogger.shared.log(
+              "VAD preparation failed: \(error)",
+              level: .info, category: "VAD"
+            )
+          }
+          return
+        }
+      }
+      detector = det
+    }
+
+    let startTime = recordingStartTime ?? Date()
+    let capture = audioCapture
+
+    await VADMonitorLoop.run(
+      detector: detector,
+      vadAutoStop: vadAutoStop,
+      maxDuration: TimingConstants.maxRecordingDuration,
+      recordingStartTime: startTime,
+      sampleProvider: { [weak capture] in capture?.capturedSamples ?? [] },
+      isRecording: { [weak self] in self?.state == .recording && !(self?.isStopping ?? true) },
+      onStop: { [weak self] _ in
+        Task { [weak self] in await self?.stopAndTranscribe() }
+      }
+    )
+  }
+
+  // MARK: - Model Lifecycle
+
+  private func scheduleModelUnloadIfNeeded() {
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+
+    switch modelUnloadPolicy {
+    case .never:
+      return
+    case .immediately:
+      modelUnloadTask = Task { [weak self] in
+        await self?.backend.unload()
+      }
+    default:
+      guard let interval = modelUnloadPolicy.interval else { return }
+      modelUnloadTask = Task { [weak self] in
+        try? await Task.sleep(for: .seconds(interval))
+        guard !Task.isCancelled else { return }
+        await self?.backend.unload()
+      }
+    }
+  }
 
 }

--- a/Sources/EnviousWisprServices/HeartPathError.swift
+++ b/Sources/EnviousWisprServices/HeartPathError.swift
@@ -1,0 +1,59 @@
+import EnviousWisprCore
+import Foundation
+
+/// Typed error for user-visible heart-path failures that reach Sentry.
+///
+/// Telemetry-only: no `do/catch` consumer in app code switches on this type for
+/// control flow. Pipeline `state = .error(...)` continues to use plain strings
+/// for the UI overlay. Exists so `SentryBreadcrumb.captureError` call sites are
+/// self-documenting and `errorDescription` formatting is consistent.
+///
+/// Per-case classification (Failure / Fallback) is documented in the round-4
+/// plan at `docs/feature-requests/issue-285-2026-04-14-heart-path-sentry-coverage.md`
+/// §3.8.
+public enum HeartPathError: LocalizedError, Sendable {
+  case audioCaptureStalled(sessionID: UInt64, ctx: CaptureStallContext)
+  case noAudioCaptured(sessionID: UInt64, durationMs: Int, wasStreaming: Bool, route: String)
+  case captureSessionInterrupted(ctx: CaptureSessionInterruptionContext)
+  case pasteCascadeClipboardFallback(
+    tiersAttempted: [String], focusClassification: String, targetBundleID: String?)
+  case pasteCGEventCreationFailed(accessibilityTrusted: Bool)
+  case pasteAppleScriptFailed(
+    errorCode: Int?, errorMessage: String?, targetBundleID: String?)
+  case audioXPCInterrupted(handler: XPCHandlerKind, wasCapturing: Bool)
+  case xpcReplyFailed(ctx: XPCReplyFailureContext)
+  case xpcServerClientProxyNil(sessionID: UInt64?, consecutiveDrops: Int)
+  case emptyAfterProcessing(route: String, wasPolishEnabled: Bool)
+
+  public var errorDescription: String? {
+    switch self {
+    case .audioCaptureStalled(let sessionID, _):
+      return "Audio capture stalled: no buffers delivered (session \(sessionID))"
+    case .noAudioCaptured(let sessionID, let durationMs, _, _):
+      return "No audio captured after \(durationMs)ms (session \(sessionID))"
+    case .captureSessionInterrupted(let ctx):
+      return
+        "AVCaptureSession \(ctx.kind.rawValue): \(ctx.reasonLabel ?? ctx.errorDescription ?? "unknown")"
+    case .pasteCascadeClipboardFallback(let tiers, _, _):
+      return "Paste cascade fell back to clipboard after tiers: \(tiers.joined(separator: ","))"
+    case .pasteCGEventCreationFailed(let trusted):
+      return "Paste CGEvent creation failed (accessibility=\(trusted))"
+    case .pasteAppleScriptFailed(let code, let message, _):
+      return "Paste AppleScript failed (code=\(code.map(String.init) ?? "nil")): \(message ?? "")"
+    case .audioXPCInterrupted(let handler, let wasCapturing):
+      return "Audio XPC \(handler.rawValue) (capturing=\(wasCapturing))"
+    case .xpcReplyFailed(let ctx):
+      return "XPC reply failed at \(ctx.replyStage): \(ctx.errorDescription)"
+    case .xpcServerClientProxyNil(_, let drops):
+      return "XPC server observed nil clientProxy for \(drops) consecutive buffer sends"
+    case .emptyAfterProcessing(_, let wasPolishEnabled):
+      return "Post-processing emptied the transcript (polish=\(wasPolishEnabled))"
+    }
+  }
+}
+
+/// Classifies the XPC handler origin for `HeartPathError.audioXPCInterrupted`.
+public enum XPCHandlerKind: String, Sendable {
+  case interrupt
+  case invalidate
+}

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1,336 +1,368 @@
 import AppKit
-import EnviousWisprCore
 import ApplicationServices
 import Carbon.HIToolbox
+import EnviousWisprCore
 
 /// Immutable snapshot of all pasteboard contents at a point in time.
 public struct ClipboardSnapshot: Sendable {
-    /// Raw data keyed by pasteboard type, preserving every representation.
-    public let items: [[NSPasteboard.PasteboardType: Data]]
-    /// `NSPasteboard.changeCount` at the moment the snapshot was taken.
-    public let changeCount: Int
+  /// Raw data keyed by pasteboard type, preserving every representation.
+  public let items: [[NSPasteboard.PasteboardType: Data]]
+  /// `NSPasteboard.changeCount` at the moment the snapshot was taken.
+  public let changeCount: Int
 
-    public init(items: [[NSPasteboard.PasteboardType: Data]], changeCount: Int) {
-        self.items = items
-        self.changeCount = changeCount
-    }
+  public init(items: [[NSPasteboard.PasteboardType: Data]], changeCount: Int) {
+    self.items = items
+    self.changeCount = changeCount
+  }
 }
 
 /// Which paste tier succeeded — logged for compatibility analytics.
-public enum PasteTier: String {
-    case axDirect = "ax_direct"
-    case cgEvent = "cgevent"
-    case appleScript = "applescript"
-    case clipboardOnly = "clipboard_only"
+public enum PasteTier: String, Sendable {
+  case axDirect = "ax_direct"
+  case cgEvent = "cgevent"
+  case appleScript = "applescript"
+  case clipboardOnly = "clipboard_only"
 }
 
 /// Handles copying text to clipboard and pasting into the active app.
 public enum PasteService {
 
-    /// AX roles that accept text insertion.
-    static let textRoles: Set<String> = [
-        kAXTextFieldRole as String,
-        kAXTextAreaRole as String,
-        kAXComboBoxRole as String,
-        "AXSearchField",
-    ]
+  /// AX roles that accept text insertion.
+  static let textRoles: Set<String> = [
+    kAXTextFieldRole as String,
+    kAXTextAreaRole as String,
+    kAXComboBoxRole as String,
+    "AXSearchField",
+  ]
 
-    /// Check if an AX element has a text input role (AXTextField, AXTextArea, etc.).
-    public static func isTextFieldRole(_ element: AXUIElement) -> Bool {
-        var roleRef: CFTypeRef?
-        let err = AXUIElementCopyAttributeValue(
-            element, kAXRoleAttribute as CFString, &roleRef
-        )
-        guard err == .success, let role = roleRef as? String else { return false }
-        return textRoles.contains(role)
-    }
+  /// Check if an AX element has a text input role (AXTextField, AXTextArea, etc.).
+  public static func isTextFieldRole(_ element: AXUIElement) -> Bool {
+    var roleRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(
+      element, kAXRoleAttribute as CFString, &roleRef
+    )
+    guard err == .success, let role = roleRef as? String else { return false }
+    return textRoles.contains(role)
+  }
 
-    /// Copy text to the system clipboard.
-    public static func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
+  /// Copy text to the system clipboard.
+  public static func copyToClipboard(_ text: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+  }
 
-    /// Copy text to clipboard and return the resulting change count.
-    public static func copyToClipboardReturningChangeCount(_ text: String) -> Int {
-        copyToClipboard(text)
-        return NSPasteboard.general.changeCount
-    }
+  /// Copy text to clipboard and return the resulting change count.
+  public static func copyToClipboardReturningChangeCount(_ text: String) -> Int {
+    copyToClipboard(text)
+    return NSPasteboard.general.changeCount
+  }
 
-    /// Capture the current pasteboard contents for later restoration.
-    public static func saveClipboard() -> ClipboardSnapshot {
-        let pasteboard = NSPasteboard.general
-        var items: [[NSPasteboard.PasteboardType: Data]] = []
+  /// Capture the current pasteboard contents for later restoration.
+  public static func saveClipboard() -> ClipboardSnapshot {
+    let pasteboard = NSPasteboard.general
+    var items: [[NSPasteboard.PasteboardType: Data]] = []
 
-        for item in pasteboard.pasteboardItems ?? [] {
-            var dict: [NSPasteboard.PasteboardType: Data] = [:]
-            for type in item.types {
-                if let data = item.data(forType: type) {
-                    dict[type] = data
-                }
-            }
-            if !dict.isEmpty {
-                items.append(dict)
-            }
+    for item in pasteboard.pasteboardItems ?? [] {
+      var dict: [NSPasteboard.PasteboardType: Data] = [:]
+      for type in item.types {
+        if let data = item.data(forType: type) {
+          dict[type] = data
         }
-
-        return ClipboardSnapshot(items: items, changeCount: pasteboard.changeCount)
+      }
+      if !dict.isEmpty {
+        items.append(dict)
+      }
     }
 
-    /// Restore a previously saved clipboard snapshot.
-    ///
-    /// - Parameters:
-    ///   - snapshot: The snapshot to restore.
-    ///   - changeCountAfterPaste: The `changeCount` observed immediately after
-    ///     our own paste write. Pass this value so we can detect if a clipboard
-    ///     manager has modified the board before the restore fires.
-    public static func restoreClipboard(_ snapshot: ClipboardSnapshot, changeCountAfterPaste: Int) {
-        let pasteboard = NSPasteboard.general
+    return ClipboardSnapshot(items: items, changeCount: pasteboard.changeCount)
+  }
 
-        // If the change count has advanced beyond what we set, a third-party
-        // tool wrote to the clipboard — don't clobber their change.
-        guard pasteboard.changeCount == changeCountAfterPaste else {
-            Task { await AppLogger.shared.log(
-                "Clipboard restore skipped: changeCount advanced (expected \(changeCountAfterPaste), got \(pasteboard.changeCount))",
-                level: .verbose, category: "PasteService"
-            ) }
-            return
-        }
+  /// Restore a previously saved clipboard snapshot.
+  ///
+  /// - Parameters:
+  ///   - snapshot: The snapshot to restore.
+  ///   - changeCountAfterPaste: The `changeCount` observed immediately after
+  ///     our own paste write. Pass this value so we can detect if a clipboard
+  ///     manager has modified the board before the restore fires.
+  public static func restoreClipboard(_ snapshot: ClipboardSnapshot, changeCountAfterPaste: Int) {
+    let pasteboard = NSPasteboard.general
 
-        // Nothing to restore (clipboard was already empty).
-        guard !snapshot.items.isEmpty else { return }
-
-        pasteboard.clearContents()
-        let pbItems: [NSPasteboardItem] = snapshot.items.map { itemDict in
-            let pbItem = NSPasteboardItem()
-            for (type, data) in itemDict {
-                pbItem.setData(data, forType: type)
-            }
-            return pbItem
-        }
-        pasteboard.writeObjects(pbItems)
-    }
-
-    /// Append a trailing space to text so consecutive dictations are naturally separated.
-    /// Same approach as WisprFlow — simpler and more reliable than reading cursor context via AX.
-    public static func appendTrailingSpace(_ text: String) -> String {
-        text.hasSuffix(" ") ? text : text + " "
-    }
-
-    // MARK: - Tier 1: AX Direct Insertion
-
-    /// Capture the system-wide focused UI element (the specific text field, not just the app).
-    /// Sets a 1-second AX timeout on the element to avoid hanging on misbehaving apps.
-    /// Returns nil if no element is focused or accessibility is not trusted.
-    public static func captureFocusedElement() -> AXUIElement? {
-        guard AXIsProcessTrusted() else {
-            Task { await AppLogger.shared.log(
-                "AXDiag capture: not trusted",
-                level: .info, category: "AXDiag"
-            ) }
-            return nil
-        }
-        let systemWide = AXUIElementCreateSystemWide()
-        var focusedRef: CFTypeRef?
-        let err = AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedRef
+    // If the change count has advanced beyond what we set, a third-party
+    // tool wrote to the clipboard — don't clobber their change.
+    guard pasteboard.changeCount == changeCountAfterPaste else {
+      Task {
+        await AppLogger.shared.log(
+          "Clipboard restore skipped: changeCount advanced (expected \(changeCountAfterPaste), got \(pasteboard.changeCount))",
+          level: .verbose, category: "PasteService"
         )
-        guard err == .success, let ref = focusedRef else {
-            Task { await AppLogger.shared.log(
-                "AXDiag capture: systemWide focus FAILED err=\(err.rawValue)",
-                level: .info, category: "AXDiag"
-            ) }
-            return nil
-        }
-        let element = ref as! AXUIElement
-        AXUIElementSetAttributeValue(
-            element,
-            "AXTimeout" as CFString,
-            Float(1.0) as CFTypeRef
+      }
+      return
+    }
+
+    // Nothing to restore (clipboard was already empty).
+    guard !snapshot.items.isEmpty else { return }
+
+    pasteboard.clearContents()
+    let pbItems: [NSPasteboardItem] = snapshot.items.map { itemDict in
+      let pbItem = NSPasteboardItem()
+      for (type, data) in itemDict {
+        pbItem.setData(data, forType: type)
+      }
+      return pbItem
+    }
+    pasteboard.writeObjects(pbItems)
+  }
+
+  /// Append a trailing space to text so consecutive dictations are naturally separated.
+  /// Same approach as WisprFlow — simpler and more reliable than reading cursor context via AX.
+  public static func appendTrailingSpace(_ text: String) -> String {
+    text.hasSuffix(" ") ? text : text + " "
+  }
+
+  // MARK: - Tier 1: AX Direct Insertion
+
+  /// Capture the system-wide focused UI element (the specific text field, not just the app).
+  /// Sets a 1-second AX timeout on the element to avoid hanging on misbehaving apps.
+  /// Returns nil if no element is focused or accessibility is not trusted.
+  public static func captureFocusedElement() -> AXUIElement? {
+    guard AXIsProcessTrusted() else {
+      Task {
+        await AppLogger.shared.log(
+          "AXDiag capture: not trusted",
+          level: .info, category: "AXDiag"
         )
-        logElementDiagnostics(element)
-        return element
+      }
+      return nil
     }
-
-    /// Log role, subrole, and key settability signals for the focused element.
-    /// One line per paste; used to diagnose cascade fall-throughs in the wild
-    /// (e.g., the Chromium lazy-AX case uncovered in #277).
-    ///
-    /// Runs off the caller's thread so the extra AX round-trips don't add
-    /// latency to the PTT-to-recording start path.
-    private static func logElementDiagnostics(_ element: AXUIElement) {
-        nonisolated(unsafe) let axElement = element
-        let bundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "<nil>"
-        Task.detached {
-            var roleRef: CFTypeRef?
-            _ = AXUIElementCopyAttributeValue(axElement, kAXRoleAttribute as CFString, &roleRef)
-            let role = (roleRef as? String) ?? "<nil>"
-
-            var subroleRef: CFTypeRef?
-            _ = AXUIElementCopyAttributeValue(axElement, kAXSubroleAttribute as CFString, &subroleRef)
-            let subrole = (subroleRef as? String) ?? "<nil>"
-
-            func settable(_ attr: String) -> Bool {
-                var s: DarwinBoolean = false
-                let err = AXUIElementIsAttributeSettable(axElement, attr as CFString, &s)
-                return err == .success && s.boolValue
-            }
-
-            let msg = "AXDiag capture: app=\(bundleId) role=\(role) subrole=\(subrole) " +
-                      "valueSettable=\(settable("AXValue")) " +
-                      "selTextSettable=\(settable("AXSelectedText")) " +
-                      "selRangeSettable=\(settable("AXSelectedTextRange"))"
-            await AppLogger.shared.log(msg, level: .info, category: "AXDiag")
-        }
-    }
-
-    /// Insert text directly into an AX element at the cursor position.
-    /// Uses kAXSelectedTextAttribute which inserts at cursor / replaces selection.
-    /// Returns true only if the text verifiably appeared in the element.
-    public static func insertViaAccessibility(_ text: String, element: AXUIElement) -> Bool {
-        // Verify the element is a text field or text area.
-        var roleRef: CFTypeRef?
-        let roleErr = AXUIElementCopyAttributeValue(
-            element,
-            kAXRoleAttribute as CFString,
-            &roleRef
+    let systemWide = AXUIElementCreateSystemWide()
+    var focusedRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(
+      systemWide,
+      kAXFocusedUIElementAttribute as CFString,
+      &focusedRef
+    )
+    guard err == .success, let ref = focusedRef else {
+      Task {
+        await AppLogger.shared.log(
+          "AXDiag capture: systemWide focus FAILED err=\(err.rawValue)",
+          level: .info, category: "AXDiag"
         )
-        guard roleErr == .success, let role = roleRef as? String else {
-            return false
-        }
-        guard textRoles.contains(role) else { return false }
+      }
+      return nil
+    }
+    let element = ref as! AXUIElement
+    AXUIElementSetAttributeValue(
+      element,
+      "AXTimeout" as CFString,
+      Float(1.0) as CFTypeRef
+    )
+    logElementDiagnostics(element)
+    return element
+  }
 
-        // Verify the element is writable (not read-only).
-        var settableRef: DarwinBoolean = false
-        let settableErr = AXUIElementIsAttributeSettable(
-            element,
-            kAXValueAttribute as CFString,
-            &settableRef
+  /// Log role, subrole, and key settability signals for the focused element.
+  /// One line per paste; used to diagnose cascade fall-throughs in the wild
+  /// (e.g., the Chromium lazy-AX case uncovered in #277).
+  ///
+  /// Runs off the caller's thread so the extra AX round-trips don't add
+  /// latency to the PTT-to-recording start path.
+  private static func logElementDiagnostics(_ element: AXUIElement) {
+    nonisolated(unsafe) let axElement = element
+    let bundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "<nil>"
+    Task.detached {
+      var roleRef: CFTypeRef?
+      _ = AXUIElementCopyAttributeValue(axElement, kAXRoleAttribute as CFString, &roleRef)
+      let role = (roleRef as? String) ?? "<nil>"
+
+      var subroleRef: CFTypeRef?
+      _ = AXUIElementCopyAttributeValue(axElement, kAXSubroleAttribute as CFString, &subroleRef)
+      let subrole = (subroleRef as? String) ?? "<nil>"
+
+      func settable(_ attr: String) -> Bool {
+        var s: DarwinBoolean = false
+        let err = AXUIElementIsAttributeSettable(axElement, attr as CFString, &s)
+        return err == .success && s.boolValue
+      }
+
+      let msg =
+        "AXDiag capture: app=\(bundleId) role=\(role) subrole=\(subrole) "
+        + "valueSettable=\(settable("AXValue")) " + "selTextSettable=\(settable("AXSelectedText")) "
+        + "selRangeSettable=\(settable("AXSelectedTextRange"))"
+      await AppLogger.shared.log(msg, level: .info, category: "AXDiag")
+    }
+  }
+
+  /// Insert text directly into an AX element at the cursor position.
+  /// Uses kAXSelectedTextAttribute which inserts at cursor / replaces selection.
+  /// Returns true only if the text verifiably appeared in the element.
+  public static func insertViaAccessibility(_ text: String, element: AXUIElement) -> Bool {
+    // Verify the element is a text field or text area.
+    var roleRef: CFTypeRef?
+    let roleErr = AXUIElementCopyAttributeValue(
+      element,
+      kAXRoleAttribute as CFString,
+      &roleRef
+    )
+    guard roleErr == .success, let role = roleRef as? String else {
+      return false
+    }
+    guard textRoles.contains(role) else { return false }
+
+    // Verify the element is writable (not read-only).
+    var settableRef: DarwinBoolean = false
+    let settableErr = AXUIElementIsAttributeSettable(
+      element,
+      kAXValueAttribute as CFString,
+      &settableRef
+    )
+    guard settableErr == .success, settableRef.boolValue else { return false }
+
+    // Snapshot character count before insertion for verification.
+    var charCountBefore: CFTypeRef?
+    AXUIElementCopyAttributeValue(
+      element,
+      kAXNumberOfCharactersAttribute as CFString,
+      &charCountBefore
+    )
+    let countBefore = (charCountBefore as? Int) ?? -1
+
+    // Insert at cursor via kAXSelectedTextAttribute.
+    let err = AXUIElementSetAttributeValue(
+      element,
+      kAXSelectedTextAttribute as CFString,
+      text as CFTypeRef
+    )
+    guard err == .success else { return false }
+
+    // Verify text actually appeared (Electron apps report success but don't render).
+    // If we can't read character counts, treat as unverified and fall through to Tier 2.
+    var charCountAfter: CFTypeRef?
+    AXUIElementCopyAttributeValue(
+      element,
+      kAXNumberOfCharactersAttribute as CFString,
+      &charCountAfter
+    )
+    let countAfter = (charCountAfter as? Int) ?? -1
+
+    if countBefore < 0 || countAfter < 0 {
+      return false  // Can't verify — let Tier 2 handle it
+    }
+    return countAfter > countBefore
+  }
+
+  // MARK: - Tier 2: CGEvent Cmd+V
+
+  /// Outcome of a Tier-2 CGEvent paste attempt. `dispatched` means the Cmd+V
+  /// keystroke was successfully posted; `cgEventCreationFailed` means CGEvent
+  /// construction failed (typically an Accessibility trust / permission issue).
+  /// Both cases carry the pasteboard change count needed by `restoreClipboard`.
+  public enum PasteDispatchResult: Sendable {
+    case dispatched(changeCount: Int)
+    case cgEventCreationFailed(accessibilityTrusted: Bool, changeCount: Int)
+
+    public var changeCount: Int {
+      switch self {
+      case .dispatched(let c): return c
+      case .cgEventCreationFailed(_, let c): return c
+      }
+    }
+  }
+
+  /// Copy text to clipboard and simulate Cmd+V to paste into the frontmost app.
+  /// - Returns: `PasteDispatchResult` telling the caller whether the keystroke
+  ///   was posted and exposing the pasteboard change count for clipboard restore.
+  @discardableResult
+  public static func pasteToActiveApp(_ text: String) -> PasteDispatchResult {
+    let pasteStart = CFAbsoluteTimeGetCurrent()
+    let accessibilityTrusted = AXIsProcessTrusted()
+
+    let pasteboard = NSPasteboard.general
+    let previousChangeCount = pasteboard.changeCount
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+    let changeCountAfterWrite = pasteboard.changeCount
+    let clipboardWriteSuccess = pasteboard.changeCount != previousChangeCount
+
+    guard dispatchCmdV() else {
+      Task {
+        await AppLogger.shared.log(
+          "Paste attempt: accessibility=\(accessibilityTrusted), cgEventAttempted=false, clipboardWrite=\(clipboardWriteSuccess) — Failed to create CGEvent",
+          level: .info, category: "PasteService"
         )
-        guard settableErr == .success, settableRef.boolValue else { return false }
-
-        // Snapshot character count before insertion for verification.
-        var charCountBefore: CFTypeRef?
-        AXUIElementCopyAttributeValue(
-            element,
-            kAXNumberOfCharactersAttribute as CFString,
-            &charCountBefore
-        )
-        let countBefore = (charCountBefore as? Int) ?? -1
-
-        // Insert at cursor via kAXSelectedTextAttribute.
-        let err = AXUIElementSetAttributeValue(
-            element,
-            kAXSelectedTextAttribute as CFString,
-            text as CFTypeRef
-        )
-        guard err == .success else { return false }
-
-        // Verify text actually appeared (Electron apps report success but don't render).
-        // If we can't read character counts, treat as unverified and fall through to Tier 2.
-        var charCountAfter: CFTypeRef?
-        AXUIElementCopyAttributeValue(
-            element,
-            kAXNumberOfCharactersAttribute as CFString,
-            &charCountAfter
-        )
-        let countAfter = (charCountAfter as? Int) ?? -1
-
-        if countBefore < 0 || countAfter < 0 {
-            return false  // Can't verify — let Tier 2 handle it
-        }
-        return countAfter > countBefore
+      }
+      return .cgEventCreationFailed(
+        accessibilityTrusted: accessibilityTrusted,
+        changeCount: changeCountAfterWrite
+      )
     }
 
-    // MARK: - Tier 2: CGEvent Cmd+V
-
-    /// Copy text to clipboard and simulate Cmd+V to paste into the frontmost app.
-    /// - Returns: The pasteboard `changeCount` after our write, needed by `restoreClipboard`.
-    @discardableResult
-    public static func pasteToActiveApp(_ text: String) -> Int {
-        let pasteStart = CFAbsoluteTimeGetCurrent()
-        let accessibilityTrusted = AXIsProcessTrusted()
-
-        let pasteboard = NSPasteboard.general
-        let previousChangeCount = pasteboard.changeCount
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-        let changeCountAfterWrite = pasteboard.changeCount
-        let clipboardWriteSuccess = pasteboard.changeCount != previousChangeCount
-
-        guard dispatchCmdV() else {
-            Task { await AppLogger.shared.log(
-                "Paste attempt: accessibility=\(accessibilityTrusted), cgEventAttempted=false, clipboardWrite=\(clipboardWriteSuccess) — Failed to create CGEvent",
-                level: .info, category: "PasteService"
-            ) }
-            return changeCountAfterWrite
-        }
-
-        let pasteEnd = CFAbsoluteTimeGetCurrent()
-        Task { await AppLogger.shared.log(
-            "Paste attempt: accessibility=\(accessibilityTrusted), cgEventAttempted=true, " +
-            "clipboardWrite=\(clipboardWriteSuccess), elapsed=\(String(format: "%.3f", pasteEnd - pasteStart))s",
-            level: .info, category: "PasteService"
-        ) }
-
-        return changeCountAfterWrite
+    let pasteEnd = CFAbsoluteTimeGetCurrent()
+    Task {
+      await AppLogger.shared.log(
+        "Paste attempt: accessibility=\(accessibilityTrusted), cgEventAttempted=true, "
+          + "clipboardWrite=\(clipboardWriteSuccess), elapsed=\(String(format: "%.3f", pasteEnd - pasteStart))s",
+        level: .info, category: "PasteService"
+      )
     }
 
-    // MARK: - Tier 2b: AppleScript Edit > Paste
+    return .dispatched(changeCount: changeCountAfterWrite)
+  }
 
-    /// Paste via AppleScript by clicking the Edit > Paste menu item via process ID.
-    /// Requires the target app to be frontmost. Returns true on success.
-    public static func pasteViaAppleScript(pid: pid_t) -> Bool {
-        let script = """
-        tell application "System Events"
-            tell (first process whose unix id is \(pid))
-                click menu item "Paste" of menu "Edit" of menu bar 1
-            end tell
-        end tell
-        """
-        var error: NSDictionary?
-        let appleScript = NSAppleScript(source: script)
-        appleScript?.executeAndReturnError(&error)
-        return error == nil
-    }
+  // MARK: - Tier 2b: AppleScript Edit > Paste
 
-    /// Simulate Cmd+V keystroke to paste from clipboard into the active app.
-    public static func simulatePaste() {
-        dispatchCmdV()
-    }
+  /// Paste via AppleScript by clicking the Edit > Paste menu item via process ID.
+  /// Requires the target app to be frontmost. Returns true on success.
+  public static func pasteViaAppleScript(pid: pid_t) -> Bool {
+    let script = """
+      tell application "System Events"
+          tell (first process whose unix id is \(pid))
+              click menu item "Paste" of menu "Edit" of menu bar 1
+          end tell
+      end tell
+      """
+    var error: NSDictionary?
+    let appleScript = NSAppleScript(source: script)
+    appleScript?.executeAndReturnError(&error)
+    return error == nil
+  }
 
-    // MARK: - App Activation via Accessibility
+  /// Simulate Cmd+V keystroke to paste from clipboard into the active app.
+  public static func simulatePaste() {
+    dispatchCmdV()
+  }
 
-    /// Force-activate an app by PID using the Accessibility API.
-    /// Bypasses macOS 14+ restrictions on background processes stealing focus.
-    /// Requires Accessibility permission (AXIsProcessTrusted).
-    public static func forceActivateApp(pid: pid_t) -> Bool {
-        guard AXIsProcessTrusted() else { return false }
-        let axApp = AXUIElementCreateApplication(pid)
-        let result = AXUIElementSetAttributeValue(
-            axApp,
-            "AXFrontmost" as CFString,
-            true as CFTypeRef
-        )
-        return result == .success
-    }
+  // MARK: - App Activation via Accessibility
 
-    // MARK: - Private
+  /// Force-activate an app by PID using the Accessibility API.
+  /// Bypasses macOS 14+ restrictions on background processes stealing focus.
+  /// Requires Accessibility permission (AXIsProcessTrusted).
+  public static func forceActivateApp(pid: pid_t) -> Bool {
+    guard AXIsProcessTrusted() else { return false }
+    let axApp = AXUIElementCreateApplication(pid)
+    let result = AXUIElementSetAttributeValue(
+      axApp,
+      "AXFrontmost" as CFString,
+      true as CFTypeRef
+    )
+    return result == .success
+  }
 
-    /// Send Cmd+V keystroke via CGEvent. Returns true on success.
-    @discardableResult
-    private static func dispatchCmdV() -> Bool {
-        guard let source = CGEventSource(stateID: .combinedSessionState),
-              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: UInt16(kVK_ANSI_V), keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: UInt16(kVK_ANSI_V), keyDown: false)
-        else { return false }
-        keyDown.flags = .maskCommand
-        keyDown.post(tap: .cgAnnotatedSessionEventTap)
-        keyUp.flags = .maskCommand
-        keyUp.post(tap: .cgAnnotatedSessionEventTap)
-        return true
-    }
+  // MARK: - Private
+
+  /// Send Cmd+V keystroke via CGEvent. Returns true on success.
+  @discardableResult
+  private static func dispatchCmdV() -> Bool {
+    guard let source = CGEventSource(stateID: .combinedSessionState),
+      let keyDown = CGEvent(
+        keyboardEventSource: source, virtualKey: UInt16(kVK_ANSI_V), keyDown: true),
+      let keyUp = CGEvent(
+        keyboardEventSource: source, virtualKey: UInt16(kVK_ANSI_V), keyDown: false)
+    else { return false }
+    keyDown.flags = .maskCommand
+    keyDown.post(tap: .cgAnnotatedSessionEventTap)
+    keyUp.flags = .maskCommand
+    keyUp.post(tap: .cgAnnotatedSessionEventTap)
+    return true
+  }
 }

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -1,0 +1,56 @@
+import EnviousWisprCore
+import Foundation
+
+/// Shared builder for the Sentry `extra` dictionary on heart-path audio events.
+/// Ensures both pipelines, the XPC proxy emission site, and the AppState
+/// interruption callback produce consistent tag shapes.
+@MainActor
+public enum SentryAudioExtras {
+
+  /// Build the common extras dictionary attached to every heart-path audio
+  /// captureError. Callers pass a stall context when the emission originated
+  /// from the liveness watchdog; otherwise nil. `polishModelSwapMs` is nil
+  /// when the polish subsystem has never observed a swap since launch.
+  public static func buildCaptureExtras(
+    route: String,
+    sourceType: String,
+    sessionID: UInt64,
+    isActivelyCapturing: Bool,
+    inputDeviceUIDPreferred: String?,
+    inputDeviceUIDSystemDefault: String?,
+    failureMode: String,
+    stallContext: CaptureStallContext? = nil,
+    polishModelSwapMs: Int? = nil
+  ) -> [String: Any] {
+    var extras: [String: Any] = [
+      "capture.source_type": sourceType,
+      "capture.route": route,
+      "capture.failure_mode": failureMode,
+      "capture.is_actively_capturing": isActivelyCapturing,
+      "capture_session_id": Int(sessionID),
+    ]
+    extras["capture.input_device_uid_preferred"] =
+      (inputDeviceUIDPreferred?.isEmpty == false) ? inputDeviceUIDPreferred! : NSNull()
+    extras["capture.input_device_uid_system_default"] =
+      (inputDeviceUIDSystemDefault?.isEmpty == false)
+      ? inputDeviceUIDSystemDefault! : NSNull()
+    extras["capture.input_device_divergence"] =
+      inputDeviceUIDPreferred != inputDeviceUIDSystemDefault
+
+    if let ctx = stallContext {
+      extras["capture.stall.armed_at_uptime_ns"] = Int(ctx.armedAtUptimeNs)
+      extras["capture.stall.fired_at_uptime_ns"] = Int(ctx.firedAtUptimeNs)
+      extras["capture.stall.window_ms"] =
+        Int((ctx.firedAtUptimeNs &- ctx.armedAtUptimeNs) / 1_000_000)
+      extras["capture.engine_started_successfully"] = ctx.engineStartedSuccessfully
+      extras["capture.tap_installed"] = ctx.tapInstalled
+      extras["capture.format_mismatch"] = ctx.formatMismatchObserved
+    }
+
+    if let swap = polishModelSwapMs {
+      extras["polish.recent_model_swap_ms"] = swap
+    }
+
+    return extras
+  }
+}

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -1,218 +1,240 @@
+import EnviousWisprCore
 import Foundation
 import Sentry
-import EnviousWisprCore
 
 /// Thin, type-safe Sentry breadcrumb + error helper for pipeline instrumentation.
 /// Limb: all methods are fire-and-forget — a Sentry call failure never blocks the pipeline.
 @MainActor
 public enum SentryBreadcrumb {
 
-    // MARK: - Recording Snapshot (for handled errors)
+  // MARK: - Recording Snapshot (for handled errors)
 
-    /// Immutable point-in-time snapshot frozen before recording teardown.
-    /// Attached directly to handled errors so post-recording events carry full context
-    /// even after the global scope's recording_state is cleared.
-    public struct RecordingSnapshot: Sendable {
-        public let backend: String
-        public let audioRoute: String
-        public let wasStreaming: Bool
-        public let startTime: Date
-        public let durationMs: Int
-        public let targetAppBundleID: String?
-        public let transcriptCharCount: Int
-        public let transcriptWordCount: Int
+  /// Immutable point-in-time snapshot frozen before recording teardown.
+  /// Attached directly to handled errors so post-recording events carry full context
+  /// even after the global scope's recording_state is cleared.
+  public struct RecordingSnapshot: Sendable {
+    public let backend: String
+    public let audioRoute: String
+    public let wasStreaming: Bool
+    public let startTime: Date
+    public let durationMs: Int
+    public let targetAppBundleID: String?
+    public let transcriptCharCount: Int
+    public let transcriptWordCount: Int
 
-        public init(
-            backend: String,
-            audioRoute: String,
-            wasStreaming: Bool,
-            startTime: Date,
-            durationMs: Int,
-            targetAppBundleID: String?,
-            transcriptCharCount: Int = 0,
-            transcriptWordCount: Int = 0
-        ) {
-            self.backend = backend
-            self.audioRoute = audioRoute
-            self.wasStreaming = wasStreaming
-            self.startTime = startTime
-            self.durationMs = durationMs
-            self.targetAppBundleID = targetAppBundleID
-            self.transcriptCharCount = transcriptCharCount
-            self.transcriptWordCount = transcriptWordCount
-        }
-
-        var sentryContext: [String: Any] {
-            var ctx: [String: Any] = [
-                "backend": backend,
-                "audio_route": audioRoute,
-                "was_streaming": wasStreaming,
-                "start_time": ISO8601DateFormatter().string(from: startTime),
-                "duration_ms": durationMs,
-                "transcript_char_count": transcriptCharCount,
-                "transcript_word_count": transcriptWordCount,
-            ]
-            if let targetAppBundleID {
-                ctx["target_app_bundle_id"] = targetAppBundleID
-            }
-            return ctx
-        }
-    }
-
-    // MARK: - Persistent Global Scope (crash-relevant state)
-
-    /// Update the active ASR backend tag. Called when user switches backend or at pipeline start.
-    public static func updateASRBackend(_ backend: String) {
-        SentrySDK.configureScope { scope in
-            scope.setTag(value: backend, key: "asr.backend")
-        }
-    }
-
-    /// Update the audio route tag. Called when capture route is resolved or changes.
-    /// Values are low-cardinality: built_in_mic, bt_headset, capture_session, audio_engine, unknown.
-    public static func updateAudioRoute(_ route: String) {
-        SentrySDK.configureScope { scope in
-            scope.setTag(value: route, key: "audio.route")
-        }
-    }
-
-    /// Update recording state on global scope. Present on fatal crashes.
-    /// - Parameters:
-    ///   - active: Whether recording is in progress.
-    ///   - backend: "parakeet" or "whisperkit" (nil when stopping).
-    ///   - isStreaming: Whether streaming ASR is active (nil when stopping).
-    public static func updateRecordingState(
-        active: Bool,
-        backend: String? = nil,
-        isStreaming: Bool? = nil
+    public init(
+      backend: String,
+      audioRoute: String,
+      wasStreaming: Bool,
+      startTime: Date,
+      durationMs: Int,
+      targetAppBundleID: String?,
+      transcriptCharCount: Int = 0,
+      transcriptWordCount: Int = 0
     ) {
-        SentrySDK.configureScope { scope in
-            scope.setTag(value: active ? "true" : "false", key: "recording.active")
-            if active, let backend {
-                scope.setContext(value: [
-                    "backend": backend,
-                    "start_time": ISO8601DateFormatter().string(from: Date()),
-                    "is_streaming": isStreaming ?? false,
-                ], key: "recording_state")
-            } else {
-                scope.removeContext(key: "recording_state")
-            }
-        }
+      self.backend = backend
+      self.audioRoute = audioRoute
+      self.wasStreaming = wasStreaming
+      self.startTime = startTime
+      self.durationMs = durationMs
+      self.targetAppBundleID = targetAppBundleID
+      self.transcriptCharCount = transcriptCharCount
+      self.transcriptWordCount = transcriptWordCount
     }
 
-    // MARK: - Breadcrumbs
+    var sentryContext: [String: Any] {
+      var ctx: [String: Any] = [
+        "backend": backend,
+        "audio_route": audioRoute,
+        "was_streaming": wasStreaming,
+        "start_time": ISO8601DateFormatter().string(from: startTime),
+        "duration_ms": durationMs,
+        "transcript_char_count": transcriptCharCount,
+        "transcript_word_count": transcriptWordCount,
+      ]
+      if let targetAppBundleID {
+        ctx["target_app_bundle_id"] = targetAppBundleID
+      }
+      return ctx
+    }
+  }
 
-    /// Add a structured breadcrumb at a pipeline stage boundary.
-    /// - Parameters:
-    ///   - stage: Pipeline stage (e.g. "recording", "asr", "polish", "paste")
-    ///   - message: Human-readable description (no PII — no transcript text)
-    ///   - level: Sentry level (default .info)
-    ///   - data: Structured key-value pairs (provider, duration, outcome, etc.)
-    public static func add(
-        stage: String,
-        message: String,
-        level: SentryLevel = .info,
-        data: [String: Any]? = nil
-    ) {
-        let crumb = Breadcrumb(level: level, category: "pipeline.\(stage)")
-        crumb.message = message
-        crumb.type = "default"
-        if let data {
-            crumb.data = data
-        }
-        SentrySDK.addBreadcrumb(crumb)
+  // MARK: - Persistent Global Scope (crash-relevant state)
+
+  /// Update the active ASR backend tag. Called when user switches backend or at pipeline start.
+  public static func updateASRBackend(_ backend: String) {
+    SentrySDK.configureScope { scope in
+      scope.setTag(value: backend, key: "asr.backend")
+    }
+  }
+
+  /// Update the audio route tag. Called when capture route is resolved or changes.
+  /// Values are low-cardinality: built_in_mic, bt_headset, capture_session, audio_engine, unknown.
+  public static func updateAudioRoute(_ route: String) {
+    SentrySDK.configureScope { scope in
+      scope.setTag(value: route, key: "audio.route")
+    }
+  }
+
+  /// Update recording state on global scope. Present on fatal crashes.
+  /// - Parameters:
+  ///   - active: Whether recording is in progress.
+  ///   - backend: "parakeet" or "whisperkit" (nil when stopping).
+  ///   - isStreaming: Whether streaming ASR is active (nil when stopping).
+  public static func updateRecordingState(
+    active: Bool,
+    backend: String? = nil,
+    isStreaming: Bool? = nil
+  ) {
+    SentrySDK.configureScope { scope in
+      scope.setTag(value: active ? "true" : "false", key: "recording.active")
+      if active, let backend {
+        scope.setContext(
+          value: [
+            "backend": backend,
+            "start_time": ISO8601DateFormatter().string(from: Date()),
+            "is_streaming": isStreaming ?? false,
+          ], key: "recording_state")
+      } else {
+        scope.removeContext(key: "recording_state")
+      }
+    }
+  }
+
+  // MARK: - Breadcrumbs
+
+  /// Add a structured breadcrumb at a pipeline stage boundary.
+  /// - Parameters:
+  ///   - stage: Pipeline stage (e.g. "recording", "asr", "polish", "paste")
+  ///   - message: Human-readable description (no PII — no transcript text)
+  ///   - level: Sentry level (default .info)
+  ///   - data: Structured key-value pairs (provider, duration, outcome, etc.)
+  public static func add(
+    stage: String,
+    message: String,
+    level: SentryLevel = .info,
+    data: [String: Any]? = nil
+  ) {
+    let crumb = Breadcrumb(level: level, category: "pipeline.\(stage)")
+    crumb.message = message
+    crumb.type = "default"
+    if let data {
+      crumb.data = data
+    }
+    SentrySDK.addBreadcrumb(crumb)
+  }
+
+  // MARK: - Handled Errors
+
+  /// Capture a handled error with pipeline context tags.
+  /// Use for failures that don't crash the app but should be diagnosable in Sentry.
+  /// - Parameters:
+  ///   - error: The error that occurred.
+  ///   - category: Structured error category for filtering.
+  ///   - stage: Pipeline stage where the error occurred.
+  ///   - extra: Additional key-value pairs for this specific event.
+  ///   - snapshot: Optional point-in-time recording state (attached via scope clone).
+  public static func captureError(
+    _ error: any Error,
+    category: ErrorCategory,
+    stage: String,
+    extra: [String: Any]? = nil,
+    snapshot: RecordingSnapshot? = nil
+  ) {
+    // Test spy hook — invoked synchronously before SDK dispatch. Production sets nil.
+    Self.captureErrorDelegate?(error, category, stage, extra)
+
+    let event = Event(level: .error)
+    event.message = SentryMessage(formatted: "\(category.rawValue): \(error.localizedDescription)")
+    event.tags = [
+      "pipeline.stage": stage,
+      "error.category": category.rawValue,
+    ]
+    if let extra {
+      event.extra = extra
     }
 
-    // MARK: - Handled Errors
+    // Also add a breadcrumb so the error appears in the trail
+    add(
+      stage: stage,
+      message: "ERROR: \(category.rawValue)",
+      level: .error,
+      data: extra
+    )
 
-    /// Capture a handled error with pipeline context tags.
-    /// Use for failures that don't crash the app but should be diagnosable in Sentry.
-    /// - Parameters:
-    ///   - error: The error that occurred.
-    ///   - category: Structured error category for filtering.
-    ///   - stage: Pipeline stage where the error occurred.
-    ///   - extra: Additional key-value pairs for this specific event.
-    ///   - snapshot: Optional point-in-time recording state (attached via scope clone).
-    public static func captureError(
-        _ error: any Error,
-        category: ErrorCategory,
-        stage: String,
-        extra: [String: Any]? = nil,
-        snapshot: RecordingSnapshot? = nil
-    ) {
-        let event = Event(level: .error)
-        event.message = SentryMessage(formatted: "\(category.rawValue): \(error.localizedDescription)")
-        event.tags = [
-            "pipeline.stage": stage,
-            "error.category": category.rawValue,
-        ]
-        if let extra {
-            event.extra = extra
-        }
-
-        // Also add a breadcrumb so the error appears in the trail
-        add(
-            stage: stage,
-            message: "ERROR: \(category.rawValue)",
-            level: .error,
-            data: extra
-        )
-
-        if let snapshot {
-            SentrySDK.capture(event: event) { scope in
-                scope.setContext(value: snapshot.sentryContext, key: "recording_snapshot")
-            }
-        } else {
-            SentrySDK.capture(event: event)
-        }
+    if let snapshot {
+      SentrySDK.capture(event: event) { scope in
+        scope.setContext(value: snapshot.sentryContext, key: "recording_snapshot")
+      }
+    } else {
+      SentrySDK.capture(event: event)
     }
+  }
 
-    // MARK: - Apple Intelligence Diagnostics
+  // MARK: - Apple Intelligence Diagnostics
 
-    /// Attach an AI diagnostics report as persistent Sentry context + breadcrumb.
-    /// Use at app launch — logs the state but does NOT fire a warning event.
-    /// The report is included in every future crash/error event automatically.
-    public static func attachAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
-        add(stage: "ai_diagnostics", message: "AI availability check completed", data: report.sentryContext)
+  /// Attach an AI diagnostics report as persistent Sentry context + breadcrumb.
+  /// Use at app launch — logs the state but does NOT fire a warning event.
+  /// The report is included in every future crash/error event automatically.
+  public static func attachAIDiagnostics(_ report: AppleIntelligenceAvailabilityReport) {
+    add(
+      stage: "ai_diagnostics", message: "AI availability check completed",
+      data: report.sentryContext)
 
-        SentrySDK.configureScope { scope in
-            scope.setContext(value: report.sentryContext, key: "apple_intelligence")
-        }
+    SentrySDK.configureScope { scope in
+      scope.setContext(value: report.sentryContext, key: "apple_intelligence")
     }
+  }
 
-    /// Report an AI failure that the user actually hit during dictation.
-    /// Attaches a fresh diagnostics report AND fires a Sentry warning event
-    /// so we can alert on real user-facing Apple Intelligence failures.
-    public static func reportAIFailure(_ report: AppleIntelligenceAvailabilityReport) {
-        // Update the persistent context with the fresh report
-        attachAIDiagnostics(report)
+  /// Report an AI failure that the user actually hit during dictation.
+  /// Attaches a fresh diagnostics report AND fires a Sentry warning event
+  /// so we can alert on real user-facing Apple Intelligence failures.
+  public static func reportAIFailure(_ report: AppleIntelligenceAvailabilityReport) {
+    // Update the persistent context with the fresh report
+    attachAIDiagnostics(report)
 
-        // Fire a warning event — this is a real user-facing failure, not just launch state
-        let event = Event(level: .warning)
-        event.message = SentryMessage(formatted: "Apple Intelligence failed during dictation: \(report.failureReasons.map(\.rawValue).joined(separator: ", "))")
-        event.tags = [
-            "ai.overall_status": report.overallStatus.rawValue,
-            "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
-        ]
-        event.extra = report.sentryContext
-        SentrySDK.capture(event: event)
-    }
+    // Fire a warning event — this is a real user-facing failure, not just launch state
+    let event = Event(level: .warning)
+    event.message = SentryMessage(
+      formatted:
+        "Apple Intelligence failed during dictation: \(report.failureReasons.map(\.rawValue).joined(separator: ", "))"
+    )
+    event.tags = [
+      "ai.overall_status": report.overallStatus.rawValue,
+      "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
+    ]
+    event.extra = report.sentryContext
+    SentrySDK.capture(event: event)
+  }
 
-    // MARK: - Error Taxonomy
+  // MARK: - Error Taxonomy
 
-    /// Structured error categories for pipeline failures.
-    /// Maps to Sentry tags for filtering and alerting.
-    public enum ErrorCategory: String, Sendable {
-        case availabilityCheckFailed = "availability_check_failed"
-        case providerInitFailed = "provider_init_failed"
-        case generationFailed = "generation_failed"
-        case fallbackFailed = "fallback_failed"
-        case pasteFailed = "paste_failed"
-        case stateMismatch = "state_mismatch"
-        case xpcServiceError = "xpc_service_error"
-        case modelLoadFailed = "model_load_failed"
-        case audioCaptureFailed = "audio_capture_failed"
-        case asrFailed = "asr_failed"
-        case asrEmptyResult = "asr_empty_result"
-    }
+  /// Structured error categories for pipeline failures.
+  /// Maps to Sentry tags for filtering and alerting.
+  public enum ErrorCategory: String, Sendable {
+    case availabilityCheckFailed = "availability_check_failed"
+    case providerInitFailed = "provider_init_failed"
+    case generationFailed = "generation_failed"
+    case fallbackFailed = "fallback_failed"
+    case pasteFailed = "paste_failed"
+    case stateMismatch = "state_mismatch"
+    case xpcServiceError = "xpc_service_error"
+    case modelLoadFailed = "model_load_failed"
+    case audioCaptureFailed = "audio_capture_failed"
+    case audioCaptureStalled = "audio_capture_stalled"
+    case asrFailed = "asr_failed"
+    case asrEmptyResult = "asr_empty_result"
+    case heartPathFinalization = "heart_path_finalization"
+  }
+}
+
+// MARK: - Test Delegate Hook
+
+extension SentryBreadcrumb {
+  /// Optional test-only delegate invoked synchronously on every `captureError` call
+  /// before the real Sentry SDK is touched. Tests set this in `setUp`, nil in
+  /// `tearDown`. Production code never reads it. Cheap alternative to a full
+  /// protocol wrapper for SDK-less unit testing.
+  public nonisolated(unsafe) static var captureErrorDelegate:
+    (@Sendable (any Error, ErrorCategory, String, [String: Any]?) -> Void)?
 }

--- a/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
+++ b/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+@Suite("HeartPathContexts")
+struct HeartPathContextsTests {
+
+  @Test("CaptureStallContext is Sendable and carries all fields")
+  func captureStallContextRoundTrip() {
+    let ctx = CaptureStallContext(
+      sessionID: 42,
+      armedAtUptimeNs: 1_000_000_000,
+      firedAtUptimeNs: 1_800_000_000,
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: "BuiltInMicrophoneDevice",
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+    )
+    #expect(ctx.sessionID == 42)
+    #expect(ctx.firedAtUptimeNs - ctx.armedAtUptimeNs == 800_000_000)
+    #expect(ctx.sourceType == "av_audio_engine")
+    #expect(ctx.formatMismatchObserved == false)
+  }
+
+  @Test("CaptureSessionInterruptionContext kinds are stable")
+  func captureSessionInterruptionKinds() {
+    #expect(CaptureSessionInterruptionContext.Kind.wasInterrupted.rawValue == "wasInterrupted")
+    #expect(CaptureSessionInterruptionContext.Kind.runtimeError.rawValue == "runtimeError")
+  }
+
+  @Test("XPCReplyFailureContext retains replyStage verbatim")
+  func xpcReplyFailureContext() {
+    let ctx = XPCReplyFailureContext(
+      replyStage: "stop_capture",
+      errorDomain: "NSCocoaErrorDomain",
+      errorCode: 4097,
+      errorDescription: "Connection invalidated.",
+      sessionID: 7
+    )
+    #expect(ctx.replyStage == "stop_capture")
+    #expect(ctx.errorCode == 4097)
+  }
+
+  @Test("XPCErrorKind rawValues match protocol contract")
+  func xpcErrorKindRawValues() {
+    #expect(XPCErrorKind.interruptCapturing.rawValue == "interruptCapturing")
+    #expect(XPCErrorKind.invalidateCapturing.rawValue == "invalidateCapturing")
+    #expect(XPCErrorKind.invalidateIdle.rawValue == "invalidateIdle")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
+++ b/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprServices
+
+@Suite("HeartPathError")
+struct HeartPathErrorTests {
+
+  @Test("every case produces a non-empty localizedDescription")
+  func localizedDescriptionCoverage() {
+    let stallCtx = CaptureStallContext(
+      sessionID: 1, armedAtUptimeNs: 0, firedAtUptimeNs: 800_000_000,
+      route: "bt", sourceType: "av_capture_session",
+      engineStartedSuccessfully: true, tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil, inputDeviceUIDSystemDefault: nil
+    )
+    let sessionCtx = CaptureSessionInterruptionContext(
+      kind: .wasInterrupted, reasonCode: 1,
+      reasonLabel: "audio_device_in_use_by_another_client",
+      errorDomain: nil, errorCode: nil, errorDescription: nil,
+      sessionID: 1, isActivelyCapturing: true
+    )
+    let replyCtx = XPCReplyFailureContext(
+      replyStage: "stop_capture", errorDomain: "NSCocoaErrorDomain",
+      errorCode: 4097, errorDescription: "invalidated", sessionID: 1
+    )
+
+    let cases: [HeartPathError] = [
+      .audioCaptureStalled(sessionID: 1, ctx: stallCtx),
+      .noAudioCaptured(sessionID: 1, durationMs: 2000, wasStreaming: true, route: "bt"),
+      .captureSessionInterrupted(ctx: sessionCtx),
+      .pasteCascadeClipboardFallback(
+        tiersAttempted: ["ax1", "cgevent"], focusClassification: "text_field",
+        targetBundleID: "com.apple.Terminal"),
+      .pasteCGEventCreationFailed(accessibilityTrusted: true),
+      .pasteAppleScriptFailed(
+        errorCode: 1002, errorMessage: "Not authorized",
+        targetBundleID: "com.apple.Terminal"),
+      .audioXPCInterrupted(handler: .invalidate, wasCapturing: true),
+      .xpcReplyFailed(ctx: replyCtx),
+      .xpcServerClientProxyNil(sessionID: 1, consecutiveDrops: 5),
+      .emptyAfterProcessing(route: "built_in_mic", wasPolishEnabled: true),
+    ]
+
+    for heart in cases {
+      let desc = heart.errorDescription ?? ""
+      #expect(!desc.isEmpty, "empty description for \(heart)")
+    }
+  }
+
+  @Test("XPCHandlerKind rawValues are stable")
+  func handlerKinds() {
+    #expect(XPCHandlerKind.interrupt.rawValue == "interrupt")
+    #expect(XPCHandlerKind.invalidate.rawValue == "invalidate")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprServices
+
+@Suite("SentryAudioExtras")
+@MainActor
+struct SentryAudioExtrasTests {
+
+  @Test("base extras include core fields with stable keys")
+  func baseExtras() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      sessionID: 3,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: "ABC",
+      inputDeviceUIDSystemDefault: "ABC",
+      failureMode: "stalled"
+    )
+    #expect(extras["capture.source_type"] as? String == "av_audio_engine")
+    #expect(extras["capture.route"] as? String == "built_in_mic")
+    #expect(extras["capture.failure_mode"] as? String == "stalled")
+    #expect(extras["capture.is_actively_capturing"] as? Bool == true)
+    #expect(extras["capture_session_id"] as? Int == 3)
+    #expect(extras["capture.input_device_divergence"] as? Bool == false)
+  }
+
+  @Test("divergence flag true when preferred differs from system default")
+  func divergence() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "bt",
+      sourceType: "av_capture_session",
+      sessionID: 1,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: "MacBookMic",
+      inputDeviceUIDSystemDefault: "AirPodsPro",
+      failureMode: "no_audio_captured"
+    )
+    #expect(extras["capture.input_device_divergence"] as? Bool == true)
+  }
+
+  @Test("stall context adds stall-specific keys + window ms math")
+  func stallContextAddsKeys() {
+    let ctx = CaptureStallContext(
+      sessionID: 9,
+      armedAtUptimeNs: 1_000_000_000,
+      firedAtUptimeNs: 1_800_000_000,
+      route: "bt",
+      sourceType: "av_capture_session",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil
+    )
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.sourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "stalled",
+      stallContext: ctx,
+      polishModelSwapMs: 4500
+    )
+    #expect(extras["capture.stall.window_ms"] as? Int == 800)
+    #expect(extras["capture.format_mismatch"] as? Bool == true)
+    #expect(extras["capture.tap_installed"] as? Bool == true)
+    #expect(extras["polish.recent_model_swap_ms"] as? Int == 4500)
+  }
+
+  @Test("nil polish swap omits the key entirely")
+  func polishSwapOmission() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      sessionID: 1,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "thrown_start"
+    )
+    #expect(extras["polish.recent_model_swap_ms"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds structured Sentry telemetry for heart-path failure modes that were previously invisible: capture stalls, XPC service errors, paste cascade fallbacks, `emptyAfterProcessing`, and `AVCaptureSession` interruption context.
- New `HeartPathError` + `HeartPathTelemetryTarget` + `PasteDeliveryOutcome` + owner-selection in AppState with edge-triggered tiebreaker for backend overlap.
- Paid off immediately: caught the BT+YouTube+polish-swap wedge (#286) on first reproduction.

## Test plan
- [x] `swift build -c release` — green
- [x] `scripts/swift-test.sh` — 307 tests, 30 suites, all green (new: `HeartPathErrorTests`, `SentryAudioExtrasTests`, `HeartPathContextsTests`)
- [x] Runtime UAT — `Tests/UITests/wispr_eyes.test_recording` — full record→transcribe→polish→paste cycle clean
- [x] Live Sentry dashboard confirmation — categories `audio_capture_stalled`, `audio_capture_failed`, `xpc_service_error`, `paste_failed`, `heart_path_finalization` are surfacing correctly in dev environment (see #286 for evidence)
- [x] 11 Codex review rounds — 8+ real bugs caught and fixed pre-merge (direct-mode telemetry silence, proxy session-id drift, Swift 6 DispatchWorkItem isolation crash on PTT, double-emit interrupts, etc.)

## Known trade-offs (explicit for review)
- Pre-existing warm-engine teardown race + XPC begin-capture buffer-drop window are NOT addressed here (not #285 scope). Stall watchdog surfacing the former is correct signal, not regression.
- Late callbacks from an ending session during rapid backend-switch overlap are filtered (`isCurrentSession(ctx.sessionID)` in AppState) rather than routed to the departing pipeline. Accurate dedup was prioritized over rare-signal completeness. Full session→pipeline ownership map is PR 2 work.

## Files
22 changed, 6 new:
- Core: `CaptureStallContext.swift`
- Services: `HeartPathError.swift`, `SentryAudioExtras.swift`
- Tests: 3 new suites
- Audio: protocol extensions + watchdog impls across 3 sources + manager caching
- Pipeline: dedup flags + cascade outcome + finalization emission
- App: unified owner-selection + single-owner callback wiring

## Related
- Closes #285
- Blocks #286 investigation (P0 BT wedge) — telemetry from this PR is what enables #286 diagnosis
