### PR TITLE
fix(audio): propagate preWarm errors + trigger watchdog recovery (#289)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -509,18 +509,49 @@ final class AppState {
       )
 
       let pttStart = ContinuousClock.now
-      await active.handle(event: .preWarm)
-      guard !Task.isCancelled else {
-        // PTT release arrived during preWarm — stop the engine that preWarm started
+      do {
+        try await active.handle(event: .preWarm)
+      } catch is CancellationError {
+        // Issue #289: PTT release mid-preWarm threw CancellationError (silent
+        // unwind). Not a user-visible failure — just clean up. The existing
+        // `Task.isCancelled` guard below no longer fires because the throw
+        // short-circuits past it, so this catch is load-bearing.
         self.audioCapture.abortPreWarm()
         self.recordingOverlay.show(intent: .hidden)
+        self.isRecordingLocked = false
+        return
+      } catch {
+        // Issue #289: real preWarm failure (XPC transport dead, AVAudioEngine
+        // `'what?'`, etc.). Abort the start cleanly — never call
+        // `.toggleRecording` against a dead capture path — and surface a brief
+        // user-visible error. Telemetry-free here: the lower layers already
+        // breadcrumbed the root cause; this is the user-facing UX.
+        self.audioCapture.abortPreWarm()
+        self.recordingOverlay.show(intent: .hidden)
+        self.isRecordingLocked = false
+        SentryBreadcrumb.add(
+          stage: "recording", message: "preWarm failed — start aborted",
+          level: .warning, data: ["error": String(describing: error)]
+        )
+        active.setExternalError("Microphone unavailable — try again.")
+        return
+      }
+      guard !Task.isCancelled else {
+        // Non-throwing cancellation path (e.g. outer Task cancel between
+        // preWarm return and .toggleRecording dispatch).
+        self.audioCapture.abortPreWarm()
+        self.recordingOverlay.show(intent: .hidden)
+        self.isRecordingLocked = false
         return
       }
       let preWarmMs = {
         let (s, a) = (ContinuousClock.now - pttStart).components
         return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
       }()
-      await active.handle(event: .toggleRecording)
+      // `.toggleRecording` is declared throws on the protocol, but today the
+      // underlying implementation doesn't throw. `try?` keeps the surface
+      // unchanged. If a future event grows a meaningful throw we revisit here.
+      try? await active.handle(event: .toggleRecording)
       let totalMs = {
         let (s, a) = (ContinuousClock.now - pttStart).components
         return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
@@ -545,7 +576,7 @@ final class AppState {
     hotkeyService.onStopRecording = { [weak self] in
       guard let self else { return }
       self.isRecordingLocked = false
-      await self.activePipeline.handle(event: .requestStop)
+      try? await self.activePipeline.handle(event: .requestStop)
       if self.asrManager.activeBackendType == .whisperKit {
         self.whisperKitPipeline.autoPasteToActiveApp = false
       } else {
@@ -833,7 +864,7 @@ final class AppState {
       )
     }
 
-    await active.handle(event: .toggleRecording)
+    try? await active.handle(event: .toggleRecording)
 
     // Clear auto-paste on completion/error
     if active is WhisperKitPipeline {
@@ -860,7 +891,7 @@ final class AppState {
         return
       }
       whisperKitPipeline.autoPasteToActiveApp = false
-      await whisperKitPipeline.handle(event: .cancelRecording)
+      try? await whisperKitPipeline.handle(event: .cancelRecording)
     } else {
       guard pipelineState == .recording || pipelineState == .loadingModel else { return }
       pipeline.autoPasteToActiveApp = false

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -1,354 +1,363 @@
-import Foundation
-import EnviousWisprCore
-import EnviousWisprAudio
 import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprPipeline
 import EnviousWisprServices
+import Foundation
 
 /// Forwards settings changes to pipelines and subsystems.
 /// Single responsibility: settings propagation. No business logic.
 @MainActor
 final class PipelineSettingsSync {
-    private let pipeline: TranscriptionPipeline
-    private let whisperKitPipeline: WhisperKitPipeline
-    private let polishService: TranscriptPolishService
-    private let audioCapture: any AudioCaptureInterface
-    private let asrManager: any ASRManagerInterface
-    private let hotkeyService: HotkeyService
-    private let whisperKitSetup: WhisperKitSetupService
+  private let pipeline: TranscriptionPipeline
+  private let whisperKitPipeline: WhisperKitPipeline
+  private let polishService: TranscriptPolishService
+  private let audioCapture: any AudioCaptureInterface
+  private let asrManager: any ASRManagerInterface
+  private let hotkeyService: HotkeyService
+  private let whisperKitSetup: WhisperKitSetupService
 
-    /// Called when backend/model changes require WhisperKit preload re-observation.
-    /// Set by AppState — keeps preload observation ownership in AppState.
-    var onNeedsPreloadObservation: (() -> Void)?
+  /// Called when backend/model changes require WhisperKit preload re-observation.
+  /// Set by AppState — keeps preload observation ownership in AppState.
+  var onNeedsPreloadObservation: (() -> Void)?
 
-    init(
-        pipeline: TranscriptionPipeline,
-        whisperKitPipeline: WhisperKitPipeline,
-        polishService: TranscriptPolishService,
-        audioCapture: any AudioCaptureInterface,
-        asrManager: any ASRManagerInterface,
-        hotkeyService: HotkeyService,
-        whisperKitSetup: WhisperKitSetupService
-    ) {
-        self.pipeline = pipeline
-        self.whisperKitPipeline = whisperKitPipeline
-        self.polishService = polishService
-        self.audioCapture = audioCapture
-        self.asrManager = asrManager
-        self.hotkeyService = hotkeyService
-        self.whisperKitSetup = whisperKitSetup
+  init(
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    polishService: TranscriptPolishService,
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    hotkeyService: HotkeyService,
+    whisperKitSetup: WhisperKitSetupService
+  ) {
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.polishService = polishService
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.hotkeyService = hotkeyService
+    self.whisperKitSetup = whisperKitSetup
+  }
+
+  /// Apply initial settings to both pipelines and audio capture. Called once from AppState.init.
+  func applyInitialSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
+    // Parakeet pipeline
+    pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
+    pipeline.llmPolish.llmProvider = settings.llmProvider
+    pipeline.llmPolish.llmModel = resolvedModel(settings)
+    pipeline.vadAutoStop = settings.vadAutoStop
+    pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
+    pipeline.vadSensitivity = settings.vadSensitivity
+    pipeline.vadEnergyGate = settings.vadEnergyGate
+    pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+    pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
+    pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+    pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+    pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    pipeline.wordCorrection.customWords = customWords
+    pipeline.llmPolish.customWords = customWords
+    pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
+    pipeline.useStreamingASR = settings.useStreamingASR
+
+    // WhisperKit pipeline
+    syncWhisperKitPipelineSettings(settings, customWords: customWords)
+
+    // Transcript polish service (re-polish from detail view)
+    syncPolishServiceSettings(settings, customWords: customWords)
+
+    // Audio capture
+    if settings.noiseSuppression {
+      audioCapture.buildEngine(noiseSuppression: true)
+    } else {
+      audioCapture.noiseSuppressionEnabled = false
     }
+    audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
+    audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    audioCapture.warmEnginePolicy = settings.warmEnginePolicy
 
-    /// Apply initial settings to both pipelines and audio capture. Called once from AppState.init.
-    func applyInitialSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
-        // Parakeet pipeline
-        pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-        pipeline.llmPolish.llmProvider = settings.llmProvider
-        pipeline.llmPolish.llmModel = resolvedModel(settings)
-        pipeline.vadAutoStop = settings.vadAutoStop
-        pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-        pipeline.vadSensitivity = settings.vadSensitivity
-        pipeline.vadEnergyGate = settings.vadEnergyGate
-        pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-        pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-        pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-        pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-        pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
-        pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
-        pipeline.wordCorrection.customWords = customWords
-        pipeline.llmPolish.customWords = customWords
-        pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-        pipeline.useStreamingASR = settings.useStreamingASR
+    // VAD config to audio capture (used by XPC service-side VAD)
+    audioCapture.configureVAD(
+      autoStop: settings.vadAutoStop,
+      silenceTimeout: settings.vadSilenceTimeout,
+      sensitivity: settings.vadSensitivity,
+      energyGate: settings.vadEnergyGate
+    )
 
-        // WhisperKit pipeline
-        syncWhisperKitPipelineSettings(settings, customWords: customWords)
+    // Transcription options (language)
+    syncTranscriptionOptions(settings)
+  }
 
-        // Transcript polish service (re-polish from detail view)
-        syncPolishServiceSettings(settings, customWords: customWords)
-
-        // Audio capture
-        if settings.noiseSuppression {
-            audioCapture.buildEngine(noiseSuppression: true)
-        } else {
-            audioCapture.noiseSuppressionEnabled = false
+  /// Handle a settings change by forwarding to the appropriate subsystem.
+  func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
+    switch key {
+    case .selectedBackend:
+      // Don't switch backends while a pipeline is actively recording/transcribing
+      let parakeetActive = pipeline.state.isActive
+      let whisperKitActive = whisperKitPipeline.state.isActive
+      if parakeetActive || whisperKitActive {
+        Task {
+          await AppLogger.shared.log(
+            "Backend switch blocked — pipeline is active",
+            level: .info, category: "PipelineSettingsSync"
+          )
         }
-        audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
-        audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
-        audioCapture.warmEnginePolicy = settings.warmEnginePolicy
-
-        // VAD config to audio capture (used by XPC service-side VAD)
-        audioCapture.configureVAD(
-            autoStop: settings.vadAutoStop,
-            silenceTimeout: settings.vadSilenceTimeout,
-            sensitivity: settings.vadSensitivity,
-            energyGate: settings.vadEnergyGate
-        )
-
-        // Transcription options (language)
-        syncTranscriptionOptions(settings)
-    }
-
-    /// Handle a settings change by forwarding to the appropriate subsystem.
-    func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
-        switch key {
-        case .selectedBackend:
-            // Don't switch backends while a pipeline is actively recording/transcribing
-            let parakeetActive = pipeline.state.isActive
-            let whisperKitActive = whisperKitPipeline.state.isActive
-            if parakeetActive || whisperKitActive {
-                Task { await AppLogger.shared.log(
-                    "Backend switch blocked — pipeline is active",
-                    level: .info, category: "PipelineSettingsSync"
-                ) }
-                break
-            }
-            let backend = settings.selectedBackend
-            Task { [weak self] in
-                await self?.asrManager.switchBackend(to: backend)
-                SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
-                if backend == .whisperKit {
-                    await self?.whisperKitSetup.detectState()
-                    self?.onNeedsPreloadObservation?()
-                }
-            }
-        case .whisperKitModel:
-            let model = settings.whisperKitModel
-            whisperKitSetup.modelVariant = model
-            Task { [weak self] in
-                await self?.asrManager.updateWhisperKitModel(model)
-                await self?.whisperKitSetup.forceDetectState()
-                self?.onNeedsPreloadObservation?()
-            }
-        case .recordingMode:
-            hotkeyService.recordingMode = settings.recordingMode
-        case .llmProvider:
-            pipeline.llmPolish.llmProvider = settings.llmProvider
-            whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
-            polishService.llmPolishStep.llmProvider = settings.llmProvider
-            // Also sync model — provider change may canonicalize the model
-            let model = resolvedModel(settings)
-            pipeline.llmPolish.llmModel = model
-            whisperKitPipeline.llmPolish.llmModel = model
-            polishService.llmPolishStep.llmModel = model
-        case .llmModel:
-            let model = resolvedModel(settings)
-            pipeline.llmPolish.llmModel = model
-            whisperKitPipeline.llmPolish.llmModel = model
-            polishService.llmPolishStep.llmModel = model
-            if settings.llmProvider == .ollama {
-                settings.ollamaModel = settings.llmModel
-            }
-        case .ollamaModel:
-            if settings.llmProvider == .ollama {
-                pipeline.llmPolish.llmModel = settings.ollamaModel
-                whisperKitPipeline.llmPolish.llmModel = settings.ollamaModel
-                polishService.llmPolishStep.llmModel = settings.ollamaModel
-            }
-        case .autoCopyToClipboard:
-            pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-            whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-        case .hotkeyEnabled:
-            if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
-        case .vadAutoStop:
-            pipeline.vadAutoStop = settings.vadAutoStop
-            whisperKitPipeline.vadAutoStop = settings.vadAutoStop
-            audioCapture.configureVAD(
-                autoStop: settings.vadAutoStop,
-                silenceTimeout: settings.vadSilenceTimeout,
-                sensitivity: settings.vadSensitivity,
-                energyGate: settings.vadEnergyGate
-            )
-        case .vadSilenceTimeout:
-            pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-            whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-            audioCapture.configureVAD(
-                autoStop: settings.vadAutoStop,
-                silenceTimeout: settings.vadSilenceTimeout,
-                sensitivity: settings.vadSensitivity,
-                energyGate: settings.vadEnergyGate
-            )
-        case .environmentPreset:
-            let sensitivity = settings.environmentPreset.vadSensitivity
-            settings.vadSensitivity = sensitivity
-        case .writingStylePreset:
-            pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-            pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-            whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-            whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-            polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
-            polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
-        case .vadSensitivity:
-            pipeline.vadSensitivity = settings.vadSensitivity
-            whisperKitPipeline.vadSensitivity = settings.vadSensitivity
-            audioCapture.configureVAD(
-                autoStop: settings.vadAutoStop,
-                silenceTimeout: settings.vadSilenceTimeout,
-                sensitivity: settings.vadSensitivity,
-                energyGate: settings.vadEnergyGate
-            )
-        case .vadEnergyGate:
-            pipeline.vadEnergyGate = settings.vadEnergyGate
-            whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
-            audioCapture.configureVAD(
-                autoStop: settings.vadAutoStop,
-                silenceTimeout: settings.vadSilenceTimeout,
-                sensitivity: settings.vadSensitivity,
-                energyGate: settings.vadEnergyGate
-            )
-        case .cancelKeyCode:
-            hotkeyService.cancelKeyCode = settings.cancelKeyCode
-        case .cancelModifiers:
-            hotkeyService.cancelModifiers = settings.cancelModifiers
-        case .toggleKeyCode:
-            hotkeyService.toggleKeyCode = settings.toggleKeyCode
-            reregisterHotkeys()
-        case .toggleModifiers:
-            hotkeyService.toggleModifiers = settings.toggleModifiers
-            reregisterHotkeys()
-        case .pushToTalkKeyCode, .pushToTalkModifiers:
-            // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
-            break
-        case .modelUnloadPolicy:
-            pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-            whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-            if settings.modelUnloadPolicy == .never {
-                asrManager.cancelIdleTimer()
-            }
-        case .restoreClipboardAfterPaste:
-            pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-            whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-        case .customSystemPrompt:
-            pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-            pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-            whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-            whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-            polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
-            polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
-        case .wordCorrectionEnabled:
-            pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
-            whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
-        case .fillerRemovalEnabled:
-            pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
-            whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
-        case .isDebugModeEnabled:
-            Task { await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled) }
-        case .debugLogLevel:
-            Task { await AppLogger.shared.setLogLevel(settings.debugLogLevel) }
-        case .useExtendedThinking:
-            pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-            whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-            polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
-        case .whisperKitLanguage:
-            syncTranscriptionOptions(settings)
-        case .languageMode:
-            // Multilingual v1 (W2): keep pipeline in sync with user's auto/locked
-            // choice. Detection itself happens in the pipeline; this path just
-            // forwards the current mode so the detector actor reads it lazily.
-            whisperKitPipeline.languageMode = settings.languageMode
-            syncTranscriptionOptions(settings)
-        case .selectedInputDeviceUID:
-            audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
-        case .preferredInputDeviceIDOverride:
-            audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
-        case .noiseSuppression:
-            // Full engine rebuild — runtime toggling of voice processing is unreliable.
-            // Cancel any active recording first to avoid corrupted state.
-            if pipeline.state == .recording {
-                Task { [weak self] in
-                    await self?.pipeline.cancelRecording()
-                    self?.audioCapture.buildEngine(noiseSuppression: settings.noiseSuppression)
-                }
-            } else {
-                audioCapture.buildEngine(noiseSuppression: settings.noiseSuppression)
-            }
-        case .onboardingState, .hasCompletedOnboarding:
-            break
-        case .useXPCAudioService:
-            // Cold flag — requires app restart. No live propagation needed.
-            break
-        case .useStreamingASR:
-            pipeline.useStreamingASR = settings.useStreamingASR
-        case .warmEnginePolicy:
-            audioCapture.warmEnginePolicy = settings.warmEnginePolicy
-        case .useRefreshedWhisperKitModel:
-            // Cold flag (Multilingual v1 W4). The active modelVariant is resolved
-            // from this default at startup; toggling requires an app restart.
-            break
+        break
+      }
+      let backend = settings.selectedBackend
+      // Issue #289: invalidate any stall-recovery token on either pipeline
+      // so a deferred cleanup from a pre-switch stall doesn't tear down
+      // the pipeline that's about to become active.
+      pipeline.clearPendingStallRecovery()
+      whisperKitPipeline.clearPendingStallRecovery()
+      Task { [weak self] in
+        await self?.asrManager.switchBackend(to: backend)
+        SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
+        if backend == .whisperKit {
+          await self?.whisperKitSetup.detectState()
+          self?.onNeedsPreloadObservation?()
         }
-    }
-
-    /// Sync shared transcription options (language, timestamps) to both pipelines.
-    private func syncTranscriptionOptions(_ settings: SettingsManager) {
-        var opts = TranscriptionOptions()
-        // Parakeet is English-only; WhisperKit uses the user's selected language.
-        // Pass the language to both pipelines: Parakeet ignores it, WhisperKit
-        // passes it through to DecodingOptions.
-        //
-        // Multilingual v1: source is now `languageMode`, not the deprecated
-        // `whisperKitLanguage` field. In auto mode, leave language empty so the
-        // detector's result (set later in the pipeline) fills it. In locked
-        // mode, push the ISO code so the incremental worker and the batch
-        // decode see the correct language from recording start.
-        switch settings.languageMode {
-        case .auto:
-            // `TranscriptionOptions.language` is String?; nil means "let the
-            // detector decide" (the pipeline overwrites it after LID runs).
-            opts.language = nil
-        case .locked(let code):
-            opts.language = code
+      }
+    case .whisperKitModel:
+      let model = settings.whisperKitModel
+      whisperKitSetup.modelVariant = model
+      Task { [weak self] in
+        await self?.asrManager.updateWhisperKitModel(model)
+        await self?.whisperKitSetup.forceDetectState()
+        self?.onNeedsPreloadObservation?()
+      }
+    case .recordingMode:
+      hotkeyService.recordingMode = settings.recordingMode
+    case .llmProvider:
+      pipeline.llmPolish.llmProvider = settings.llmProvider
+      whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
+      polishService.llmPolishStep.llmProvider = settings.llmProvider
+      // Also sync model — provider change may canonicalize the model
+      let model = resolvedModel(settings)
+      pipeline.llmPolish.llmModel = model
+      whisperKitPipeline.llmPolish.llmModel = model
+      polishService.llmPolishStep.llmModel = model
+    case .llmModel:
+      let model = resolvedModel(settings)
+      pipeline.llmPolish.llmModel = model
+      whisperKitPipeline.llmPolish.llmModel = model
+      polishService.llmPolishStep.llmModel = model
+      if settings.llmProvider == .ollama {
+        settings.ollamaModel = settings.llmModel
+      }
+    case .ollamaModel:
+      if settings.llmProvider == .ollama {
+        pipeline.llmPolish.llmModel = settings.ollamaModel
+        whisperKitPipeline.llmPolish.llmModel = settings.ollamaModel
+        polishService.llmPolishStep.llmModel = settings.ollamaModel
+      }
+    case .autoCopyToClipboard:
+      pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
+      whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
+    case .hotkeyEnabled:
+      if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
+    case .vadAutoStop:
+      pipeline.vadAutoStop = settings.vadAutoStop
+      whisperKitPipeline.vadAutoStop = settings.vadAutoStop
+      audioCapture.configureVAD(
+        autoStop: settings.vadAutoStop,
+        silenceTimeout: settings.vadSilenceTimeout,
+        sensitivity: settings.vadSensitivity,
+        energyGate: settings.vadEnergyGate
+      )
+    case .vadSilenceTimeout:
+      pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
+      whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
+      audioCapture.configureVAD(
+        autoStop: settings.vadAutoStop,
+        silenceTimeout: settings.vadSilenceTimeout,
+        sensitivity: settings.vadSensitivity,
+        energyGate: settings.vadEnergyGate
+      )
+    case .environmentPreset:
+      let sensitivity = settings.environmentPreset.vadSensitivity
+      settings.vadSensitivity = sensitivity
+    case .writingStylePreset:
+      pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+      pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+      whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+      whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+    case .vadSensitivity:
+      pipeline.vadSensitivity = settings.vadSensitivity
+      whisperKitPipeline.vadSensitivity = settings.vadSensitivity
+      audioCapture.configureVAD(
+        autoStop: settings.vadAutoStop,
+        silenceTimeout: settings.vadSilenceTimeout,
+        sensitivity: settings.vadSensitivity,
+        energyGate: settings.vadEnergyGate
+      )
+    case .vadEnergyGate:
+      pipeline.vadEnergyGate = settings.vadEnergyGate
+      whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
+      audioCapture.configureVAD(
+        autoStop: settings.vadAutoStop,
+        silenceTimeout: settings.vadSilenceTimeout,
+        sensitivity: settings.vadSensitivity,
+        energyGate: settings.vadEnergyGate
+      )
+    case .cancelKeyCode:
+      hotkeyService.cancelKeyCode = settings.cancelKeyCode
+    case .cancelModifiers:
+      hotkeyService.cancelModifiers = settings.cancelModifiers
+    case .toggleKeyCode:
+      hotkeyService.toggleKeyCode = settings.toggleKeyCode
+      reregisterHotkeys()
+    case .toggleModifiers:
+      hotkeyService.toggleModifiers = settings.toggleModifiers
+      reregisterHotkeys()
+    case .pushToTalkKeyCode, .pushToTalkModifiers:
+      // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
+      break
+    case .modelUnloadPolicy:
+      pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+      whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+      if settings.modelUnloadPolicy == .never {
+        asrManager.cancelIdleTimer()
+      }
+    case .restoreClipboardAfterPaste:
+      pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
+      whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
+    case .customSystemPrompt:
+      pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+      pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+      whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+      whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+    case .wordCorrectionEnabled:
+      pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+      whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    case .fillerRemovalEnabled:
+      pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+      whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    case .isDebugModeEnabled:
+      Task { await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled) }
+    case .debugLogLevel:
+      Task { await AppLogger.shared.setLogLevel(settings.debugLogLevel) }
+    case .useExtendedThinking:
+      pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
+      whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
+      polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
+    case .whisperKitLanguage:
+      syncTranscriptionOptions(settings)
+    case .languageMode:
+      // Multilingual v1 (W2): keep pipeline in sync with user's auto/locked
+      // choice. Detection itself happens in the pipeline; this path just
+      // forwards the current mode so the detector actor reads it lazily.
+      whisperKitPipeline.languageMode = settings.languageMode
+      syncTranscriptionOptions(settings)
+    case .selectedInputDeviceUID:
+      audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
+    case .preferredInputDeviceIDOverride:
+      audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    case .noiseSuppression:
+      // Full engine rebuild — runtime toggling of voice processing is unreliable.
+      // Cancel any active recording first to avoid corrupted state.
+      if pipeline.state == .recording {
+        Task { [weak self] in
+          await self?.pipeline.cancelRecording()
+          self?.audioCapture.buildEngine(noiseSuppression: settings.noiseSuppression)
         }
-        pipeline.transcriptionOptions = opts
-        whisperKitPipeline.transcriptionOptions = opts
+      } else {
+        audioCapture.buildEngine(noiseSuppression: settings.noiseSuppression)
+      }
+    case .onboardingState, .hasCompletedOnboarding:
+      break
+    case .useXPCAudioService:
+      // Cold flag — requires app restart. No live propagation needed.
+      break
+    case .useStreamingASR:
+      pipeline.useStreamingASR = settings.useStreamingASR
+    case .warmEnginePolicy:
+      audioCapture.warmEnginePolicy = settings.warmEnginePolicy
+    case .useRefreshedWhisperKitModel:
+      // Cold flag (Multilingual v1 W4). The active modelVariant is resolved
+      // from this default at startup; toggling requires an app restart.
+      break
     }
+  }
 
-    /// Sync all user-facing settings to the WhisperKit pipeline.
-    private func syncWhisperKitPipelineSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
-        whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-        whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-        whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
-        whisperKitPipeline.llmPolish.llmModel = resolvedModel(settings)
-        whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-        whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-        whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-        whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
-        whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
-        whisperKitPipeline.wordCorrection.customWords = customWords
-        whisperKitPipeline.llmPolish.customWords = customWords
-        whisperKitPipeline.vadAutoStop = settings.vadAutoStop
-        whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-        whisperKitPipeline.vadSensitivity = settings.vadSensitivity
-        whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
-        whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-        // Multilingual v1 (W2): mirror the current auto/locked mode on startup.
-        whisperKitPipeline.languageMode = settings.languageMode
+  /// Sync shared transcription options (language, timestamps) to both pipelines.
+  private func syncTranscriptionOptions(_ settings: SettingsManager) {
+    var opts = TranscriptionOptions()
+    // Parakeet is English-only; WhisperKit uses the user's selected language.
+    // Pass the language to both pipelines: Parakeet ignores it, WhisperKit
+    // passes it through to DecodingOptions.
+    //
+    // Multilingual v1: source is now `languageMode`, not the deprecated
+    // `whisperKitLanguage` field. In auto mode, leave language empty so the
+    // detector's result (set later in the pipeline) fills it. In locked
+    // mode, push the ISO code so the incremental worker and the batch
+    // decode see the correct language from recording start.
+    switch settings.languageMode {
+    case .auto:
+      // `TranscriptionOptions.language` is String?; nil means "let the
+      // detector decide" (the pipeline overwrites it after LID runs).
+      opts.language = nil
+    case .locked(let code):
+      opts.language = code
     }
+    pipeline.transcriptionOptions = opts
+    whisperKitPipeline.transcriptionOptions = opts
+  }
 
-    /// Sync all LLM settings to the transcript polish service (re-polish from detail view).
-    /// TODO: Replace 3-way sync with shared LLMPolishConfig provider (#206 follow-up)
-    private func syncPolishServiceSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
-        polishService.llmPolishStep.llmProvider = settings.llmProvider
-        polishService.llmPolishStep.llmModel = resolvedModel(settings)
-        polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
-        polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
-        polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
-        polishService.llmPolishStep.customWords = customWords
-    }
+  /// Sync all user-facing settings to the WhisperKit pipeline.
+  private func syncWhisperKitPipelineSettings(
+    _ settings: SettingsManager, customWords: [CustomWord]
+  ) {
+    whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
+    whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
+    whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
+    whisperKitPipeline.llmPolish.llmModel = resolvedModel(settings)
+    whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
+    whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+    whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
+    whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    whisperKitPipeline.wordCorrection.customWords = customWords
+    whisperKitPipeline.llmPolish.customWords = customWords
+    whisperKitPipeline.vadAutoStop = settings.vadAutoStop
+    whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
+    whisperKitPipeline.vadSensitivity = settings.vadSensitivity
+    whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
+    whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+    // Multilingual v1 (W2): mirror the current auto/locked mode on startup.
+    whisperKitPipeline.languageMode = settings.languageMode
+  }
 
-    /// Resolve the effective LLM model ID for the current provider.
-    /// Apple Intelligence has a fixed model; Ollama uses its own model field.
-    private func resolvedModel(_ settings: SettingsManager) -> String {
-        switch settings.llmProvider {
-        case .appleIntelligence: return "apple-intelligence"
-        case .ollama: return settings.ollamaModel
-        default: return settings.llmModel
-        }
-    }
+  /// Sync all LLM settings to the transcript polish service (re-polish from detail view).
+  /// TODO: Replace 3-way sync with shared LLMPolishConfig provider (#206 follow-up)
+  private func syncPolishServiceSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
+    polishService.llmPolishStep.llmProvider = settings.llmProvider
+    polishService.llmPolishStep.llmModel = resolvedModel(settings)
+    polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+    polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+    polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
+    polishService.llmPolishStep.customWords = customWords
+  }
 
-    /// Re-register Carbon hotkeys after a config change.
-    private func reregisterHotkeys() {
-        guard hotkeyService.isEnabled else { return }
-        hotkeyService.stop()
-        hotkeyService.start()
+  /// Resolve the effective LLM model ID for the current provider.
+  /// Apple Intelligence has a fixed model; Ollama uses its own model field.
+  private func resolvedModel(_ settings: SettingsManager) -> String {
+    switch settings.llmProvider {
+    case .appleIntelligence: return "apple-intelligence"
+    case .ollama: return settings.ollamaModel
+    default: return settings.llmModel
     }
+  }
+
+  /// Re-register Carbon hotkeys after a config change.
+  private func reregisterHotkeys() {
+    guard hotkeyService.isEnabled else { return }
+    hotkeyService.stop()
+    hotkeyService.start()
+  }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -86,7 +86,7 @@ public protocol AudioCaptureInterface: AnyObject {
   func stopCapture() async -> CaptureResult
   func rebuildEngine()
   func buildEngine(noiseSuppression: Bool)
-  func preWarm() async
+  func preWarm() async throws
   func abortPreWarm()
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -290,7 +290,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     }
   }
 
-  public func preWarm() async {
+  public func preWarm() async throws {
     let preWarmStart = ContinuousClock.now
     let source = resolveSource()
     let resolveMs = Self.ms(ContinuousClock.now - preWarmStart)
@@ -308,7 +308,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
           level: .info, category: "Audio"
         )
       }
-      return
+      // Issue #289: propagate so callers can abort the start cleanly.
+      throw error
     }
     let prepareMs = Self.ms(ContinuousClock.now - preWarmStart)
     let stabStart = ContinuousClock.now

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -292,7 +292,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     serviceProxy { proxy in proxy.buildEngine(noiseSuppression: noiseSuppression) }
   }
 
-  public func preWarm() async {
+  public func preWarm() async throws {
     let proxyStart = ContinuousClock.now
 
     // Derive route label so Sentry telemetry is populated even when
@@ -331,7 +331,10 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           level: .info, category: "XPC"
         )
       }
-      return
+      // Issue #289: propagate so the pipeline / AppState can abort the
+      // recording cleanly instead of flipping isPreWarmed=true against a
+      // dead capture path.
+      throw error
     }
     let enginePhaseMs = Self.ms(ContinuousClock.now - enginePhaseStart)
     // Phase 2: wait for format stabilization

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -39,7 +39,23 @@ public enum OverlayIntent: Equatable, Sendable {
 @MainActor
 public protocol DictationPipeline: AnyObject {
   var overlayIntent: OverlayIntent { get }
-  func handle(event: PipelineEvent) async
+  /// Issue #289: `.preWarm` may now throw if the audio input fails to
+  /// start (XPC transport error, AVAudioEngine start refusal, etc.). Other
+  /// events never throw today but the unified signature lets callers observe
+  /// failures without a second protocol method.
+  func handle(event: PipelineEvent) async throws
+  /// Surface an error to the pipeline from outside (e.g. `AppState` after
+  /// `handle(.preWarm)` threw). Intentionally dumb: sets `state = .error(msg)`
+  /// and clears transient state. No retry scheduling, no transition logic.
+  func setExternalError(_ message: String)
+
+  /// Issue #289: invalidate any pending stall-recovery cleanup token so a
+  /// deferred `finishStallRecovery` won't call `stopCapture()` on a session
+  /// this pipeline no longer owns. Called by `PipelineSettingsSync` on
+  /// backend switch — the deactivating pipeline may still hold a token for a
+  /// pre-switch stall, and the shared `AudioCaptureInterface.currentCaptureSessionID`
+  /// doesn't advance until the other pipeline reaches `beginCapturePhase()`.
+  func clearPendingStallRecovery()
 }
 
 /// Issue #285 — heart-path telemetry callbacks that AppState routes to

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -90,6 +90,15 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// instead of also firing `no_audio_captured` for the same incident.
   private var xpcReplyFailedThisSession: Bool = false
 
+  /// Issue #289 stall-recovery ownership token. Set to the stalled session's
+  /// ID when `handleCaptureStall` flips state to `.error`, cleared by any path
+  /// that takes ownership back (fresh `startRecording`, `cancelRecording`,
+  /// `reset`, engine interruption). `finishStallRecovery` bails unless the
+  /// token still matches, so a fast retry that hasn't yet reached
+  /// `beginCapturePhase()` (and therefore hasn't advanced
+  /// `currentCaptureSessionID`) is not torn down by stale cleanup.
+  private var pendingStallRecoveryToken: UInt64?
+
   public init(
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
@@ -180,6 +189,49 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       stage: "recording",
       extra: extras
     )
+
+    // Issue #289: flip terminal state SYNCHRONOUSLY before any await so a
+    // racing PTT key-up can't slip into `stopAndTranscribe` against a live
+    // `.recording` state. `stallEventAlreadyCaptured` already dedups re-entry.
+    guard state == .recording else { return }
+    stopRequested = true
+    isPreWarmed = false
+    recordingStartTime = nil
+    pendingStallRecoveryToken = ctx.sessionID
+    state = .error("No audio detected — try again.")
+
+    // Async cleanup — token-gated. `currentCaptureSessionID` alone is
+    // insufficient because `preWarm()` / `startEnginePhase()` do not advance
+    // it (Codex 2026-04-15); a fast retry would slip through a sessionID-only
+    // gate while still pre-`beginCapturePhase`. The token is cleared by any
+    // path that takes ownership back, so fast-retry + cross-pipeline races
+    // both bail cleanly here.
+    Task { @MainActor [weak self, sessionID = ctx.sessionID] in
+      await self?.finishStallRecovery(for: sessionID)
+    }
+  }
+
+  /// Issue #289: token-gated cleanup after `handleCaptureStall` flipped
+  /// terminal state. Bails if any path has taken ownership back.
+  /// `stopCapture()` is required — the source-side watchdog is only cancelled
+  /// by stop / deactivate / interruption paths, so a state-only recovery
+  /// would leak it in the committed-recovery case.
+  @MainActor
+  private func finishStallRecovery(for sessionID: UInt64) async {
+    // Defense-in-depth: if state has moved off `.error` since we scheduled
+    // cleanup, another path is in-flight (retry, cancel, interruption) —
+    // do not stopCapture.
+    guard case .error = state else { return }
+    guard pendingStallRecoveryToken == sessionID else { return }
+    guard audioCapture.currentCaptureSessionID == sessionID else { return }
+    pendingStallRecoveryToken = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    if streamingASRActive {
+      await asrManager.cancelStreaming()
+    }
+    deactivateStreamingForwarding()
+    _ = await audioCapture.stopCapture()
   }
 
   private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
@@ -240,11 +292,23 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Pre-warm the audio input to trigger any Bluetooth codec switch before recording.
   /// Called on PTT key-down to hide the 0.5-2s Bluetooth negotiation latency.
   /// Sets `isPreWarmed` so `startRecording()` skips engine phase 1.
-  public func preWarmAudioInput() async {
+  public func preWarmAudioInput() async throws {
     guard !state.isActive, state != .recording else { return }
+    // Issue #289: earliest new-attempt signal — clear any stale stall-recovery
+    // token BEFORE the cleanup Task can race against this retry's `preWarm`
+    // and `startEnginePhase`, neither of which advance currentCaptureSessionID.
+    // Clearing in `startRecording` alone was too late: the async cleanup could
+    // fire during the window between `preWarmAudioInput` start and
+    // `startRecording` entry (PTT event flow is `.preWarm` then
+    // `.toggleRecording`). Same-pipeline retry only; cross-pipeline backend
+    // switch is a narrower window handled by the sessionID gate once
+    // `beginCapturePhase()` runs on the other pipeline.
+    pendingStallRecoveryToken = nil
     stopRequested = false
     let start = ContinuousClock.now
-    await audioCapture.preWarm()
+    // Issue #289: propagate preWarm failures. `isPreWarmed` is only flipped
+    // to true on a real success — never against a dead capture path.
+    try await audioCapture.preWarm()
     guard !Task.isCancelled else { return }
     isPreWarmed = true
     let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
@@ -270,6 +334,9 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
 
   /// Start recording audio from the microphone.
   public func startRecording() async {
+    // Issue #289: new attempt takes ownership — any pending stall recovery
+    // from a prior session must not tear down the fresh source.
+    pendingStallRecoveryToken = nil
     guard !Task.isCancelled else { return }
     guard !isStarting else { return }
     guard !state.isActive || state == .complete else { return }
@@ -892,6 +959,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   public func reset() {
     guard !isStopping, !isStarting else { return }
     stopRequested = false
+    pendingStallRecoveryToken = nil
     vadMonitorTask?.cancel()
     vadMonitorTask = nil
     // Cancel any active streaming ASR session to prevent orphaned sessions.
@@ -915,6 +983,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
   /// Called by AppState's unified interruption handler, not set directly on audioCapture.
   public func handleEngineInterruption() {
+    pendingStallRecoveryToken = nil
     // Issue #285 — Sentry emission for audio/XPC interruptions is owned by
     // AppState.onXPCServiceError (single-owner per plan §3.4a). This handler
     // is control-flow only: clean up pipeline state + transition UI.
@@ -944,6 +1013,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Called by AppState's unified ASR interruption handler when this pipeline is active.
   /// Must stop audio capture (still running — only ASR died) and clean up fully.
   public func handleASRServiceInterruption() {
+    pendingStallRecoveryToken = nil
     let snapshot = buildInterruptionSnapshot()
     SentryBreadcrumb.captureError(
       NSError(
@@ -990,6 +1060,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Guards on `.recording` state — safe to call from any other state.
   public func cancelRecording() async {
     stopRequested = false
+    pendingStallRecoveryToken = nil
 
     // Cancel during model loading: abort the load task and return to idle.
     if state == .loadingModel {
@@ -1165,10 +1236,10 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     }
   }
 
-  public func handle(event: PipelineEvent) async {
+  public func handle(event: PipelineEvent) async throws {
     switch event {
     case .preWarm:
-      await preWarmAudioInput()
+      try await preWarmAudioInput()
     case .toggleRecording:
       await toggleRecording()
     case .requestStop:
@@ -1178,5 +1249,17 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     case .reset:
       reset()
     }
+  }
+
+  /// Issue #289: dumb external-error sink. No transition side-effects, no
+  /// retry scheduling — callers own the decision to surface an error here.
+  public func setExternalError(_ message: String) {
+    currentTranscript = nil
+    state = .error(message)
+  }
+
+  /// Issue #289: see `DictationPipeline.clearPendingStallRecovery`.
+  public func clearPendingStallRecovery() {
+    pendingStallRecoveryToken = nil
   }
 }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -118,6 +118,9 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   private var incrementalWorker: WhisperKitIncrementalWorker?
   private var modelUnloadTask: Task<Void, Never>?
 
+  /// Issue #289 stall-recovery ownership token (see TranscriptionPipeline).
+  private var pendingStallRecoveryToken: UInt64?
+
   public init(
     audioCapture: any AudioCaptureInterface,
     backend: WhisperKitBackend,
@@ -214,6 +217,35 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       stage: "recording",
       extra: extras
     )
+
+    // Issue #289: synchronous terminal-state flip before any await — see
+    // TranscriptionPipeline.handleCaptureStall for the race-closure rationale.
+    guard state == .recording else { return }
+    isPreWarmed = false
+    recordingStartTime = nil
+    pendingStallRecoveryToken = ctx.sessionID
+    state = .error("No audio detected — try again.")
+
+    Task { @MainActor [weak self, sessionID = ctx.sessionID] in
+      await self?.finishStallRecovery(for: sessionID)
+    }
+  }
+
+  /// Issue #289: token-gated cleanup (mirrors `TranscriptionPipeline`).
+  /// See TranscriptionPipeline.finishStallRecovery for the sessionID-stale
+  /// race that the token gate closes.
+  @MainActor
+  private func finishStallRecovery(for sessionID: UInt64) async {
+    // Defense-in-depth (see TranscriptionPipeline).
+    guard case .error = state else { return }
+    guard pendingStallRecoveryToken == sessionID else { return }
+    guard audioCapture.currentCaptureSessionID == sessionID else { return }
+    pendingStallRecoveryToken = nil
+    vadMonitorTask?.cancel()
+    vadMonitorTask = nil
+    await incrementalWorker?.cancel()
+    incrementalWorker = nil
+    _ = await audioCapture.stopCapture()
   }
 
   private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
@@ -287,10 +319,10 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     }
   }
 
-  public func handle(event: PipelineEvent) async {
+  public func handle(event: PipelineEvent) async throws {
     switch event {
     case .preWarm:
-      await preWarmAudioInput()
+      try await preWarmAudioInput()
     case .toggleRecording:
       await toggleRecording()
     case .requestStop:
@@ -300,6 +332,17 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     case .reset:
       reset()
     }
+  }
+
+  /// Issue #289: dumb external-error sink (mirrors `TranscriptionPipeline`).
+  public func setExternalError(_ message: String) {
+    currentTranscript = nil
+    state = .error(message)
+  }
+
+  /// Issue #289: see `DictationPipeline.clearPendingStallRecovery`.
+  public func clearPendingStallRecovery() {
+    pendingStallRecoveryToken = nil
   }
 
   // MARK: - Background Pre-load
@@ -340,10 +383,14 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
   // MARK: - Recording Lifecycle
 
-  public func preWarmAudioInput() async {
+  public func preWarmAudioInput() async throws {
     guard !state.isActive, state != .recording else { return }
+    // Issue #289: earliest new-attempt signal — see TranscriptionPipeline
+    // for rationale. Clearing in `startRecording` alone left a race window.
+    pendingStallRecoveryToken = nil
     let start = ContinuousClock.now
-    await audioCapture.preWarm()
+    // Issue #289: propagate preWarm failures (see TranscriptionPipeline).
+    try await audioCapture.preWarm()
     guard !Task.isCancelled else { return }
     isPreWarmed = true
     let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
@@ -373,6 +420,9 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   private var isStarting = false
 
   public func startRecording() async {
+    // Issue #289: new attempt takes ownership — invalidate any pending stall
+    // recovery token so an in-flight cleanup cannot tear down this session.
+    pendingStallRecoveryToken = nil
     guard !isStarting else { return }
     guard !state.isActive || state == .complete || state == .ready else { return }
     isStarting = true
@@ -978,6 +1028,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   /// Handle audio engine interruption (device disconnect, service crash, max duration cap).
   /// Called by AppState's unified interruption handler, not set directly on audioCapture.
   public func handleEngineInterruption() {
+    pendingStallRecoveryToken = nil
     // Issue #285 — Sentry emission for audio/XPC interruptions is owned by
     // AppState.onXPCServiceError (single-owner per plan §3.4a). Control-flow
     // cleanup only.
@@ -1002,6 +1053,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   /// Called by AppState's unified ASR interruption handler when this pipeline is active.
   /// Must stop audio capture (still running — only ASR died) and clean up fully.
   public func handleASRServiceInterruption() {
+    pendingStallRecoveryToken = nil
     let snapshot = buildInterruptionSnapshot()
     SentryBreadcrumb.captureError(
       NSError(
@@ -1041,6 +1093,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   }
 
   public func cancelRecording() async {
+    pendingStallRecoveryToken = nil
     if state == .startingUp || state == .loadingModel {
       // Cancel during startup or model load — transition to idle
       state = .idle
@@ -1061,6 +1114,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   }
 
   public func reset() {
+    pendingStallRecoveryToken = nil
     vadMonitorTask?.cancel()
     vadMonitorTask = nil
     // Fire-and-forget cancel — reset() is synchronous, worker cancel is safe to defer

--- a/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
@@ -1,0 +1,131 @@
+@preconcurrency import AVFoundation
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// Issue #289 — verify the `AudioCaptureInterface.preWarm` contract now
+/// propagates errors. Full pipeline-level integration tests for the
+/// `handle(event:)` / `handleCaptureStall` recovery paths are gapped for
+/// follow-up (requires mocks for `ASRManagerInterface` + `WhisperKitBackend`
+/// that don't yet exist in this repo). The core behavior is validated by
+/// deliberate-failure UAT in the PR (inject `PreWarmFailedError.simulated`
+/// and observe recovery to `.error`).
+@Suite("PreWarm throws contract")
+struct PreWarmThrowsTests {
+
+  @Test("conforming mock can throw on preWarm, callers observe error")
+  @MainActor
+  func preWarmPropagatesError() async {
+    let mock = ThrowingAudioCapture()
+    await #expect(throws: PreWarmFailedError.self) {
+      try await mock.preWarm()
+    }
+  }
+
+  @Test("mock preWarm returns cleanly when not configured to throw")
+  @MainActor
+  func preWarmSucceedsByDefault() async throws {
+    let mock = PassthroughAudioCapture()
+    try await mock.preWarm()
+    #expect(mock.preWarmCallCount == 1)
+  }
+}
+
+enum PreWarmFailedError: Error, Equatable {
+  case simulated
+}
+
+// MARK: - Minimal AudioCaptureInterface conformers for protocol-contract tests
+
+@MainActor
+final class ThrowingAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "unknown"
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "mock"
+  var noiseSuppressionEnabled: Bool = false
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func buildEngine(noiseSuppression: Bool) {}
+  func preWarm() async throws {
+    throw PreWarmFailedError.simulated
+  }
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}
+
+@MainActor
+final class PassthroughAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "unknown"
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "mock"
+  var noiseSuppressionEnabled: Bool = false
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  private(set) var preWarmCallCount: Int = 0
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func buildEngine(noiseSuppression: Bool) {}
+  func preWarm() async throws { preWarmCallCount += 1 }
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}


### PR DESCRIPTION
Closes #289. Follow-ups: #290 (extract HeartPathTelemetryEmitter), #291 (pipeline-level integration test coverage).

## Summary

Two orthogonal heart-path recovery gaps, both surfacing as a stuck recording overlay that only kill-app clears:

1. **`preWarm` swallow** — `AudioCaptureProxy` / `AudioCaptureManager` caught XPC / AVAudioEngine start failures and returned normally. Pipeline then flipped `isPreWarmed = true` against a dead capture path and entered `.recording`. `AudioCaptureInterface.preWarm` is now `async throws`; pipelines + `AppState` propagate. `AppState.startRecording` catches, splitting `CancellationError` (silent PTT-release unwind) from real failures (user-visible "Microphone unavailable — try again") via the new `DictationPipeline.setExternalError` sink.

2. **Watchdog telemetry-only** — #285's 800 ms stall watchdog emitted Sentry but never transitioned pipeline state, leaving the overlay up. `handleCaptureStall` now flips `state = .error` synchronously after the captureError (closes the PTT-key-up race), then runs token-gated async cleanup (`finishStallRecovery`) that cancels VAD / streaming and calls `stopCapture()`. `stopCapture()` is required: the source-side watchdog is only cancelled by stop / deactivate / interruption paths, so a state-only recovery would leak it.

Net: today's "kill-app required" wedge becomes a ~1-second error flash. User retries, works.

## Recovery-race gates (after Codex + council review)

The deferred `finishStallRecovery(sessionID:)` guards against three races surfaced during review (Codex round 1, Gemini, GPT-5):

1. **`sessionID`-stale** (Codex round 1): `currentCaptureSessionID` only bumps in `beginCapturePhase()`; `preWarm()` / `startEnginePhase()` don't advance it, so a fast retry slips through a sessionID-only gate. → Added per-pipeline `pendingStallRecoveryToken: UInt64?`.
2. **Token cleared too late** (Gemini): clearing in `startRecording` alone left the `preWarmAudioInput → startRecording` window open. → Clear moved to `preWarmAudioInput` entry (earliest MainActor sync point).
3. **Cross-pipeline backend switch** (GPT): Parakeet stalls → user switches to WhisperKit (allowed because `.error.isActive == false`) → WhisperKit PTT fires before its session ID advances → Parakeet's deferred cleanup kills WhisperKit's fresh session. → New `clearPendingStallRecovery()` on both pipelines, called from `PipelineSettingsSync` on backend switch.

Final gate order in `finishStallRecovery`:
```swift
guard case .error = state else { return }           // defense-in-depth
guard pendingStallRecoveryToken == sessionID else { return }
guard audioCapture.currentCaptureSessionID == sessionID else { return }
```

## Scope

- 9 files, ~660 inserts / ~340 deletes. The `PipelineSettingsSync.swift` delta is dominated by a one-time swift-format reflow (4-space → project 2-space) triggered by the formatter hook after a single-line edit. The semantic change in that file is a 4-line `clearPendingStallRecovery()` call pair.
- 0 test doubles to update (whole-repo rg audit clean — only `AudioCaptureProxy` and `AudioCaptureManager` conform to `AudioCaptureInterface`).
- 0 `Task { try await handle(event: ...) }` swallowed-throws sites (A7 audit clean).

## Testing

- **Unit (new):** `PreWarmThrowsTests` — protocol-level contract for `preWarm` error propagation. 309 tests green (was 307).
- **Pipeline-level integration tests: gapped** per workflow-process.md §9 allowance (no existing mocks for `ASRManagerInterface` / `WhisperKitBackend`, no seam to force `state = .recording` from a unit test without driving the full pipeline). Tracked as #291 for prereq mock infrastructure. Core behavior validated by deliberate-failure UAT below.
- **Deliberate-failure UAT:**
  - Injected one-shot `throw XPCTransportError.serviceUnreachable` at the top of `AudioCaptureProxy.preWarm`, rebuilt + relaunched via `bundle-dev.sh`.
  - PTT on the dev build: injection fired at `19:51:15Z`, subsequent PTT at `19:51:39Z` completed full Recording → ASR → Paste in 0.45s. No stuck overlay; hands-free lock cleared; retry worked on first attempt.
  - Reverted injection, rebuilt, re-verified: happy path 0.44s end-to-end.

## Out of scope / follow-ups

- Architectural centralization of recovery ownership on `AudioCaptureInterface` — tracked in **#290** (`HeartPathTelemetryEmitter` extraction). Would also eliminate the remaining narrow edges (e.g., backend switch during a live stalled session leaves the shared capture briefly dirty; `resolveSource()` self-heals on next `beginCapturePhase`).
- Warm-engine teardown race (the `'what?'` AVAudioEngine error) — PR 2 of #285, not this one. This PR turns the observable symptom from "stuck forever" into "brief hiccup, retry works" so we can ship while the root-cause data collects.
- OnboardingV2View pre-existing Swift 6 actor-isolated warnings on `Timer` closure — last touched months ago, not introduced here.

## Review trail

- Plan: `docs/feature-requests/issue-289-2026-04-15-preWarm-throws-and-watchdog-recovery.md`
- Upstream hypothesis: `docs/feature-requests/issue-289-heart-path-recovery-gap-hypothesis.md`
- Plan-stage reviewers: GPT (4 amendments A1-A4), Codex on plan (A5-A6), GPT Desktop greenlight (A7-A10), Gemini unavailable at plan stage.
- Code-diff reviewers: Codex round 1 → P1 fix (token gate), Codex round 2 → P2 flag on cross-pipeline leak (accepted as narrow tradeoff, self-healing via `resolveSource()`), Gemini + GPT on fix design.
