### PR TITLE
fix(llm): unload previous Ollama model on polish-model swap (#295)

### DIFF
--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -22,6 +22,14 @@ final class PipelineSettingsSync {
   /// Set by AppState — keeps preload observation ownership in AppState.
   var onNeedsPreloadObservation: (() -> Void)?
 
+  /// Last effective Ollama model name seen by this observer, or nil if the
+  /// last known state was non-Ollama. Tracked independently of
+  /// `polishService.llmPolishStep` because SettingsManager's cascading
+  /// didSet (e.g., `llmProvider = .appleIntelligence` synchronously writes
+  /// `llmModel = "apple-intelligence"`) can corrupt a pre-snapshot read from
+  /// the polish step. Sole source of truth for #295 eviction decisions.
+  private var lastEvictableOllamaModel: String?
+
   init(
     pipeline: TranscriptionPipeline,
     whisperKitPipeline: WhisperKitPipeline,
@@ -87,6 +95,13 @@ final class PipelineSettingsSync {
 
     // Transcription options (language)
     syncTranscriptionOptions(settings)
+
+    // #295: seed the eviction tracker so the first swap captures the right
+    // "previous" model. No initial eviction fires (this is app launch, not
+    // a user swap).
+    lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
+      provider: settings.llmProvider, model: resolvedModel(settings)
+    )
   }
 
   /// Handle a settings change by forwarding to the appropriate subsystem.
@@ -138,6 +153,7 @@ final class PipelineSettingsSync {
       pipeline.llmPolish.llmModel = model
       whisperKitPipeline.llmPolish.llmModel = model
       polishService.llmPolishStep.llmModel = model
+      reconcileOllamaEviction(settings: settings)
     case .llmModel:
       let model = resolvedModel(settings)
       pipeline.llmPolish.llmModel = model
@@ -146,12 +162,14 @@ final class PipelineSettingsSync {
       if settings.llmProvider == .ollama {
         settings.ollamaModel = settings.llmModel
       }
+      reconcileOllamaEviction(settings: settings)
     case .ollamaModel:
       if settings.llmProvider == .ollama {
         pipeline.llmPolish.llmModel = settings.ollamaModel
         whisperKitPipeline.llmPolish.llmModel = settings.ollamaModel
         polishService.llmPolishStep.llmModel = settings.ollamaModel
       }
+      reconcileOllamaEviction(settings: settings)
     case .autoCopyToClipboard:
       pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
       whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
@@ -351,6 +369,35 @@ final class PipelineSettingsSync {
     case .appleIntelligence: return "apple-intelligence"
     case .ollama: return settings.ollamaModel
     default: return settings.llmModel
+    }
+  }
+
+  // MARK: - Ollama eviction on swap (#295)
+
+  /// Reconcile `lastEvictableOllamaModel` with the current effective state
+  /// and fire a best-effort unload if the tracked previous model differs
+  /// from the new one (including new = nil when the user leaves Ollama).
+  ///
+  /// Using an internal tracker — not a polishStep snapshot — avoids the
+  /// SettingsManager cascading-didSet trap where
+  /// `settings.llmProvider = .appleIntelligence` synchronously writes
+  /// `settings.llmModel = "apple-intelligence"` before the provider change
+  /// notification fires, which would otherwise corrupt a pre-snapshot and
+  /// lead to an eviction attempt on "apple-intelligence" (#295 UAT bug).
+  ///
+  /// The tracker is also the coalesce guard for the cascading
+  /// `.llmModel` → `.ollamaModel` fire: after the first case reconciles,
+  /// the second sees `pre == new` and skips.
+  private func reconcileOllamaEviction(settings: SettingsManager) {
+    let new = OllamaConnector.effectiveOllamaModel(
+      provider: settings.llmProvider, model: resolvedModel(settings)
+    )
+    let pre = lastEvictableOllamaModel
+    lastEvictableOllamaModel = new
+    guard let pre, pre != new else { return }
+    let polishStep = polishService.llmPolishStep
+    Task { [polishStep, pre] in
+      await polishStep.evictPreviousOllamaModel(pre)
     }
   }
 

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -1,281 +1,354 @@
-import Foundation
 import EnviousWisprCore
+import Foundation
 
 /// Ollama local LLM connector. Uses Ollama's native /api/chat endpoint
 /// for access to `think`, `keep_alive`, and timing telemetry.
 /// Requires Ollama to be running: https://ollama.com
 public struct OllamaConnector: TranscriptPolisher {
-    private let baseURL: String
+  private let baseURL: String
 
-    /// Simplified prompt for weak/small models that struggle with complex instructions.
-    private static let weakModelSystemPrompt = "Fix grammar and punctuation. Return only the corrected text."
+  /// Simplified prompt for weak/small models that struggle with complex instructions.
+  private static let weakModelSystemPrompt =
+    "Fix grammar and punctuation. Return only the corrected text."
 
-    public init(baseURL: String = "http://localhost:11434") {
-        self.baseURL = baseURL
+  public init(baseURL: String = "http://localhost:11434") {
+    self.baseURL = baseURL
+  }
+
+  public func polish(
+    text: String,
+    instructions: PolishInstructions,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    let endpointURL = "\(baseURL)/api/chat"
+    guard let url = URL(string: endpointURL) else {
+      throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
     }
 
-    public func polish(
-        text: String,
-        instructions: PolishInstructions,
-        config: LLMProviderConfig,
-        onToken: (@Sendable (String) -> Void)?
-    ) async throws -> LLMResult {
-        let endpointURL = "\(baseURL)/api/chat"
-        guard let url = URL(string: endpointURL) else {
-            throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
-        }
+    // Use a simplified prompt for weak/small models; full prompt for capable models.
+    let systemPrompt =
+      OllamaSetupService.isWeakModel(config.model)
+      ? Self.weakModelSystemPrompt
+      : instructions.systemPrompt
 
-        // Use a simplified prompt for weak/small models; full prompt for capable models.
-        let systemPrompt = OllamaSetupService.isWeakModel(config.model)
-            ? Self.weakModelSystemPrompt
-            : instructions.systemPrompt
-
-        var messages: [[String: String]] = [
-            ["role": "system", "content": systemPrompt],
-        ]
-        if !text.isEmpty {
-            messages.append(["role": "user", "content": text])
-        }
-
-        let body = Self.makeRequestBody(
-            model: config.model,
-            messages: messages,
-            maxTokens: config.maxTokens,
-            temperature: config.temperature
-        )
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        request.timeoutInterval = 60
-
-        let (data, _) = try await performWithRetry(request: request, config: config)
-
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let message = json?["message"] as? [String: Any],
-              let content = message["content"] as? String,
-              !content.isEmpty else {
-            throw LLMError.emptyResponse
-        }
-
-        Self.logTelemetry(json: json, message: message, model: config.model)
-
-        // Check for truncation via done_reason
-        if let doneReason = json?["done_reason"] as? String, doneReason != "stop" {
-            Task { await AppLogger.shared.log(
-                "WARNING: Ollama response truncated (done_reason=\(doneReason), model=\(config.model))",
-                level: .info, category: "LLM"
-            ) }
-        }
-
-        return LLMResult(
-            polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
-                .strippingLLMPreamble()
-        )
+    var messages: [[String: String]] = [
+      ["role": "system", "content": systemPrompt]
+    ]
+    if !text.isEmpty {
+      messages.append(["role": "user", "content": text])
     }
 
-    public func polish(
-        envelope: PromptEnvelope,
-        config: LLMProviderConfig,
-        onToken: (@Sendable (String) -> Void)?
-    ) async throws -> LLMResult {
-        // Ollama supports the full messages array (needed for Gemma few-shot).
-        // Map PromptEnvelope roles directly to Ollama API roles.
-        let messages: [[String: String]] = envelope.messages.map { msg in
-            let role: String
-            switch msg.role {
-            case .system: role = "system"
-            case .user: role = "user"
-            case .assistant: role = "assistant"
-            }
-            return ["role": role, "content": msg.content]
-        }
+    let body = Self.makeRequestBody(
+      model: config.model,
+      messages: messages,
+      maxTokens: config.maxTokens,
+      temperature: config.temperature
+    )
 
-        let endpointURL = "\(baseURL)/api/chat"
-        guard let url = URL(string: endpointURL) else {
-            throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
-        }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    request.timeoutInterval = 60
 
-        let body = Self.makeRequestBody(
-            model: config.model,
-            messages: messages,
-            maxTokens: config.maxTokens,
-            temperature: config.temperature
-        )
+    let (data, _) = try await performWithRetry(request: request, config: config)
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        request.timeoutInterval = 60
-
-        let (data, _) = try await performWithRetry(request: request, config: config)
-
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let message = json?["message"] as? [String: Any],
-              let content = message["content"] as? String,
-              !content.isEmpty
-        else {
-            throw LLMError.emptyResponse
-        }
-
-        Self.logTelemetry(json: json, message: message, model: config.model)
-
-        if let doneReason = json?["done_reason"] as? String, doneReason != "stop" {
-            Task {
-                await AppLogger.shared.log(
-                    "WARNING: Ollama response truncated (done_reason=\(doneReason), model=\(config.model))",
-                    level: .info, category: "LLM"
-                )
-            }
-        }
-
-        return LLMResult(
-            polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
-                .strippingLLMPreamble()
-        )
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    guard let message = json?["message"] as? [String: Any],
+      let content = message["content"] as? String,
+      !content.isEmpty
+    else {
+      throw LLMError.emptyResponse
     }
 
-    // MARK: - Telemetry
+    Self.logTelemetry(json: json, message: message, model: config.model)
 
-    /// Logs Ollama `/api/chat` timing + reasoning-output telemetry (#276).
-    ///
-    /// `thinking` captures the char count of `message.thinking`, which we
-    /// discard but which gemma4 spends significant eval time producing. Non-
-    /// thinking models (llama3.2 etc.) log `thinking=0`. Compare against
-    /// `eval`/`tokens` to see what fraction of eval time was spent on
-    /// reasoning vs the final answer.
-    private static func logTelemetry(
-        json: [String: Any]?,
-        message: [String: Any],
-        model: String
-    ) {
-        guard
-            let loadNs = json?["load_duration"] as? Int64,
-            let promptNs = json?["prompt_eval_duration"] as? Int64,
-            let evalNs = json?["eval_duration"] as? Int64,
-            let evalCount = json?["eval_count"] as? Int
-        else { return }
-        let loadMs = Double(loadNs) / 1_000_000
-        let promptMs = Double(promptNs) / 1_000_000
-        let evalMs = Double(evalNs) / 1_000_000
-        let thinkingChars = (message["thinking"] as? String)?.count ?? 0
-        let contentChars = (message["content"] as? String)?.count ?? 0
+    // Check for truncation via done_reason
+    if let doneReason = json?["done_reason"] as? String, doneReason != "stop" {
+      Task {
+        await AppLogger.shared.log(
+          "WARNING: Ollama response truncated (done_reason=\(doneReason), model=\(config.model))",
+          level: .info, category: "LLM"
+        )
+      }
+    }
+
+    return LLMResult(
+      polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
+        .strippingLLMPreamble()
+    )
+  }
+
+  public func polish(
+    envelope: PromptEnvelope,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    // Ollama supports the full messages array (needed for Gemma few-shot).
+    // Map PromptEnvelope roles directly to Ollama API roles.
+    let messages: [[String: String]] = envelope.messages.map { msg in
+      let role: String
+      switch msg.role {
+      case .system: role = "system"
+      case .user: role = "user"
+      case .assistant: role = "assistant"
+      }
+      return ["role": role, "content": msg.content]
+    }
+
+    let endpointURL = "\(baseURL)/api/chat"
+    guard let url = URL(string: endpointURL) else {
+      throw LLMError.requestFailed("Invalid Ollama URL: \(endpointURL)")
+    }
+
+    let body = Self.makeRequestBody(
+      model: config.model,
+      messages: messages,
+      maxTokens: config.maxTokens,
+      temperature: config.temperature
+    )
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    request.timeoutInterval = 60
+
+    let (data, _) = try await performWithRetry(request: request, config: config)
+
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    guard let message = json?["message"] as? [String: Any],
+      let content = message["content"] as? String,
+      !content.isEmpty
+    else {
+      throw LLMError.emptyResponse
+    }
+
+    Self.logTelemetry(json: json, message: message, model: config.model)
+
+    if let doneReason = json?["done_reason"] as? String, doneReason != "stop" {
+      Task {
+        await AppLogger.shared.log(
+          "WARNING: Ollama response truncated (done_reason=\(doneReason), model=\(config.model))",
+          level: .info, category: "LLM"
+        )
+      }
+    }
+
+    return LLMResult(
+      polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
+        .strippingLLMPreamble()
+    )
+  }
+
+  // MARK: - Eviction (#295)
+
+  /// Tells Ollama to unload the named model from memory immediately.
+  ///
+  /// Prevents dual-resident model pressure when the user swaps polish models
+  /// mid-session. Ollama's default `keep_alive` holds the previous model in
+  /// VRAM for its full window, which on constrained machines has disrupted
+  /// CoreAudio BT audio (root cause for #286).
+  ///
+  /// Fire-and-forget: returns void, swallows all errors, short timeout.
+  /// Uses `/api/generate` per Ollama docs — `keep_alive: 0` on `/api/chat`
+  /// is not a documented unload pattern.
+  public func evictModel(_ modelName: String) async {
+    let endpointURL = "\(baseURL)/api/generate"
+    guard !modelName.isEmpty, let url = URL(string: endpointURL) else { return }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.timeoutInterval = 3.0
+
+    let start = Date()
+    do {
+      request.httpBody = try JSONSerialization.data(
+        withJSONObject: Self.makeEvictRequestBody(model: modelName)
+      )
+      let (_, response) = try await LLMNetworkSession.shared.session.data(for: request)
+      let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+      let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
+      let result = (200...299).contains(status) ? "unloaded" : "error"
+      await AppLogger.shared.log(
+        "Ollama evict: model=\(modelName) result=\(result) http=\(status) duration_ms=\(elapsedMs)",
+        level: .info, category: "LLM"
+      )
+    } catch {
+      let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
+      let reason = (error as? URLError)?.code.rawValue.description ?? "error"
+      await AppLogger.shared.log(
+        "Ollama evict: model=\(modelName) result=error reason=\(reason) duration_ms=\(elapsedMs)",
+        level: .info, category: "LLM"
+      )
+    }
+  }
+
+  // MARK: - Telemetry
+
+  /// Logs Ollama `/api/chat` timing + reasoning-output telemetry (#276).
+  ///
+  /// `thinking` captures the char count of `message.thinking`, which we
+  /// discard but which gemma4 spends significant eval time producing. Non-
+  /// thinking models (llama3.2 etc.) log `thinking=0`. Compare against
+  /// `eval`/`tokens` to see what fraction of eval time was spent on
+  /// reasoning vs the final answer.
+  private static func logTelemetry(
+    json: [String: Any]?,
+    message: [String: Any],
+    model: String
+  ) {
+    guard
+      let loadNs = json?["load_duration"] as? Int64,
+      let promptNs = json?["prompt_eval_duration"] as? Int64,
+      let evalNs = json?["eval_duration"] as? Int64,
+      let evalCount = json?["eval_count"] as? Int
+    else { return }
+    let loadMs = Double(loadNs) / 1_000_000
+    let promptMs = Double(promptNs) / 1_000_000
+    let evalMs = Double(evalNs) / 1_000_000
+    let thinkingChars = (message["thinking"] as? String)?.count ?? 0
+    let contentChars = (message["content"] as? String)?.count ?? 0
+    Task {
+      await AppLogger.shared.log(
+        "Ollama timing: load=\(String(format: "%.0f", loadMs))ms prompt=\(String(format: "%.0f", promptMs))ms eval=\(String(format: "%.0f", evalMs))ms tokens=\(evalCount) thinking=\(thinkingChars)chars content=\(contentChars)chars (model=\(model))",
+        level: .verbose, category: "LLM"
+      )
+    }
+  }
+
+  // MARK: - Request body
+
+  /// Builds the `/api/chat` request body shared by both polish entry points.
+  ///
+  /// The `think` parameter is intentionally omitted (#272):
+  /// - Setting `think: false` (boolean) is silently ignored by gemma4:latest and
+  ///   causes reasoning to leak into `message.content` as a 5-13× expansion that
+  ///   the validator rejects.
+  /// - Omitting the key lets Ollama route any reasoning to `message.thinking`
+  ///   (which we don't read) and deliver the clean final answer in `message.content`,
+  ///   provided `num_predict` is large enough to accommodate both (see
+  ///   `LLMConstants.ollamaMaxTokens`).
+  /// Non-thinking models (llama3.2 etc.) are unaffected: they emit empty
+  /// `message.thinking` regardless.
+  /// Returns the model name iff the provider is `.ollama` and the model
+  /// is non-empty; nil otherwise. Pure helper used by the settings
+  /// observer to snapshot the pre-swap effective Ollama model (#295).
+  public static func effectiveOllamaModel(provider: LLMProvider, model: String) -> String? {
+    provider == .ollama && !model.isEmpty ? model : nil
+  }
+
+  /// Builds the `/api/generate` unload request body (#295).
+  /// Uses `keep_alive: 0` with empty prompt. Some Ollama versions
+  /// 400 on missing `prompt` key, so it is emitted explicitly.
+  static func makeEvictRequestBody(model: String) -> [String: Any] {
+    [
+      "model": model,
+      "prompt": "",
+      "keep_alive": 0,
+    ]
+  }
+
+  static func makeRequestBody(
+    model: String,
+    messages: [[String: String]],
+    maxTokens: Int,
+    temperature: Double
+  ) -> [String: Any] {
+    [
+      "model": model,
+      "messages": messages,
+      "stream": false,
+      "keep_alive": "60m",
+      "options": [
+        "num_predict": maxTokens,
+        "temperature": temperature,
+      ],
+    ]
+  }
+
+  // MARK: - Retry
+
+  private func performWithRetry(
+    request: URLRequest,
+    config: LLMProviderConfig,
+    maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
+    delays: [UInt64] = LLMRetryPolicy.defaultDelays
+  ) async throws -> (Data, HTTPURLResponse) {
+    var lastError: Error?
+    for attempt in 0...maxRetries {
+      if attempt > 0 {
+        let delay = delays[min(attempt - 1, delays.count - 1)]
         Task {
-            await AppLogger.shared.log(
-                "Ollama timing: load=\(String(format: "%.0f", loadMs))ms prompt=\(String(format: "%.0f", promptMs))ms eval=\(String(format: "%.0f", evalMs))ms tokens=\(evalCount) thinking=\(thinkingChars)chars content=\(contentChars)chars (model=\(model))",
+          await AppLogger.shared.log(
+            "Ollama retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
+            level: .verbose, category: "LLM"
+          )
+        }
+        try await Task.sleep(nanoseconds: delay)
+      }
+
+      do {
+        let (data, response): (Data, URLResponse)
+        do {
+          (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
+        } catch let urlError as URLError {
+          switch urlError.code {
+          case .notConnectedToInternet, .cannotFindHost:
+            throw LLMError.providerUnavailable  // not transient, fail fast
+          default:
+            throw urlError  // let LLMRetryPolicy.isRetryable() decide
+          }
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+          throw LLMError.requestFailed("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+          return (data, httpResponse)
+        case 404:
+          throw LLMError.modelNotFound(config.model)
+        default:
+          #if DEBUG
+            let body = String(data: data, encoding: .utf8) ?? ""
+            let truncated = String(body.prefix(200))
+            Task {
+              await AppLogger.shared.log(
+                "Ollama HTTP \(httpResponse.statusCode): \(truncated)",
                 level: .verbose, category: "LLM"
-            )
-        }
-    }
-
-    // MARK: - Request body
-
-    /// Builds the `/api/chat` request body shared by both polish entry points.
-    ///
-    /// The `think` parameter is intentionally omitted (#272):
-    /// - Setting `think: false` (boolean) is silently ignored by gemma4:latest and
-    ///   causes reasoning to leak into `message.content` as a 5-13× expansion that
-    ///   the validator rejects.
-    /// - Omitting the key lets Ollama route any reasoning to `message.thinking`
-    ///   (which we don't read) and deliver the clean final answer in `message.content`,
-    ///   provided `num_predict` is large enough to accommodate both (see
-    ///   `LLMConstants.ollamaMaxTokens`).
-    /// Non-thinking models (llama3.2 etc.) are unaffected: they emit empty
-    /// `message.thinking` regardless.
-    static func makeRequestBody(
-        model: String,
-        messages: [[String: String]],
-        maxTokens: Int,
-        temperature: Double
-    ) -> [String: Any] {
-        [
-            "model": model,
-            "messages": messages,
-            "stream": false,
-            "keep_alive": "60m",
-            "options": [
-                "num_predict": maxTokens,
-                "temperature": temperature,
-            ],
-        ]
-    }
-
-    // MARK: - Retry
-
-    private func performWithRetry(
-        request: URLRequest,
-        config: LLMProviderConfig,
-        maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
-        delays: [UInt64] = LLMRetryPolicy.defaultDelays
-    ) async throws -> (Data, HTTPURLResponse) {
-        var lastError: Error?
-        for attempt in 0...maxRetries {
-            if attempt > 0 {
-                let delay = delays[min(attempt - 1, delays.count - 1)]
-                Task { await AppLogger.shared.log(
-                    "Ollama retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
-                    level: .verbose, category: "LLM"
-                ) }
-                try await Task.sleep(nanoseconds: delay)
+              )
             }
-
-            do {
-                let (data, response): (Data, URLResponse)
-                do {
-                    (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
-                } catch let urlError as URLError {
-                    switch urlError.code {
-                    case .notConnectedToInternet, .cannotFindHost:
-                        throw LLMError.providerUnavailable  // not transient, fail fast
-                    default:
-                        throw urlError  // let LLMRetryPolicy.isRetryable() decide
-                    }
-                }
-
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw LLMError.requestFailed("Invalid response")
-                }
-
-                switch httpResponse.statusCode {
-                case 200:
-                    return (data, httpResponse)
-                case 404:
-                    throw LLMError.modelNotFound(config.model)
-                default:
-                    #if DEBUG
-                    let body = String(data: data, encoding: .utf8) ?? ""
-                    let truncated = String(body.prefix(200))
-                    Task { await AppLogger.shared.log(
-                        "Ollama HTTP \(httpResponse.statusCode): \(truncated)",
-                        level: .verbose, category: "LLM"
-                    ) }
-                    #else
-                    Task { await AppLogger.shared.log(
-                        "Ollama HTTP \(httpResponse.statusCode)",
-                        level: .verbose, category: "LLM"
-                    ) }
-                    #endif
-                    throw LLMError.requestFailed(Self.friendlyMessage(for: httpResponse.statusCode))
-                }
-            } catch {
-                lastError = error
-                if !LLMRetryPolicy.isRetryable(error) { throw error }
+          #else
+            Task {
+              await AppLogger.shared.log(
+                "Ollama HTTP \(httpResponse.statusCode)",
+                level: .verbose, category: "LLM"
+              )
             }
+          #endif
+          throw LLMError.requestFailed(Self.friendlyMessage(for: httpResponse.statusCode))
         }
-        // Convert exhausted connection errors to domain error for UI
-        if let urlError = lastError as? URLError, urlError.code == .cannotConnectToHost {
-            throw LLMError.providerUnavailable
-        }
-        throw lastError ?? LLMError.requestFailed("All retries exhausted")
+      } catch {
+        lastError = error
+        if !LLMRetryPolicy.isRetryable(error) { throw error }
+      }
     }
+    // Convert exhausted connection errors to domain error for UI
+    if let urlError = lastError as? URLError, urlError.code == .cannotConnectToHost {
+      throw LLMError.providerUnavailable
+    }
+    throw lastError ?? LLMError.requestFailed("All retries exhausted")
+  }
 
-    private static func friendlyMessage(for statusCode: Int) -> String {
-        switch statusCode {
-        case 400: return "Ollama rejected the request. Check model name and parameters."
-        case 500...599: return "Ollama server error (HTTP \(statusCode)). Try restarting Ollama."
-        default: return "Ollama request failed (HTTP \(statusCode))."
-        }
+  private static func friendlyMessage(for statusCode: Int) -> String {
+    switch statusCode {
+    case 400: return "Ollama rejected the request. Check model name and parameters."
+    case 500...599: return "Ollama server error (HTTP \(statusCode)). Try restarting Ollama."
+    default: return "Ollama request failed (HTTP \(statusCode))."
     }
+  }
 }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -1,456 +1,493 @@
-import Foundation
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
+import Foundation
 
 /// Polishes transcribed text using an LLM provider.
 @MainActor
 public final class LLMPolishStep: TextProcessingStep {
-    public let name = "LLM Polish"
+  public let name = "LLM Polish"
 
-    public var llmProvider: LLMProvider = .none
-    public var llmModel: String = LLMProvider.defaultModel(for: .openAI)
-    public var polishInstructions: PolishInstructions = .default
-    public var styleConfig: PolishStyleConfig = PolishStyleConfig(
-        writingStylePreset: .standard, customSystemPrompt: "", customPromptMode: .normal
-    )
-    public var useExtendedThinking: Bool = false
-    public var customWords: [CustomWord] = []
+  public var llmProvider: LLMProvider = .none
+  public var llmModel: String = LLMProvider.defaultModel(for: .openAI)
+  public var polishInstructions: PolishInstructions = .default
+  public var styleConfig: PolishStyleConfig = PolishStyleConfig(
+    writingStylePreset: .standard, customSystemPrompt: "", customPromptMode: .normal
+  )
+  public var useExtendedThinking: Bool = false
+  public var customWords: [CustomWord] = []
 
-    // MARK: - Multilingual v1 (W3)
+  // MARK: - Multilingual v1 (W3)
 
-    /// Language detection outcome from the autodetect stack. Set by
-    /// `WhisperKitPipeline` after the detector runs, before finalization.
-    /// Nil for the Parakeet highway or pre-W2 callsites. The planner falls
-    /// back to legacy (locked-equivalent) behavior when nil.
-    public var languageDetection: LanguageDetectionResult?
+  /// Language detection outcome from the autodetect stack. Set by
+  /// `WhisperKitPipeline` after the detector runs, before finalization.
+  /// Nil for the Parakeet highway or pre-W2 callsites. The planner falls
+  /// back to legacy (locked-equivalent) behavior when nil.
+  public var languageDetection: LanguageDetectionResult?
 
-    /// Active ASR backend for this polish step. Set at init time by the
-    /// owning pipeline (Parakeet or WhisperKit) so the prompt planner can
-    /// dispatch on explicit engine identity rather than inferring it from
-    /// the absence of `languageDetection`. Nil for standalone callsites
-    /// (e.g., `TranscriptPolishService`) that do not know the original ASR
-    /// engine; the planner preserves legacy passthrough in that case.
-    public var backend: ASRBackendType?
+  /// Active ASR backend for this polish step. Set at init time by the
+  /// owning pipeline (Parakeet or WhisperKit) so the prompt planner can
+  /// dispatch on explicit engine identity rather than inferring it from
+  /// the absence of `languageDetection`. Nil for standalone callsites
+  /// (e.g., `TranscriptPolishService`) that do not know the original ASR
+  /// engine; the planner preserves legacy passthrough in that case.
+  public var backend: ASRBackendType?
 
-    /// Injectable prompt planner. DefaultPromptPlanner in production, mockable in tests.
-    public var promptPlanner: any PromptPlanning = DefaultPromptPlanner()
+  /// Injectable prompt planner. DefaultPromptPlanner in production, mockable in tests.
+  public var promptPlanner: any PromptPlanning = DefaultPromptPlanner()
 
-    /// Called before LLM processing starts (pipeline uses this to set .polishing state).
-    public var onWillProcess: (() -> Void)?
+  /// Called before LLM processing starts (pipeline uses this to set .polishing state).
+  public var onWillProcess: (() -> Void)?
 
-    /// Streaming token callback — invoked with each text fragment as it arrives from the LLM.
-    public var onToken: (@Sendable (String) -> Void)?
+  /// Streaming token callback — invoked with each text fragment as it arrives from the LLM.
+  public var onToken: (@Sendable (String) -> Void)?
 
-    private let keychainManager: KeychainManager
+  private let keychainManager: KeychainManager
 
-    public var isEnabled: Bool {
-        llmProvider != .none
+  public var isEnabled: Bool {
+    llmProvider != .none
+  }
+
+  /// Provider-aware timeout budget. Cloud providers respond in <2s so 5s is generous.
+  /// Local models (Ollama 12B) generate ~18 tok/s and need 10-15s for long dictations.
+  /// Apple Intelligence runs on-device with variable latency depending on model size.
+  public var maxDuration: Duration {
+    switch llmProvider {
+    case .ollama: return .seconds(15)
+    case .appleIntelligence: return .seconds(10)
+    case .openAI, .gemini, .none: return .seconds(5)
     }
+  }
 
-    /// Provider-aware timeout budget. Cloud providers respond in <2s so 5s is generous.
-    /// Local models (Ollama 12B) generate ~18 tok/s and need 10-15s for long dictations.
-    /// Apple Intelligence runs on-device with variable latency depending on model size.
-    public var maxDuration: Duration {
-        switch llmProvider {
-        case .ollama: return .seconds(15)
-        case .appleIntelligence: return .seconds(10)
-        case .openAI, .gemini, .none: return .seconds(5)
+  public init(keychainManager: KeychainManager) {
+    self.keychainManager = keychainManager
+  }
+
+  /// Asks Ollama to unload the named model from memory (fire-and-forget).
+  ///
+  /// Called by `PipelineSettingsSync` when the user swaps away from an
+  /// Ollama model, so the previous model doesn't linger in VRAM and
+  /// starve CoreAudio (#286 root cause, #295 mitigation). No-op if
+  /// `modelName` is empty. Swallows all errors; only logs.
+  public func evictPreviousOllamaModel(_ modelName: String) async {
+    guard !modelName.isEmpty else { return }
+    await OllamaConnector().evictModel(modelName)
+  }
+
+  /// Minimum word count to send to the LLM (Latin/Cyrillic/Indic/Arabic etc).
+  /// Transcripts at or below this threshold are passed through verbatim — LLMs
+  /// hallucinate on ultra-short input (e.g., "Yeah" → a full essay). See ew-zr4.
+  private static let minWordsForPolish = 3
+
+  /// Minimum character count for CJK/Thai/Lao scripts which don't use spaces.
+  /// Japanese/Chinese word-counting treats a 31-char sentence as 2 words,
+  /// which would wrongly short-circuit polish. Character-count is the correct
+  /// gate for non-whitespace-segmented scripts. 10 chars ≈ a short utterance.
+  private static let minCharsForCJKPolish = 10
+
+  public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+    onWillProcess?()
+    SentryBreadcrumb.add(
+      stage: "polish", message: "LLM polish started",
+      data: [
+        "provider": llmProvider.rawValue,
+        "model": llmModel,
+      ])
+
+    // Short-circuit: ultra-short transcripts get passed through verbatim.
+    // LLMs treat 1-3 word inputs as prompts to respond to, not text to clean.
+    // Language-aware: CJK/Thai/Lao scripts use char-count since they don't
+    // segment words with whitespace (a 31-char Japanese utterance is 1-2
+    // "words" by split, which would wrongly skip polish).
+    let lang = languageDetection?.lang ?? context.language
+    let useCharCount = lang.map(LanguageTypes.isUnsegmentedScript) ?? false
+    if useCharCount {
+      let charCount = context.text.unicodeScalars.filter { !$0.properties.isWhitespace }.count
+      if charCount < Self.minCharsForCJKPolish {
+        Task {
+          await AppLogger.shared.log(
+            "LLM polish skipped: transcript too short (\(charCount) chars, minimum \(Self.minCharsForCJKPolish), lang=\(lang ?? "?"))",
+            level: .info, category: "LLM"
+          )
         }
-    }
-
-    public init(keychainManager: KeychainManager) {
-        self.keychainManager = keychainManager
-    }
-
-    /// Minimum word count to send to the LLM (Latin/Cyrillic/Indic/Arabic etc).
-    /// Transcripts at or below this threshold are passed through verbatim — LLMs
-    /// hallucinate on ultra-short input (e.g., "Yeah" → a full essay). See ew-zr4.
-    private static let minWordsForPolish = 3
-
-    /// Minimum character count for CJK/Thai/Lao scripts which don't use spaces.
-    /// Japanese/Chinese word-counting treats a 31-char sentence as 2 words,
-    /// which would wrongly short-circuit polish. Character-count is the correct
-    /// gate for non-whitespace-segmented scripts. 10 chars ≈ a short utterance.
-    private static let minCharsForCJKPolish = 10
-
-    public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
-        onWillProcess?()
-        SentryBreadcrumb.add(stage: "polish", message: "LLM polish started", data: [
-            "provider": llmProvider.rawValue,
-            "model": llmModel,
-        ])
-
-        // Short-circuit: ultra-short transcripts get passed through verbatim.
-        // LLMs treat 1-3 word inputs as prompts to respond to, not text to clean.
-        // Language-aware: CJK/Thai/Lao scripts use char-count since they don't
-        // segment words with whitespace (a 31-char Japanese utterance is 1-2
-        // "words" by split, which would wrongly skip polish).
-        let lang = languageDetection?.lang ?? context.language
-        let useCharCount = lang.map(LanguageTypes.isUnsegmentedScript) ?? false
-        if useCharCount {
-            let charCount = context.text.unicodeScalars.filter { !$0.properties.isWhitespace }.count
-            if charCount < Self.minCharsForCJKPolish {
-                Task { await AppLogger.shared.log(
-                    "LLM polish skipped: transcript too short (\(charCount) chars, minimum \(Self.minCharsForCJKPolish), lang=\(lang ?? "?"))",
-                    level: .info, category: "LLM"
-                ) }
-                var ctx = context
-                ctx.polishedText = context.text
-                return ctx
-            }
-        } else {
-            let wordCount = context.text.split(whereSeparator: \.isWhitespace).count
-            if wordCount <= Self.minWordsForPolish {
-                Task { await AppLogger.shared.log(
-                    "LLM polish skipped: transcript too short (\(wordCount) words, minimum \(Self.minWordsForPolish + 1))",
-                    level: .info, category: "LLM"
-                ) }
-                var ctx = context
-                ctx.polishedText = context.text
-                return ctx
-            }
-        }
-
-        Task { await AppLogger.shared.log(
-            "LLM polish requested: provider=\(llmProvider.rawValue), model=\(llmModel)",
-            level: .verbose, category: "LLM"
-        ) }
-
-        let polisher: any TranscriptPolisher = switch llmProvider {
-        case .openAI: OpenAIConnector(keychainManager: keychainManager)
-        case .gemini: GeminiConnector(keychainManager: keychainManager)
-        case .ollama: OllamaConnector()
-        case .appleIntelligence: AppleIntelligenceConnector()
-        case .none:
-            SentryBreadcrumb.captureError(LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
-            throw LLMError.providerUnavailable
-        }
-
-        let keychainId: String? = switch llmProvider {
-        case .openAI:  KeychainManager.openAIKeyID
-        case .gemini:  KeychainManager.geminiKeyID
-        default:       nil
-        }
-
-        let (thinkingBudget, reasoningEffort) = resolveThinkingConfig()
-        let maxTokens: Int = {
-            if llmProvider == .ollama {
-                // Estimate tokens (~3 chars per token for English), add headroom.
-                // For 921-char input: 921/3 + 100 = 407 tokens (~2x actual output of ~195).
-                // The pipeline-level timeout (15s) caps runaway generation.
-                //
-                // Only thinking-capable families (Gemma4, qwen3, deepseek-r1,
-                // gpt-oss) get the larger 2048-token floor — they emit reasoning
-                // into `message.thinking` separately from `message.content`, and
-                // that reasoning still counts against `num_predict` (#272). All
-                // other Ollama models (weak or not) keep the tight 256 floor so
-                // a rambly generation can't outrun the 15s pipeline timeout.
-                // `done_reason=stop` ends generation early for short transcripts.
-                let floor = OllamaSetupService.isThinkingCapableModel(llmModel)
-                    ? LLMConstants.ollamaThinkingMaxTokens
-                    : LLMConstants.ollamaMaxTokens
-                return max(context.text.count / 3 + 100, floor)
-            }
-            // OpenAI reasoning models include reasoning in max_completion_tokens — keep generous.
-            if reasoningEffort != nil { return LLMConstants.defaultMaxTokens }
-            // Character-based cap: ~1 token per 4 chars, so charCount ≈ 4× token estimate.
-            // Using charCount directly as token cap gives ~4x headroom. Safe for CJK too.
-            return max(context.text.count, LLMConstants.polishMaxTokensFloor)
-        }()
-
-        // Prefer live LID but fall back to the context's persisted language
-        // so saved-transcript re-polish paths (e.g. TranscriptPolishService
-        // which clears languageDetection) still hit the Apple Intelligence
-        // preflight gate and language-aware prompt.
-        let detectedLanguage = languageDetection?.lang ?? context.language
-
-        let config = LLMProviderConfig(
-            model: llmModel,
-            apiKeyKeychainId: keychainId,
-            maxTokens: maxTokens,
-            temperature: 0,
-            thinkingBudget: thinkingBudget,
-            reasoningEffort: reasoningEffort,
-            detectedLanguage: detectedLanguage
-        )
-
-        // Apple Intelligence: own prompt path (unchanged, out of scope for planner).
-        if llmProvider == .appleIntelligence {
-            let enriched = appleIntelligenceInstructions(polishInstructions)
-            var resolvedInstructions = enriched
-            var userText = context.text
-            if enriched.systemPrompt.contains("${transcript}") {
-                resolvedInstructions = PolishInstructions(
-                    systemPrompt: enriched.systemPrompt.replacingOccurrences(
-                        of: "${transcript}", with: context.text
-                    )
-                )
-                userText = ""
-            }
-            // Let `LLMError.unsupportedInputLanguage` and
-            // `LLMError.outputLanguageDrift` propagate. The live dictation
-            // path (TextProcessingRunner) treats them as silent skips. The
-            // saved-transcript re-polish path (TranscriptPolishService)
-            // surfaces them to the user so they can retry with another
-            // provider instead of the transcript being mislabeled AI-polished.
-            let llmStart = CFAbsoluteTimeGetCurrent()
-            let result = try await polisher.polish(
-                text: userText,
-                instructions: resolvedInstructions,
-                config: config,
-                onToken: onToken
-            )
-            let llmEnd = CFAbsoluteTimeGetCurrent()
-            logPolishCompletion(result: result, duration: llmEnd - llmStart)
-            let validatedText = validatePolishOutput(
-                polished: result.polishedText, original: context.text, mode: .message
-            )
-            var ctx = context
-            ctx.polishedText = validatedText
-            ctx.llmProvider = llmProvider.rawValue
-            ctx.llmModel = llmModel
-            return ctx
-        }
-
-        // All other providers: PromptPlanner path.
-        // Resolve ${transcript} placeholder before passing to planner.
-        let resolvedCustomPrompt: String? = {
-            guard styleConfig.customPromptMode == .legacyTemplate,
-                  let prompt = styleConfig.customSystemPrompt.nilIfEmpty
-            else { return styleConfig.customSystemPrompt.nilIfEmpty }
-            return prompt.replacingOccurrences(of: "${transcript}", with: context.text)
-        }()
-
-        // Multilingual v1 (W3): snapshot the active vocabulary at construction
-        // time so the planner/builders see a stable list even if the user edits
-        // custom words mid-polish. Migration default: all entries tagged global.
-        let vocabularySnapshot = PromptVocabulary.fromLegacy(customWords)
-
-        let input = PromptBuildInput(
-            transcript: context.text,
-            provider: llmProvider,
-            modelID: llmModel,
-            stylePreset: styleConfig.writingStylePreset,
-            customSystemPrompt: resolvedCustomPrompt,
-            customPromptMode: styleConfig.customPromptMode,
-            appName: context.targetAppName,
-            language: context.language,
-            customWords: customWords,
-            focusSnapshot: nil,  // PR 3
-            customVocabulary: vocabularySnapshot,
-            languageDetection: languageDetection,
-            backend: backend
-        )
-        let plan = promptPlanner.plan(input: input)
-
-        let llmStart = CFAbsoluteTimeGetCurrent()
-        let result = try await polisher.polish(
-            envelope: plan.envelope,
-            config: config,
-            onToken: onToken
-        )
-        let llmEnd = CFAbsoluteTimeGetCurrent()
-
-        let family = DefaultPromptPlanner.family(for: llmProvider, modelID: llmModel)
-        logPolishCompletion(result: result, duration: llmEnd - llmStart, extraData: [
-            "polish_mode": plan.mode.rawValue,
-            "prompt_family": family.rawValue,
-            "custom_prompt_mode": styleConfig.customPromptMode.rawValue,
-        ])
-
-        let validatedText = validatePolishOutput(
-            polished: result.polishedText,
-            original: context.text,
-            mode: plan.mode
-        )
-
         var ctx = context
-        ctx.polishedText = validatedText
-        ctx.llmProvider = llmProvider.rawValue
-        ctx.llmModel = llmModel
+        ctx.polishedText = context.text
         return ctx
+      }
+    } else {
+      let wordCount = context.text.split(whereSeparator: \.isWhitespace).count
+      if wordCount <= Self.minWordsForPolish {
+        Task {
+          await AppLogger.shared.log(
+            "LLM polish skipped: transcript too short (\(wordCount) words, minimum \(Self.minWordsForPolish + 1))",
+            level: .info, category: "LLM"
+          )
+        }
+        var ctx = context
+        ctx.polishedText = context.text
+        return ctx
+      }
     }
 
-    // MARK: - Output Validation
-
-    /// Validate LLM polish output with mode-aware thresholds.
-    /// Falls back to original text when the output looks like a hallucination,
-    /// content drop, or question-to-answer conversion.
-    func validatePolishOutput(polished: String, original: String, mode: PolishMode) -> String {
-        guard !original.isEmpty else { return polished }
-
-        // Mode-aware thresholds (from plan Appendix C)
-        let expansionThreshold: Int
-        let contentDropFraction: (numerator: Int, denominator: Int)
-        switch mode {
-        case .inline:
-            expansionThreshold = max(original.count * 3, 150)
-            contentDropFraction = (2, 5)  // 40% retention minimum
-        case .message:
-            expansionThreshold = max(original.count * 3, 200)
-            contentDropFraction = (2, 5)
-        case .structured:
-            expansionThreshold = max(original.count * 4, 300)
-            contentDropFraction = (1, 3)  // 33% retention minimum (more aggressive cleanup ok)
-        case .edit:
-            expansionThreshold = max(original.count * 4, 300)
-            contentDropFraction = (1, 3)
-        }
-
-        // Guard 1: Expansion hallucination
-        if polished.count > expansionThreshold {
-            Task { await AppLogger.shared.log(
-                "LLM polish validator: expansion \(polished.count)/\(original.count) chars " +
-                "exceeds \(expansionThreshold) (mode=\(mode.rawValue)) — falling back " +
-                "(provider=\(llmProvider.rawValue), model=\(llmModel))",
-                level: .info, category: "LLM"
-            ) }
-            return original
-        }
-
-        // Guard 2: Content drop
-        let originalWords = original.split(whereSeparator: \.isWhitespace)
-        let polishedWords = polished.split(whereSeparator: \.isWhitespace)
-        let dropThreshold =
-            (originalWords.count * contentDropFraction.numerator + contentDropFraction.denominator - 1)
-            / contentDropFraction.denominator
-        if originalWords.count >= 10 && polishedWords.count < dropThreshold {
-            Task { await AppLogger.shared.log(
-                "LLM polish validator: content drop \(polishedWords.count)/\(originalWords.count) words " +
-                "(mode=\(mode.rawValue)) — falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
-                level: .info, category: "LLM"
-            ) }
-            return original
-        }
-
-        // Guard 3: Question-to-answer conversion (unchanged across modes)
-        if looksLikeQuestion(original) && !looksLikeQuestion(polished) {
-            Task { await AppLogger.shared.log(
-                "LLM polish validator: question-to-answer conversion detected — " +
-                "falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
-                level: .info, category: "LLM"
-            ) }
-            return original
-        }
-
-        return polished
+    Task {
+      await AppLogger.shared.log(
+        "LLM polish requested: provider=\(llmProvider.rawValue), model=\(llmModel)",
+        level: .verbose, category: "LLM"
+      )
     }
 
-    /// Conservative question detection using strong signals only.
-    /// Returns true if the text contains `?` or starts with an interrogative pattern.
-    /// Leading fillers and common preambles are stripped before checking.
-    private func looksLikeQuestion(_ text: String) -> Bool {
-        if text.contains("?") { return true }
+    let polisher: any TranscriptPolisher =
+      switch llmProvider {
+      case .openAI: OpenAIConnector(keychainManager: keychainManager)
+      case .gemini: GeminiConnector(keychainManager: keychainManager)
+      case .ollama: OllamaConnector()
+      case .appleIntelligence: AppleIntelligenceConnector()
+      case .none:
+        SentryBreadcrumb.captureError(
+          LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
+        throw LLMError.providerUnavailable
+      }
 
-        // Strip leading fillers to find the real sentence start.
-        let fillers: Set<String> = ["um", "uh", "so", "like", "well", "okay", "ok"]
-        var words = text.lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: \.isWhitespace)
-            .map(String.init)
-        while let first = words.first, fillers.contains(first.trimmingCharacters(in: .punctuationCharacters)) {
-            words.removeFirst()
-        }
-        guard let firstWord = words.first else { return false }
+    let keychainId: String? =
+      switch llmProvider {
+      case .openAI: KeychainManager.openAIKeyID
+      case .gemini: KeychainManager.geminiKeyID
+      default: nil
+      }
 
-        // Modal/auxiliary verbs at sentence start are always interrogative.
-        let auxiliaryStarts: Set<String> = [
-            "should", "can", "do", "does", "did", "is", "are", "could", "would",
-            "has", "have", "will",
-        ]
-        if auxiliaryStarts.contains(firstWord) { return true }
+    let (thinkingBudget, reasoningEffort) = resolveThinkingConfig()
+    let maxTokens: Int = {
+      if llmProvider == .ollama {
+        // Estimate tokens (~3 chars per token for English), add headroom.
+        // For 921-char input: 921/3 + 100 = 407 tokens (~2x actual output of ~195).
+        // The pipeline-level timeout (15s) caps runaway generation.
+        //
+        // Only thinking-capable families (Gemma4, qwen3, deepseek-r1,
+        // gpt-oss) get the larger 2048-token floor — they emit reasoning
+        // into `message.thinking` separately from `message.content`, and
+        // that reasoning still counts against `num_predict` (#272). All
+        // other Ollama models (weak or not) keep the tight 256 floor so
+        // a rambly generation can't outrun the 15s pipeline timeout.
+        // `done_reason=stop` ends generation early for short transcripts.
+        let floor =
+          OllamaSetupService.isThinkingCapableModel(llmModel)
+          ? LLMConstants.ollamaThinkingMaxTokens
+          : LLMConstants.ollamaMaxTokens
+        return max(context.text.count / 3 + 100, floor)
+      }
+      // OpenAI reasoning models include reasoning in max_completion_tokens — keep generous.
+      if reasoningEffort != nil { return LLMConstants.defaultMaxTokens }
+      // Character-based cap: ~1 token per 4 chars, so charCount ≈ 4× token estimate.
+      // Using charCount directly as token cap gives ~4x headroom. Safe for CJK too.
+      return max(context.text.count, LLMConstants.polishMaxTokensFloor)
+    }()
 
-        // Wh-words need a following auxiliary to be a question.
-        // "How do we..." = question. "How we handle this..." = declarative.
-        let whWords: Set<String> = ["how", "what", "where", "when", "who", "why"]
-        if whWords.contains(firstWord) {
-            let secondWord = words.count > 1 ? words[1] : ""
-            let followedByAuxiliary = auxiliaryStarts.contains(secondWord)
-                || ["many", "much", "long", "often"].contains(secondWord)  // "how many", "how long"
-            if followedByAuxiliary { return true }
-        }
+    // Prefer live LID but fall back to the context's persisted language
+    // so saved-transcript re-polish paths (e.g. TranscriptPolishService
+    // which clears languageDetection) still hit the Apple Intelligence
+    // preflight gate and language-aware prompt.
+    let detectedLanguage = languageDetection?.lang ?? context.language
 
-        // Check for common indirect question preambles.
-        let joined = words.prefix(5).joined(separator: " ")
-        let indirectPreambles = [
-            "i was wondering if",
-            "i'm wondering if",
-            "wondering if",
-            "whether we should",
-            "do you know if",
-            "is there a",
-            "are we",
-        ]
-        return indirectPreambles.contains { joined.hasPrefix($0) }
+    let config = LLMProviderConfig(
+      model: llmModel,
+      apiKeyKeychainId: keychainId,
+      maxTokens: maxTokens,
+      temperature: 0,
+      thinkingBudget: thinkingBudget,
+      reasoningEffort: reasoningEffort,
+      detectedLanguage: detectedLanguage
+    )
+
+    // Apple Intelligence: own prompt path (unchanged, out of scope for planner).
+    if llmProvider == .appleIntelligence {
+      let enriched = appleIntelligenceInstructions(polishInstructions)
+      var resolvedInstructions = enriched
+      var userText = context.text
+      if enriched.systemPrompt.contains("${transcript}") {
+        resolvedInstructions = PolishInstructions(
+          systemPrompt: enriched.systemPrompt.replacingOccurrences(
+            of: "${transcript}", with: context.text
+          )
+        )
+        userText = ""
+      }
+      // Let `LLMError.unsupportedInputLanguage` and
+      // `LLMError.outputLanguageDrift` propagate. The live dictation
+      // path (TextProcessingRunner) treats them as silent skips. The
+      // saved-transcript re-polish path (TranscriptPolishService)
+      // surfaces them to the user so they can retry with another
+      // provider instead of the transcript being mislabeled AI-polished.
+      let llmStart = CFAbsoluteTimeGetCurrent()
+      let result = try await polisher.polish(
+        text: userText,
+        instructions: resolvedInstructions,
+        config: config,
+        onToken: onToken
+      )
+      let llmEnd = CFAbsoluteTimeGetCurrent()
+      logPolishCompletion(result: result, duration: llmEnd - llmStart)
+      let validatedText = validatePolishOutput(
+        polished: result.polishedText, original: context.text, mode: .message
+      )
+      var ctx = context
+      ctx.polishedText = validatedText
+      ctx.llmProvider = llmProvider.rawValue
+      ctx.llmModel = llmModel
+      return ctx
     }
 
-    // MARK: - Apple Intelligence Prompt (Compressed Enrichment + Custom Vocab)
+    // All other providers: PromptPlanner path.
+    // Resolve ${transcript} placeholder before passing to planner.
+    let resolvedCustomPrompt: String? = {
+      guard styleConfig.customPromptMode == .legacyTemplate,
+        let prompt = styleConfig.customSystemPrompt.nilIfEmpty
+      else { return styleConfig.customSystemPrompt.nilIfEmpty }
+      return prompt.replacingOccurrences(of: "${transcript}", with: context.text)
+    }()
 
-    /// Apple Intelligence uses a simplified on-device prompt (set in makeSession()).
-    /// We append compressed enrichment (ASR awareness, tone preservation) and custom
-    /// vocabulary. Full cloud-style enrichment is too verbose for the small on-device model.
-    private func appleIntelligenceInstructions(
-        _ base: PolishInstructions
-    ) -> PolishInstructions {
-        var systemPrompt = base.systemPrompt
+    // Multilingual v1 (W3): snapshot the active vocabulary at construction
+    // time so the planner/builders see a stable list even if the user edits
+    // custom words mid-polish. Migration default: all entries tagged global.
+    let vocabularySnapshot = PromptVocabulary.fromLegacy(customWords)
 
-        // Compressed enrichment for on-device model: key behavioral rules only.
-        // Targets eval failures: false starts (#17), formality downgrade (#19).
-        systemPrompt += "\nThis is speech-to-text output. Remove false starts. " +
-            "Preserve the speaker's tone and formality level. If unsure about a correction, leave unchanged."
+    let input = PromptBuildInput(
+      transcript: context.text,
+      provider: llmProvider,
+      modelID: llmModel,
+      stylePreset: styleConfig.writingStylePreset,
+      customSystemPrompt: resolvedCustomPrompt,
+      customPromptMode: styleConfig.customPromptMode,
+      appName: context.targetAppName,
+      language: context.language,
+      customWords: customWords,
+      focusSnapshot: nil,  // PR 3
+      customVocabulary: vocabularySnapshot,
+      languageDetection: languageDetection,
+      backend: backend
+    )
+    let plan = promptPlanner.plan(input: input)
 
-        if !customWords.isEmpty {
-            if let vocab = CustomVocabularyFormatter.render(customWords) {
-                systemPrompt += "\n\n" + vocab
-            }
-        }
+    let llmStart = CFAbsoluteTimeGetCurrent()
+    let result = try await polisher.polish(
+      envelope: plan.envelope,
+      config: config,
+      onToken: onToken
+    )
+    let llmEnd = CFAbsoluteTimeGetCurrent()
 
-        return PolishInstructions(systemPrompt: systemPrompt)
+    let family = DefaultPromptPlanner.family(for: llmProvider, modelID: llmModel)
+    logPolishCompletion(
+      result: result, duration: llmEnd - llmStart,
+      extraData: [
+        "polish_mode": plan.mode.rawValue,
+        "prompt_family": family.rawValue,
+        "custom_prompt_mode": styleConfig.customPromptMode.rawValue,
+      ])
+
+    let validatedText = validatePolishOutput(
+      polished: result.polishedText,
+      original: context.text,
+      mode: plan.mode
+    )
+
+    var ctx = context
+    ctx.polishedText = validatedText
+    ctx.llmProvider = llmProvider.rawValue
+    ctx.llmModel = llmModel
+    return ctx
+  }
+
+  // MARK: - Output Validation
+
+  /// Validate LLM polish output with mode-aware thresholds.
+  /// Falls back to original text when the output looks like a hallucination,
+  /// content drop, or question-to-answer conversion.
+  func validatePolishOutput(polished: String, original: String, mode: PolishMode) -> String {
+    guard !original.isEmpty else { return polished }
+
+    // Mode-aware thresholds (from plan Appendix C)
+    let expansionThreshold: Int
+    let contentDropFraction: (numerator: Int, denominator: Int)
+    switch mode {
+    case .inline:
+      expansionThreshold = max(original.count * 3, 150)
+      contentDropFraction = (2, 5)  // 40% retention minimum
+    case .message:
+      expansionThreshold = max(original.count * 3, 200)
+      contentDropFraction = (2, 5)
+    case .structured:
+      expansionThreshold = max(original.count * 4, 300)
+      contentDropFraction = (1, 3)  // 33% retention minimum (more aggressive cleanup ok)
+    case .edit:
+      expansionThreshold = max(original.count * 4, 300)
+      contentDropFraction = (1, 3)
     }
 
-    // MARK: - Telemetry
-
-    private func logPolishCompletion(
-        result: LLMResult, duration: Double,
-        extraData: [String: String] = [:]
-    ) {
-        var data: [String: String] = [
-            "provider": llmProvider.rawValue,
-            "model": llmModel,
-            "duration_s": String(format: "%.3f", duration),
-            "char_count": String(result.polishedText.count),
-        ]
-        data.merge(extraData) { _, new in new }
-
-        SentryBreadcrumb.add(stage: "polish", message: "LLM polish completed", data: data)
-        Task { await AppLogger.shared.log(
-            "LLM polish complete: \(result.polishedText.count) chars in \(String(format: "%.3f", duration))s " +
-            "(provider=\(llmProvider.rawValue), model=\(llmModel))",
-            level: .info, category: "PipelineTiming"
-        ) }
+    // Guard 1: Expansion hallucination
+    if polished.count > expansionThreshold {
+      Task {
+        await AppLogger.shared.log(
+          "LLM polish validator: expansion \(polished.count)/\(original.count) chars "
+            + "exceeds \(expansionThreshold) (mode=\(mode.rawValue)) — falling back "
+            + "(provider=\(llmProvider.rawValue), model=\(llmModel))",
+          level: .info, category: "LLM"
+        )
+      }
+      return original
     }
 
-    /// Resolve thinking/reasoning config based on provider, model, and user toggle.
-    private func resolveThinkingConfig() -> (thinkingBudget: Int?, reasoningEffort: String?) {
-        guard llmProvider.supportsReasoning(model: llmModel) else { return (nil, nil) }
-        switch llmProvider {
-        case .gemini:
-            return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)
-        case .openAI:
-            return (nil, useExtendedThinking ? "medium" : "low")
-        case .ollama, .appleIntelligence, .none:
-            return (nil, nil)
-        }
+    // Guard 2: Content drop
+    let originalWords = original.split(whereSeparator: \.isWhitespace)
+    let polishedWords = polished.split(whereSeparator: \.isWhitespace)
+    let dropThreshold =
+      (originalWords.count * contentDropFraction.numerator + contentDropFraction.denominator - 1)
+      / contentDropFraction.denominator
+    if originalWords.count >= 10 && polishedWords.count < dropThreshold {
+      Task {
+        await AppLogger.shared.log(
+          "LLM polish validator: content drop \(polishedWords.count)/\(originalWords.count) words "
+            + "(mode=\(mode.rawValue)) — falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
+          level: .info, category: "LLM"
+        )
+      }
+      return original
     }
+
+    // Guard 3: Question-to-answer conversion (unchanged across modes)
+    if looksLikeQuestion(original) && !looksLikeQuestion(polished) {
+      Task {
+        await AppLogger.shared.log(
+          "LLM polish validator: question-to-answer conversion detected — "
+            + "falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
+          level: .info, category: "LLM"
+        )
+      }
+      return original
+    }
+
+    return polished
+  }
+
+  /// Conservative question detection using strong signals only.
+  /// Returns true if the text contains `?` or starts with an interrogative pattern.
+  /// Leading fillers and common preambles are stripped before checking.
+  private func looksLikeQuestion(_ text: String) -> Bool {
+    if text.contains("?") { return true }
+
+    // Strip leading fillers to find the real sentence start.
+    let fillers: Set<String> = ["um", "uh", "so", "like", "well", "okay", "ok"]
+    var words = text.lowercased()
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .split(whereSeparator: \.isWhitespace)
+      .map(String.init)
+    while let first = words.first,
+      fillers.contains(first.trimmingCharacters(in: .punctuationCharacters))
+    {
+      words.removeFirst()
+    }
+    guard let firstWord = words.first else { return false }
+
+    // Modal/auxiliary verbs at sentence start are always interrogative.
+    let auxiliaryStarts: Set<String> = [
+      "should", "can", "do", "does", "did", "is", "are", "could", "would",
+      "has", "have", "will",
+    ]
+    if auxiliaryStarts.contains(firstWord) { return true }
+
+    // Wh-words need a following auxiliary to be a question.
+    // "How do we..." = question. "How we handle this..." = declarative.
+    let whWords: Set<String> = ["how", "what", "where", "when", "who", "why"]
+    if whWords.contains(firstWord) {
+      let secondWord = words.count > 1 ? words[1] : ""
+      let followedByAuxiliary =
+        auxiliaryStarts.contains(secondWord)
+        || ["many", "much", "long", "often"].contains(secondWord)  // "how many", "how long"
+      if followedByAuxiliary { return true }
+    }
+
+    // Check for common indirect question preambles.
+    let joined = words.prefix(5).joined(separator: " ")
+    let indirectPreambles = [
+      "i was wondering if",
+      "i'm wondering if",
+      "wondering if",
+      "whether we should",
+      "do you know if",
+      "is there a",
+      "are we",
+    ]
+    return indirectPreambles.contains { joined.hasPrefix($0) }
+  }
+
+  // MARK: - Apple Intelligence Prompt (Compressed Enrichment + Custom Vocab)
+
+  /// Apple Intelligence uses a simplified on-device prompt (set in makeSession()).
+  /// We append compressed enrichment (ASR awareness, tone preservation) and custom
+  /// vocabulary. Full cloud-style enrichment is too verbose for the small on-device model.
+  private func appleIntelligenceInstructions(
+    _ base: PolishInstructions
+  ) -> PolishInstructions {
+    var systemPrompt = base.systemPrompt
+
+    // Compressed enrichment for on-device model: key behavioral rules only.
+    // Targets eval failures: false starts (#17), formality downgrade (#19).
+    systemPrompt +=
+      "\nThis is speech-to-text output. Remove false starts. "
+      + "Preserve the speaker's tone and formality level. If unsure about a correction, leave unchanged."
+
+    if !customWords.isEmpty {
+      if let vocab = CustomVocabularyFormatter.render(customWords) {
+        systemPrompt += "\n\n" + vocab
+      }
+    }
+
+    return PolishInstructions(systemPrompt: systemPrompt)
+  }
+
+  // MARK: - Telemetry
+
+  private func logPolishCompletion(
+    result: LLMResult, duration: Double,
+    extraData: [String: String] = [:]
+  ) {
+    var data: [String: String] = [
+      "provider": llmProvider.rawValue,
+      "model": llmModel,
+      "duration_s": String(format: "%.3f", duration),
+      "char_count": String(result.polishedText.count),
+    ]
+    data.merge(extraData) { _, new in new }
+
+    SentryBreadcrumb.add(stage: "polish", message: "LLM polish completed", data: data)
+    Task {
+      await AppLogger.shared.log(
+        "LLM polish complete: \(result.polishedText.count) chars in \(String(format: "%.3f", duration))s "
+          + "(provider=\(llmProvider.rawValue), model=\(llmModel))",
+        level: .info, category: "PipelineTiming"
+      )
+    }
+  }
+
+  /// Resolve thinking/reasoning config based on provider, model, and user toggle.
+  private func resolveThinkingConfig() -> (thinkingBudget: Int?, reasoningEffort: String?) {
+    guard llmProvider.supportsReasoning(model: llmModel) else { return (nil, nil) }
+    switch llmProvider {
+    case .gemini:
+      return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)
+    case .openAI:
+      return (nil, useExtendedThinking ? "medium" : "low")
+    case .ollama, .appleIntelligence, .none:
+      return (nil, nil)
+    }
+  }
 }
 
 // MARK: - String helpers
 
 extension String {
-    /// Returns nil if the string is empty or whitespace-only.
-    var nilIfEmpty: String? {
-        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : self
-    }
+  /// Returns nil if the string is empty or whitespace-only.
+  var nilIfEmpty: String? {
+    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : self
+  }
 }

--- a/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
@@ -1,47 +1,125 @@
+import EnviousWisprCore
+import Foundation
 import Testing
+
 @testable import EnviousWisprLLM
 
 @Suite("OllamaConnector request body")
 struct OllamaConnectorRequestBodyTests {
 
-    private func makeBody(temperature: Double = 0.3, maxTokens: Int = 512) -> [String: Any] {
-        OllamaConnector.makeRequestBody(
-            model: "gemma4:latest",
-            messages: [
-                ["role": "system", "content": "sys"],
-                ["role": "user", "content": "hello"],
-            ],
-            maxTokens: maxTokens,
-            temperature: temperature
-        )
-    }
+  private func makeBody(temperature: Double = 0.3, maxTokens: Int = 512) -> [String: Any] {
+    OllamaConnector.makeRequestBody(
+      model: "gemma4:latest",
+      messages: [
+        ["role": "system", "content": "sys"],
+        ["role": "user", "content": "hello"],
+      ],
+      maxTokens: maxTokens,
+      temperature: temperature
+    )
+  }
 
-    /// Primary regression guard for #272. Passing `think: false` at the top level
-    /// is silently ignored by gemma4:latest and causes chain-of-thought to leak
-    /// into `message.content` (5-13× expansion). Omitting the key uses Ollama's
-    /// documented default (thinking OFF) and restores polish behavior.
-    @Test func requestBodyDoesNotIncludeThinkKey() {
-        let body = makeBody()
-        #expect(body["think"] == nil)
-    }
+  /// Primary regression guard for #272. Passing `think: false` at the top level
+  /// is silently ignored by gemma4:latest and causes chain-of-thought to leak
+  /// into `message.content` (5-13× expansion). Omitting the key uses Ollama's
+  /// documented default (thinking OFF) and restores polish behavior.
+  @Test func requestBodyDoesNotIncludeThinkKey() {
+    let body = makeBody()
+    #expect(body["think"] == nil)
+  }
 
-    @Test func requestBodyDisablesStreaming() {
-        let body = makeBody()
-        #expect(body["stream"] as? Bool == false)
-    }
+  @Test func requestBodyDisablesStreaming() {
+    let body = makeBody()
+    #expect(body["stream"] as? Bool == false)
+  }
 
-    @Test func requestBodyPassesModelAndMessages() {
-        let body = makeBody()
-        #expect(body["model"] as? String == "gemma4:latest")
-        let messages = body["messages"] as? [[String: String]]
-        #expect(messages?.count == 2)
-        #expect(messages?.first?["role"] == "system")
-    }
+  @Test func requestBodyPassesModelAndMessages() {
+    let body = makeBody()
+    #expect(body["model"] as? String == "gemma4:latest")
+    let messages = body["messages"] as? [[String: String]]
+    #expect(messages?.count == 2)
+    #expect(messages?.first?["role"] == "system")
+  }
 
-    @Test func requestBodyMapsOptions() {
-        let body = makeBody(temperature: 0.42, maxTokens: 777)
-        let options = body["options"] as? [String: Any]
-        #expect(options?["num_predict"] as? Int == 777)
-        #expect(options?["temperature"] as? Double == 0.42)
-    }
+  @Test func requestBodyMapsOptions() {
+    let body = makeBody(temperature: 0.42, maxTokens: 777)
+    let options = body["options"] as? [String: Any]
+    #expect(options?["num_predict"] as? Int == 777)
+    #expect(options?["temperature"] as? Double == 0.42)
+  }
+
+  // MARK: - Eviction body (#295)
+
+  @Test func evictRequestBodyCarriesModel() {
+    let body = OllamaConnector.makeEvictRequestBody(model: "gemma4:latest")
+    #expect(body["model"] as? String == "gemma4:latest")
+  }
+
+  /// `keep_alive: 0` is the documented Ollama unload trigger. Must be an
+  /// integer 0, not the string "0" — Ollama parses these differently.
+  @Test func evictRequestBodyUsesKeepAliveZero() {
+    let body = OllamaConnector.makeEvictRequestBody(model: "gemma4:latest")
+    #expect(body["keep_alive"] as? Int == 0)
+  }
+
+  /// Empty prompt is included explicitly. Some Ollama builds 400 on missing
+  /// `prompt` key even for unload calls, so we always emit it.
+  @Test func evictRequestBodyIncludesEmptyPrompt() {
+    let body = OllamaConnector.makeEvictRequestBody(model: "gemma4:latest")
+    #expect(body["prompt"] as? String == "")
+  }
+
+  /// Nothing else should be in the unload body — no streaming, no options,
+  /// no messages. Keeps the call as narrow as possible.
+  @Test func evictRequestBodyHasOnlyExpectedKeys() {
+    let body = OllamaConnector.makeEvictRequestBody(model: "gemma4:latest")
+    let keys = Set(body.keys)
+    #expect(keys == Set(["model", "prompt", "keep_alive"]))
+  }
+
+  // MARK: - effectiveOllamaModel classifier (#295)
+
+  @Test func effectiveOllamaModelReturnsModelWhenProviderIsOllama() {
+    #expect(
+      OllamaConnector.effectiveOllamaModel(provider: .ollama, model: "gemma4:latest")
+        == "gemma4:latest"
+    )
+  }
+
+  @Test func effectiveOllamaModelReturnsNilWhenProviderIsNotOllama() {
+    #expect(
+      OllamaConnector.effectiveOllamaModel(provider: .openAI, model: "gemma4:latest") == nil
+    )
+    #expect(
+      OllamaConnector.effectiveOllamaModel(provider: .gemini, model: "gemma4:latest") == nil
+    )
+    #expect(
+      OllamaConnector.effectiveOllamaModel(
+        provider: .appleIntelligence, model: "apple-intelligence"
+      ) == nil
+    )
+    #expect(
+      OllamaConnector.effectiveOllamaModel(provider: .none, model: "") == nil
+    )
+  }
+
+  @Test func effectiveOllamaModelReturnsNilWhenModelIsEmpty() {
+    #expect(OllamaConnector.effectiveOllamaModel(provider: .ollama, model: "") == nil)
+  }
+
+  // MARK: - evictModel fire-and-forget guard (#295)
+
+  /// Empty model names are a no-op — the method must return immediately
+  /// without hitting the network. Regression guard for callers that pass
+  /// the stored model field without first checking `isEmpty`.
+  @Test func evictModelWithEmptyNameIsNoOp() async {
+    // Pointed at a non-routable address so any accidental network
+    // call would time out rather than succeed; the test completes
+    // in well under the 3s connector timeout because the guard
+    // short-circuits before `URLSession.data(for:)` is invoked.
+    let connector = OllamaConnector(baseURL: "http://127.0.0.1:1")
+    let start = Date()
+    await connector.evictModel("")
+    #expect(Date().timeIntervalSince(start) < 0.5)
+  }
 }


### PR DESCRIPTION
Closes #295. Mitigates #286.

## Summary

- When the user swaps polish models, fire a best-effort `POST /api/generate { "keep_alive": 0 }` to Ollama to unload the previous model immediately, rather than letting it squat in VRAM for the 60 m `keep_alive` window.
- Eliminates the observed 17 GB dual-resident peak (gemma3n 7.4 GB + gemma4 9.6 GB on a 24 GB M4 Pro) that disrupts CoreAudio BT and zombies our AVAudioEngine tap — root cause for #286.
- `PipelineSettingsSync` owns a `lastEvictableOllamaModel` tracker that sidesteps the SettingsManager cascading-didSet trap (setting `llmProvider = .appleIntelligence` synchronously writes `llmModel = "apple-intelligence"` before emitting the provider change). Without the tracker, a snapshot from `polishStep` yields a stale/half-updated view and produces a bogus eviction attempt on `apple-intelligence` (Ollama 404s it — benign but wrong) plus a double-fire on the `.llmModel` → `.ollamaModel` cascade. With the tracker, each logical swap produces exactly one eviction call.

## Test plan

- [x] `scripts/swift-test.sh` — 317 tests pass (4 new eviction-body / classifier / no-op-guard tests added)
- [x] `swift build -c release` — clean
- [x] Empirical UAT on Storm BT + YouTube playing:
  - Apple Intelligence → Ollama/gemma3n (no eviction, pre was nil) ✓
  - gemma3n → gemma4 (one `gemma3n:e4b` unload, http=200) ✓
  - gemma4 → gemma3n (one `gemma4:latest` unload, http=200) ✓
  - gemma3n → llama3.2 (one `gemma3n:e4b` unload, http=200) ✓
  - llama3.2 → Apple Intelligence (one `llama3.2:latest` unload, http=200 — **no bogus apple-intelligence 404**) ✓
  - Zero double-fires, zero `0/0 fed` events, zero Sentry `audio_capture_*` emissions, `ollama ps` never showed more than one app-controlled runner
- [x] Council review (GPT + Gemini, both Approve-with-edits — all blocking edits incorporated into the final design)

## Not in scope

Zombie AVAudioEngine liveness probe in `resolveSource()` — when external pressure (FaceTime, games, anything that hammers Metal) produces the same zero-buffer symptom without an Ollama swap involved. Planned as a separate MEDIUM-tier change against #286.
