### PR TITLE
fix(llm): pre-warm with real inference request instead of HEAD (#266)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -1,7 +1,7 @@
 import AppKit
 import EnviousWisprCore
-import EnviousWisprServices
 import EnviousWisprLLM
+import EnviousWisprServices
 @preconcurrency import Sparkle
 import SwiftUI
 
@@ -12,428 +12,450 @@ import SwiftUI
 /// native approach that reliably handles clicks on all macOS versions.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    private var statusItem: NSStatusItem?
-    private(set) var updaterController: SPUStandardUpdaterController?
-    private let iconAnimator = MenuBarIconAnimator()
-    private weak var mainWindow: NSWindow?
-    private var windowCloseObserver: (any NSObjectProtocol)?
+  private var statusItem: NSStatusItem?
+  private(set) var updaterController: SPUStandardUpdaterController?
+  private let iconAnimator = MenuBarIconAnimator()
+  private weak var mainWindow: NSWindow?
+  private var windowCloseObserver: (any NSObjectProtocol)?
 
-    /// Shared app state — created here so it's available before any SwiftUI scene loads.
-    let appState = AppState()
+  /// Shared app state — created here so it's available before any SwiftUI scene loads.
+  let appState = AppState()
 
-    /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
-    var openMainWindowAction: (() -> Void)?
+  /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
+  var openMainWindowAction: (() -> Void)?
 
-    /// Callback set by SwiftUI to open the onboarding window.
-    var openOnboardingAction: (() -> Void)?
+  /// Callback set by SwiftUI to open the onboarding window.
+  var openOnboardingAction: (() -> Void)?
 
-    /// Callback set by SwiftUI to dismiss the onboarding window (state-driven).
-    var dismissOnboardingAction: (() -> Void)?
+  /// Callback set by SwiftUI to dismiss the onboarding window (state-driven).
+  var dismissOnboardingAction: (() -> Void)?
 
-    /// Weak reference to the onboarding window so we can detect when user closes it early.
-    private weak var onboardingWindow: NSWindow?
-    private var onboardingCloseObserver: (any NSObjectProtocol)?
+  /// Weak reference to the onboarding window so we can detect when user closes it early.
+  private weak var onboardingWindow: NSWindow?
+  private var onboardingCloseObserver: (any NSObjectProtocol)?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        // Hide dock icon on launch — we're a menu bar utility.
-        // If onboarding is needed, stay .regular so SwiftUI creates the main window hierarchy
-        // and ActionWirer can wire callbacks before opening the onboarding window.
-        if appState.settings.onboardingState == .completed {
-            NSApp.setActivationPolicy(.accessory)
-        }
-
-        // When the unified window closes, revert to .accessory immediately.
-        // There's only one window now, so no need for the 200ms re-check delay.
-        // Store token so we can remove on termination (H11 observer leak fix).
-        windowCloseObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let window = notification.object as? NSWindow else { return }
-            MainActor.assumeIsolated {
-                guard let self else { return }
-                // Capture the main window reference on first titled window appearance.
-                if self.mainWindow == nil, window.styleMask.contains(.titled),
-                   window.title == AppConstants.appName {
-                    self.mainWindow = window
-                }
-                // Match by identity so status-bar/panel windows never trigger the reset.
-                guard window === self.mainWindow else { return }
-                NSApp.setActivationPolicy(.accessory)
-            }
-        }
-
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: self
-        )
-
-        setupStatusItem()
-
-        // Update menu bar icon whenever pipeline state or accessibility changes
-        appState.onPipelineStateChange = { [weak self] _ in
-            self?.updateIcon()
-        }
-        appState.permissions.onAccessibilityChange = { [weak self] in
-            self?.updateIcon()
-        }
-
-        // Start hotkeys now that the event loop is running.
-        // Carbon RegisterEventHotKey requires an active run loop for event delivery.
-        appState.startHotkeyServiceIfEnabled()
-
-        if appState.settings.onboardingState == .completed {
-            let s = appState.settings
-            let hasKeys = (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
-                || (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
-            TelemetryService.shared.settingsSnapshot(
-                asrBackend: s.selectedBackend.rawValue,
-                llmProvider: s.llmProvider.rawValue,
-                recordingMode: s.recordingMode.rawValue,
-                writingStyle: s.writingStylePreset.rawValue,
-                fillerRemoval: s.fillerRemovalEnabled,
-                customWordsCount: appState.customWordsCoordinator.customWords.count,
-                hasApiKeys: hasKeys,
-                noiseSuppression: s.noiseSuppression
-            )
-        }
-
-        // Run Apple Intelligence diagnostics via coordinator.
-        // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
-        let isFreshInstall = appState.settings.onboardingState != .completed
-        if isFreshInstall {
-            appState.aiAvailability.firstLaunchCheck()
-        } else {
-            Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
-        }
-
-        // Fire structured app.launched event — uses cached report (loaded from UserDefaults in coordinator init).
-        // No async wait needed — cached snapshot is available synchronously.
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-        let osVer = ProcessInfo.processInfo.operatingSystemVersion
-        let cachedReport = appState.aiAvailability.latestReport
-        TelemetryService.shared.appLaunched(
-            version: version,
-            build: build,
-            osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
-            hardware: cachedReport?.hardwareClass ?? "unknown",
-            isFreshInstall: isFreshInstall,
-            aiAvailable: cachedReport?.overallStatus == .available
-        )
-
-        // Check Accessibility permission on launch (query only — never auto-prompt).
-        appState.permissions.refreshOnLaunch()
-        updateIcon() // Reflect accessibility warning state in menu bar icon
-
-        // Begin smart polling if Accessibility is not yet granted.
-        appState.permissions.startMonitoring()
-
-        // Pre-warm LLM network connection (TLS + HTTP/2 setup).
-        LLMNetworkSession.shared.preWarmIfConfigured(
-            provider: appState.settings.llmProvider,
-            keychainManager: appState.keychainManager
-        )
-
-        // Onboarding auto-open is handled by ActionWirer inside the main Window scene.
-        // ActionWirer wires all callbacks first, then calls openOnboardingWindow() if needed.
-        // No deferred dispatch required here.
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    // Hide dock icon on launch — we're a menu bar utility.
+    // If onboarding is needed, stay .regular so SwiftUI creates the main window hierarchy
+    // and ActionWirer can wire callbacks before opening the onboarding window.
+    if appState.settings.onboardingState == .completed {
+      NSApp.setActivationPolicy(.accessory)
     }
 
-    func applicationDidBecomeActive(_ notification: Notification) {
-        // Re-warm LLM connection when app comes to foreground.
-        LLMNetworkSession.shared.preWarmIfConfigured(
-            provider: appState.settings.llmProvider,
-            keychainManager: appState.keychainManager
-        )
-    }
-
-    // MARK: - Onboarding Window
-
-    /// Open the onboarding window and begin monitoring for early close (abort flow).
-    func openOnboardingWindow() {
-        guard appState.settings.onboardingState != .completed else { return }
-        openOnboardingAction?()
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
-        // Hide the main window so only the onboarding window is visible during setup.
-        if let mainWin = self.mainWindow {
-            mainWin.orderOut(nil)
+    // When the unified window closes, revert to .accessory immediately.
+    // There's only one window now, so no need for the 200ms re-check delay.
+    // Store token so we can remove on termination (H11 observer leak fix).
+    windowCloseObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] notification in
+      guard let window = notification.object as? NSWindow else { return }
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        // Capture the main window reference on first titled window appearance.
+        if self.mainWindow == nil, window.styleMask.contains(.titled),
+          window.title == AppConstants.appName
+        {
+          self.mainWindow = window
         }
-
-        // Capture the onboarding NSWindow by identity on first open.
-        // We defer one run-loop cycle so SwiftUI has time to create/order the window
-        // before we search NSApp.windows.
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            // SwiftUI Window(id: "onboarding") sets the title to the scene name ("Setup").
-            // We capture by identity here so the close observer can match by reference,
-            // not by title — title matching would fail if the scene name ever changes.
-            if self.onboardingWindow == nil {
-                self.onboardingWindow = NSApp.windows.first { $0.title == AppConstants.onboardingWindowTitle }
-            }
-            // Ensure the window is visible — openWindow(id:) is a silent no-op when
-            // reopening a single-instance Window scene that was previously dismissed.
-            self.onboardingWindow?.makeKeyAndOrderFront(nil)
-        }
-
-        // Monitor for user closing the onboarding window before completion.
-        // Match by window identity (captured above), not by title string.
-        if onboardingCloseObserver == nil {
-            onboardingCloseObserver = NotificationCenter.default.addObserver(
-                forName: NSWindow.willCloseNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let window = notification.object as? NSWindow else { return }
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    // Match by captured identity; fall back to title if not yet captured.
-                    let isOnboardingWindow = (self.onboardingWindow != nil)
-                        ? window === self.onboardingWindow
-                        : window.title == AppConstants.onboardingWindowTitle
-                    guard isOnboardingWindow else { return }
-                    self.onboardingWindow = nil
-                    // Only treat as abort if onboarding not yet completed.
-                    if self.appState.settings.onboardingState != .completed {
-                        self.updateIcon()
-                    }
-                }
-            }
-        }
-    }
-
-    /// Called by the onboarding Done button via the onComplete callback.
-    /// State-driven: flips isOnboardingPresented to false, ActionWirer's onChange dismisses the window.
-    func closeOnboardingWindow() {
-        dismissOnboardingAction?()
+        // Match by identity so status-bar/panel windows never trigger the reset.
+        guard window === self.mainWindow else { return }
         NSApp.setActivationPolicy(.accessory)
-        updateIcon()
+      }
     }
 
-    private func setupStatusItem() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        guard let button = statusItem?.button else { return }
+    updaterController = SPUStandardUpdaterController(
+      startingUpdater: true,
+      updaterDelegate: nil,
+      userDriverDelegate: self
+    )
 
-        iconAnimator.configure(button: button)
-        iconAnimator.audioLevelProvider = { [weak self] in self?.appState.audioCapture.audioLevel ?? 0 }
+    setupStatusItem()
 
-        let menu = NSMenu()
-        menu.delegate = self
-        statusItem?.menu = menu
-        populateMenu(menu)
+    // Update menu bar icon whenever pipeline state or accessibility changes
+    appState.onPipelineStateChange = { [weak self] _ in
+      self?.updateIcon()
+    }
+    appState.permissions.onAccessibilityChange = { [weak self] in
+      self?.updateIcon()
     }
 
-    /// Load a menu bar icon from the app bundle's Resources directory.
-    /// At runtime the bundle is a proper .app with Contents/Resources/;
-    /// during development we fall back to the source Resources/ directory.
-    ///
-    /// Resolution order:
-    ///   1. Bundle.main.resourceURL  (production .app bundle)
-    ///   2. Derived from executable path (fallback when Bundle.main mis-resolves)
-    ///   3. Source tree via #filePath (development / bare binary)
-    ///   4. SF Symbol "mic" (last resort)
-    /// Populate the given menu with items reflecting current AppState.
-    private func populateMenu(_ menu: NSMenu) {
-        menu.removeAllItems()
+    // Start hotkeys now that the event loop is running.
+    // Carbon RegisterEventHotKey requires an active run loop for event delivery.
+    appState.startHotkeyServiceIfEnabled()
 
-        let state = appState.pipelineState
-        let onboardingIncomplete = appState.settings.onboardingState != .completed
+    if appState.settings.onboardingState == .completed {
+      let s = appState.settings
+      let hasKeys =
+        (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
+        || (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
+      TelemetryService.shared.settingsSnapshot(
+        asrBackend: s.selectedBackend.rawValue,
+        llmProvider: s.llmProvider.rawValue,
+        recordingMode: s.recordingMode.rawValue,
+        writingStyle: s.writingStylePreset.rawValue,
+        fillerRemoval: s.fillerRemovalEnabled,
+        customWordsCount: appState.customWordsCoordinator.customWords.count,
+        hasApiKeys: hasKeys,
+        noiseSuppression: s.noiseSuppression
+      )
+    }
 
-        // Onboarding abort item — shown at the very top when setup is incomplete.
-        if onboardingIncomplete {
-            let setupItem = NSMenuItem(
-                title: "Setup Required: Continue Setup…",
-                action: #selector(continueOnboarding),
-                keyEquivalent: ""
-            )
-            setupItem.image = NSImage(systemSymbolName: "exclamationmark.circle.fill", accessibilityDescription: "Setup required")
-            setupItem.target = self
-            menu.addItem(setupItem)
-            menu.addItem(.separator())
+    // Run Apple Intelligence diagnostics via coordinator.
+    // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
+    let isFreshInstall = appState.settings.onboardingState != .completed
+    if isFreshInstall {
+      appState.aiAvailability.firstLaunchCheck()
+    } else {
+      Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
+    }
+
+    // Fire structured app.launched event — uses cached report (loaded from UserDefaults in coordinator init).
+    // No async wait needed — cached snapshot is available synchronously.
+    let version =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+    let osVer = ProcessInfo.processInfo.operatingSystemVersion
+    let cachedReport = appState.aiAvailability.latestReport
+    TelemetryService.shared.appLaunched(
+      version: version,
+      build: build,
+      osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
+      hardware: cachedReport?.hardwareClass ?? "unknown",
+      isFreshInstall: isFreshInstall,
+      aiAvailable: cachedReport?.overallStatus == .available
+    )
+
+    // Check Accessibility permission on launch (query only — never auto-prompt).
+    appState.permissions.refreshOnLaunch()
+    updateIcon()  // Reflect accessibility warning state in menu bar icon
+
+    // Begin smart polling if Accessibility is not yet granted.
+    appState.permissions.startMonitoring()
+
+    // Pre-warm LLM backend with a real inference request.
+    LLMNetworkSession.shared.preWarmModel(
+      provider: appState.settings.llmProvider,
+      model: appState.settings.llmModel,
+      keychainManager: appState.keychainManager
+    )
+
+    // Onboarding auto-open is handled by ActionWirer inside the main Window scene.
+    // ActionWirer wires all callbacks first, then calls openOnboardingWindow() if needed.
+    // No deferred dispatch required here.
+  }
+
+  func applicationDidBecomeActive(_ notification: Notification) {
+    // Re-warm LLM backend when app comes to foreground.
+    LLMNetworkSession.shared.preWarmModel(
+      provider: appState.settings.llmProvider,
+      model: appState.settings.llmModel,
+      keychainManager: appState.keychainManager
+    )
+  }
+
+  // MARK: - Onboarding Window
+
+  /// Open the onboarding window and begin monitoring for early close (abort flow).
+  func openOnboardingWindow() {
+    guard appState.settings.onboardingState != .completed else { return }
+    openOnboardingAction?()
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+    // Hide the main window so only the onboarding window is visible during setup.
+    if let mainWin = self.mainWindow {
+      mainWin.orderOut(nil)
+    }
+
+    // Capture the onboarding NSWindow by identity on first open.
+    // We defer one run-loop cycle so SwiftUI has time to create/order the window
+    // before we search NSApp.windows.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      // SwiftUI Window(id: "onboarding") sets the title to the scene name ("Setup").
+      // We capture by identity here so the close observer can match by reference,
+      // not by title — title matching would fail if the scene name ever changes.
+      if self.onboardingWindow == nil {
+        self.onboardingWindow = NSApp.windows.first {
+          $0.title == AppConstants.onboardingWindowTitle
         }
+      }
+      // Ensure the window is visible — openWindow(id:) is a silent no-op when
+      // reopening a single-instance Window scene that was previously dismissed.
+      self.onboardingWindow?.makeKeyAndOrderFront(nil)
+    }
 
-        // Status: ASR model — LLM model
-        let asrModel = appState.activeModelName
-        let llmInfo = appState.activeLLMDisplayName
-        let statusTitle = "\(asrModel) — \(llmInfo)"
-        let statusItem = NSMenuItem(title: statusTitle, action: nil, keyEquivalent: "")
-        statusItem.isEnabled = false
-        menu.addItem(statusItem)
-
-        // Version
-        let versionItem = NSMenuItem(title: "Version: \(AppConstants.appVersion)", action: nil, keyEquivalent: "")
-        versionItem.isEnabled = false
-        menu.addItem(versionItem)
-
-        menu.addItem(.separator())
-
-        // Record / Stop
-        let recordTitle = state == .recording ? "Stop Recording" : "Start Recording"
-        let recordSymbol = state == .recording ? "stop.circle" : "mic.fill"
-        let recordDescription = state == .recording ? "Stop" : "Record"
-        let recordItem = NSMenuItem(title: recordTitle, action: #selector(toggleRecording), keyEquivalent: "")
-        recordItem.image = NSImage(systemSymbolName: recordSymbol, accessibilityDescription: recordDescription)
-        recordItem.target = self
-        recordItem.isEnabled = !(state.isActive && state != .recording)
-        menu.addItem(recordItem)
-
-        // Auto-stop on silence indicator
-        if appState.settings.vadAutoStop {
-            let autoStopTitle = state == .recording
-                ? "Auto-stop: Active (\(String(format: "%.1fs", appState.settings.vadSilenceTimeout)) silence)"
-                : "Auto-stop on silence: On"
-            let autoStopItem = NSMenuItem(title: autoStopTitle, action: nil, keyEquivalent: "")
-            autoStopItem.image = NSImage(systemSymbolName: "waveform.badge.minus", accessibilityDescription: "Auto-stop on silence")
-            autoStopItem.isEnabled = false
-            menu.addItem(autoStopItem)
+    // Monitor for user closing the onboarding window before completion.
+    // Match by window identity (captured above), not by title string.
+    if onboardingCloseObserver == nil {
+      onboardingCloseObserver = NotificationCenter.default.addObserver(
+        forName: NSWindow.willCloseNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] notification in
+        guard let window = notification.object as? NSWindow else { return }
+        MainActor.assumeIsolated {
+          guard let self else { return }
+          // Match by captured identity; fall back to title if not yet captured.
+          let isOnboardingWindow =
+            (self.onboardingWindow != nil)
+            ? window === self.onboardingWindow
+            : window.title == AppConstants.onboardingWindowTitle
+          guard isOnboardingWindow else { return }
+          self.onboardingWindow = nil
+          // Only treat as abort if onboarding not yet completed.
+          if self.appState.settings.onboardingState != .completed {
+            self.updateIcon()
+          }
         }
+      }
+    }
+  }
 
-        // Accessibility warning — shown only when paste is unavailable and not dismissed.
-        if appState.permissions.shouldShowAccessibilityWarning {
-            let warningItem = NSMenuItem(
-                title: "Paste disabled — Accessibility required",
-                action: #selector(openPermissionsSettings),
-                keyEquivalent: ""
-            )
-            warningItem.image = NSImage(systemSymbolName: "exclamationmark.shield.fill", accessibilityDescription: "Accessibility required")
-            warningItem.target = self
-            menu.addItem(warningItem)
-        }
+  /// Called by the onboarding Done button via the onComplete callback.
+  /// State-driven: flips isOnboardingPresented to false, ActionWirer's onChange dismisses the window.
+  func closeOnboardingWindow() {
+    dismissOnboardingAction?()
+    NSApp.setActivationPolicy(.accessory)
+    updateIcon()
+  }
 
-        menu.addItem(.separator())
+  private func setupStatusItem() {
+    statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    guard let button = statusItem?.button else { return }
 
-        // Settings (opens unified window to Speech Engine tab)
-        let settingsItem = NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ",")
-        settingsItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")
-        settingsItem.target = self
-        menu.addItem(settingsItem)
+    iconAnimator.configure(button: button)
+    iconAnimator.audioLevelProvider = { [weak self] in self?.appState.audioCapture.audioLevel ?? 0 }
 
-        // Check for Updates
-        if let updaterController {
-            let updateItem = NSMenuItem(title: "Check for Updates…", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
-            updateItem.image = NSImage(systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
-            updateItem.target = updaterController
-            menu.addItem(updateItem)
-        }
+    let menu = NSMenu()
+    menu.delegate = self
+    statusItem?.menu = menu
+    populateMenu(menu)
+  }
 
-        menu.addItem(.separator())
+  /// Load a menu bar icon from the app bundle's Resources directory.
+  /// At runtime the bundle is a proper .app with Contents/Resources/;
+  /// during development we fall back to the source Resources/ directory.
+  ///
+  /// Resolution order:
+  ///   1. Bundle.main.resourceURL  (production .app bundle)
+  ///   2. Derived from executable path (fallback when Bundle.main mis-resolves)
+  ///   3. Source tree via #filePath (development / bare binary)
+  ///   4. SF Symbol "mic" (last resort)
+  /// Populate the given menu with items reflecting current AppState.
+  private func populateMenu(_ menu: NSMenu) {
+    menu.removeAllItems()
 
-        // Quit
-        let quitItem = NSMenuItem(title: "Quit \(AppConstants.appName)", action: #selector(quitApp), keyEquivalent: "q")
-        quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")
-        quitItem.target = self
-        menu.addItem(quitItem)
+    let state = appState.pipelineState
+    let onboardingIncomplete = appState.settings.onboardingState != .completed
+
+    // Onboarding abort item — shown at the very top when setup is incomplete.
+    if onboardingIncomplete {
+      let setupItem = NSMenuItem(
+        title: "Setup Required: Continue Setup…",
+        action: #selector(continueOnboarding),
+        keyEquivalent: ""
+      )
+      setupItem.image = NSImage(
+        systemSymbolName: "exclamationmark.circle.fill", accessibilityDescription: "Setup required")
+      setupItem.target = self
+      menu.addItem(setupItem)
+      menu.addItem(.separator())
     }
 
-    /// Update the status item icon based on pipeline state.
-    func updateIcon() {
-        let state = appState.pipelineState
-        let needsAccessWarning = state == .idle && appState.permissions.shouldShowAccessibilityWarning
-        let onboardingIncomplete = appState.settings.onboardingState != .completed
+    // Status: ASR model — LLM model
+    let asrModel = appState.activeModelName
+    let llmInfo = appState.activeLLMDisplayName
+    let statusTitle = "\(asrModel) — \(llmInfo)"
+    let statusItem = NSMenuItem(title: statusTitle, action: nil, keyEquivalent: "")
+    statusItem.isEnabled = false
+    menu.addItem(statusItem)
 
-        if needsAccessWarning || (onboardingIncomplete && state == .idle) {
-            iconAnimator.transition(to: .error)
-        } else if case .error = state {
-            iconAnimator.transition(to: .error)
-        } else if state == .recording {
-            iconAnimator.transition(to: .recording)
-        } else if state == .transcribing || state == .polishing || state == .loadingModel {
-            iconAnimator.transition(to: .processing)
-        } else {
-            iconAnimator.transition(to: .idle)
-        }
+    // Version
+    let versionItem = NSMenuItem(
+      title: "Version: \(AppConstants.appVersion)", action: nil, keyEquivalent: "")
+    versionItem.isEnabled = false
+    menu.addItem(versionItem)
+
+    menu.addItem(.separator())
+
+    // Record / Stop
+    let recordTitle = state == .recording ? "Stop Recording" : "Start Recording"
+    let recordSymbol = state == .recording ? "stop.circle" : "mic.fill"
+    let recordDescription = state == .recording ? "Stop" : "Record"
+    let recordItem = NSMenuItem(
+      title: recordTitle, action: #selector(toggleRecording), keyEquivalent: "")
+    recordItem.image = NSImage(
+      systemSymbolName: recordSymbol, accessibilityDescription: recordDescription)
+    recordItem.target = self
+    recordItem.isEnabled = !(state.isActive && state != .recording)
+    menu.addItem(recordItem)
+
+    // Auto-stop on silence indicator
+    if appState.settings.vadAutoStop {
+      let autoStopTitle =
+        state == .recording
+        ? "Auto-stop: Active (\(String(format: "%.1fs", appState.settings.vadSilenceTimeout)) silence)"
+        : "Auto-stop on silence: On"
+      let autoStopItem = NSMenuItem(title: autoStopTitle, action: nil, keyEquivalent: "")
+      autoStopItem.image = NSImage(
+        systemSymbolName: "waveform.badge.minus", accessibilityDescription: "Auto-stop on silence")
+      autoStopItem.isEnabled = false
+      menu.addItem(autoStopItem)
     }
 
-    @objc private func continueOnboarding() {
-        openOnboardingWindow()
+    // Accessibility warning — shown only when paste is unavailable and not dismissed.
+    if appState.permissions.shouldShowAccessibilityWarning {
+      let warningItem = NSMenuItem(
+        title: "Paste disabled — Accessibility required",
+        action: #selector(openPermissionsSettings),
+        keyEquivalent: ""
+      )
+      warningItem.image = NSImage(
+        systemSymbolName: "exclamationmark.shield.fill",
+        accessibilityDescription: "Accessibility required")
+      warningItem.target = self
+      menu.addItem(warningItem)
     }
 
-    @objc private func toggleRecording() {
-        Task {
-            await appState.toggleRecording()
-            updateIcon()
-        }
+    menu.addItem(.separator())
+
+    // Settings (opens unified window to Speech Engine tab)
+    let settingsItem = NSMenuItem(
+      title: "Settings...", action: #selector(openSettings), keyEquivalent: ",")
+    settingsItem.image = NSImage(
+      systemSymbolName: "gearshape", accessibilityDescription: "Settings")
+    settingsItem.target = self
+    menu.addItem(settingsItem)
+
+    // Check for Updates
+    if let updaterController {
+      let updateItem = NSMenuItem(
+        title: "Check for Updates…",
+        action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
+      updateItem.image = NSImage(
+        systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
+      updateItem.target = updaterController
+      menu.addItem(updateItem)
     }
 
-    /// Show the unified window: bring it to front, set .regular, activate.
-    private func showWindow() {
-        if let action = openMainWindowAction {
-            action()
-        } else {
-            // Fallback: find and show an existing window
-            for window in NSApp.windows where window.title == AppConstants.appName {
-                window.makeKeyAndOrderFront(nil)
-                break
-            }
-        }
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
-    }
+    menu.addItem(.separator())
 
-    @objc private func openSettings() {
-        appState.pendingNavigationSection = .speechEngine
-        showWindow()
-    }
+    // Quit
+    let quitItem = NSMenuItem(
+      title: "Quit \(AppConstants.appName)", action: #selector(quitApp), keyEquivalent: "q")
+    quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")
+    quitItem.target = self
+    menu.addItem(quitItem)
+  }
 
-    @objc private func openPermissionsSettings() {
-        appState.pendingNavigationSection = .permissions
-        showWindow()
-    }
+  /// Update the status item icon based on pipeline state.
+  func updateIcon() {
+    let state = appState.pipelineState
+    let needsAccessWarning = state == .idle && appState.permissions.shouldShowAccessibilityWarning
+    let onboardingIncomplete = appState.settings.onboardingState != .completed
 
-    func applicationWillTerminate(_ notification: Notification) {
-        if let observer = windowCloseObserver {
-            NotificationCenter.default.removeObserver(observer)
-            windowCloseObserver = nil
-        }
-        if let observer = onboardingCloseObserver {
-            NotificationCenter.default.removeObserver(observer)
-            onboardingCloseObserver = nil
-        }
-        appState.ollamaSetup.cleanup()
-        appState.hotkeyService.stop()
-        LLMNetworkSession.shared.invalidate()
+    if needsAccessWarning || (onboardingIncomplete && state == .idle) {
+      iconAnimator.transition(to: .error)
+    } else if case .error = state {
+      iconAnimator.transition(to: .error)
+    } else if state == .recording {
+      iconAnimator.transition(to: .recording)
+    } else if state == .transcribing || state == .polishing || state == .loadingModel {
+      iconAnimator.transition(to: .processing)
+    } else {
+      iconAnimator.transition(to: .idle)
     }
+  }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // Menu bar app — keep running when windows close.
-        // User quits via "Quit EnviousWispr" in the status bar menu.
-        return false
-    }
+  @objc private func continueOnboarding() {
+    openOnboardingWindow()
+  }
 
-    @objc private func quitApp() {
-        NSApp.terminate(nil)
+  @objc private func toggleRecording() {
+    Task {
+      await appState.toggleRecording()
+      updateIcon()
     }
+  }
+
+  /// Show the unified window: bring it to front, set .regular, activate.
+  private func showWindow() {
+    if let action = openMainWindowAction {
+      action()
+    } else {
+      // Fallback: find and show an existing window
+      for window in NSApp.windows where window.title == AppConstants.appName {
+        window.makeKeyAndOrderFront(nil)
+        break
+      }
+    }
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  @objc private func openSettings() {
+    appState.pendingNavigationSection = .speechEngine
+    showWindow()
+  }
+
+  @objc private func openPermissionsSettings() {
+    appState.pendingNavigationSection = .permissions
+    showWindow()
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    if let observer = windowCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      windowCloseObserver = nil
+    }
+    if let observer = onboardingCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      onboardingCloseObserver = nil
+    }
+    appState.ollamaSetup.cleanup()
+    appState.hotkeyService.stop()
+    LLMNetworkSession.shared.invalidate()
+  }
+
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // Menu bar app — keep running when windows close.
+    // User quits via "Quit EnviousWispr" in the status bar menu.
+    return false
+  }
+
+  @objc private func quitApp() {
+    NSApp.terminate(nil)
+  }
 }
 
 // MARK: - NSMenuDelegate
 
 extension AppDelegate: NSMenuDelegate {
-    /// Repopulate menu items each time the menu opens so state is fresh.
-    /// NSMenu delegate methods are always called on the main thread.
-    nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
-        MainActor.assumeIsolated {
-            if let currentMenu = self.statusItem?.menu {
-                self.populateMenu(currentMenu)
-            }
-            self.updateIcon()
-        }
+  /// Repopulate menu items each time the menu opens so state is fresh.
+  /// NSMenu delegate methods are always called on the main thread.
+  nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
+    MainActor.assumeIsolated {
+      if let currentMenu = self.statusItem?.menu {
+        self.populateMenu(currentMenu)
+      }
+      self.updateIcon()
     }
+  }
 }
 
 // MARK: - SPUStandardUserDriverDelegate
 
 extension AppDelegate: @preconcurrency SPUStandardUserDriverDelegate {
-    /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
-    func standardUserDriverWillShowModalAlert() {
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate()
-    }
+  /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
+  func standardUserDriverWillShowModalAlert() {
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate()
+  }
 
-    /// Return to accessory mode when the entire update session ends.
-    func standardUserDriverWillFinishUpdateSession() {
-        NSApp.setActivationPolicy(.accessory)
-    }
+  /// Return to accessory mode when the entire update session ends.
+  func standardUserDriverWillFinishUpdateSession() {
+    NSApp.setActivationPolicy(.accessory)
+  }
 }

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -1,6 +1,6 @@
+import EnviousWisprCore
 import Foundation
 import os
-import EnviousWisprCore
 
 /// Singleton URLSession for LLM API requests.
 /// Reuses a single session for HTTP/2 multiplexing and TLS session resumption.
@@ -8,76 +8,120 @@ import EnviousWisprCore
 ///
 /// URLSession is thread-safe, so this class is safe to use from any isolation domain.
 public final class LLMNetworkSession: Sendable {
-    public static let shared = LLMNetworkSession()
+  public static let shared = LLMNetworkSession()
 
-    public let session: URLSession
+  public let session: URLSession
 
-    /// Per-process monotonic counter for polish calls. Increments from 1. Lets
-    /// diagnostic log lines distinguish the very first call after launch from
-    /// subsequent calls without carrying extra state.
-    private let callCounter = OSAllocatedUnfairLock<Int>(initialState: 0)
+  /// Per-process monotonic counter for polish calls. Increments from 1. Lets
+  /// diagnostic log lines distinguish the very first call after launch from
+  /// subsequent calls without carrying extra state.
+  private let callCounter = OSAllocatedUnfairLock<Int>(initialState: 0)
 
-    private init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 60
-        config.timeoutIntervalForResource = 180
-        config.waitsForConnectivity = false
-        config.networkServiceType = .responsiveData
-        session = URLSession(configuration: config)
+  private init() {
+    let config = URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = 60
+    config.timeoutIntervalForResource = 180
+    config.waitsForConnectivity = false
+    config.networkServiceType = .responsiveData
+    session = URLSession(configuration: config)
+  }
+
+  /// Returns the next process-wide polish call number (starting at 1).
+  func nextCallNumber() -> Int {
+    callCounter.withLock { n in
+      n += 1
+      return n
     }
+  }
 
-    /// Returns the next process-wide polish call number (starting at 1).
-    func nextCallNumber() -> Int {
-        callCounter.withLock { n in
-            n += 1
-            return n
-        }
+  /// Pre-warm the LLM backend with a real lightweight inference request.
+  /// Warms both the transport layer (QUIC/TLS) AND the provider's model routing.
+  /// Silently ignores errors — pre-warming is best-effort.
+  public func preWarmModel(
+    provider: LLMProvider, model: String, keychainManager: KeychainManager
+  ) {
+    guard provider == .gemini || provider == .openAI else { return }
+    guard !model.isEmpty else { return }
+
+    let keychainId =
+      provider == .openAI
+      ? KeychainManager.openAIKeyID : KeychainManager.geminiKeyID
+    guard let key = try? keychainManager.retrieve(key: keychainId),
+      !key.isEmpty
+    else { return }
+
+    guard
+      let request = buildWarmupRequest(
+        provider: provider, model: model, apiKey: key
+      )
+    else { return }
+
+    Task.detached { [session] in
+      let start = CFAbsoluteTimeGetCurrent()
+      do {
+        let (_, response) = try await session.data(for: request)
+        let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+        let status = (response as? HTTPURLResponse)?.statusCode.description ?? "n/a"
+        await AppLogger.shared.log(
+          "preWarm completed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) status=\(status)",
+          level: .info, category: "LLM"
+        )
+      } catch {
+        let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+        await AppLogger.shared.log(
+          "preWarm failed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) error=\(String(describing: error))",
+          level: .info, category: "LLM"
+        )
+      }
     }
+  }
 
-    /// Pre-warm the connection to the given URL by sending a lightweight HEAD request.
-    /// Establishes TLS + HTTP/2 connection so subsequent requests skip the handshake.
-    /// Silently ignores errors — pre-warming is best-effort.
-    public func preWarm(url: URL) {
-        var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-        request.timeoutInterval = 5
+  private func buildWarmupRequest(
+    provider: LLMProvider, model: String, apiKey: String
+  ) -> URLRequest? {
+    switch provider {
+    case .gemini:
+      let urlString =
+        "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent"
+      guard let url = URL(string: urlString) else { return nil }
+      var request = URLRequest(url: url)
+      request.httpMethod = "POST"
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+      request.timeoutInterval = 5
+      let body: [String: Any] = [
+        "contents": [["parts": [["text": "."]]]],
+        "generationConfig": ["maxOutputTokens": 1],
+      ]
+      request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+      return request
 
-        Task.detached { [session] in
-            let start = CFAbsoluteTimeGetCurrent()
-            do {
-                let (_, response) = try await session.data(for: request)
-                let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
-                let status = (response as? HTTPURLResponse)?.statusCode.description ?? "n/a"
-                await AppLogger.shared.log(
-                    "preWarm completed url=\(url.absoluteString) duration_ms=\(ms) status=\(status)",
-                    level: .info, category: "LLM"
-                )
-            } catch {
-                let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
-                await AppLogger.shared.log(
-                    "preWarm failed url=\(url.absoluteString) duration_ms=\(ms) "
-                        + "error=\(String(describing: error))",
-                    level: .info, category: "LLM"
-                )
-            }
-        }
+    case .openAI:
+      guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+        return nil
+      }
+      var request = URLRequest(url: url)
+      request.httpMethod = "POST"
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+      request.timeoutInterval = 5
+      let body: [String: Any] = [
+        "model": model,
+        "messages": [["role": "user", "content": "."]],
+        "max_tokens": 1,
+        "store": false,
+      ]
+      request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+      return request
+
+    default:
+      return nil
     }
+  }
 
-    /// Pre-warm the Gemini API connection using the configured model.
-    /// Only fires if Gemini is the configured provider and an API key exists.
-    public func preWarmIfConfigured(provider: LLMProvider, keychainManager: KeychainManager) {
-        guard provider == .gemini else { return }
-        guard let key = try? keychainManager.retrieve(key: KeychainManager.geminiKeyID),
-              !key.isEmpty else { return }
-
-        let baseURL = "https://generativelanguage.googleapis.com"
-        guard let url = URL(string: baseURL) else { return }
-        preWarm(url: url)
-    }
-
-    /// Invalidate the session on app termination.
-    /// Uses finishTasksAndInvalidate to allow in-flight requests to complete.
-    public func invalidate() {
-        session.finishTasksAndInvalidate()
-    }
+  /// Invalidate the session on app termination.
+  /// Uses finishTasksAndInvalidate to allow in-flight requests to complete.
+  public func invalidate() {
+    session.finishTasksAndInvalidate()
+  }
 }

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -108,7 +108,7 @@ public final class LLMNetworkSession: Sendable {
       let body: [String: Any] = [
         "model": model,
         "messages": [["role": "user", "content": "."]],
-        "max_tokens": 1,
+        "max_completion_tokens": 1,
         "store": false,
       ]
       request.httpBody = try? JSONSerialization.data(withJSONObject: body)

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -642,10 +642,10 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     // Defense: if cancelRecording() ran during yield, bail out
     guard state == .recording else { return }
 
-    // Pre-warm the LLM connection while ASR is still running (fire-and-forget).
-    // Establishes TLS + HTTP/2 so the polish request skips the handshake.
-    LLMNetworkSession.shared.preWarmIfConfigured(
+    // Pre-warm the LLM backend while ASR is still running (fire-and-forget).
+    LLMNetworkSession.shared.preWarmModel(
       provider: llmPolishStep.llmProvider,
+      model: llmPolishStep.llmModel,
       keychainManager: keychainManager
     )
 

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -593,9 +593,10 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       data: ["sample_count": rawSamples.count])
     SentryBreadcrumb.updateRecordingState(active: false)
 
-    // Pre-warm LLM connection while ASR runs
-    LLMNetworkSession.shared.preWarmIfConfigured(
+    // Pre-warm LLM backend while ASR runs
+    LLMNetworkSession.shared.preWarmModel(
       provider: llmPolishStep.llmProvider,
+      model: llmPolishStep.llmModel,
       keychainManager: keychainManager
     )
 


### PR DESCRIPTION
## Summary

- Replace HEAD-to-root pre-warm (returned 404, warmed QUIC/TLS only) with a real lightweight `generateContent`/`chat/completions` request (`maxOutputTokens: 1`) targeting the user's selected model
- Warms both transport layer AND provider's backend model routing, eliminating cold-start TTFB spikes
- Extends pre-warm coverage from Gemini-only to both Gemini and OpenAI

Closes #266

## Context

Issue #266 reported intermittent 5s+ TTFB on first Gemini polish call after idle. Instrumentation (PR #270) showed `reused=true` (QUIC warm) but backend could be cold. Council (GPT + Gemini) confirmed HEAD warms the socket, not the inference path. Competitor analysis (WisprFlow) showed they send real POST requests for warmup.

Plan: `docs/feature-requests/issue-266-2026-04-15-llm-prewarm-real-request.md`

## Test plan

- [ ] `swift build -c release` passes
- [ ] `scripts/swift-test.sh` passes (317 tests)
- [ ] Rebuild + dictate with Gemini: log shows `preWarm completed provider=gemini ... status=200` (not 404)
- [ ] Polish timing unchanged (500-800ms range)
- [ ] No references to old `preWarmIfConfigured` / `preWarm(url:)` remain
