### PR TITLE
feat(telemetry): Sentry event on zombie-engine zero-peak recordings (#302)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -26,6 +26,7 @@ final class AppState {
   let ollamaSetup = OllamaSetupService()
   let whisperKitSetup = WhisperKitSetupService()
   let audioDeviceList = AudioDeviceList()
+  let captureTelemetry = CaptureTelemetryState()
 
   /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
   private var whisperKitPreloadTask: Task<Void, Never>?
@@ -106,7 +107,8 @@ final class AppState {
       audioCapture: audioCapture,
       asrManager: asrManager,
       transcriptStore: transcriptStore,
-      keychainManager: keychainManager
+      keychainManager: keychainManager,
+      captureTelemetry: captureTelemetry
     )
     // W6: wire language-flip telemetry into the detector via a closure so
     // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
@@ -131,7 +133,8 @@ final class AppState {
       backend: WhisperKitBackend(),
       transcriptStore: transcriptStore,
       keychainManager: keychainManager,
-      languageDetector: languageDetector
+      languageDetector: languageDetector,
+      captureTelemetry: captureTelemetry
     )
     // Transcript polish service (re-polish from detail view, decoupled from pipelines)
     polishService = TranscriptPolishService(
@@ -261,7 +264,9 @@ final class AppState {
       forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
     ) { [weak self] _ in
       Task { @MainActor in
-        let route = self?.audioCapture.currentAudioRoute ?? "unknown"
+        guard let self else { return }
+        self.captureTelemetry.incrementConfigChange()
+        let route = self.audioCapture.currentAudioRoute
         SentryBreadcrumb.add(
           stage: "audio", message: "Audio route changed", level: .warning,
           data: [

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -39,6 +39,11 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   // Shared services
   private let transcriptFinalizer: TranscriptFinalizer
 
+  /// App-wide capture telemetry state (shared with WhisperKit pipeline).
+  /// Owns dedupe for zombie-engine events (#302) and the
+  /// AVAudioEngineConfigurationChange counter (#294 smoking-gun diagnostic).
+  private let captureTelemetry: CaptureTelemetryState
+
   // Text processing steps
   private let wordCorrectionStep = WordCorrectionStep()
   private let fillerRemovalStep = FillerRemovalStep()
@@ -103,12 +108,14 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
     transcriptStore: TranscriptStore,
-    keychainManager: KeychainManager = KeychainManager()
+    keychainManager: KeychainManager = KeychainManager(),
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
   ) {
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.transcriptStore = transcriptStore
     self.keychainManager = keychainManager
+    self.captureTelemetry = captureTelemetry
     self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: makes the Parakeet path non-inferred. The
@@ -728,6 +735,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
           "peak_audio_level": peakAudioLevel,
         ]
       )
+      emitZombieEngineEventIfNeeded(rawSamples: rawSamples, peakAudioLevel: peakAudioLevel)
       frozenSnapshot = nil
       state = .idle
       Task {
@@ -939,6 +947,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
           "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
           "backend": asrManager.activeBackendType.rawValue,
         ])
+      captureTelemetry.recordSuccessfulRecording()
       frozenSnapshot = nil
       state = .complete
     } catch {
@@ -950,6 +959,51 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       frozenSnapshot = nil
       state = .error("Transcription failed: \(error.localizedDescription)")
     }
+  }
+
+  /// Issue #302: emit a Sentry event when the VAD gate gets a full recording's
+  /// worth of exactly-zero audio. That signature (`peak == 0.0` with non-empty
+  /// samples) matches the zombie-engine failure described in gotchas.md, not
+  /// genuine silence (which has a noise floor). Dedupes via captureTelemetry.
+  private func emitZombieEngineEventIfNeeded(rawSamples: [Float], peakAudioLevel: Float) {
+    guard peakAudioLevel == 0.0,
+      rawSamples.count >= AudioConstants.minimumTranscriptionSamples
+    else { return }
+
+    let route = audioCapture.currentAudioRoute
+    let sessionID = audioCapture.currentCaptureSessionID
+    let durationMs = rawSamples.count * 1000 / 16_000
+    let shouldEmit = captureTelemetry.shouldEmitZombie(
+      route: route, window: .seconds(30))
+    captureTelemetry.markZombieEmitted(route: route)
+
+    guard shouldEmit else { return }
+
+    let err = HeartPathError.zombieEngineZeroPeak(
+      sessionID: sessionID,
+      durationMs: durationMs,
+      route: route,
+      sampleCount: rawSamples.count
+    )
+    SentryBreadcrumb.captureError(
+      err,
+      category: .audioCaptureFailed,
+      stage: "recording",
+      extra: SentryAudioExtras.buildCaptureExtras(
+        route: route,
+        sourceType: audioCapture.captureSourceType,
+        sessionID: sessionID,
+        isActivelyCapturing: audioCapture.isActivelyCapturing,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: "zombie_engine_zero_peak",
+        timeSinceLastSuccessfulRecordingMs:
+          captureTelemetry
+          .timeSinceLastSuccessfulRecordingMs(),
+        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+      )
+    )
   }
 
   // polishExistingTranscript() removed — re-polish is now handled by TranscriptPolishService,

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -85,6 +85,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   // Shared services
   private let transcriptFinalizer: TranscriptFinalizer
 
+  /// App-wide capture telemetry state (shared with Parakeet pipeline). Owns
+  /// dedupe for zombie-engine events (#302) and the AVAudioEngineConfigurationChange
+  /// counter (#294 smoking-gun diagnostic).
+  private let captureTelemetry: CaptureTelemetryState
+
   // Text processing steps (own instances — not shared with Parakeet)
   public let wordCorrectionStep = WordCorrectionStep()
   public let fillerRemovalStep = FillerRemovalStep()
@@ -126,12 +131,14 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     backend: WhisperKitBackend,
     transcriptStore: TranscriptStore,
     keychainManager: KeychainManager,
-    languageDetector: LanguageDetector = LanguageDetector()
+    languageDetector: LanguageDetector = LanguageDetector(),
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
   ) {
     self.audioCapture = audioCapture
     self.backend = backend
     self.keychainManager = keychainManager
     self.languageDetector = languageDetector
+    self.captureTelemetry = captureTelemetry
     self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: prevents a future codepath that skips the
@@ -672,6 +679,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           "peak_audio_level": peakAudioLevel,
         ]
       )
+      emitZombieEngineEventIfNeeded(rawSamples: rawSamples, peakAudioLevel: peakAudioLevel)
       frozenSnapshot = nil
       state = .idle
       Task {
@@ -1014,6 +1022,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           "polish_s": String(format: "%.3f", polishDuration),
           "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
         ])
+      captureTelemetry.recordSuccessfulRecording()
       frozenSnapshot = nil
       state = .complete
       scheduleModelUnloadIfNeeded()
@@ -1225,6 +1234,53 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       onStop: { [weak self] _ in
         Task { [weak self] in await self?.stopAndTranscribe() }
       }
+    )
+  }
+
+  // MARK: - Zombie engine telemetry (#302)
+
+  /// Emit a Sentry event when the VAD gate gets a full recording of exactly-zero
+  /// audio. That signature (`peak == 0.0` with non-empty samples) matches the
+  /// zombie-engine failure described in gotchas.md, not genuine silence (which
+  /// has a noise floor). Dedupes via captureTelemetry.
+  private func emitZombieEngineEventIfNeeded(rawSamples: [Float], peakAudioLevel: Float) {
+    guard peakAudioLevel == 0.0,
+      rawSamples.count >= AudioConstants.minimumTranscriptionSamples
+    else { return }
+
+    let route = audioCapture.currentAudioRoute
+    let sessionID = audioCapture.currentCaptureSessionID
+    let durationMs = rawSamples.count * 1000 / 16_000
+    let shouldEmit = captureTelemetry.shouldEmitZombie(
+      route: route, window: .seconds(30))
+    captureTelemetry.markZombieEmitted(route: route)
+
+    guard shouldEmit else { return }
+
+    let err = HeartPathError.zombieEngineZeroPeak(
+      sessionID: sessionID,
+      durationMs: durationMs,
+      route: route,
+      sampleCount: rawSamples.count
+    )
+    SentryBreadcrumb.captureError(
+      err,
+      category: .audioCaptureFailed,
+      stage: "recording",
+      extra: SentryAudioExtras.buildCaptureExtras(
+        route: route,
+        sourceType: audioCapture.captureSourceType,
+        sessionID: sessionID,
+        isActivelyCapturing: audioCapture.isActivelyCapturing,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: "zombie_engine_zero_peak",
+        timeSinceLastSuccessfulRecordingMs:
+          captureTelemetry
+          .timeSinceLastSuccessfulRecordingMs(),
+        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+      )
     )
   }
 

--- a/Sources/EnviousWisprServices/CaptureTelemetryState.swift
+++ b/Sources/EnviousWisprServices/CaptureTelemetryState.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// App-wide telemetry state for audio capture diagnostics. Owns dedupe state
+/// for zombie-engine zero-peak events (#302) and the monotonic counter of
+/// `AVAudioEngineConfigurationChange` notifications since launch (used as the
+/// smoking-gun diagnostic for #294).
+///
+/// Shared across both pipelines so a Parakeet-to-WhisperKit switch does not
+/// reset dedupe, and so `timeSinceLastSuccessfulRecordingMs` is an app-level
+/// baseline rather than pipeline-local.
+@MainActor
+public final class CaptureTelemetryState {
+  private var lastZombieEmittedAt: ContinuousClock.Instant?
+  private var lastZombieRoute: String?
+  private var lastSuccessfulRecordingAt: ContinuousClock.Instant?
+  private(set) public var configurationChangeCount: Int = 0
+
+  public init() {}
+
+  /// Called at transcript save (not paste end) so clipboard-only users are
+  /// covered. Resets zombie dedupe so a successful recording sandwiched
+  /// between two zombie events still surfaces the second event.
+  public func recordSuccessfulRecording() {
+    lastSuccessfulRecordingAt = .now
+    lastZombieEmittedAt = nil
+    lastZombieRoute = nil
+  }
+
+  /// Returns true if a zombie event on `route` should emit to Sentry now.
+  /// False when a prior event fired less than `window` ago on the same route
+  /// with no intervening successful recording.
+  public func shouldEmitZombie(route: String, window: Duration) -> Bool {
+    guard let last = lastZombieEmittedAt, lastZombieRoute == route else {
+      return true
+    }
+    return .now - last >= window
+  }
+
+  /// Marks that a zombie event was observed (regardless of whether it emitted
+  /// to Sentry). The 30s window is relative to the most recent observation,
+  /// not the most recent emission, so rapid retries stay suppressed.
+  public func markZombieEmitted(route: String) {
+    lastZombieEmittedAt = .now
+    lastZombieRoute = route
+  }
+
+  public func incrementConfigChange() {
+    configurationChangeCount += 1
+  }
+
+  /// Milliseconds since the last successful recording. Nil if the app session
+  /// has never produced a successful recording yet.
+  public func timeSinceLastSuccessfulRecordingMs() -> Int? {
+    guard let last = lastSuccessfulRecordingAt else { return nil }
+    let elapsed = ContinuousClock.now - last
+    let (seconds, attoseconds) = elapsed.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+  }
+}

--- a/Sources/EnviousWisprServices/HeartPathError.swift
+++ b/Sources/EnviousWisprServices/HeartPathError.swift
@@ -24,6 +24,7 @@ public enum HeartPathError: LocalizedError, Sendable {
   case xpcReplyFailed(ctx: XPCReplyFailureContext)
   case xpcServerClientProxyNil(sessionID: UInt64?, consecutiveDrops: Int)
   case emptyAfterProcessing(route: String, wasPolishEnabled: Bool)
+  case zombieEngineZeroPeak(sessionID: UInt64, durationMs: Int, route: String, sampleCount: Int)
 
   public var errorDescription: String? {
     switch self {
@@ -48,6 +49,9 @@ public enum HeartPathError: LocalizedError, Sendable {
       return "XPC server observed nil clientProxy for \(drops) consecutive buffer sends"
     case .emptyAfterProcessing(_, let wasPolishEnabled):
       return "Post-processing emptied the transcript (polish=\(wasPolishEnabled))"
+    case .zombieEngineZeroPeak(let sessionID, let durationMs, let route, let sampleCount):
+      return
+        "Zombie engine: zero-peak \(sampleCount) samples over \(durationMs)ms (session \(sessionID), route=\(route))"
     }
   }
 }

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -20,7 +20,9 @@ public enum SentryAudioExtras {
     inputDeviceUIDSystemDefault: String?,
     failureMode: String,
     stallContext: CaptureStallContext? = nil,
-    polishModelSwapMs: Int? = nil
+    polishModelSwapMs: Int? = nil,
+    timeSinceLastSuccessfulRecordingMs: Int? = nil,
+    configChangeCountSinceLaunch: Int? = nil
   ) -> [String: Any] {
     var extras: [String: Any] = [
       "capture.source_type": sourceType,
@@ -49,6 +51,14 @@ public enum SentryAudioExtras {
 
     if let swap = polishModelSwapMs {
       extras["polish.recent_model_swap_ms"] = swap
+    }
+
+    if let ms = timeSinceLastSuccessfulRecordingMs {
+      extras["capture.time_since_last_successful_recording_ms"] = ms
+    }
+
+    if let count = configChangeCountSinceLaunch {
+      extras["capture.config_change_count_since_launch"] = count
     }
 
     return extras

--- a/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
+++ b/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@Suite("CaptureTelemetryState")
+@MainActor
+struct CaptureTelemetryStateTests {
+
+  @Test("shouldEmitZombie on first call returns true")
+  func firstCallEmits() {
+    let state = CaptureTelemetryState()
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == true)
+  }
+
+  @Test("shouldEmitZombie within window on same route returns false")
+  func sameRouteSuppressed() {
+    let state = CaptureTelemetryState()
+    state.markZombieEmitted(route: "bt")
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == false)
+  }
+
+  @Test("shouldEmitZombie when route changes returns true")
+  func routeChangeReEmits() {
+    let state = CaptureTelemetryState()
+    state.markZombieEmitted(route: "bt")
+    #expect(state.shouldEmitZombie(route: "built_in_mic", window: .seconds(30)) == true)
+  }
+
+  @Test("shouldEmitZombie when window is zero always returns true")
+  func zeroWindowAlwaysEmits() {
+    let state = CaptureTelemetryState()
+    state.markZombieEmitted(route: "bt")
+    #expect(state.shouldEmitZombie(route: "bt", window: .zero) == true)
+  }
+
+  @Test("recordSuccessfulRecording clears dedupe so the next zombie re-emits")
+  func successResetsDedupe() {
+    let state = CaptureTelemetryState()
+    state.markZombieEmitted(route: "bt")
+    state.recordSuccessfulRecording()
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == true)
+  }
+
+  @Test("recordSuccessfulRecording sets a time-since baseline")
+  func successSetsBaseline() {
+    let state = CaptureTelemetryState()
+    #expect(state.timeSinceLastSuccessfulRecordingMs() == nil)
+    state.recordSuccessfulRecording()
+    let ms = state.timeSinceLastSuccessfulRecordingMs()
+    #expect(ms != nil)
+    #expect((ms ?? -1) >= 0)
+  }
+
+  @Test("incrementConfigChange is monotonic")
+  func configChangeMonotonic() {
+    let state = CaptureTelemetryState()
+    #expect(state.configurationChangeCount == 0)
+    state.incrementConfigChange()
+    state.incrementConfigChange()
+    state.incrementConfigChange()
+    #expect(state.configurationChangeCount == 3)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
+++ b/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
@@ -42,6 +42,7 @@ struct HeartPathErrorTests {
       .xpcReplyFailed(ctx: replyCtx),
       .xpcServerClientProxyNil(sessionID: 1, consecutiveDrops: 5),
       .emptyAfterProcessing(route: "built_in_mic", wasPolishEnabled: true),
+      .zombieEngineZeroPeak(sessionID: 7, durationMs: 9000, route: "bt", sampleCount: 145360),
     ]
 
     for heart in cases {
@@ -54,5 +55,17 @@ struct HeartPathErrorTests {
   func handlerKinds() {
     #expect(XPCHandlerKind.interrupt.rawValue == "interrupt")
     #expect(XPCHandlerKind.invalidate.rawValue == "invalidate")
+  }
+
+  @Test("zombieEngineZeroPeak description includes all fields")
+  func zombieEngineZeroPeakDescription() {
+    let err = HeartPathError.zombieEngineZeroPeak(
+      sessionID: 42, durationMs: 9000, route: "bt", sampleCount: 145360
+    )
+    let desc = err.errorDescription ?? ""
+    #expect(desc.contains("42"))
+    #expect(desc.contains("9000ms"))
+    #expect(desc.contains("bt"))
+    #expect(desc.contains("145360"))
   }
 }

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -85,4 +85,36 @@ struct SentryAudioExtrasTests {
     )
     #expect(extras["polish.recent_model_swap_ms"] == nil)
   }
+
+  @Test("zombie telemetry extras: nil inputs omit both keys")
+  func zombieExtrasOmitted() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "bt",
+      sourceType: "xpc_proxy",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "zombie_engine_zero_peak"
+    )
+    #expect(extras["capture.time_since_last_successful_recording_ms"] == nil)
+    #expect(extras["capture.config_change_count_since_launch"] == nil)
+  }
+
+  @Test("zombie telemetry extras: values passed through with stable keys")
+  func zombieExtrasPassthrough() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "bt",
+      sourceType: "xpc_proxy",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "zombie_engine_zero_peak",
+      timeSinceLastSuccessfulRecordingMs: 45_000,
+      configChangeCountSinceLaunch: 0
+    )
+    #expect(extras["capture.time_since_last_successful_recording_ms"] as? Int == 45_000)
+    #expect(extras["capture.config_change_count_since_launch"] as? Int == 0)
+  }
 }


### PR DESCRIPTION
## Summary

- When the warm AVAudioEngine goes zombie (all-zero audio), the VAD gate silently discards the recording — no telemetry, no user signal
- Adds a Sentry error event when \`peak == 0.0\` AND samples >= minimum
- Telemetry-only: no UI change, no control-flow change, no heart-path risk
- Covers both Parakeet and WhisperKit pipelines

Closes #302

## Context

Related to #294 (warm-engine zero-buffer contamination). We currently cannot measure how often real users hit the zombie state because the VAD gate treats it as normal silence. Without frequency data, we can't prioritize the fix.

Plan (council-approved): \`docs/feature-requests/issue-302-2026-04-15-zombie-engine-telemetry.md\`

## Key design decisions

- Shared \`CaptureTelemetryState\` across both pipelines (not per-pipeline) so a backend switch doesn't reset dedupe and time-since-success is app-wide
- 30s dedupe window, reset on every successful recording (so zombie→recover→zombie emits two events, not one)
- Success timestamp at transcript save, not paste end (covers clipboard-only mode)
- Strict \`peak == 0.0\` check (AUHAL zero-fills on failure; real mic has noise floor)
- Includes \`config_change_count_since_launch\` — smoking-gun diagnostic for #294

## Test plan

- [ ] \`swift build -c release\` passes
- [ ] \`scripts/swift-test.sh\` passes (327 tests, +10 new)
- [ ] Manual: dictate normally → no new Sentry events
- [ ] Manual: induce zombie (Zoom call, end call, dictate immediately) → ONE event with \`failure_mode=zombie_engine_zero_peak\`
- [ ] Manual: 3-4 dictations within 30s → still ONE event (dedupe working)
- [ ] Manual: wait 30s+ → second event emitted
- [ ] Post-merge: 24h in production → confirm \`failureMode: zombie_engine_zero_peak\` appears in Sentry with populated extras
