### PR TITLE
chore(release): What's New entries for v1.9.4

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -27,6 +27,25 @@ enum WhatsNewContent {
     }
 
     static let entries: [Entry] = [
+        // MARK: - v1.9.4
+
+        Entry(
+            id: "smoother-model-switching",
+            icon: "arrow.triangle.swap",
+            title: "Smoother model switching",
+            description: "Switching between local AI polish models now frees up the previous model cleanly, so your Mac stays responsive and recordings keep working.",
+            category: .betterOllamaSupport,
+            version: "1.9.4"
+        ),
+        Entry(
+            id: "more-reliable-recordings",
+            icon: "waveform.badge.checkmark",
+            title: "More reliable recordings",
+            description: "Improved recovery when the microphone gets into a bad state, so recordings start cleanly even after long idle periods or audio interruptions.",
+            category: .fasterAndMoreReliable,
+            version: "1.9.4"
+        ),
+
         // MARK: - v1.9.3
 
         Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
     /// Bump when bundled What's New content changes in a user-visible way.
-    public static let currentContentVersion = "1.9.3"
+    public static let currentContentVersion = "1.9.4"
 
     /// UserDefaults key for the last content version the user has viewed.
     public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary
- Adds two user-facing What's New entries for v1.9.4 (Smoother model switching, More reliable recordings)
- Bumps `WhatsNewConstants.currentContentVersion` from 1.9.3 to 1.9.4

## Commits covered
Bug-fix PRs since v1.9.3 surfaced to users:
- #296 unload previous Ollama model on polish-model swap → "Smoother model switching"
- #292 propagate preWarm errors + watchdog recovery → "More reliable recordings"
- #301 pre-warm with real inference request → "More reliable recordings"

Telemetry-only work since v1.9.3 (#288 heart-path Sentry, #293 triage pipeline, #298 local-tz logs, #305 zombie-engine event) intentionally omitted from user-facing notes.

## Process
- Scope: 20 LOC, 2 files, user-facing copy + version bump
- Qualifies for `council-skip: zero-blast-radius (user-facing copy, version bump)` per `.claude/rules/workflow-process.md` §1
- Codex review: clean ("No discrete, user-impacting bugs introduced by this diff")
- Release build: `swift build -c release --arch arm64` green

## Test plan
- [x] swift build -c release --arch arm64 exits 0
- [ ] CI build-check green
- [ ] After merge: preflight + tag v1.9.4, CI handles build/sign/notarize/DMG/appcast/release
