### PR TITLE
chore(benchmark): update harness.py path for Developer/ layout

### DIFF
--- a/benchmark-results/apple-polish-2026-04-12/harness.py
+++ b/benchmark-results/apple-polish-2026-04-12/harness.py
@@ -2,7 +2,7 @@
 """Apple Intelligence polish test across 20 languages x 3 utterance types.
 Uses Google Cloud Chirp3-HD TTS (natural voices) and native-language disfluencies."""
 import os, subprocess, sys, time, threading, json, base64, urllib.request, urllib.parse, tempfile
-sys.path.insert(0, '/Users/m4pro_sv/Desktop/EnviousWispr/Tests/UITests')
+sys.path.insert(0, '/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/Tests/UITests')
 import simulate_input as si
 
 APP_LOG = os.path.expanduser("~/Library/Logs/EnviousWispr/app.log")


### PR DESCRIPTION
## Summary
- One-line path fix updating `harness.py`'s hardcoded `Tests/UITests` sys.path insertion from the old `~/Desktop/EnviousWispr` location to `~/Developer/EnviousLabs/EnviousWispr`.
- Follows the 2026-04-13 iCloud→local migration that moved the project tree.
- Benchmark script, not shipped code. No runtime impact on the app.

## Context
This edit had been sitting as an uncommitted modification on the local main working tree since the migration. A prior session did not wind it down. Picking it up now to clear loose ends.

council-skip: zero-blast-radius (single-value config / path constant, ≤ 20 LOC, ≤ 3 files, no new APIs, no migration, non-shipped script)

## Test plan
- [x] `git diff` verified — 1 line changed, path string only
- [ ] CI `build-check` passes (harness.py isn't on the build path, should be trivially green)
