### PR TITLE
fix(llm): Ollama Manage Models row shows download progress + Cancel (#282)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -874,7 +874,23 @@ struct AIPolishSettingsView: View {
 
           Spacer()
 
-          if entry.isDownloaded {
+          if appState.ollamaSetup.currentPullingModel == entry.name {
+            // Active pull for THIS row: show progress + Cancel.
+            HStack(spacing: 8) {
+              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
+                .font(.caption)
+                .foregroundStyle(Color.secondary)
+                .monospacedDigit()
+              Button {
+                appState.ollamaSetup.cancelPull()
+              } label: {
+                Text("Cancel")
+                  .foregroundStyle(.stError)
+              }
+              .controlSize(.small)
+              .buttonStyle(.borderless)
+            }
+          } else if entry.isDownloaded {
             Button {
               appState.ollamaSetup.deleteModel(name: entry.name)
             } label: {

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -595,17 +595,22 @@ public final class OllamaSetupService {
       do {
         try await self.performStreamingPull(modelName: modelName, epoch: epoch)
         guard self.pullEpoch == epoch else { return }
-        // Commit point: Ollama reported "success" for this pull. Snap the
-        // service into a completed state BEFORE awaiting the refresh so a
-        // concurrent cancelPull() during refresh can't corrupt setupState
-        // from the stale (pre-refresh) downloadedModels array. After this
-        // point, cancelPull() is a no-op for this pull (pullTask is nil and
-        // currentPullingModel is nil; the guard in cancelPull() short-circuits).
+        // Pull stream succeeded. Clear pullTask so cancelPull() short-circuits
+        // during the post-success refresh window (see cancelPull guard). Keep
+        // setupState = .pullingModel(1.0, "success") from the last stream chunk
+        // AND keep currentPullingModel = modelName so isPulling stays true and
+        // the catalog UI stays disabled until the refresh confirms the new
+        // model is visible. This prevents a duplicate pull for the same model
+        // while /api/tags is in flight (up to 5s).
         self.pullTask = nil
-        self.currentPullingModel = nil
-        self.setupState = .ready
         UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
         await self.refreshDownloadedModels()
+        // Only commit to .ready if we are still the current pull. A newer
+        // pullModel() during the refresh would have bumped pullEpoch and set
+        // its own setupState; overwriting with .ready would clobber it.
+        guard self.pullEpoch == epoch else { return }
+        self.currentPullingModel = nil
+        self.setupState = .ready
       } catch is CancellationError {
         guard self.pullEpoch == epoch else { return }
         self.currentPullingModel = nil
@@ -638,12 +643,13 @@ public final class OllamaSetupService {
 
   /// Cancel an in-progress model pull.
   public func cancelPull() {
-    // Nothing to cancel — short-circuit. This matters during the post-success
-    // refreshDownloadedModels() window: the stream already committed setupState
-    // to .ready, pullTask is nil, and currentPullingModel is nil. Without this
-    // guard, a late Cancel tap would overwrite the freshly-ready state using
-    // the still-stale downloadedModels array.
-    guard pullTask != nil || currentPullingModel != nil else { return }
+    // Guard on pullTask only. During the post-success refresh window, pullTask
+    // is nil but currentPullingModel may still be the just-finished model name
+    // (kept so the catalog UI stays disabled until /api/tags returns). A Cancel
+    // tap in that window must NOT fire — the download already succeeded. Once
+    // pullTask is nil there is nothing left to cancel; the pull Task will
+    // commit .ready when refreshDownloadedModels() returns.
+    guard pullTask != nil else { return }
     pullTask?.cancel()
     pullTask = nil
     pullEpoch &+= 1

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -91,8 +91,15 @@ public final class OllamaSetupService {
   public private(set) var setupState: OllamaSetupState = .detecting
   public private(set) var pullProgress: Double = 0
   public private(set) var pullStatusText: String = ""
+  public private(set) var currentPullingModel: String?
   public private(set) var downloadedModels: [OllamaDownloadedModel] = []
   public private(set) var warmupState: OllamaWarmupState = .idle
+
+  // Per-pull generation token. Bumped on every pullModel/cancelPull call so stale
+  // tasks can no-op their writes (Swift Task cancellation is cooperative; without
+  // this, a late chunk or terminal-branch cleanup from an old task could clobber
+  // the newer pull's state, most acutely on cancel-then-re-download-same-model).
+  private var pullEpoch: UInt64 = 0
 
   /// Canonical names of downloaded models. Backward-compatible with old Set<String> consumers.
   public var downloadedModelNames: Set<String> {
@@ -571,38 +578,51 @@ public final class OllamaSetupService {
 
   /// Pull a model by name, streaming progress updates.
   public func pullModel(_ modelName: String) {
-    // Cancel any in-flight pull
+    // Cancel any in-flight pull and invalidate its epoch so stale writes no-op.
     pullTask?.cancel()
     pullTask = nil
+    pullEpoch &+= 1
+    let epoch = pullEpoch
 
     // Reset progress
+    currentPullingModel = modelName
     pullProgress = 0
     pullStatusText = "Starting download..."
     setupState = .pullingModel(progress: 0, status: "Starting download...")
 
-    pullTask = Task {
+    pullTask = Task { [weak self] in
+      guard let self else { return }
       do {
-        try await performStreamingPull(modelName: modelName)
-        await refreshDownloadedModels()
-        setupState = .ready
+        try await self.performStreamingPull(modelName: modelName, epoch: epoch)
+        guard self.pullEpoch == epoch else { return }
+        await self.refreshDownloadedModels()
+        guard self.pullEpoch == epoch else { return }
+        self.currentPullingModel = nil
+        self.setupState = .ready
         UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
       } catch is CancellationError {
+        guard self.pullEpoch == epoch else { return }
+        self.currentPullingModel = nil
         // Bug fix: don't force .runningNoModels if models exist
-        if downloadedModels.isEmpty {
-          setupState = .runningNoModels
+        if self.downloadedModels.isEmpty {
+          self.setupState = .runningNoModels
         } else {
-          setupState = .ready
+          self.setupState = .ready
         }
       } catch let urlError as URLError {
-        setupState = .error(friendlyMessage(for: urlError))
+        guard self.pullEpoch == epoch else { return }
+        self.currentPullingModel = nil
+        self.setupState = .error(self.friendlyMessage(for: urlError))
       } catch {
+        guard self.pullEpoch == epoch else { return }
+        self.currentPullingModel = nil
         let message = error.localizedDescription.lowercased()
         if message.contains("no space") || message.contains("errno 28") {
-          setupState = .error(
+          self.setupState = .error(
             "Not enough disk space. The model needs about 2 GB free."
           )
         } else {
-          setupState = .error(
+          self.setupState = .error(
             "Download failed. Check your internet connection and try again."
           )
         }
@@ -614,6 +634,8 @@ public final class OllamaSetupService {
   public func cancelPull() {
     pullTask?.cancel()
     pullTask = nil
+    pullEpoch &+= 1
+    currentPullingModel = nil
     // Bug fix: don't force .runningNoModels if models exist
     if downloadedModels.isEmpty {
       setupState = .runningNoModels
@@ -702,7 +724,7 @@ public final class OllamaSetupService {
 
   // MARK: - Streaming Pull (Private)
 
-  private func performStreamingPull(modelName: String) async throws {
+  private func performStreamingPull(modelName: String, epoch: UInt64) async throws {
     guard let url = URL(string: "\(Self.baseURL)/api/pull") else {
       throw LLMError.requestFailed("Invalid Ollama URL")
     }
@@ -725,6 +747,9 @@ public final class OllamaSetupService {
 
     for try await line in bytes.lines {
       try Task.checkCancellation()
+      // Drop stale writes from a task whose pull was superseded by a newer
+      // pullModel()/cancelPull() call. Epoch mismatch → bail silently.
+      guard pullEpoch == epoch else { return }
 
       guard let lineData = line.data(using: .utf8),
         let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -661,17 +661,24 @@ public final class OllamaSetupService {
     } else if currentPullingModel != nil {
       // Post-success refresh window (pullTask was cleared at the commit point
       // but currentPullingModel is kept to hold the row UI). The download
-      // already succeeded, so we must NOT mutate setupState here — the pull
-      // Task will commit .ready when refreshDownloadedModels() returns. But:
-      //   1. Clear currentPullingModel so callers like provider switch don't
-      //      leave a stale "Downloading…" row visible if the user returns to
-      //      Ollama settings before /api/tags finishes.
-      //   2. Bump pullEpoch so the pull Task's final guard (after the refresh
+      // already succeeded. Three things must happen:
+      //   1. Bump pullEpoch so the pull Task's final guard (after the refresh
       //      await) bails and does NOT overwrite setupState. Otherwise a
       //      detectState() reassignment (e.g. .installedNotRunning after a
       //      provider switch/back) would be clobbered by a late .ready write.
+      //   2. Clear currentPullingModel so callers like provider switch don't
+      //      leave a stale "Downloading…" row visible if the user returns to
+      //      Ollama settings before /api/tags finishes.
+      //   3. Commit setupState = .ready here. The stream reported success, so
+      //      Ollama has at least one model downloaded even if the /api/tags
+      //      refresh hasn't updated downloadedModels yet. Without this, the
+      //      Task's bail (step 1) would leave setupState stuck at
+      //      .pullingModel(1.0, "success") until some later detectState()
+      //      runs. Provider-switch path overwrites this moments later via
+      //      detectState() on switch-back; same-pane Cancel just settles here.
       pullEpoch &+= 1
       currentPullingModel = nil
+      setupState = .ready
     }
   }
 

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -595,11 +595,17 @@ public final class OllamaSetupService {
       do {
         try await self.performStreamingPull(modelName: modelName, epoch: epoch)
         guard self.pullEpoch == epoch else { return }
-        await self.refreshDownloadedModels()
-        guard self.pullEpoch == epoch else { return }
+        // Commit point: Ollama reported "success" for this pull. Snap the
+        // service into a completed state BEFORE awaiting the refresh so a
+        // concurrent cancelPull() during refresh can't corrupt setupState
+        // from the stale (pre-refresh) downloadedModels array. After this
+        // point, cancelPull() is a no-op for this pull (pullTask is nil and
+        // currentPullingModel is nil; the guard in cancelPull() short-circuits).
+        self.pullTask = nil
         self.currentPullingModel = nil
         self.setupState = .ready
         UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
+        await self.refreshDownloadedModels()
       } catch is CancellationError {
         guard self.pullEpoch == epoch else { return }
         self.currentPullingModel = nil
@@ -632,6 +638,12 @@ public final class OllamaSetupService {
 
   /// Cancel an in-progress model pull.
   public func cancelPull() {
+    // Nothing to cancel — short-circuit. This matters during the post-success
+    // refreshDownloadedModels() window: the stream already committed setupState
+    // to .ready, pullTask is nil, and currentPullingModel is nil. Without this
+    // guard, a late Cancel tap would overwrite the freshly-ready state using
+    // the still-stale downloadedModels array.
+    guard pullTask != nil || currentPullingModel != nil else { return }
     pullTask?.cancel()
     pullTask = nil
     pullEpoch &+= 1

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -662,10 +662,15 @@ public final class OllamaSetupService {
       // Post-success refresh window (pullTask was cleared at the commit point
       // but currentPullingModel is kept to hold the row UI). The download
       // already succeeded, so we must NOT mutate setupState here — the pull
-      // Task will commit .ready when refreshDownloadedModels() returns. But
-      // we DO clear currentPullingModel so that caller contexts like provider
-      // switch don't leave a stale "Downloading…" row visible if the user
-      // returns to Ollama settings before /api/tags finishes.
+      // Task will commit .ready when refreshDownloadedModels() returns. But:
+      //   1. Clear currentPullingModel so callers like provider switch don't
+      //      leave a stale "Downloading…" row visible if the user returns to
+      //      Ollama settings before /api/tags finishes.
+      //   2. Bump pullEpoch so the pull Task's final guard (after the refresh
+      //      await) bails and does NOT overwrite setupState. Otherwise a
+      //      detectState() reassignment (e.g. .installedNotRunning after a
+      //      provider switch/back) would be clobbered by a late .ready write.
+      pullEpoch &+= 1
       currentPullingModel = nil
     }
   }

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -641,24 +641,32 @@ public final class OllamaSetupService {
     }
   }
 
-  /// Cancel an in-progress model pull.
+  /// Cancel an in-progress model pull. Also clears stale row UI during the
+  /// post-success refresh window (pullTask nil + currentPullingModel still
+  /// set). Called from Cancel buttons AND from `onChange(llmProvider)` in
+  /// `AIPolishSettingsView` when the user switches providers.
   public func cancelPull() {
-    // Guard on pullTask only. During the post-success refresh window, pullTask
-    // is nil but currentPullingModel may still be the just-finished model name
-    // (kept so the catalog UI stays disabled until /api/tags returns). A Cancel
-    // tap in that window must NOT fire — the download already succeeded. Once
-    // pullTask is nil there is nothing left to cancel; the pull Task will
-    // commit .ready when refreshDownloadedModels() returns.
-    guard pullTask != nil else { return }
-    pullTask?.cancel()
-    pullTask = nil
-    pullEpoch &+= 1
-    currentPullingModel = nil
-    // Bug fix: don't force .runningNoModels if models exist
-    if downloadedModels.isEmpty {
-      setupState = .runningNoModels
-    } else {
-      setupState = .ready
+    if pullTask != nil {
+      // Active pull in flight: cancel, bump epoch, reset state.
+      pullTask?.cancel()
+      pullTask = nil
+      pullEpoch &+= 1
+      currentPullingModel = nil
+      // Bug fix: don't force .runningNoModels if models exist
+      if downloadedModels.isEmpty {
+        setupState = .runningNoModels
+      } else {
+        setupState = .ready
+      }
+    } else if currentPullingModel != nil {
+      // Post-success refresh window (pullTask was cleared at the commit point
+      // but currentPullingModel is kept to hold the row UI). The download
+      // already succeeded, so we must NOT mutate setupState here — the pull
+      // Task will commit .ready when refreshDownloadedModels() returns. But
+      // we DO clear currentPullingModel so that caller contexts like provider
+      // switch don't leave a stale "Downloading…" row visible if the user
+      // returns to Ollama settings before /api/tags finishes.
+      currentPullingModel = nil
     }
   }
 


### PR DESCRIPTION
Closes #282. Parent: #317 (Bugs).

## Summary

When a user clicks Download on an Ollama model row in Settings, the row now shows `Downloading... NN%` with a Cancel button right there. The top banner still works; the Cancel button in both places shares the same path. Previously the button greyed out silently while progress only appeared in a distant top banner, causing rage-clicks during first-run Ollama setup.

## Scope

- **Only Ollama.** Apple Intelligence, Gemini, OpenAI have no local-model download concept and are untouched.
- **Two files:** `OllamaSetupService.swift` (service state + epoch gating), `AIPolishSettingsView.swift` (three-way row branch).
- **No heart path, no audio, no pipeline.** Rollback is a single revert.

## Concurrency correctness

5 Codex review rounds surfaced real P1/P2 races in the post-success `/api/tags` refresh window. Each round found a distinct bug, not a tradeoff-only race. Fixed via:

- Per-pull `pullEpoch: UInt64` counter. Every published-state write inside the pull task is gated on the captured epoch matching the service's current epoch.
- `cancelPull()` is split into two branches: active-pull cleanup, and post-success cleanup (pullTask already nil, currentPullingModel still set). Post-success cleanup bumps epoch and commits `setupState = .ready` so UI settles cleanly.
- Commit-point sequencing in the success path: clear `pullTask` before awaiting `refreshDownloadedModels`, keep `setupState = .pullingModel(1.0, "success")` during the refresh so `isPulling` stays true and the catalog stays disabled (prevents duplicate pulls).

## Plan

Local plan at `docs/feature-requests/issue-282-2026-04-17-ollama-download-row-feedback.md` (gitignored; summary in the commit messages).

## Review

- GPT council: 3 rounds, final ship
- Gemini council: 1 round, ship
- Codex: 5 rounds, all real P1/P2 findings addressed; shipping at round 5 per founder call (original P0 long solved, remaining risks are ~5s edge-case windows)

## Test plan
- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` — 327 tests passing
- [ ] CI `build-check` green
- [ ] Post-merge UAT via wispr-eyes: click Download, verify row shows Downloading... NN% + Cancel. Row-level Cancel reverts. Banner-level Cancel on row-started pull reverts.
