### PR TITLE
fix(asr): gate WhisperKit pre-load on active backend; classify incomplete cache (#329)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -650,6 +650,12 @@ final class AppState {
       while !Task.isCancelled {
         guard let self else { return }
 
+        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+        // users shouldn't pay CPU/memory cost warming a backend they never use.
+        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+        // restarts this observer; the re-entry sees the new activeBackendType.
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+
         // Check current state — if already .ready, trigger pre-load
         let currentState = self.whisperKitSetup.setupState
         if currentState == .ready {

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -379,11 +379,27 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         }
       }
     } catch {
+      // A partial on-disk cache (model folder present, a `.mlmodelc` subfile
+      // missing) surfaces as `WhisperError.modelsUnavailable("Model file not
+      // found at <path>")` — a typed case with a hardcoded English payload
+      // (WhisperKit.swift line 379; not locale-dependent). Pattern-match the
+      // case and confirm the payload indicates a missing file so other
+      // `.modelsUnavailable` reasons (e.g., initialization misconfiguration)
+      // still surface as a failure. Anything that isn't `.modelsUnavailable`
+      // also falls through to the legacy failure log.
+      let cacheIncomplete: Bool
+      if case let WhisperError.modelsUnavailable(msg) = error {
+        let lower = msg.lowercased()
+        cacheIncomplete = lower.contains("not found") || lower.contains("no such file")
+      } else {
+        cacheIncomplete = false
+      }
+      let text =
+        cacheIncomplete
+        ? "WhisperKit model cache incomplete, skipping silent pre-load"
+        : "WhisperKit model pre-load failed: \(error)"
       Task {
-        await AppLogger.shared.log(
-          "WhisperKit model pre-load failed: \(error.localizedDescription)",
-          level: .info, category: "WhisperKitPipeline"
-        )
+        await AppLogger.shared.log(text, level: .info, category: "WhisperKitPipeline")
       }
     }
   }


### PR DESCRIPTION
Closes #329. Tier: SMALL. Autopilot session 2026-04-17.

## What this changes
Two pre-existing bugs on the WhisperKit pre-load path, surfaced during #282 post-merge log review.

1. **`AppState.startWhisperKitPreloadObservation()` ran regardless of `activeBackendType`.**
   Parakeet-only users paid CPU/memory warming a backend they would never use. Added a guard inside the observer loop; backend switches already re-trigger this observer via `settingsSync.onNeedsPreloadObservation`, so the switch-to-WhisperKit path stays covered.

2. **A partial on-disk cache threw `WhisperError.modelsUnavailable(\"Model file not found at <path>\")`,** which `prepareBackendSilently()` caught and logged as `"pre-load failed"` — same severity as a genuine failure, cluttering triage. Pattern-match the typed case (empirically verified: `.modelsUnavailable` is thrown from `WhisperKit.swift:379` when a `.mlmodelc` subfile is missing from an otherwise-present model folder) and check the payload for a missing-file indicator. On match, log "cache incomplete, skipping silent pre-load" at info level. Other `.modelsUnavailable` reasons (init misconfig) and any non-`WhisperError` still surface as a failure. Payload string is hardcoded English in WhisperKit (not localized), so the substring check is locale-invariant.

## Process notes
- Council (GPT + Gemini, background subagents) reviewed the plan. GPT approved. Gemini flagged the initial `error.localizedDescription` string match as a ship-blocker and suggested `CocoaError` casting. Per validation-discipline §6 (empirical over council), I read WhisperKit's source and found the actual throw site (`WhisperKit.swift:379`) uses `WhisperError.modelsUnavailable`, not `CocoaError`. Adjusted the fix to pattern-match the typed enum case.
- Codex reviewed the committed diff locally: "no actionable findings."
- No test added. `WhisperKitPipeline` concretely owns `WhisperKitBackend` (actor, not protocol) — mocking requires the same protocol-seam refactor #326 is scoping for `TranscriptFinalizer`. Runtime-log validation substitutes per workflow-process §9.

## Runtime validation
- **Parakeet-selected relaunch (03:37 window):** zero `[WhisperKitPipeline]` log entries. Fix #1 validated — observer exits cleanly without touching WhisperKit.
- **WhisperKit-selected relaunch (03:42 window):** pre-load fires exactly once at 03:43:52, logs `WhisperKit model pre-loaded successfully (background)`. Observer path still works correctly.
- **"cache incomplete" branch:** not exercised at runtime (my local model cache is now intact after Saurabh redownloaded between the pre-fix log at 01:18:25 and now). Code is compile-verified; pattern-match on `WhisperError.modelsUnavailable` is checked by the Swift compiler. The literal string that triggers the soft-skip branch — "Model file not found at …" — is the exact payload that fired the three `pre-load failed` log entries on main at 2026-04-16 12:05:09, 2026-04-16 12:21:25, and 2026-04-17 01:18:25.
- **App stability:** post-relaunch the dev app ran for 1m32s at 138 MB RSS, no crash.
- **Tests:** 327 unit tests across 32 suites pass (`scripts/swift-test.sh`).

## Blast radius
- 2 files, 22 net LOC. No new symbols, no API changes, no new dependencies, no migrations.
- Log content reads: Sentry breadcrumb ingest is category-based (text is payload — content change doesn't affect alert rules). Human triage gets slightly more accurate wording.
- No UI change, no setting change, no persistence touched.

## Rollback
Squash-merge → `gh pr revert` or `git revert <sha>`. Clean revert, no downstream cleanup.

## Zero-blast-radius exception (workflow-process §1)
Does NOT qualify. This is logic change (observer guard + catch-branch classification), not catalog row / prompt / copy / single-value config. Full council gate applied.

---