### PR TITLE
fix(asr): gate WhisperKit pre-load on active backend; partial-download guard (#329)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -650,6 +650,12 @@ final class AppState {
       while !Task.isCancelled {
         guard let self else { return }
 
+        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+        // users shouldn't pay CPU/memory cost warming a backend they never use.
+        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+        // restarts this observer; the re-entry sees the new activeBackendType.
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+
         // Check current state — if already .ready, trigger pre-load
         let currentState = self.whisperKitSetup.setupState
         if currentState == .ready {

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -59,14 +59,58 @@ public actor WhisperKitBackend: ASRBackend {
     try await loadFromPath(modelPath)
   }
 
-  /// Load model from local cache only. Returns false if model is not cached.
-  /// Used by silent/background warmup paths that must never trigger a network download.
+  /// Load model from local cache only. Returns false if model is not cached
+  /// OR if the cached directory is incomplete (missing one of the required
+  /// `.mlmodelc` artifacts). Partial-download detection is enforced upstream in
+  /// `WhisperKitSetupService.getLocalModelPath`, so a non-nil path here implies
+  /// the artifacts are all present. Used by silent/background warmup paths
+  /// that must never trigger a network download.
   public func prepareIfCached() async throws -> Bool {
     guard !isReady else { return true }
     guard let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) else {
-      return false  // Model not downloaded, skip silently
+      return false  // Model not cached or cache incomplete — skip silently.
     }
     try await loadFromPath(cached)
+    return true
+  }
+
+  /// WhisperKit 0.12+ model folder artifacts required for a successful load.
+  /// Aligned with `WhisperKit.loadModels()` at
+  /// `.build/checkouts/WhisperKit/Sources/WhisperKit/Core/WhisperKit.swift:372-381`
+  /// — it hard-fails when any of these three are missing. `TextDecoderContextPrefill`
+  /// is intentionally excluded: upstream loads it conditionally and tolerates its
+  /// absence, so requiring it here would over-reject otherwise-valid caches.
+  /// Scope: `.mlmodelc` layout only; our shipped variant is produced by
+  /// `WhisperKit.download` which emits this format. `.mlpackage` caches (not used
+  /// by our product) are not modeled here.
+  internal static let requiredArtifacts: [String] = [
+    "AudioEncoder.mlmodelc",
+    "MelSpectrogram.mlmodelc",
+    "TextDecoder.mlmodelc",
+  ]
+
+  /// Canonical inner-file marker that a CoreML compiled-model bundle is complete.
+  /// Hugging Face downloads each `.mlmodelc` subfile individually, so an interrupted
+  /// pull can leave the outer directory present but its contents partial. Checking
+  /// `coremldata.bin` (always the first write Apple's compiler emits at the root of
+  /// the bundle) rules out the common "outer dir created, inner files missing" state
+  /// without coupling to CoreML's full internal layout.
+  internal static let artifactCompletionMarker = "coremldata.bin"
+
+  /// Returns true iff every required `.mlmodelc` artifact exists and contains the
+  /// completion marker. Used as a proactive partial-download guard so silent
+  /// pre-load (and `detectState`) can distinguish "incomplete cache" from "ready."
+  internal static func hasRequiredArtifacts(at modelFolder: String) -> Bool {
+    let fm = FileManager.default
+    for name in requiredArtifacts {
+      let artifactPath = (modelFolder as NSString).appendingPathComponent(name)
+      var isDir: ObjCBool = false
+      guard fm.fileExists(atPath: artifactPath, isDirectory: &isDir), isDir.boolValue else {
+        return false
+      }
+      let markerPath = (artifactPath as NSString).appendingPathComponent(artifactCompletionMarker)
+      if !fm.fileExists(atPath: markerPath) { return false }
+    }
     return true
   }
 

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -86,8 +86,15 @@ public final class WhisperKitSetupService {
     return getLocalModelPath(variant: variant) != nil
   }
 
-  /// Returns the local path to a cached WhisperKit model, or nil if not downloaded.
-  /// WhisperKit 0.12+ stores models as direct subdirectories like `openai_whisper-large-v3`.
+  /// Returns the local path to a fully-cached WhisperKit model, or nil if not
+  /// downloaded OR if the cache is incomplete (missing one of the required
+  /// `.mlmodelc` artifacts — e.g. an interrupted download).
+  /// WhisperKit 0.12+ stores models as direct subdirectories like
+  /// `openai_whisper-large-v3`. Partial-download semantics (issue #329):
+  /// treating an incomplete folder as "not cached" keeps `detectState` →
+  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+  /// back to `WhisperKit.download(...)` instead of trying to load a
+  /// corrupt path.
   public nonisolated static func getLocalModelPath(variant: String) -> String? {
     guard let root = whisperKitModelRoot else { return nil }
 
@@ -106,9 +113,11 @@ public final class WhisperKitSetupService {
       if lower.contains(variantLower) || lower.contains(sanitizedLower) {
         let fullPath = root.appendingPathComponent(dir).path
         var isDir: ObjCBool = false
-        if fm.fileExists(atPath: fullPath, isDirectory: &isDir), isDir.boolValue {
-          return fullPath
+        guard fm.fileExists(atPath: fullPath, isDirectory: &isDir), isDir.boolValue else {
+          continue
         }
+        guard WhisperKitBackend.hasRequiredArtifacts(at: fullPath) else { continue }
+        return fullPath
       }
     }
     return nil

--- a/Tests/EnviousWisprASRTests/WhisperKitBackendArtifactsTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitBackendArtifactsTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+@Suite("WhisperKitBackend partial-download guard (issue #329)")
+struct WhisperKitBackendArtifactsTests {
+
+  private func makeTempModelFolder() -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("whisperkit-329-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  /// Create a complete artifact (dir + inner `coremldata.bin` marker).
+  private func createArtifact(_ name: String, in folder: URL, complete: Bool = true) {
+    let path = folder.appendingPathComponent(name, isDirectory: true)
+    try? FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+    if complete {
+      let marker = path.appendingPathComponent(WhisperKitBackend.artifactCompletionMarker)
+      FileManager.default.createFile(atPath: marker.path, contents: Data())
+    }
+  }
+
+  @Test("All four required artifacts complete → returns true")
+  func allFourComplete() {
+    let folder = makeTempModelFolder()
+    defer { try? FileManager.default.removeItem(at: folder) }
+    for name in WhisperKitBackend.requiredArtifacts {
+      createArtifact(name, in: folder, complete: true)
+    }
+    #expect(WhisperKitBackend.hasRequiredArtifacts(at: folder.path) == true)
+  }
+
+  @Test("Any single artifact directory missing entirely → returns false")
+  func partialDownloadOuterMissing() {
+    for missing in WhisperKitBackend.requiredArtifacts {
+      let folder = makeTempModelFolder()
+      defer { try? FileManager.default.removeItem(at: folder) }
+      for name in WhisperKitBackend.requiredArtifacts where name != missing {
+        createArtifact(name, in: folder, complete: true)
+      }
+      #expect(
+        WhisperKitBackend.hasRequiredArtifacts(at: folder.path) == false,
+        "Expected false when \(missing) is absent")
+    }
+  }
+
+  @Test("Outer artifact dirs present but inner coremldata.bin missing → returns false")
+  func partialDownloadInnerMissing() {
+    // Simulates mid-download interrupt where HF created the .mlmodelc dirs but
+    // hadn't yet written their inner files.
+    for halfBaked in WhisperKitBackend.requiredArtifacts {
+      let folder = makeTempModelFolder()
+      defer { try? FileManager.default.removeItem(at: folder) }
+      for name in WhisperKitBackend.requiredArtifacts {
+        createArtifact(name, in: folder, complete: name != halfBaked)
+      }
+      #expect(
+        WhisperKitBackend.hasRequiredArtifacts(at: folder.path) == false,
+        "Expected false when \(halfBaked) is an empty shell (coremldata.bin missing)")
+    }
+  }
+
+  @Test("Empty folder → returns false")
+  func emptyFolder() {
+    let folder = makeTempModelFolder()
+    defer { try? FileManager.default.removeItem(at: folder) }
+    #expect(WhisperKitBackend.hasRequiredArtifacts(at: folder.path) == false)
+  }
+
+  @Test("Non-existent folder → returns false (does not throw)")
+  func nonexistentFolder() {
+    let ghost = FileManager.default.temporaryDirectory
+      .appendingPathComponent("whisperkit-329-nonexistent-\(UUID().uuidString)").path
+    #expect(WhisperKitBackend.hasRequiredArtifacts(at: ghost) == false)
+  }
+
+  @Test("Required artifact list matches WhisperKit.loadModels hard-required set")
+  func requiredArtifactsCoverage() {
+    // WhisperKit.swift:372-381 only throws when these three are missing;
+    // TextDecoderContextPrefill is loaded conditionally and must NOT be
+    // in the required set (would over-reject otherwise-valid caches).
+    let expected: Set<String> = [
+      "AudioEncoder.mlmodelc",
+      "MelSpectrogram.mlmodelc",
+      "TextDecoder.mlmodelc",
+    ]
+    #expect(Set(WhisperKitBackend.requiredArtifacts) == expected)
+  }
+
+  @Test("Prefill artifact absent is acceptable (matches WhisperKit contract)")
+  func prefillOptional() {
+    let folder = makeTempModelFolder()
+    defer { try? FileManager.default.removeItem(at: folder) }
+    for name in WhisperKitBackend.requiredArtifacts {
+      createArtifact(name, in: folder, complete: true)
+    }
+    // Do NOT create TextDecoderContextPrefill.mlmodelc. Upstream tolerates.
+    #expect(WhisperKitBackend.hasRequiredArtifacts(at: folder.path) == true)
+  }
+}


### PR DESCRIPTION
Closes #329. Tier: SMALL. Autopilot session 2026-04-17. Supersedes #330 (closed without merge — shipped original plan before I read @m13v's feedback + Saurabh's revision in the issue thread).

## What this changes

Two pre-existing bugs on the WhisperKit pre-load path surfaced during #282 post-merge log review.

### 1. Observer runs regardless of active backend

`AppState.startWhisperKitPreloadObservation()` didn't read `asrManager.activeBackendType` — Parakeet-only users paid CPU/memory warming a backend they never used. Added a guard inside the observer loop; backend switches already re-trigger via `settingsSync.onNeedsPreloadObservation`, so the switch-to-WhisperKit path stays covered.

### 2. Partial-download detection (per @m13v + Saurabh's revised plan)

`WhisperKitSetupService.getLocalModelPath` previously verified only that the variant folder existed. An interrupted HuggingFace download leaves some `.mlmodelc` dirs populated and others partial or missing; `WhisperKit(config)` then threw mid-load and `prepareBackendSilently()` logged it as `"pre-load failed"` — same severity as a genuine failure. Worse, `setupState` stayed `.ready` so the UI still claimed the model was available, and the first real recording reproduced the same crash.

Pushed the partial-download check into `getLocalModelPath` so all three call sites (`isModelCached` → setupState, `prepare`, `prepareIfCached`) see a consistent "not cached" signal for partial caches. UI now offers Download, `prepare()` falls back to `WhisperKit.download()` to resume/recover, and silent pre-load exits cleanly without a "failed" log.

The guard itself (`WhisperKitBackend.hasRequiredArtifacts`) verifies:
- All three WhisperKit-required `.mlmodelc` directories exist (MelSpectrogram, AudioEncoder, TextDecoder — aligned with `WhisperKit.loadModels()` at `WhisperKit.swift:372-381`).
- Each contains `coremldata.bin` (Apple's canonical "compiled model bundle is complete" marker — catches the mid-download case where HF created the outer dir before writing the inner files).

Intentionally excluded: `TextDecoderContextPrefill` (loaded conditionally upstream; requiring it would over-reject valid caches), `.mlpackage` layout (our product only downloads `.mlmodelc` via `WhisperKit.download`; `.mlpackage` is YAGNI and scoped-out in the comment).

## Process

Original plan (post-throw string-match) approved by GPT council. Gemini suggested `CocoaError` cast; I empirically verified WhisperKit uses its own `WhisperError.modelsUnavailable` (`WhisperKit.swift:379`), so neither the string match nor the CocoaError cast would have been correct. After pushing PR #330, I re-read the session log and issue thread, found Saurabh had already adopted a proactive 4-artifact pre-check based on @m13v's comment. Closed #330, pivoted to that plan here. Codex rounds:
- Round 1: flagged "returning false doesn't invalidate `setupState`" — incorporated (moved check into `getLocalModelPath`).
- Round 2: flagged "outer `.mlmodelc` existence alone doesn't detect inner-file partial" — incorporated (added `coremldata.bin` marker).
- Round 3: flagged "prefill is optional + `.mlpackage` not supported" — incorporated prefill (removed from required list), scoped-out `.mlpackage` with a documented comment (not our download format, empirically verified HF serves `.mlmodelc` for `argmaxinc/whisperkit-coreml`).
- Round 4: re-raised `.mlpackage` as an upgrade-regression concern. Not actioned per `zoom_out_instead_of_iterating` — original P0 solved, remaining concerns are theoretical for our user population.

## Tests

Added `WhisperKitBackendArtifactsTests.swift` in `EnviousWisprASRTests` (7 `@Test` cases, 333 total pass):

1. All three complete artifacts present → `true`.
2. Any single artifact directory missing entirely → `false` (covers each of the 3 in turn).
3. Outer dirs present but `coremldata.bin` missing inside → `false` (covers mid-download case).
4. Empty model folder → `false`.
5. Non-existent folder → `false` (does not throw).
6. Required list matches WhisperKit's hard-required set.
7. Prefill-only absent → `true` (does NOT over-reject valid caches lacking optional prefill).

## Runtime validation

- **Parakeet-selected relaunch:** zero `[WhisperKitPipeline]` log entries in the post-launch window. Observer guard validated.
- **WhisperKit-selected relaunch:** pre-load fires exactly once, logs `WhisperKit model pre-loaded successfully (background)` at 03:43:52 UTC-04 after an ~100s observer-ready wait.
- **Tests:** 333 pass (`scripts/swift-test.sh`).
- **App stability:** ~1m30s uptime post-relaunch, no crash.
- **Partial-cache at runtime:** not exercised destructively (would require deleting a `.mlmodelc` from my disk; risk of leaving Saurabh's dev cache broken if cleanup fails). Covered by unit tests above.

## Blast radius

- 3 source files changed (`WhisperKitBackend.swift`, `WhisperKitSetupService.swift`, `WhisperKitPipeline.swift` reverted to original catch), 1 new test file. 148 net LOC.
- No new API surface, no new types, no new deps, no migrations.
- Semantic change: `WhisperKitSetupService.getLocalModelPath` now returns nil for partial caches (previously returned the path). Three callers (`isModelCached`, `prepare`, `prepareIfCached`) all behave consistently afterward — UI shows Download, load falls back to `WhisperKit.download()`, soft-skip exits cleanly.
- User-visible outcome: an interrupted download now shows as "not downloaded" instead of "ready but crashes on record." Correct framing.

## Rollback

Squash-merge → `gh pr revert` or `git revert <sha>`. Clean revert, no migrations.

## Zero-blast-radius exception

Does NOT qualify (workflow-process §1): logic change spanning module boundary, not catalog/prompt/copy/config. Full council gate applied.

---
🤖 Generated during overnight autopilot session. Checkpoint tag \`autopilot-checkpoint-2026-04-17-0315\` is main HEAD pre-autopilot for easy rollback.