### PR TITLE
chore: prune three unused imports

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
@@ -1,4 +1,3 @@
-import EnviousWisprCore
 import SwiftUI
 
 struct WhatsNewSettingsView: View {

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -1,4 +1,3 @@
-import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
 @preconcurrency import WhisperKit

--- a/Sources/EnviousWisprPipeline/SampleFilter.swift
+++ b/Sources/EnviousWisprPipeline/SampleFilter.swift
@@ -1,4 +1,3 @@
-import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
 


### PR DESCRIPTION
Periphery follow-up from the overnight autopilot triage. Three single-line removals.

## Changes
- `Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift` — drop `import EnviousWisprCore` (no symbols referenced).
- `Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift` — drop `import EnviousWisprAudio` (no symbols referenced).
- `Sources/EnviousWisprPipeline/SampleFilter.swift` — drop `import EnviousWisprAudio` (no symbols referenced).

## Validation
- Each import verified via `git grep` against the target module's symbols before removal.
- `swift build -c release`: clean (no missing references).
- `scripts/swift-test.sh`: 324 tests pass.
- Codex review: "referenced symbols in the touched files resolve from other modules or the same target. No introduced functional or build-impacting issue."

## Rollback
Pure additive revert. No migrations.

---
🤖 Overnight autopilot cleanup, PR 3 of session.