### PR TITLE
fix(xpc): sanitize NSError userInfo before XPC reply (#297)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -72,6 +72,10 @@ jobs:
         if: steps.changes.outputs.needs_build == 'true'
         run: swift build -c release --arch arm64
 
+      - name: XPC error hygiene
+        if: steps.changes.outputs.needs_build == 'true'
+        run: scripts/check-xpc-error-hygiene.sh
+
       - name: Run logic tests
         if: steps.changes.outputs.needs_build == 'true'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ EnviousType/
 scripts/*
 !scripts/build-dmg.sh
 !scripts/bundle-dev.sh
+!scripts/check-xpc-error-hygiene.sh
 !scripts/release-preflight.sh
 !scripts/swift-test.sh
 docs/

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -83,7 +83,8 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         self.activeBackendType = backendType
         safeReply(nil)
       } catch {
-        safeReply(error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }
@@ -161,7 +162,8 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         let encoded = try PropertyListEncoder().encode(result)
         safeReply(encoded, nil)
       } catch {
-        safeReply(nil, error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(nil, XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }
@@ -188,7 +190,8 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         self.isStreamingActive = true
         safeReply(nil)
       } catch {
-        safeReply(error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }
@@ -231,7 +234,8 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         safeReply(encoded, nil)
       } catch {
         self.isStreamingActive = false
-        safeReply(nil, error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(nil, XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -149,7 +149,8 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
         try await captureManager.startEnginePhase()
         safeReply(nil)
       } catch {
-        safeReply(error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }
@@ -177,7 +178,8 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
         self.startVADMonitoring()
         safeReply(nil)
       } catch {
-        safeReply(error as NSError)
+        // XPC error sanitization boundary.
+        safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }

--- a/Sources/EnviousWisprCore/XPCErrorSanitizer.swift
+++ b/Sources/EnviousWisprCore/XPCErrorSanitizer.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Converts an `Error` into an `NSError` whose userInfo contains exactly
+/// one key (`NSLocalizedDescriptionKey`), safe to cross an `NSXPCConnection`
+/// without `NSXPCInterface.setClasses(_:for:argumentIndex:ofReply:)` registration.
+///
+/// The `NSLocalizedDescriptionKey` value is the flattened `localizedDescription`
+/// of the error plus every `NSUnderlyingErrorKey` ancestor, joined by ` <- `.
+/// Preserves OSStatus / AVFoundation diagnostic chains that would otherwise
+/// be lost when userInfo is stripped. When there is no underlying chain but
+/// `NSLocalizedFailureReasonErrorKey` is present and differs from the top
+/// description, the failure reason is appended (preserves Cocoa-style errors
+/// that encode detail only in `failureReason`).
+///
+/// Invariants:
+/// - Output userInfo keys == [NSLocalizedDescriptionKey] exactly.
+/// - Output domain == (error as NSError).domain.
+/// - Output code == (error as NSError).code.
+/// - Output is securely codable over XPC by construction.
+///
+/// Note: this sanitizer targets service→host XPC reply boundaries today. If
+/// future XPC methods pass `NSError` host→service (as a method argument, not
+/// a reply), those arguments must also be sanitized or the service will crash
+/// on decode. The CI check `scripts/check-xpc-error-hygiene.sh` guards against
+/// raw `safeReply(error as NSError)` regressions.
+public enum XPCErrorSanitizer {
+  /// Maximum depth of `NSUnderlyingErrorKey` ancestry to flatten. Real-world
+  /// chains are usually ≤ 3-4; 8 is a failsafe against pathological recursion.
+  private static let maxChainDepth = 8
+
+  public static func sanitizeForXPC(_ error: any Error) -> NSError {
+    let ns = error as NSError
+    var descriptions: [String] = [ns.localizedDescription]
+    var cursor = ns
+
+    for _ in 0..<maxChainDepth {
+      guard let underlying = cursor.userInfo[NSUnderlyingErrorKey] as? NSError else { break }
+      descriptions.append(underlying.localizedDescription)
+      cursor = underlying
+    }
+
+    // If no underlying chain was walked and `failureReason` adds signal,
+    // append it so callers still see the detail on Cocoa-style errors.
+    if descriptions.count == 1,
+      let reason = ns.userInfo[NSLocalizedFailureReasonErrorKey] as? String,
+      !reason.isEmpty,
+      reason != ns.localizedDescription
+    {
+      descriptions.append(reason)
+    }
+
+    return NSError(
+      domain: ns.domain,
+      code: ns.code,
+      userInfo: [NSLocalizedDescriptionKey: descriptions.joined(separator: " <- ")]
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Core/XPCErrorSanitizerTests.swift
+++ b/Tests/EnviousWisprTests/Core/XPCErrorSanitizerTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+@Suite("XPCErrorSanitizer")
+struct XPCErrorSanitizerTests {
+
+  private enum SampleError: LocalizedError {
+    case formatCreationFailed
+
+    var errorDescription: String? {
+      switch self {
+      case .formatCreationFailed: return "Failed to create audio format."
+      }
+    }
+  }
+
+  @Test(
+    "Swift enum error: domain, code, description preserved; userInfo has only NSLocalizedDescriptionKey"
+  )
+  func swiftEnumSanitized() {
+    let ns = SampleError.formatCreationFailed as NSError
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(SampleError.formatCreationFailed)
+
+    #expect(sanitized.domain == ns.domain)
+    #expect(sanitized.code == ns.code)
+    #expect(sanitized.localizedDescription == "Failed to create audio format.")
+    #expect(Array(sanitized.userInfo.keys) == [NSLocalizedDescriptionKey])
+  }
+
+  @Test("One-level NSUnderlyingError chain flattens into localizedDescription")
+  func oneLevelChain() {
+    let underlying = NSError(
+      domain: "NSOSStatusErrorDomain", code: -50,
+      userInfo: [NSLocalizedDescriptionKey: "OSStatus -50: invalid parameter"])
+    let top = NSError(
+      domain: "com.enviouswispr.audio", code: 1,
+      userInfo: [
+        NSLocalizedDescriptionKey: "Engine start failed",
+        NSUnderlyingErrorKey: underlying,
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(top)
+
+    #expect(sanitized.domain == "com.enviouswispr.audio")
+    #expect(sanitized.code == 1)
+    #expect(
+      sanitized.localizedDescription == "Engine start failed <- OSStatus -50: invalid parameter")
+    #expect(Array(sanitized.userInfo.keys) == [NSLocalizedDescriptionKey])
+  }
+
+  @Test("Three-level NSUnderlyingError chain: all four descriptions joined")
+  func threeLevelChain() {
+    let d = NSError(domain: "D", code: 4, userInfo: [NSLocalizedDescriptionKey: "d"])
+    let c = NSError(
+      domain: "C", code: 3,
+      userInfo: [NSLocalizedDescriptionKey: "c", NSUnderlyingErrorKey: d])
+    let b = NSError(
+      domain: "B", code: 2,
+      userInfo: [NSLocalizedDescriptionKey: "b", NSUnderlyingErrorKey: c])
+    let a = NSError(
+      domain: "A", code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "a", NSUnderlyingErrorKey: b])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(a)
+
+    #expect(sanitized.localizedDescription == "a <- b <- c <- d")
+    #expect(sanitized.domain == "A")
+    #expect(sanitized.code == 1)
+  }
+
+  @Test("Deep chain caps at depth 8, does not hang or stack-overflow")
+  func deepChainCapped() {
+    // Build a 20-level chain; sanitizer should walk at most 8.
+    var current = NSError(
+      domain: "L", code: 20, userInfo: [NSLocalizedDescriptionKey: "level20"])
+    for i in (1..<20).reversed() {
+      current = NSError(
+        domain: "L", code: i,
+        userInfo: [
+          NSLocalizedDescriptionKey: "level\(i)",
+          NSUnderlyingErrorKey: current,
+        ])
+    }
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(current)
+
+    // Expect top + 8 underlyings = 9 segments joined by 8 separators.
+    let segments = sanitized.localizedDescription.components(separatedBy: " <- ")
+    #expect(segments.count == 9)
+    #expect(segments.first == "level1")
+    #expect(segments.last == "level9")
+  }
+
+  @Test("URL in userInfo is dropped, only NSLocalizedDescriptionKey remains")
+  func urlInUserInfoDropped() {
+    let url = URL(string: "file:///var/tmp/foo")!
+    let err = NSError(
+      domain: "Cocoa", code: 260,
+      userInfo: [
+        NSLocalizedDescriptionKey: "File not found",
+        NSURLErrorKey: url,
+        "com.example.customClass": NSArray(array: [NSNumber(value: 1)]),
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(err)
+
+    #expect(Array(sanitized.userInfo.keys) == [NSLocalizedDescriptionKey])
+    #expect(sanitized.localizedDescription == "File not found")
+  }
+
+  @Test(
+    "failureReason is appended when there's no underlying chain and it differs from description")
+  func failureReasonAppendedWithoutChain() {
+    let err = NSError(
+      domain: "Cocoa", code: 4,
+      userInfo: [
+        NSLocalizedDescriptionKey: "The operation couldn't be completed.",
+        NSLocalizedFailureReasonErrorKey: "No such file or directory.",
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(err)
+
+    #expect(
+      sanitized.localizedDescription
+        == "The operation couldn't be completed. <- No such file or directory.")
+    #expect(Array(sanitized.userInfo.keys) == [NSLocalizedDescriptionKey])
+  }
+
+  @Test("failureReason NOT appended when identical to localizedDescription")
+  func failureReasonSkippedWhenIdentical() {
+    let text = "Operation failed."
+    let err = NSError(
+      domain: "X", code: 1,
+      userInfo: [
+        NSLocalizedDescriptionKey: text,
+        NSLocalizedFailureReasonErrorKey: text,
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(err)
+
+    #expect(sanitized.localizedDescription == text)
+  }
+
+  @Test("failureReason is NOT used when there is an underlying chain")
+  func failureReasonIgnoredWithChain() {
+    let underlying = NSError(domain: "U", code: 2, userInfo: [NSLocalizedDescriptionKey: "under"])
+    let err = NSError(
+      domain: "X", code: 1,
+      userInfo: [
+        NSLocalizedDescriptionKey: "top",
+        NSLocalizedFailureReasonErrorKey: "reason-only",
+        NSUnderlyingErrorKey: underlying,
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(err)
+
+    #expect(sanitized.localizedDescription == "top <- under")
+  }
+
+  @Test("Sanitized NSError round-trips through NSKeyedArchiver with XPC-allowed classes")
+  func xpcAllowedClassRoundTrip() throws {
+    let underlying = NSError(
+      domain: "NSOSStatusErrorDomain", code: -10877,
+      userInfo: [NSLocalizedDescriptionKey: "audio hardware unspecified error"])
+    let top = NSError(
+      domain: "com.enviouswispr.audio", code: 42,
+      userInfo: [
+        NSLocalizedDescriptionKey: "engine.start() failed",
+        NSUnderlyingErrorKey: underlying,
+        NSURLErrorKey: URL(string: "https://example.com")!,
+      ])
+
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(top)
+
+    // Apple-documented XPC-allowed class set (excluding NSError itself which is the outer object).
+    let allowed: [AnyClass] = [
+      NSError.self, NSString.self, NSNumber.self, NSDictionary.self,
+      NSArray.self, NSData.self, NSDate.self, NSURL.self, NSUUID.self, NSNull.self,
+    ]
+
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: sanitized, requiringSecureCoding: true)
+
+    let unarchived =
+      try NSKeyedUnarchiver.unarchivedObject(
+        ofClasses: allowed, from: data) as? NSError
+
+    #expect(unarchived != nil)
+    #expect(unarchived?.domain == sanitized.domain)
+    #expect(unarchived?.code == sanitized.code)
+    #expect(unarchived?.localizedDescription == sanitized.localizedDescription)
+  }
+
+  @Test("Property-based: representative errors all yield single-key userInfo")
+  func representativeErrorsAllSafe() {
+    let cases: [any Error] = [
+      SampleError.formatCreationFailed,
+      NSError(
+        domain: "NSURLErrorDomain", code: -1001,
+        userInfo: [NSLocalizedDescriptionKey: "request timed out"]),
+      NSError(
+        domain: "NSOSStatusErrorDomain", code: -10877,
+        userInfo: [NSLocalizedDescriptionKey: "audio hardware error"]),
+      NSError(
+        domain: "NSCocoaErrorDomain", code: 4,
+        userInfo: [
+          NSLocalizedDescriptionKey: "File not found",
+          NSLocalizedFailureReasonErrorKey: "The file doesn't exist.",
+        ]),
+      URLError(.timedOut),
+    ]
+
+    for error in cases {
+      let sanitized = XPCErrorSanitizer.sanitizeForXPC(error)
+      let originalNS = error as NSError
+      #expect(Array(sanitized.userInfo.keys) == [NSLocalizedDescriptionKey])
+      #expect(sanitized.domain == originalNS.domain)
+      #expect(sanitized.code == originalNS.code)
+      #expect(sanitized.localizedDescription.hasPrefix(originalNS.localizedDescription))
+    }
+  }
+}

--- a/scripts/check-xpc-error-hygiene.sh
+++ b/scripts/check-xpc-error-hygiene.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Anti-regression check for issue #297.
+#
+# XPC reply paths must sanitize thrown errors via `XPCErrorSanitizer.sanitizeForXPC(...)`.
+# Raw `safeReply(error as NSError)` or `safeReply(nil, error as NSError)` patterns
+# cause SIGABRT in the helper when NSError userInfo contains classes outside
+# XPC's default allowlist (e.g., NSOSStatusErrorDomain underlying errors).
+#
+# This check greps the two XPC service handler directories for the forbidden
+# pattern and exits non-zero if any match is found.
+
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+cd "$ROOT"
+
+targets=(
+  "Sources/EnviousWisprAudioService"
+  "Sources/EnviousWisprASRService"
+)
+
+# grep -E: `safeReply(...arg(s)..., anything as NSError ... )`. Matches with or
+# without leading nil/Data? first argument and with whitespace variations.
+pattern='safeReply\s*\([^)]*\bas\s+NSError\b'
+
+matches="$(grep -RnE --include='*.swift' "$pattern" "${targets[@]}" || true)"
+
+if [ -n "$matches" ]; then
+  echo "ERROR: found forbidden 'safeReply(... as NSError)' pattern in XPC service handlers."
+  echo "Use 'XPCErrorSanitizer.sanitizeForXPC(error)' instead. See issue #297."
+  echo
+  echo "$matches"
+  exit 1
+fi
+
+echo "OK: no raw 'safeReply(... as NSError)' patterns found in XPC handlers."
+exit 0


### PR DESCRIPTION
Closes #297. Parent epic: #319.

## Summary

- Fixes the `NSXPCEncoder _checkObject:` SIGABRT in `EnviousWisprAudioService` when an NSError reply carries a class outside XPC's default allowlist.
- Adds `XPCErrorSanitizer.sanitizeForXPC(_:)` in Core; applies at all 6 XPC reply sites across both helpers (Audio + ASR).
- CI grep (`scripts/check-xpc-error-hygiene.sh`) blocks regressions.

## What crashed

`EnviousWisprAudioService-2026-04-15-191124.ips`:

```
-[NSXPCEncoder _checkObject:]
-[NSXPCEncoder _encodeUnkeyedObject:]
-[NSXPCEncoder _encodeArrayOfObjects:forKey:]
-[NSDictionary(NSDictionary) encodeWithCoder:]
closure #1 in AudioServiceHandler.startEnginePhase
```

The Swift error's bridged NSError carried userInfo with an array of a non-allowlisted class. `NSXPCInterface.setClasses(...)` was never registered, so XPC fell back to its narrow default class set.

## Fix

`XPCErrorSanitizer.sanitizeForXPC(_:)` returns a fresh `NSError(domain:code:userInfo:)` with **exactly one** userInfo key: `NSLocalizedDescriptionKey`. The value flattens `NSUnderlyingErrorKey` descriptions (depth-limited to 8) so AVFoundation OSStatus chains stay debuggable. When there's no chain, `NSLocalizedFailureReasonErrorKey` is appended if present and distinct.

All 6 call sites switched:
- `AudioServiceHandler` lines 152, 180
- `ASRServiceHandler` lines 86, 164, 191, 234

Each gets a `// XPC error sanitization boundary.` anchor comment for future greps.

## Anti-regression

`scripts/check-xpc-error-hygiene.sh` greps both service handler dirs for `safeReply\s*\([^)]*\bas\s+NSError\b`; exits 1 on match. Wired into `pr-check.yml` as required step.

## Tests

10 cases in `Tests/EnviousWisprTests/Core/XPCErrorSanitizerTests.swift`:
- Swift enum bridge → domain/code/description preserved, single-key userInfo.
- 1-level + 3-level `NSUnderlyingError` chains flatten correctly.
- 20-level chain caps at depth 8 (no hang, no overflow).
- URL + custom-class userInfo values stripped.
- `failureReason` appended when no chain + differs; skipped when identical; ignored when chain exists.
- `NSKeyedArchiver(requiringSecureCoding: true)` round-trip against Apple's documented XPC-allowed class set.
- Property-based sweep across Swift enum, URLError, Cocoa NSError, OSStatus-bridged NSError.

## Test plan

- [x] `swift build -c release` green
- [x] `scripts/swift-test.sh --filter XPCErrorSanitizerTests` all 10 pass
- [x] `scripts/check-xpc-error-hygiene.sh` OK on this branch; confirmed it catches the forbidden pattern
- [x] Rebuild + relaunch via `scripts/bundle-dev.sh` (signed fresh XPC helpers)
- [x] Heart smoke: `wispr_eyes.test_recording()` — end-to-end PTT cycle, transcript pasted, no helper crash
- [x] No new `EnviousWisprAudioService-*.ips` or `EnviousWispr-*.ips` since rebuild
- [x] Codex `review --uncommitted` — zero findings

## Follow-up tickets to file

- Gemini (round 2) correctly identified UI truncation as a UI concern, not a sanitizer concern. Separate ticket: add `lineLimit(2)` + "Details" expander to the error banner at `TranscriptionPipeline.swift:813` so long flattened chains don't overflow.
