### PR TITLE
chore(release): bump version to 1.9.4

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.2</string>
+	<string>1.9.4</string>
 	<key>CFBundleVersion</key>
-	<string>1.9.2</string>
+	<string>1.9.4</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -43,8 +43,44 @@ enum WhatsNewContent {
       icon: "waveform.badge.checkmark",
       title: "More reliable recordings",
       description:
-        "Improved recovery when the microphone gets into a bad state, so recordings start cleanly even after long idle periods or audio interruptions.",
+        "Fewer silent failures. The audio helper now recovers cleanly from a rare crash class, and the microphone bounces back better from bad states after long idle periods or audio interruptions.",
       category: .fasterAndMoreReliable,
+      version: "1.9.4"
+    ),
+    Entry(
+      id: "ollama-download-progress",
+      icon: "arrow.down.circle",
+      title: "Ollama downloads show progress and can be cancelled",
+      description:
+        "The Manage Models row now shows a live progress bar while an Ollama model downloads, plus a Cancel button. No more wondering whether the download is stuck or how big it is.",
+      category: .betterOllamaSupport,
+      version: "1.9.4"
+    ),
+    Entry(
+      id: "faster-polish-after-pause",
+      icon: "bolt.horizontal",
+      title: "Faster first polish after a pause",
+      description:
+        "Your first dictation after a quiet stretch now gets polished faster. The pre-warm probe talks to the LLM the same way a real polish does, so the first real call doesn't pay a cold-start tax.",
+      category: .fasterAndMoreReliable,
+      version: "1.9.4"
+    ),
+    Entry(
+      id: "paste-chromium-electron",
+      icon: "doc.on.clipboard",
+      title: "Paste works in more apps",
+      description:
+        "Dictating into Chrome, Slack, Discord, VS Code, and other Electron-based apps now pastes cleanly even when the focused text field isn't fully reported. Previously the text would sometimes sit on the clipboard instead of landing in place.",
+      category: .fasterAndMoreReliable,
+      version: "1.9.4"
+    ),
+    Entry(
+      id: "gemma-3-nano",
+      icon: "cpu",
+      title: "Gemma 3 Nano joins the Ollama lineup",
+      description:
+        "Google's 4B Gemma 3 Nano is now available in the Ollama model picker. A tight on-device option for AI polish when you want speed and privacy and don't need a large model.",
+      category: .betterOllamaSupport,
       version: "1.9.4"
     ),
 


### PR DESCRIPTION
Version bump + What's New entries for the v1.9.4 release. CI has already validated every underlying fix; this PR just stamps the version and finalizes the user-facing release notes.

## User-visible changes since v1.9.3

Covered in What's New:
- More reliable recordings — merges XPC audio helper crash recovery (#297) + AudioCapture preWarm error propagation (#289)
- Ollama downloads show progress and can be cancelled (#282)
- Faster first polish after a pause (#266)
- Paste works in more apps — Chrome, Slack, Discord, VS Code (#277)
- Smoother model switching — Ollama model unload on swap (#295)
- Gemma 3 Nano joins the Ollama lineup (#281)

Deliberately NOT in What's New (internal / zero user-visible delta):
- WhisperKit partial-download handling (#329)
- Sentry zero-peak telemetry (#302/#305)
- Sentry triage pipeline (#287/#293)
- Ollama thinking-chars telemetry (#276)
- Swift 2-space reformat (#307)
- WhisperKit variant-swap removal (#256)
- Log timezone fix (#298)
- LegacyPromptEnricher scaffolding removal (#332)
- Unused import prune (#333)

## Test plan

- [x] Info.plist CFBundleShortVersionString + CFBundleVersion bumped to 1.9.4
- [x] WhatsNewConstants.currentContentVersion matches (already 1.9.4)
- [x] What's New entries use SF Symbols + plain English, no em-dashes in user-facing copy
- [ ] CI build-check green
- [ ] After merge: release-preflight on main, tag v1.9.4, push tag
- [ ] Release workflow produces signed/notarized DMG + GitHub Release + appcast update
