### PR TITLE
fix(sentry-triage): harden Path D HTTP handling + paginate dedup (#345, #346)

### DIFF
--- a/workers/sentry-triage/routine-prompt-v2.md
+++ b/workers/sentry-triage/routine-prompt-v2.md
@@ -248,11 +248,17 @@ This is an isolated block executed AFTER finishing all Sentry work (Paths A/B/C)
 
 ### Step D1 — Fetch Codex review events
 
-Single HTTP call to the repo-wide events feed:
+Fetch the repo-wide events feed and check the HTTP status explicitly. Non-2xx is fatal for Path D (per the Path D error policy below) — a silent `[]` would mask rate-limit and outage errors and contradict the stated policy.
 
 ```bash
-curl -s "https://api.github.com/repos/saurabhav88/EnviousWispr/events?per_page=100" \
-  | jq '[.[] | select(.type=="PullRequestReviewEvent" and .actor.login=="chatgpt-codex-connector[bot]")]'
+RESPONSE=$(curl -s -w '\n%{http_code}' "https://api.github.com/repos/saurabhav88/EnviousWispr/events?per_page=100")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "Path D: events API HTTP $HTTP_CODE. Exiting Path D cleanly."
+  exit 0
+fi
+echo "$BODY" | jq '[.[] | select(.type=="PullRequestReviewEvent" and .actor.login=="chatgpt-codex-connector[bot]")]'
 ```
 
 Each item surfaces:
@@ -262,16 +268,42 @@ Each item surfaces:
 - `.payload.review.commit_id` — head SHA at review time
 - `.created_at` — event timestamp
 
-If the list is empty, log "Path D: no Codex events" and exit Path D cleanly.
+If the filtered list is empty, log "Path D: no Codex events" and exit Path D cleanly.
 
 Bot identity fallback: if the strict filter returns zero but you expected results, retry with `.actor.type=="Bot"` AND require the fetched review body to contain the literal string "Codex Review".
 
 ### Step D2 — Dedup against prior triage
 
-Fetch issues already triaged by Path D:
+Fetch every `codex-review`-labelled issue and scan bodies for `codex-source` markers. GitHub Search API defaults to 30 items/page; reading only page 1 would silently drop older markers once the repo grows past the first page and cause duplicate issue creation. Paginate with `per_page=100` up to the Search API's hard ceiling of 1000 results (10 pages), stopping early when a page returns fewer than 100 items.
+
+`sleep 2` between pages is REQUIRED — unauthenticated Search is capped at 10 req/min primary + a stricter secondary/abuse limit that fires on burst patterns. Skipping the sleep will cause page 2+ to return HTTP 403/429 and the script will exit Path D cleanly with no dedup coverage, which is wasted work.
+
+Do NOT switch to `Link`-header-following pagination here — `grep`-ing `rel="next"` out of a `curl` header dump in bash is notoriously brittle; the simpler `page=N + break on < 100 items` pattern is easier to audit.
 
 ```bash
-curl -s "https://api.github.com/search/issues?q=label:codex-review+repo:saurabhav88/EnviousWispr"
+PAGE=1
+ALL_ITEMS="[]"
+COUNT=0
+while [ "$PAGE" -le 10 ]; do
+  if [ "$PAGE" -gt 1 ]; then sleep 2; fi
+  RESP=$(curl -s -w '\n%{http_code}' "https://api.github.com/search/issues?q=label:codex-review+repo:saurabhav88/EnviousWispr&per_page=100&page=$PAGE")
+  CODE=$(echo "$RESP" | tail -1)
+  BODY=$(echo "$RESP" | sed '$d')
+  if [ "$CODE" != "200" ]; then
+    echo "Path D dedup: search HTTP $CODE on page $PAGE. Exiting Path D cleanly."
+    exit 0
+  fi
+  ITEMS=$(echo "$BODY" | jq '.items')
+  COUNT=$(echo "$ITEMS" | jq 'length')
+  ALL_ITEMS=$(echo "$ALL_ITEMS $ITEMS" | jq -s 'add')
+  if [ "$COUNT" -lt 100 ]; then break; fi
+  PAGE=$((PAGE + 1))
+done
+if [ "$PAGE" -gt 10 ] && [ "$COUNT" -eq 100 ]; then
+  echo "Path D dedup: hit 10-page cap with full page; dedup may be incomplete. Revisit cap."
+fi
+# Preserve the object shape downstream steps expect (`items` at top level).
+echo "{\"items\": $ALL_ITEMS}"
 ```
 
 For each returned issue, scan its `body` field for markers matching:

--- a/workers/sentry-triage/routine-prompt-v2.md
+++ b/workers/sentry-triage/routine-prompt-v2.md
@@ -276,7 +276,9 @@ Bot identity fallback: if the strict filter returns zero but you expected result
 
 Fetch every `codex-review`-labelled issue and scan bodies for `codex-source` markers. GitHub Search API defaults to 30 items/page; reading only page 1 would silently drop older markers once the repo grows past the first page and cause duplicate issue creation. Paginate with `per_page=100` up to the Search API's hard ceiling of 1000 results (10 pages), stopping early when a page returns fewer than 100 items.
 
-`sleep 2` between pages is REQUIRED — unauthenticated Search is capped at 10 req/min primary + a stricter secondary/abuse limit that fires on burst patterns. Skipping the sleep will cause page 2+ to return HTTP 403/429 and the script will exit Path D cleanly with no dedup coverage, which is wasted work.
+`sleep 6` between pages is REQUIRED. Unauthenticated Search is capped at 10 req/min primary + a stricter secondary/abuse limit, AND that budget is shared with Step 2 (Sentry-side search/issues calls, one per Sentry issue). Six seconds between pagination requests keeps even a worst-case combined burst (Step 2's ~5 lookups + 10 dedup pages) inside the rolling-minute window. Skipping the sleep will cause page 2+ to return HTTP 403/429; the script will then exit Path D cleanly with no dedup coverage, which is wasted work AND risks duplicate codex-review issue creation.
+
+Future note: once the `codex-review` issue count exceeds ~200 (>2 pages are routine), reconsider either authenticating the Search call via the built-in GitHub tools (5000 req/hr authenticated budget) or staggering Path D by a minute after Step 2 completes. For 2026-04 volume (&lt;30 issues) this is not needed.
 
 Do NOT switch to `Link`-header-following pagination here — `grep`-ing `rel="next"` out of a `curl` header dump in bash is notoriously brittle; the simpler `page=N + break on < 100 items` pattern is easier to audit.
 
@@ -285,7 +287,7 @@ PAGE=1
 ALL_ITEMS="[]"
 COUNT=0
 while [ "$PAGE" -le 10 ]; do
-  if [ "$PAGE" -gt 1 ]; then sleep 2; fi
+  if [ "$PAGE" -gt 1 ]; then sleep 6; fi
   RESP=$(curl -s -w '\n%{http_code}' "https://api.github.com/search/issues?q=label:codex-review+repo:saurabhav88/EnviousWispr&per_page=100&page=$PAGE")
   CODE=$(echo "$RESP" | tail -1)
   BODY=$(echo "$RESP" | sed '$d')


### PR DESCRIPTION
## Summary
- **#345:** Step D1 events fetch now captures the HTTP code and exits Path D cleanly on non-2xx, instead of letting a silent `curl -s` mask rate-limit / outage errors as "no Codex events." Matches the Step 1 pattern already used for Sentry.
- **#346:** Step D2 dedup search now paginates up to GitHub Search's 1000-result ceiling (10 pages × `per_page=100`) with `sleep 6` between pages, and wraps the accumulated items back in `{"items": ...}` so downstream steps see the same JSON envelope the unpaginated call returned.

Closes #345, #346.

## Design notes (expanded after council + Codex)
- **Sleep timing (6s, not 2s).** Step 2 (Sentry-side `search/issues`, one per Sentry issue) and Path D Step D2 share the unauthenticated Search rolling-minute budget. Codex flagged on first pass that `sleep 2` could combine with Step 2's burst and trip 403/429 on page 2+, leaving Path D without dedup coverage (and risking duplicate codex-review issues). Six seconds keeps even a worst-case combined burst inside the rolling window.
- **Pagination cap (10 pages).** GitHub Search API returns HTTP 422 on `page=11` at `per_page=100`; 10 is the hard ceiling, not a soft guardrail. A cap-hit-with-full-page condition logs a warning so we notice before duplicates start.
- **Wrap as `{"items": ...}`.** Today's single-call output is `{total_count, items}`. Emitting a raw array would silently break downstream `jq '.items[]'` dedup-set construction. Shape preservation.
- **Explicitly not using `Link` headers.** Grep-ing `rel="next"` out of a curl header dump in bash is notoriously brittle; `page=N` + break-on-<100 is easier to audit.

## Reference-copy note
`workers/sentry-triage/routine-prompt-v2.md` is a reference copy. The live Routine config lives at https://claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK. **After merge, Saurabh must manually paste the updated prompt into the Routine edit dialog** for the fix to take effect in production. The PR itself changes documentation only.

## Test plan
- [x] Council (GPT + Gemini) reviewed plan; both findings (rate-limit shared budget, shape-preservation) baked into commit
- [x] Codex reviewed diff twice; first round surfaced the shared-budget concern, addressed with 6s sleep; second round clean
- [ ] After merge: paste updated prompt into live Routine, verify next scheduled tick (every 4h) logs a sane dedup run
- [ ] Watch the next Routine execution for HTTP error log path if API hiccups

Plan doc: [`docs/feature-requests/issue-345-346-2026-04-17-sentry-triage-hardening.md`](docs/feature-requests/issue-345-346-2026-04-17-sentry-triage-hardening.md)
