### PR TITLE
fix(release-preflight): compile tests via swift-test.sh wrapper under CLT-only (#336)

### DIFF
--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -60,9 +60,13 @@ if ! swift build -c release --arch arm64 2>&1 | tee /tmp/release-preflight-build
 fi
 echo "  OK  Release build passed"
 
-# 6. Test target compiles
-echo "  ... Running swift build --build-tests"
-if ! swift build --build-tests 2>&1 | tail -3; then
+# 6. Test target compiles.
+# Use scripts/swift-test.sh --no-run so the CLT Testing.framework flags are
+# applied. Bare `swift build --build-tests` fails under CLT-only because
+# Testing.framework and lib_TestingInterop.dylib aren't on the default path.
+echo "  ... Running scripts/swift-test.sh --no-run"
+if ! BUILD_OUTPUT=$(scripts/swift-test.sh --no-run 2>&1); then
+    echo "$BUILD_OUTPUT" | tail -10
     echo "FAIL: Test target failed to compile"
     exit 1
 fi

--- a/scripts/swift-test.sh
+++ b/scripts/swift-test.sh
@@ -16,6 +16,7 @@
 # Usage:
 #   scripts/swift-test.sh              # run all tests
 #   scripts/swift-test.sh --filter Foo # filter to tests matching "Foo"
+#   scripts/swift-test.sh --no-run     # compile tests only (used by release-preflight)
 
 set -euo pipefail
 
@@ -30,10 +31,26 @@ if [ ! -d "$FRAMEWORKS_DIR/Testing.framework" ]; then
     exit 1
 fi
 
-exec swift test \
-    -Xswiftc "-F${FRAMEWORKS_DIR}" \
-    -Xlinker "-F${FRAMEWORKS_DIR}" \
-    -Xlinker -rpath -Xlinker "${FRAMEWORKS_DIR}" \
-    -Xlinker -rpath -Xlinker "${USR_LIB_DIR}" \
-    -Xlinker -rpath -Xlinker "${INTEROP_LIB_DIR}" \
-    "$@"
+# Shared flag set — single source of truth for CLT Testing.framework wiring.
+CLT_FLAGS=(
+    -Xswiftc "-F${FRAMEWORKS_DIR}"
+    -Xlinker "-F${FRAMEWORKS_DIR}"
+    -Xlinker -rpath -Xlinker "${FRAMEWORKS_DIR}"
+    -Xlinker -rpath -Xlinker "${USR_LIB_DIR}"
+    -Xlinker -rpath -Xlinker "${INTEROP_LIB_DIR}"
+)
+
+NO_RUN=0
+REMAINING_ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --no-run) NO_RUN=1 ;;
+        *)        REMAINING_ARGS+=("$arg") ;;
+    esac
+done
+
+if [[ $NO_RUN -eq 1 ]]; then
+    exec swift build --build-tests "${CLT_FLAGS[@]}" "${REMAINING_ARGS[@]}"
+fi
+
+exec swift test "${CLT_FLAGS[@]}" "${REMAINING_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Adds a `--no-run` flag to `scripts/swift-test.sh` that compiles the test target with the CLT Testing.framework flags applied (shared `CLT_FLAGS` bash array, single source of truth).
- `scripts/release-preflight.sh` step 6 now calls `scripts/swift-test.sh --no-run` instead of bare `swift build --build-tests`. Failure detection uses `BUILD_OUTPUT=$(...)` so the exit code is the command's own, independent of `set -o pipefail`.
- Hit during v1.9.4 release (2026-04-17); workaround was running `swift-test.sh` manually.

Closes #336.

## Council & Codex

- GPT + Gemini, 1 round. Both reviewers raised the `if ! cmd | tail -3` pipe exit-code concern even though `set -euo pipefail` is active. Adopted the reviewer-preferred `BUILD_OUTPUT=$(...)` shape anyway — strictly more robust.
- Codex review raised a P2 about full-Xcode support. Validated against project stance: CLAUDE.md states "Swift 6 / CLT-only (no Xcode)", and `swift-test.sh`'s header already documents CLT hardcoding with a manual-edit note for Xcode machines. The prior preflight also failed on CLT-only (which is why #336 exists). Not a regression for this project's supported environment.

## Test plan

- [x] `scripts/swift-test.sh --no-run` exits 0 on a clean worktree (Build complete! 4.9s)
- [x] `scripts/swift-test.sh --filter PasteFocusClassificationTests` still runs the filtered tests (4 tests pass)
- [ ] Full `scripts/release-preflight.sh` run on main post-merge (preflight gates on `git branch == main` + remote parity, so full end-to-end runs first when preparing the next release)
