### PR TITLE
fix: three Codex findings from PRs #347 / #348 / #349 (closes #350, #351, #352)

### DIFF
--- a/scripts/check-xpc-error-hygiene.sh
+++ b/scripts/check-xpc-error-hygiene.sh
@@ -64,18 +64,24 @@ scan_dir() {
       my $stripped = $orig;
       # Equal-length blanking preserves byte offsets so $-[0] still maps
       # to the correct line in the original file.
-      # Order matters: raw strings (#"..."#) and multi-line strings first so
-      # we do not shred a raw-string body character-by-char when the simple
-      # pattern hits the inner quotes. Then ordinary strings, then comments.
-      $stripped =~ s/((#+)".*?"\2)/" " x length($1)/sge;
-      $stripped =~ s/(""".*?""")/" " x length($1)/sge;
-      $stripped =~ s/("(?:[^"\\\n]|\\.)*")/" " x length($1)/ge;
-      # Block comments (non-nested). Swift does allow nested block comments,
-      # but they are rare in practice and this check is a regression net,
-      # not a security boundary.
-      $stripped =~ s/(\/\*[\s\S]*?\*\/)/" " x length($1)/ge;
-      # Line comments // to end-of-line. Keep the newline so line numbers stay correct.
-      $stripped =~ s/(\/\/[^\n]*)/" " x length($1)/ge;
+      # Single-pass alternation with left-priority is required: sequential
+      # stripping cannot simultaneously (a) blank `// #"` in a line comment
+      # before the raw-string regex sees it, and (b) avoid blanking the
+      # `//` inside a legitimate string literal like `"https://..."`.
+      # Perls alternation tries each branch left-to-right at each cursor
+      # position, so at the first `"` of a string, the string branches
+      # match before the comment branches can; conversely, at `//` outside
+      # any string, the comment branch matches before raw-string can
+      # confuse itself on a quote character inside the comment body.
+      # Order within the alternation: raw string, triple string, ordinary
+      # string, block comment, line comment.
+      $stripped =~ s{
+        ( (\#+) " .*? " \2 )                      # (1,2) raw string #"..."#
+        | ( """ .*? """ )                         # (3)   triple-quoted string
+        | ( " (?: [^"\\\n] | \\. )* " )           # (4)   ordinary string
+        | ( /\* [\s\S]*? \*/ )                    # (5)   block comment (non-nested)
+        | ( // [^\n]* )                           # (6)   line comment to end-of-line
+      }{" " x length($&)}sgex;
       while ($stripped =~ /(safeReply\s*(\((?:[^()]++|(?2))*+\)))/g) {
         my $whole = $1;
         next unless $whole =~ /\bas\s+NSError\b/;
@@ -230,6 +236,43 @@ import Foundation
 func j() {}
 EOF
 
+  # Fixture K: line comment that seeds a fake raw-string opener (`// #"`)
+  # above a real violation, closed by a later legitimate raw string. Under
+  # the prior string-before-comment ordering, the raw-string regex would
+  # consume the comment body, the newline, and the real safeReply call up
+  # to `"#`, blanking the violation and returning OK. This fixture guards
+  # issue #351 — comments must be stripped before raw strings at the same
+  # cursor position.
+  cat > "$tmp/fixture_k.swift" <<'EOF'
+import Foundation
+// #"
+func k(err: Error) {
+    safeReply(nil, err as NSError)
+}
+let ok = #"ok"#
+EOF
+
+  # Fixture L: forbidden call with a URL literal (`"https://..."`) in the
+  # arg list. The string body contains `//`, so a naive comment-first pass
+  # would blank from `//` to end of line, destroying the closing `)` of the
+  # call and hiding the violation. Single-pass alternation with string
+  # branches tried before comment branches must keep this visible.
+  cat > "$tmp/fixture_l.swift" <<'EOF'
+import Foundation
+func l(err: Error) {
+    safeReply(URL(string: "https://example.com"), err as NSError)
+}
+EOF
+
+  # Fixture M: forbidden call with a string literal containing `/*`. Same
+  # shape as L but for block-comment confusion inside a string body.
+  cat > "$tmp/fixture_m.swift" <<'EOF'
+import Foundation
+func m(err: Error) {
+    safeReply("start /* not a comment */ end", err as NSError)
+}
+EOF
+
   local out
   out="$(scan_dir "$tmp")"
 
@@ -274,6 +317,18 @@ EOF
     echo "self-test FAILED: commented-out violation (J) matched" >&2
     fail=1
   fi
+  if ! printf '%s' "$out" | grep -q "fixture_k.swift:"; then
+    echo "self-test FAILED: fake raw-string opener in comment (K) not matched" >&2
+    fail=1
+  fi
+  if ! printf '%s' "$out" | grep -q "fixture_l.swift:"; then
+    echo "self-test FAILED: // inside URL string literal (L) not matched" >&2
+    fail=1
+  fi
+  if ! printf '%s' "$out" | grep -q "fixture_m.swift:"; then
+    echo "self-test FAILED: /* inside string literal (M) not matched" >&2
+    fail=1
+  fi
 
   if [ "$fail" -eq 1 ]; then
     echo >&2
@@ -282,7 +337,7 @@ EOF
     exit 1
   fi
 
-  echo "self-test PASSED: 10 fixtures (single-line, multi-line, safe, nested parens, cross-call negatives x2, paren-in-string +/-, raw-string, commented-out)"
+  echo "self-test PASSED: 13 fixtures (single-line, multi-line, safe, nested parens, cross-call negatives x2, paren-in-string +/-, raw-string, commented-out, fake-raw-string-opener-in-comment, //-in-string, /*-in-string)"
   exit 0
 }
 

--- a/scripts/eval/overpolish-eval.py
+++ b/scripts/eval/overpolish-eval.py
@@ -25,7 +25,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-PROJ_ROOT = Path(__file__).parent.parent
+PROJ_ROOT = Path(__file__).parent.parent.parent
 AUDIO_DIR = Path("/tmp/overpolish-eval-audio")
 LOG_PATH = os.path.expanduser("~/Library/Logs/EnviousWispr/app.log")
 RESULTS_DIR = PROJ_ROOT / "benchmark-results" / "overpolish-eval"

--- a/workers/sentry-triage/routine-prompt-v2.md
+++ b/workers/sentry-triage/routine-prompt-v2.md
@@ -282,12 +282,14 @@ Future note: once the `codex-review` issue count exceeds ~200 (>2 pages are rout
 
 Do NOT switch to `Link`-header-following pagination here — `grep`-ing `rel="next"` out of a `curl` header dump in bash is notoriously brittle; the simpler `page=N + break on < 100 items` pattern is easier to audit.
 
+The inter-page delay is 10 seconds, not 6, because Step 2 of this routine also hits `/search/issues` on the same unauthenticated IP quota (10 req/min). At 10 pages × 10s between them, Path D's own burst stays under the cap and leaves headroom for Step 2's 2-3 prior calls in the rolling 60-second window.
+
 ```bash
 PAGE=1
 ALL_ITEMS="[]"
 COUNT=0
 while [ "$PAGE" -le 10 ]; do
-  if [ "$PAGE" -gt 1 ]; then sleep 6; fi
+  if [ "$PAGE" -gt 1 ]; then sleep 10; fi
   RESP=$(curl -s -w '\n%{http_code}' "https://api.github.com/search/issues?q=label:codex-review+repo:saurabhav88/EnviousWispr&per_page=100&page=$PAGE")
   CODE=$(echo "$RESP" | tail -1)
   BODY=$(echo "$RESP" | sed '$d')


### PR DESCRIPTION
## Summary

Three auto-triaged Codex findings addressed in one PR. All three are zero-blast-radius, non-Sources/ scope (CI script, routine prompt, benchmark tooling).

- **#350** (from #347) — `workers/sentry-triage/routine-prompt-v2.md`: bump Path D dedup sleep 6s → 10s. Step 2 of the same routine shares the unauthenticated IP quota (10 req/min); 6s cadence could push the rolling 60s total past the cap and cause Path D to bail without dedup coverage.
- **#351** (from #348) — `scripts/check-xpc-error-hygiene.sh`: replace sequential string/comment stripping with single-pass alternation. Initial naive swap (comments-first) shipped in round 1 hid violations inside `"https://..."` literals; Codex caught it; fix pivoted to left-priority alternation so strings are tried before comments at each cursor position. Added fixtures K (fake raw-string opener in comment), L (`//` inside URL literal), M (`/*` inside string literal). Self-test: 11 → 13 fixtures.
- **#352** (from #349) — `scripts/eval/overpolish-eval.py`: fix `PROJ_ROOT` resolution after relocation from `test/` to `scripts/eval/` (add one more `.parent`).

## Plans

- `docs/feature-requests/issue-350-2026-04-18-path-d-rate-limit.md`
- `docs/feature-requests/issue-351-2026-04-18-xpc-hygiene-comment-order.md`
- `docs/feature-requests/issue-352-2026-04-18-proj-root-fix.md`

Council round 1 clean on all three (session-log 2026-04-18). Plan #351 missed the same edge case Codex caught in round 1; pivoted mid-implementation to alternation approach + fixture regression coverage. Codex round 2 clean.

council-skip: zero-blast-radius (routine prompt / CI script / benchmark tooling — none under Sources/, Tests/, Package.swift, website/, .github/)

## Test plan

- [x] `bash scripts/check-xpc-error-hygiene.sh --self-test` passes (13 fixtures)
- [x] `bash scripts/check-xpc-error-hygiene.sh` clean on current Sources/ tree
- [x] `python3 -c "from pathlib import Path; assert (Path('scripts/eval/overpolish-eval.py').resolve().parent.parent.parent / 'Package.swift').exists()"` — PROJ_ROOT resolves to repo root
- [x] Codex review clean on the diff
- [ ] CI `build-check` green post-merge
