### PR TITLE
fix(brand): align favicon and README icon with Nav heart-waveform

### DIFF
--- a/assets/readme/icon.svg
+++ b/assets/readme/icon.svg
@@ -1,22 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-  <g transform="translate(8,13)">
-    <rect x="16" y="84.2" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.92"/>
-    <rect x="40" y="65.75" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.92"/>
-    <rect x="64" y="43.36" width="14" height="48" rx="5" fill="#ffd700" opacity="0.92"/>
-    <rect x="88" y="63.04" width="14" height="36" rx="5" fill="#adff2f" opacity="0.92"/>
-    <rect x="112" y="81.43" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.92"/>
-    <rect x="136" y="63.04" width="14" height="36" rx="5" fill="#00ffff" opacity="0.92"/>
-    <rect x="160" y="43.36" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.92"/>
-    <rect x="184" y="65.75" width="14" height="32" rx="5" fill="#4169e1" opacity="0.92"/>
-    <rect x="208" y="84.2" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.92"/>
-    <rect x="16" y="116.8" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.92"/>
-    <rect x="40" y="116.8" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.92"/>
-    <rect x="64" y="116.8" width="14" height="48" rx="5" fill="#ffd700" opacity="0.92"/>
-    <rect x="88" y="116.8" width="14" height="36" rx="5" fill="#adff2f" opacity="0.92"/>
-    <rect x="112" y="116.8" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.92"/>
-    <rect x="136" y="116.8" width="14" height="36" rx="5" fill="#00ffff" opacity="0.92"/>
-    <rect x="160" y="116.8" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.92"/>
-    <rect x="184" y="116.8" width="14" height="32" rx="5" fill="#4169e1" opacity="0.92"/>
-    <rect x="208" y="116.8" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.92"/>
+  <defs>
+    <filter id="nav-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <g transform="translate(8,13)" filter="url(#nav-glow)">
+    <rect x="16" y="84.2" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.9"/>
+    <rect x="40" y="65.75" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.9"/>
+    <rect x="64" y="43.36" width="14" height="48" rx="5" fill="#ffd700" opacity="0.9"/>
+    <rect x="88" y="63.04" width="14" height="36" rx="5" fill="#adff2f" opacity="0.9"/>
+    <rect x="112" y="81.43" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.9"/>
+    <rect x="136" y="63.04" width="14" height="36" rx="5" fill="#00ffff" opacity="0.9"/>
+    <rect x="160" y="43.36" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.9"/>
+    <rect x="184" y="65.75" width="14" height="32" rx="5" fill="#4169e1" opacity="0.9"/>
+    <rect x="208" y="84.2" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.9"/>
+    <rect x="16" y="125.8" width="14" height="20" rx="5" fill="#4169e1" opacity="0.85"/>
+    <rect x="40" y="119.35" width="14" height="36" rx="5" fill="#1e90ff" opacity="0.85"/>
+    <rect x="64" y="112.96" width="14" height="48" rx="5" fill="#00ffff" opacity="0.85"/>
+    <rect x="88" y="120.64" width="14" height="60" rx="5" fill="#00fa9a" opacity="0.85"/>
+    <rect x="112" y="127.03" width="14" height="68" rx="5" fill="#adff2f" opacity="0.85"/>
+    <rect x="136" y="120.64" width="14" height="60" rx="5" fill="#ffd700" opacity="0.85"/>
+    <rect x="160" y="112.96" width="14" height="48" rx="5" fill="#ff8c00" opacity="0.85"/>
+    <rect x="184" y="119.35" width="14" height="36" rx="5" fill="#ff2a40" opacity="0.85"/>
+    <rect x="208" y="125.8" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.85"/>
   </g>
 </svg>

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,22 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-  <g transform="translate(8,13)">
-    <rect x="16" y="84.2" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.92"/>
-    <rect x="40" y="65.75" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.92"/>
-    <rect x="64" y="43.36" width="14" height="48" rx="5" fill="#ffd700" opacity="0.92"/>
-    <rect x="88" y="63.04" width="14" height="36" rx="5" fill="#adff2f" opacity="0.92"/>
-    <rect x="112" y="81.43" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.92"/>
-    <rect x="136" y="63.04" width="14" height="36" rx="5" fill="#00ffff" opacity="0.92"/>
-    <rect x="160" y="43.36" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.92"/>
-    <rect x="184" y="65.75" width="14" height="32" rx="5" fill="#4169e1" opacity="0.92"/>
-    <rect x="208" y="84.2" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.92"/>
-    <rect x="16" y="116.8" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.92"/>
-    <rect x="40" y="116.8" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.92"/>
-    <rect x="64" y="116.8" width="14" height="48" rx="5" fill="#ffd700" opacity="0.92"/>
-    <rect x="88" y="116.8" width="14" height="36" rx="5" fill="#adff2f" opacity="0.92"/>
-    <rect x="112" y="116.8" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.92"/>
-    <rect x="136" y="116.8" width="14" height="36" rx="5" fill="#00ffff" opacity="0.92"/>
-    <rect x="160" y="116.8" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.92"/>
-    <rect x="184" y="116.8" width="14" height="32" rx="5" fill="#4169e1" opacity="0.92"/>
-    <rect x="208" y="116.8" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.92"/>
+  <defs>
+    <filter id="nav-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <g transform="translate(8,13)" filter="url(#nav-glow)">
+    <rect x="16" y="84.2" width="14" height="20" rx="5" fill="#ff2a40" opacity="0.9"/>
+    <rect x="40" y="65.75" width="14" height="32" rx="5" fill="#ff8c00" opacity="0.9"/>
+    <rect x="64" y="43.36" width="14" height="48" rx="5" fill="#ffd700" opacity="0.9"/>
+    <rect x="88" y="63.04" width="14" height="36" rx="5" fill="#adff2f" opacity="0.9"/>
+    <rect x="112" y="81.43" width="14" height="24" rx="5" fill="#00fa9a" opacity="0.9"/>
+    <rect x="136" y="63.04" width="14" height="36" rx="5" fill="#00ffff" opacity="0.9"/>
+    <rect x="160" y="43.36" width="14" height="48" rx="5" fill="#1e90ff" opacity="0.9"/>
+    <rect x="184" y="65.75" width="14" height="32" rx="5" fill="#4169e1" opacity="0.9"/>
+    <rect x="208" y="84.2" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.9"/>
+    <rect x="16" y="125.8" width="14" height="20" rx="5" fill="#4169e1" opacity="0.85"/>
+    <rect x="40" y="119.35" width="14" height="36" rx="5" fill="#1e90ff" opacity="0.85"/>
+    <rect x="64" y="112.96" width="14" height="48" rx="5" fill="#00ffff" opacity="0.85"/>
+    <rect x="88" y="120.64" width="14" height="60" rx="5" fill="#00fa9a" opacity="0.85"/>
+    <rect x="112" y="127.03" width="14" height="68" rx="5" fill="#adff2f" opacity="0.85"/>
+    <rect x="136" y="120.64" width="14" height="60" rx="5" fill="#ffd700" opacity="0.85"/>
+    <rect x="160" y="112.96" width="14" height="48" rx="5" fill="#ff8c00" opacity="0.85"/>
+    <rect x="184" y="119.35" width="14" height="36" rx="5" fill="#ff2a40" opacity="0.85"/>
+    <rect x="208" y="125.8" width="14" height="20" rx="5" fill="#8a2be2" opacity="0.85"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Both `website/public/favicon.svg` and `assets/readme/icon.svg` carried a legacy bell-curve design with a flat bottom row.
- Live site header (`website/src/components/Nav.astro:11-38`) renders a mirrored heart-waveform with glow.
- Replaces both SVGs with the Nav version verbatim so browser tab, Organization schema logo, BlogPost publisher logo, and README icon all match what users see in the header.
- No code or behavior change. Pure asset swap.

## Why this matters

`favicon.svg` is wired into production three ways: `BaseLayout.astro:59` (browser tab), `index.astro:25` (Google Organization schema logo), `BlogPost.astro:73` (schema publisher logo). Until now, Google was reading a different mark than what users saw on the site.

## Test plan

- [x] Diff reviewed locally against `main` via `codex review --base main` — clean, no actionable findings.
- [x] SVG opens correctly in Preview and renders the heart-waveform matching Nav.
- [ ] CI `build-check` green.
- [ ] Post-merge: spot-check browser tab favicon on enviouswispr.com after Cloudflare Pages rebuild.

## Scope

council-skip: zero-blast-radius (user-facing asset in `website/public/` and `assets/readme/`, 2 files, asset-only, same design already live in `Nav.astro`)
