### PR TITLE
seo(compare): rewrite /compare/ index for category query

### DIFF
--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -41,22 +41,38 @@ const legacyDev = [
   { name: "Apple Dictation", slug: "apple-dictation", angle: "Built-in macOS dictation vs dedicated dictation app" },
   { name: "whisper.cpp", slug: "whisper-cpp", angle: "Developer CLI vs ready-to-use Mac dictation app" },
 ];
+
+const allComparisons = [...cloudTools, ...onDeviceApps, ...legacyDev];
+const itemListJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Free dictation software for Mac: 11 apps compared",
+  "description": "Side-by-side comparisons of EnviousWispr against the major Mac dictation apps.",
+  "itemListElement": allComparisons.map((tool, idx) => ({
+    "@type": "ListItem",
+    "position": idx + 1,
+    "url": `${siteUrl}/compare/${tool.slug}/`,
+    "name": `EnviousWispr vs ${tool.name}`,
+  })),
+});
 ---
 
 <BaseLayout
-  title="EnviousWispr Comparisons: Free Mac Dictation vs Alternatives"
-  description="See how EnviousWispr compares to WisprFlow, Dragon, Apple Dictation, Otter.ai, and more. Free on-device Mac dictation."
+  title="Free Dictation Software for Mac: 11 Apps Compared"
+  description="Honest side-by-side comparisons of free Mac dictation apps. EnviousWispr vs WisprFlow, Superwhisper, MacWhisper, Apple Dictation, Dragon, Otter.ai, and more."
   activePage="compare"
   canonicalPath="/compare/"
 >
   <Fragment slot="head">
     <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+    <script type="application/ld+json" set:html={itemListJsonLd}></script>
   </Fragment>
 
 <style>
 .compare-hero { padding: 100px 0 48px; text-align: center; }
 .compare-hero h1 { font-size: 48px; font-weight: 800; letter-spacing: -2.5px; line-height: 1.1; color: var(--text); margin-bottom: 14px; }
 .compare-hero p { font-size: 18px; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.compare-hero .compare-intro { font-size: 16px; max-width: 720px; margin-top: 24px; text-align: left; }
 
 .compare-group { margin-bottom: 48px; }
 .compare-group-label {
@@ -97,8 +113,9 @@ const legacyDev = [
 
 <div class="compare-hero">
   <div class="container">
-    <h1>How EnviousWispr compares</h1>
-    <p>Honest, side-by-side comparisons with every major dictation tool.</p>
+    <h1>Free dictation software for Mac, compared</h1>
+    <p>Honest, side-by-side breakdowns of EnviousWispr against the 11 major Mac dictation apps people actually use.</p>
+    <p class="compare-intro">Mac dictation tools split into three groups: cloud-based services that send your audio to a server (WisprFlow, Otter.ai, Notta, Google Docs Voice Typing), on-device apps that keep audio local (Superwhisper, MacWhisper, VoiceInk, Willow Voice), and legacy or developer-focused tools (Dragon, Apple Dictation, whisper.cpp). Pricing ranges from free to $144 a year. Each comparison below covers price, accuracy, latency, privacy architecture, and the specific use case the tool fits best, so you can pick the right one without trying all 11.</p>
   </div>
 </div>
 


### PR DESCRIPTION
Refs audit #373, finding #378.

## What changed

`/compare/` index page rewrite:

- **Title:** generic → keyword-targeted ("Free Dictation Software for Mac: 11 Apps Compared")
- **Meta description:** includes the category query + names major competitors
- **H1:** "How EnviousWispr compares" → "Free dictation software for Mac, compared"
- **Intro paragraph (~100 words):** new, explains the cloud/on-device/legacy split, pricing range, and what each comparison covers. Gives Google semantic context; gives users orientation.
- **ItemList JSON-LD:** new, enumerates all 11 sub-comparisons with URLs. Helps Google parse this as a structured list page.

Pure copy + schema. No layout, component, or routing changes.

## Why

Search Console (90d) shows `/compare/` ranks position 88 for "free dictation software for Mac" — a category-defining query we should own. Page-1 viability requires keyword in H1/title + content depth + structured data.

## Test plan

- [ ] CI build-check passes
- [ ] After deploy, verify SERP snippet at `https://enviouswispr.com/compare/` updates within 1-2 weeks
- [ ] Re-pull Search Console at next monthly audit to track position change

council-skip: zero-blast-radius (user-facing copy + schema, no Sources/ or Tests/)
