### PR TITLE
test(services): PasteService clipboard helpers (partial target 2, epic #385)

### DIFF
--- a/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@MainActor
+@Suite("PasteService clipboard helpers", .serialized)
+struct PasteServiceClipboardTests {
+
+  @Test("copyToClipboardReturningChangeCount writes string and returns the new changeCount")
+  func copyToClipboardReturningChangeCountWritesString() {
+    let original = PasteService.saveClipboard()
+    defer { Self.restoreExactly(original) }
+
+    let text = "dictation-\(UUID().uuidString)"
+    let returnedChangeCount = PasteService.copyToClipboardReturningChangeCount(text)
+
+    #expect(NSPasteboard.general.string(forType: .string) == text)
+    #expect(NSPasteboard.general.changeCount == returnedChangeCount)
+  }
+
+  @Test("restoreClipboard restores a saved snapshot when changeCount still matches our paste write")
+  func restoreClipboardRestoresSavedSnapshot() {
+    let initial = PasteService.saveClipboard()
+    defer { Self.restoreExactly(initial) }
+
+    let originalText = "before-\(UUID().uuidString)"
+    Self.setClipboardString(originalText)
+    let snapshot = PasteService.saveClipboard()
+
+    let pastedText = "after-\(UUID().uuidString)"
+    let changeCountAfterPaste = PasteService.copyToClipboardReturningChangeCount(pastedText)
+    #expect(NSPasteboard.general.string(forType: .string) == pastedText)
+
+    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
+
+    #expect(NSPasteboard.general.string(forType: .string) == originalText)
+  }
+
+  @Test("restoreClipboard skips restore when clipboard changed after our paste write")
+  func restoreClipboardSkipsWhenClipboardAdvanced() {
+    let initial = PasteService.saveClipboard()
+    defer { Self.restoreExactly(initial) }
+
+    let originalText = "before-\(UUID().uuidString)"
+    Self.setClipboardString(originalText)
+    let snapshot = PasteService.saveClipboard()
+
+    let pastedText = "after-\(UUID().uuidString)"
+    let changeCountAfterPaste = PasteService.copyToClipboardReturningChangeCount(pastedText)
+    #expect(NSPasteboard.general.string(forType: .string) == pastedText)
+
+    let userClipboardText = "user-followup-\(UUID().uuidString)"
+    Self.setClipboardString(userClipboardText)
+
+    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCountAfterPaste)
+
+    #expect(NSPasteboard.general.string(forType: .string) == userClipboardText)
+  }
+
+  private static func setClipboardString(_ text: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+  }
+
+  private static func restoreExactly(_ snapshot: ClipboardSnapshot) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+
+    guard !snapshot.items.isEmpty else { return }
+
+    let items = snapshot.items.map { itemDict in
+      let item = NSPasteboardItem()
+      for (type, data) in itemDict {
+        item.setData(data, forType: type)
+      }
+      return item
+    }
+    pasteboard.writeObjects(items)
+  }
+}


### PR DESCRIPTION
## Summary
Partial closure of epic #385 Target 2. Codex truth-audit (`.codex/truth-audit-test-template.md`) classified cascade-level scenarios as NOT_TESTABLE_WITHOUT_REFACTOR or NOT_IMPLEMENTED. Honest LOW-risk coverage: 3 tests on `PasteService` clipboard helpers.

## What ships
- `copyToClipboardReturningChangeCount` writes to NSPasteboard and returns the resulting changeCount
- `restoreClipboard` restores a saved snapshot when changeCount still matches the paste write
- `restoreClipboard` SKIPS restore when the clipboard changed after the paste write (anti-clobber guard)

All 3 tests exercise real `PasteService` calls against real `NSPasteboard`. Zero mocks.

## What does NOT ship (with rationale)
| Scenario | Classification | Why |
|---|---|---|
| a. AX direct path succeeds → cascade stops | NOT_TESTABLE_WITHOUT_REFACTOR | `PasteCascadeExecutor` hard-calls AX/AppKit statics, no injection seam |
| b. AX fails → CGEvent succeeds → clipboard not reached | NOT_TESTABLE_WITHOUT_REFACTOR | Same reason |
| c. AX fails → CGEvent fails → AppleScript invoked | NOT_IMPLEMENTED | Production does not route CGEvent failure to AppleScript; AppleScript only fires on activation timeout |
| e. Clipboard save/restore around failed paste | PARTIALLY_OBSERVABLE | Restore helper tested here; executor orchestration not injectable |
| f. Delayed-restore timing race | PARTIALLY_OBSERVABLE | changeCount anti-clobber guard tested here; executor scheduling not injectable |

Filed as #396: "PasteCascadeExecutor needs DI seams for honest cascade-level testing."

## Why the honest split
Writer-mode Codex in the first pass (discarded) would have written fake cascade tests. Truth-audit mode refused and produced a DO_NOT_MERGE verdict for cascade claims + LOW-risk clipboard helpers worth merging on their own. Per feedback_codex_truth_audit_first: "which tests are lying by implication?" is the gate before push.

## Test plan
- [x] `scripts/swift-test.sh --filter PasteServiceClipboardTests` → 3/3 pass
- [x] Full `scripts/swift-test.sh` → 349/349 pass locally (after rebase onto main with PR #391 + #395)
- [x] No production code changed

council-skip: not-ship-path (tests only)
