### PR TITLE
test(asr): ASRManager cold-state contract tests (target 3, epic #385)

### DIFF
--- a/Tests/EnviousWisprASRTests/ASRManagerColdStateContractTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerColdStateContractTests.swift
@@ -1,0 +1,141 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprASR
+
+@Suite("ASRManager cold-state contract")
+@MainActor
+struct ASRManagerColdStateContractTests {
+
+  @Test("default manager starts on Parakeet, unloaded, not streaming")
+  func defaultState() async {
+    let sut = ASRManager()
+
+    #expect(sut.activeBackendType == .parakeet)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+    #expect(await sut.activeBackendSupportsStreaming == true)
+  }
+
+  @Test(
+    "setInitialBackendType on a cold manager selects WhisperKit and reports no streaming support")
+  func setInitialBackendTypeSelectsWhisperKitFromCold() async {
+    // Adversarial-review note. Starting from cold means `isModelLoaded` and
+    // `isStreaming` are already false, so this test does not prove the reset
+    // branch inside `setInitialBackendType`. It only proves backend selection
+    // and capability bit on a fresh manager. Proving the reset branch requires
+    // a seam to put flags into a non-default state first (see #398 for the
+    // proposed refactor).
+    let sut = ASRManager()
+
+    sut.setInitialBackendType(.whisperKit)
+
+    #expect(sut.activeBackendType == .whisperKit)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+    #expect(await sut.activeBackendSupportsStreaming == false)
+  }
+
+  @Test("sequential switchBackend calls leave the last requested backend active")
+  func sequentialSwitchesTrackLastRequest() async {
+    let sut = ASRManager()
+
+    await sut.switchBackend(to: .whisperKit)
+    #expect(sut.activeBackendType == .whisperKit)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+
+    await sut.switchBackend(to: .parakeet)
+    #expect(sut.activeBackendType == .parakeet)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+
+    await sut.switchBackend(to: .whisperKit)
+    #expect(sut.activeBackendType == .whisperKit)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+  }
+
+  @Test("transcribe before load throws notReady and preserves manager flags")
+  func transcribeBeforeLoadThrowsNotReady() async {
+    let sut = ASRManager()
+
+    do {
+      _ = try await sut.transcribe(audioSamples: [], options: .default)
+      Issue.record("expected ASRError.notReady, got success")
+    } catch let error as ASRError {
+      switch error {
+      case .notReady:
+        break
+      default:
+        Issue.record("expected ASRError.notReady, got \(error)")
+      }
+    } catch {
+      Issue.record("expected ASRError.notReady, got \(error)")
+    }
+
+    #expect(sut.activeBackendType == .parakeet)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+  }
+
+  @Test("startStreaming before prepare on Parakeet throws notReady and leaves isStreaming false")
+  func startStreamingBeforePrepareOnParakeet() async {
+    let sut = ASRManager()
+
+    do {
+      try await sut.startStreaming(options: .default)
+      Issue.record("expected ASRError.notReady, got success")
+    } catch let error as ASRError {
+      switch error {
+      case .notReady:
+        break
+      default:
+        Issue.record("expected ASRError.notReady, got \(error)")
+      }
+    } catch {
+      Issue.record("expected ASRError.notReady, got \(error)")
+    }
+
+    #expect(sut.activeBackendType == .parakeet)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+  }
+
+  @Test("startStreaming on WhisperKit is a no-op because streaming is unsupported")
+  func startStreamingOnWhisperKitDoesNothing() async throws {
+    let sut = ASRManager()
+    sut.setInitialBackendType(.whisperKit)
+
+    try await sut.startStreaming(options: .default)
+
+    #expect(sut.activeBackendType == .whisperKit)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+    #expect(await sut.activeBackendSupportsStreaming == false)
+  }
+
+  @Test(
+    "finalizeStreaming without an active stream throws streamingNotSupported and preserves flags")
+  func finalizeWithoutActiveStreamThrows() async {
+    let sut = ASRManager()
+
+    do {
+      _ = try await sut.finalizeStreaming()
+      Issue.record("expected ASRError.streamingNotSupported, got success")
+    } catch let error as ASRError {
+      switch error {
+      case .streamingNotSupported:
+        break
+      default:
+        Issue.record("expected ASRError.streamingNotSupported, got \(error)")
+      }
+    } catch {
+      Issue.record("expected ASRError.streamingNotSupported, got \(error)")
+    }
+
+    #expect(sut.activeBackendType == .parakeet)
+    #expect(sut.isModelLoaded == false)
+    #expect(sut.isStreaming == false)
+  }
+}


### PR DESCRIPTION
## Summary
Target 3 of epic #385 autopilot. First test PR through the new 3-layer quality gate (writer Codex + adversarial Codex + Claude grep-verify). 7 substantive tests; one original test name was flagged SUBTLE_THEATER by adversarial pass and renamed.

## Audit readout (plain English)

| Test (renamed where needed) | What it proves | What production does | Match? |
|---|---|---|---|
| default manager starts on Parakeet, unloaded, not streaming | Fresh manager picks Parakeet, no model, no stream, streaming supported | ASRManager.swift:9 init defaults + ParakeetBackend.swift:24 supportsStreaming=true | Yes |
| setInitialBackendType on a cold manager selects WhisperKit and reports no streaming support | From cold, selecting WhisperKit → that backend + no streaming capability | ASRManager.swift:45 assigns backend + ASRProtocol.swift:42 default false, WhisperKit no override | Yes (narrow — does NOT prove the reset branch, see #398) |
| sequential switchBackend calls leave the last requested backend active | Each switch updates active backend and clears flags | ASRManager.swift:52 switchBackend body | Yes |
| transcribe before load throws notReady and preserves manager flags | Calling transcribe cold throws .notReady, state unchanged | ASRManager.swift:120 delegates to ParakeetBackend.swift:93 which guards on !isReady | Yes |
| startStreaming before prepare on Parakeet throws notReady and leaves isStreaming false | Cold startStreaming throws; flag stays false because assignment happens after success | ASRManager.swift:130-138 sets isStreaming only after backend returns | Yes |
| startStreaming on WhisperKit is a no-op | WhisperKit doesn't support streaming; call returns without flipping state | ASRManager.swift:131 early-returns when supportsStreaming is false | Yes |
| finalizeStreaming without an active stream throws streamingNotSupported | Finalizing cold throws, flags preserved | ASRManager.swift:148-151 guards on isStreaming | Yes |

## Adversarial-pass findings applied

- **Renamed**: "setInitialBackendType selects WhisperKit and resets flags" → "setInitialBackendType on a cold manager selects WhisperKit and reports no streaming support". The original name claimed the reset branch was proven, but from cold both flags are already false so a broken impl could still pass. Test is now honestly named; #398 tracks the seam needed to actually cover the reset branch.
- **Filed #399**: production doc-comment on `ASRManager.finalizeStreaming` says "falls back to batch" but code throws. Not fixed here (autopilot: tests only).

## What does NOT ship

- Backend switching while backend is actively preparing/transcribing — NOT_TESTABLE_WITHOUT_REFACTOR (#398)
- Pre-warm retry paths — NOT_IMPLEMENTED in production
- In-flight transcription error recovery — needs backend DI (#398)

## Test plan

- [x] Writer Codex truth-audit verdict: DO NOT MERGE broad scope, but 7 LOW-risk tests worth shipping standalone
- [x] Adversarial Codex verdict: MERGE AFTER FIXES (one rename + one production-doc issue to file) — both applied/filed
- [x] Claude grep-verified every assertion against production FILE:LINE
- [x] `scripts/swift-test.sh --filter ASRManagerColdStateContract` → 7/7 pass
- [x] Full `scripts/swift-test.sh` → 355/355 pass (was 348; +7)
- [x] No production code changed

council-skip: not-ship-path (tests only)
