### PR TITLE
test(pipeline): TextProcessingRunner race tests (target 5, epic #385)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingChainRacesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingChainRacesTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@MainActor
+@Suite("TextProcessingRunner Races")
+struct TextProcessingChainRacesTests {
+
+  @Test(
+    "cancelling the outer task while a step is suspended rethrows CancellationError and stops the chain"
+  )
+  func cancellationMidStepRethrowsAndStopsLaterSteps() async {
+    let runner = TextProcessingRunner()
+    let started = AsyncStream.makeStream(of: Void.self)
+
+    let suspending = GateStep(
+      name: "Filler Removal",
+      maxDuration: .seconds(120)
+    ) { context, _ in
+      started.continuation.yield(())
+      started.continuation.finish()
+
+      // Honest coverage: this is cooperative cancellation through a real
+      // suspension point, not a fake step that throws CancellationError
+      // immediately.
+      try await Task.sleep(for: .seconds(60))
+      return context
+    }
+
+    let after = GateStep(name: "After") { context, _ in
+      var next = context
+      next.text += "-after"
+      return next
+    }
+
+    let task = Task { @MainActor in
+      try await runner.run(
+        rawText: "start",
+        language: "en",
+        targetAppName: nil,
+        steps: [suspending, after]
+      )
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()
+    task.cancel()
+
+    let outcome = await task.result
+    switch outcome {
+    case .success:
+      Issue.record("expected CancellationError, got success")
+    case .failure(let error):
+      #expect(error is CancellationError, "expected CancellationError, got \(error)")
+    }
+
+    #expect(suspending.runCount == 1)
+    #expect(after.runCount == 0)
+  }
+
+  @Test(
+    "TextProcessingRunner is per-call stateless: two overlapping run() invocations each execute the chain through to completion"
+  )
+  func overlappingRunsEachExecuteChainToCompletion() async throws {
+    // Adversarial-review note. This proves the runner has no shared
+    // per-call state and cannot merge overlapping invocations — NOT that
+    // there is an explicit anti-coalescing guarantee anywhere else in the
+    // product. The claim here is only about the runner's statelessness
+    // (see TextProcessingRunner.swift:15 "does not own step instances").
+    let runner = TextProcessingRunner()
+    let entered = AsyncStream.makeStream(of: Int.self)
+
+    let blocking = GateStep(
+      name: "Word Correction",
+      maxDuration: .seconds(120)
+    ) { context, invocation in
+      entered.continuation.yield(invocation)
+      if invocation == 2 {
+        entered.continuation.finish()
+      }
+
+      // Keep the first run suspended long enough for the second run to enter.
+      try await Task.sleep(for: .milliseconds(200))
+
+      var next = context
+      next.text += "-\(invocation)"
+      return next
+    }
+
+    let firstTask = Task { @MainActor in
+      try await runner.run(
+        rawText: "start",
+        language: "en",
+        targetAppName: nil,
+        steps: [blocking]
+      )
+    }
+
+    var iterator = entered.stream.makeAsyncIterator()
+    _ = await iterator.next()
+
+    let secondTask = Task { @MainActor in
+      try await runner.run(
+        rawText: "start",
+        language: "en",
+        targetAppName: nil,
+        steps: [blocking]
+      )
+    }
+
+    _ = await iterator.next()
+
+    let first = try await firstTask.value
+    let second = try await secondTask.value
+
+    #expect(blocking.runCount == 2)
+    #expect(blocking.seenInputs.count == 2)
+    #expect(blocking.seenInputs[0].text == "start")
+    #expect(blocking.seenInputs[1].text == "start")
+
+    let outputs = Set([first.context.text, second.context.text])
+    #expect(outputs == Set(["start-1", "start-2"]))
+
+    #expect(first.polishError == nil)
+    #expect(second.polishError == nil)
+  }
+}
+
+@MainActor
+private final class GateStep: TextProcessingStep {
+  let name: String
+  let isEnabled: Bool
+  let maxDuration: Duration
+
+  private let transform:
+    @MainActor (TextProcessingContext, Int) async throws -> TextProcessingContext
+
+  private(set) var runCount = 0
+  private(set) var seenInputs: [TextProcessingContext] = []
+
+  init(
+    name: String,
+    isEnabled: Bool = true,
+    maxDuration: Duration = .seconds(5),
+    transform: @escaping @MainActor (TextProcessingContext, Int) async throws ->
+      TextProcessingContext
+  ) {
+    self.name = name
+    self.isEnabled = isEnabled
+    self.maxDuration = maxDuration
+    self.transform = transform
+  }
+
+  func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+    runCount += 1
+    let invocation = runCount
+    seenInputs.append(context)
+    return try await transform(context, invocation)
+  }
+}


### PR DESCRIPTION
## Summary
Target 5 of epic #385 autopilot. Writer + adversarial Codex passes ran. Adversarial caught one test name overclaiming ("not coalesced" was broader than what the stateless runner actually proves); renamed.

## Audit readout (plain English)

| Test (renamed where needed) | What it proves | What production does | Match? |
|---|---|---|---|
| cancelling the outer task while a step is suspended rethrows CancellationError and stops the chain | Outer task.cancel() while step is suspended → runner throws CancellationError, later step never runs | TextProcessingRunner.swift:50 uses withThrowingTimeout; :78 catches CancellationError and rethrows; :39 loop unwinds on throw so later steps skip | Yes (HONEST per adversarial) |
| TextProcessingRunner is per-call stateless: two overlapping run() invocations each execute the chain through to completion | Runner has no shared per-call state; two overlapping .run() calls each run the chain | TextProcessingRunner.swift:28 creates fresh context per call; :15 states runner does not own step instances | Yes (adversarial renamed from "not coalesced" → proves narrower statelessness only) |

## Adversarial-pass findings applied
- **Renamed**: original "concurrent runs with identical input are not coalesced and each executes the chain" → "TextProcessingRunner is per-call stateless: two overlapping run() invocations each execute the chain through to completion". The original name implied an anti-coalescing guarantee. The stateless runner can't coalesce because it has no state, but that's not the same as a product-wide anti-coalescing contract. Test now names what it actually proves.

## What this PR does NOT cover (honestly)
- Step timeout during polish: already covered in existing `TextProcessingRunnerTests.recordsPolishErrorWhenLLMPolishTimesOut` — adversarial said don't duplicate
- Non-cooperative CPU-bound cancellation: NOT_TESTABLE with cooperative Task.cancel alone
- Step-level thread-safety: steps are caller-owned; out of scope

## Test plan
- [x] Writer Codex verdict: MERGE AFTER RENAMES (scenario a "timeout" already covered; 2 new LOW-risk tests for b, c)
- [x] Adversarial Codex verdict: MERGE AFTER FIXES (one rename + applied)
- [x] Claude grep-verified both assertions against production FILE:LINE
- [x] `scripts/swift-test.sh --filter TextProcessingChainRacesTests` → 2/2 pass
- [x] Full `scripts/swift-test.sh` → 352/352 pass (was 350; +2)
- [x] No production code changed

council-skip: not-ship-path (tests only)
