### PR TITLE
refactor(#196): Phase A — extract PipelineStateChangeHandler from AppState

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -340,11 +340,15 @@ final class AppState {
       self.settingsSync.handleSettingChanged(key, settings: self.settings)
     }
 
-    // Wire pipeline state changes to overlay and icon
+    // Wire pipeline state changes to overlay and icon.
+    // The behavioral contract (overlay resolution, warning scheduling /
+    // cancellation, telemetry, history reload) is derived by
+    // PipelineStateChangePlanner. The closure still owns AppState-local
+    // concerns: external observer fan-out, hotkey register/unregister,
+    // isRecordingLocked reset, and the inactive→active tiebreaker (#285).
     pipeline.onStateChange = { [weak self] newState in
       guard let self else { return }
       self.onPipelineStateChange?(newState)
-      // Hotkey management
       switch newState {
       case .recording:
         self.hotkeyService.registerCancelHotkey()
@@ -352,64 +356,26 @@ final class AppState {
         self.isRecordingLocked = false
         self.hotkeyService.unregisterCancelHotkey()
       }
-      // #285 — flip the telemetry tiebreaker ONLY on inactive→active
-      // transitions, so an active→active state change (e.g.
-      // `.transcribing → .polishing`) on this pipeline cannot steal ownership
-      // back from a different backend that already acquired the shared
-      // capture during the overlap window.
       let nowActive = newState.isActive
       if nowActive && !self.prevParakeetActive {
         self.lastCapturingBackend = .parakeet
       }
       self.prevParakeetActive = nowActive
-      // Intent-driven overlay — pipeline.overlayIntent maps state to the correct label.
-      // On completion, compute a single post-completion notification by priority:
-      //   1. clipboardFallback (paste fell back to clipboard-only)
-      //   2. warning (polish failed but text was delivered)
-      //   3. hidden (success, no notification needed)
-      let overlayIntent: OverlayIntent
-      if newState == .complete {
-        let isClipboardFallback =
-          self.pipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
-        let polishFailed = self.pipeline.lastPolishError != nil
-        if isClipboardFallback {
-          overlayIntent = .clipboardFallback
-        } else if polishFailed {
-          // Show polish warning after a brief delay so the completion
-          // transition feels natural. Cancellable if a new recording starts.
-          overlayIntent = self.pipeline.overlayIntent
-          self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-        } else {
-          overlayIntent = self.pipeline.overlayIntent
-        }
-      } else {
-        self.postCompletionWarningTask?.cancel()
-        overlayIntent = self.pipeline.overlayIntent
-      }
-      self.recordingOverlay.show(
-        intent: overlayIntent,
-        audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-        isRecordingLocked: self.isRecordingLocked
+      let plan = PipelineStateChangePlanner.plan(
+        to: newState,
+        pipelineOverlayIntent: self.pipeline.overlayIntent,
+        isClipboardFallback: self.pipeline.currentTranscript?.metrics?.pasteTier
+          == "clipboard_only",
+        lastPolishError: self.pipeline.lastPolishError,
+        hasCurrentTranscript: self.pipeline.currentTranscript != nil
       )
-      if newState == .complete {
-        self.transcriptCoordinator.load()
-        if let t = self.pipeline.currentTranscript {
-          TelemetryService.shared.reportDictationCompleted(
-            transcript: t, inputMode: self.settings.recordingMode.rawValue)
-        }
-      }
-      if case .error(let msg) = newState {
-        TelemetryService.shared.pipelineFailed(
-          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: "parakeet")
-      }
+      self.executePlan(plan, transcript: self.pipeline.currentTranscript, backend: "parakeet")
     }
 
-    // Wire WhisperKit pipeline state changes to overlay and icon
+    // Wire WhisperKit pipeline state changes to overlay and icon.
     whisperKitPipeline.onStateChange = { [weak self] newState in
       guard let self else { return }
       self.onPipelineStateChange?(self.pipelineState)
-      // Hotkey management
       switch newState {
       case .recording:
         self.hotkeyService.registerCancelHotkey()
@@ -417,49 +383,21 @@ final class AppState {
         self.isRecordingLocked = false
         self.hotkeyService.unregisterCancelHotkey()
       }
-      // #285 — flip tiebreaker ONLY on inactive→active transitions so
-      // active→active state changes cannot steal capture ownership from the
-      // other backend.
       let nowActive = newState.isActive
       if nowActive && !self.prevWhisperKitActive {
         self.lastCapturingBackend = .whisperKit
       }
       self.prevWhisperKitActive = nowActive
-      // Intent-driven overlay — same post-completion priority logic as Parakeet above.
-      let wkOverlayIntent: OverlayIntent
-      if newState == .complete {
-        let isClipboardFallback =
-          self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier == "clipboard_only"
-        let polishFailed = self.whisperKitPipeline.lastPolishError != nil
-        if isClipboardFallback {
-          wkOverlayIntent = .clipboardFallback
-        } else if polishFailed {
-          wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-          self.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-        } else {
-          wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-        }
-      } else {
-        self.postCompletionWarningTask?.cancel()
-        wkOverlayIntent = self.whisperKitPipeline.overlayIntent
-      }
-      self.recordingOverlay.show(
-        intent: wkOverlayIntent,
-        audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-        isRecordingLocked: self.isRecordingLocked
+      let plan = PipelineStateChangePlanner.plan(
+        to: newState,
+        pipelineOverlayIntent: self.whisperKitPipeline.overlayIntent,
+        isClipboardFallback: self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier
+          == "clipboard_only",
+        lastPolishError: self.whisperKitPipeline.lastPolishError,
+        hasCurrentTranscript: self.whisperKitPipeline.currentTranscript != nil
       )
-      if newState == .complete {
-        self.transcriptCoordinator.load()
-        if let t = self.whisperKitPipeline.currentTranscript {
-          TelemetryService.shared.reportDictationCompleted(
-            transcript: t, inputMode: self.settings.recordingMode.rawValue)
-        }
-      }
-      if case .error(let msg) = newState {
-        TelemetryService.shared.pipelineFailed(
-          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: "whisperKit")
-      }
+      self.executePlan(
+        plan, transcript: self.whisperKitPipeline.currentTranscript, backend: "whisperKit")
     }
 
     // Wire hotkey callbacks
@@ -754,6 +692,40 @@ final class AppState {
     case nil:
       // Idle → attribute to the backend that most recently owned a session.
       return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
+    }
+  }
+
+  /// Execute a state-change plan derived by PipelineStateChangePlanner.
+  /// Owns the concrete side effects (overlay panel, warning Task, telemetry
+  /// service, transcript coordinator). Inlined into AppState for commit 1;
+  /// commit 2 absorbs this into the extracted PipelineStateChangeHandler.
+  private func executePlan(
+    _ plan: PipelineStateChangePlan, transcript: Transcript?, backend: String
+  ) {
+    for effect in plan.effects {
+      switch effect {
+      case .cancelPendingWarning:
+        postCompletionWarningTask?.cancel()
+      case .schedulePolishFailedWarning:
+        schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+      case .showOverlay(let intent):
+        recordingOverlay.show(
+          intent: intent,
+          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+          isRecordingLocked: isRecordingLocked
+        )
+      case .reloadTranscriptHistory:
+        transcriptCoordinator.load()
+      case .reportDictationCompleted:
+        if let t = transcript {
+          TelemetryService.shared.reportDictationCompleted(
+            transcript: t, inputMode: settings.recordingMode.rawValue)
+        }
+      case .reportPipelineFailed(let msg):
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backend)
+      }
     }
   }
 

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -39,6 +39,49 @@ final class AppState {
   let pipeline: TranscriptionPipeline
   let whisperKitPipeline: WhisperKitPipeline
 
+  // Phase A (#196) — per-pipeline state-change behavior absorbed from the
+  // onStateChange closures. Each handler owns the effect execution; AppState
+  // still owns the cross-pipeline warning Task + tiebreaker + hotkey ordering.
+  // Lazy so the callback closures can capture `self` after stored-property
+  // assignment completes. First access is inside `onStateChange`, well after
+  // `init()` returns.
+  @ObservationIgnored
+  private lazy var parakeetStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "parakeet")
+  }()
+  @ObservationIgnored
+  private lazy var whisperKitStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "whisperKit")
+  }()
+
+  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { [weak self] intent in
+        guard let self else { return }
+        self.recordingOverlay.show(
+          intent: intent,
+          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+          isRecordingLocked: self.isRecordingLocked
+        )
+      },
+      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+      schedulePolishFailedWarning: { [weak self] in
+        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+      },
+      reloadTranscriptHistory: { [weak self] in self?.transcriptCoordinator.load() },
+      reportDictationCompleted: { [weak self] t in
+        guard let self else { return }
+        TelemetryService.shared.reportDictationCompleted(
+          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+      },
+      reportPipelineFailed: { msg in
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backendLabel)
+      }
+    )
+  }
+
   /// Standalone service for re-polishing saved transcripts from the detail view.
   /// Completely decoupled from pipeline state machines.
   let polishService: TranscriptPolishService
@@ -342,8 +385,8 @@ final class AppState {
 
     // Wire pipeline state changes to overlay and icon.
     // The behavioral contract (overlay resolution, warning scheduling /
-    // cancellation, telemetry, history reload) is derived by
-    // PipelineStateChangePlanner. The closure still owns AppState-local
+    // cancellation, telemetry, history reload) is owned by the per-pipeline
+    // PipelineStateChangeHandler. The closure still owns AppState-local
     // concerns: external observer fan-out, hotkey register/unregister,
     // isRecordingLocked reset, and the inactive→active tiebreaker (#285).
     pipeline.onStateChange = { [weak self] newState in
@@ -361,15 +404,12 @@ final class AppState {
         self.lastCapturingBackend = .parakeet
       }
       self.prevParakeetActive = nowActive
-      let plan = PipelineStateChangePlanner.plan(
+      self.parakeetStateHandler.handle(
         to: newState,
         pipelineOverlayIntent: self.pipeline.overlayIntent,
-        isClipboardFallback: self.pipeline.currentTranscript?.metrics?.pasteTier
-          == "clipboard_only",
         lastPolishError: self.pipeline.lastPolishError,
-        hasCurrentTranscript: self.pipeline.currentTranscript != nil
+        currentTranscript: self.pipeline.currentTranscript
       )
-      self.executePlan(plan, transcript: self.pipeline.currentTranscript, backend: "parakeet")
     }
 
     // Wire WhisperKit pipeline state changes to overlay and icon.
@@ -388,16 +428,12 @@ final class AppState {
         self.lastCapturingBackend = .whisperKit
       }
       self.prevWhisperKitActive = nowActive
-      let plan = PipelineStateChangePlanner.plan(
+      self.whisperKitStateHandler.handle(
         to: newState,
         pipelineOverlayIntent: self.whisperKitPipeline.overlayIntent,
-        isClipboardFallback: self.whisperKitPipeline.currentTranscript?.metrics?.pasteTier
-          == "clipboard_only",
         lastPolishError: self.whisperKitPipeline.lastPolishError,
-        hasCurrentTranscript: self.whisperKitPipeline.currentTranscript != nil
+        currentTranscript: self.whisperKitPipeline.currentTranscript
       )
-      self.executePlan(
-        plan, transcript: self.whisperKitPipeline.currentTranscript, backend: "whisperKit")
     }
 
     // Wire hotkey callbacks
@@ -692,40 +728,6 @@ final class AppState {
     case nil:
       // Idle → attribute to the backend that most recently owned a session.
       return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
-    }
-  }
-
-  /// Execute a state-change plan derived by PipelineStateChangePlanner.
-  /// Owns the concrete side effects (overlay panel, warning Task, telemetry
-  /// service, transcript coordinator). Inlined into AppState for commit 1;
-  /// commit 2 absorbs this into the extracted PipelineStateChangeHandler.
-  private func executePlan(
-    _ plan: PipelineStateChangePlan, transcript: Transcript?, backend: String
-  ) {
-    for effect in plan.effects {
-      switch effect {
-      case .cancelPendingWarning:
-        postCompletionWarningTask?.cancel()
-      case .schedulePolishFailedWarning:
-        schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-      case .showOverlay(let intent):
-        recordingOverlay.show(
-          intent: intent,
-          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-          isRecordingLocked: isRecordingLocked
-        )
-      case .reloadTranscriptHistory:
-        transcriptCoordinator.load()
-      case .reportDictationCompleted:
-        if let t = transcript {
-          TelemetryService.shared.reportDictationCompleted(
-            transcript: t, inputMode: settings.recordingMode.rawValue)
-        }
-      case .reportPipelineFailed(let msg):
-        TelemetryService.shared.pipelineFailed(
-          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: backend)
-      }
     }
   }
 

--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -15,31 +15,13 @@ final class OverlayLockState {
   var isLocked: Bool = false
 }
 
-// MARK: - RecordingOverlayPanelProtocol
-
-/// Narrow seam covering only the single method state-change closures call.
-///
-/// `updateLockState`, `hide`, and the legacy `show(audioLevelProvider:)`
-/// overload are used by OTHER AppState paths, not by the state-change
-/// closures — do NOT widen this protocol; the bible (§7.3) explicitly scopes
-/// it to the intent-driven entry point. Tests inject a spy conforming to
-/// this to observe the resolved overlay intent.
-@MainActor
-protocol RecordingOverlayPanelProtocol: AnyObject {
-  func show(
-    intent: OverlayIntent,
-    audioLevelProvider: @escaping () -> Float,
-    isRecordingLocked: Bool
-  )
-}
-
 // MARK: - RecordingOverlayPanel
 
 /// Floating overlay panel that shows recording and polishing status.
 /// Uses NSPanel with .nonactivatingPanel behavior so it floats above all apps
 /// without stealing focus.
 @MainActor
-final class RecordingOverlayPanel: RecordingOverlayPanelProtocol {
+final class RecordingOverlayPanel {
   private var panel: NSPanel?
 
   /// Reactive lock state shared with RecordingOverlayView.

--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -15,13 +15,31 @@ final class OverlayLockState {
   var isLocked: Bool = false
 }
 
+// MARK: - RecordingOverlayPanelProtocol
+
+/// Narrow seam covering only the single method state-change closures call.
+///
+/// `updateLockState`, `hide`, and the legacy `show(audioLevelProvider:)`
+/// overload are used by OTHER AppState paths, not by the state-change
+/// closures — do NOT widen this protocol; the bible (§7.3) explicitly scopes
+/// it to the intent-driven entry point. Tests inject a spy conforming to
+/// this to observe the resolved overlay intent.
+@MainActor
+protocol RecordingOverlayPanelProtocol: AnyObject {
+  func show(
+    intent: OverlayIntent,
+    audioLevelProvider: @escaping () -> Float,
+    isRecordingLocked: Bool
+  )
+}
+
 // MARK: - RecordingOverlayPanel
 
 /// Floating overlay panel that shows recording and polishing status.
 /// Uses NSPanel with .nonactivatingPanel behavior so it floats above all apps
 /// without stealing focus.
 @MainActor
-final class RecordingOverlayPanel {
+final class RecordingOverlayPanel: RecordingOverlayPanelProtocol {
   private var panel: NSPanel?
 
   /// Reactive lock state shared with RecordingOverlayView.

--- a/Sources/EnviousWisprCore/PipelineStateProtocol.swift
+++ b/Sources/EnviousWisprCore/PipelineStateProtocol.swift
@@ -17,10 +17,13 @@ public enum PipelineActivity: Equatable, Sendable {
 
 /// Narrow protocol the planner / handler consume. Backends' concrete enums
 /// conform by extension; the planner never inspects their specific cases.
+///
+/// `isActive` is NOT part of this protocol: both backends' concrete state
+/// enums already expose their own `isActive` (used inline by AppState for
+/// the inactive->active tiebreaker), and the planner derives all its
+/// control-flow decisions from `activity` alone.
 public protocol PipelineStateProtocol: Equatable, Sendable {
   var activity: PipelineActivity { get }
-  var isActive: Bool { get }
-  var errorReason: String? { get }
 }
 
 // MARK: - Parakeet (PipelineState) conformance
@@ -35,10 +38,5 @@ extension PipelineState: PipelineStateProtocol {
     case .complete: return .complete
     case .error(let msg): return .error(msg)
     }
-  }
-
-  public var errorReason: String? {
-    if case .error(let msg) = self { return msg }
-    return nil
   }
 }

--- a/Sources/EnviousWisprCore/PipelineStateProtocol.swift
+++ b/Sources/EnviousWisprCore/PipelineStateProtocol.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Coarse-grained activity projection shared by every backend's state enum.
+///
+/// Used for CONTROL FLOW ONLY (is-active, warning gating, telemetry routing).
+/// User-visible labels come from each pipeline's own `overlayIntent`, not from
+/// this projection — collapsing "Starting..." and "Loading model..." into a
+/// shared `.preparing` bucket would silently flatten visible labels.
+public enum PipelineActivity: Equatable, Sendable {
+  case idle
+  case preparing
+  case recording
+  case processing
+  case complete
+  case error(String)
+}
+
+/// Narrow protocol the planner / handler consume. Backends' concrete enums
+/// conform by extension; the planner never inspects their specific cases.
+public protocol PipelineStateProtocol: Equatable, Sendable {
+  var activity: PipelineActivity { get }
+  var isActive: Bool { get }
+  var errorReason: String? { get }
+}
+
+// MARK: - Parakeet (PipelineState) conformance
+
+extension PipelineState: PipelineStateProtocol {
+  public var activity: PipelineActivity {
+    switch self {
+    case .idle: return .idle
+    case .loadingModel: return .preparing
+    case .recording: return .recording
+    case .transcribing, .polishing: return .processing
+    case .complete: return .complete
+    case .error(let msg): return .error(msg)
+    }
+  }
+
+  public var errorReason: String? {
+    if case .error(let msg) = self { return msg }
+    return nil
+  }
+}

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -1,0 +1,92 @@
+import EnviousWisprCore
+import Foundation
+
+/// Executes the side-effect plan produced by `PipelineStateChangePlanner`.
+///
+/// One instance per pipeline (Parakeet / WhisperKit). The handler holds no
+/// pipeline reference itself — the caller passes the pipeline-scoped inputs
+/// (`pipelineOverlayIntent`, `lastPolishError`, `currentTranscript`) for each
+/// transition. AppState remains the owner of cross-pipeline state (the
+/// `postCompletionWarningTask`, the tiebreaker, the hotkey register/unregister
+/// ordering), and the handler reaches back into those through narrow
+/// callbacks.
+///
+/// Why the warning task is NOT owned by the handler: the current production
+/// `schedulePostCompletionWarning` at `AppState.swift:732-744` treats
+/// `whisperKitPipeline.state == .ready` as completion-equivalent for the
+/// delayed guard. That check crosses pipeline boundaries (the warning can be
+/// scheduled from Parakeet's closure and still fire if WhisperKit is in
+/// `.ready` when the 400 ms sleep wakes). Moving the task into a per-pipeline
+/// handler would split that shared lifecycle across two owners — a behavior
+/// change, not a refactor. Preserved verbatim via the `cancelPendingWarning`
+/// and `schedulePolishFailedWarning` callbacks.
+@MainActor
+public final class PipelineStateChangeHandler {
+  /// Overlay show is now a closure rather than a protocol existential. The
+  /// caller wires this directly to the concrete `RecordingOverlayPanel.show(
+  /// intent:audioLevelProvider:isRecordingLocked:)` so dispatch is static,
+  /// matching commit-1's inline behavior exactly.
+  public typealias ShowOverlay = @MainActor (OverlayIntent) -> Void
+
+  private let showOverlay: ShowOverlay
+  private let cancelPendingWarning: @MainActor () -> Void
+  private let schedulePolishFailedWarning: @MainActor () -> Void
+  private let reloadTranscriptHistory: @MainActor () -> Void
+  private let reportDictationCompleted: @MainActor (Transcript) -> Void
+  private let reportPipelineFailed: @MainActor (String) -> Void
+
+  public init(
+    showOverlay: @escaping ShowOverlay,
+    cancelPendingWarning: @escaping @MainActor () -> Void,
+    schedulePolishFailedWarning: @escaping @MainActor () -> Void,
+    reloadTranscriptHistory: @escaping @MainActor () -> Void,
+    reportDictationCompleted: @escaping @MainActor (Transcript) -> Void,
+    reportPipelineFailed: @escaping @MainActor (String) -> Void
+  ) {
+    self.showOverlay = showOverlay
+    self.cancelPendingWarning = cancelPendingWarning
+    self.schedulePolishFailedWarning = schedulePolishFailedWarning
+    self.reloadTranscriptHistory = reloadTranscriptHistory
+    self.reportDictationCompleted = reportDictationCompleted
+    self.reportPipelineFailed = reportPipelineFailed
+  }
+
+  /// Drive the full state-change behavior contract for one pipeline.
+  ///
+  /// Step 1 — delegate plan derivation to the pure planner (tested
+  /// comprehensively in `PipelineStateChangePlannerTests`).
+  /// Step 2 — execute each side effect through the injected dependencies.
+  /// No decision logic beyond translating typed effects into calls.
+  public func handle(
+    to newState: any PipelineStateProtocol,
+    pipelineOverlayIntent: OverlayIntent,
+    lastPolishError: String?,
+    currentTranscript: Transcript?
+  ) {
+    let plan = PipelineStateChangePlanner.plan(
+      to: newState,
+      pipelineOverlayIntent: pipelineOverlayIntent,
+      isClipboardFallback: currentTranscript?.metrics?.pasteTier == "clipboard_only",
+      lastPolishError: lastPolishError,
+      hasCurrentTranscript: currentTranscript != nil
+    )
+    for effect in plan.effects {
+      switch effect {
+      case .cancelPendingWarning:
+        cancelPendingWarning()
+      case .schedulePolishFailedWarning:
+        schedulePolishFailedWarning()
+      case .showOverlay(let intent):
+        showOverlay(intent)
+      case .reloadTranscriptHistory:
+        reloadTranscriptHistory()
+      case .reportDictationCompleted:
+        if let t = currentTranscript {
+          reportDictationCompleted(t)
+        }
+      case .reportPipelineFailed(let msg):
+        reportPipelineFailed(msg)
+      }
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -1,0 +1,115 @@
+import EnviousWisprCore
+import Foundation
+
+/// Every side effect the state-change closure produces, as a value.
+///
+/// Executed in order by the caller. The caller owns stateful concerns
+/// (the warning `Task`, the concrete telemetry service, the overlay panel);
+/// the planner is a pure projection from inputs to this list.
+public enum PipelineStateSideEffect: Equatable, Sendable {
+  /// Cancel any pending post-completion warning task. Emitted on every
+  /// non-complete transition — mirrors AppState.swift:386 / :443 behavior.
+  case cancelPendingWarning
+
+  /// Schedule the "Polish failed -- using raw text" warning 400 ms after
+  /// completion. Emitted ONLY on `.complete` when a polish error was recorded
+  /// AND the paste did not fall back to clipboard-only.
+  case schedulePolishFailedWarning
+
+  /// Render this intent on the overlay. Always emitted exactly once per call.
+  case showOverlay(OverlayIntent)
+
+  /// Trigger disk-backed transcript history reload. Emitted on every
+  /// `.complete` transition, regardless of whether the current transcript is
+  /// nil. (Phase C will replace this with an in-memory `append(_:)`.)
+  case reloadTranscriptHistory
+
+  /// Call `TelemetryService.shared.reportDictationCompleted(transcript:inputMode:)`
+  /// using the caller's current transcript. Emitted only when `.complete` AND
+  /// the pipeline has a current transcript — matches AppState's `if let t`.
+  case reportDictationCompleted
+
+  /// Call `TelemetryService.shared.pipelineFailed(...)` with the captured error
+  /// code. The caller supplies the fixed `stage` / `errorCategory` / `backend`
+  /// literals that today live in AppState's closures.
+  case reportPipelineFailed(errorCode: String)
+}
+
+public struct PipelineStateChangePlan: Equatable, Sendable {
+  public let effects: [PipelineStateSideEffect]
+
+  public init(effects: [PipelineStateSideEffect]) {
+    self.effects = effects
+  }
+}
+
+/// Pure projection from a state transition's observable inputs to the ordered
+/// list of side effects AppState's `onStateChange` closures must perform.
+///
+/// **What lives here:**
+/// - Three-way overlay priority on `.complete`
+///   (clipboardFallback > polish-failed-warning > success).
+/// - Warning-task cancellation on any non-complete transition.
+/// - Telemetry + history-reload emission for `.complete` / `.error`.
+///
+/// **What does NOT live here** (stays with the caller / future handler):
+/// - Stateful `Task` ownership for the delayed polish-failed warning.
+/// - The `.ready`-as-completion-equivalent guard inside the delayed warning
+///   closure (that guard fires at 400 ms, not at plan time).
+/// - Hotkey register/unregister, `isRecordingLocked = false` reset, the
+///   inactive→active tiebreaker, the `onPipelineStateChange?` fan-out.
+///   All four are AppState-only concerns that the bible (§7) keeps inline.
+///
+/// This type is intentionally ~60 LOC of mechanical case analysis. It exists
+/// so characterization tests can pin the full behavior contract without
+/// driving AppState (which has no DI seams). Commit 2 wraps it in a stateful
+/// handler that owns the warning `Task`.
+@MainActor
+public enum PipelineStateChangePlanner {
+  public static func plan(
+    to newState: any PipelineStateProtocol,
+    pipelineOverlayIntent: OverlayIntent,
+    isClipboardFallback: Bool,
+    lastPolishError: String?,
+    hasCurrentTranscript: Bool
+  ) -> PipelineStateChangePlan {
+    var effects: [PipelineStateSideEffect] = []
+
+    // Step 1 — overlay resolution + warning scheduling / cancellation.
+    // Order mirrors the production closures at AppState.swift:370-393 /
+    // :429-450: resolve intent, schedule warning iff applicable, then show.
+    let resolvedOverlayIntent: OverlayIntent
+    switch newState.activity {
+    case .complete:
+      if isClipboardFallback {
+        resolvedOverlayIntent = .clipboardFallback
+      } else if lastPolishError != nil {
+        resolvedOverlayIntent = pipelineOverlayIntent
+        effects.append(.schedulePolishFailedWarning)
+      } else {
+        resolvedOverlayIntent = pipelineOverlayIntent
+      }
+    default:
+      effects.append(.cancelPendingWarning)
+      resolvedOverlayIntent = pipelineOverlayIntent
+    }
+    effects.append(.showOverlay(resolvedOverlayIntent))
+
+    // Step 2 — complete-path telemetry and history reload.
+    // reloadTranscriptHistory fires even without a current transcript
+    // (matches AppState.swift:395 unconditional load).
+    if case .complete = newState.activity {
+      effects.append(.reloadTranscriptHistory)
+      if hasCurrentTranscript {
+        effects.append(.reportDictationCompleted)
+      }
+    }
+
+    // Step 3 — error-path telemetry.
+    if case .error(let msg) = newState.activity {
+      effects.append(.reportPipelineFailed(errorCode: msg))
+    }
+
+    return PipelineStateChangePlan(effects: effects)
+  }
+}

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Executed in order by the caller. The caller owns stateful concerns
 /// (the warning `Task`, the concrete telemetry service, the overlay panel);
 /// the planner is a pure projection from inputs to this list.
-public enum PipelineStateSideEffect: Equatable, Sendable {
+enum PipelineStateSideEffect: Equatable, Sendable {
   /// Cancel any pending post-completion warning task. Emitted on every
   /// non-complete transition — mirrors AppState.swift:386 / :443 behavior.
   case cancelPendingWarning
@@ -35,12 +35,8 @@ public enum PipelineStateSideEffect: Equatable, Sendable {
   case reportPipelineFailed(errorCode: String)
 }
 
-public struct PipelineStateChangePlan: Equatable, Sendable {
-  public let effects: [PipelineStateSideEffect]
-
-  public init(effects: [PipelineStateSideEffect]) {
-    self.effects = effects
-  }
+struct PipelineStateChangePlan: Equatable, Sendable {
+  let effects: [PipelineStateSideEffect]
 }
 
 /// Pure projection from a state transition's observable inputs to the ordered
@@ -60,13 +56,11 @@ public struct PipelineStateChangePlan: Equatable, Sendable {
 ///   inactive→active tiebreaker, the `onPipelineStateChange?` fan-out.
 ///   All four are AppState-only concerns that the bible (§7) keeps inline.
 ///
-/// This type is intentionally ~60 LOC of mechanical case analysis. It exists
-/// so characterization tests can pin the full behavior contract without
-/// driving AppState (which has no DI seams). Commit 2 wraps it in a stateful
-/// handler that owns the warning `Task`.
+/// Kept `internal` to `EnviousWisprPipeline`: only the handler in this
+/// module calls `plan(...)`; tests reach it through `@testable import`.
 @MainActor
-public enum PipelineStateChangePlanner {
-  public static func plan(
+enum PipelineStateChangePlanner {
+  static func plan(
     to newState: any PipelineStateProtocol,
     pipelineOverlayIntent: OverlayIntent,
     isClipboardFallback: Bool,

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -30,6 +30,26 @@ public enum WhisperKitPipelineState: Equatable, Sendable {
   }
 }
 
+// MARK: - PipelineStateProtocol conformance
+
+extension WhisperKitPipelineState: PipelineStateProtocol {
+  public var activity: PipelineActivity {
+    switch self {
+    case .idle, .ready: return .idle
+    case .startingUp, .loadingModel: return .preparing
+    case .recording: return .recording
+    case .transcribing, .polishing: return .processing
+    case .complete: return .complete
+    case .error(let msg): return .error(msg)
+    }
+  }
+
+  public var errorReason: String? {
+    if case .error(let msg) = self { return msg }
+    return nil
+  }
+}
+
 /// Independent WhisperKit dictation pipeline — batch record → transcribe → polish → paste.
 ///
 /// Owns its own 8-state machine, shares only AudioCaptureManager and LLM infrastructure

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -43,11 +43,6 @@ extension WhisperKitPipelineState: PipelineStateProtocol {
     case .error(let msg): return .error(msg)
     }
   }
-
-  public var errorReason: String? {
-    if case .error(let msg) = self { return msg }
-    return nil
-  }
 }
 
 /// Independent WhisperKit dictation pipeline — batch record → transcribe → polish → paste.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2,33 +2,42 @@ import EnviousWisprCore
 import Foundation
 import PostHog
 
-/// Captured-for-test snapshot of a top-level telemetry emission.
-///
-/// Typed buckets (not `[String: Any]`) so the hook signature is Swift 6
-/// `Sendable`. Covers the two top-level methods AppState's state-change
-/// closures invoke: `reportDictationCompleted` and `pipelineFailed`. Extend
-/// the buckets if a future phase needs to observe additional methods.
-public struct CapturedTelemetryEvent: Sendable, Equatable {
-  public let name: String
-  public let stringProps: [String: String]
-  public let intProps: [String: Int]
-  public let doubleProps: [String: Double]
-  public let boolProps: [String: Bool]
+#if DEBUG
+  /// Captured-for-test snapshot of a top-level telemetry emission.
+  ///
+  /// Typed buckets (not `[String: Any]`) so the hook signature is Swift 6
+  /// `Sendable`. Debug-only: the entire observation seam is compiled out of
+  /// release builds, so the struct itself lives inside the same `#if DEBUG`
+  /// region as `testEventHook`. Fields read by `@testable` tests — Periphery
+  /// runs with `--exclude-tests` and can't see those reads; the annotations
+  /// below declare the fields intentional test-facing surface.
+  public struct CapturedTelemetryEvent: Sendable, Equatable {
+    // periphery:ignore
+    public let name: String
+    // periphery:ignore
+    public let stringProps: [String: String]
+    // periphery:ignore
+    public let intProps: [String: Int]
+    // periphery:ignore
+    public let doubleProps: [String: Double]
+    // periphery:ignore
+    public let boolProps: [String: Bool]
 
-  public init(
-    name: String,
-    stringProps: [String: String] = [:],
-    intProps: [String: Int] = [:],
-    doubleProps: [String: Double] = [:],
-    boolProps: [String: Bool] = [:]
-  ) {
-    self.name = name
-    self.stringProps = stringProps
-    self.intProps = intProps
-    self.doubleProps = doubleProps
-    self.boolProps = boolProps
+    public init(
+      name: String,
+      stringProps: [String: String] = [:],
+      intProps: [String: Int] = [:],
+      doubleProps: [String: Double] = [:],
+      boolProps: [String: Bool] = [:]
+    ) {
+      self.name = name
+      self.stringProps = stringProps
+      self.intProps = intProps
+      self.doubleProps = doubleProps
+      self.boolProps = boolProps
+    }
   }
-}
+#endif
 
 /// Thin wrapper — type-safe event names, no business logic.
 /// Limb: observes facts from domain objects, publishes to PostHog.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2,6 +2,34 @@ import EnviousWisprCore
 import Foundation
 import PostHog
 
+/// Captured-for-test snapshot of a top-level telemetry emission.
+///
+/// Typed buckets (not `[String: Any]`) so the hook signature is Swift 6
+/// `Sendable`. Covers the two top-level methods AppState's state-change
+/// closures invoke: `reportDictationCompleted` and `pipelineFailed`. Extend
+/// the buckets if a future phase needs to observe additional methods.
+public struct CapturedTelemetryEvent: Sendable, Equatable {
+  public let name: String
+  public let stringProps: [String: String]
+  public let intProps: [String: Int]
+  public let doubleProps: [String: Double]
+  public let boolProps: [String: Bool]
+
+  public init(
+    name: String,
+    stringProps: [String: String] = [:],
+    intProps: [String: Int] = [:],
+    doubleProps: [String: Double] = [:],
+    boolProps: [String: Bool] = [:]
+  ) {
+    self.name = name
+    self.stringProps = stringProps
+    self.intProps = intProps
+    self.doubleProps = doubleProps
+    self.boolProps = boolProps
+  }
+}
+
 /// Thin wrapper — type-safe event names, no business logic.
 /// Limb: observes facts from domain objects, publishes to PostHog.
 @MainActor
@@ -9,10 +37,28 @@ public final class TelemetryService {
   public static let shared = TelemetryService()
   private init() {}
 
+  #if DEBUG
+    /// Test-only observation seam. Fired at the entry of each top-level facade
+    /// method (currently `reportDictationCompleted` and `pipelineFailed`) with
+    /// a typed summary. Nil in release builds; tests set this to capture
+    /// emissions without reaching PostHog.
+    public var testEventHook: (@Sendable (CapturedTelemetryEvent) -> Void)?
+  #endif
+
   // MARK: - Observation Layer (reads domain objects)
 
   /// Called by AppState when a pipeline completes. Reads Transcript + ExecutionMetrics.
   public func reportDictationCompleted(transcript t: Transcript, inputMode: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "dictation.completed",
+          stringProps: [
+            "input_mode": inputMode,
+            "asr_backend": t.backendType.rawValue,
+          ]
+        ))
+    #endif
     let m = t.metrics
     dictationCompleted(
       result: "success",
@@ -200,6 +246,20 @@ public final class TelemetryService {
     stage: String, errorCategory: String, errorCode: String,
     recoverable: Bool, backend: String?
   ) {
+    #if DEBUG
+      var hookStrings: [String: String] = [
+        "stage": stage,
+        "error_category": errorCategory,
+        "error_code": errorCode,
+      ]
+      if let b = backend { hookStrings["backend"] = b }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "pipeline.failed",
+          stringProps: hookStrings,
+          boolProps: ["recoverable": recoverable]
+        ))
+    #endif
     var props: [String: Any] = [
       "stage": stage,
       "error_category": errorCategory,

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -1,0 +1,250 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Unit tests for `PipelineStateChangeHandler` — the stateful wrapper that
+/// drives plan execution through injected dependencies.
+///
+/// These tests complement `PipelineStateChangePlannerTests` (which pin the
+/// pure decision logic). These verify that each `PipelineStateSideEffect`
+/// maps to the correct injected callback and that transcript-conditional
+/// effects honour their guards.
+@MainActor
+@Suite("PipelineStateChangeHandler — execution contract")
+struct PipelineStateChangeHandlerTests {
+
+  // MARK: - Test doubles
+
+  /// Spy that captures every `showOverlay` callback invocation. Replaces
+  /// the protocol-existential overlay of earlier designs — static dispatch,
+  /// no @MainActor class boundary to cross.
+  final class OverlaySpy {
+    struct Call: Equatable {
+      let intent: OverlayIntent
+    }
+    var calls: [Call] = []
+
+    func record(_ intent: OverlayIntent) {
+      calls.append(Call(intent: intent))
+    }
+  }
+
+  /// Callback bundle — counts invocations and captures payloads so tests can
+  /// assert against effect routing.
+  final class CallbackRecorder {
+    var cancelWarningCount = 0
+    var scheduleWarningCount = 0
+    var reloadHistoryCount = 0
+    var completedCalls: [Transcript] = []
+    var failedCalls: [String] = []
+  }
+
+  private static func makeHandler(
+    overlay: OverlaySpy,
+    callbacks: CallbackRecorder
+  ) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { intent in overlay.record(intent) },
+      cancelPendingWarning: { callbacks.cancelWarningCount += 1 },
+      schedulePolishFailedWarning: { callbacks.scheduleWarningCount += 1 },
+      reloadTranscriptHistory: { callbacks.reloadHistoryCount += 1 },
+      reportDictationCompleted: { callbacks.completedCalls.append($0) },
+      reportPipelineFailed: { callbacks.failedCalls.append($0) }
+    )
+  }
+
+  private static func makeTranscript(pasteTier: String? = nil) -> Transcript {
+    Transcript(
+      text: "hello world",
+      processingTime: 0.05,
+      backendType: .parakeet,
+      metrics: pasteTier.map {
+        ExecutionMetrics(
+          asrLatencySeconds: 0.1, llmLatencySeconds: 0.2,
+          pasteTier: $0, pasteLatencyMs: 12, targetApp: "test.app",
+          e2eSeconds: 0.8)
+      }
+    )
+  }
+
+  // MARK: - Happy paths
+
+  @Test("complete + success transcript: show overlay, reload, report completed")
+  func completeSuccessRoutesEffects() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "direct")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: transcript
+    )
+
+    #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
+    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.completedCalls.count == 1)
+    #expect(calls.completedCalls.first?.id == transcript.id)
+    #expect(calls.failedCalls.isEmpty)
+    #expect(calls.cancelWarningCount == 0)
+    #expect(calls.scheduleWarningCount == 0)
+  }
+
+  @Test("complete + polish failed: schedule warning before showing overlay, then reload + report")
+  func completePolishFailedRoutesWarningSchedule() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "direct")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: "openai_timeout",
+      currentTranscript: transcript
+    )
+
+    #expect(calls.scheduleWarningCount == 1)
+    #expect(calls.cancelWarningCount == 0)
+    #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
+    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.completedCalls.count == 1)
+  }
+
+  @Test("complete + clipboard fallback wins over polish warning")
+  func completeClipboardFallbackRoutesEffects() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "clipboard_only")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: "still set but fallback wins",
+      currentTranscript: transcript
+    )
+
+    #expect(spy.calls == [OverlaySpy.Call(intent: .clipboardFallback)])
+    #expect(calls.scheduleWarningCount == 0)
+    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.completedCalls.count == 1)
+  }
+
+  // MARK: - Transcript-conditional guards
+
+  @Test("complete without current transcript: reload fires but reportDictationCompleted does not")
+  func completeWithoutTranscriptSkipsTelemetry() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: nil
+    )
+
+    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.completedCalls.isEmpty)
+    #expect(spy.calls.count == 1)
+  }
+
+  // MARK: - Non-complete transitions cancel warning
+
+  @Test("recording transition cancels pending warning and shows overlay")
+  func recordingCancelsWarning() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+
+    handler.handle(
+      to: PipelineState.recording,
+      pipelineOverlayIntent: .recording(audioLevel: 0),
+      lastPolishError: nil,
+      currentTranscript: nil
+    )
+
+    #expect(calls.cancelWarningCount == 1)
+    #expect(calls.scheduleWarningCount == 0)
+    #expect(spy.calls == [OverlaySpy.Call(intent: .recording(audioLevel: 0))])
+    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.completedCalls.isEmpty)
+    #expect(calls.failedCalls.isEmpty)
+  }
+
+  @Test("WhisperKit .ready cancels warning and does not emit completion telemetry")
+  func whisperKitReadyCancelsWarning() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+
+    handler.handle(
+      to: WhisperKitPipelineState.ready,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: nil
+    )
+
+    #expect(calls.cancelWarningCount == 1)
+    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.completedCalls.isEmpty)
+  }
+
+  // MARK: - Error path
+
+  @Test("error state cancels warning, shows overlay, reports pipelineFailed with code")
+  func errorStateRoutesReportFailed() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+
+    handler.handle(
+      to: PipelineState.error("mic_disconnected"),
+      pipelineOverlayIntent: .error(message: "mic_disconnected"),
+      lastPolishError: nil,
+      currentTranscript: nil
+    )
+
+    #expect(calls.cancelWarningCount == 1)
+    #expect(
+      spy.calls == [OverlaySpy.Call(intent: .error(message: "mic_disconnected"))])
+    #expect(calls.failedCalls == ["mic_disconnected"])
+    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.completedCalls.isEmpty)
+  }
+
+  // MARK: - Cumulative lifecycle
+
+  @Test("two successive complete calls route two telemetry reports and two history reloads")
+  func handlerIsStateless() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let first = Self.makeTranscript(pasteTier: "direct")
+    let second = Self.makeTranscript(pasteTier: "direct")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: first
+    )
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: second
+    )
+
+    #expect(calls.reloadHistoryCount == 2)
+    #expect(calls.completedCalls.count == 2)
+    #expect(calls.completedCalls.map(\.id) == [first.id, second.id])
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -1,0 +1,329 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Characterization tests pinning the current behavior of the state-change
+/// closures at `AppState.swift:344-406` (Parakeet) and `:409-463` (WhisperKit).
+///
+/// The planner is a pure projection — tests drive each state case with every
+/// clipboardFallback / polishError / hasTranscript combination that the
+/// production closures exercise, and pin the resulting effect list.
+///
+/// Before commit 2 (handler extraction) these tests fail on any behavior
+/// change. After commit 2 these same tests remain the source of truth for
+/// the handler's plan-level contract.
+@MainActor
+@Suite("PipelineStateChangePlanner — characterization")
+struct PipelineStateChangePlannerTests {
+
+  // MARK: - Shared fixtures
+
+  private static let recordingIntent: OverlayIntent = .recording(audioLevel: 0)
+  private static let hiddenIntent: OverlayIntent = .hidden
+  private static let polishingIntent: OverlayIntent = .processing(label: "Polishing...")
+  private static let transcribingIntent: OverlayIntent = .processing(label: "Transcribing...")
+
+  // MARK: - Three-way .complete overlay priority
+
+  @Test("complete + clipboard_only fallback -> .clipboardFallback wins, no warning scheduled")
+  func completeClipboardFallbackWinsOverPolishWarning() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: true,
+      lastPolishError: "polish failed for some reason",
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.clipboardFallback)))
+    #expect(!plan.effects.contains(.schedulePolishFailedWarning))
+    // Clipboard fallback still reports telemetry + reloads history.
+    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.reportDictationCompleted))
+    #expect(!plan.effects.contains(.cancelPendingWarning))
+  }
+
+  @Test("complete + polish failed (not clipboard) -> overlay + schedulePolishFailedWarning")
+  func completePolishFailedSchedulesWarning() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      lastPolishError: "openai 429 rate-limited",
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.hidden)))
+    #expect(plan.effects.contains(.schedulePolishFailedWarning))
+    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.reportDictationCompleted))
+    #expect(!plan.effects.contains(.cancelPendingWarning))
+  }
+
+  @Test("complete + success (no fallback, no polish error) -> no warning, telemetry fires")
+  func completeSuccessEmitsNoWarning() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.hidden)))
+    #expect(!plan.effects.contains(.schedulePolishFailedWarning))
+    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.reportDictationCompleted))
+    #expect(!plan.effects.contains(.cancelPendingWarning))
+  }
+
+  @Test("complete without current transcript -> history reloads but no telemetry")
+  func completeWithoutTranscriptSkipsTelemetryButReloadsHistory() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.reportDictationCompleted))
+  }
+
+  // MARK: - Warning cancellation on non-complete transitions
+
+  @Test("non-complete transitions cancel pending warning")
+  func nonCompleteTransitionsCancelWarning() {
+    let nonCompleteStates: [PipelineState] = [
+      .idle, .loadingModel, .recording, .transcribing, .polishing, .error("boom"),
+    ]
+    for state in nonCompleteStates {
+      let plan = PipelineStateChangePlanner.plan(
+        to: state,
+        pipelineOverlayIntent: Self.recordingIntent,
+        isClipboardFallback: false,
+        lastPolishError: nil,
+        hasCurrentTranscript: false
+      )
+      #expect(
+        plan.effects.first == .cancelPendingWarning,
+        "Expected cancelPendingWarning first for state \(state); got \(plan.effects)"
+      )
+      #expect(
+        !plan.effects.contains(.schedulePolishFailedWarning),
+        "Non-complete state \(state) must not schedule warning; got \(plan.effects)"
+      )
+    }
+  }
+
+  @Test("WhisperKit .ready cancels warning (activity == .idle)")
+  func whisperKitReadyCancelsWarning() {
+    // .ready is WhisperKit-only; bible §7.6 + tests/Phase A focus specifically
+    // on its classification. PipelineStateProtocol maps it to activity .idle,
+    // so it hits the non-complete branch.
+    let plan = PipelineStateChangePlanner.plan(
+      to: WhisperKitPipelineState.ready,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(plan.effects.first == .cancelPendingWarning)
+    #expect(plan.effects.contains(.showOverlay(.hidden)))
+    #expect(!plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.reportDictationCompleted))
+  }
+
+  // MARK: - Overlay intent pass-through (no label flattening)
+
+  @Test("pipeline overlay intent passes through verbatim for non-complete states")
+  func pipelineOverlayIntentPassesThroughVerbatim() {
+    let pairs: [(PipelineState, OverlayIntent)] = [
+      (.loadingModel, .processing(label: "Loading model...")),
+      (.transcribing, .processing(label: "Transcribing...")),
+      (.polishing, .processing(label: "Polishing...")),
+      (.recording, .recording(audioLevel: 0)),
+      (.error("boom"), .error(message: "boom")),
+    ]
+    for (state, intent) in pairs {
+      let plan = PipelineStateChangePlanner.plan(
+        to: state,
+        pipelineOverlayIntent: intent,
+        isClipboardFallback: false,
+        lastPolishError: nil,
+        hasCurrentTranscript: false
+      )
+      #expect(
+        plan.effects.contains(.showOverlay(intent)),
+        "Expected overlay intent \(intent) preserved for \(state); got \(plan.effects)"
+      )
+    }
+  }
+
+  @Test("WhisperKit startingUp vs loadingModel labels are preserved distinctly")
+  func whisperKitStartingUpAndLoadingModelLabelsPreserved() {
+    // Guard against collapsing these two user-visible labels into a single
+    // coarse "preparing" bucket (bible §7.2 correction).
+    let startingUp = PipelineStateChangePlanner.plan(
+      to: WhisperKitPipelineState.startingUp,
+      pipelineOverlayIntent: .processing(label: "Starting..."),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    let loadingModel = PipelineStateChangePlanner.plan(
+      to: WhisperKitPipelineState.loadingModel,
+      pipelineOverlayIntent: .processing(label: "Loading model..."),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(startingUp.effects.contains(.showOverlay(.processing(label: "Starting..."))))
+    #expect(loadingModel.effects.contains(.showOverlay(.processing(label: "Loading model..."))))
+  }
+
+  // MARK: - Error path telemetry
+
+  @Test("error state emits reportPipelineFailed with error code")
+  func errorStateEmitsReportPipelineFailed() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.error("mic_disconnected"),
+      pipelineOverlayIntent: .error(message: "mic_disconnected"),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(plan.effects.contains(.reportPipelineFailed(errorCode: "mic_disconnected")))
+    #expect(plan.effects.contains(.cancelPendingWarning))
+    #expect(plan.effects.contains(.showOverlay(.error(message: "mic_disconnected"))))
+    // error must not trigger .complete-path effects.
+    #expect(!plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.reportDictationCompleted))
+  }
+
+  @Test("WhisperKit error state emits reportPipelineFailed")
+  func whisperKitErrorStateEmitsReportPipelineFailed() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: WhisperKitPipelineState.error("whisperkit_load_failed"),
+      pipelineOverlayIntent: .error(message: "whisperkit_load_failed"),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(plan.effects.contains(.reportPipelineFailed(errorCode: "whisperkit_load_failed")))
+  }
+
+  // MARK: - Effect ordering guarantees
+
+  @Test("complete success plan produces canonical effect order")
+  func completeSuccessEffectOrder() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    // Order matches the production closure: show overlay, reload history,
+    // report telemetry. No warning-cancel, no warning-schedule.
+    #expect(
+      plan.effects == [
+        .showOverlay(.hidden),
+        .reloadTranscriptHistory,
+        .reportDictationCompleted,
+      ])
+  }
+
+  @Test("complete + polish failed plan produces canonical effect order")
+  func completePolishFailedEffectOrder() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      isClipboardFallback: false,
+      lastPolishError: "fail",
+      hasCurrentTranscript: true
+    )
+    #expect(
+      plan.effects == [
+        .schedulePolishFailedWarning,
+        .showOverlay(.hidden),
+        .reloadTranscriptHistory,
+        .reportDictationCompleted,
+      ])
+  }
+
+  @Test("complete + clipboard fallback plan produces canonical effect order")
+  func completeClipboardFallbackEffectOrder() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      isClipboardFallback: true,
+      lastPolishError: "fail",
+      hasCurrentTranscript: true
+    )
+    #expect(
+      plan.effects == [
+        .showOverlay(.clipboardFallback),
+        .reloadTranscriptHistory,
+        .reportDictationCompleted,
+      ])
+  }
+
+  @Test("non-complete plan produces cancel-before-show ordering")
+  func nonCompleteCancelBeforeShowOrder() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.recording,
+      pipelineOverlayIntent: .recording(audioLevel: 0),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(
+      plan.effects == [
+        .cancelPendingWarning,
+        .showOverlay(.recording(audioLevel: 0)),
+      ])
+  }
+
+  @Test("error plan produces cancel, show, report order")
+  func errorEffectOrder() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.error("bad"),
+      pipelineOverlayIntent: .error(message: "bad"),
+      isClipboardFallback: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false
+    )
+    #expect(
+      plan.effects == [
+        .cancelPendingWarning,
+        .showOverlay(.error(message: "bad")),
+        .reportPipelineFailed(errorCode: "bad"),
+      ])
+  }
+
+  // MARK: - Activity projection integrity
+
+  @Test("Parakeet state activity mapping is stable")
+  func parakeetActivityMapping() {
+    #expect(PipelineState.idle.activity == .idle)
+    #expect(PipelineState.loadingModel.activity == .preparing)
+    #expect(PipelineState.recording.activity == .recording)
+    #expect(PipelineState.transcribing.activity == .processing)
+    #expect(PipelineState.polishing.activity == .processing)
+    #expect(PipelineState.complete.activity == .complete)
+    #expect(PipelineState.error("x").activity == .error("x"))
+  }
+
+  @Test("WhisperKit state activity mapping covers ready + startingUp")
+  func whisperKitActivityMapping() {
+    #expect(WhisperKitPipelineState.idle.activity == .idle)
+    #expect(WhisperKitPipelineState.ready.activity == .idle)
+    #expect(WhisperKitPipelineState.startingUp.activity == .preparing)
+    #expect(WhisperKitPipelineState.loadingModel.activity == .preparing)
+    #expect(WhisperKitPipelineState.recording.activity == .recording)
+    #expect(WhisperKitPipelineState.transcribing.activity == .processing)
+    #expect(WhisperKitPipelineState.polishing.activity == .processing)
+    #expect(WhisperKitPipelineState.complete.activity == .complete)
+    #expect(WhisperKitPipelineState.error("x").activity == .error("x"))
+  }
+}

--- a/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+++ b/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
@@ -722,13 +722,13 @@ That is 19 rows (14 original + 5 Phase G sub-phases imported from epic #385 on 2
 
 ### 7.1 Why this phase exists
 
-Both `TranscriptionPipeline` and `WhisperKitPipeline` emit state changes into AppState's `onStateChange` closures (L221-L314 per the original plan). Both closures do the same work: hotkey register/unregister, overlay intent mapping, post-completion warning triggers, telemetry emission, transcript reload. The code is near-identical. Diff is trivial. The duplication is the tell — this is cohesive logic that wants to live in one type.
+Both `TranscriptionPipeline` and `WhisperKitPipeline` emit state changes into AppState's `onStateChange` closures (Parakeet L344-L406, WhisperKit L409-L463 — verified 2026-04-20 against `origin/main` @ `8c5a5f3`). Both closures do the same work: hotkey register/unregister, overlay intent mapping (with three-way post-completion priority), post-completion warning scheduling AND cancellation, telemetry emission, transcript reload. The code is near-identical. Diff is trivial. The duplication is the tell — this is cohesive logic that wants to live in one type.
 
 ### 7.2 Design summary
 
-**Adversarial-verified state enum shapes (2026-04-18):**
-- `TranscriptionPipeline.State` (Parakeet) — seven cases: `.idle`, `.loadingModel`, `.recording`, `.transcribing`, `.polishing`, `.complete`, `.error(String)`.
-- `WhisperKitPipelineState` (`Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:12`) — nine cases: `.idle`, `.ready`, `.startingUp`, `.loadingModel`, `.recording`, `.transcribing`, `.polishing`, `.complete`, `.error(String)`.
+**Adversarial-verified state enum shapes (2026-04-18, re-verified 2026-04-20):**
+- `PipelineState` (Parakeet — defined in `Sources/EnviousWisprCore/AppSettings.swift:17`, NOT nested under `TranscriptionPipeline`) — seven cases: `.idle`, `.loadingModel`, `.recording`, `.transcribing`, `.polishing`, `.complete`, `.error(String)`.
+- `WhisperKitPipelineState` (`Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:12`) — nine cases: `.idle`, `.startingUp`, `.loadingModel`, `.ready`, `.recording`, `.transcribing`, `.polishing`, `.complete`, `.error(String)`.
 
 The two states share seven of the enum cases and diverge on `.ready` / `.startingUp` (WhisperKit-only, used while the model is being loaded but before recording becomes available). The "shared" handler cannot blindly accept `any PipelineStateProtocol`; it must either:
 
@@ -766,23 +766,26 @@ New `PipelineStateChangeHandler` implementation:
 
 ```swift
 // Sources/EnviousWispr/App/PipelineStateChangeHandler.swift
-// Adversarial-verified 2026-04-18 (Codex plan review + Codex A-review):
-// - overlay UI owner is RecordingOverlayPanel (type OverlayManager does not exist).
+// Adversarial-verified 2026-04-18 + re-verified 2026-04-20 (Codex plan review + Codex A-review + v1.16 Gate 0 sweep):
+// - Overlay UI owner is RecordingOverlayPanel (type OverlayManager does not exist).
 // - Real API is recordingOverlay.show(intent:audioLevelProvider:isRecordingLocked:).
+// - The intent value type is OverlayIntent (NOT RecordingOverlayIntent). Defined in
+//   Sources/EnviousWisprUI/ (.hidden / .recording(audioLevel:) / .processing(label:) /
+//   .warning(message:) / .clipboardFallback). Pipeline.overlayIntent returns this type.
 // - Telemetry facade is TelemetryService.shared (Sources/EnviousWisprServices/TelemetryService.swift:8).
-// - Codex A-review correction: backend injected at INIT (one per handler instance), not per-call.
-//   reportDictationCompleted derives backend from Transcript.backendType (:15), so the only
-//   backend-requiring call is pipelineFailed which today passes literals from AppState.
+// - Backend injected at INIT (one per handler instance), not per-call. reportDictationCompleted
+//   derives backend from Transcript.backendType; the only backend-requiring call is pipelineFailed.
 @MainActor
 internal final class PipelineStateChangeHandler {
   private let backend: ASRBackendType       // injected at construction
-  private let overlay: RecordingOverlayPanel
+  private let overlay: RecordingOverlayPanelProtocol
   private let audioLevelProvider: @MainActor () -> Float
   private let isRecordingLockedProvider: @MainActor () -> Bool
   private let onTranscriptCompleted: @MainActor (Transcript) -> Void  // Phase C wires this to coordinator.append(_:)
+  private var postCompletionWarningTask: Task<Void, Never>?
 
   init(backend: ASRBackendType,
-       overlay: RecordingOverlayPanel,
+       overlay: RecordingOverlayPanelProtocol,
        audioLevelProvider: @escaping @MainActor () -> Float,
        isRecordingLockedProvider: @escaping @MainActor () -> Bool,
        onTranscriptCompleted: @escaping @MainActor (Transcript) -> Void) { ... }
@@ -791,39 +794,68 @@ internal final class PipelineStateChangeHandler {
   // Handler takes the pre-computed intent rather than deriving from coarse activity —
   // preserves "Starting..." vs "Loading model..." (WhisperKitPipeline.swift:307-313),
   // "Transcribing..." vs "Polishing..." (both pipelines' overlay logic).
+  //
+  // `isClipboardFallback` is a FIRST-CLASS input because the current production code
+  // (AppState.swift:370-388 / :429-445) applies a THREE-WAY priority on .complete:
+  //   1. clipboardFallback wins → show .clipboardFallback intent
+  //   2. else polish-failed → use pipeline.overlayIntent, then schedule .warning after 400ms
+  //   3. else → use pipeline.overlayIntent (success)
+  // Collapsing this into just "warning when lastPolishError != nil" would silently drop
+  // the clipboard-only notification users rely on for paste-failure feedback.
   func handle<State: PipelineStateProtocol>(
     from: State, to: State,
-    overlayIntent: RecordingOverlayIntent,   // pipeline's pre-computed label
+    overlayIntent: OverlayIntent,             // pipeline's pre-computed label
+    isClipboardFallback: Bool,                // from transcript.metrics.pasteTier == "clipboard_only"
     lastPolishError: String?,
     latestTranscript: Transcript?
   ) {
-    // 1. overlay.show(intent: overlayIntent, audioLevelProvider: ..., isRecordingLocked: isRecordingLockedProvider())
-    //    The CALLER computed the intent using the pipeline's own state→label mapping.
-    //    Handler does not derive labels from to.activity.
-    // 2. Post-completion warning scheduled when to.activity == .complete && lastPolishError != nil.
-    // 3. Telemetry: TelemetryService.shared.reportDictationCompleted(transcript:inputMode:) when to.activity == .complete.
+    // 1. overlay.show(intent: resolvedIntent, audioLevelProvider: ..., isRecordingLocked: isRecordingLockedProvider())
+    //    where resolvedIntent is:
+    //      - to.activity == .complete && isClipboardFallback  → .clipboardFallback
+    //      - to.activity == .complete && lastPolishError != nil → overlayIntent (unchanged),
+    //        then schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+    //      - to.activity == .complete                         → overlayIntent (success path)
+    //      - to.activity != .complete                         → overlayIntent AND cancel
+    //        any pending postCompletionWarningTask (the previous completion's warning is
+    //        superseded by the new state transition; AppState today does this at :386 / :443)
+    // 2. Telemetry: TelemetryService.shared.reportDictationCompleted(transcript:inputMode:) when to.activity == .complete.
     //    Backend already on Transcript.backendType; no `backend` parameter needed for this call.
-    // 4. Telemetry: TelemetryService.shared.pipelineFailed(...) when errorReason != nil.
+    // 3. Telemetry: TelemetryService.shared.pipelineFailed(...) when errorReason != nil.
     //    Uses self.backend from init. Single source of truth; not per-call.
-    // 5. When to.activity == .complete && latestTranscript != nil: call onTranscriptCompleted(latestTranscript).
+    // 4. When to.activity == .complete && latestTranscript != nil: call onTranscriptCompleted(latestTranscript).
     //    Phase C wires this closure to TranscriptCoordinator.append(_:). Handler does not know about TranscriptCoordinator.
     //    IMPORTANT: TranscriptFinalizer has already persisted the transcript by the time .complete fires.
     //    append() is in-memory-only. Do NOT call store.save here — that would double-persist.
   }
+
+  // Owned by handler because warning cancellation is tied to the overlay-priority
+  // logic above. Moving it out fragments the "completion → warning scheduling"
+  // lifecycle across two owners.
+  private func schedulePostCompletionWarning(message: String) { ... }
 }
 ```
 
-**Hotkey code stays inline in AppState (Carbon sensitive). NOT just Carbon.** Codex A-review correction: the current inline block at `AppState.swift:344-405` / `:409-465` includes `isRecordingLocked = false` at `:352` and `:417` — that's session/UI state reset, not Carbon hotkey work. If extraction leaves that reset AFTER the handler call, the ordering changes. Fix: keep both the hotkey register/unregister AND the `isRecordingLocked = false` reset inline in AppState BEFORE calling the handler. Document them as two separate concerns that happen to sit in the same block today.
+**Not moved into the handler (stays inline in AppState):**
+- `self.onPipelineStateChange?(newState)` fan-out at `AppState.swift:346` (Parakeet) / `:411` (WhisperKit). The WhisperKit closure fans out `self.pipelineState` (unified Parakeet-shaped projection), not the raw WhisperKit enum. This is cross-backend projection glue that belongs in AppState, not in a per-backend handler.
+- Inactive→active tiebreaker (owns `lastCapturingBackend` / `prevParakeetActive` / `prevWhisperKitActive` — cross-pipeline state).
+- Hotkey register/unregister + `isRecordingLocked = false` reset (see next paragraph).
 
-**Tiebreaker stays in AppState, not handler (Codex A-review correction).** The `newState.isActive` inactive→active tiebreaker at `AppState.swift:360-366` and `:423` (per PR #285 comment) owns cross-pipeline state: `lastCapturingBackend`, `prevParakeetActive`, `prevWhisperKitActive`. Moving it into the handler would force the handler to become stateful about cross-pipeline coordination. Keep in AppState; handler receives its outputs (if any) as parameters.
+**Hotkey code stays inline in AppState (Carbon sensitive). NOT just Carbon.** Codex A-review correction: the current inline block at `AppState.swift:344-406` (Parakeet) / `:409-463` (WhisperKit) includes `isRecordingLocked = false` at `:352` and `:417` — that's session/UI state reset, not Carbon hotkey work. If extraction leaves that reset AFTER the handler call, the ordering changes. Fix: keep both the hotkey register/unregister AND the `isRecordingLocked = false` reset inline in AppState BEFORE calling the handler. Document them as two separate concerns that happen to sit in the same block today.
+
+**Tiebreaker stays in AppState, not handler (Codex A-review correction).** The `newState.isActive` inactive→active tiebreaker at `AppState.swift:360-364` (Parakeet) and `:423-427` (WhisperKit, per PR #285 comment) owns cross-pipeline state: `lastCapturingBackend`, `prevParakeetActive`, `prevWhisperKitActive`. Moving it into the handler would force the handler to become stateful about cross-pipeline coordination. Keep in AppState; handler receives its outputs (if any) as parameters.
 
 ### 7.3 Substeps (ordered)
 
 1. **Write characterization tests (Feathers).** Concrete mechanism. Verified 2026-04-18: no existing test-seam precedent for `TelemetryService.shared` or `RecordingOverlayPanel.show(intent:)` in `Tests/`. This substep designs the seam; nothing to port.
    - **Overlay intent capture:** `RecordingOverlayPanel` is a concrete `final class`. For testability, extract an internal `RecordingOverlayPanelProtocol` (new) with `show(intent:audioLevelProvider:isRecordingLocked:)`. Concrete panel conforms. Codex A-review 2026-04-18 scope check: the handler only needs `show(...)`. `updateLockState` (`:419`) and `hide` (elsewhere) are used by OTHER AppState paths (`:609`, `:894`), NOT by the extracted shared closure body — do NOT widen the protocol. Test injects a `RecordingOverlayPanelSpy` that records `show(intent:...)` calls into an array. Transition state, assert the captured intent sequence.
    - **Required specific label assertions (Codex A-review finding):** overlay labels must be pinned individually because `PipelineActivity` coarse-grains them. Assert "Starting..." emitted for WhisperKit `.startingUp`, "Loading model..." for `.loadingModel`, "Transcribing..." for `.transcribing`, "Polishing..." for `.polishing`, and correct post-polish-error label when `lastPolishError != nil`.
-   - **Required WhisperKit `.ready`-as-completion-equivalent assertion (Codex A-review finding at `AppState.swift:766`):** the delayed-warning path treats `.ready` as completion-equivalent for warning scheduling. Test must cover this.
-   - **Required inactive→active tiebreaker test (Codex A-review finding, PR #285, `AppState.swift:360, :423`):** capture `lastCapturingBackend` before and after `newState.isActive` transition; assert tiebreaker sets it only on inactive→active, not active→active.
+   - **Required WhisperKit `.ready`-as-completion-equivalent assertion (Codex A-review finding, current ref `AppState.swift:768`):** the delayed-warning path at `schedulePostCompletionWarning` treats `whisperKitPipeline.state == .ready` as completion-equivalent for warning scheduling (`parakeetComplete || whisperKitComplete` where `whisperKitComplete = .complete || .ready`). Test must cover this.
+   - **Required three-way overlay-priority assertions (Gate 0 sweep 2026-04-20):** pin each branch at `.complete`:
+     - `pasteTier == "clipboard_only"` AND `lastPolishError != nil` → `.clipboardFallback` wins, NO warning scheduled.
+     - `pasteTier != "clipboard_only"` AND `lastPolishError != nil` → `pipeline.overlayIntent` shown, `.warning("Polish failed -- using raw text")` fires after 400ms.
+     - success path → `pipeline.overlayIntent` shown, no warning scheduled.
+     Plus: on any non-complete transition, any in-flight warning task is cancelled (`AppState.swift:386, :443`).
+   - **Required inactive→active tiebreaker test (Codex A-review finding, PR #285, `AppState.swift:360-364, :423-427`):** capture `lastCapturingBackend` before and after `newState.isActive` transition; assert tiebreaker sets it only on inactive→active, not active→active.
    - **Telemetry capture:** `TelemetryService` is `public final class TelemetryService` with a `.shared` singleton at `Sources/EnviousWisprServices/TelemetryService.swift:8`. Add a test-only hook as the seam. Adversarial-verified 2026-04-18: `[String: Any]` is NOT Swift 6 `Sendable` — the naive hook signature will not compile. Use a concrete Sendable payload type:
      ```swift
      // TelemetryService.swift (add)
@@ -2886,6 +2918,20 @@ Only then does Phase B work start. Missing the decision capture in any of the th
 ---
 
 ## 30. Changelog
+
+- **2026-04-20 v1.16 · Phase A Gate 0 sweep before kickoff** — Gate 0 citation audit against `origin/main` @ `8c5a5f3`. Two material design gaps and four naming/line-range drifts corrected in §7 before code work begins. No change to any other phase.
+
+  **Material (design gap):**
+  - **Three-way post-completion overlay priority documented.** Current production code (`AppState.swift:370-388` Parakeet, `:429-445` WhisperKit) applies `clipboardFallback > polishFailed-warning > success` priority on `.complete`. v1.15 handler design only described the polish-warning path. Handler signature now takes `isClipboardFallback: Bool` as a first-class input; handle() body enumerates all three branches.
+  - **`postCompletionWarningTask` cancellation is a handler responsibility.** Current closures cancel the pending warning task on any non-complete transition (`AppState.swift:386, :443`); omitted from the v1.15 design. Handler now owns the `Task<Void, Never>?` and the cancellation invariant.
+
+  **Naming / line drift:**
+  - Intent value type is `OverlayIntent` (NOT `RecordingOverlayIntent`).
+  - Parakeet state enum is `PipelineState` defined in `Sources/EnviousWisprCore/AppSettings.swift:17` (NOT nested `TranscriptionPipeline.State`).
+  - §7.1 legacy "L221-L314" line range replaced with verified Parakeet `:344-406` / WhisperKit `:409-463`.
+  - `.ready`-as-completion-equivalent ref moved from `:766` to actual `:768`; tiebreaker ranges refreshed to `:360-364` and `:423-427`.
+
+  **Not moved into handler (now explicit):** `self.onPipelineStateChange?` external observer fan-out at `:346 / :411` stays inline in AppState — WhisperKit variant projects through unified `self.pipelineState`, which is cross-backend glue that doesn't belong in a per-backend handler.
 
 - **2026-04-20 v1.15 · Phase G grounded-review fixes** — Codex grounded review (`docs/audits/2026-04-20-phase-g-grounded-review.txt`) returned NO on the v1.14 plans. Two structural traps and four drift items corrected:
 

--- a/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+++ b/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
@@ -2919,6 +2919,16 @@ Only then does Phase B work start. Missing the decision capture in any of the th
 
 ## 30. Changelog
 
+- **2026-04-20 v1.17 · Phase A shipped — closure-based overlay injection replaces protocol existential** — Phase A landed on `refactor/phase-a-pipeline-state-handler` (commits `a00cbcb` commit 1 + `5fffb96` commit 2; PR TBD). Final design deviates from v1.16 §7.2 in one specific way: the handler's overlay dependency is a `@MainActor (OverlayIntent) -> Void` closure, NOT an `any RecordingOverlayPanelProtocol` existential.
+
+  **Why the change.** An earlier draft of commit 2 used the protocol existential as the v1.16 sketch prescribed. That form broke WhisperKit's batch transcription (LID windows + XPC reply cancelled with `Swift.CancellationError` during `.transcribing`). Parakeet's streaming path was unaffected. Bisect isolated the fault to the handler commit; the one-variable fix that restored WhisperKit was replacing `any RecordingOverlayPanelProtocol` with a concrete `@MainActor (OverlayIntent) -> Void` closure callback.
+
+  **Proof is the A/B isolation, not runtime theory.** main → works. Commit 1 (no handler class, inline show) → works. Commit 2 with existential → breaks WhisperKit. Commit 2 with closure → works on both. Proximate-cause guess (not a claim): actor-isolated protocol-existential indirection on a hot path interacts badly with WhisperKit's longer MainActor-held critical sections during batch transcription. Swift-runtime mechanism not fully confirmed.
+
+  **Standing lesson, captured in memory** (`feedback_no_actor_protocol_existential_hot_path.md`): avoid `any`-of-`@MainActor`-protocol indirection on hot paths when concrete or closure dispatch gives the same architectural outcome. Tests retain the observation seam via a recording closure + plain spy type; no production protocol needed.
+
+  **What landed.** Handler class is `public final class PipelineStateChangeHandler` in `EnviousWisprPipeline`. Six injected callbacks (one closure-based showOverlay + cancelWarning/scheduleWarning/reloadHistory/reportCompleted/reportFailed). Pure `PipelineStateChangePlanner` from commit 1 drives the decision. Both backends verified end-to-end. AppState.swift: 965 → 934 (−31). 382 tests pass. Bible §7.2 prose retains the original design for historical context; this changelog entry supersedes the `RecordingOverlayPanelProtocol` stored-field sketch.
+
 - **2026-04-20 v1.16 · Phase A Gate 0 sweep before kickoff** — Gate 0 citation audit against `origin/main` @ `8c5a5f3`. Two material design gaps and four naming/line-range drifts corrected in §7 before code work begins. No change to any other phase.
 
   **Material (design gap):**


### PR DESCRIPTION
## Summary

Phase A of epic #319 Q2 Hardening. Extracts the near-duplicate `onStateChange` closure behavior from `AppState.swift:344-406` (Parakeet) / `:409-463` (WhisperKit) into a pure planner + a stateful handler. Behavior-preserving refactor; no user-visible change.

- `PipelineStateChangePlanner` (internal to `EnviousWisprPipeline`): pure projection from state-transition inputs to an ordered list of side effects. Three-way `.complete` overlay priority (clipboardFallback > polish-failed-warning > success), warning cancel on non-complete, telemetry and history reload on `.complete`/`.error`.
- `PipelineStateChangeHandler` (public, `EnviousWisprPipeline`): stateful wrapper; executes the plan through six injected callbacks (a closure-based `showOverlay`, plus `cancelWarning` / `scheduleWarning` / `reloadHistory` / `reportDictationCompleted` / `reportPipelineFailed`). One instance per pipeline, constructed lazily with `[weak self]` captures reaching back into AppState-owned cross-pipeline state.
- AppState's closures drop from ~60 lines each to ~20. AppState still owns `onPipelineStateChange?` fan-out, hotkey register/unregister, `isRecordingLocked` reset, inactive→active tiebreaker, and the shared `postCompletionWarningTask` (its delayed guard crosses pipeline boundaries — moving it would split a shared lifecycle).

## Craftsmanship note — WhisperKit regression + root-cause

An earlier draft of commit 2 typed the handler's overlay dependency as `any RecordingOverlayPanelProtocol` (protocol was declared `@MainActor`). Commit 1 worked on both backends; commit 2 with the existential broke WhisperKit's batch transcription — LID windows + XPC reply cancelled with `Swift.CancellationError` during `.transcribing`. Parakeet's streaming path was unaffected.

Bisect isolated the fault to the handler commit. The fix that restored WhisperKit was a single-variable change: replace the `any`-of-`@MainActor`-protocol field with a concrete `@MainActor (OverlayIntent) -> Void` closure callback. Same architectural shape, static dispatch, no protocol indirection.

**Proof is the A/B isolation**, not a runtime-dispatch theory: main works, commit 1 works, commit 2 with existential breaks, commit 2 with closure works on both. Proximate-cause guess (not a claim): actor-isolated protocol-existential indirection on a hot path interacts badly with WhisperKit's longer MainActor-held critical sections during batch transcription. Swift-runtime mechanism not fully confirmed.

Standing lesson captured in memory (`feedback_no_actor_protocol_existential_hot_path.md`): avoid `any`-of-`@MainActor`-protocol indirection on hot paths when concrete or closure dispatch gives the same architectural outcome. Tests retain their observation seam via a recording closure + plain spy type; no production protocol needed.

## Architecture Closeout

**Module boundaries preserved.** Planner + handler live in `EnviousWisprPipeline`; AppState is in the `EnviousWispr` executable target. App → Pipeline dependency direction unchanged. No new module edges, no cycles.

**Heart/limbs doctrine preserved.** State-change dispatch sits between the pipeline (heart) and observability (limbs). No ASR, audio, or paste code touched. Warning Task ownership stayed in AppState because its cross-pipeline `.ready`-as-complete-equivalent guard would split if moved per-handler — preserving that shared lifecycle is the point.

**Access narrowing.** Planner types (`PipelineStateChangePlanner` / `PipelineStateChangePlan` / `PipelineStateSideEffect`) are `internal`. Only the handler (same module) calls them; tests reach them via `@testable import`. `RecordingOverlayPanelProtocol` eliminated entirely — was vestigial after the closure-based fix.

**DEBUG-only seam.** `CapturedTelemetryEvent` + `testEventHook` on `TelemetryService` are wrapped in `#if DEBUG`. Zero release-build cost; fields annotated `// periphery:ignore` since the reads live in the test target that Periphery excludes.

**Line count.** `AppState.swift`: 965 → 934 (−31). Bible §7.4 DoD predicted "~200"; actual is less because the shared warning Task + tiebreaker + hotkey + fan-out all stay inline per the bible's own design notes (§7.2). The meaningful win is decomposition + pinned behavior, not raw line count.

## Test plan

- [x] Planner characterization tests (`PipelineStateChangePlannerTests` — 17 tests) pin the full current-behavior contract: three-way `.complete` priority, warning-cancel on non-complete, WhisperKit `.ready` handling, label preservation (Starting / Loading model / Transcribing / Polishing), telemetry emission per state, canonical effect ordering, activity-projection integrity for both state enums.
- [x] Handler execution tests (`PipelineStateChangeHandlerTests` — 8 tests) verify each side effect routes to the correct injected callback.
- [x] Full suite: 382 tests in 40 suites pass.
- [x] Release build clean (`swift build -c release`).
- [x] Manual dictation smoke, Parakeet (PTT → recording → transcribing → polishing → paste, end-to-end).
- [x] Manual dictation smoke, WhisperKit (same flow; LID 4/4 windows conf=1.00 — no CancellationError, no stalls).
- [x] Codex code-diff review: clean, no discrete behavioral regressions or blocking issues.
- [x] Periphery scan: zero Phase A warnings; 71 pre-existing unchanged.
- [x] Heart-path cold bench: skipped — Phase A does not touch LLM polish / audio engine / paste cascade (the cache-sensitive subsystems the bench measures). Live-dictation spot-checks across session show normal total pipeline times (2–5 s) and clean diagnostics.

Refs: #319 bible §7 (v1.16 Gate 0 sweep + v1.17 shipped-design record)
