### PR TITLE
fix(ci): track UAT helper scripts so every worktree has the sanctioned clear path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,11 @@ scripts/*
 !scripts/release-preflight.sh
 !scripts/swift-test.sh
 !scripts/indexnow-submit.py
+# UAT scripts — required by workflow hooks in every worktree (validation-discipline.md § UAT modes)
+!scripts/attest.sh
+!scripts/clear-uat.sh
+!scripts/test-validation.sh
+!scripts/validation-status.sh
 # Polish eval harness — PUBLIC tracked files only (see .claude/knowledge/polish-eval.md for scope rules)
 !scripts/eval/
 scripts/eval/*

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# attest.sh — Record completion of a validation check.
+# Usage: scripts/attest.sh <check_name> "what I observed"
+# Validates: check is in required_checks, tree hash matches current state.
+# Appends to .validation/events.jsonl. Never deletes old events.
+
+set -eo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATION_DIR="$PROJECT_ROOT/.validation"
+STATE_FILE="$VALIDATION_DIR/state.json"
+EVENTS_FILE="$VALIDATION_DIR/events.jsonl"
+
+# --- Args ---
+if [ $# -lt 2 ]; then
+  echo "Usage: scripts/attest.sh <check_name> \"what I observed\"" >&2
+  exit 1
+fi
+
+check_name="$1"
+shift
+note="$*"
+
+if [ -z "$note" ]; then
+  echo "ERROR: Attestation note cannot be empty. Describe what you observed." >&2
+  exit 1
+fi
+
+# --- State file must exist ---
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ERROR: No validation state found. Run tier-check.sh first (or edit a file to trigger the hook)." >&2
+  exit 1
+fi
+
+# --- Validate check name against required_checks ---
+required=$(jq -r '.required_checks[]' "$STATE_FILE" 2>/dev/null)
+if ! echo "$required" | grep -qx "$check_name"; then
+  echo "ERROR: '$check_name' is not in required_checks for this change." >&2
+  echo "Required checks: $(jq -r '.required_checks | join(", ")' "$STATE_FILE")" >&2
+  exit 1
+fi
+
+# --- Compute current tree hash and compare ---
+state_hash=$(jq -r '.tree_hash' "$STATE_FILE")
+
+current_hash=$(
+  cd "$PROJECT_ROOT"
+  {
+    git diff HEAD -- . ':(exclude).validation' 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null | grep -v '^\.validation/' | while read -r f; do
+      [ -f "$f" ] && echo "untracked:$f:$(shasum "$f" 2>/dev/null | cut -d' ' -f1)"
+    done || true
+  } | shasum | cut -d' ' -f1
+)
+
+if [ "$current_hash" != "$state_hash" ]; then
+  echo "ERROR: Tree hash changed since last tier-check." >&2
+  echo "  State hash:   $state_hash" >&2
+  echo "  Current hash: $current_hash" >&2
+  echo "Code was edited after tier-check ran. Re-run tier-check.sh or rebuild to update state." >&2
+  exit 1
+fi
+
+# --- Check if already attested for this hash ---
+if [ -f "$EVENTS_FILE" ]; then
+  already=$(jq -r "select(.check == \"$check_name\" and .tree_hash == \"$state_hash\") | .check" "$EVENTS_FILE" 2>/dev/null || true)
+  if [ -n "$already" ]; then
+    echo "NOTE: '$check_name' already attested for this tree hash. Updating note." >&2
+  fi
+fi
+
+# --- Append attestation event ---
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+jq -n -c \
+  --arg check "$check_name" \
+  --arg tree_hash "$state_hash" \
+  --arg note "$note" \
+  --arg ts "$timestamp" \
+  '{check:$check, tree_hash:$tree_hash, note:$note, ts:$ts}' >> "$EVENTS_FILE"
+
+echo "Attested: $check_name"
+echo "  Note: $note"
+echo "  Tree hash: $state_hash"

--- a/scripts/clear-uat.sh
+++ b/scripts/clear-uat.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clear the .needs-uat marker after a passing rebuild + UAT cycle.
+# This script is the ONLY sanctioned way to clear the marker.
+
+PROJ_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MARKER="$PROJ_ROOT/.needs-uat"
+
+if [ ! -f "$MARKER" ]; then
+    echo "No .needs-uat marker to clear."
+    exit 0
+fi
+
+rm -f "$MARKER"
+echo "UAT marker cleared."

--- a/scripts/test-validation.sh
+++ b/scripts/test-validation.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# test-validation.sh — Run full validation system test suite.
+# ShellCheck + Bats + summary.
+
+set -eo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PASS=0
+FAIL=0
+
+section() { echo ""; echo "=== $1 ==="; echo ""; }
+
+# --- ShellCheck ---
+section "ShellCheck"
+if shellcheck scripts/tier-check.sh scripts/attest.sh scripts/validation-status.sh; then
+  echo "ShellCheck: PASS"
+  PASS=$((PASS + 1))
+else
+  echo "ShellCheck: FAIL"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Bats: tier-check ---
+section "Bats: tier-check"
+if bats test/tier-check.bats; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Bats: attest ---
+section "Bats: attest"
+if bats test/attest.bats; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Bats: validation-status ---
+section "Bats: validation-status"
+if bats test/validation-status.bats; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Bats: hooks ---
+section "Bats: hooks"
+if bats test/hooks.bats; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---
+section "Summary"
+TOTAL=$((PASS + FAIL))
+echo "$PASS/$TOTAL suites passed."
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILURES: $FAIL suite(s) failed."
+  exit 1
+else
+  echo "ALL GREEN."
+  exit 0
+fi

--- a/scripts/validation-status.sh
+++ b/scripts/validation-status.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# validation-status.sh — Print current validation state dashboard.
+# Shows: tier, tree hash, required checks, completed vs missing.
+
+set -eo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATION_DIR="$PROJECT_ROOT/.validation"
+STATE_FILE="$VALIDATION_DIR/state.json"
+EVENTS_FILE="$VALIDATION_DIR/events.jsonl"
+
+# --- No state ---
+if [ ! -f "$STATE_FILE" ]; then
+  echo "No validation state. No code changes detected or tier-check has not run."
+  exit 0
+fi
+
+# --- Read state ---
+tier=$(jq -r '.tier' "$STATE_FILE")
+state_hash=$(jq -r '.tree_hash' "$STATE_FILE")
+updated_at=$(jq -r '.updated_at' "$STATE_FILE")
+reasons=$(jq -r '.reasons | join(", ")' "$STATE_FILE")
+
+# --- Compute current hash ---
+current_hash=$(
+  cd "$PROJECT_ROOT"
+  {
+    git diff HEAD -- . ':(exclude).validation' 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null | grep -v '^\.validation/' | while read -r f; do
+      [ -f "$f" ] && echo "untracked:$f:$(shasum "$f" 2>/dev/null | cut -d' ' -f1)"
+    done || true
+  } | shasum | cut -d' ' -f1
+)
+
+hash_fresh="true"
+if [ "$current_hash" != "$state_hash" ]; then
+  hash_fresh="false"
+fi
+
+# --- Collect completed checks for current hash ---
+completed=""
+if [ -f "$EVENTS_FILE" ]; then
+  completed=$(jq -r "select(.tree_hash == \"$state_hash\") | .check" "$EVENTS_FILE" 2>/dev/null | sort -u || true)
+fi
+
+# --- Required checks ---
+required=$(jq -r '.required_checks[]' "$STATE_FILE" | sort -u)
+
+# --- Compute missing ---
+missing=""
+while IFS= read -r check; do
+  [ -z "$check" ] && continue
+  if [ -z "$completed" ] || ! echo "$completed" | grep -qx "$check"; then
+    if [ -z "$missing" ]; then
+      missing="$check"
+    else
+      missing=$(printf '%s\n%s' "$missing" "$check")
+    fi
+  fi
+done <<< "$required"
+
+# --- Print dashboard ---
+echo "=== Validation Status ==="
+echo ""
+echo "Tier:       $tier"
+echo "Reasons:    $reasons"
+echo "State hash: $state_hash"
+echo "Updated:    $updated_at"
+echo ""
+
+if [ "$hash_fresh" = "false" ]; then
+  echo "WARNING: Tree hash is STALE. Code changed since last tier-check."
+  echo "  State hash:   $state_hash"
+  echo "  Current hash: $current_hash"
+  echo "  All prior attestations are invalid. Re-run tier-check.sh."
+  echo ""
+fi
+
+echo "Required checks:"
+while IFS= read -r check; do
+  [ -z "$check" ] && continue
+  if [ -n "$completed" ] && echo "$completed" | grep -qx "$check"; then
+    note=$(jq -r "select(.tree_hash == \"$state_hash\" and .check == \"$check\") | .note" "$EVENTS_FILE" 2>/dev/null | tail -1 || true)
+    echo "  [x] $check: $note"
+  else
+    echo "  [ ] $check"
+  fi
+done <<< "$required"
+
+echo ""
+if [ -z "$missing" ]; then
+  echo "Status: ALL CHECKS COMPLETE. Ready to close."
+else
+  missing_count=$(echo "$missing" | grep -c . || true)
+  echo "Status: $missing_count check(s) remaining."
+fi


### PR DESCRIPTION
## Summary
- Allowlist `scripts/{attest,clear-uat,test-validation,validation-status}.sh` in `.gitignore` and commit them.
- Sanctioned UAT clear path now exists in every worktree, not just the one the scripts were first created in.

## Why
`.needs-uat` markers are created per-worktree by global Claude Code hooks on ship-path edits. The blocking hook that rejects manual marker removal also fires in every worktree. But the four UAT helper scripts were covered by the `scripts/*` gitignore pattern without an allowlist exception, so they only existed in whichever tree they were first created in.

Hooks fire everywhere; the fix scripts lived one place. During Phase B of #195 I hit this from a worktree off main: the sanctioned clear path did nothing because the script wasn't in my worktree, and the unsanctioned path was (correctly) blocked.

## Policy (kept in local `.claude/rules/validation-discipline.md`)
UAT can be satisfied via auto / mixed / full-human mode:
- **Auto:** Claude runs TTS dictation on both backends plus menu-click-through via wispr-eyes.
- **Mixed:** human runs voice dictation; Claude runs the app-level UI checks.
- **Full human:** human verifies everything.

Any of the three passing lets Claude clear the gate once the human-confirmed checks are recorded.

## Test plan
- [ ] Pull branch into a fresh worktree, confirm the four scripts are present.
- [ ] Trigger `.needs-uat` via a ship-path edit, run `scripts/clear-uat.sh`, confirm the marker is cleared.
- [ ] Confirm no accidental unignores via `git ls-files scripts/`.
