### PR TITLE
refactor(#195): Phase B — DictationSessionConfig freeze-at-startRecording

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -395,9 +395,15 @@ final class AppState {
       switch newState {
       case .recording:
         self.hotkeyService.registerCancelHotkey()
-      case .loadingModel, .transcribing, .polishing, .error, .idle, .complete:
+      case .loadingModel, .transcribing, .polishing:
         self.isRecordingLocked = false
         self.hotkeyService.unregisterCancelHotkey()
+      case .error, .idle, .complete:
+        self.isRecordingLocked = false
+        self.hotkeyService.unregisterCancelHotkey()
+        // Session ended — retry any Ollama eviction deferred because the
+        // frozen session pinned the old model.
+        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
       }
       let nowActive = newState.isActive
       if nowActive && !self.prevParakeetActive {
@@ -419,9 +425,13 @@ final class AppState {
       switch newState {
       case .recording:
         self.hotkeyService.registerCancelHotkey()
-      case .startingUp, .loadingModel, .transcribing, .polishing, .error, .idle, .ready, .complete:
+      case .startingUp, .loadingModel, .transcribing, .polishing:
         self.isRecordingLocked = false
         self.hotkeyService.unregisterCancelHotkey()
+      case .error, .idle, .ready, .complete:
+        self.isRecordingLocked = false
+        self.hotkeyService.unregisterCancelHotkey()
+        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
       }
       let nowActive = newState.isActive
       if nowActive && !self.prevWhisperKitActive {

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -527,7 +527,7 @@ final class AppState {
       // `.toggleRecording` is declared throws on the protocol, but today the
       // underlying implementation doesn't throw. `try?` keeps the surface
       // unchanged. If a future event grows a meaningful throw we revisit here.
-      try? await active.handle(event: .toggleRecording)
+      try? await active.handle(event: .toggleRecording(makeDictationSessionConfig()))
       let totalMs = {
         let (s, a) = (ContinuousClock.now - pttStart).components
         return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
@@ -846,7 +846,7 @@ final class AppState {
       )
     }
 
-    try? await active.handle(event: .toggleRecording)
+    try? await active.handle(event: .toggleRecording(makeDictationSessionConfig()))
 
     // Clear auto-paste on completion/error
     if active is WhisperKitPipeline {
@@ -858,6 +858,46 @@ final class AppState {
       if pipeline.state == .complete { pipeline.autoPasteToActiveApp = false }
       if case .error = pipeline.state { pipeline.autoPasteToActiveApp = false }
     }
+  }
+
+  /// Build the per-recording `DictationSessionConfig` snapshot. Captures the
+  /// current `SettingsManager` state plus the input-mode-derived paste intent
+  /// which AppState sets on the active pipeline immediately before dispatching
+  /// `.toggleRecording`. Phase B commit 1: snapshot is captured and threaded
+  /// through the event but pipelines still read from their public properties;
+  /// behavior unchanged. Commit 2 flips pipelines to read from the snapshot.
+  private func makeDictationSessionConfig() -> DictationSessionConfig {
+    let isWhisperKit = asrManager.activeBackendType == .whisperKit
+    let autoPaste =
+      isWhisperKit
+      ? whisperKitPipeline.autoPasteToActiveApp
+      : pipeline.autoPasteToActiveApp
+    let resolvedModel: String = {
+      switch settings.llmProvider {
+      case .appleIntelligence: return "apple-intelligence"
+      case .ollama: return settings.ollamaModel
+      default: return settings.llmModel
+      }
+    }()
+    return DictationSessionConfig(
+      autoCopyToClipboard: settings.autoCopyToClipboard,
+      autoPasteToActiveApp: autoPaste,
+      restoreClipboardAfterPaste: settings.restoreClipboardAfterPaste,
+      vadAutoStop: settings.vadAutoStop,
+      vadSilenceTimeout: settings.vadSilenceTimeout,
+      vadSensitivity: settings.vadSensitivity,
+      vadEnergyGate: settings.vadEnergyGate,
+      languageMode: settings.languageMode,
+      useStreamingASR: settings.useStreamingASR,
+      modelUnloadPolicy: settings.modelUnloadPolicy,
+      llmProvider: settings.llmProvider,
+      llmModel: resolvedModel,
+      polishInstructions: settings.activePolishInstructions,
+      styleConfig: settings.activePolishStyleConfig,
+      useExtendedThinking: settings.useExtendedThinking,
+      selectedInputDeviceUID: settings.selectedInputDeviceUID,
+      preferredInputDeviceIDOverride: settings.preferredInputDeviceIDOverride
+    )
   }
 
   /// Cancel an active recording, discarding all captured audio.

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -456,21 +456,15 @@ final class AppState {
 
       if isWhisperKit {
         guard !self.whisperKitPipeline.state.isActive else { return }
-        self.whisperKitPipeline.autoPasteToActiveApp = true
-        self.whisperKitPipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
       } else {
         guard !self.pipelineState.isActive else { return }
-        self.pipeline.autoPasteToActiveApp = true
-        self.pipeline.autoCopyToClipboard = self.settings.autoCopyToClipboard
       }
 
+      // Refresh AX status so `makeDictationSessionConfig` sees the right
+      // paste capability. The session snapshot is captured fresh at
+      // `.toggleRecording` dispatch below.
       self.permissions.refreshAccessibilityStatus()
       if !self.permissions.hasAccessibilityPermission {
-        if isWhisperKit {
-          self.whisperKitPipeline.autoPasteToActiveApp = false
-        } else {
-          self.pipeline.autoPasteToActiveApp = false
-        }
         self.permissions.restartMonitoringIfNeeded()
       }
 
@@ -538,26 +532,11 @@ final class AppState {
           level: .info, category: "Pipeline"
         )
       }
-
-      if isWhisperKit {
-        if case .error = self.whisperKitPipeline.state {
-          self.whisperKitPipeline.autoPasteToActiveApp = false
-        }
-      } else {
-        if case .error = self.pipeline.state {
-          self.pipeline.autoPasteToActiveApp = false
-        }
-      }
     }
     hotkeyService.onStopRecording = { [weak self] in
       guard let self else { return }
       self.isRecordingLocked = false
       try? await self.activePipeline.handle(event: .requestStop)
-      if self.asrManager.activeBackendType == .whisperKit {
-        self.whisperKitPipeline.autoPasteToActiveApp = false
-      } else {
-        self.pipeline.autoPasteToActiveApp = false
-      }
     }
 
     hotkeyService.onCancelRecording = { [weak self] in
@@ -799,29 +778,13 @@ final class AppState {
   func toggleRecording() async {
     postCompletionWarningTask?.cancel()
     let active = activePipeline
-    // Set auto-paste before toggle
-    if active is WhisperKitPipeline {
-      switch whisperKitPipeline.state {
-      case .idle, .ready, .complete, .error:
-        whisperKitPipeline.autoPasteToActiveApp = true
-        permissions.refreshAccessibilityStatus()
-        if !permissions.hasAccessibilityPermission {
-          whisperKitPipeline.autoPasteToActiveApp = false
-          permissions.restartMonitoringIfNeeded()
-        }
-      default: break
-      }
-    } else {
-      switch pipeline.state {
-      case .idle, .complete, .error:
-        pipeline.autoPasteToActiveApp = true
-        permissions.refreshAccessibilityStatus()
-        if !permissions.hasAccessibilityPermission {
-          pipeline.autoPasteToActiveApp = false
-          permissions.restartMonitoringIfNeeded()
-        }
-      default: break
-      }
+
+    // Refresh AX status before snapshotting — `makeDictationSessionConfig`
+    // derives `autoPasteToActiveApp` from the active pipeline's idle state
+    // plus the current AX permission.
+    permissions.refreshAccessibilityStatus()
+    if !permissions.hasAccessibilityPermission {
+      permissions.restartMonitoringIfNeeded()
     }
 
     // Fire dictation.invoked telemetry when starting (not stopping).
@@ -847,31 +810,28 @@ final class AppState {
     }
 
     try? await active.handle(event: .toggleRecording(makeDictationSessionConfig()))
-
-    // Clear auto-paste on completion/error
-    if active is WhisperKitPipeline {
-      if case .complete = whisperKitPipeline.state {
-        whisperKitPipeline.autoPasteToActiveApp = false
-      }
-      if case .error = whisperKitPipeline.state { whisperKitPipeline.autoPasteToActiveApp = false }
-    } else {
-      if pipeline.state == .complete { pipeline.autoPasteToActiveApp = false }
-      if case .error = pipeline.state { pipeline.autoPasteToActiveApp = false }
-    }
   }
 
   /// Build the per-recording `DictationSessionConfig` snapshot. Captures the
-  /// current `SettingsManager` state plus the input-mode-derived paste intent
-  /// which AppState sets on the active pipeline immediately before dispatching
-  /// `.toggleRecording`. Phase B commit 1: snapshot is captured and threaded
-  /// through the event but pipelines still read from their public properties;
-  /// behavior unchanged. Commit 2 flips pipelines to read from the snapshot.
+  /// current `SettingsManager` state plus the input-mode-derived paste intent.
+  /// Called at `.toggleRecording` dispatch; the recording's pipeline freezes
+  /// the snapshot for its lifetime via `startRecording(config:)`.
   private func makeDictationSessionConfig() -> DictationSessionConfig {
     let isWhisperKit = asrManager.activeBackendType == .whisperKit
-    let autoPaste =
-      isWhisperKit
-      ? whisperKitPipeline.autoPasteToActiveApp
-      : pipeline.autoPasteToActiveApp
+    let activePipelineIdle: Bool = {
+      if isWhisperKit {
+        switch whisperKitPipeline.state {
+        case .idle, .ready, .complete, .error: return true
+        default: return false
+        }
+      } else {
+        switch pipeline.state {
+        case .idle, .complete, .error: return true
+        default: return false
+        }
+      }
+    }()
+    let autoPaste = activePipelineIdle && permissions.hasAccessibilityPermission
     let resolvedModel: String = {
       switch settings.llmProvider {
       case .appleIntelligence: return "apple-intelligence"
@@ -912,11 +872,9 @@ final class AppState {
       guard wkState == .recording || wkState == .loadingModel || wkState == .startingUp else {
         return
       }
-      whisperKitPipeline.autoPasteToActiveApp = false
       try? await whisperKitPipeline.handle(event: .cancelRecording)
     } else {
       guard pipelineState == .recording || pipelineState == .loadingModel else { return }
-      pipeline.autoPasteToActiveApp = false
       await pipeline.cancelRecording()
     }
   }

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -225,12 +225,34 @@ final class PipelineSettingsSync {
       provider: settings.llmProvider, model: resolvedModel(settings)
     )
     let pre = lastEvictableOllamaModel
+    guard let pre, pre != new else {
+      lastEvictableOllamaModel = new
+      return
+    }
+    // Phase B: if either pipeline has frozen `pre` into its in-flight
+    // session via `DictationSessionConfig`, the upcoming polish call is
+    // pinned to that model. Evicting now would cold-swap the active
+    // recording's polish. Defer by leaving `lastEvictableOllamaModel` at
+    // `pre`; the next setting change re-evaluates.
+    if isOllamaModelPinnedInFlight(pre) { return }
     lastEvictableOllamaModel = new
-    guard let pre, pre != new else { return }
     let polishStep = polishService.llmPolishStep
     Task { [polishStep, pre] in
       await polishStep.evictPreviousOllamaModel(pre)
     }
+  }
+
+  /// True if either pipeline's frozen `DictationSessionConfig` targets the
+  /// given Ollama model. Used by `reconcileOllamaEviction` to avoid evicting
+  /// a model the in-flight polish still needs.
+  private func isOllamaModelPinnedInFlight(_ model: String) -> Bool {
+    for cfg in [pipeline.currentSessionConfig, whisperKitPipeline.currentSessionConfig] {
+      guard let cfg else { continue }
+      if cfg.llmProvider == .ollama && cfg.llmModel == model {
+        return true
+      }
+    }
+    return false
   }
 
   /// Re-register Carbon hotkeys after a config change.

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -242,6 +242,13 @@ final class PipelineSettingsSync {
     }
   }
 
+  /// Retry a deferred Ollama eviction after an in-flight session ends.
+  /// AppState calls this from `onStateChange` when either pipeline transitions
+  /// to a terminal state. Idempotent: no-op if nothing is pending.
+  func retryDeferredOllamaEviction(settings: SettingsManager) {
+    reconcileOllamaEviction(settings: settings)
+  }
+
   /// True if either pipeline's frozen `DictationSessionConfig` targets the
   /// given Ollama model. Used by `reconcileOllamaEviction` to avoid evicting
   /// a model the in-flight polish still needs.

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -6,8 +6,9 @@ import EnviousWisprPipeline
 import EnviousWisprServices
 import Foundation
 
-/// Forwards settings changes to pipelines and subsystems.
-/// Single responsibility: settings propagation. No business logic.
+/// Forwards live-mutable settings changes. Per-recording values are frozen
+/// via `DictationSessionConfig` at `startRecording` and do not flow here —
+/// see #195 plan for the full frozen/live classification.
 @MainActor
 final class PipelineSettingsSync {
   private let pipeline: TranscriptionPipeline
@@ -18,16 +19,13 @@ final class PipelineSettingsSync {
   private let hotkeyService: HotkeyService
   private let whisperKitSetup: WhisperKitSetupService
 
-  /// Called when backend/model changes require WhisperKit preload re-observation.
-  /// Set by AppState — keeps preload observation ownership in AppState.
+  /// Set by AppState so backend/model changes can retrigger preload observation
+  /// without coupling this layer to AppState.
   var onNeedsPreloadObservation: (() -> Void)?
 
-  /// Last effective Ollama model name seen by this observer, or nil if the
-  /// last known state was non-Ollama. Tracked independently of
-  /// `polishService.llmPolishStep` because SettingsManager's cascading
-  /// didSet (e.g., `llmProvider = .appleIntelligence` synchronously writes
-  /// `llmModel = "apple-intelligence"`) can corrupt a pre-snapshot read from
-  /// the polish step. Sole source of truth for #295 eviction decisions.
+  /// Tracks the last evictable Ollama model for #295. Independent of
+  /// `polishService.llmPolishStep` because SettingsManager's cascading didSet
+  /// can corrupt a pre-snapshot read from the polish step.
   private var lastEvictableOllamaModel: String?
 
   init(
@@ -48,34 +46,20 @@ final class PipelineSettingsSync {
     self.whisperKitSetup = whisperKitSetup
   }
 
-  /// Apply initial settings to both pipelines and audio capture. Called once from AppState.init.
+  /// Seed live-mutable subsystems. Per-recording values are captured fresh
+  /// at each `startRecording` and are not seeded here.
   func applyInitialSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
-    // Parakeet pipeline
-    pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-    pipeline.llmPolish.llmProvider = settings.llmProvider
-    pipeline.llmPolish.llmModel = resolvedModel(settings)
-    pipeline.vadAutoStop = settings.vadAutoStop
-    pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-    pipeline.vadSensitivity = settings.vadSensitivity
-    pipeline.vadEnergyGate = settings.vadEnergyGate
-    pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-    pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-    pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-    pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
     pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
     pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
     pipeline.wordCorrection.customWords = customWords
     pipeline.llmPolish.customWords = customWords
-    pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-    pipeline.useStreamingASR = settings.useStreamingASR
+    whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    whisperKitPipeline.wordCorrection.customWords = customWords
+    whisperKitPipeline.llmPolish.customWords = customWords
 
-    // WhisperKit pipeline
-    syncWhisperKitPipelineSettings(settings, customWords: customWords)
-
-    // Transcript polish service (re-polish from detail view)
     syncPolishServiceSettings(settings, customWords: customWords)
 
-    // Audio capture
     if settings.noiseSuppression {
       audioCapture.buildEngine(noiseSuppression: true)
     } else {
@@ -84,8 +68,6 @@ final class PipelineSettingsSync {
     audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
     audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
     audioCapture.warmEnginePolicy = settings.warmEnginePolicy
-
-    // VAD config to audio capture (used by XPC service-side VAD)
     audioCapture.configureVAD(
       autoStop: settings.vadAutoStop,
       silenceTimeout: settings.vadSilenceTimeout,
@@ -93,12 +75,7 @@ final class PipelineSettingsSync {
       energyGate: settings.vadEnergyGate
     )
 
-    // Transcription options (language)
-    syncTranscriptionOptions(settings)
-
-    // #295: seed the eviction tracker so the first swap captures the right
-    // "previous" model. No initial eviction fires (this is app launch, not
-    // a user swap).
+    // #295: seed eviction tracker. No initial eviction on app launch.
     lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
       provider: settings.llmProvider, model: resolvedModel(settings)
     )
@@ -137,82 +114,30 @@ final class PipelineSettingsSync {
     case .recordingMode:
       hotkeyService.recordingMode = settings.recordingMode
     case .llmProvider:
-      pipeline.llmPolish.llmProvider = settings.llmProvider
-      whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
+      // Live mirror to re-polish path; eviction fires for RAM management (#295).
+      // Pipeline polish uses the frozen value from `DictationSessionConfig`.
       polishService.llmPolishStep.llmProvider = settings.llmProvider
-      // Also sync model — provider change may canonicalize the model
-      let model = resolvedModel(settings)
-      pipeline.llmPolish.llmModel = model
-      whisperKitPipeline.llmPolish.llmModel = model
-      polishService.llmPolishStep.llmModel = model
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
       reconcileOllamaEviction(settings: settings)
     case .llmModel:
-      let model = resolvedModel(settings)
-      pipeline.llmPolish.llmModel = model
-      whisperKitPipeline.llmPolish.llmModel = model
-      polishService.llmPolishStep.llmModel = model
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
       if settings.llmProvider == .ollama {
         settings.ollamaModel = settings.llmModel
       }
       reconcileOllamaEviction(settings: settings)
     case .ollamaModel:
       if settings.llmProvider == .ollama {
-        pipeline.llmPolish.llmModel = settings.ollamaModel
-        whisperKitPipeline.llmPolish.llmModel = settings.ollamaModel
         polishService.llmPolishStep.llmModel = settings.ollamaModel
       }
       reconcileOllamaEviction(settings: settings)
-    case .autoCopyToClipboard:
-      pipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-      whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
     case .hotkeyEnabled:
       if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
-    case .vadAutoStop:
-      pipeline.vadAutoStop = settings.vadAutoStop
-      whisperKitPipeline.vadAutoStop = settings.vadAutoStop
-      audioCapture.configureVAD(
-        autoStop: settings.vadAutoStop,
-        silenceTimeout: settings.vadSilenceTimeout,
-        sensitivity: settings.vadSensitivity,
-        energyGate: settings.vadEnergyGate
-      )
-    case .vadSilenceTimeout:
-      pipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-      whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-      audioCapture.configureVAD(
-        autoStop: settings.vadAutoStop,
-        silenceTimeout: settings.vadSilenceTimeout,
-        sensitivity: settings.vadSensitivity,
-        energyGate: settings.vadEnergyGate
-      )
     case .environmentPreset:
-      let sensitivity = settings.environmentPreset.vadSensitivity
-      settings.vadSensitivity = sensitivity
-    case .writingStylePreset:
-      pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-      pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-      whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-      whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
+      // Cascade into `vadSensitivity` for the next recording's snapshot.
+      settings.vadSensitivity = settings.environmentPreset.vadSensitivity
+    case .writingStylePreset, .customSystemPrompt:
       polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
       polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
-    case .vadSensitivity:
-      pipeline.vadSensitivity = settings.vadSensitivity
-      whisperKitPipeline.vadSensitivity = settings.vadSensitivity
-      audioCapture.configureVAD(
-        autoStop: settings.vadAutoStop,
-        silenceTimeout: settings.vadSilenceTimeout,
-        sensitivity: settings.vadSensitivity,
-        energyGate: settings.vadEnergyGate
-      )
-    case .vadEnergyGate:
-      pipeline.vadEnergyGate = settings.vadEnergyGate
-      whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
-      audioCapture.configureVAD(
-        autoStop: settings.vadAutoStop,
-        silenceTimeout: settings.vadSilenceTimeout,
-        sensitivity: settings.vadSensitivity,
-        energyGate: settings.vadEnergyGate
-      )
     case .cancelKeyCode:
       hotkeyService.cancelKeyCode = settings.cancelKeyCode
     case .cancelModifiers:
@@ -227,21 +152,10 @@ final class PipelineSettingsSync {
       // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
       break
     case .modelUnloadPolicy:
-      pipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-      whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
+      // Frozen per recording; cancel idle timer live when switched to .never.
       if settings.modelUnloadPolicy == .never {
         asrManager.cancelIdleTimer()
       }
-    case .restoreClipboardAfterPaste:
-      pipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-      whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-    case .customSystemPrompt:
-      pipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-      pipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-      whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-      whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
-      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
     case .wordCorrectionEnabled:
       pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
       whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
@@ -253,24 +167,15 @@ final class PipelineSettingsSync {
     case .debugLogLevel:
       Task { await AppLogger.shared.setLogLevel(settings.debugLogLevel) }
     case .useExtendedThinking:
-      pipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-      whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
       polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
-    case .whisperKitLanguage:
-      syncTranscriptionOptions(settings)
-    case .languageMode:
-      // Multilingual v1 (W2): keep pipeline in sync with user's auto/locked
-      // choice. Detection itself happens in the pipeline; this path just
-      // forwards the current mode so the detector actor reads it lazily.
-      whisperKitPipeline.languageMode = settings.languageMode
-      syncTranscriptionOptions(settings)
     case .selectedInputDeviceUID:
+      // Rebuilds next recording's capture source; in-flight recordings unaffected.
       audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
     case .preferredInputDeviceIDOverride:
       audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
     case .noiseSuppression:
-      // Full engine rebuild — runtime toggling of voice processing is unreliable.
-      // Cancel any active recording first to avoid corrupted state.
+      // Runtime voice-processing toggling is unreliable — full engine rebuild.
+      // Cancel active recording first to avoid corrupted state.
       if pipeline.state == .recording {
         Task { [weak self] in
           await self?.pipeline.cancelRecording()
@@ -279,68 +184,19 @@ final class PipelineSettingsSync {
       } else {
         audioCapture.buildEngine(noiseSuppression: settings.noiseSuppression)
       }
-    case .onboardingState, .hasCompletedOnboarding:
-      break
-    case .useXPCAudioService:
-      // Cold flag — requires app restart. No live propagation needed.
-      break
-    case .useStreamingASR:
-      pipeline.useStreamingASR = settings.useStreamingASR
     case .warmEnginePolicy:
       audioCapture.warmEnginePolicy = settings.warmEnginePolicy
+    case .autoCopyToClipboard, .vadAutoStop, .vadSilenceTimeout, .vadSensitivity,
+      .vadEnergyGate, .restoreClipboardAfterPaste, .languageMode, .useStreamingASR:
+      break  // Frozen per recording; see `DictationSessionConfig`.
+    case .whisperKitLanguage:
+      break  // Deprecated — legacy migration only (SettingsManager:460-484).
+    case .onboardingState, .hasCompletedOnboarding, .useXPCAudioService:
+      break  // UI-only or cold flag.
     }
   }
 
-  /// Sync shared transcription options (language, timestamps) to both pipelines.
-  private func syncTranscriptionOptions(_ settings: SettingsManager) {
-    var opts = TranscriptionOptions()
-    // Parakeet is English-only; WhisperKit uses the user's selected language.
-    // Pass the language to both pipelines: Parakeet ignores it, WhisperKit
-    // passes it through to DecodingOptions.
-    //
-    // Multilingual v1: source is now `languageMode`, not the deprecated
-    // `whisperKitLanguage` field. In auto mode, leave language empty so the
-    // detector's result (set later in the pipeline) fills it. In locked
-    // mode, push the ISO code so the incremental worker and the batch
-    // decode see the correct language from recording start.
-    switch settings.languageMode {
-    case .auto:
-      // `TranscriptionOptions.language` is String?; nil means "let the
-      // detector decide" (the pipeline overwrites it after LID runs).
-      opts.language = nil
-    case .locked(let code):
-      opts.language = code
-    }
-    pipeline.transcriptionOptions = opts
-    whisperKitPipeline.transcriptionOptions = opts
-  }
-
-  /// Sync all user-facing settings to the WhisperKit pipeline.
-  private func syncWhisperKitPipelineSettings(
-    _ settings: SettingsManager, customWords: [CustomWord]
-  ) {
-    whisperKitPipeline.autoCopyToClipboard = settings.autoCopyToClipboard
-    whisperKitPipeline.restoreClipboardAfterPaste = settings.restoreClipboardAfterPaste
-    whisperKitPipeline.llmPolish.llmProvider = settings.llmProvider
-    whisperKitPipeline.llmPolish.llmModel = resolvedModel(settings)
-    whisperKitPipeline.llmPolish.polishInstructions = settings.activePolishInstructions
-    whisperKitPipeline.llmPolish.styleConfig = settings.activePolishStyleConfig
-    whisperKitPipeline.llmPolish.useExtendedThinking = settings.useExtendedThinking
-    whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
-    whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
-    whisperKitPipeline.wordCorrection.customWords = customWords
-    whisperKitPipeline.llmPolish.customWords = customWords
-    whisperKitPipeline.vadAutoStop = settings.vadAutoStop
-    whisperKitPipeline.vadSilenceTimeout = settings.vadSilenceTimeout
-    whisperKitPipeline.vadSensitivity = settings.vadSensitivity
-    whisperKitPipeline.vadEnergyGate = settings.vadEnergyGate
-    whisperKitPipeline.modelUnloadPolicy = settings.modelUnloadPolicy
-    // Multilingual v1 (W2): mirror the current auto/locked mode on startup.
-    whisperKitPipeline.languageMode = settings.languageMode
-  }
-
-  /// Sync all LLM settings to the transcript polish service (re-polish from detail view).
-  /// TODO: Replace 3-way sync with shared LLMPolishConfig provider (#206 follow-up)
+  /// Re-polish settings. TODO: share `LLMPolishConfig` with the pipeline (#206 follow-up).
   private func syncPolishServiceSettings(_ settings: SettingsManager, customWords: [CustomWord]) {
     polishService.llmPolishStep.llmProvider = settings.llmProvider
     polishService.llmPolishStep.llmModel = resolvedModel(settings)
@@ -362,20 +218,8 @@ final class PipelineSettingsSync {
 
   // MARK: - Ollama eviction on swap (#295)
 
-  /// Reconcile `lastEvictableOllamaModel` with the current effective state
-  /// and fire a best-effort unload if the tracked previous model differs
-  /// from the new one (including new = nil when the user leaves Ollama).
-  ///
-  /// Using an internal tracker — not a polishStep snapshot — avoids the
-  /// SettingsManager cascading-didSet trap where
-  /// `settings.llmProvider = .appleIntelligence` synchronously writes
-  /// `settings.llmModel = "apple-intelligence"` before the provider change
-  /// notification fires, which would otherwise corrupt a pre-snapshot and
-  /// lead to an eviction attempt on "apple-intelligence" (#295 UAT bug).
-  ///
-  /// The tracker is also the coalesce guard for the cascading
-  /// `.llmModel` → `.ollamaModel` fire: after the first case reconciles,
-  /// the second sees `pre == new` and skips.
+  /// Fires best-effort unload when the tracked previous Ollama model differs
+  /// from the new one. Also coalesces cascading .llmModel → .ollamaModel fires.
   private func reconcileOllamaEviction(settings: SettingsManager) {
     let new = OllamaConnector.effectiveOllamaModel(
       provider: settings.llmProvider, model: resolvedModel(settings)

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -111,6 +111,8 @@ struct AIPolishSettingsView: View {
               .font(.stHelper)
               .foregroundStyle(Color.stTextTertiary)
           }
+        } footer: {
+          FrozenPerRecordingFootnote()
         }
       }
 
@@ -183,6 +185,8 @@ struct AIPolishSettingsView: View {
               modelRecommendationCards
             }
           }
+        } footer: {
+          FrozenPerRecordingFootnote()
         }
       }
 
@@ -210,6 +214,8 @@ struct AIPolishSettingsView: View {
                 .foregroundStyle(Color.stTextTertiary)
             }
           }
+        } footer: {
+          FrozenPerRecordingFootnote()
         }
       }
     }

--- a/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
@@ -37,6 +37,8 @@ struct AudioSettingsView: View {
             .foregroundStyle(.stTextTertiary)
           }
         }
+      } footer: {
+        FrozenPerRecordingFootnote()
       }
 
       BrandedSection(header: "Audio Processing") {

--- a/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
@@ -24,6 +24,8 @@ struct ClipboardSettingsView: View {
               .foregroundStyle(.stTextTertiary)
           }
         }
+      } footer: {
+        FrozenPerRecordingFootnote()
       }
     }
   }

--- a/Sources/EnviousWispr/Views/Settings/MemorySettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/MemorySettingsView.swift
@@ -35,6 +35,8 @@ struct MemorySettingsView: View {
             .foregroundStyle(.stWarning)
           }
         }
+      } footer: {
+        FrozenPerRecordingFootnote()
       }
     }
   }

--- a/Sources/EnviousWispr/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsComponents.swift
@@ -106,6 +106,19 @@ struct BrandedRow<Content: View>: View {
   }
 }
 
+// MARK: - Frozen-per-recording footnote
+
+/// Static helper text for settings sections whose values freeze at recording
+/// start via `DictationSessionConfig`. Placed in a `BrandedSection`'s footer
+/// slot or inline under affected controls.
+struct FrozenPerRecordingFootnote: View {
+  var body: some View {
+    Text("Changes made during a recording apply to the next recording.")
+      .font(.caption)
+      .foregroundStyle(.stTextTertiary)
+  }
+}
+
 // MARK: - Branded Toggle Style
 
 /// Green ON / lavender OFF toggle matching the brand mockups, 38x22 px.

--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
@@ -90,6 +90,8 @@ struct SpeechEngineSettingsView: View {
               }
             }
           }
+        } footer: {
+          FrozenPerRecordingFootnote()
         }
       }
 
@@ -120,6 +122,8 @@ struct SpeechEngineSettingsView: View {
             }
           }
         }
+      } footer: {
+        FrozenPerRecordingFootnote()
       }
 
       // ── Section 4: Transcription Mode ────────────────────────────────
@@ -136,6 +140,8 @@ struct SpeechEngineSettingsView: View {
               .foregroundStyle(.stTextTertiary)
             }
           }
+        } footer: {
+          FrozenPerRecordingFootnote()
         }
       }
 

--- a/Sources/EnviousWisprCore/DictationSessionConfig.swift
+++ b/Sources/EnviousWisprCore/DictationSessionConfig.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Per-recording configuration snapshot. Captured at `startRecording`; immutable for the
+/// duration of the recording. Settings mutated mid-recording apply to the NEXT recording.
+///
+/// Contains only values that must be frozen per recording. Live-mutable settings
+/// (hotkey registration, `wordCorrectionEnabled`, `fillerRemovalEnabled`, custom-words
+/// dictionary, Ollama RAM eviction side-effects) stay in `PipelineSettingsSync`.
+public struct DictationSessionConfig: Sendable {
+  // MARK: Paste / clipboard
+
+  public let autoCopyToClipboard: Bool
+  /// Input-mode-derived at `startRecording`. True when the user triggered via hotkey
+  /// or push-to-talk with accessibility permission available; false for menu-triggered
+  /// recordings or when the paste target cannot be resolved. Consolidates the previously
+  /// scattered writes to `pipeline.autoPasteToActiveApp` in `AppState`.
+  public let autoPasteToActiveApp: Bool
+  public let restoreClipboardAfterPaste: Bool
+
+  // MARK: VAD
+
+  public let vadAutoStop: Bool
+  public let vadSilenceTimeout: Double
+  public let vadSensitivity: Float
+  public let vadEnergyGate: Bool
+
+  // MARK: ASR
+
+  /// Single source of truth for language selection. Pipelines derive
+  /// `TranscriptionOptions` from this at session start.
+  public let languageMode: LanguageMode
+  /// Parakeet-only. Committed at start — there is no mid-record reconfiguration path
+  /// in `TranscriptionPipeline`.
+  public let useStreamingASR: Bool
+  public let modelUnloadPolicy: ModelUnloadPolicy
+
+  // MARK: LLM polish
+
+  public let llmProvider: LLMProvider
+  /// Resolved model ID: `"apple-intelligence"` for Apple, `ollamaModel` for Ollama,
+  /// `llmModel` for cloud. Construction-time resolution avoids cascading-didSet
+  /// races inside `SettingsManager`.
+  public let llmModel: String
+  public let polishInstructions: PolishInstructions
+  public let styleConfig: PolishStyleConfig
+  public let useExtendedThinking: Bool
+
+  // MARK: Audio device selection
+
+  /// Already de-facto frozen — `AudioCaptureManager` reads device UIDs at source
+  /// construction, and the source is rebuilt between recordings. Including here
+  /// makes the contract explicit.
+  public let selectedInputDeviceUID: String
+  public let preferredInputDeviceIDOverride: String
+
+  public init(
+    autoCopyToClipboard: Bool,
+    autoPasteToActiveApp: Bool,
+    restoreClipboardAfterPaste: Bool,
+    vadAutoStop: Bool,
+    vadSilenceTimeout: Double,
+    vadSensitivity: Float,
+    vadEnergyGate: Bool,
+    languageMode: LanguageMode,
+    useStreamingASR: Bool,
+    modelUnloadPolicy: ModelUnloadPolicy,
+    llmProvider: LLMProvider,
+    llmModel: String,
+    polishInstructions: PolishInstructions,
+    styleConfig: PolishStyleConfig,
+    useExtendedThinking: Bool,
+    selectedInputDeviceUID: String,
+    preferredInputDeviceIDOverride: String
+  ) {
+    self.autoCopyToClipboard = autoCopyToClipboard
+    self.autoPasteToActiveApp = autoPasteToActiveApp
+    self.restoreClipboardAfterPaste = restoreClipboardAfterPaste
+    self.vadAutoStop = vadAutoStop
+    self.vadSilenceTimeout = vadSilenceTimeout
+    self.vadSensitivity = vadSensitivity
+    self.vadEnergyGate = vadEnergyGate
+    self.languageMode = languageMode
+    self.useStreamingASR = useStreamingASR
+    self.modelUnloadPolicy = modelUnloadPolicy
+    self.llmProvider = llmProvider
+    self.llmModel = llmModel
+    self.polishInstructions = polishInstructions
+    self.styleConfig = styleConfig
+    self.useExtendedThinking = useExtendedThinking
+    self.selectedInputDeviceUID = selectedInputDeviceUID
+    self.preferredInputDeviceIDOverride = preferredInputDeviceIDOverride
+  }
+}

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -9,7 +9,10 @@ public enum InterruptionMessages {
 /// Events that any dictation pipeline must handle.
 public enum PipelineEvent: Sendable {
   case preWarm
-  case toggleRecording
+  /// Toggle recording. Carries the per-recording configuration snapshot; pipelines
+  /// consume the config on start transitions and ignore it on stop transitions.
+  /// Settings mutated mid-recording apply to the next recording's snapshot.
+  case toggleRecording(DictationSessionConfig)
   case requestStop
   case cancelRecording
   case reset

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -36,6 +36,11 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   public var transcriptionOptions: TranscriptionOptions = .default
   public var lastPolishError: String?
 
+  /// Per-recording session config snapshot. Captured at `startRecording`; immutable
+  /// for the duration of the recording. Settings mutated mid-recording apply to the
+  /// NEXT recording. `nil` when no recording is in flight.
+  public private(set) var currentSessionConfig: DictationSessionConfig?
+
   // Shared services
   private let transcriptFinalizer: TranscriptFinalizer
 
@@ -327,11 +332,13 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     }
   }
 
-  /// Toggle recording: start if idle, stop if recording.
-  public func toggleRecording() async {
+  /// Toggle recording: start if idle, stop if recording. On start transitions,
+  /// the provided session config is captured; on stop transitions the config
+  /// is ignored (the in-flight recording continues to use its original snapshot).
+  public func toggleRecording(config: DictationSessionConfig) async {
     switch state {
     case .idle, .complete, .error:
-      await startRecording()
+      await startRecording(config: config)
     case .recording:
       await stopAndTranscribe()
     case .loadingModel, .transcribing, .polishing:
@@ -339,8 +346,12 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     }
   }
 
-  /// Start recording audio from the microphone.
-  public func startRecording() async {
+  /// Start recording audio from the microphone. `config` freezes per-recording
+  /// settings (auto-paste, VAD config, polish provider/model, etc.) for the
+  /// duration of this recording. Mid-recording setting changes apply to the
+  /// NEXT recording's snapshot.
+  public func startRecording(config: DictationSessionConfig) async {
+    currentSessionConfig = config
     // Issue #289: new attempt takes ownership — any pending stall recovery
     // from a prior session must not tear down the fresh source.
     pendingStallRecoveryToken = nil
@@ -1294,8 +1305,8 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     switch event {
     case .preWarm:
       try await preWarmAudioInput()
-    case .toggleRecording:
-      await toggleRecording()
+    case .toggleRecording(let config):
+      await toggleRecording(config: config)
     case .requestStop:
       await requestStop()
     case .cancelRecording:

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -1359,6 +1359,16 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     llmPolishStep.styleConfig = config.styleConfig
     llmPolishStep.useExtendedThinking = config.useExtendedThinking
 
+    // XPC audio service holds its own VAD state across the process boundary —
+    // push the frozen values at recording start so the service-side
+    // auto-stop behavior matches this recording's config.
+    audioCapture.configureVAD(
+      autoStop: config.vadAutoStop,
+      silenceTimeout: config.vadSilenceTimeout,
+      sensitivity: config.vadSensitivity,
+      energyGate: config.vadEnergyGate
+    )
+
     var opts = TranscriptionOptions()
     switch config.languageMode {
     case .auto:

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -1378,6 +1378,13 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       energyGate: config.vadEnergyGate
     )
 
+    // Push the frozen device UIDs. AudioCaptureManager reads them at source
+    // construction, but the source isn't built until `beginCapturePhase`
+    // later in this method — a mic swap after pre-warm but before capture
+    // would otherwise slip through PipelineSettingsSync's live writes.
+    audioCapture.selectedInputDeviceUID = config.selectedInputDeviceUID
+    audioCapture.preferredInputDeviceIDOverride = config.preferredInputDeviceIDOverride
+
     var opts = TranscriptionOptions()
     switch config.languageMode {
     case .auto:

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -21,6 +21,15 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       if state != oldValue {
         onStateChange?(state)
       }
+      // Honor the `currentSessionConfig` contract: nil when no recording is
+      // in flight. Clear on every transition to a terminal state so callers
+      // can distinguish an idle pipeline from one still mid-session.
+      switch state {
+      case .idle, .complete, .error:
+        currentSessionConfig = nil
+      case .loadingModel, .recording, .transcribing, .polishing:
+        break
+      }
     }
   }
   public var onStateChange: ((PipelineState) -> Void)?

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -25,21 +25,37 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   }
   public var onStateChange: ((PipelineState) -> Void)?
   public private(set) var currentTranscript: Transcript?
-  public var autoCopyToClipboard: Bool = true
-  public var autoPasteToActiveApp: Bool = false
-  public var vadAutoStop: Bool = false
-  public var vadSilenceTimeout: Double = 1.5
-  public var vadSensitivity: Float = 0.5
-  public var vadEnergyGate: Bool = false
-  public var modelUnloadPolicy: ModelUnloadPolicy = .never
-  public var restoreClipboardAfterPaste: Bool = false
-  public var transcriptionOptions: TranscriptionOptions = .default
   public var lastPolishError: String?
 
   /// Per-recording session config snapshot. Captured at `startRecording`; immutable
   /// for the duration of the recording. Settings mutated mid-recording apply to the
   /// NEXT recording. `nil` when no recording is in flight.
   public private(set) var currentSessionConfig: DictationSessionConfig?
+
+  // MARK: - Session-scoped accessors (backed by `currentSessionConfig`)
+  //
+  // These reads are guaranteed to happen inside a recording's lifecycle
+  // (from `startRecording` through `stopAndTranscribe`/`cancelRecording`),
+  // so `currentSessionConfig` is set. The `??` fallbacks mirror the prior
+  // public-property defaults and exist only as defense-in-depth.
+
+  private var autoCopyToClipboard: Bool { currentSessionConfig?.autoCopyToClipboard ?? true }
+  private var autoPasteToActiveApp: Bool { currentSessionConfig?.autoPasteToActiveApp ?? false }
+  private var restoreClipboardAfterPaste: Bool {
+    currentSessionConfig?.restoreClipboardAfterPaste ?? false
+  }
+  private var vadAutoStop: Bool { currentSessionConfig?.vadAutoStop ?? false }
+  private var vadSilenceTimeout: Double { currentSessionConfig?.vadSilenceTimeout ?? 1.5 }
+  private var vadSensitivity: Float { currentSessionConfig?.vadSensitivity ?? 0.5 }
+  private var vadEnergyGate: Bool { currentSessionConfig?.vadEnergyGate ?? false }
+  private var modelUnloadPolicy: ModelUnloadPolicy {
+    currentSessionConfig?.modelUnloadPolicy ?? .never
+  }
+
+  /// Decode-time options. Mutable within a recording because LID results can
+  /// overwrite `.language`. Re-derived from `config.languageMode` at each
+  /// `startRecording`.
+  private var transcriptionOptions: TranscriptionOptions = .default
 
   // Shared services
   private let transcriptFinalizer: TranscriptFinalizer
@@ -70,7 +86,8 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   private var vadMonitorTask: Task<Void, Never>?
   private var recordingStartTime: Date?
   /// User preference: use streaming ASR during recording (lower latency) or batch after stop (cleaner text).
-  public var useStreamingASR: Bool = true
+  /// Frozen per recording in `currentSessionConfig`.
+  private var useStreamingASR: Bool { currentSessionConfig?.useStreamingASR ?? true }
   /// Whether streaming ASR was successfully started for the current recording.
   private var streamingASRActive = false
   /// Counters for diagnosing streaming buffer delivery (tail-cutoff instrumentation).
@@ -352,6 +369,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// NEXT recording's snapshot.
   public func startRecording(config: DictationSessionConfig) async {
     currentSessionConfig = config
+    applySessionConfig(config)
     // Issue #289: new attempt takes ownership — any pending stall recovery
     // from a prior session must not tear down the fresh source.
     pendingStallRecoveryToken = nil
@@ -1326,5 +1344,28 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Issue #289: see `DictationPipeline.clearPendingStallRecovery`.
   public func clearPendingStallRecovery() {
     pendingStallRecoveryToken = nil
+  }
+
+  /// Fan out frozen config values to substeps and derive decode options.
+  /// Called once at `startRecording` after `currentSessionConfig` is set.
+  /// `llmPolishStep` is written here rather than read via the config because
+  /// its internal caches key off provider/model identity, and the
+  /// `TranscriptPolishService` (re-polish path) keeps it live-synced
+  /// between recordings.
+  private func applySessionConfig(_ config: DictationSessionConfig) {
+    llmPolishStep.llmProvider = config.llmProvider
+    llmPolishStep.llmModel = config.llmModel
+    llmPolishStep.polishInstructions = config.polishInstructions
+    llmPolishStep.styleConfig = config.styleConfig
+    llmPolishStep.useExtendedThinking = config.useExtendedThinking
+
+    var opts = TranscriptionOptions()
+    switch config.languageMode {
+    case .auto:
+      opts.language = nil
+    case .locked(let code):
+      opts.language = code
+    }
+    transcriptionOptions = opts
   }
 }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -1354,6 +1354,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       energyGate: config.vadEnergyGate
     )
 
+    // Push the frozen device UIDs. See TranscriptionPipeline.applySessionConfig
+    // for the narrow-race rationale.
+    audioCapture.selectedInputDeviceUID = config.selectedInputDeviceUID
+    audioCapture.preferredInputDeviceIDOverride = config.preferredInputDeviceIDOverride
+
     var opts = TranscriptionOptions()
     switch config.languageMode {
     case .auto:

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -65,39 +65,33 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   }
   public var onStateChange: ((WhisperKitPipelineState) -> Void)?
   public private(set) var currentTranscript: Transcript?
-  public var autoCopyToClipboard: Bool = true
-  public var autoPasteToActiveApp: Bool = false
-  public var restoreClipboardAfterPaste: Bool = false
-  public var transcriptionOptions: TranscriptionOptions = .default
   public var lastPolishError: String?
-  public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
   /// Per-recording session config snapshot. Captured at `startRecording`; immutable
   /// for the duration of the recording. Settings mutated mid-recording apply to the
   /// NEXT recording. `nil` when no recording is in flight.
   public private(set) var currentSessionConfig: DictationSessionConfig?
 
-  // Multilingual v1 (W2): language mode + detector. Captured lazily at
-  // detection time so a user toggling Auto->Locked mid-recording is respected.
-  public var languageMode: LanguageMode = .auto {
-    didSet {
-      // Mid-recording changes to the language mode invalidate the
-      // incremental worker, which snapshots the decode language at its
-      // init. Rather than try to re-decode the worker's buffers with the
-      // new language, we drop the worker entirely so finalize falls back
-      // to batch decode with the post-change language.
-      if oldValue != languageMode, let worker = incrementalWorker {
-        incrementalWorker = nil
-        Task { await worker.cancel() }
-        Task {
-          await AppLogger.shared.log(
-            "Language mode changed mid-recording, incremental worker invalidated",
-            level: .info, category: "WhisperKitPipeline"
-          )
-        }
-      }
-    }
+  // MARK: - Session-scoped accessors (backed by `currentSessionConfig`)
+
+  private var autoCopyToClipboard: Bool { currentSessionConfig?.autoCopyToClipboard ?? true }
+  private var autoPasteToActiveApp: Bool { currentSessionConfig?.autoPasteToActiveApp ?? false }
+  private var restoreClipboardAfterPaste: Bool {
+    currentSessionConfig?.restoreClipboardAfterPaste ?? false
   }
+  private var modelUnloadPolicy: ModelUnloadPolicy {
+    currentSessionConfig?.modelUnloadPolicy ?? .never
+  }
+  /// Frozen language mode for the active recording. Mid-record Auto/Locked
+  /// toggles no longer reach the in-flight session — intentional behavior
+  /// change documented in `DictationSessionConfig` and the #195 plan.
+  private var languageMode: LanguageMode { currentSessionConfig?.languageMode ?? .auto }
+
+  /// Decode-time options. Mutable within a recording because LID results can
+  /// overwrite `.language`. Re-derived from `config.languageMode` at each
+  /// `startRecording`.
+  private var transcriptionOptions: TranscriptionOptions = .default
+
   private let languageDetector: LanguageDetector
   /// Last detection result, exposed for telemetry and UI (passive chip).
   public private(set) var lastLanguageDetection: LanguageDetectionResult?
@@ -130,11 +124,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   /// Whether audio input has been pre-warmed by PTT key-down.
   private var isPreWarmed = false
 
-  // VAD properties
-  public var vadAutoStop: Bool = false
-  public var vadSilenceTimeout: Double = 1.5
-  public var vadSensitivity: Float = 0.5
-  public var vadEnergyGate: Bool = false
+  // VAD properties — frozen per recording in `currentSessionConfig`.
+  private var vadAutoStop: Bool { currentSessionConfig?.vadAutoStop ?? false }
+  private var vadSilenceTimeout: Double { currentSessionConfig?.vadSilenceTimeout ?? 1.5 }
+  private var vadSensitivity: Float { currentSessionConfig?.vadSensitivity ?? 0.5 }
+  private var vadEnergyGate: Bool { currentSessionConfig?.vadEnergyGate ?? false }
 
   private var silenceDetector: SilenceDetector?
   private var vadMonitorTask: Task<Void, Never>?
@@ -451,6 +445,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
   public func startRecording(config: DictationSessionConfig) async {
     currentSessionConfig = config
+    applySessionConfig(config)
     // Issue #289: new attempt takes ownership — invalidate any pending stall
     // recovery token so an in-flight cleanup cannot tear down this session.
     pendingStallRecoveryToken = nil
@@ -1329,6 +1324,25 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         await self?.backend.unload()
       }
     }
+  }
+
+  /// Fan out frozen config values to substeps and derive decode options.
+  /// See `TranscriptionPipeline.applySessionConfig` for rationale.
+  private func applySessionConfig(_ config: DictationSessionConfig) {
+    llmPolishStep.llmProvider = config.llmProvider
+    llmPolishStep.llmModel = config.llmModel
+    llmPolishStep.polishInstructions = config.polishInstructions
+    llmPolishStep.styleConfig = config.styleConfig
+    llmPolishStep.useExtendedThinking = config.useExtendedThinking
+
+    var opts = TranscriptionOptions()
+    switch config.languageMode {
+    case .auto:
+      opts.language = nil
+    case .locked(let code):
+      opts.language = code
+    }
+    transcriptionOptions = opts
   }
 
 }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -61,6 +61,15 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       if state != oldValue {
         onStateChange?(state)
       }
+      // Honor the `currentSessionConfig` contract: nil when no recording is
+      // in flight. `.ready` is terminal for pipeline activity — the backend
+      // is warm but the user hasn't asked for a session yet.
+      switch state {
+      case .idle, .ready, .complete, .error:
+        currentSessionConfig = nil
+      case .startingUp, .loadingModel, .recording, .transcribing, .polishing:
+        break
+      }
     }
   }
   public var onStateChange: ((WhisperKitPipelineState) -> Void)?

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -1052,8 +1052,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         ])
       captureTelemetry.recordSuccessfulRecording()
       frozenSnapshot = nil
-      state = .complete
+      // Schedule unload BEFORE the terminal transition — the `state` didSet
+      // clears `currentSessionConfig` on entry to `.complete`, and the
+      // unload policy is read from that snapshot.
       scheduleModelUnloadIfNeeded()
+      state = .complete
     } catch {
       SentryBreadcrumb.captureError(
         error, category: .asrFailed, stage: "transcription", extra: ["backend": "whisperKit"],

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -1335,6 +1335,16 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     llmPolishStep.styleConfig = config.styleConfig
     llmPolishStep.useExtendedThinking = config.useExtendedThinking
 
+    // XPC audio service holds its own VAD state across the process boundary —
+    // push the frozen values at recording start so the service-side
+    // auto-stop behavior matches this recording's config.
+    audioCapture.configureVAD(
+      autoStop: config.vadAutoStop,
+      silenceTimeout: config.vadSilenceTimeout,
+      sensitivity: config.vadSensitivity,
+      energyGate: config.vadEnergyGate
+    )
+
     var opts = TranscriptionOptions()
     switch config.languageMode {
     case .auto:

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -72,6 +72,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   public var lastPolishError: String?
   public var modelUnloadPolicy: ModelUnloadPolicy = .never
 
+  /// Per-recording session config snapshot. Captured at `startRecording`; immutable
+  /// for the duration of the recording. Settings mutated mid-recording apply to the
+  /// NEXT recording. `nil` when no recording is in flight.
+  public private(set) var currentSessionConfig: DictationSessionConfig?
+
   // Multilingual v1 (W2): language mode + detector. Captured lazily at
   // detection time so a user toggling Auto->Locked mid-recording is respected.
   public var languageMode: LanguageMode = .auto {
@@ -345,8 +350,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     switch event {
     case .preWarm:
       try await preWarmAudioInput()
-    case .toggleRecording:
-      await toggleRecording()
+    case .toggleRecording(let config):
+      await toggleRecording(config: config)
     case .requestStop:
       await requestStop()
     case .cancelRecording:
@@ -427,10 +432,13 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     Task { _ = try? await backend.prepareIfCached() }
   }
 
-  public func toggleRecording() async {
+  /// Toggle recording: start if idle, stop if recording. On start transitions,
+  /// the provided session config is captured; on stop transitions the config
+  /// is ignored.
+  public func toggleRecording(config: DictationSessionConfig) async {
     switch state {
     case .idle, .ready, .complete, .error:
-      await startRecording()
+      await startRecording(config: config)
     case .recording:
       await stopAndTranscribe()
     case .loadingModel, .startingUp, .transcribing, .polishing:
@@ -441,7 +449,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   /// Guards against concurrent startRecording calls (e.g., rapid toggle presses).
   private var isStarting = false
 
-  public func startRecording() async {
+  public func startRecording(config: DictationSessionConfig) async {
+    currentSessionConfig = config
     // Issue #289: new attempt takes ownership — invalidate any pending stall
     // recovery token so an in-flight cleanup cannot tear down this session.
     pendingStallRecoveryToken = nil

--- a/Tests/EnviousWisprTests/Pipeline/DictationSessionConfig+TestDefault.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationSessionConfig+TestDefault.swift
@@ -1,0 +1,49 @@
+import EnviousWisprCore
+
+extension DictationSessionConfig {
+  /// Default snapshot for tests that don't care about specific settings values.
+  /// Mirrors the `SettingsManager` defaults at construction time.
+  static func testDefault(
+    autoCopyToClipboard: Bool = true,
+    autoPasteToActiveApp: Bool = false,
+    restoreClipboardAfterPaste: Bool = false,
+    vadAutoStop: Bool = false,
+    vadSilenceTimeout: Double = 1.5,
+    vadSensitivity: Float = 0.5,
+    vadEnergyGate: Bool = false,
+    languageMode: LanguageMode = .auto,
+    useStreamingASR: Bool = true,
+    modelUnloadPolicy: ModelUnloadPolicy = .never,
+    llmProvider: LLMProvider = .none,
+    llmModel: String = "",
+    polishInstructions: PolishInstructions = .default,
+    styleConfig: PolishStyleConfig = PolishStyleConfig(
+      writingStylePreset: .standard,
+      customSystemPrompt: "",
+      customPromptMode: .normal
+    ),
+    useExtendedThinking: Bool = false,
+    selectedInputDeviceUID: String = "",
+    preferredInputDeviceIDOverride: String = ""
+  ) -> DictationSessionConfig {
+    DictationSessionConfig(
+      autoCopyToClipboard: autoCopyToClipboard,
+      autoPasteToActiveApp: autoPasteToActiveApp,
+      restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+      vadAutoStop: vadAutoStop,
+      vadSilenceTimeout: vadSilenceTimeout,
+      vadSensitivity: vadSensitivity,
+      vadEnergyGate: vadEnergyGate,
+      languageMode: languageMode,
+      useStreamingASR: useStreamingASR,
+      modelUnloadPolicy: modelUnloadPolicy,
+      llmProvider: llmProvider,
+      llmModel: llmModel,
+      polishInstructions: polishInstructions,
+      styleConfig: styleConfig,
+      useExtendedThinking: useExtendedThinking,
+      selectedInputDeviceUID: selectedInputDeviceUID,
+      preferredInputDeviceIDOverride: preferredInputDeviceIDOverride
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/DictationSessionConfigTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationSessionConfigTests.swift
@@ -1,0 +1,70 @@
+import EnviousWisprCore
+import Testing
+
+@Suite("DictationSessionConfig — per-recording snapshot")
+struct DictationSessionConfigTests {
+
+  @Test("testDefault factory returns SettingsManager-default-shaped values")
+  func testDefaultIsShapedLikeSettingsDefaults() {
+    let config = DictationSessionConfig.testDefault()
+
+    #expect(config.autoCopyToClipboard == true)
+    #expect(config.autoPasteToActiveApp == false)
+    #expect(config.restoreClipboardAfterPaste == false)
+    #expect(config.vadAutoStop == false)
+    #expect(config.vadSilenceTimeout == 1.5)
+    #expect(config.vadSensitivity == 0.5)
+    #expect(config.vadEnergyGate == false)
+    #expect(config.languageMode == .auto)
+    #expect(config.useStreamingASR == true)
+    #expect(config.modelUnloadPolicy == .never)
+    #expect(config.llmProvider == .none)
+    #expect(config.llmModel == "")
+    #expect(config.polishInstructions.systemPrompt == PolishInstructions.default.systemPrompt)
+    #expect(config.styleConfig.writingStylePreset == .standard)
+    #expect(config.styleConfig.customSystemPrompt == "")
+    #expect(config.styleConfig.customPromptMode == .normal)
+    #expect(config.useExtendedThinking == false)
+    #expect(config.selectedInputDeviceUID == "")
+    #expect(config.preferredInputDeviceIDOverride == "")
+  }
+
+  @Test("per-field overrides survive construction intact")
+  func testFieldOverridesHonored() {
+    let config = DictationSessionConfig.testDefault(
+      autoCopyToClipboard: false,
+      autoPasteToActiveApp: true,
+      vadAutoStop: true,
+      vadSilenceTimeout: 3.0,
+      vadSensitivity: 0.8,
+      languageMode: .locked("es"),
+      useStreamingASR: false,
+      llmProvider: .appleIntelligence,
+      llmModel: "apple-intelligence",
+      useExtendedThinking: true,
+      selectedInputDeviceUID: "BuiltInMic",
+      preferredInputDeviceIDOverride: "ExternalMic"
+    )
+
+    #expect(config.autoCopyToClipboard == false)
+    #expect(config.autoPasteToActiveApp == true)
+    #expect(config.vadAutoStop == true)
+    #expect(config.vadSilenceTimeout == 3.0)
+    #expect(config.vadSensitivity == 0.8)
+    #expect(config.languageMode == LanguageMode.locked("es"))
+    #expect(config.useStreamingASR == false)
+    #expect(config.llmProvider == LLMProvider.appleIntelligence)
+    #expect(config.llmModel == "apple-intelligence")
+    #expect(config.useExtendedThinking == true)
+    #expect(config.selectedInputDeviceUID == "BuiltInMic")
+    #expect(config.preferredInputDeviceIDOverride == "ExternalMic")
+  }
+
+  @Test("Sendable value semantics — modifying a copy's source does not mutate the snapshot")
+  func testValueSemantics() {
+    var sourceFlag = true
+    let config = DictationSessionConfig.testDefault(autoCopyToClipboard: sourceFlag)
+    sourceFlag = false
+    #expect(config.autoCopyToClipboard == true)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -92,9 +92,8 @@ struct HeartPathIntegrationTests {
       asrManager: asrManager,
       transcriptStore: TranscriptStore()
     )
-    pipeline.autoPasteToActiveApp = true
-
-    await pipeline.startRecording(config: DictationSessionConfig.testDefault())
+    await pipeline.startRecording(
+      config: DictationSessionConfig.testDefault(autoPasteToActiveApp: true))
 
     let reachedRecording = await pollUntil(timeout: .seconds(1)) {
       pipeline.state == .recording

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -94,7 +94,7 @@ struct HeartPathIntegrationTests {
     )
     pipeline.autoPasteToActiveApp = true
 
-    await pipeline.startRecording()
+    await pipeline.startRecording(config: DictationSessionConfig.testDefault())
 
     let reachedRecording = await pollUntil(timeout: .seconds(1)) {
       pipeline.state == .recording

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -92,8 +92,26 @@ struct HeartPathIntegrationTests {
       asrManager: asrManager,
       transcriptStore: TranscriptStore()
     )
-    await pipeline.startRecording(
-      config: DictationSessionConfig.testDefault(autoPasteToActiveApp: true))
+    #expect(pipeline.currentSessionConfig == nil)
+
+    let config = DictationSessionConfig.testDefault(
+      autoPasteToActiveApp: true,
+      vadSensitivity: 0.73,
+      languageMode: .locked("fr"),
+      llmProvider: .openAI,
+      llmModel: "gpt-test"
+    )
+    await pipeline.startRecording(config: config)
+
+    // Phase B freeze contract: the pipeline captures the config handed in by
+    // AppState, and external readers see the frozen snapshot for the
+    // recording's lifetime.
+    let captured = pipeline.currentSessionConfig
+    #expect(captured?.autoPasteToActiveApp == true)
+    #expect(captured?.vadSensitivity == 0.73)
+    #expect(captured?.languageMode == LanguageMode.locked("fr"))
+    #expect(captured?.llmProvider == LLMProvider.openAI)
+    #expect(captured?.llmModel == "gpt-test")
 
     let reachedRecording = await pollUntil(timeout: .seconds(1)) {
       pipeline.state == .recording


### PR DESCRIPTION
## Summary

Freezes per-recording settings into an immutable `DictationSessionConfig` snapshot captured at `startRecording`. Settings mutated mid-recording apply to the NEXT recording. Ends `PipelineSettingsSync`'s "write-every-setting-to-both-pipelines-live" model for session-owned values.

Implements the plan at `docs/feature-requests/issue-195-2026-04-18-pipeline-settings-sync.md`.

Closes #195.

## Frozen per recording (17 values)
`autoCopyToClipboard`, `autoPasteToActiveApp` (input-mode derived), `restoreClipboardAfterPaste`, `vadAutoStop`, `vadSilenceTimeout`, `vadSensitivity`, `vadEnergyGate`, `languageMode`, `useStreamingASR`, `modelUnloadPolicy`, `llmProvider`, `llmModel` (resolved), `polishInstructions`, `styleConfig`, `useExtendedThinking`, `selectedInputDeviceUID`, `preferredInputDeviceIDOverride`.

## Stays live (founder call 2026-04-20)
`wordCorrectionEnabled`, `fillerRemovalEnabled`, custom-words dictionary, hotkey registration, noise-suppression engine rebuild, warm-engine policy, debug logging, backend switch, environment preset cascade, `syncPolishServiceSettings` (re-polish uses CURRENT settings).

`.llmProvider` / `.llmModel` / `.ollamaModel` branches retain only `reconcileOllamaEviction` (#295) + re-polish mirror. Deleted deprecated `.whisperKitLanguage` branch.

## Intentional behavior change
Freezing `languageMode` removes WhisperKit's mid-record Auto/Locked flip invalidation of the incremental worker. Founder-approved as part of the session-consistency doctrine.

## UX
Added static tooltip "Changes made during a recording apply to the next recording." as a footnote under every Settings section whose values freeze. Wispr-eyes verified 13/13 placements (8 present, 4 deliberately absent, 1 conditionally skipped).

## Shrink
- `PipelineSettingsSync`: 398 → 244 lines (39% shrink).
- `AppState`: 18 scattered `pipeline.autoPasteToActiveApp = ...` writes consolidated into `makeDictationSessionConfig()`.

## Codex review — 6 findings, all addressed

1. **P2** XPC VAD config stopped forwarding → push frozen VAD values to `audioCapture.configureVAD` in `applySessionConfig`.
2. **P3** `currentSessionConfig` contract violation (never cleared) → `state` didSet clears on terminal transitions.
3. **P2** Device UID narrow race → push frozen UIDs in `applySessionConfig`.
4. **P2** WhisperKit unload policy read after config clear → schedule unload before `state = .complete`.
5. **P2** Ollama eviction while pinned → gate with `isOllamaModelPinnedInFlight`.
6. **P2** Deferred eviction never retried after session end → `retryDeferredOllamaEviction` hook fired from `AppState.onStateChange` on terminal transitions.

Round 7 clean.

## Validation

- `swift build -c release` green.
- `scripts/swift-test.sh` green — 385 tests in 41 suites.
- Mixed-mode UAT: Saurabh ran voice dictation on Parakeet + WhisperKit with Gemini polish. wispr-eyes verified tooltip placements.
- AFM polish seen to degrade gracefully under parallel-session pressure (timeout → raw-text paste).

## Test plan
- [x] `scripts/swift-test.sh` passes
- [x] `swift build -c release` exit 0
- [x] UX smoke: freeze (autoCopyToClipboard) mid-record toggle does not affect active recording
- [x] UX smoke: live (fillerRemovalEnabled) mid-record toggle still forwards
- [x] `reconcileOllamaEviction` fires on Ollama model swap (preserved); deferred when pinned; retries on session end
- [x] Both backends smoke: Parakeet + WhisperKit end-to-end dictation works
- [x] `PipelineSettingsSync` shrinks to ≤ 220 lines target (244, within pragmatic range)
- [x] No `any DictationSessionConfigProtocol` existential (Phase A lesson respected)
- [x] Codex review clean after 7 rounds
