### PR TITLE
feat(llm): ApplePolishRouter for dual-mode polish selection (#381)

### DIFF
--- a/Sources/EnviousWisprLLM/ApplePolishRouter.swift
+++ b/Sources/EnviousWisprLLM/ApplePolishRouter.swift
@@ -1,0 +1,357 @@
+import Foundation
+
+/// The two polish prompt families used by Apple Intelligence on-device polish.
+///
+/// - `natural`: v30-family prompt. Aggressive filler cleanup, self-correction
+///              collapse, terminal-punctuation repair. Used for conversational
+///              dictation where hallucination risk is low.
+/// - `technical`: v31-family prompt. Conservative preservation of imperatives,
+///                code-adjacent nouns, spoken formatting, and code-request
+///                phrasing. Used when the transcript carries signals that the
+///                user is dictating an instruction *about* content (to be
+///                pasted into another app) rather than requesting polish.
+public enum ApplePolishMode: String, Sendable, Equatable {
+  case natural
+  case technical
+}
+
+/// Structured, telemetry-safe signal emitted by the router. Prefer this over
+/// free-form strings so future tuning doesn't break log consumers and so
+/// tests can assert on structure instead of label text.
+public enum RouterSignal: Sendable, Equatable {
+  case emptyInput
+  case strongPhrase(String)
+  case preservationIntent(String)
+  case imperativeStart(String)
+  case conversationalImperativeStart(String)
+  case techNouns([String])
+  case spokenFormatting([String])
+  case selfCorrection([String])
+  case filler([String])
+}
+
+/// How the router arrived at its decision. Useful for distinguishing
+/// "technical because Tier-1 matched" from "natural because nothing
+/// scored" — both return the same `mode` but have different failure
+/// implications for tuning.
+public enum RouterBasis: Sendable, Equatable {
+  case empty
+  case tier1
+  case scored
+}
+
+/// Deterministic, inspectable classifier that selects between `natural` and
+/// `technical` polish modes based on the post-ASR transcript.
+///
+/// Design constraints (2026-04-20, issue #381):
+///   - No network, no model call, no AI classifier.
+///   - Bias toward `natural` unless technical signals clearly dominate.
+///   - Signals must be inspectable so the caller can log *why* a route was
+///     chosen and so the rules can be tuned later from telemetry.
+///   - Short-circuit on strong technical patterns so a single "write a python
+///     script" or "convert this into json" doesn't need a scoring majority.
+///
+/// Tunability: every threshold, noun list, and weight lives in one file so
+/// later telemetry-driven adjustments are a single PR.
+public enum ApplePolishRouter {
+
+  /// A routing decision with the mode and the signals that produced it.
+  public struct Decision: Equatable, Sendable {
+    public let mode: ApplePolishMode
+    public let score: Int
+    public let basis: RouterBasis
+    public let signals: [RouterSignal]
+
+    public init(
+      mode: ApplePolishMode, score: Int, basis: RouterBasis, signals: [RouterSignal]
+    ) {
+      self.mode = mode
+      self.score = score
+      self.basis = basis
+      self.signals = signals
+    }
+  }
+
+  // MARK: - Public entry points
+
+  /// Classify a post-ASR transcript and return `natural` or `technical`.
+  public static func classify(_ text: String) -> ApplePolishMode {
+    decide(text).mode
+  }
+
+  /// Classify and return the full decision with signals (for logging / tests).
+  public static func decide(_ text: String) -> Decision {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return Decision(mode: .natural, score: 0, basis: .empty, signals: [.emptyInput])
+    }
+
+    var signals: [RouterSignal] = []
+    let lower = trimmed.lowercased()
+
+    // ---------------- Tier 1 — short-circuit to technical -----------------
+
+    if let hit = strongPhraseMatch(lower) {
+      signals.append(.strongPhrase(hit))
+      return Decision(mode: .technical, score: 100, basis: .tier1, signals: signals)
+    }
+
+    // Preservation intent is more specific than a generic imperative-at-start,
+    // so it must run first. Otherwise "Dictate the words ... exactly as words"
+    // short-circuits as `imperativeStart(dictate)` and hides the real signal.
+    if let phrase = preservationIntent(lower) {
+      signals.append(.preservationIntent(phrase))
+      return Decision(mode: .technical, score: 100, basis: .tier1, signals: signals)
+    }
+
+    if let verb = hardImperativeAtStart(trimmed) {
+      signals.append(.imperativeStart(verb))
+      return Decision(mode: .technical, score: 100, basis: .tier1, signals: signals)
+    }
+
+    // ---------------- Tier 2 — additive score ----------------------------
+
+    var score = 0
+
+    // Conversational imperatives at sentence start contribute but don't
+    // short-circuit. `Remind me to pick up eggs` scores +3; without a
+    // corroborating signal it stays natural.
+    if let verb = conversationalImperativeAtStart(trimmed) {
+      score += conversationalImperativeWeight
+      signals.append(.conversationalImperativeStart(verb))
+    }
+
+    let techNounHits = countHits(lower, terms: techNouns, cap: 2)
+    if !techNounHits.isEmpty {
+      score += techNounHits.count * techNounWeight
+      signals.append(.techNouns(techNounHits))
+    }
+
+    // Cap at 3 because heavy dictation of structure ("heading colon, bullet
+    // one, bullet two") is an unambiguous technical signal; 2 hits capped too
+    // low to clear the technical threshold alone.
+    let formattingHits = countHits(lower, terms: spokenFormatting, cap: 3)
+    if !formattingHits.isEmpty {
+      score += formattingHits.count * formattingWeight
+      signals.append(.spokenFormatting(formattingHits))
+    }
+
+    let correctionHits = countHits(lower, terms: selfCorrection, cap: 2)
+    if !correctionHits.isEmpty {
+      score += correctionHits.count * selfCorrectionWeight
+      signals.append(.selfCorrection(correctionHits))
+    }
+
+    let fillerHits = countHits(lower, terms: filler, cap: 2)
+    if !fillerHits.isEmpty {
+      score += fillerHits.count * fillerWeight
+      signals.append(.filler(fillerHits))
+    }
+
+    let mode: ApplePolishMode = score >= technicalThreshold ? .technical : .natural
+    return Decision(mode: mode, score: score, basis: .scored, signals: signals)
+  }
+
+  // MARK: - Tier 1 helpers
+
+  /// Regex fragments for "write/create/generate/draft a <code-language> ..."
+  /// style phrases. Case-insensitive; anchored on word boundaries except for
+  /// symbol-ending languages (c++, c#) where `\b` can't match.
+  ///
+  /// Determiners (a / an / some / the) are optional — ASR frequently emits
+  /// "write python code" or "generate SQL to find duplicates" without an
+  /// article. "c sharp" and "c plus plus" are included alongside their symbol
+  /// forms because ASR typically transcribes the spoken words rather than `#`
+  /// or `++`.
+  private static let strongPhrasePatterns: [String] = [
+    // Word-character-ending language nouns.
+    // `go` replaced with `golang` because bare `go` is a common English verb
+    // ("write go live messaging", "build go to market materials") that would
+    // short-circuit to technical. Users who want the language should say
+    // "golang" which is unambiguous in dictation.
+    #"\b(write|create|generate|draft|compose|build)\s+(?:(?:a|an|some|the)\s+)?(python|sql|bash|swift|regex|javascript|typescript|react|vue|node|github|docker|kubernetes|html|css|yaml|xml|shell|perl|ruby|rust|golang|java|elixir|scala|haskell|c sharp|c plus plus)\b"#,
+    // Symbol-ending languages: \b after `+` or `#` never matches (both are
+    // non-word chars). Use a lookahead for end-of-token instead.
+    #"\b(write|create|generate|draft|compose|build)\s+(?:(?:a|an|some|the)\s+)?(c\+\+|c#)(?=\s|[.!?,;:]|$)"#,
+    #"\bconvert\s+(this|that|it)\s+(into|to)\s+(json|yaml|xml|markdown|html|csv|sql)\b"#,
+    #"\bgenerate\s+(?:(?:a|an|some|the)\s+)?(sql|regex|graphql)\s+(query|pattern|mutation|schema)\b"#,
+    #"\bturn\s+(this|that|it)\s+into\s+(json|yaml|xml|markdown|html|csv|sql|code)\b"#,
+    #"\brespond\s+(with|in)\s+(only\s+)?(json|yaml|xml|markdown|html)\b"#,
+  ]
+
+  private static func strongPhraseMatch(_ lower: String) -> String? {
+    for pattern in strongPhrasePatterns {
+      if let range = lower.range(of: pattern, options: .regularExpression) {
+        return String(lower[range])
+      }
+    }
+    return nil
+  }
+
+  /// Hard imperatives — sentence-start occurrences unambiguously signal a
+  /// transformation or composition request. Safe to short-circuit to
+  /// technical regardless of surrounding context.
+  ///
+  /// Verbs kept narrow per council feedback: conversational verbs like
+  /// "send / schedule / remind / reply" are in `conversationalImperatives`
+  /// below so casual speech ("Remind me to pick up eggs") stays natural.
+  private static let hardImperatives: Set<String> = [
+    "write", "draft", "generate", "create", "compose", "build", "make",
+    "convert", "translate", "summarize", "summarise", "paraphrase", "rewrite",
+    "refactor", "implement", "turn",
+    "chart", "plot", "calculate", "parse", "compile",
+    // "Answer this question ..." is an execution-risk imperative the router
+    // exists to catch (AFM answers the question instead of preserving it).
+    "answer",
+  ]
+
+  /// Conversational imperatives — contribute Tier-2 score but do not
+  /// short-circuit. A bare "Schedule lunch with Sam" stays natural.
+  ///
+  /// `answer` is intentionally NOT here (see hardImperatives above). `respond`
+  /// stays conversational because "respond with json" is already a Tier-1
+  /// strong-phrase match, and bare "respond to Sarah" should stay natural.
+  private static let conversationalImperatives: Set<String> = [
+    "send", "schedule", "remind", "respond", "reply",
+    "list", "record", "administer", "dictate",
+  ]
+
+  /// Politeness/filler prefixes skipped when locating the first "real" word
+  /// of a sentence. Lets "Um, draft an email" and "Please write a memo" still
+  /// short-circuit to technical via imperative-at-start.
+  private static let leadingSkipWords: Set<String> = [
+    "um", "uh", "please", "hey", "okay", "ok", "so", "well",
+  ]
+
+  private static func firstMeaningfulWord(_ trimmed: String) -> String {
+    let separators: Set<Character> = [" ", "\t", "\n", ",", "."]
+    let tokens =
+      trimmed
+      .split(whereSeparator: { separators.contains($0) })
+      .map { String($0).trimmingCharacters(in: .punctuationCharacters).lowercased() }
+    for token in tokens {
+      if !token.isEmpty && !leadingSkipWords.contains(token) {
+        return token
+      }
+    }
+    return ""
+  }
+
+  private static func hardImperativeAtStart(_ trimmed: String) -> String? {
+    let word = firstMeaningfulWord(trimmed)
+    return hardImperatives.contains(word) ? word : nil
+  }
+
+  private static func conversationalImperativeAtStart(_ trimmed: String) -> String? {
+    let word = firstMeaningfulWord(trimmed)
+    return conversationalImperatives.contains(word) ? word : nil
+  }
+
+  /// Explicit preservation intent — the user is telling the polisher not to
+  /// paraphrase.
+  ///
+  /// Both `literally` and `verbatim` bare are intentionally excluded:
+  /// conversational usages ("I literally forgot my keys", "he quoted the
+  /// email verbatim") would otherwise flip to technical. The remaining
+  /// phrases all carry unambiguous preserve-these-words intent. Users who
+  /// genuinely need verbatim preservation should say "preserve the words"
+  /// or "exactly as said".
+  private static let preservationPhrases: [String] = [
+    "preserve the words",
+    "preserve the word",
+    "exactly as words",
+    "exactly as said",
+    "exactly as dictated",
+    "keep the words",
+    "keep it literal",
+    "dictate the words",
+    "dictate the word",
+  ]
+
+  private static func preservationIntent(_ lower: String) -> String? {
+    for phrase in preservationPhrases where lower.contains(phrase) {
+      return phrase
+    }
+    return nil
+  }
+
+  // MARK: - Tier 2 weighted signals
+
+  /// Code / technical nouns. Each hit adds `techNounWeight`, capped at two.
+  private static let techNouns: [String] = [
+    "python", "sql", "regex", "swift", "json", "markdown", "yaml",
+    "api", "endpoint", "webhook", "docker", "github", "kubernetes",
+    "react", "typescript", "javascript", "repository", "repo",
+    "commit", "merge", "branch", "hotfix",
+    "function", "prisma", "tailwind", "vercel", "cors",
+  ]
+
+  /// Spoken-formatting words — when the user dictates punctuation/structure
+  /// by name, preservation matters.
+  ///
+  /// Exclusions:
+  ///   - `dash` bare: `\bdash\b` matches inside "em dash"/"en dash",
+  ///     double-counting a single dictated concept.
+  ///   - `colon` bare: anatomical term in clinical speech ("colon pain",
+  ///     "colon cancer") would incorrectly signal formatting. The
+  ///     scoped phrase `heading colon` is included instead to catch
+  ///     structure dictation ("heading colon launch checklist"). Kept
+  ///     `semicolon` because it's unambiguously punctuation.
+  private static let spokenFormatting: [String] = [
+    "bullet", "heading colon", "heading", "backtick", "backticks", "underscore",
+    "open paren", "close paren", "open parenthesis", "close parenthesis",
+    "slash", "quote", "unquote", "em dash", "en dash",
+    "semicolon",
+  ]
+
+  /// Self-correction markers. Mild natural-mode bias. `"no"` is included as
+  /// a bare word (word-boundary anchored) so "feature slash billing, no,
+  /// hotfix slash billing" registers the correction.
+  private static let selfCorrection: [String] = [
+    "wait", "no", "sorry", "actually", "scratch that",
+  ]
+
+  /// Filler words. Mild natural-mode bias (filler-heavy = conversational).
+  /// Bare "like" is matched (word-boundary anchored). Acceptable over-fire on
+  /// legitimate usage like "I like it" because a single filler hit is only
+  /// -1 and never flips a Tier-1 decision.
+  private static let filler: [String] = [
+    "um", "uh", "you know", "i mean", "like", "basically",
+    "honestly", "essentially",
+  ]
+
+  private static let techNounWeight = 2
+  private static let formattingWeight = 2
+  private static let selfCorrectionWeight = -1
+  private static let fillerWeight = -1
+  private static let conversationalImperativeWeight = 3
+  // Threshold 5 kept deliberately high given the empirical asymmetry:
+  // technical-mode-on-natural-speech is a ~24-point regression; natural-mode-on-
+  // technical-imperative is a ~8-point regression. Bias toward natural.
+  private static let technicalThreshold = 5
+
+  // MARK: - Utility
+
+  /// Case-insensitive whole-word/phrase hit counter with per-term dedupe and
+  /// a global cap (to prevent a single overused signal from dominating).
+  ///
+  /// Uses `\b` word-boundary anchors so "api" does not match "apiary" and
+  /// "swift" does not match "swiftly". Multi-word terms like "you know" and
+  /// "open paren" are matched as anchored phrases.
+  ///
+  /// Dedupe is per-term: a sentence with "bullet bullet bullet" contributes
+  /// one hit for "bullet", not three — consistent with the "multiple kinds
+  /// of formatting words" signal we want (bullet + heading + colon counts as
+  /// 3, not 3× bullet).
+  private static func countHits(_ lower: String, terms: [String], cap: Int) -> [String] {
+    var hits: [String] = []
+    for term in terms {
+      let pattern = "\\b\(NSRegularExpression.escapedPattern(for: term))\\b"
+      if lower.range(of: pattern, options: .regularExpression) != nil {
+        hits.append(term)
+        if hits.count >= cap { break }
+      }
+    }
+    return hits
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
@@ -1,0 +1,481 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// Helpers for asserting on typed signals. Keeps the test body readable and
+/// stable against future label changes.
+extension Array where Element == RouterSignal {
+  var hasStrongPhrase: Bool {
+    contains { if case .strongPhrase = $0 { return true } else { return false } }
+  }
+  var hasPreservationIntent: Bool {
+    contains { if case .preservationIntent = $0 { return true } else { return false } }
+  }
+  var hasImperativeStart: Bool {
+    contains { if case .imperativeStart = $0 { return true } else { return false } }
+  }
+  var hasConversationalImperative: Bool {
+    contains {
+      if case .conversationalImperativeStart = $0 { return true } else { return false }
+    }
+  }
+  var hasTechNouns: Bool {
+    contains { if case .techNouns = $0 { return true } else { return false } }
+  }
+  var hasSpokenFormatting: Bool {
+    contains { if case .spokenFormatting = $0 { return true } else { return false } }
+  }
+  var hasSelfCorrection: Bool {
+    contains { if case .selfCorrection = $0 { return true } else { return false } }
+  }
+  var hasFiller: Bool {
+    contains { if case .filler = $0 { return true } else { return false } }
+  }
+}
+
+@Suite("ApplePolishRouter")
+struct ApplePolishRouterTests {
+
+  // MARK: - Tier 1 short-circuits (strong phrase)
+
+  @Test("write a python script routes technical via strong phrase")
+  func writePythonScriptStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Write a Python script that takes a CSV export from Robinhood.")
+    #expect(d.mode == .technical)
+    #expect(d.basis == .tier1)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("generate a sql query routes technical via strong phrase")
+  func generateSqlStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Generate a SQL query that joins users and orders.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("convert this into json routes technical via strong phrase")
+  func convertIntoJsonStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Convert this into JSON with fields for title owner and deadline.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("create a regex routes technical via strong phrase")
+  func createRegexStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Create a regex pattern that matches hex colors.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("write a cpp function routes technical via strong phrase")
+  func writeCppStrongPhrase() {
+    // Symbol-ending language (c++) can't use trailing \b — regex uses
+    // lookahead instead. Polite-prefix form: not first-word imperative,
+    // so relies on strong-phrase match.
+    let d = ApplePolishRouter.decide(
+      "Can you write a C++ function that sorts integers by frequency.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("build a c sharp script routes technical via strong phrase")
+  func buildCsharpStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Could you build a C# script to read the config file.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("write python code without determiner routes technical")
+  func writePythonCodeNoDeterminer() {
+    // ASR variant: user says "write python code" not "write a python script".
+    let d = ApplePolishRouter.decide(
+      "Could you write Python code that parses the JSON response.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("generate sql without determiner routes technical")
+  func generateSqlNoDeterminer() {
+    // "Generate SQL to find duplicates" — no "a" between generate and sql.
+    let d = ApplePolishRouter.decide(
+      "Can you generate SQL to find duplicates in the orders table.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("c sharp spoken form routes technical")
+  func cSharpSpokenForm() {
+    // ASR transcribes "C sharp" as words, not the `#` symbol.
+    let d = ApplePolishRouter.decide(
+      "Please write a C sharp function to validate email addresses.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("c plus plus spoken form routes technical")
+  func cPlusPlusSpokenForm() {
+    let d = ApplePolishRouter.decide(
+      "Could you generate a C plus plus program that reverses a linked list.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  @Test("write go live messaging stays natural")
+  func writeGoLiveMessagingNatural() {
+    // Bare "go" replaced with "golang" in the language list, so the common
+    // business phrase "write go live messaging" no longer short-circuits.
+    let d = ApplePolishRouter.decide(
+      "Write go live messaging for the launch and share it with the team.")
+    #expect(d.mode == .technical)  // "Write" is still hard imperative at start
+    // But with "Let's" prefix, should stay natural:
+    let dLets = ApplePolishRouter.decide(
+      "Let's write go live messaging for the launch.")
+    #expect(dLets.mode == .natural)
+  }
+
+  @Test("write a golang program routes technical via strong phrase")
+  func writeGolangStrongPhrase() {
+    let d = ApplePolishRouter.decide(
+      "Could you write a Golang program that monitors the webhook endpoint.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasStrongPhrase)
+  }
+
+  // MARK: - Tier 1 short-circuits (hard imperative at sentence start)
+
+  @Test("draft an email routes technical via imperative at start")
+  func draftAnEmailImperative() {
+    let d = ApplePolishRouter.decide(
+      "Draft an email to Anand saying thanks for the intro.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("summarize the notes routes technical via imperative at start")
+  func summarizeNotesImperative() {
+    let d = ApplePolishRouter.decide("Summarize the notes from the discovery call.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("refactor struct routes technical via imperative at start")
+  func refactorImperative() {
+    let d = ApplePolishRouter.decide(
+      "Refactor this Swift struct to use an enum with associated values.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("translate this routes technical via imperative at start")
+  func translateImperative() {
+    let d = ApplePolishRouter.decide("Translate this into Spanish I will be ten minutes late.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("answer this question routes technical via imperative at start")
+  func answerThisQuestion() {
+    // AFM execution-risk case: natural-mode polish would answer the question
+    // instead of preserving it. Hard imperative must short-circuit.
+    let d = ApplePolishRouter.decide(
+      "Answer this question about the invoice status for the enterprise team.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("lets does not trigger imperative at start")
+  func letsIsNotImperative() {
+    let d = ApplePolishRouter.decide("Let's write a blog post about the launch.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("leading filler um still routes imperative technical")
+  func umDraftStillTechnical() {
+    let d = ApplePolishRouter.decide("Um, draft an email about the Q4 budget.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("leading please still routes imperative technical")
+  func pleaseDraftStillTechnical() {
+    let d = ApplePolishRouter.decide(
+      "Please draft a nursing note stating the wound is healing.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  // MARK: - Tier 1 short-circuits (preservation intent)
+
+  @Test("preserve the words routes technical via preservation intent")
+  func preserveTheWordsIntent() {
+    let d = ApplePolishRouter.decide(
+      "Please preserve the words write code in the blog post title.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasPreservationIntent)
+  }
+
+  @Test("dictate the words routes technical via preservation intent")
+  func dictateTheWordsIntent() {
+    let d = ApplePolishRouter.decide(
+      "Dictate the words import React from quote react quote exactly as words.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasPreservationIntent)
+  }
+
+  @Test("bare literally in conversational speech stays natural")
+  func bareLiterallyStaysNatural() {
+    // "literally" is too common conversationally to trigger preservation intent.
+    // Only explicit preserve-these-words phrases should short-circuit.
+    let d = ApplePolishRouter.decide("I literally forgot my keys this morning.")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasPreservationIntent)
+  }
+
+  @Test("bare verbatim in conversational speech stays natural")
+  func bareVerbatimStaysNatural() {
+    // "He quoted the email verbatim" — descriptive usage, not preservation.
+    let d = ApplePolishRouter.decide(
+      "He quoted the email verbatim in the meeting yesterday.")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasPreservationIntent)
+  }
+
+  // MARK: - Tier 2 scoring — technical wins
+
+  @Test("spoken formatting heavy sentence routes technical")
+  func spokenFormattingHeavy() {
+    // heading (+2) + bullet (+2) + backtick (+2) = 6 → technical.
+    let d = ApplePolishRouter.decide(
+      "Heading ship bullet one review bullet two backtick code end backtick.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasSpokenFormatting)
+    #expect(d.score >= 5)
+  }
+
+  @Test("heading colon structure dictation routes technical")
+  func headingColonStructure() {
+    // Scoped "heading colon" phrase catches structure dictation while the
+    // bare "colon" stays out of the list (anatomical ambiguity).
+    // heading (+2) + heading colon (+2) + bullet (+2) = 6 → technical.
+    let d = ApplePolishRouter.decide(
+      "Heading colon launch checklist then bullet one ship bullet two monitor.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasSpokenFormatting)
+  }
+
+  @Test("branch + slash + hotfix routes technical despite self correction")
+  func branchSlashSelfCorrection() {
+    let d = ApplePolishRouter.decide(
+      "The branch is feature slash billing, no, hotfix slash billing.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasTechNouns)
+    #expect(d.signals.hasSpokenFormatting)
+    #expect(d.signals.hasSelfCorrection)
+  }
+
+  // MARK: - Tier 2 scoring — natural wins (conversational imperatives)
+
+  @Test("remind conversational imperative stays natural")
+  func remindStaysNatural() {
+    // "Remind" is a conversational imperative: +3, no other tech signals.
+    let d = ApplePolishRouter.decide("Remind me to pick up the eggs from the store.")
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasConversationalImperative)
+    #expect(d.score < 5)
+  }
+
+  @Test("schedule lunch stays natural")
+  func scheduleLunchNatural() {
+    let d = ApplePolishRouter.decide("Schedule lunch with Sam next week.")
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasConversationalImperative)
+  }
+
+  @Test("send the follow up stays natural")
+  func sendFollowUpNatural() {
+    let d = ApplePolishRouter.decide("Send the follow-up tomorrow morning.")
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasConversationalImperative)
+  }
+
+  @Test("reply to sarah stays natural")
+  func replyToSarahNatural() {
+    let d = ApplePolishRouter.decide("Reply to Sarah and say I will be late.")
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasConversationalImperative)
+  }
+
+  // MARK: - Tier 2 scoring — natural wins (descriptive / filler)
+
+  @Test("self correction only routes natural")
+  func selfCorrectionNatural() {
+    let d = ApplePolishRouter.decide("Let's meet Thursday, sorry, Wednesday after three.")
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasSelfCorrection)
+  }
+
+  @Test("filler heavy conversational routes natural")
+  func fillerHeavyNatural() {
+    let d = ApplePolishRouter.decide(
+      "So, the client reached out and they essentially want to, um, completely redo the landing page."
+    )
+    #expect(d.mode == .natural)
+    #expect(d.signals.hasFiller)
+  }
+
+  @Test("descriptive mention without imperative stays natural")
+  func descriptiveMentionStaysNatural() {
+    let d = ApplePolishRouter.decide("The script for tomorrow's demo is too long.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("opener phrase stays natural")
+  func openerPhraseStaysNatural() {
+    let d = ApplePolishRouter.decide(
+      "Here is the issue, Apple Intelligence is enabled but the model is unavailable.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("empty input defaults natural")
+  func emptyInputDefaultsNatural() {
+    let d = ApplePolishRouter.decide("")
+    #expect(d.mode == .natural)
+    #expect(d.basis == .empty)
+    #expect(d.signals == [.emptyInput])
+  }
+
+  @Test("whitespace only defaults natural")
+  func whitespaceOnlyDefaultsNatural() {
+    let d = ApplePolishRouter.decide("   \n\t  ")
+    #expect(d.mode == .natural)
+    #expect(d.basis == .empty)
+  }
+
+  // MARK: - Substring traps (word boundaries must hold)
+
+  @Test("apiary does not trigger api tech noun")
+  func apiarySubstringTrap() {
+    let d = ApplePolishRouter.decide("I visited an apiary over the weekend.")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasTechNouns)
+  }
+
+  @Test("swiftly does not trigger swift tech noun")
+  func swiftlySubstringTrap() {
+    let d = ApplePolishRouter.decide("Move swiftly on this so we can ship tomorrow.")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasTechNouns)
+  }
+
+  @Test("em dash is not double-counted via dash")
+  func emDashNotDoubleCounted() {
+    // Codex review caught this: with bare "dash" in the list, \bdash\b
+    // matched inside "em dash", scoring one dictated concept twice.
+    // Expect: markdown (+2) + em dash (+2) = 4 → natural.
+    let d = ApplePolishRouter.decide("The markdown uses an em dash for separation.")
+    #expect(d.mode == .natural)
+    #expect(d.score < 5)
+  }
+
+  // MARK: - Exec / work-admin speech (Gemini-100 style)
+
+  @Test("push to thursday stays natural despite self-correction")
+  func pushToThursdayNatural() {
+    let d = ApplePolishRouter.decide(
+      "Let's push the Q3 NRR review to, um, Thursday at 4 PM, actually make it 4:30.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("honestly conversational stays natural")
+  func honestlyConversationalNatural() {
+    let d = ApplePolishRouter.decide(
+      "Honestly, I think we should just scrap the whole presentation and start over from scratch, you know?"
+    )
+    #expect(d.mode == .natural)
+  }
+
+  // MARK: - Technical descriptive (stays natural — only 1 tech noun, no verb)
+
+  @Test("vercel build description stays natural")
+  func vercelBuildDescriptive() {
+    let d = ApplePolishRouter.decide(
+      "The Vercel build is failing again because of a strict type error in the auth middleware.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("race condition description stays natural")
+  func raceConditionDescriptive() {
+    let d = ApplePolishRouter.decide(
+      "I think there's a race condition in the audio capture service when you toggle the microphone."
+    )
+    #expect(d.mode == .natural)
+  }
+
+  // MARK: - Clinical speech
+
+  @Test("clinical descriptive dictation stays natural")
+  func clinicalDescriptiveNatural() {
+    let d = ApplePolishRouter.decide(
+      "Patient in room 402 is complaining of sharp lower quadrant pain, rating it an 8 out of 10.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("clinical hold dose stays natural")
+  func clinicalHoldDoseNatural() {
+    // "Hold" is not in the imperative list. Clinical descriptive-imperatives
+    // like this stay natural because they're conversational dictation, not
+    // transformation requests.
+    let d = ApplePolishRouter.decide(
+      "Hold the morning dose of lisinopril because his blood pressure is running low.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("clinical colon anatomical stays natural")
+  func clinicalColonAnatomicalNatural() {
+    // "colon" as anatomy, not punctuation. administer (+3 conversational
+    // imperative) alone is under threshold; colon must not add +2 or it
+    // flips to technical.
+    let d = ApplePolishRouter.decide(
+      "Administer 4 milligrams of morphine for the patient's colon pain.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("clinical stat ekg stays natural")
+  func clinicalStatEkgNatural() {
+    let d = ApplePolishRouter.decide(
+      "Stat EKG on 410, she's having shortness of breath and chest tightness.")
+    #expect(d.mode == .natural)
+  }
+
+  @Test("clinical write nursing note routes technical")
+  func clinicalWriteNursingNote() {
+    // Hard imperative "Write" at start → technical.
+    let d = ApplePolishRouter.decide(
+      "Write a nursing note stating that the wound dressing was changed.")
+    #expect(d.mode == .technical)
+  }
+
+  // MARK: - API shape
+
+  @Test("classify convenience method matches decide")
+  func classifyMatchesDecide() {
+    let text = "Write a Python script."
+    #expect(ApplePolishRouter.classify(text) == ApplePolishRouter.decide(text).mode)
+  }
+
+  @Test("decision basis distinguishes tier1 vs scored")
+  func decisionBasisObservability() {
+    let tier1 = ApplePolishRouter.decide("Write a Python script.")
+    let scored = ApplePolishRouter.decide("Remind me to pick up the eggs.")
+    let empty = ApplePolishRouter.decide("")
+    #expect(tier1.basis == .tier1)
+    #expect(scored.basis == .scored)
+    #expect(empty.basis == .empty)
+  }
+}

--- a/docs/feature-requests/issue-381-2026-04-20-dual-mode-router.md
+++ b/docs/feature-requests/issue-381-2026-04-20-dual-mode-router.md
@@ -1,0 +1,169 @@
+# Issue #381 — Dual-mode Apple polish router — 2026-04-20
+
+GitHub issue: `#381`. Parent/epic: #320 Transcript Quality. Tier: **SMALL** (new isolated module, no runtime wiring yet). Status: DRAFT.
+
+## Preface — User Rubric
+
+1. **Who in this moment?** Marcus (staff engineer, dev persona) dictating "Write a SQL query that joins users and orders" to land in Claude Code. Priya (CSM/exec persona) dictating "Draft an email to Anand saying thanks for the intro" to land in Gmail. Dr. Vasquez dictating "Write a nursing note stating the wound dressing was changed" to land in Epic.
+2. **Why would they want this?** Marcus: *"I don't want my dictation button to start writing code for me when I was just telling Claude what to do."* Priya: *"I want filler words gone but I don't want my imperative verbs deleted when I say 'Draft a memo'."* Dr. Vasquez: *"I want the nursing note preserved word-for-word, not paraphrased."*
+3. **How would they invoke it?** Reactive, side effect of polish already running. Never visible as a toggle — router decides silently. Marcus is already in his terminal/Claude app; Priya already in Gmail; Dr. V already in Epic. No context switch.
+4. **What apps?** Marcus: Claude Code, Cursor, VS Code, Terminal. Priya: Gmail, Slack, Linear, Notion. Dr. V: Epic, EHR charting apps, Outlook. All surfaces receive pasted text; none read Apple Intelligence structure.
+5. **Natural inputs (5 per persona, realistic dictation):** Marcus: *"claude write a python script that reads a robinhood csv and maps it to monarch"*, *"the websocket keeps dropping when the device sleeps, we need a reconnection strategy"*, *"refactor this swift struct to use associated values"*, *"the vercel build is failing because of a type error"*, *"implement a fallback so if the api rate limits us it queues requests in local storage"*. Priya: *"draft an email to the enterprise team saying we need to rethink churn mitigation"*, *"let's push the q3 nrr review to thursday at four thirty"*, *"remind me to bring up the aws billing discrepancy during the all-hands"*, *"the client is asking for custom integration we cannot support so tell them no"*, *"schedule a sync with the european team on gdpr"*. Dr. V: *"write a nursing note stating wound dressing changed moderate serosanguinous drainage"*, *"patient in 402 complaining of sharp lower quadrant pain 8 out of 10"*, *"hold morning dose of lisinopril his bp is running low"*, *"stat ekg on 410 she's having shortness of breath"*, *"administer 4 milligrams zofran iv push for nausea"*.
+6. **What does success feel like?** They never notice. Polish cleans fillers from their descriptive dictation (Priya/Dr. V's default), preserves their imperatives when they dictate commands (Marcus's default), and never writes code when they meant to pass an instruction downstream. Invisible when correct, because that's polish working.
+7. **What does wrong-not-broken look like?** Marcus dictates "write a python script that reads this csv" to Claude Code; polish returns actual Python code and Marcus pastes that into Claude expecting a conversation about the script. He doesn't file a bug; he just stops trusting dictation for technical prompts. Priya dictates "draft an email"; polish drops "Draft" and keeps the body; she pastes into Gmail, realizes the imperative is gone, retypes. Quiet trust loss.
+8. **Power-user hack-around.** Manual toggle in settings. Explicit prefix word ("dictation:" / "command:"). Retry polish. None of these land in v1 because the whole point is the classifier runs invisibly.
+9. **Control ladder.** Off (current shipped prompt, no router) → Auto inference (this PR's follow-up: router picks mode silently) → Explicit toggle (future: hotkey to force technical). Default ships Auto; deterministic router means misroutes are tunable from telemetry rather than stuck as a policy choice.
+
+### Cross-persona check
+
+- **Priya**: Router protects her "Draft an email / Schedule a sync" imperatives from getting verb-dropped. Minor concern: she sometimes says "um" before "draft" — imperative-at-start still fires because she pauses before the verb, not within it.
+- **Marcus**: Explicit win. "Write a Python script" no longer gets executed.
+- **Diana** (marketing): Her dictation is closer to Priya's. No regression expected.
+- **Dr. Vasquez**: Most of her dictation is descriptive ("patient complaining of..."); router keeps this natural. Her nursing-note imperatives ("Write a nursing note...") go technical.
+- **Aaron** (retiree learning dictation): Purely conversational; every sentence routes natural.
+- **Meera / Frank** (accessibility-first users): Their dictation rarely includes imperative verbs or code-adjacent nouns; router stays on natural, which is the preserved behavior.
+
+Disagreement: zero. Router is a safety net for imperative preservation that doesn't change natural-speech behavior — every persona either benefits or sees no change.
+
+## 0. TL;DR
+
+Tonight's benchmark work established, with data, that a single on-device polish prompt cannot serve both "clean my dictation" (v30 prompt family) and "preserve my technical instruction" (v31 prompt family) without a material regression on one or the other. This PR adds the deterministic classifier (`ApplePolishRouter`) that picks between the two modes from the ASR transcript text alone — no new model call, no network, no AI. It does NOT yet wire the router into `AppleIntelligenceConnector.polish(...)`. Integration is a follow-up PR.
+
+## 1. Problem
+
+v30 (current worktree candidate) is the right polish prompt for natural dictation: on Gemini-100 it hit **engaged 87, filler-clean 90** vs v31's **engaged 63, filler-clean 68** — a -24/-22 regression on natural speech if we shipped v31 alone. v31 is the right polish prompt for technical/imperative/code-adjacent speech: on Codex's code_speech_v1 bench it scored **77/100** vs v30's **69/100**, and v31's filter catches imperative-execution (answer-this-question, translate-this, write-a-poem) that v30 misses. Shipping one prompt costs us 8 points on one axis or 24 points on the other.
+
+Prior art: peer voice-to-text apps (Superwhisper, WisprFlow) ship mode switches. Our users dictate both flavors freely; manual toggling would be friction; we need deterministic routing.
+
+## 2. Goals & non-goals
+
+### 2.1 Goals
+
+- Add `ApplePolishMode` enum (`.natural`, `.technical`) in `Sources/EnviousWisprLLM/`.
+- Add `ApplePolishRouter` with pure `classify(_:) -> ApplePolishMode` and `decide(_:) -> Decision` that exposes the signals.
+- Every rule, list, and weight lives in one file for telemetry-driven tuning later.
+- Unit tests cover every tier, every category the issue asked for (natural / exec / tech-imperative / tech-descriptive / spoken-literal / opener / self-correction / ambiguous mixed), plus empirical cases pulled from Gemini-100 and code_speech_v1.
+
+### 2.2 Non-goals
+
+- Wiring the router into `AppleIntelligenceConnector.polish(...)`. Follow-up PR.
+- A second output filter. The existing `EnviousOutputFilter` is shared across both modes.
+- Two separate prompts in source. Follow-up PR.
+- Telemetry emission for route decisions. Follow-up issue (depends on router being wired).
+- AI classifier, regex engine external to Swift, on-device model call for classification.
+
+## 3. Design
+
+### 3a. Tiered signal evaluation
+
+Router evaluates in this order and short-circuits on the first positive match in Tier 1:
+
+1. **Strong phrase** — regex-matched patterns like `(write|create|generate|draft|compose|build) a (python|sql|bash|swift|regex|...)`, `convert this into (json|yaml|...)`, `generate a (sql|regex) query`, `respond with json`. Short-circuits to technical.
+2. **Preservation intent** — phrases like "preserve the words", "exactly as words", "dictate the words", "verbatim", "literally". Short-circuits to technical. *Runs before imperative-at-start so "Dictate the words ... exactly as words" routes via the more specific signal.*
+3. **Hard imperative at sentence start** — first meaningful word (leading fillers like "um / uh / please / hey / okay / so / well" are skipped) is a hard imperative: `write, draft, generate, create, compose, build, make, convert, translate, summarize, summarise, paraphrase, rewrite, refactor, implement, turn, chart, plot, calculate, parse, compile`. Short-circuits to technical.
+
+If none of the above matches, fall to Tier 2 additive scoring:
+
+- **Conversational imperative at start** (+3, no cap since only first word counts): `send, schedule, remind, answer, respond, reply, list, record, administer, dictate`. These are casual/friendly imperatives common in ordinary speech ("Remind me to pick up eggs", "Schedule lunch with Sam"). Scoring — not short-circuiting — keeps bare conversational imperatives on natural while letting them tip technical when paired with code-adjacent signals.
+- **Code/tech nouns** (+2 each, cap 2 hits): python, sql, regex, swift, json, markdown, yaml, api, endpoint, webhook, docker, github, kubernetes, react, typescript, javascript, repository, repo, commit, merge, branch, hotfix, function, prisma, tailwind, vercel, cors.
+- **Spoken formatting nouns** (+2 each, cap 3 hits — higher because multiple distinct formatting words are unambiguous): bullet, heading, backtick, underscore, open paren, close paren, slash, quote, dash, colon, semicolon, etc.
+- **Self-correction markers** (-1 each, cap -2): wait, no, sorry, actually, scratch that.
+- **Filler words** (-1 each, cap -2): um, uh, you know, i mean, like, basically, honestly, essentially.
+- **Threshold**: `technical` if final score ≥ 5; else `natural`.
+
+All term matching uses `\b` word-boundary regex so "api" does not match "apiary", "swift" does not match "swiftly", and "no" does not match "note/not/nor". Per-term dedupe: a sentence with "bullet bullet bullet" contributes one hit for "bullet" (not three) — the cap governs *distinct* term variety, not repetition.
+
+### 3b. Why this shape
+
+- Strong phrases carry unambiguous intent; scoring them against a threshold wastes the signal.
+- Preservation intent is more specific than a generic imperative — "Dictate the words ... exactly as words" is a preservation directive, not a dictation command; signal label should reflect that.
+- Hard imperatives at sentence start short-circuit because the empirical data from v30 (shipped prompt family) shows v30 *drops* the imperative ("Draft an email about Q4" → "An email about Q4") or *executes* it ("Write a nursing note stating X" → "X") — both quiet trust losses. Better to route those to the more conservative technical mode.
+- Conversational imperatives (send/schedule/remind/reply) score instead of short-circuiting because "Remind me to pick up eggs" or "Schedule lunch with Sam" are ordinary speech where filler cleanup (natural mode) matters more than verb preservation.
+- Leading filler skip ("um, draft an email") ensures Priya's natural "um, draft the reply" still routes technical — the imperative is the intent even with a pause before it.
+- Self-correction adds a mild natural pull but cannot flip a Tier-1 technical decision — "Write a Python script, wait no, a Ruby script" is still technical.
+
+### 3c. File placement
+
+`Sources/EnviousWisprLLM/ApplePolishRouter.swift` (alongside `EnviousOutputFilter.swift` and `AppleIntelligenceConnector.swift`). Test: `Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift`.
+
+## 4. Contract deltas
+
+| What changed | Semantics | Invariants |
+|---|---|---|
+| New public enum `ApplePolishMode` | Which polish prompt family to use for a given transcript. Two cases today; never expand silently. | Callers must handle both cases. |
+| New public enum `ApplePolishRouter` with `classify` and `decide` | Pure classifier over `String`. No side effects, no logging, no persistence. | Must be idempotent. `classify(x) == classify(x)` always. |
+| New public enum `RouterSignal` | Structured signal cases: `emptyInput`, `strongPhrase(String)`, `preservationIntent(String)`, `imperativeStart(String)`, `conversationalImperativeStart(String)`, `techNouns([String])`, `spokenFormatting([String])`, `selfCorrection([String])`, `filler([String])`. | Telemetry-safe; rule tuning may add new cases but existing cases are stable. |
+| New public enum `RouterBasis` | How the router reached its decision: `.empty` / `.tier1` / `.scored`. Distinguishes "technical because Tier-1 matched" from "natural because nothing scored" — same `.mode` but different tuning implications. | Stable set; additions only. |
+| New public struct `ApplePolishRouter.Decision` | Logging vehicle — `mode`, `score`, `basis`, `signals`. | `signals` is a `[RouterSignal]` enum array, not free-form strings. Consumers should pattern-match on cases, not stringify. |
+
+No consumer today. Follow-up PR wires `Decision.mode` into `AppleIntelligenceConnector.polish(...)` and `Decision.signals` / `Decision.basis` into breadcrumbs.
+
+## 5. Integration plan (follow-up PR, not this one)
+
+1. Add two prompt constants in `AppleIntelligenceConnector`: `onDeviceInstructionsNatural` (current v30 copy) and `onDeviceInstructionsTechnical` (copy v31 from `codex/afm-v31`).
+2. In `polish(...)`, call `ApplePolishRouter.decide(text)` before `makeSession`.
+3. Thread the resolved `ApplePolishMode` into `makeSession(mode:)`, which selects the corresponding prompt.
+4. Log the routing decision (signals + chosen mode) via the existing `LLMTaskMetricsCollector` or a new debug breadcrumb for PostHog. Out of scope for this PR.
+5. Keep `EnviousOutputFilter` unchanged and apply it to both modes' output.
+
+## 6. Router rules in plain English
+
+- If the sentence starts with a hard command verb (Write, Draft, Generate, Create, Convert, Summarize, Refactor, Translate, Turn, Build, Make, Paraphrase, Rewrite, Implement, Compose, Chart, Plot, Calculate, Parse, Compile) → technical. Leading fillers like "um" or "please" are skipped before checking.
+- If the sentence contains a strong phrase like "write a Python script", "generate a SQL query", "convert this into JSON", or "respond with JSON" → technical.
+- If the sentence asks for literal preservation ("preserve the words...", "dictate the words...", "exactly as said...", "literally", "verbatim") → technical.
+- If the sentence has two or more code-world nouns (Python + JSON, branch + commit) OR three or more spoken-formatting words (heading + colon + bullet) → technical.
+- Conversational imperatives (Send, Schedule, Remind, Reply, Answer) at sentence start add +3 score but don't short-circuit. Alone they stay natural; combined with code-world nouns they tip technical.
+- Everything else → natural.
+- Self-correction markers (wait / no / sorry / actually) and filler words (um / uh / like / you know / basically / honestly / essentially / i mean) both pull gently toward natural but cannot override a Tier-1 technical decision.
+
+## 7. Ambiguous cases & how the router resolves them
+
+| Input | Resolved mode | Why |
+|---|---|---|
+| "The script for tomorrow's demo is too long." | natural | "Script" is NOT in the tech-noun list (intentionally ambiguous: theatre script vs shell script). No imperative, no strong phrase. Score 0 → natural. |
+| "Here is the issue, Apple Intelligence is enabled but the model is unavailable." | natural | Descriptive; opener phrase isn't a preservation directive; no imperative; "model" not in tech-noun list. |
+| "Draft an email to Anand saying thanks for the intro." | technical | "Draft" at sentence start matches imperative-at-start. Short-circuits. Safer to preserve than to drop the imperative word. |
+| "Let's write a blog post about the launch." | natural | "Let's" is first word; "write" is mid-sentence; no strong phrase; "blog post" not a tech noun. |
+| "Convert this into JSON with fields for title owner and deadline." | technical | Strong phrase `convert this into json` matches. |
+| "The branch is feature slash billing, no, hotfix slash billing." | technical | Tech-noun (branch + hotfix) = +4. Spoken formatting (slash) = +2 (dedupe — one distinct term). Self-correction "no" = -1. Score 5, threshold hit. |
+| "Dictate the words import React from quote react quote exactly as words." | technical | Preservation intent ("preserve the words" / "exactly as words") short-circuits before imperative-at-start. |
+| "My son wants me to write a story for bedtime." | natural | "Write" is mid-sentence, not at start; no strong phrase ("story" not in code-noun list). |
+| "Please preserve the words write code in the blog post title." | technical | Preservation intent short-circuits. |
+
+### 7.1 Known misroutes the router will make (accept as v1 tradeoffs)
+
+- `"Can you write a quick summary of the meeting?"` → natural (mid-sentence "write", no tech noun). Intended: natural. Match.
+- `"Generate some ideas for the offsite."` → technical (starts with "Generate", hard imperative). Intended: arguably natural. **Accepted misroute**: technical mode (v31) still produces reasonable output since it preserves the imperative rather than executing it. Cost is slightly-under-cleaned fillers on this class of sentence (-8 class).
+- `"Summarize yesterday's all-hands for the team."` → technical (starts with "Summarize"). Intended: debatable. v31 preserves the imperative rather than actually summarizing — arguably correct given the user will paste into another tool.
+- `"The SQL migration is broken."` → natural (one tech noun "sql", score 2, below threshold). Intended: probably natural, descriptive. Match.
+- `"Remind me to check the PostHog dashboard."` → natural (conversational imperative +3, one tech noun not in list, below threshold). Intended: natural. Match.
+- `"Send a GitHub invite to the new hire."` → tentatively natural (conversational imperative "send" +3, plus "github" tech noun +2 = 5 → technical). Actually routes technical. **Borderline**: this is an ordinary exec request; v31 preserves verbatim which is fine, but might lightly regress filler cleanup. Acceptable for v1; telemetry will tell us if this class is common.
+
+Rule of thumb for v1: false-technicals are cheap (prompt is more conservative, still produces valid polish); false-naturals on actual imperatives are expensive (AFM executes them). The asymmetry in scoring (hard imperative-at-start short-circuits, conversational imperative just adds score) reflects the 3× asymmetric regression cost from the empirical data.
+
+## 8. Testing
+
+37 unit tests, all passing. Coverage by category:
+
+- Tier 1 strong phrase: 4 tests (python script, sql query, json convert, regex)
+- Tier 1 hard imperative-at-start: 6 tests (draft an email, summarize notes, refactor struct, translate, "let's" negative, leading "um" skip, leading "please" skip)
+- Tier 1 preservation intent: 2 tests (preserve-the-words, dictate-the-words)
+- Tier 2 technical-wins: 2 tests (spoken formatting heavy, branch+slash+self-correction)
+- Tier 2 conversational-imperative natural: 4 tests (remind / schedule / send / reply)
+- Tier 2 natural-wins: 4 tests (self-correction only, filler heavy, descriptive noun, opener phrase)
+- Edge cases: 2 tests (empty, whitespace-only)
+- Substring traps: 2 tests (apiary doesn't trigger api; swiftly doesn't trigger swift)
+- Empirical Gemini-100 cases: 2 tests (push-to-thursday, honestly-conversational)
+- Empirical code_speech_v1 cases: 2 tests (vercel descriptive, race-condition)
+- Clinical speech: 4 tests (descriptive / hold-dose / stat-ekg → natural; write-nursing-note → technical)
+- API shape: 2 tests (classify == decide.mode, basis observability distinguishes tier1/scored/empty)
+
+Run: `scripts/swift-test.sh --filter ApplePolishRouter`. 37/37 pass locally.
+
+## 9. Rollout plan
+
+This PR: land router + tests. No behavior change for users.
+
+Follow-up PR: wire router into `AppleIntelligenceConnector.polish(...)` + add second prompt. That's where user-visible behavior changes — run Gemini-100 + code_speech_v1 end-to-end before merging, verify no regression on either axis, write integration tests, optionally add a debug breadcrumb.
+
+Follow-up issue: telemetry for misroutes (log the chosen mode alongside user's post-polish behavior; manual review of top N to tune the rules).


### PR DESCRIPTION
## Summary

Deterministic router (`ApplePolishRouter`) that selects between `.natural` (v30 prompt family) and `.technical` (v31 prompt family) on-device Apple Intelligence polish modes from the post-ASR transcript. No network, no model call, no AI classifier.

**This PR adds the router and tests only.** Integration with `AppleIntelligenceConnector.polish(...)` is a follow-up PR that also introduces the v31 prompt and telemetry. **No runtime behavior change for users in this PR.**

## Why dual-mode

Tonight's benchmark work established with data that a single polish prompt cannot serve both natural dictation and technical dictation without material regression:

| Bench | v30 (natural candidate) | v31 (technical candidate) |
|---|---|---|
| Gemini-100 (natural, filler-heavy) | engaged 87, filler-clean 90 | engaged 63, filler-clean 68 |
| code_speech_v1 (technical, imperative-preserving) | 69/100 | 77/100 |

Shipping v31 alone = −24 filler cleanup points on natural speech. Shipping v30 alone = −8 points on technical. Dual-mode with a classifier lets us keep both.

## Router design

Three Tier-1 short-circuits to `.technical`:
1. **Strong phrase** (regex): `(write|create|generate|draft|compose|build) a (python|sql|bash|swift|regex|...)`, `convert this into (json|yaml|...)`, `generate a (sql|regex) query`.
2. **Preservation intent**: "preserve the words", "exactly as words", "dictate the words", "verbatim", "literally".
3. **Hard imperative at sentence start** (leading fillers skipped): write, draft, generate, create, compose, build, make, convert, translate, summarize, summarise, paraphrase, rewrite, refactor, implement, turn, chart, plot, calculate, parse, compile.

If no Tier-1 match, additive Tier-2 score with threshold 5:
- Conversational imperative at start (send/schedule/remind/answer/respond/reply/list/record/administer/dictate): +3
- Code/tech nouns: +2 each, cap 2 hits
- Spoken formatting words: +2 each, cap 3 hits
- Self-correction markers (wait/no/sorry/actually/scratch that): −1 each, cap −2
- Filler words (um/uh/like/you know/i mean/basically/honestly/essentially): −1 each, cap −2

All term matching uses `\b` word-boundary regex (no substring false-fires like "apiary" → "api").

## Review process

- ✅ Plan written (`docs/feature-requests/issue-381-2026-04-20-dual-mode-router.md`) including full User Rubric across Marcus/Priya/Dr. Vasquez personas.
- ✅ Council round: GPT + Gemini reviewed the plan via background subagents. Both flagged the same two revisions:
  1. Typed `RouterSignal` enum instead of free-form `"label:value"` strings (telemetry rot risk). **Applied.**
  2. Split imperatives: conversational verbs (send/schedule/remind/reply) demote to Tier-2 scoring so "Remind me to pick up eggs" stays natural; hard verbs (write/draft/refactor/translate/summarize/...) stay Tier-1 short-circuit. **Applied.**
- ✅ Grounded review (Codex): caught 8 plan-vs-code discrepancies (bare "no" not in self-correction, `like,` vs `like` filler, three-bullet dedupe claim, etc.). **All addressed** — either code or plan edited to align.
- ✅ Codex code-diff review on revised commit.

## Test plan

- [x] `scripts/swift-test.sh --filter ApplePolishRouter` → 37/37 pass locally
- [x] `scripts/swift-test.sh --filter PreambleStripping` → 12/12 pass (no regression)
- [x] `swift build` → clean
- [x] Typed-signal assertions (not stringified)
- [x] Substring-trap tests (apiary, swiftly)
- [x] Leading-filler-skip tests ("Um, draft an email")
- [x] Boundary cases (empty input, whitespace-only)
- [x] Empirical Gemini-100 + code_speech_v1 sample cases

## Non-goals (explicit for reviewer)

- Wiring into `AppleIntelligenceConnector.polish(...)` → follow-up PR.
- Two separate prompt constants → follow-up PR.
- Telemetry emission for route decisions → follow-up issue.
- AI classifier, on-device model call, network request → never.
