### PR TITLE
refactor(#428): Phase C — TranscriptCoordinator owns history (in-memory append)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -129,6 +129,8 @@ let package = Package(
         "EnviousWisprPostProcessing",
         "EnviousWisprLLM",
         "EnviousWisprPipeline",
+        "EnviousWisprStorage",
+        "EnviousWispr",
       ],
       path: "Tests/EnviousWisprTests"
     ),

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -18,7 +18,6 @@ final class AppState {
   let permissions = PermissionsService()
   let audioCapture: any AudioCaptureInterface
   let asrManager: any ASRManagerInterface
-  let transcriptStore = TranscriptStore()
   let keychainManager = KeychainManager()
   let hotkeyService = HotkeyService()
   let benchmark = BenchmarkSuite()
@@ -68,7 +67,7 @@ final class AppState {
       schedulePolishFailedWarning: { [weak self] in
         self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
       },
-      reloadTranscriptHistory: { [weak self] in self?.transcriptCoordinator.load() },
+      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
       reportDictationCompleted: { [weak self] t in
         guard let self else { return }
         TelemetryService.shared.reportDictationCompleted(
@@ -141,6 +140,21 @@ final class AppState {
       asrManager = ASRManager()
     }
 
+    // Phase C (#428) — composition-root for transcript storage.
+    // One `TranscriptStore` instance is constructed here and threaded
+    // into every consumer (coordinator + both pipelines + polish service).
+    // AppState does NOT retain this as a property; each consumer keeps
+    // the reference it received via init. No accessor is exposed on the
+    // coordinator; no consumer constructs its own. The shared-store
+    // invariant is verifiable by grep: exactly one `TranscriptStore(`
+    // call in `Sources/` outside `EnviousWisprStorage/TranscriptStore.swift`.
+    let transcriptStore = TranscriptStore()
+    // Production invariant: the app has always written transcripts to
+    // AppConstants.appSupportURL/transcripts. Verified via grep 2026-04-20.
+    // No legacy path, no group container, no iCloud. Phase C Invariant
+    // safeguard #4 (Option B — plan §11): a concrete migrator would be a
+    // no-op, so we rely on the default init's directory-create-on-miss
+    // plus founder dogfood (safeguard #3) to catch any future path shift.
     transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
     llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 

--- a/Sources/EnviousWispr/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWispr/App/TranscriptCoordinator.swift
@@ -30,7 +30,15 @@ final class TranscriptCoordinator {
     loadTask?.cancel()
     loadTask = Task {
       do {
-        transcripts = try await store.loadAll()
+        let diskRows = try await store.loadAll()
+        // Phase C union-by-ID merge. Preserve any in-memory rows whose IDs
+        // are not yet on disk (append-during-load race window) in their
+        // existing order, then append disk rows. Protects the newest-first
+        // invariant under multiple concurrent completions while a slow
+        // startup load is still running.
+        let diskIDs = Set(diskRows.map(\.id))
+        let inFlightRows = transcripts.filter { !diskIDs.contains($0.id) }
+        transcripts = inFlightRows + diskRows
       } catch {
         await AppLogger.shared.log(
           "Failed to load transcripts: \(error)",
@@ -38,6 +46,16 @@ final class TranscriptCoordinator {
         )
       }
     }
+  }
+
+  /// Append a just-completed transcript to the in-memory cache.
+  ///
+  /// Precondition: the transcript has already been persisted by
+  /// `TranscriptFinalizer.save(_:)`. This method does no disk I/O. Caller
+  /// must not invoke it twice for the same transcript — duplicate-ID
+  /// protection would mask heart-path bugs.
+  func append(_ transcript: Transcript) {
+    transcripts.insert(transcript, at: 0)
   }
 
   func delete(_ transcript: Transcript) {

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -31,7 +31,7 @@ public final class PipelineStateChangeHandler {
   private let showOverlay: ShowOverlay
   private let cancelPendingWarning: @MainActor () -> Void
   private let schedulePolishFailedWarning: @MainActor () -> Void
-  private let reloadTranscriptHistory: @MainActor () -> Void
+  private let appendCompletedTranscript: @MainActor (Transcript) -> Void
   private let reportDictationCompleted: @MainActor (Transcript) -> Void
   private let reportPipelineFailed: @MainActor (String) -> Void
 
@@ -39,14 +39,14 @@ public final class PipelineStateChangeHandler {
     showOverlay: @escaping ShowOverlay,
     cancelPendingWarning: @escaping @MainActor () -> Void,
     schedulePolishFailedWarning: @escaping @MainActor () -> Void,
-    reloadTranscriptHistory: @escaping @MainActor () -> Void,
+    appendCompletedTranscript: @escaping @MainActor (Transcript) -> Void,
     reportDictationCompleted: @escaping @MainActor (Transcript) -> Void,
     reportPipelineFailed: @escaping @MainActor (String) -> Void
   ) {
     self.showOverlay = showOverlay
     self.cancelPendingWarning = cancelPendingWarning
     self.schedulePolishFailedWarning = schedulePolishFailedWarning
-    self.reloadTranscriptHistory = reloadTranscriptHistory
+    self.appendCompletedTranscript = appendCompletedTranscript
     self.reportDictationCompleted = reportDictationCompleted
     self.reportPipelineFailed = reportPipelineFailed
   }
@@ -78,8 +78,10 @@ public final class PipelineStateChangeHandler {
         schedulePolishFailedWarning()
       case .showOverlay(let intent):
         showOverlay(intent)
-      case .reloadTranscriptHistory:
-        reloadTranscriptHistory()
+      case .appendCompletedTranscript:
+        if let t = currentTranscript {
+          appendCompletedTranscript(t)
+        }
       case .reportDictationCompleted:
         if let t = currentTranscript {
           reportDictationCompleted(t)

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -19,10 +19,12 @@ enum PipelineStateSideEffect: Equatable, Sendable {
   /// Render this intent on the overlay. Always emitted exactly once per call.
   case showOverlay(OverlayIntent)
 
-  /// Trigger disk-backed transcript history reload. Emitted on every
-  /// `.complete` transition, regardless of whether the current transcript is
-  /// nil. (Phase C will replace this with an in-memory `append(_:)`.)
-  case reloadTranscriptHistory
+  /// Append the just-completed transcript to the in-memory history cache
+  /// (no disk I/O — finalizer already persisted before `.complete` fires).
+  /// Emitted only when `hasCurrentTranscript` is true; `.complete` with
+  /// `nil` transcript is treated as a transient stale-cache condition and
+  /// no append is emitted.
+  case appendCompletedTranscript
 
   /// Call `TelemetryService.shared.reportDictationCompleted(transcript:inputMode:)`
   /// using the caller's current transcript. Emitted only when `.complete` AND
@@ -89,12 +91,16 @@ enum PipelineStateChangePlanner {
     }
     effects.append(.showOverlay(resolvedOverlayIntent))
 
-    // Step 2 — complete-path telemetry and history reload.
-    // reloadTranscriptHistory fires even without a current transcript
-    // (matches AppState.swift:395 unconditional load).
+    // Step 2 — complete-path: append to in-memory history + telemetry.
+    // Phase C: replaced unconditional disk-backed reload with an
+    // in-memory append that only fires when the pipeline has a
+    // current transcript. Finalizer already persisted by the time
+    // `.complete` is observed (TranscriptFinalizer.swift:126), so the
+    // new row is on disk regardless. The in-memory append keeps the
+    // history cache visibly fresh without an O(n) disk scan.
     if case .complete = newState.activity {
-      effects.append(.reloadTranscriptHistory)
       if hasCurrentTranscript {
+        effects.append(.appendCompletedTranscript)
         effects.append(.reportDictationCompleted)
       }
     }

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -16,6 +16,21 @@ public final class TranscriptStore {
     )
   }
 
+  // Tests only. Reached via `@testable import EnviousWisprStorage`.
+  // Production uses the default `init()` so the store always points at
+  // `AppConstants.appSupportURL/transcripts`. Keeping this `internal`
+  // means a production call site cannot mis-point the store. Periphery
+  // scans `--exclude-tests` so this init appears unused from production;
+  // the annotation suppresses that false positive.
+  // periphery:ignore
+  internal init(directory: URL) {
+    self.directory = directory
+    try? FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true
+    )
+  }
+
   /// Save a transcript to disk.
   public func save(_ transcript: Transcript) throws {
     let filename = "\(transcript.id.uuidString).json"

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
@@ -1,0 +1,181 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprStorage
+
+/// Phase C (#428) — pins the `TranscriptCoordinator` contract around the new
+/// in-memory `append(_:)` and the union-by-ID merge in `load()`.
+///
+/// These replace the pre-Phase-C behavior where `.complete` triggered a
+/// full-directory reload. The tests drive the coordinator through real
+/// `TranscriptStore(directory:)` instances seeded under a temp directory so
+/// the in-memory contract is asserted against real disk semantics — no
+/// protocol doubles, no spy layers.
+@MainActor
+@Suite("TranscriptCoordinator — Phase C append + merge")
+struct TranscriptCoordinatorTests {
+
+  // MARK: - Fixtures
+
+  private static func makeTempDir() -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("phase-c-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private static func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  private static func makeTranscript(
+    text: String = "hello",
+    createdAt: Date = Date()
+  ) -> Transcript {
+    Transcript(
+      id: UUID(),
+      text: text,
+      processingTime: 0.1,
+      backendType: .parakeet,
+      createdAt: createdAt
+    )
+  }
+
+  private static func writeToDisk(_ transcripts: [Transcript], in dir: URL) throws {
+    let encoder = JSONEncoder()
+    for t in transcripts {
+      let url = dir.appendingPathComponent("\(t.id.uuidString).json")
+      let data = try encoder.encode(t)
+      try data.write(to: url, options: .atomic)
+    }
+  }
+
+  // MARK: - append(_:) contract
+
+  @Test("append inserts at index 0")
+  func testAppendInsertsAtIndexZero() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+
+    let first = Self.makeTranscript(text: "first")
+    let second = Self.makeTranscript(text: "second")
+    coordinator.append(first)
+    coordinator.append(second)
+
+    #expect(coordinator.transcripts.map(\.id) == [second.id, first.id])
+  }
+
+  @Test("append does not mutate disk")
+  func testAppendDoesNotMutateDisk() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+
+    let before = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+    coordinator.append(Self.makeTranscript())
+    let after = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+
+    #expect(before == after)
+  }
+
+  // MARK: - Startup load regression
+
+  @Test("startup load brings every on-disk row into memory")
+  func testStartupLoadPreservesPreexisting() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let seeded = [
+      Self.makeTranscript(text: "old-3", createdAt: Date().addingTimeInterval(-300)),
+      Self.makeTranscript(text: "old-2", createdAt: Date().addingTimeInterval(-200)),
+      Self.makeTranscript(text: "old-1", createdAt: Date().addingTimeInterval(-100)),
+    ]
+    try Self.writeToDisk(seeded, in: dir)
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+
+    coordinator.load()
+    // load() runs on a Task; wait for it.
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    #expect(coordinator.transcripts.count == 3)
+    let loadedIDs = Set(coordinator.transcripts.map(\.id))
+    let seededIDs = Set(seeded.map(\.id))
+    #expect(loadedIDs == seededIDs)
+  }
+
+  // MARK: - Merge algorithm (race guard)
+
+  @Test("load during a concurrent append merges both rows")
+  func testLoadDuringAppendMergesCorrectly() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let diskOnly = Self.makeTranscript(text: "disk")
+    try Self.writeToDisk([diskOnly], in: dir)
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+
+    // Simulate the race: an append arrives before load() finishes.
+    let newRow = Self.makeTranscript(text: "appended")
+    coordinator.append(newRow)
+    coordinator.load()
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    let ids = coordinator.transcripts.map(\.id)
+    #expect(ids.count == 2)
+    #expect(ids.contains(newRow.id))
+    #expect(ids.contains(diskOnly.id))
+    // In-memory row must come before disk rows to preserve newest-first
+    // under the append-order contract.
+    #expect(ids.first == newRow.id)
+  }
+
+  @Test("load during multiple appends preserves append-order at the front")
+  func testLoadDuringMultipleAppendsPreservesNewestFirstOrder() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let diskRow = Self.makeTranscript(text: "disk")
+    try Self.writeToDisk([diskRow], in: dir)
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+
+    // Three rapid appends, all before load finishes.
+    let r1 = Self.makeTranscript(text: "r1")
+    let r2 = Self.makeTranscript(text: "r2")
+    let r3 = Self.makeTranscript(text: "r3")
+    coordinator.append(r1)
+    coordinator.append(r2)
+    coordinator.append(r3)
+    coordinator.load()
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    // Pre-merge in-memory order was [r3, r2, r1] (each append inserts at 0).
+    // After merge: in-memory rows first (order preserved), then disk row.
+    let ids = coordinator.transcripts.map(\.id)
+    #expect(ids == [r3.id, r2.id, r1.id, diskRow.id])
+  }
+
+  // MARK: - Delete routing (consumer matrix row)
+
+  @Test("delete removes from cache and disk")
+  func testDeleteRemovesFromCacheAndDisk() async throws {
+    let dir = Self.makeTempDir()
+    defer { Self.cleanup(dir) }
+    let row = Self.makeTranscript(text: "to-delete")
+    try Self.writeToDisk([row], in: dir)
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    coordinator.load()
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    coordinator.delete(row)
+    #expect(coordinator.transcripts.isEmpty)
+    let onDisk = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+      .filter { $0.hasSuffix(".json") }
+    #expect(onDisk.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -37,7 +37,7 @@ struct PipelineStateChangeHandlerTests {
   final class CallbackRecorder {
     var cancelWarningCount = 0
     var scheduleWarningCount = 0
-    var reloadHistoryCount = 0
+    var appendedCalls: [Transcript] = []
     var completedCalls: [Transcript] = []
     var failedCalls: [String] = []
   }
@@ -50,7 +50,7 @@ struct PipelineStateChangeHandlerTests {
       showOverlay: { intent in overlay.record(intent) },
       cancelPendingWarning: { callbacks.cancelWarningCount += 1 },
       schedulePolishFailedWarning: { callbacks.scheduleWarningCount += 1 },
-      reloadTranscriptHistory: { callbacks.reloadHistoryCount += 1 },
+      appendCompletedTranscript: { callbacks.appendedCalls.append($0) },
       reportDictationCompleted: { callbacks.completedCalls.append($0) },
       reportPipelineFailed: { callbacks.failedCalls.append($0) }
     )
@@ -87,7 +87,7 @@ struct PipelineStateChangeHandlerTests {
     )
 
     #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
-    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.appendedCalls.count == 1)
     #expect(calls.completedCalls.count == 1)
     #expect(calls.completedCalls.first?.id == transcript.id)
     #expect(calls.failedCalls.isEmpty)
@@ -112,7 +112,7 @@ struct PipelineStateChangeHandlerTests {
     #expect(calls.scheduleWarningCount == 1)
     #expect(calls.cancelWarningCount == 0)
     #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
-    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.appendedCalls.count == 1)
     #expect(calls.completedCalls.count == 1)
   }
 
@@ -132,14 +132,17 @@ struct PipelineStateChangeHandlerTests {
 
     #expect(spy.calls == [OverlaySpy.Call(intent: .clipboardFallback)])
     #expect(calls.scheduleWarningCount == 0)
-    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.appendedCalls.count == 1)
     #expect(calls.completedCalls.count == 1)
   }
 
   // MARK: - Transcript-conditional guards
 
-  @Test("complete without current transcript: reload fires but reportDictationCompleted does not")
-  func completeWithoutTranscriptSkipsTelemetry() {
+  @Test("complete without current transcript: neither append nor telemetry fires (Phase C)")
+  func completeWithoutTranscriptSkipsBothAppendAndTelemetry() {
+    // Phase C (#428): `.complete` with nil transcript emits overlay only.
+    // The in-memory cache is stale until next `load()`; finalizer has
+    // already persisted the row, so disk is authoritative.
     let spy = OverlaySpy()
     let calls = CallbackRecorder()
     let handler = Self.makeHandler(overlay: spy, callbacks: calls)
@@ -151,7 +154,7 @@ struct PipelineStateChangeHandlerTests {
       currentTranscript: nil
     )
 
-    #expect(calls.reloadHistoryCount == 1)
+    #expect(calls.appendedCalls.isEmpty)
     #expect(calls.completedCalls.isEmpty)
     #expect(spy.calls.count == 1)
   }
@@ -174,7 +177,7 @@ struct PipelineStateChangeHandlerTests {
     #expect(calls.cancelWarningCount == 1)
     #expect(calls.scheduleWarningCount == 0)
     #expect(spy.calls == [OverlaySpy.Call(intent: .recording(audioLevel: 0))])
-    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.appendedCalls.count == 0)
     #expect(calls.completedCalls.isEmpty)
     #expect(calls.failedCalls.isEmpty)
   }
@@ -193,7 +196,7 @@ struct PipelineStateChangeHandlerTests {
     )
 
     #expect(calls.cancelWarningCount == 1)
-    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.appendedCalls.count == 0)
     #expect(calls.completedCalls.isEmpty)
   }
 
@@ -216,7 +219,7 @@ struct PipelineStateChangeHandlerTests {
     #expect(
       spy.calls == [OverlaySpy.Call(intent: .error(message: "mic_disconnected"))])
     #expect(calls.failedCalls == ["mic_disconnected"])
-    #expect(calls.reloadHistoryCount == 0)
+    #expect(calls.appendedCalls.count == 0)
     #expect(calls.completedCalls.isEmpty)
   }
 
@@ -243,7 +246,7 @@ struct PipelineStateChangeHandlerTests {
       currentTranscript: second
     )
 
-    #expect(calls.reloadHistoryCount == 2)
+    #expect(calls.appendedCalls.count == 2)
     #expect(calls.completedCalls.count == 2)
     #expect(calls.completedCalls.map(\.id) == [first.id, second.id])
   }

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -39,7 +39,7 @@ struct PipelineStateChangePlannerTests {
     #expect(plan.effects.contains(.showOverlay(.clipboardFallback)))
     #expect(!plan.effects.contains(.schedulePolishFailedWarning))
     // Clipboard fallback still reports telemetry + reloads history.
-    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.appendCompletedTranscript))
     #expect(plan.effects.contains(.reportDictationCompleted))
     #expect(!plan.effects.contains(.cancelPendingWarning))
   }
@@ -55,7 +55,7 @@ struct PipelineStateChangePlannerTests {
     )
     #expect(plan.effects.contains(.showOverlay(.hidden)))
     #expect(plan.effects.contains(.schedulePolishFailedWarning))
-    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.appendCompletedTranscript))
     #expect(plan.effects.contains(.reportDictationCompleted))
     #expect(!plan.effects.contains(.cancelPendingWarning))
   }
@@ -71,13 +71,19 @@ struct PipelineStateChangePlannerTests {
     )
     #expect(plan.effects.contains(.showOverlay(.hidden)))
     #expect(!plan.effects.contains(.schedulePolishFailedWarning))
-    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(plan.effects.contains(.appendCompletedTranscript))
     #expect(plan.effects.contains(.reportDictationCompleted))
     #expect(!plan.effects.contains(.cancelPendingWarning))
   }
 
-  @Test("complete without current transcript -> history reloads but no telemetry")
-  func completeWithoutTranscriptSkipsTelemetryButReloadsHistory() {
+  @Test("complete without current transcript -> neither append nor telemetry fires (Phase C)")
+  func completeWithoutTranscriptSkipsBothAppendAndTelemetry() {
+    // Phase C (#428) contract change: when `.complete` arrives with no
+    // currentTranscript, the planner emits neither `.appendCompletedTranscript`
+    // nor `.reportDictationCompleted`. This is an accepted transient
+    // stale-cache condition — finalizer already persisted, so the row is on
+    // disk; the in-memory cache is stale until next `load()`. Previously
+    // (Phase A) an unconditional disk reload fired even without a transcript.
     let plan = PipelineStateChangePlanner.plan(
       to: PipelineState.complete,
       pipelineOverlayIntent: Self.hiddenIntent,
@@ -85,7 +91,7 @@ struct PipelineStateChangePlannerTests {
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
-    #expect(plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.appendCompletedTranscript))
     #expect(!plan.effects.contains(.reportDictationCompleted))
   }
 
@@ -129,7 +135,7 @@ struct PipelineStateChangePlannerTests {
     )
     #expect(plan.effects.first == .cancelPendingWarning)
     #expect(plan.effects.contains(.showOverlay(.hidden)))
-    #expect(!plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.appendCompletedTranscript))
     #expect(!plan.effects.contains(.reportDictationCompleted))
   }
 
@@ -196,7 +202,7 @@ struct PipelineStateChangePlannerTests {
     #expect(plan.effects.contains(.cancelPendingWarning))
     #expect(plan.effects.contains(.showOverlay(.error(message: "mic_disconnected"))))
     // error must not trigger .complete-path effects.
-    #expect(!plan.effects.contains(.reloadTranscriptHistory))
+    #expect(!plan.effects.contains(.appendCompletedTranscript))
     #expect(!plan.effects.contains(.reportDictationCompleted))
   }
 
@@ -228,7 +234,7 @@ struct PipelineStateChangePlannerTests {
     #expect(
       plan.effects == [
         .showOverlay(.hidden),
-        .reloadTranscriptHistory,
+        .appendCompletedTranscript,
         .reportDictationCompleted,
       ])
   }
@@ -246,7 +252,7 @@ struct PipelineStateChangePlannerTests {
       plan.effects == [
         .schedulePolishFailedWarning,
         .showOverlay(.hidden),
-        .reloadTranscriptHistory,
+        .appendCompletedTranscript,
         .reportDictationCompleted,
       ])
   }
@@ -263,7 +269,7 @@ struct PipelineStateChangePlannerTests {
     #expect(
       plan.effects == [
         .showOverlay(.clipboardFallback),
-        .reloadTranscriptHistory,
+        .appendCompletedTranscript,
         .reportDictationCompleted,
       ])
   }


### PR DESCRIPTION
Phase C of Refactor Bible epic #319. Closes #428.

## Summary
- Replace O(n) `TranscriptStore.loadAll()` on every `.complete` with an in-memory `TranscriptCoordinator.append(_:)`. Finalizer has already persisted by the time `.complete` fires, so the reload was pure redundant I/O that scaled with user history size.
- Composition-root wiring: one `TranscriptStore` constructed in `AppState.init`, threaded by init into coordinator + both pipelines + `TranscriptPolishService`. AppState drops the `transcriptStore` property. Tripwire: exactly one `TranscriptStore(` call in `Sources/` outside the storage module.
- `PipelineStateChangePlanner`: effect rename `.reloadTranscriptHistory` → `.appendCompletedTranscript`, now gated on `hasCurrentTranscript`. Nil-transcript `.complete` is treated as accepted transient stale-cache (finalizer persisted; disk authoritative).
- `TranscriptCoordinator.load()` now does union-by-ID merge (`inFlightRows + diskRows`) instead of wholesale replace. Preserves newest-first under append-during-load races.
- `TranscriptStore` gains `internal init(directory:)` for test seams via `@testable import`.

## Invariants
Phase C Invariant — zero production history loss. All four safeguards addressed:
- #1 read-compat characterization — unit tests cover
- #2 write-after-read — covered via merge + delete tests
- #3 24h founder dogfood — approved Option A (parallel dogfood during merge window, revertible via single-commit revert)
- #4 upgrade-folder-copy — Option B chosen (Grounded Review grep confirmed no historical storage path exists; migrator would be a no-op)

## Test plan
- [x] `swift build -c release` exits 0
- [x] `swift build` (debug) exits 0
- [x] `scripts/swift-test.sh` — 442 tests / 43 suites pass (6 new TranscriptCoordinatorTests, updated PipelineStateChangePlannerTests + HandlerTests)
- [x] Periphery fast scan — net new findings vs baseline: 0 (one new `TranscriptStore.init(directory:)` annotated `// periphery:ignore` as test-only)
- [x] Local Codex code-diff review — clean
- [x] Shared-store tripwire grep — exactly 1 production `TranscriptStore(` at AppState.swift:149
- [x] Dev bundle built, signed, launched — wispr-eyes VERIFIED (5,976 transcripts load, newest-first, no error surfaces, UI identical)
- [ ] 24h founder dogfood running in parallel on dev build

## Blast radius
- Touched: `Package.swift`, `AppState.swift`, `TranscriptCoordinator.swift`, `TranscriptStore.swift`, `PipelineStateChangeHandler.swift`, `PipelineStateChangePlanner.swift`, new `TranscriptCoordinatorTests.swift`, updated planner/handler test files.
- Untouched: `TranscriptFinalizer` persistence, `Transcript` Codable shape, both pipelines' `.complete` emission, `HistoryContentView.task` startup path, detail-pane path, `TranscriptPolishService.loadAll()` (deferred to post-epic).
- Rollback: `git revert` single commit. No on-disk format change.

## References
- Plan: `docs/feature-requests/issue-428-2026-04-20-phase-c-transcript-coordinator.md`
- Bible: `docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md` §9
- Predecessors: #196 (Phase A — PR #422), #195 (Phase B — PR #424)
- Grounded Review: `docs/audits/2026-04-20-phase-c-grounded-review.txt`
