### PR TITLE
fix(router): polite-prefix imperatives + preservationIntent word-boundary (#430, #431)

### DIFF
--- a/Sources/EnviousWisprLLM/ApplePolishRouter.swift
+++ b/Sources/EnviousWisprLLM/ApplePolishRouter.swift
@@ -264,13 +264,18 @@ public enum ApplePolishRouter {
     "um", "uh", "please", "hey", "okay", "ok", "so", "well",
   ]
 
-  /// Multi-word polite prefixes. When the first two tokens match one of these
-  /// pairs, both are skipped so the imperative still reaches `hardImperatives`.
-  /// Covers "Could you make …", "Can you answer …", "Would you draft …",
-  /// "Will you write …", "Do you draft …".
+  /// Multi-word polite prefixes that soften a following imperative. When the
+  /// first two tokens match, both are skipped so the imperative still reaches
+  /// `hardImperatives`. "could/can/would/will" + "you" read as softened
+  /// requests ("Could you make …", "Will you draft …").
+  ///
+  /// `"do you"` is deliberately NOT in this set — "Do you answer customer
+  /// emails?" is a yes/no question, not a softened imperative. Skipping it
+  /// would route genuine conversational questions to .technical. Codex flagged
+  /// this on PR #436.
   private static let leadingSkipBigrams: Set<[String]> = [
     ["could", "you"], ["can", "you"], ["would", "you"],
-    ["will", "you"], ["do", "you"],
+    ["will", "you"],
   ]
 
   private static func firstMeaningfulWord(_ trimmed: String) -> String {

--- a/Sources/EnviousWisprLLM/ApplePolishRouter.swift
+++ b/Sources/EnviousWisprLLM/ApplePolishRouter.swift
@@ -264,16 +264,40 @@ public enum ApplePolishRouter {
     "um", "uh", "please", "hey", "okay", "ok", "so", "well",
   ]
 
+  /// Multi-word polite prefixes. When the first two tokens match one of these
+  /// pairs, both are skipped so the imperative still reaches `hardImperatives`.
+  /// Covers "Could you make …", "Can you answer …", "Would you draft …",
+  /// "Will you write …", "Do you draft …".
+  private static let leadingSkipBigrams: Set<[String]> = [
+    ["could", "you"], ["can", "you"], ["would", "you"],
+    ["will", "you"], ["do", "you"],
+  ]
+
   private static func firstMeaningfulWord(_ trimmed: String) -> String {
     let separators: Set<Character> = [" ", "\t", "\n", ",", "."]
     let tokens =
       trimmed
       .split(whereSeparator: { separators.contains($0) })
       .map { String($0).trimmingCharacters(in: .punctuationCharacters).lowercased() }
-    for token in tokens {
-      if !token.isEmpty && !leadingSkipWords.contains(token) {
-        return token
+    var i = 0
+    while i < tokens.count {
+      let token = tokens[i]
+      if token.isEmpty {
+        i += 1
+        continue
       }
+      // Skip two-token polite prefix like "could you" / "can you".
+      if i + 1 < tokens.count,
+        leadingSkipBigrams.contains([token, tokens[i + 1]])
+      {
+        i += 2
+        continue
+      }
+      if leadingSkipWords.contains(token) {
+        i += 1
+        continue
+      }
+      return token
     }
     return ""
   }
@@ -310,8 +334,16 @@ public enum ApplePolishRouter {
   ]
 
   private static func preservationIntent(_ lower: String) -> String? {
-    for phrase in preservationPhrases where lower.contains(phrase) {
-      return phrase
+    // Word-boundary match so "keep it literal" does NOT fire inside
+    // "keep it literally simple" (the conversational `literally` hazard
+    // the file guards against everywhere else). Other matchers in this
+    // file use regex with `\b`; this one was the inconsistency.
+    for phrase in preservationPhrases {
+      let escaped = NSRegularExpression.escapedPattern(for: phrase)
+      let pattern = "\\b\(escaped)\\b"
+      if lower.range(of: pattern, options: .regularExpression) != nil {
+        return phrase
+      }
     }
     return nil
   }

--- a/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
@@ -583,6 +583,26 @@ struct ApplePolishRouterTests {
     #expect(!d.signals.hasImperativeStart)
   }
 
+  @Test("do you answer yes/no question stays natural (not a softened imperative)")
+  func doYouInterrogativeStaysNatural() {
+    // Codex flag on PR #436: adding `do you` to skip-bigrams would make
+    // "Do you answer customer emails?" route technical via impStart(answer).
+    // `do you` is a yes/no question marker, not a polite-prefix softener.
+    let d = ApplePolishRouter.decide("Do you answer customer emails on Sundays?")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasImperativeStart)
+  }
+
+  @Test("do you draft question stays natural")
+  func doYouDraftStaysNatural() {
+    // Same pattern as "do you answer": a habit question, not a softened
+    // imperative. `draft` is in hardImperatives but should not Tier-1 fire
+    // here because `do` is the first meaningful word, not `draft`.
+    let d = ApplePolishRouter.decide("Do you draft your replies on mobile or desktop?")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasImperativeStart)
+  }
+
   // MARK: - #431: preservationIntent word-boundary match
 
   @Test("keep it literally simple does not trip preservation")

--- a/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ApplePolishRouterTests.swift
@@ -537,4 +537,70 @@ struct ApplePolishRouterTests {
     #expect(!s.contains("\n"))
     #expect(s == "tech(api key,sdk)")
   }
+
+  // MARK: - #430: polite-prefixed imperatives reach hardImperatives
+
+  @Test("could you make routes technical")
+  func couldYouMakeRoutesTechnical() {
+    let d = ApplePolishRouter.decide("Could you make a Python script that parses logs?")
+    #expect(d.mode == .technical)
+    #expect(d.basis == .tier1)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("can you answer routes technical")
+  func canYouAnswerRoutesTechnical() {
+    let d = ApplePolishRouter.decide("Can you answer what the migration plan is?")
+    #expect(d.mode == .technical)
+    #expect(d.basis == .tier1)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("would you draft routes technical")
+  func wouldYouDraftRoutesTechnical() {
+    let d = ApplePolishRouter.decide("Would you draft a calendar invite for tomorrow?")
+    #expect(d.mode == .technical)
+    #expect(d.basis == .tier1)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("please could you draft stacks single + bigram skip")
+  func pleaseCouldYouDraftRoutesTechnical() {
+    // "please" (single skip) then "could you" (bigram skip) then "draft"
+    // which is a hardImperative but does not match any strongPhrasePattern
+    // (those need a language noun). Tier 1 should fire via imperativeStart.
+    let d = ApplePolishRouter.decide("Please could you draft a note for the landlord?")
+    #expect(d.mode == .technical)
+    #expect(d.basis == .tier1)
+    #expect(d.signals.hasImperativeStart)
+  }
+
+  @Test("could you followed by non-imperative stays natural")
+  func couldYouNonImperativeStaysNatural() {
+    // "could you" skipped, lands on "hand" which is not in hardImperatives.
+    let d = ApplePolishRouter.decide("Could you hand me the notes from Monday?")
+    #expect(d.mode == .natural)
+    #expect(!d.signals.hasImperativeStart)
+  }
+
+  // MARK: - #431: preservationIntent word-boundary match
+
+  @Test("keep it literally simple does not trip preservation")
+  func keepItLiterallySimpleDoesNotMatch() {
+    let d = ApplePolishRouter.decide("Just keep it literally simple for the demo.")
+    #expect(!d.signals.hasPreservationIntent)
+  }
+
+  @Test("keep it literal still routes via preservation")
+  func keepItLiteralStillMatches() {
+    let d = ApplePolishRouter.decide("Just keep it literal.")
+    #expect(d.mode == .technical)
+    #expect(d.signals.hasPreservationIntent)
+  }
+
+  @Test("preserve the word does not match inside wordsmith")
+  func preserveTheWordNotMatchWordsmith() {
+    let d = ApplePolishRouter.decide("We could preserve the wordsmith tone in the copy.")
+    #expect(!d.signals.hasPreservationIntent)
+  }
 }


### PR DESCRIPTION
## Summary

Closes #430 and #431 — two router coverage gaps Codex flagged on #427.

- **#430** — `firstMeaningfulWord` only skipped single-token prefixes, so "Could you make a Python script…", "Can you answer this question…", "Would you draft…" fell through Tier 1 and got scored down to natural. Now the helper also skips two-token polite prefixes (`could you`, `can you`, `would you`, `will you`, `do you`) and stacks with single-word skips, so "Please could you draft a note" reaches `draft` correctly.
- **#431** — `preservationIntent` was a bare `lower.contains(phrase)`. The phrase `"keep it literal"` matched inside `"keep it literally simple"` — the same `literally` substring hazard the rest of the router guards against everywhere else. Replaced with word-boundary regex (`\\b<phrase>\\b`) matching the style of `strongPhraseMatch`.

## Validation

- **Unit tests.** 5 new router cases for #430 (positive polite-prefix imperatives + negative non-imperative case) and 3 for #431 (literally-simple stays natural, bare `keep it literal` still routes, `preserve the wordsmith` false match blocked). All 74 router + filter tests pass.
- **apple_runner A/B** on the 100-case labeled corpus:
  - 99/100 polished outputs unchanged vs pre-fix baseline.
  - 1 case improved — T085 "Could you answer this in the doc later…" was baseline-routed natural (rewrote with `:` and capitalization); candidate routes technical and preserves verbatim. The ground-truth label for T085 is technical, so the fix landed the correct mode.
  - Zero regressions.

## Test plan

- [x] `scripts/swift-test.sh --filter "ApplePolishRouter|EnviousOutputFilter"` — 74/74 pass
- [x] `swift build -c release` green
- [x] apple_runner A/B on 100-case corpus: 99/100 unchanged, 1 improvement, 0 regressions

