### PR TITLE
ci: skip polish-eval-smoke jobs on Dependabot PRs

### DIFF
--- a/.github/workflows/polish-eval-smoke.yml
+++ b/.github/workflows/polish-eval-smoke.yml
@@ -13,6 +13,13 @@ on:
 # acceptance_gate.py with auth errors and block an external contribution on
 # infrastructure it cannot satisfy. Skip forks entirely by gating every job
 # on same-repo PR origin — jobs that don't run report as "not required."
+# Dependabot PRs are skipped the same way. Dependabot diffs only touch
+# Package.resolved or .github/workflows/*.yml — they cannot change prompts,
+# models, or the eval corpus, so the judge-drift check has nothing to verify.
+# Mirroring secrets to Dependabot scope would create a supply-chain exfil
+# surface without adding coverage. If a Dependabot PR ever looks like it
+# should run polish evaluation (hypothetical), re-trigger manually as a
+# regular PR.
 # If secrets are missing in the main repo itself, that's a legitimate config
 # error and the job fails red; fix the repo's Actions secrets.
 #
@@ -21,7 +28,7 @@ on:
 jobs:
   meta-test:
     name: judge-drift-check
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -83,7 +90,7 @@ jobs:
   acceptance-gate:
     name: polish-quality-gate
     needs: meta-test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
## Summary
- Dependabot diffs can only touch `Package.resolved` or `.github/workflows/*.yml` — they cannot change prompts, models, or the eval corpus
- Therefore `judge-drift-check` has nothing to verify on bot PRs and blocks merges by design (secrets aren't available to Dependabot scope, and mirroring them there creates a supply-chain exfil surface)
- Fix: extend the existing fork-PR skip condition (`github.event.pull_request.head.repo.full_name == github.repository`) to also exclude `github.actor == 'dependabot[bot]'`
- Unblocks #410, #411, #412

## Test plan
- [x] Diff review — 4 functional LOC + comment extension
- [ ] CI on this PR passes (judge-drift + polish-quality-gate run as normal — I am not Dependabot)
- [ ] Post-merge: rebase PRs #410, #411, #412 and confirm their `judge-drift-check` is skipped (not red)

council-skip: zero-blast-radius (single-value config)
