### PR TITLE
fix(sentry-triage): v3.1 hardened prompt — fail-fast scope, Step 2.5 state gate, Step 2.6 Sentry-list fields (#459)

### DIFF
--- a/docs/audits/2026-04-25-routine-v3.1-code-diff-review-pass1.txt
+++ b/docs/audits/2026-04-25-routine-v3.1-code-diff-review-pass1.txt
@@ -1,0 +1,2770 @@
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/m4pro_sv/.codex/memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc54d-06cd-7d81-9ef6-5ac740764c8f
+--------
+user
+changes against 'origin/main'
+exec
+/bin/zsh -lc 'git diff --stat b59d55a4cf8e1b4b9667baae194d9d061f697d4a && git diff --name-only b59d55a4cf8e1b4b9667baae194d9d061f697d4a' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+ ...26-04-25-routine-v3.1-grounded-review-pass1.txt | 1760 ++++++++++++++++++++
+ ...26-04-25-routine-v3.1-grounded-review-pass2.txt | 1505 +++++++++++++++++
+ workers/sentry-triage/routine-prompt-v2.md         |  149 +-
+ 3 files changed, 3383 insertions(+), 31 deletions(-)
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt
+workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'git diff --find-renames --find-copies --stat b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md && git diff b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+ workers/sentry-triage/routine-prompt-v2.md | 149 +++++++++++++++++++++++------
+ 1 file changed, 118 insertions(+), 31 deletions(-)
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..e4cc475 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -8,6 +8,8 @@ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+@@ -29,7 +31,27 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
++- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
++- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
++- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
++- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
++- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
++- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
++- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+@@ -43,9 +65,12 @@ This protects against duplicate-issue creation when MCP search returns false-emp
+ 
+ ## Per-run idempotency
+ 
+-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
++Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
++
++- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
++- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+ 
+-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
++This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+ 
+ ## Tool usage
+ 
+@@ -72,12 +97,12 @@ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TO
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then
+-  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
++  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   exit 0
+ fi
+ # JSON sanity check (Sentry returns HTML on 5xx)
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+-  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
++  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   exit 0
+ fi
+@@ -91,6 +116,10 @@ Each issue object has these fields (use exact names):
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+@@ -144,7 +173,12 @@ Grep the combined body+comments for markers matching:
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+@@ -155,25 +189,52 @@ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ign
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+ 
+ ```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
++# Independent queries — run each one whose key field is non-empty.
++# Order does not matter; results are aggregated for the matching bar below.
++
++If metadata.function is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.type is non-empty AND distinct from metadata.function
++   (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
++If metadata.function is empty
++   AND metadata.filename is empty
++   AND metadata.type is empty
++   AND culprit is non-empty:
++  mcp__github__search_issues(
++    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
+ ```
+ 
++If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
++
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+@@ -223,7 +284,7 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
+ 
+ **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+ 
+-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
++**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+ 
+ Title: `P{n}: {area} — {symptom in plain English}`
+ 
+@@ -286,7 +347,7 @@ mcp__github__sub_issue_write(
+ )
+ ```
+ 
+-If the sub-issue link fails, log it and continue.
++If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+@@ -306,17 +367,23 @@ Comment via `mcp__github__add_issue_comment`:
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
++After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
++
+ If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+ 
+ ---
+ 
+ ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+ 
+-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+-3. Fetch latest Sentry event (Path A Step 1).
+-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
++**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
++
++1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
++2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
++3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
++4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+ 5. Post regression comment via `mcp__github__add_issue_comment`:
++
++   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+ ```
+ **Regression detected** — This issue recurred after being closed.
+ | Metric | Value |
+@@ -328,23 +395,43 @@ If new severity differs from prior agent comment's severity, prepend `**Reversin
+ [View in Sentry]({permalink})
+ 
+ **Fresh hypothesis** (current source at {tag}):
+-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
++> [2 sentences — re-analyze, don't copy original.]
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+-6. Add label `regression`.
++
++   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
++```
++**Regression detected** — This issue recurred after being closed.
++| Metric | Value |
++|--------|-------|
++| Users now | {userCount} |
++| Occurrences now | {count} |
++| Last seen | {lastSeen} |
++| Release now | {release} |
++
++[View in Sentry]({permalink})
++
++**Fresh hypothesis:**
++> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
++
++<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
++```
++
++   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
++6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ## Rules (Sentry Paths A/B/C)
+ 
+ - Never write code or open PRs. Triage only.
+-- If Sentry API fails, log + stop. Do not retry.
+-- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
++- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
++- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+ - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+ - Use exact label names listed above.
+ - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+-- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
++- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+ 
+ ---
+ 
+@@ -609,4 +696,4 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
+ - Process events in chronological order (oldest `submitted_at` first).
+ - All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+ - GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+-- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
++- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '1,760p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	
+    12	v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+    13	-->
+    14	
+    15	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    16	
+    17	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    18	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    19	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    20	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    21	  - Adding labels (via `mcp__github__issue_write`)
+    22	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    23	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    24	
+    25	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    26	
+    27	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    28	
+    29	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    30	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    31	- Any tool that prompts the user to visit a URL or perform an action.
+    32	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    33	
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+    41	- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+    42	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+    43	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    44	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+    45	- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+    46	- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+    47	- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+    48	- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+    49	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    50	- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+    51	- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+    52	- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+    53	
+    54	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+    55	
+    56	## MCP auth-expiry policy (HARD)
+    57	
+    58	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    59	
+    60	1. STOP all GitHub writes for the rest of this run, immediately.
+    61	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    62	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    63	
+    64	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    65	
+    66	## Per-run idempotency
+    67	
+    68	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+    69	
+    70	- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+    71	- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+    72	
+    73	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+    74	
+    75	## Tool usage
+    76	
+    77	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    78	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    79	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    80	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    81	
+    82	## Step 0 — Fetch git tags
+    83	
+    84	```bash
+    85	git fetch --tags 2>/dev/null || true
+    86	```
+    87	
+    88	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    89	
+    90	## Step 1 — Query Sentry for recent activity
+    91	
+    92	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    93	
+    94	```bash
+    95	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    96	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    97	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    98	BODY=$(echo "$RESPONSE" | sed '$d')
+    99	if [ "$HTTP_CODE" != "200" ]; then
+   100	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   101	  exit 0
+   102	fi
+   103	# JSON sanity check (Sentry returns HTML on 5xx)
+   104	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   105	  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   106	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   107	  exit 0
+   108	fi
+   109	```
+   110	
+   111	Each issue object has these fields (use exact names):
+   112	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+   113	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+   114	- `count` — total event count (integer).
+   115	- `userCount` — distinct users affected (integer).
+   116	- `level` — "error" or "fatal".
+   117	- `firstSeen`, `lastSeen` — ISO timestamps.
+   118	- `permalink` — full Sentry URL to the issue.
+   119	- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+   120	- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+   121	
+   122	When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+   123	
+   124	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+   125	
+   126	```python
+   127	from datetime import datetime, timezone, timedelta
+   128	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   129	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   130	```
+   131	
+   132	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   133	
+   134	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   135	
+   136	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   137	
+   138	```
+   139	mcp__github__search_issues(
+   140	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   141	  perPage=10
+   142	)
+   143	```
+   144	
+   145	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   146	
+   147	If the MCP call errors:
+   148	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   149	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   150	
+   151	Route based on result:
+   152	
+   153	---
+   154	
+   155	## Step 2.5 — Read prior agent decisions (durable memory)
+   156	
+   157	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   158	
+   159	```
+   160	mcp__github__issue_read(
+   161	  owner="saurabhav88",
+   162	  repo="EnviousWispr",
+   163	  issue_number=<N>,
+   164	  method="get_comments"  # or fetch issue + comments separately
+   165	)
+   166	```
+   167	
+   168	Grep the combined body+comments for markers matching:
+   169	
+   170	```
+   171	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   172	```
+   173	
+   174	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   175	
+   176	**Default action when prior agent marker exists — gate on issue state FIRST:**
+   177	
+   178	- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   179	- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+   180	
+   181	This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+   182	
+   183	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   184	- New severity differs from prior severity, OR
+   185	- You're routing to a different `source_issue` than prior, OR
+   186	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   187	
+   188	---
+   189	
+   190	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   191	
+   192	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+   193	
+   194	Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+   195	
+   196	```
+   197	# Independent queries — run each one whose key field is non-empty.
+   198	# Order does not matter; results are aggregated for the matching bar below.
+   199	
+   200	If metadata.function is non-empty:
+   201	  mcp__github__search_issues(
+   202	    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   203	    perPage = 10
+   204	  )
+   205	
+   206	If metadata.filename is non-empty:
+   207	  mcp__github__search_issues(
+   208	    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   209	    perPage = 10
+   210	  )
+   211	
+   212	If metadata.type is non-empty AND distinct from metadata.function
+   213	   (e.g., an exception class like `audio_capture_failed`):
+   214	  mcp__github__search_issues(
+   215	    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   216	    perPage = 10
+   217	  )
+   218	
+   219	# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+   220	If metadata.function is empty
+   221	   AND metadata.filename is empty
+   222	   AND metadata.type is empty
+   223	   AND culprit is non-empty:
+   224	  mcp__github__search_issues(
+   225	    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   226	    perPage = 10
+   227	  )
+   228	```
+   229	
+   230	If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+   231	
+   232	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   233	1. Same crashing function name (`metadata.function`)
+   234	2. Same source filename (`metadata.filename`)
+   235	3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+   236	4. Same release range (issue's stated release vs Sentry's `release` field)
+   237	5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+   238	
+   239	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   240	
+   241	---
+   242	
+   243	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   244	
+   245	**1. Fetch full event with stack trace:**
+   246	
+   247	```bash
+   248	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   249	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   250	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   251	BODY=$(echo "$RESPONSE" | sed '$d')
+   252	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   253	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   254	  echo "Event response not JSON. Skipping this issue."
+   255	  continue
+   256	fi
+   257	```
+   258	
+   259	Use the numeric `id` field, NOT `shortId`.
+   260	
+   261	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   262	
+   263	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   264	
+   265	**3. Extract git tag from `release` field:**
+   266	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   267	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   268	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   269	- If release is null or missing, note it and use HEAD.
+   270	
+   271	**4. Read source at crash site:**
+   272	
+   273	```bash
+   274	git show {tag}:{filename} | sed -n '{start},{end}p'
+   275	```
+   276	
+   277	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   278	
+   279	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   280	- P0-critical: level=fatal OR userCount >= 10
+   281	- P1-high: userCount >= 3 OR count >= 20
+   282	- P2-medium: userCount >= 2 OR count >= 5
+   283	- P3-low: everything else
+   284	
+   285	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   286	
+   287	**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+   288	
+   289	Title: `P{n}: {area} — {symptom in plain English}`
+   290	
+   291	Labels (exact names — they exist in the repo):
+   292	- `bug`
+   293	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   294	- `sentry-triage`
+   295	- `auto-triaged`
+   296	- One of: `env-production`, `env-development`
+   297	
+   298	Body:
+   299	```
+   300	## Summary
+   301	[1-2 sentences: what error occurred, in plain English]
+   302	
+   303	## Impact
+   304	| Metric | Value |
+   305	|--------|-------|
+   306	| Users affected | {userCount} |
+   307	| Total occurrences | {count} |
+   308	| First seen | {firstSeen} |
+   309	| Last seen | {lastSeen} |
+   310	| Environment | production or development |
+   311	| Release | {release} |
+   312	
+   313	## Crash site
+   314	\`{filename}:{lineNo}\` in \`{function}\`
+   315	
+   316	## Source at crash
+   317	<details><summary>Code at {tag}</summary>
+   318	
+   319	[~20 lines centered on crash line]
+   320	
+   321	</details>
+   322	
+   323	## Hypothesis
+   324	> Unvalidated. Auto-generated from stack trace analysis only.
+   325	
+   326	[2 sentences OR fail-soft sentence per Step 6]
+   327	
+   328	## References
+   329	- [Sentry issue]({permalink})
+   330	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   331	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   332	
+   333	<!-- sentry-issue-id: {shortId} -->
+   334	<!-- auto-triaged: true -->
+   335	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   336	```
+   337	
+   338	**8. Parent the new issue under the Bugs epic (#317):**
+   339	
+   340	```
+   341	mcp__github__sub_issue_write(
+   342	  owner="saurabhav88",
+   343	  repo="EnviousWispr",
+   344	  issue_number=317,
+   345	  method="add",
+   346	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   347	)
+   348	```
+   349	
+   350	If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   351	
+   352	---
+   353	
+   354	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   355	
+   356	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   357	- Event count has at least doubled since last reported in any prior agent comment, OR
+   358	- New users affected since last comment, OR
+   359	- No `agent:sentry-triage` comment in the last 24h
+   360	
+   361	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   362	
+   363	Comment via `mcp__github__add_issue_comment`:
+   364	```
+   365	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   366	
+   367	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   368	```
+   369	
+   370	After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
+   371	
+   372	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   373	
+   374	---
+   375	
+   376	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   377	
+   378	**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+   379	
+   380	1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
+   381	2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+   382	3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
+   383	4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+   384	5. Post regression comment via `mcp__github__add_issue_comment`:
+   385	
+   386	   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+   387	```
+   388	**Regression detected** — This issue recurred after being closed.
+   389	| Metric | Value |
+   390	|--------|-------|
+   391	| Users now | {userCount} |
+   392	| Occurrences now | {count} |
+   393	| Release now | {release} |
+   394	
+   395	[View in Sentry]({permalink})
+   396	
+   397	**Fresh hypothesis** (current source at {tag}):
+   398	> [2 sentences — re-analyze, don't copy original.]
+   399	
+   400	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   401	```
+   402	
+   403	   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
+   404	```
+   405	**Regression detected** — This issue recurred after being closed.
+   406	| Metric | Value |
+   407	|--------|-------|
+   408	| Users now | {userCount} |
+   409	| Occurrences now | {count} |
+   410	| Last seen | {lastSeen} |
+   411	| Release now | {release} |
+   412	
+   413	[View in Sentry]({permalink})
+   414	
+   415	**Fresh hypothesis:**
+   416	> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+   417	
+   418	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   419	```
+   420	
+   421	   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+   422	6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   423	
+   424	---
+   425	
+   426	## Rules (Sentry Paths A/B/C)
+   427	
+   428	- Never write code or open PRs. Triage only.
+   429	- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
+   430	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+   431	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   432	- Use exact label names listed above.
+   433	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   434	- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+   435	
+   436	---
+   437	
+   438	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   439	
+   440	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   441	
+   442	### Path D HARD CONSTRAINTS
+   443	
+   444	- Read + triage only. Write allowlist:
+   445	  - Create GitHub issues (`mcp__github__issue_write`)
+   446	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   447	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   448	  - Edit issue body to APPEND the codex-source marker (append only)
+   449	  - Apply the `codex-review` label
+   450	  - Sub-issue link via `mcp__github__sub_issue_write`
+   451	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   452	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   453	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   454	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   455	
+   456	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   457	
+   458	```
+   459	mcp__github__list_pull_requests(
+   460	  owner="saurabhav88",
+   461	  repo="EnviousWispr",
+   462	  state="all",          # Codex reviews land on still-open PRs too
+   463	  sort="updated",
+   464	  direction="desc",
+   465	  perPage=20            # camelCase, NOT per_page
+   466	)
+   467	```
+   468	
+   469	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   470	
+   471	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   472	
+   473	For each returned PR, fetch its reviews via authenticated MCP:
+   474	
+   475	```
+   476	mcp__github__pull_request_read(
+   477	  owner="saurabhav88",
+   478	  repo="EnviousWispr",
+   479	  pull_number={pr_number},
+   480	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   481	)
+   482	```
+   483	
+   484	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   485	
+   486	**Filter reviews:**
+   487	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   488	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   489	
+   490	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   491	
+   492	### Step D2 — Dedup against prior triage (authenticated MCP)
+   493	
+   494	```
+   495	mcp__github__search_issues(
+   496	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   497	  perPage=100
+   498	)
+   499	```
+   500	
+   501	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   502	
+   503	For each returned issue, scan its `body` field for markers matching:
+   504	
+   505	```
+   506	<!-- codex-source: pr=<N>, review=<review_id> -->
+   507	```
+   508	
+   509	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   510	
+   511	### Step D3 — Per-event processing
+   512	
+   513	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   514	
+   515	**D3.1 Check merge state.**
+   516	
+   517	```
+   518	mcp__github__pull_request_read(
+   519	  owner="saurabhav88",
+   520	  repo="EnviousWispr",
+   521	  pull_number={pr_number},
+   522	  method="get"   # default; returns full PR object
+   523	)
+   524	```
+   525	
+   526	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   527	
+   528	**D3.2 Fetch the review body and inline comments.**
+   529	
+   530	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   531	
+   532	```
+   533	mcp__github__pull_request_read(
+   534	  owner="saurabhav88",
+   535	  repo="EnviousWispr",
+   536	  pull_number={pr_number},
+   537	  method="get_review_comments"   # or get_comments depending on MCP shape
+   538	)
+   539	```
+   540	
+   541	Filter comments by `pull_request_review_id == {review_id}`.
+   542	
+   543	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   544	
+   545	**D3.4 Consolidate findings.**
+   546	
+   547	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   548	- Each surviving inline comment is a candidate finding.
+   549	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   550	
+   551	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   552	
+   553	**D3.5 Resolve source issue.**
+   554	
+   555	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   556	
+   557	If non-null, fetch via authenticated MCP:
+   558	
+   559	```
+   560	mcp__github__issue_read(
+   561	  owner="saurabhav88",
+   562	  repo="EnviousWispr",
+   563	  issue_number={source_issue},
+   564	  method="get"
+   565	)
+   566	```
+   567	
+   568	Extract `number`, `title`, `body`, `state`, labels.
+   569	
+   570	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   571	
+   572	```
+   573	mcp__github__get_file_contents(
+   574	  owner="saurabhav88",
+   575	  repo="EnviousWispr",
+   576	  path="{path}",
+   577	  ref="{head_sha}"
+   578	)
+   579	```
+   580	
+   581	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   582	
+   583	**D3.7 Triage decision.** For each finding, ONE of:
+   584	
+   585	---
+   586	
+   587	**(a) ATTACH to source issue.** ALL of these must hold:
+   588	
+   589	1. `source_issue` is non-null.
+   590	2. Source issue does NOT have the `sentry-triage` label.
+   591	3. Finding falls within the source issue's original scope (compare against title + body).
+   592	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   593	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   594	
+   595	If any condition fails, do NOT use ATTACH. Reclassify.
+   596	
+   597	Actions:
+   598	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   599	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   600	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   601	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   602	
+   603	Comment template:
+   604	
+   605	```
+   606	**Codex post-merge feedback — related to this issue.**
+   607	
+   608	<1-3 sentences summarizing the finding in plain English>
+   609	
+   610	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   611	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   612	
+   613	<details><summary>Codex's exact text</summary>
+   614	
+   615	<quoted review body or inline comment body>
+   616	
+   617	</details>
+   618	
+   619	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   620	<!-- auto-triaged: true -->
+   621	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   622	```
+   623	
+   624	---
+   625	
+   626	**(b) CREATE new issue.** Conditions:
+   627	
+   628	- `source_issue` is null, OR
+   629	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   630	- Finding is clearly out-of-scope for the source issue.
+   631	
+   632	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   633	
+   634	Actions:
+   635	1. Create a new issue via `mcp__github__issue_write`:
+   636	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   637	   - Labels: `codex-review`, `auto-triaged`
+   638	   - Body (template below)
+   639	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   640	   ```
+   641	   mcp__github__sub_issue_write(
+   642	     owner="saurabhav88",
+   643	     repo="EnviousWispr",
+   644	     issue_number=319,
+   645	     method="add",
+   646	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   647	   )
+   648	   ```
+   649	   422 means link already exists — fine. Other failure: log + continue.
+   650	
+   651	Issue body template:
+   652	
+   653	```
+   654	## Source
+   655	- PR: #{pr_number}
+   656	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   657	- Related issue (if any): #{source_issue}
+   658	
+   659	## Finding
+   660	<1-2 sentence plain-English summary>
+   661	
+   662	## Code location
+   663	`{file}:{line}`
+   664	
+   665	## Codex's full text
+   666	<quoted>
+   667	
+   668	## Source snippet
+   669	<code around the line, fetched via mcp__github__get_file_contents>
+   670	
+   671	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   672	<!-- auto-triaged: true -->
+   673	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   674	```
+   675	
+   676	---
+   677	
+   678	**(c) IGNORE.** Conditions (ANY):
+   679	
+   680	- Finding is vague, stylistic, or purely subjective.
+   681	- You cannot confidently state why the finding is valid against the current code.
+   682	- Finding references code that no longer exists at `head_sha`.
+   683	
+   684	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   685	
+   686	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   687	
+   688	### Path D error policy
+   689	
+   690	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   691	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+   692	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+   693	
+   694	### Path D rules
+   695	
+   696	- Process events in chronological order (oldest `submitted_at` first).
+   697	- All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+   698	- GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+   699	- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '243,355p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   243	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   244	
+   245	**1. Fetch full event with stack trace:**
+   246	
+   247	```bash
+   248	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   249	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   250	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   251	BODY=$(echo "$RESPONSE" | sed '$d')
+   252	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   253	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   254	  echo "Event response not JSON. Skipping this issue."
+   255	  continue
+   256	fi
+   257	```
+   258	
+   259	Use the numeric `id` field, NOT `shortId`.
+   260	
+   261	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   262	
+   263	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   264	
+   265	**3. Extract git tag from `release` field:**
+   266	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   267	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   268	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   269	- If release is null or missing, note it and use HEAD.
+   270	
+   271	**4. Read source at crash site:**
+   272	
+   273	```bash
+   274	git show {tag}:{filename} | sed -n '{start},{end}p'
+   275	```
+   276	
+   277	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   278	
+   279	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   280	- P0-critical: level=fatal OR userCount >= 10
+   281	- P1-high: userCount >= 3 OR count >= 20
+   282	- P2-medium: userCount >= 2 OR count >= 5
+   283	- P3-low: everything else
+   284	
+   285	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   286	
+   287	**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+   288	
+   289	Title: `P{n}: {area} — {symptom in plain English}`
+   290	
+   291	Labels (exact names — they exist in the repo):
+   292	- `bug`
+   293	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   294	- `sentry-triage`
+   295	- `auto-triaged`
+   296	- One of: `env-production`, `env-development`
+   297	
+   298	Body:
+   299	```
+   300	## Summary
+   301	[1-2 sentences: what error occurred, in plain English]
+   302	
+   303	## Impact
+   304	| Metric | Value |
+   305	|--------|-------|
+   306	| Users affected | {userCount} |
+   307	| Total occurrences | {count} |
+   308	| First seen | {firstSeen} |
+   309	| Last seen | {lastSeen} |
+   310	| Environment | production or development |
+   311	| Release | {release} |
+   312	
+   313	## Crash site
+   314	\`{filename}:{lineNo}\` in \`{function}\`
+   315	
+   316	## Source at crash
+   317	<details><summary>Code at {tag}</summary>
+   318	
+   319	[~20 lines centered on crash line]
+   320	
+   321	</details>
+   322	
+   323	## Hypothesis
+   324	> Unvalidated. Auto-generated from stack trace analysis only.
+   325	
+   326	[2 sentences OR fail-soft sentence per Step 6]
+   327	
+   328	## References
+   329	- [Sentry issue]({permalink})
+   330	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   331	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   332	
+   333	<!-- sentry-issue-id: {shortId} -->
+   334	<!-- auto-triaged: true -->
+   335	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   336	```
+   337	
+   338	**8. Parent the new issue under the Bugs epic (#317):**
+   339	
+   340	```
+   341	mcp__github__sub_issue_write(
+   342	  owner="saurabhav88",
+   343	  repo="EnviousWispr",
+   344	  issue_number=317,
+   345	  method="add",
+   346	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   347	)
+   348	```
+   349	
+   350	If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   351	
+   352	---
+   353	
+   354	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   355	
+
+exec
+/bin/zsh -lc "head -60 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt && printf '\\n---pass2---\\n' && head -60 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc535-cdd0-7bd1-942a-44a980f42959
+--------
+user
+# Grounded review — Sentry triage v3.1 prompt patch (issue #459)
+
+## What you're reviewing
+
+A v3.1 patch to `workers/sentry-triage/routine-prompt-v2.md` (the live Sentry triage Routine prompt at `trig_01Crr6qjS5HyQ1i3KbrezPfK`) that fixes three defects flagged by your prior review on PR #458 (review id 4175283434). The diff is in the worktree at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/` on branch `fix/issue-459-routine-prompt-v3.1` (vs `origin/main`).
+
+Run `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main -- workers/sentry-triage/routine-prompt-v2.md` to see the diff. Read the full file at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` for context.
+
+## The three v3 defects (your prior findings)
+
+1. **P1 — Global `If a step fails, log the failure and exit cleanly` rule at v3 line 32 conflicts with later per-step skip/continue policies** (Step 2 GH-search recovery, Step D1 per-PR continue). A model following the global rule terminates the whole run on any single transient error.
+
+2. **P1 — Step 2.5 default action applies Path B throttle without first checking issue state.** For closed issues with prior agent markers, the throttle silently swallows reopens (Path C never fires).
+
+3. **P2 — Step 2.6 cross-reference search references `<crashing-function-name>` and `<source-filename>`, which are only bound from the stack trace later in Path A.** Step 2.6 fires before Path A, so the placeholders are never bound, making the queries non-executable.
+
+## What v3.1 does
+
+- **Fix 1:** Replaced the absolute fail-fast rule (which lived under `## ABSOLUTELY FORBIDDEN`) with a new `## Failure handling (default vs per-step recovery)` section that enumerates ALL documented per-step recoveries (Step 1 Sentry HTTP guard, Step 2 GH-MCP non-auth, MCP auth-expiry, Path A Step 4 git-tag miss, Path A Step 8 sub-issue link, Path D Step D1 per-PR read failure, Path A Step 1 event-fetch failure). Default-vs-per-step distinction is explicit.
+- **Fix 2:** Step 2.5 default action now branches on issue state FIRST. Open → throttle. Closed → Path C (reopen + regression comment), throttle does NOT apply. Reversal-required rules unchanged.
+- **Fix 3:** Step 1 field documentation expanded to declare `culprit`, `metadata.function`, `metadata.filename`, `metadata.type`, `metadata.value` (verified empirically as bound at `is:unresolved` issue-list time via Sentry's GroupSerializer). Step 2.6 rewritten to use these fields by name with per-field `is non-empty` guards. Vacuous queries are now explicitly forbidden.
+
+## Your job — return a verdict
+
+Read the diff and the full file. Answer:
+
+1. **Does Fix 1 cleanly resolve the conflict between the global fail-fast and per-step recoveries?** Specifically: is the new `## Failure handling` section authoritative enough that a model reading the prompt top-to-bottom will follow per-step recoveries instead of bailing out at the first error? Are all per-step recoveries documented in the prompt actually listed in the new section (use grep to verify completeness — search for `skip`, `continue`, `fall back`, `log` patterns in the document and check each documented recovery is in the new list)?
+
+2. **Does Fix 2's open-vs-closed gate correctly route closed-issue regressions to Path C?** Verify that Path C (search later in the file) actually exists, accepts a reopen, and that the gate in Step 2.5 wires correctly to it. Watch for: any other clause downstream of Step 2.5 that could re-block the closed-issue path before it reaches Path C.
+
+3. **Does Fix 3's reliance on Sentry-list `culprit` / `metadata.*` fields hold up?** Specifically:
+   - Are these fields actually bound at `is:unresolved + sort=date` issue-list time? (You can verify against Sentry's API docs or by inspecting the past Sentry response shape — a real response from run 1 at session_018ucrzNMKKmxJTNoKypLkFu showed `id, shortId, count, userCount, level, firstSeen, lastSeen, permalink, title, release, status` because the prior jq stripped them, but the underlying Sentry response includes more.)
+   - Does the per-field `is non-empty` guard cleanly handle the case where, e.g., `metadata.function` is empty but `metadata.filename` is bound?
+   - Is the `elif culprit is non-empty` fallback's elif/if structure correct as written (will the prompt's natural-language pseudocode be parsed by the model the way it reads, or will the model hallucinate a different control flow)?
+
+4. **Anything else.** Bugs you notice in the diff that aren't covered above. Drift between the v3.1 changes and the rest of the prompt. Wording that's ambiguous. Be ruthless — this is a prompt that runs unattended on cron against a live Sentry account and live GitHub repo.
+
+## Output format
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Fix 1 (fail-fast)
+[your assessment]
+
+## Fix 2 (Step 2.5 state gate)
+[your assessment]
+
+---pass2---
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2
+--------
+user
+# Grounded review pass 2 — Sentry triage v3.1 (post-revision)
+
+You did pass 1 and returned YES_WITH_REVISIONS with six concrete revisions:
+1. Failure list at top is incomplete — add Path C sub-issue, Step 2 ambiguous-search, Path D generic non-auth, D3.1-D3.7, Path D create-issue sub-link.
+2. Auth-expiry "writes only" contradicts the hard policy — remove the writes-only clause.
+3. Step 2.6 elif binds only to `metadata.type`; rewrite as explicit "all three empty AND culprit non-empty".
+4. Step 1 field doc says "fall back to culprit, then title" but Step 2.6 never uses title — drop title.
+5. Path C idempotency bug — `WRITTEN_THIS_RUN` add at step 1 (after reopen) blocks subsequent writes; move to end of sequence OR redefine as branch-entry check.
+6. Path C reopens before fetching Sentry event; on event-fetch failure the issue is reopened without a regression comment — fetch first OR fail-soft regression comment.
+
+All six revisions have been applied. The patch is now +110/-25 (was +58/-18).
+
+## Your job
+
+Re-read `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` (full file) and the diff `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main`. Confirm:
+
+A. Each of the 6 revisions is correctly applied.
+B. The revisions did not introduce new bugs (e.g., Path C reordering broke a downstream invariant; the idempotency rephrase broke Path A or Path D semantics; the failure list is now over-broad).
+C. There is nothing else in the diff that contradicts the rest of the file.
+
+Be ruthless. The same file:line citation rule applies. Output:
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Revision 1 (failure list completeness)
+[verified | issue at file:line]
+
+## Revision 2 (auth-expiry contradiction)
+[verified | issue]
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+[verified | issue]
+
+## Revision 4 (drop "then title")
+[verified | issue]
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+[verified | issue]
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+[verified | issue]
+
+## New issues introduced (if any)
+[file:line + description]
+
+## Recommendation
+
+exec
+/bin/zsh -lc 'tail -160 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+ )
+ ```
+ 
+ Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+ 
+
+codex
+The core revisions are present, but I’m seeing at least one remaining internal contradiction around Step 1 failure handling: the new recovery list says Sentry API failure should still allow Path D, while the Step 1 shell block and later Sentry rules still say to exit/stop. I’m checking for any other stale idempotency or title references before I write the verdict.
+exec
+/bin/zsh -lc "rg -n \"title|WRITTEN_THIS_RUN|auth-expiry|Sentry API fails|exit 0|Stopping|Path D|ambiguous|culprit|metadata\\.function|metadata\\.filename|metadata\\.type\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+10:v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+12:v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+23:  - Editing an issue body to APPEND a marker (Path D only; append-only)
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+41:- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+42:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+47:- **Path C step 2 sub-issue link failure** (and any other Path C sub-step write failure between reopen and the regression comment): log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+48:- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+49:- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+50:- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+51:- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+52:- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+56:## MCP auth-expiry policy (HARD)
+68:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+70:- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C, OR Path D Step D3 decides ATTACH vs CREATE for a finding): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+71:- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-finding sequence): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence.
+100:  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+101:  exit 0
+107:  exit 0
+119:- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+120:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+122:When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+132:If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+145:Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+148:- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+192:If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+194:Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+200:If metadata.function is non-empty:
+202:    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+206:If metadata.filename is non-empty:
+208:    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+212:If metadata.type is non-empty AND distinct from metadata.function
+215:    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+219:# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+220:If metadata.function is empty
+221:   AND metadata.filename is empty
+222:   AND metadata.type is empty
+223:   AND culprit is non-empty:
+225:    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+230:If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+233:1. Same crashing function name (`metadata.function`)
+234:2. Same source filename (`metadata.filename`)
+235:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+237:5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+287:**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+350:If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+361:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+376:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+379:2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+419:   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+420:6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+427:- If Sentry API fails, log + stop. Do not retry.
+428:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+432:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+436:## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+438:Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+440:### Path D HARD CONSTRAINTS
+450:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+451:- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+452:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+488:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+524:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+566:Extract `number`, `title`, `body`, `state`, labels.
+589:3. Finding falls within the source issue's original scope (compare against title + body).
+686:### Path D error policy
+688:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+690:- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+692:### Path D rules
+697:- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc 'git diff --check origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Hg122DOX' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-tklw6S2w' (errno=Operation not permitted)
+
+exec
+/bin/zsh -lc 'git status --short' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Wrek7AHN' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-1mV6kdQA' (errno=Operation not permitted)
+ M workers/sentry-triage/routine-prompt-v2.md
+
+codex
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship
+2026-04-25T15:36:45.156185Z ERROR codex_core::session: failed to record rollout items: thread 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2 not found
+tokens used
+62,686
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship
+
+exec
+/bin/zsh -lc "git show b59d55a4cf8e1b4b9667baae194d9d061f697d4a:workers/sentry-triage/routine-prompt-v2.md | nl -ba | sed -n '1,740p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	-->
+    12	
+    13	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    14	
+    15	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    16	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    17	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    18	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    19	  - Adding labels (via `mcp__github__issue_write`)
+    20	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    21	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    22	
+    23	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    24	
+    25	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    26	
+    27	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    28	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    29	- Any tool that prompts the user to visit a URL or perform an action.
+    30	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    31	
+    32	If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
+    33	
+    34	## MCP auth-expiry policy (HARD)
+    35	
+    36	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    37	
+    38	1. STOP all GitHub writes for the rest of this run, immediately.
+    39	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    40	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    41	
+    42	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    43	
+    44	## Per-run idempotency
+    45	
+    46	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+    47	
+    48	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
+    49	
+    50	## Tool usage
+    51	
+    52	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    53	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    54	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    55	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    56	
+    57	## Step 0 — Fetch git tags
+    58	
+    59	```bash
+    60	git fetch --tags 2>/dev/null || true
+    61	```
+    62	
+    63	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    64	
+    65	## Step 1 — Query Sentry for recent activity
+    66	
+    67	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    68	
+    69	```bash
+    70	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    71	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    72	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    73	BODY=$(echo "$RESPONSE" | sed '$d')
+    74	if [ "$HTTP_CODE" != "200" ]; then
+    75	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+    76	  exit 0
+    77	fi
+    78	# JSON sanity check (Sentry returns HTML on 5xx)
+    79	if ! echo "$BODY" | jq empty 2>/dev/null; then
+    80	  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+    81	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+    82	  exit 0
+    83	fi
+    84	```
+    85	
+    86	Each issue object has these fields (use exact names):
+    87	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+    88	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+    89	- `count` — total event count (integer).
+    90	- `userCount` — distinct users affected (integer).
+    91	- `level` — "error" or "fatal".
+    92	- `firstSeen`, `lastSeen` — ISO timestamps.
+    93	- `permalink` — full Sentry URL to the issue.
+    94	
+    95	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+    96	
+    97	```python
+    98	from datetime import datetime, timezone, timedelta
+    99	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   100	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   101	```
+   102	
+   103	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   104	
+   105	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   106	
+   107	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   108	
+   109	```
+   110	mcp__github__search_issues(
+   111	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   112	  perPage=10
+   113	)
+   114	```
+   115	
+   116	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   117	
+   118	If the MCP call errors:
+   119	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   120	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   121	
+   122	Route based on result:
+   123	
+   124	---
+   125	
+   126	## Step 2.5 — Read prior agent decisions (durable memory)
+   127	
+   128	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   129	
+   130	```
+   131	mcp__github__issue_read(
+   132	  owner="saurabhav88",
+   133	  repo="EnviousWispr",
+   134	  issue_number=<N>,
+   135	  method="get_comments"  # or fetch issue + comments separately
+   136	)
+   137	```
+   138	
+   139	Grep the combined body+comments for markers matching:
+   140	
+   141	```
+   142	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   143	```
+   144	
+   145	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   146	
+   147	**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   148	
+   149	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   150	- New severity differs from prior severity, OR
+   151	- You're routing to a different `source_issue` than prior, OR
+   152	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   153	
+   154	---
+   155	
+   156	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   157	
+   158	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
+   159	
+   160	```
+   161	mcp__github__search_issues(
+   162	  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   163	  perPage=10
+   164	)
+   165	mcp__github__search_issues(
+   166	  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   167	  perPage=10
+   168	)
+   169	```
+   170	
+   171	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   172	1. Same crashing function name
+   173	2. Same source filename
+   174	3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
+   175	4. Same release range (issue's stated release vs Sentry's `release` field)
+   176	5. Same plausible precondition (issue's hypothesis vs new stack)
+   177	
+   178	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   179	
+   180	---
+   181	
+   182	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   183	
+   184	**1. Fetch full event with stack trace:**
+   185	
+   186	```bash
+   187	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   188	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   189	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   190	BODY=$(echo "$RESPONSE" | sed '$d')
+   191	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   192	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   193	  echo "Event response not JSON. Skipping this issue."
+   194	  continue
+   195	fi
+   196	```
+   197	
+   198	Use the numeric `id` field, NOT `shortId`.
+   199	
+   200	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   201	
+   202	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   203	
+   204	**3. Extract git tag from `release` field:**
+   205	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   206	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   207	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   208	- If release is null or missing, note it and use HEAD.
+   209	
+   210	**4. Read source at crash site:**
+   211	
+   212	```bash
+   213	git show {tag}:{filename} | sed -n '{start},{end}p'
+   214	```
+   215	
+   216	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   217	
+   218	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   219	- P0-critical: level=fatal OR userCount >= 10
+   220	- P1-high: userCount >= 3 OR count >= 20
+   221	- P2-medium: userCount >= 2 OR count >= 5
+   222	- P3-low: everything else
+   223	
+   224	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   225	
+   226	**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+   227	
+   228	Title: `P{n}: {area} — {symptom in plain English}`
+   229	
+   230	Labels (exact names — they exist in the repo):
+   231	- `bug`
+   232	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   233	- `sentry-triage`
+   234	- `auto-triaged`
+   235	- One of: `env-production`, `env-development`
+   236	
+   237	Body:
+   238	```
+   239	## Summary
+   240	[1-2 sentences: what error occurred, in plain English]
+   241	
+   242	## Impact
+   243	| Metric | Value |
+   244	|--------|-------|
+   245	| Users affected | {userCount} |
+   246	| Total occurrences | {count} |
+   247	| First seen | {firstSeen} |
+   248	| Last seen | {lastSeen} |
+   249	| Environment | production or development |
+   250	| Release | {release} |
+   251	
+   252	## Crash site
+   253	\`{filename}:{lineNo}\` in \`{function}\`
+   254	
+   255	## Source at crash
+   256	<details><summary>Code at {tag}</summary>
+   257	
+   258	[~20 lines centered on crash line]
+   259	
+   260	</details>
+   261	
+   262	## Hypothesis
+   263	> Unvalidated. Auto-generated from stack trace analysis only.
+   264	
+   265	[2 sentences OR fail-soft sentence per Step 6]
+   266	
+   267	## References
+   268	- [Sentry issue]({permalink})
+   269	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   270	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   271	
+   272	<!-- sentry-issue-id: {shortId} -->
+   273	<!-- auto-triaged: true -->
+   274	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   275	```
+   276	
+   277	**8. Parent the new issue under the Bugs epic (#317):**
+   278	
+   279	```
+   280	mcp__github__sub_issue_write(
+   281	  owner="saurabhav88",
+   282	  repo="EnviousWispr",
+   283	  issue_number=317,
+   284	  method="add",
+   285	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   286	)
+   287	```
+   288	
+   289	If the sub-issue link fails, log it and continue.
+   290	
+   291	---
+   292	
+   293	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   294	
+   295	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   296	- Event count has at least doubled since last reported in any prior agent comment, OR
+   297	- New users affected since last comment, OR
+   298	- No `agent:sentry-triage` comment in the last 24h
+   299	
+   300	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   301	
+   302	Comment via `mcp__github__add_issue_comment`:
+   303	```
+   304	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   305	
+   306	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   307	```
+   308	
+   309	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   310	
+   311	---
+   312	
+   313	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   314	
+   315	1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+   316	2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+   317	3. Fetch latest Sentry event (Path A Step 1).
+   318	4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+   319	5. Post regression comment via `mcp__github__add_issue_comment`:
+   320	```
+   321	**Regression detected** — This issue recurred after being closed.
+   322	| Metric | Value |
+   323	|--------|-------|
+   324	| Users now | {userCount} |
+   325	| Occurrences now | {count} |
+   326	| Release now | {release} |
+   327	
+   328	[View in Sentry]({permalink})
+   329	
+   330	**Fresh hypothesis** (current source at {tag}):
+   331	> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+   332	
+   333	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   334	```
+   335	6. Add label `regression`.
+   336	
+   337	---
+   338	
+   339	## Rules (Sentry Paths A/B/C)
+   340	
+   341	- Never write code or open PRs. Triage only.
+   342	- If Sentry API fails, log + stop. Do not retry.
+   343	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+   344	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   345	- Use exact label names listed above.
+   346	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   347	- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+   348	
+   349	---
+   350	
+   351	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   352	
+   353	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   354	
+   355	### Path D HARD CONSTRAINTS
+   356	
+   357	- Read + triage only. Write allowlist:
+   358	  - Create GitHub issues (`mcp__github__issue_write`)
+   359	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   360	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   361	  - Edit issue body to APPEND the codex-source marker (append only)
+   362	  - Apply the `codex-review` label
+   363	  - Sub-issue link via `mcp__github__sub_issue_write`
+   364	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   365	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   366	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   367	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   368	
+   369	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   370	
+   371	```
+   372	mcp__github__list_pull_requests(
+   373	  owner="saurabhav88",
+   374	  repo="EnviousWispr",
+   375	  state="all",          # Codex reviews land on still-open PRs too
+   376	  sort="updated",
+   377	  direction="desc",
+   378	  perPage=20            # camelCase, NOT per_page
+   379	)
+   380	```
+   381	
+   382	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   383	
+   384	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   385	
+   386	For each returned PR, fetch its reviews via authenticated MCP:
+   387	
+   388	```
+   389	mcp__github__pull_request_read(
+   390	  owner="saurabhav88",
+   391	  repo="EnviousWispr",
+   392	  pull_number={pr_number},
+   393	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   394	)
+   395	```
+   396	
+   397	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   398	
+   399	**Filter reviews:**
+   400	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   401	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   402	
+   403	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   404	
+   405	### Step D2 — Dedup against prior triage (authenticated MCP)
+   406	
+   407	```
+   408	mcp__github__search_issues(
+   409	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   410	  perPage=100
+   411	)
+   412	```
+   413	
+   414	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   415	
+   416	For each returned issue, scan its `body` field for markers matching:
+   417	
+   418	```
+   419	<!-- codex-source: pr=<N>, review=<review_id> -->
+   420	```
+   421	
+   422	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   423	
+   424	### Step D3 — Per-event processing
+   425	
+   426	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   427	
+   428	**D3.1 Check merge state.**
+   429	
+   430	```
+   431	mcp__github__pull_request_read(
+   432	  owner="saurabhav88",
+   433	  repo="EnviousWispr",
+   434	  pull_number={pr_number},
+   435	  method="get"   # default; returns full PR object
+   436	)
+   437	```
+   438	
+   439	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   440	
+   441	**D3.2 Fetch the review body and inline comments.**
+   442	
+   443	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   444	
+   445	```
+   446	mcp__github__pull_request_read(
+   447	  owner="saurabhav88",
+   448	  repo="EnviousWispr",
+   449	  pull_number={pr_number},
+   450	  method="get_review_comments"   # or get_comments depending on MCP shape
+   451	)
+   452	```
+   453	
+   454	Filter comments by `pull_request_review_id == {review_id}`.
+   455	
+   456	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   457	
+   458	**D3.4 Consolidate findings.**
+   459	
+   460	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   461	- Each surviving inline comment is a candidate finding.
+   462	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   463	
+   464	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   465	
+   466	**D3.5 Resolve source issue.**
+   467	
+   468	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   469	
+   470	If non-null, fetch via authenticated MCP:
+   471	
+   472	```
+   473	mcp__github__issue_read(
+   474	  owner="saurabhav88",
+   475	  repo="EnviousWispr",
+   476	  issue_number={source_issue},
+   477	  method="get"
+   478	)
+   479	```
+   480	
+   481	Extract `number`, `title`, `body`, `state`, labels.
+   482	
+   483	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   484	
+   485	```
+   486	mcp__github__get_file_contents(
+   487	  owner="saurabhav88",
+   488	  repo="EnviousWispr",
+   489	  path="{path}",
+   490	  ref="{head_sha}"
+   491	)
+   492	```
+   493	
+   494	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   495	
+   496	**D3.7 Triage decision.** For each finding, ONE of:
+   497	
+   498	---
+   499	
+   500	**(a) ATTACH to source issue.** ALL of these must hold:
+   501	
+   502	1. `source_issue` is non-null.
+   503	2. Source issue does NOT have the `sentry-triage` label.
+   504	3. Finding falls within the source issue's original scope (compare against title + body).
+   505	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   506	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   507	
+   508	If any condition fails, do NOT use ATTACH. Reclassify.
+   509	
+   510	Actions:
+   511	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   512	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   513	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   514	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   515	
+   516	Comment template:
+   517	
+   518	```
+   519	**Codex post-merge feedback — related to this issue.**
+   520	
+   521	<1-3 sentences summarizing the finding in plain English>
+   522	
+   523	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   524	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   525	
+   526	<details><summary>Codex's exact text</summary>
+   527	
+   528	<quoted review body or inline comment body>
+   529	
+   530	</details>
+   531	
+   532	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   533	<!-- auto-triaged: true -->
+   534	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   535	```
+   536	
+   537	---
+   538	
+   539	**(b) CREATE new issue.** Conditions:
+   540	
+   541	- `source_issue` is null, OR
+   542	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   543	- Finding is clearly out-of-scope for the source issue.
+   544	
+   545	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   546	
+   547	Actions:
+   548	1. Create a new issue via `mcp__github__issue_write`:
+   549	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   550	   - Labels: `codex-review`, `auto-triaged`
+   551	   - Body (template below)
+   552	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   553	   ```
+   554	   mcp__github__sub_issue_write(
+   555	     owner="saurabhav88",
+   556	     repo="EnviousWispr",
+   557	     issue_number=319,
+   558	     method="add",
+   559	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   560	   )
+   561	   ```
+   562	   422 means link already exists — fine. Other failure: log + continue.
+   563	
+   564	Issue body template:
+   565	
+   566	```
+   567	## Source
+   568	- PR: #{pr_number}
+   569	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   570	- Related issue (if any): #{source_issue}
+   571	
+   572	## Finding
+   573	<1-2 sentence plain-English summary>
+   574	
+   575	## Code location
+   576	`{file}:{line}`
+   577	
+   578	## Codex's full text
+   579	<quoted>
+   580	
+   581	## Source snippet
+   582	<code around the line, fetched via mcp__github__get_file_contents>
+   583	
+   584	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   585	<!-- auto-triaged: true -->
+   586	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   587	```
+   588	
+   589	---
+   590	
+   591	**(c) IGNORE.** Conditions (ANY):
+   592	
+   593	- Finding is vague, stylistic, or purely subjective.
+   594	- You cannot confidently state why the finding is valid against the current code.
+   595	- Finding references code that no longer exists at `head_sha`.
+   596	
+   597	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   598	
+   599	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   600	
+   601	### Path D error policy
+   602	
+   603	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   604	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+   605	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+   606	
+   607	### Path D rules
+   608	
+   609	- Process events in chronological order (oldest `submitted_at` first).
+   610	- All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+   611	- GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+   612	- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '34,54p;416,424p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+    41	- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+    42	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+    43	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    44	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+    45	- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+    46	- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+    47	- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+    48	- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+    49	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    50	- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+    51	- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+    52	- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+    53	
+    54	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+   416	> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+   417	
+   418	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   419	```
+   420	
+   421	   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+   422	6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   423	
+   424	---
+
+exec
+/bin/zsh -lc 'rg -n "SENTRY_AUTH_TOKEN|Bearer|token|Authorization|secret|password|api[_ -]?key|CLAUDE_CODE_REMOTE_SESSION_ID|session id" docs/audits workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+workers/sentry-triage/routine-prompt-v2.md:42:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+workers/sentry-triage/routine-prompt-v2.md:58:If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+workers/sentry-triage/routine-prompt-v2.md:77:- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+workers/sentry-triage/routine-prompt-v2.md:95:RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+workers/sentry-triage/routine-prompt-v2.md:248:RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+workers/sentry-triage/routine-prompt-v2.md:330:- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+workers/sentry-triage/routine-prompt-v2.md:335:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+workers/sentry-triage/routine-prompt-v2.md:367:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+workers/sentry-triage/routine-prompt-v2.md:400:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+workers/sentry-triage/routine-prompt-v2.md:418:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+workers/sentry-triage/routine-prompt-v2.md:471:**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+workers/sentry-triage/routine-prompt-v2.md:621:<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+workers/sentry-triage/routine-prompt-v2.md:673:<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:11:session id: 019dc535-cdd0-7bd1-942a-44a980f42959
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:148:    41	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:158:    51	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:174:    67	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:192:    85	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:334:   227	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:416:   309	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:421:   314	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:453:   346	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:480:   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:531:   424	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:681:   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:733:   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:793:+- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:905:373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:915:41:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:921:51:If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:955:424:**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1056:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:314:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1058:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:346:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1060:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1145:workers/crisp-kb/markdown/55-api-key-security.md
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1282:40:async function verifyHmac(body, sigHeader, secret) {
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1309:    41	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1319:    51	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1335:41:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1412:   424	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1562:   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1614:   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1667:   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1726:tokens used
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:11:session id: 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:129:    42	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:145:    58	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:164:    77	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:182:    95	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:339:   248	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:421:   330	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:426:   335	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:462:   367	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:493:   398	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:511:   416	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:564:   469	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:718:   619	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:770:   671	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:856: RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:939: - [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:944: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:977: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1013: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1080:+- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1096: If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1117: - **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1135: RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1266:+<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1319: **Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1362:42:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1475:tokens used
+
+exec
+/bin/zsh -lc "rg -n \"before any write|Stopping\\.|Exiting cleanly|log \\+ stop|Per-run idempotency|WRITTEN_THIS_RUN|skip silently|exit 0|Path C step|Path D.*idempotency|source of truth|continue|exit|fatal|FAIL|failure\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+29:- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+36:If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+38:If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+40:- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+41:- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+42:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+43:- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+45:- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+46:- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+47:- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+48:- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+49:- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+50:- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+51:- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+52:- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+54:A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+61:2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+66:## Per-run idempotency
+68:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+70:- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+92:Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+101:  exit 0
+107:  exit 0
+116:- `level` — "error" or "fatal".
+148:- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+178:- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+252:if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+255:  continue
+280:- P0-critical: level=fatal OR userCount >= 10
+285:**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+287:**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+350:If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+361:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+370:After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
+378:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+381:2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+382:3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
+421:   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+422:6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+429:- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
+430:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+434:- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+452:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+454:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+471:**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+490:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+513:For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+649:   422 means link already exists — fine. Other failure: log + continue.
+690:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+691:- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+699:- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "git diff --unified=3 b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md | sed -n '1,260p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..e4cc475 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -8,6 +8,8 @@ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+@@ -29,7 +31,27 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
++- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
++- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
++- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
++- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
++- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
++- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
++- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+@@ -43,9 +65,12 @@ This protects against duplicate-issue creation when MCP search returns false-emp
+ 
+ ## Per-run idempotency
+ 
+-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
++Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
++
++- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
++- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+ 
+-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
++This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+ 
+ ## Tool usage
+ 
+@@ -72,12 +97,12 @@ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TO
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then
+-  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
++  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   exit 0
+ fi
+ # JSON sanity check (Sentry returns HTML on 5xx)
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+-  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
++  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   exit 0
+ fi
+@@ -91,6 +116,10 @@ Each issue object has these fields (use exact names):
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+@@ -144,7 +173,12 @@ Grep the combined body+comments for markers matching:
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+@@ -155,25 +189,52 @@ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ign
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+ 
+ ```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
++# Independent queries — run each one whose key field is non-empty.
++# Order does not matter; results are aggregated for the matching bar below.
++
++If metadata.function is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.type is non-empty AND distinct from metadata.function
++   (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
++If metadata.function is empty
++   AND metadata.filename is empty
++   AND metadata.type is empty
++   AND culprit is non-empty:
++  mcp__github__search_issues(
++    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
+ ```
+ 
++If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
++
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+@@ -223,7 +284,7 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
+ 
+ **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+ 
+-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
++**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+ 
+ Title: `P{n}: {area} — {symptom in plain English}`
+ 
+@@ -286,7 +347,7 @@ mcp__github__sub_issue_write(
+ )
+ ```
+ 
+-If the sub-issue link fails, log it and continue.
++If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+@@ -306,17 +367,23 @@ Comment via `mcp__github__add_issue_comment`:
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
++After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
++
+ If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+ 
+ ---
+ 
+ ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+ 
+-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+-3. Fetch latest Sentry event (Path A Step 1).
+-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
++**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
++
++1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
++2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
++3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
++4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+ 5. Post regression comment via `mcp__github__add_issue_comment`:
++
++   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+ ```
+ **Regression detected** — This issue recurred after being closed.
+ | Metric | Value |
+@@ -328,23 +395,43 @@ If new severity differs from prior agent comment's severity, prepend `**Reversin
+ [View in Sentry]({permalink})
+ 
+ **Fresh hypothesis** (current source at {tag}):
+-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
++> [2 sentences — re-analyze, don't copy original.]
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+-6. Add label `regression`.
++
++   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
++```
++**Regression detected** — This issue recurred after being closed.
++| Metric | Value |
++|--------|-------|
++| Users now | {userCount} |
++| Occurrences now | {count} |
++| Last seen | {lastSeen} |
++| Release now | {release} |
++
++[View in Sentry]({permalink})
++
++**Fresh hypothesis:**
++> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
++
++<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
++```
++
++   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
++6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ## Rules (Sentry Paths A/B/C)
+ 
+ - Never write code or open PRs. Triage only.
+-- If Sentry API fails, log + stop. Do not retry.
+-- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
++- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
++- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+ - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+ - Use exact label names listed above.
+ - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+-- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
++- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+ 
+ ---
+ 
+@@ -609,4 +696,4 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
+ - Process events in chronological order (oldest `submitted_at` first).
+
+exec
+/bin/zsh -lc "git diff --unified=3 b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md | sed -n '260,360p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+ - Process events in chronological order (oldest `submitted_at` first).
+ - All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+ - GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+-- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
++- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "ls -la docs/audits | tail -20 && find . -maxdepth 3 -name 'CLAUDE.md' -o -name 'AGENTS.md' -o -name 'README.md' | sort" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+total 504
+drwxr-xr-x@ 6 m4pro_sv  staff     192 Apr 25 11:39 .
+drwxr-xr-x@ 6 m4pro_sv  staff     192 Apr 25 11:07 ..
+-rw-r--r--@ 1 m4pro_sv  staff   10016 Apr 25 11:07 2026-04-20-phase-c-grounded-review.txt
+-rw-r--r--@ 1 m4pro_sv  staff   11434 Apr 25 11:07 2026-04-20-phase-g-grounded-review.txt
+-rw-r--r--@ 1 m4pro_sv  staff  128573 Apr 25 11:24 2026-04-25-routine-v3.1-grounded-review-pass1.txt
+-rw-r--r--@ 1 m4pro_sv  staff  100633 Apr 25 11:39 2026-04-25-routine-v3.1-grounded-review-pass2.txt
+./README.md
+./website/README.md
+
+exec
+/bin/zsh -lc "sed -n '1,220p' README.md && find docs -maxdepth 2 -type f -name '*.md' -o -name '*.txt' | sort | sed -n '1,100p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+<p align="center">
+  <img src="assets/readme/icon.svg" width="80" alt="EnviousWispr icon" />
+</p>
+
+<h1 align="center">EnviousWispr</h1>
+
+<p align="center">
+  <strong>Talk naturally. Paste perfectly.</strong><br/>
+  Free, on-device AI dictation and speech-to-text for macOS.<br/>
+  Powered by Apple Silicon. No cloud, no account, your voice never leaves your Mac.
+</p>
+
+<p align="center">
+  <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest"><img src="https://img.shields.io/github/v/release/saurabhav88/EnviousWispr?style=flat-square&label=latest&color=7c3aed" alt="Latest Release" /></a>
+  <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg"><img src="https://img.shields.io/badge/download-DMG-black?style=flat-square" alt="Download DMG" /></a>
+  <a href="https://enviouswispr.com"><img src="https://img.shields.io/badge/web-enviouswispr.com-7c3aed?style=flat-square" alt="Website" /></a>
+  <a href="https://x.com/EnviousLabs"><img src="https://img.shields.io/badge/follow-@EnviousLabs-black?style=flat-square&logo=x" alt="Follow on X" /></a>
+</p>
+
+<p align="center">
+  <img src="assets/readme/hero.gif" width="720" alt="EnviousWispr hero - Talk naturally, paste perfectly" />
+</p>
+
+---
+
+## Demo
+
+https://github.com/user-attachments/assets/e636e1a0-a0d1-4f7c-be0a-b7c907c6d5ab
+
+## What is this?
+
+EnviousWispr is a free AI dictation app for macOS that runs entirely on-device. It uses Whisper and Parakeet speech-to-text models on Apple Silicon to transcribe your voice locally, polishes the output with an optional LLM, and pastes clean text into whatever app you're working in. The entire pipeline runs in under 2 seconds.
+
+No cloud. No account required. No subscription. No audio ever leaves your Mac. Works fully offline.
+
+## Why EnviousWispr?
+
+| | EnviousWispr | Cloud dictation services |
+|---|---|---|
+| **Privacy** | 100% on-device transcription | Audio uploaded to servers |
+| **Speed** | Sub-second pipeline, paste-on-stop | Network round-trip latency |
+| **Models** | Parakeet v3 (NVIDIA NeMo) + WhisperKit (OpenAI Whisper) | Single vendor model |
+| **Polish** | Optional LLM cleanup (GPT, Gemini) with your own keys | Basic punctuation only |
+| **Cost** | One-time purchase, no subscription for core features | Monthly subscription |
+| **Works offline** | Yes, fully functional without internet | No |
+
+## How it works
+
+```
+Press hotkey  -->  Record  -->  Transcribe  -->  Polish (optional)  -->  Paste
+    ~0ms          live        ~400-800ms         ~200-500ms            instant
+```
+
+1. **Press your hotkey** from any app. Toggle mode or push-to-talk, your choice.
+2. **Speak naturally.** Silero VAD detects when you stop talking and ends recording automatically.
+3. **On-device transcription.** Choose Parakeet v3 (fastest, 25 languages) or WhisperKit (99 languages).
+4. **AI polish** (optional). Clean up grammar, punctuation, and formatting via OpenAI or Gemini with your own API key.
+5. **Text lands in your clipboard** and optionally auto-pastes into the active app.
+
+> See the full interactive pipeline demo at [enviouswispr.com/how-it-works](https://enviouswispr.com/how-it-works)
+
+## Supported Models
+
+| Model | Best for | Languages | Download size | Hardware |
+|---|---|---|---|---|
+| **Parakeet TDT v3** | Fastest multilingual dictation (default) | 25 languages | ~500 MB | Apple Silicon |
+| **WhisperKit** (Whisper Large v3 Turbo) | Broadest language coverage | 99 languages | ~800 MB | Apple Silicon |
+
+Both models run entirely on-device using CoreML. First launch downloads and compiles the model; subsequent launches are instant.
+
+## Features
+
+- **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/WhisperKit) (OpenAI Whisper)
+- **Voice Activity Detection** via Silero VAD for hands-free stop
+- **LLM polish** with OpenAI GPT or Google Gemini (bring your own API key)
+- **Custom vocabulary** for names, brands, and technical terms the ASR might miss
+- **Global hotkey** with toggle and push-to-talk modes
+- **Auto-paste** directly into the active app, or just copy to clipboard
+- **Transcript history** for browsing, searching, and reviewing past dictations
+- **Menu bar native** with minimal footprint
+- **Auto-updates** via Sparkle
+
+## Quick Start
+
+1. Download [EnviousWispr.dmg](https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg) from the latest release
+2. Drag to Applications, launch
+3. Grant **Microphone** and **Accessibility** permissions when prompted
+4. Set your preferred hotkey in Settings > Shortcuts
+5. Start talking
+
+**Optional:** Add an OpenAI or Gemini API key in Settings > AI Polish for transcript cleanup.
+
+## Requirements
+
+- macOS 14 (Sonoma) or later
+- Apple Silicon (M1 or newer)
+
+## Building from Source
+
+```bash
+git clone https://github.com/saurabhav88/EnviousWispr.git
+cd EnviousWispr
+swift build
+```
+
+Dependencies resolve automatically via Swift Package Manager. First build takes several minutes as ML models compile.
+
+For a distributable `.app` bundle and DMG:
+
+```bash
+./scripts/build-dmg.sh
+```
+
+Requires macOS 14+ with Swift 6.0+ toolchain (Xcode Command Line Tools or full Xcode).
+
+## Architecture
+
+The app follows a pipeline state machine: **idle --> recording --> transcribing --> polishing --> complete**.
+
+Key design choices:
+- **Swift 6 strict concurrency** with full actor isolation
+- **Dual pipeline architecture** with deliberately separate Parakeet and WhisperKit backends (isolation is a feature, not tech debt)
+- **Heart & Limbs pattern** where the critical path (audio, ASR, paste) never fails, and features (polish, custom words, filler removal) degrade gracefully
+- **Local-first** with LLM polish as an opt-in enhancement using your own keys
+
+## Contributing
+
+Contributions are welcome. Please open an issue to discuss significant changes before submitting a PR.
+
+This project uses conventional commits: `feat(scope):`, `fix(scope):`, `refactor(scope):`.
+
+## Privacy
+
+EnviousWispr is built on a simple principle: **your voice is yours.**
+
+- Audio is captured, transcribed, and discarded locally. Nothing is uploaded, stored, or shared.
+- LLM polish (if enabled) sends only the text transcript to your chosen provider using your own API key. Audio is never sent.
+- Anonymous product analytics (PostHog) can be disabled in Settings.
+- Crash reporting (Sentry) contains no transcript content, audio, or personal data.
+
+## Connect
+
+- **Website:** [enviouswispr.com](https://enviouswispr.com)
+- **X:** [@EnviousLabs](https://x.com/EnviousLabs)
+- **Email:** hello@enviouswispr.com
+
+Built by [Envious Labs](https://enviouslabs.co)
+
+## License
+
+EnviousWispr is source-available under the [Business Source License 1.1](LICENSE). You may view, fork, and modify the code for personal, non-commercial use. Commercial use requires a license from Envious Labs. The code converts to Apache 2.0 on March 10, 2030.
+
+For commercial licensing inquiries: hello@enviouswispr.com
+docs/apple-intelligence-diagnostics-spec.md
+docs/audits/2026-04-20-phase-c-grounded-review.txt
+docs/audits/2026-04-20-phase-g-grounded-review.txt
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt
+docs/feature-requests/apple-intelligence-lang-gate.md
+docs/feature-requests/ctc-vocabulary-boosting.md
+docs/feature-requests/issue-256-2026-04-16-remove-useRefreshedWhisperKitModel-flag.md
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+docs/feature-requests/issue-381-2026-04-20-dual-mode-router.md
+docs/feature-requests/issue-385-2026-04-20-acceptance-gate-drift-options.md
+docs/feature-requests/issue-388-2026-04-20-textprocessingrunner-polish-step-type.md
+docs/feature-requests/issue-389-2026-04-20-textprocessingrunner-logger-di.md
+docs/feature-requests/issue-394-2026-04-20-transcriptionpipeline-di-seams.md
+docs/feature-requests/issue-396-2026-04-20-pastecascadeexecutor-di-seams.md
+docs/feature-requests/issue-398-2026-04-20-asrmanager-backend-injection.md
+docs/feature-requests/issue-428-2026-04-20-phase-c-transcript-coordinator.md
+docs/feature-requests/multilingual-v1-followup.md
+docs/feature-requests/multilingual-v1.md
+docs/self-hosted-runner.md
+
+exec
+/bin/zsh -lc 'rg -n "Path C.*event|event-fetch|source read|git show|label add|Step 4" workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+43:- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+44:- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+47:- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+71:- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+80:- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+88:Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+274:git show {tag}:{filename} | sed -n '{start},{end}p'
+378:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+380:1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
+383:4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '48,52p;511,582p;688,691p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+    48	- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+    49	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    50	- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+    51	- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+    52	- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+   511	### Step D3 — Per-event processing
+   512	
+   513	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   514	
+   515	**D3.1 Check merge state.**
+   516	
+   517	```
+   518	mcp__github__pull_request_read(
+   519	  owner="saurabhav88",
+   520	  repo="EnviousWispr",
+   521	  pull_number={pr_number},
+   522	  method="get"   # default; returns full PR object
+   523	)
+   524	```
+   525	
+   526	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   527	
+   528	**D3.2 Fetch the review body and inline comments.**
+   529	
+   530	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   531	
+   532	```
+   533	mcp__github__pull_request_read(
+   534	  owner="saurabhav88",
+   535	  repo="EnviousWispr",
+   536	  pull_number={pr_number},
+   537	  method="get_review_comments"   # or get_comments depending on MCP shape
+   538	)
+   539	```
+   540	
+   541	Filter comments by `pull_request_review_id == {review_id}`.
+   542	
+   543	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   544	
+   545	**D3.4 Consolidate findings.**
+   546	
+   547	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   548	- Each surviving inline comment is a candidate finding.
+   549	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   550	
+   551	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   552	
+   553	**D3.5 Resolve source issue.**
+   554	
+   555	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   556	
+   557	If non-null, fetch via authenticated MCP:
+   558	
+   559	```
+   560	mcp__github__issue_read(
+   561	  owner="saurabhav88",
+   562	  repo="EnviousWispr",
+   563	  issue_number={source_issue},
+   564	  method="get"
+   565	)
+   566	```
+   567	
+   568	Extract `number`, `title`, `body`, `state`, labels.
+   569	
+   570	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   571	
+   572	```
+   573	mcp__github__get_file_contents(
+   574	  owner="saurabhav88",
+   575	  repo="EnviousWispr",
+   576	  path="{path}",
+   577	  ref="{head_sha}"
+   578	)
+   579	```
+   580	
+   581	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   582	
+   688	### Path D error policy
+   689	
+   690	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   691	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+
+2026-04-25T15:48:15.419411Z ERROR codex_core::session: failed to record rollout items: thread 019dc54d-0754-7cf1-a911-7a8ba11570dd not found
+codex
+The prompt still has recovery-scope contradictions in unattended paths. Path C can miss its intended fail-soft regression comment on evidence failures, and Path D can continue after shared dedup/setup failures in ways that risk duplicate or under-grounded triage.
+
+Full review comments:
+
+- [P1] Make Path C evidence failures use the fail-soft path — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:380-383
+  In the closed-issue regression path, if the latest-event fetch fails or `git show {tag}:{filename}` fails because the tag/file is missing, these evidence-gathering failures are not covered by the authoritative recovery list; the list only has Path A's event-fetch "skip this issue" recovery and no Path C source-read fallback. Since that list is declared to win over step-body contradictions, the routine can still skip/exit before posting the regression comment instead of using the 5b fail-soft template.
+
+- [P2] Don’t continue Path D after shared setup failures — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:50-51
+  When the Step D2 dedup search has a non-auth failure, there is no single PR to skip—the codex-source set is unavailable for all reviews—so continuing can retriage already-handled Codex reviews. Similarly, failures in D3.1/D3.2/D3.5 happen before or outside a specific finding; treating all D3.1–D3.7 failures as "skip one finding" can leave later findings running without merge/head/source-issue context.
+2026-04-25T15:48:15.460630Z ERROR codex_core::session: failed to record rollout items: thread 019dc54d-06cd-7d81-9ef6-5ac740764c8f not found
+The prompt still has recovery-scope contradictions in unattended paths. Path C can miss its intended fail-soft regression comment on evidence failures, and Path D can continue after shared dedup/setup failures in ways that risk duplicate or under-grounded triage.
+
+Full review comments:
+
+- [P1] Make Path C evidence failures use the fail-soft path — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:380-383
+  In the closed-issue regression path, if the latest-event fetch fails or `git show {tag}:{filename}` fails because the tag/file is missing, these evidence-gathering failures are not covered by the authoritative recovery list; the list only has Path A's event-fetch "skip this issue" recovery and no Path C source-read fallback. Since that list is declared to win over step-body contradictions, the routine can still skip/exit before posting the regression comment instead of using the 5b fail-soft template.
+
+- [P2] Don’t continue Path D after shared setup failures — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:50-51
+  When the Step D2 dedup search has a non-auth failure, there is no single PR to skip—the codex-source set is unavailable for all reviews—so continuing can retriage already-handled Codex reviews. Similarly, failures in D3.1/D3.2/D3.5 happen before or outside a specific finding; treating all D3.1–D3.7 failures as "skip one finding" can leave later findings running without merge/head/source-issue context.

--- a/docs/audits/2026-04-25-routine-v3.1-code-diff-review-pass2.txt
+++ b/docs/audits/2026-04-25-routine-v3.1-code-diff-review-pass2.txt
@@ -1,0 +1,2528 @@
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/m4pro_sv/.codex/memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc554-eac3-7542-8786-6c4563878fb9
+--------
+user
+changes against 'origin/main'
+exec
+/bin/zsh -lc 'git diff b59d55a4cf8e1b4b9667baae194d9d061f697d4a --stat && git diff --name-only b59d55a4cf8e1b4b9667baae194d9d061f697d4a' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+ ...26-04-25-routine-v3.1-grounded-review-pass1.txt | 1760 ++++++++++++++++++++
+ ...26-04-25-routine-v3.1-grounded-review-pass2.txt | 1505 +++++++++++++++++
+ workers/sentry-triage/routine-prompt-v2.md         |  160 +-
+ 3 files changed, 3392 insertions(+), 33 deletions(-)
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt
+workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'git diff --unified=80 b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..f79ef58 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -1,427 +1,516 @@
+ <!--
+ Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+ 
+ Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+ This file may drift from the live prompt. To sync, copy from the Routine
+ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ 
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+ 
+ HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+   - Creating GitHub issues (via `mcp__github__issue_write`)
+   - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+   - Reopening GitHub issues (via `mcp__github__issue_write`)
+   - Adding labels (via `mcp__github__issue_write`)
+   - Linking sub-issues (via `mcp__github__sub_issue_write`)
+   - Editing an issue body to APPEND a marker (Path D only; append-only)
+ 
+ ## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+ 
+ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ 
+ - `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+ - POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
++- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
++- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
++- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
++- **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
++- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
++- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path D Step D2 dedup-search (`label:codex-review` issues fetch) non-auth failure**: this is a SHARED setup step, not per-PR. Without it the agent cannot tell which `(pr, review)` pairs are already triaged. Log + EXIT Path D cleanly. Do NOT continue retriaging without the dedup set. Auth-expiry triggers the hard policy.
++- **Path D Step D3.1, D3.2, or D3.5 failures** (PR merge-state read, review-body/comments fetch, source-issue resolution — these run BEFORE any per-finding work): log + skip the ENTIRE review (all findings on this `(pr, review)` together). Do NOT proceed to D3.6/D3.7 without merge-state, review-body, or source-issue context. Continue to the next un-triaged review.
++- **Path D Step D3.3, D3.4, D3.6, or D3.7 per-finding failures** (filter outdated, consolidate, fetch code context for one finding, single-finding `issue_write`/comment/label/sub-link): log + skip THAT one finding, continue with the next finding on the same review.
++- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue with the next finding.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+ If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+ 
+ 1. STOP all GitHub writes for the rest of this run, immediately.
+ 2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+ 3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+ 
+ This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+ 
+ ## Per-run idempotency
+ 
+-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
++Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
++
++- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
++- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+ 
+-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
++This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+ 
+ ## Tool usage
+ 
+ - **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+ - **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+ - **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+ - **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+ 
+ ## Step 0 — Fetch git tags
+ 
+ ```bash
+ git fetch --tags 2>/dev/null || true
+ ```
+ 
+ Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+ 
+ ## Step 1 — Query Sentry for recent activity
+ 
+ Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+ 
+ ```bash
+ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then
+-  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
++  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   exit 0
+ fi
+ # JSON sanity check (Sentry returns HTML on 5xx)
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+-  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
++  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   exit 0
+ fi
+ ```
+ 
+ Each issue object has these fields (use exact names):
+ - `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+ - `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+ - `count` — total event count (integer).
+ - `userCount` — distinct users affected (integer).
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+ ```python
+ from datetime import datetime, timezone, timedelta
+ cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+ # Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+ ```
+ 
+ If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+ 
+ ## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+ 
+ For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+ 
+ ```
+ mcp__github__search_issues(
+   query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   perPage=10
+ )
+ ```
+ 
+ Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+ 
+ If the MCP call errors:
+ - If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+ - If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+ 
+ Route based on result:
+ 
+ ---
+ 
+ ## Step 2.5 — Read prior agent decisions (durable memory)
+ 
+ Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+ 
+ ```
+ mcp__github__issue_read(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   issue_number=<N>,
+   method="get_comments"  # or fetch issue + comments separately
+ )
+ ```
+ 
+ Grep the combined body+comments for markers matching:
+ 
+ ```
+ <!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+ ```
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+ - You're routing to a different `source_issue` than prior, OR
+ - You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+ 
+ ---
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+ 
+ ```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
++# Independent queries — run each one whose key field is non-empty.
++# Order does not matter; results are aggregated for the matching bar below.
++
++If metadata.function is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.type is non-empty AND distinct from metadata.function
++   (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
++If metadata.function is empty
++   AND metadata.filename is empty
++   AND metadata.type is empty
++   AND culprit is non-empty:
++  mcp__github__search_issues(
++    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
+ ```
+ 
++If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
++
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+ ---
+ 
+ ### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+ 
+ **1. Fetch full event with stack trace:**
+ 
+ ```bash
+ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+   echo "Event response not JSON. Skipping this issue."
+   continue
+ fi
+ ```
+ 
+ Use the numeric `id` field, NOT `shortId`.
+ 
+ The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+ 
+ **2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+ 
+ **3. Extract git tag from `release` field:**
+ - Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+ - Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+ - Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+ - If release is null or missing, note it and use HEAD.
+ 
+ **4. Read source at crash site:**
+ 
+ ```bash
+ git show {tag}:{filename} | sed -n '{start},{end}p'
+ ```
+ 
+ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+ 
+ **5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+ - P0-critical: level=fatal OR userCount >= 10
+ - P1-high: userCount >= 3 OR count >= 20
+ - P2-medium: userCount >= 2 OR count >= 5
+ - P3-low: everything else
+ 
+ **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+ 
+-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
++**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+ 
+ Title: `P{n}: {area} — {symptom in plain English}`
+ 
+ Labels (exact names — they exist in the repo):
+ - `bug`
+ - One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+ - `sentry-triage`
+ - `auto-triaged`
+ - One of: `env-production`, `env-development`
+ 
+ Body:
+ ```
+ ## Summary
+ [1-2 sentences: what error occurred, in plain English]
+ 
+ ## Impact
+ | Metric | Value |
+ |--------|-------|
+ | Users affected | {userCount} |
+ | Total occurrences | {count} |
+ | First seen | {firstSeen} |
+ | Last seen | {lastSeen} |
+ | Environment | production or development |
+ | Release | {release} |
+ 
+ ## Crash site
+ \`{filename}:{lineNo}\` in \`{function}\`
+ 
+ ## Source at crash
+ <details><summary>Code at {tag}</summary>
+ 
+ [~20 lines centered on crash line]
+ 
+ </details>
+ 
+ ## Hypothesis
+ > Unvalidated. Auto-generated from stack trace analysis only.
+ 
+ [2 sentences OR fail-soft sentence per Step 6]
+ 
+ ## References
+ - [Sentry issue]({permalink})
+ - [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+ [- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+ 
+ <!-- sentry-issue-id: {shortId} -->
+ <!-- auto-triaged: true -->
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
+ **8. Parent the new issue under the Bugs epic (#317):**
+ 
+ ```
+ mcp__github__sub_issue_write(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   issue_number=317,
+   method="add",
+   sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+ )
+ ```
+ 
+-If the sub-issue link fails, log it and continue.
++If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+ 
+ **Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+ - Event count has at least doubled since last reported in any prior agent comment, OR
+ - New users affected since last comment, OR
+ - No `agent:sentry-triage` comment in the last 24h
+ 
+ If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+ 
+ Comment via `mcp__github__add_issue_comment`:
+ ```
+ **Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
++After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
++
+ If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+ 
+ ---
+ 
+ ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+ 
+-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+-3. Fetch latest Sentry event (Path A Step 1).
+-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
++**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
++
++1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
++2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
++3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
++4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+ 5. Post regression comment via `mcp__github__add_issue_comment`:
++
++   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+ ```
+ **Regression detected** — This issue recurred after being closed.
+ | Metric | Value |
+ |--------|-------|
+ | Users now | {userCount} |
+ | Occurrences now | {count} |
+ | Release now | {release} |
+ 
+ [View in Sentry]({permalink})
+ 
+ **Fresh hypothesis** (current source at {tag}):
+-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
++> [2 sentences — re-analyze, don't copy original.]
++
++<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
++```
++
++   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
++```
++**Regression detected** — This issue recurred after being closed.
++| Metric | Value |
++|--------|-------|
++| Users now | {userCount} |
++| Occurrences now | {count} |
++| Last seen | {lastSeen} |
++| Release now | {release} |
++
++[View in Sentry]({permalink})
++
++**Fresh hypothesis:**
++> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+-6. Add label `regression`.
++
++   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
++6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ## Rules (Sentry Paths A/B/C)
+ 
+ - Never write code or open PRs. Triage only.
+-- If Sentry API fails, log + stop. Do not retry.
+-- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
++- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
++- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+ - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+ - Use exact label names listed above.
+ - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+-- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
++- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+ 
+ ---
+ 
+ ## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+ 
+ Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+ 
+ ### Path D HARD CONSTRAINTS
+ 
+ - Read + triage only. Write allowlist:
+   - Create GitHub issues (`mcp__github__issue_write`)
+   - Reopen GitHub issues (`mcp__github__issue_write`)
+   - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   - Edit issue body to APPEND the codex-source marker (append only)
+   - Apply the `codex-review` label
+   - Sub-issue link via `mcp__github__sub_issue_write`
+ - Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+ - On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+ - Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+ - Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+ 
+ ### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+ 
+ ```
+ mcp__github__list_pull_requests(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   state="all",          # Codex reviews land on still-open PRs too
+   sort="updated",
+   direction="desc",
+   perPage=20            # camelCase, NOT per_page
+ )
+ ```
+ 
+ **Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+ 
+ **Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+ 
+ For each returned PR, fetch its reviews via authenticated MCP:
+ 
+ ```
+ mcp__github__pull_request_read(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   pull_number={pr_number},
+   method="get_reviews"          # NOT summary="reviews" — that's not valid
+ )
+ ```
+ 
+ Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+ 
+ **Filter reviews:**
+ - `user.login == "chatgpt-codex-connector[bot]"` — strict match
+ - AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+ 
+ **Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+ 
+ ### Step D2 — Dedup against prior triage (authenticated MCP)
+ 
+ ```
+ mcp__github__search_issues(
+   query="label:codex-review repo:saurabhav88/EnviousWispr",
+   perPage=100
+ )
+ ```
+ 
+ Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+ 
+ For each returned issue, scan its `body` field for markers matching:
+ 
+ ```
+ <!-- codex-source: pr=<N>, review=<review_id> -->
+ ```
+ 
+ Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+ 
+ ### Step D3 — Per-event processing
+ 
+ For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+ 
+@@ -523,90 +612,95 @@ Comment template:
+ **Code location:** `{file}:{line}` (from PR #{pr_number})
+ **Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+ 
+ <details><summary>Codex's exact text</summary>
+ 
+ <quoted review body or inline comment body>
+ 
+ </details>
+ 
+ <!-- codex-source: pr={pr_number}, review={review_id} -->
+ <!-- auto-triaged: true -->
+ <!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
+ ---
+ 
+ **(b) CREATE new issue.** Conditions:
+ 
+ - `source_issue` is null, OR
+ - `source_issue` carries the `sentry-triage` label (off-limits), OR
+ - Finding is clearly out-of-scope for the source issue.
+ 
+ AND the finding is CONCRETE and you can confidently explain why it is valid.
+ 
+ Actions:
+ 1. Create a new issue via `mcp__github__issue_write`:
+    - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+    - Labels: `codex-review`, `auto-triaged`
+    - Body (template below)
+ 2. Sub-issue link to Epic: Hardening & Refactors (#319):
+    ```
+    mcp__github__sub_issue_write(
+      owner="saurabhav88",
+      repo="EnviousWispr",
+      issue_number=319,
+      method="add",
+      sub_issue_id=<numeric .id of new issue, NOT .number>
+    )
+    ```
+    422 means link already exists — fine. Other failure: log + continue.
+ 
+ Issue body template:
+ 
+ ```
+ ## Source
+ - PR: #{pr_number}
+ - Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+ - Related issue (if any): #{source_issue}
+ 
+ ## Finding
+ <1-2 sentence plain-English summary>
+ 
+ ## Code location
+ `{file}:{line}`
+ 
+ ## Codex's full text
+ <quoted>
+ 
+ ## Source snippet
+ <code around the line, fetched via mcp__github__get_file_contents>
+ 
+ <!-- codex-source: pr={pr_number}, review={review_id} -->
+ <!-- auto-triaged: true -->
+ <!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
+ ---
+ 
+ **(c) IGNORE.** Conditions (ANY):
+ 
+ - Finding is vague, stylistic, or purely subjective.
+ - You cannot confidently state why the finding is valid against the current code.
+ - Finding references code that no longer exists at `head_sha`.
+ 
+ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+ 
+ **Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+ 
+ ### Path D error policy
+ 
+-- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+-- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
++See the authoritative Failure-handling list at the top of the prompt for the canonical Path D recoveries. Summary by failure scope:
++
++- **Exit Path D entirely (non-auth):** Step D1 outer `mcp__github__list_pull_requests` failure, Step D2 dedup-search failure (shared setup — without it, dedup is broken across all reviews).
++- **Auth-expiry on any GitHub MCP call (Path D scope):** trigger global MCP auth-expiry policy. Run terminates.
++- **Skip one PR, continue Path D:** per-PR `pull_request_read` failure in Step D1's inner loop.
++- **Skip the WHOLE review, continue Path D:** Step D3.1 (merge state), D3.2 (review body / inline comments), or D3.5 (source-issue resolve) failure. These run BEFORE any per-finding work; without them, downstream findings would be under-grounded.
++- **Skip ONE finding, continue with the next finding on the same review:** D3.3, D3.4, D3.6, D3.7 per-finding failures, AND the create-issue sub-issue link failure.
+ - **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+ 
+ ### Path D rules
+ 
+ - Process events in chronological order (oldest `submitted_at` first).
+ - All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+ - GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+-- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
++- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '1,260p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	
+    12	v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+    13	-->
+    14	
+    15	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    16	
+    17	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    18	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    19	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    20	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    21	  - Adding labels (via `mcp__github__issue_write`)
+    22	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    23	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    24	
+    25	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    26	
+    27	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    28	
+    29	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    30	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    31	- Any tool that prompts the user to visit a URL or perform an action.
+    32	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    33	
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+    41	- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+    42	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+    43	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    44	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+    45	- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+    46	- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+    47	- **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
+    48	- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+    49	- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+    50	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    51	- **Path D Step D2 dedup-search (`label:codex-review` issues fetch) non-auth failure**: this is a SHARED setup step, not per-PR. Without it the agent cannot tell which `(pr, review)` pairs are already triaged. Log + EXIT Path D cleanly. Do NOT continue retriaging without the dedup set. Auth-expiry triggers the hard policy.
+    52	- **Path D Step D3.1, D3.2, or D3.5 failures** (PR merge-state read, review-body/comments fetch, source-issue resolution — these run BEFORE any per-finding work): log + skip the ENTIRE review (all findings on this `(pr, review)` together). Do NOT proceed to D3.6/D3.7 without merge-state, review-body, or source-issue context. Continue to the next un-triaged review.
+    53	- **Path D Step D3.3, D3.4, D3.6, or D3.7 per-finding failures** (filter outdated, consolidate, fetch code context for one finding, single-finding `issue_write`/comment/label/sub-link): log + skip THAT one finding, continue with the next finding on the same review.
+    54	- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue with the next finding.
+    55	
+    56	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+    57	
+    58	## MCP auth-expiry policy (HARD)
+    59	
+    60	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    61	
+    62	1. STOP all GitHub writes for the rest of this run, immediately.
+    63	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    64	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    65	
+    66	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    67	
+    68	## Per-run idempotency
+    69	
+    70	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+    71	
+    72	- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+    73	- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+    74	
+    75	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+    76	
+    77	## Tool usage
+    78	
+    79	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    80	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    81	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    82	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    83	
+    84	## Step 0 — Fetch git tags
+    85	
+    86	```bash
+    87	git fetch --tags 2>/dev/null || true
+    88	```
+    89	
+    90	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    91	
+    92	## Step 1 — Query Sentry for recent activity
+    93	
+    94	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    95	
+    96	```bash
+    97	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    98	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    99	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   100	BODY=$(echo "$RESPONSE" | sed '$d')
+   101	if [ "$HTTP_CODE" != "200" ]; then
+   102	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   103	  exit 0
+   104	fi
+   105	# JSON sanity check (Sentry returns HTML on 5xx)
+   106	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   107	  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   108	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   109	  exit 0
+   110	fi
+   111	```
+   112	
+   113	Each issue object has these fields (use exact names):
+   114	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+   115	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+   116	- `count` — total event count (integer).
+   117	- `userCount` — distinct users affected (integer).
+   118	- `level` — "error" or "fatal".
+   119	- `firstSeen`, `lastSeen` — ISO timestamps.
+   120	- `permalink` — full Sentry URL to the issue.
+   121	- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+   122	- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+   123	
+   124	When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+   125	
+   126	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+   127	
+   128	```python
+   129	from datetime import datetime, timezone, timedelta
+   130	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   131	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   132	```
+   133	
+   134	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   135	
+   136	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   137	
+   138	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   139	
+   140	```
+   141	mcp__github__search_issues(
+   142	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   143	  perPage=10
+   144	)
+   145	```
+   146	
+   147	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   148	
+   149	If the MCP call errors:
+   150	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   151	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   152	
+   153	Route based on result:
+   154	
+   155	---
+   156	
+   157	## Step 2.5 — Read prior agent decisions (durable memory)
+   158	
+   159	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   160	
+   161	```
+   162	mcp__github__issue_read(
+   163	  owner="saurabhav88",
+   164	  repo="EnviousWispr",
+   165	  issue_number=<N>,
+   166	  method="get_comments"  # or fetch issue + comments separately
+   167	)
+   168	```
+   169	
+   170	Grep the combined body+comments for markers matching:
+   171	
+   172	```
+   173	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   174	```
+   175	
+   176	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   177	
+   178	**Default action when prior agent marker exists — gate on issue state FIRST:**
+   179	
+   180	- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   181	- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+   182	
+   183	This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+   184	
+   185	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   186	- New severity differs from prior severity, OR
+   187	- You're routing to a different `source_issue` than prior, OR
+   188	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   189	
+   190	---
+   191	
+   192	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   193	
+   194	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+   195	
+   196	Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+   197	
+   198	```
+   199	# Independent queries — run each one whose key field is non-empty.
+   200	# Order does not matter; results are aggregated for the matching bar below.
+   201	
+   202	If metadata.function is non-empty:
+   203	  mcp__github__search_issues(
+   204	    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   205	    perPage = 10
+   206	  )
+   207	
+   208	If metadata.filename is non-empty:
+   209	  mcp__github__search_issues(
+   210	    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   211	    perPage = 10
+   212	  )
+   213	
+   214	If metadata.type is non-empty AND distinct from metadata.function
+   215	   (e.g., an exception class like `audio_capture_failed`):
+   216	  mcp__github__search_issues(
+   217	    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   218	    perPage = 10
+   219	  )
+   220	
+   221	# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+   222	If metadata.function is empty
+   223	   AND metadata.filename is empty
+   224	   AND metadata.type is empty
+   225	   AND culprit is non-empty:
+   226	  mcp__github__search_issues(
+   227	    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   228	    perPage = 10
+   229	  )
+   230	```
+   231	
+   232	If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+   233	
+   234	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   235	1. Same crashing function name (`metadata.function`)
+   236	2. Same source filename (`metadata.filename`)
+   237	3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+   238	4. Same release range (issue's stated release vs Sentry's `release` field)
+   239	5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+   240	
+   241	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   242	
+   243	---
+   244	
+   245	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   246	
+   247	**1. Fetch full event with stack trace:**
+   248	
+   249	```bash
+   250	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   251	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   252	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   253	BODY=$(echo "$RESPONSE" | sed '$d')
+   254	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   255	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   256	  echo "Event response not JSON. Skipping this issue."
+   257	  continue
+   258	fi
+   259	```
+   260	
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '260,560p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   260	
+   261	Use the numeric `id` field, NOT `shortId`.
+   262	
+   263	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   264	
+   265	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   266	
+   267	**3. Extract git tag from `release` field:**
+   268	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   269	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   270	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   271	- If release is null or missing, note it and use HEAD.
+   272	
+   273	**4. Read source at crash site:**
+   274	
+   275	```bash
+   276	git show {tag}:{filename} | sed -n '{start},{end}p'
+   277	```
+   278	
+   279	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   280	
+   281	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   282	- P0-critical: level=fatal OR userCount >= 10
+   283	- P1-high: userCount >= 3 OR count >= 20
+   284	- P2-medium: userCount >= 2 OR count >= 5
+   285	- P3-low: everything else
+   286	
+   287	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   288	
+   289	**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+   290	
+   291	Title: `P{n}: {area} — {symptom in plain English}`
+   292	
+   293	Labels (exact names — they exist in the repo):
+   294	- `bug`
+   295	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   296	- `sentry-triage`
+   297	- `auto-triaged`
+   298	- One of: `env-production`, `env-development`
+   299	
+   300	Body:
+   301	```
+   302	## Summary
+   303	[1-2 sentences: what error occurred, in plain English]
+   304	
+   305	## Impact
+   306	| Metric | Value |
+   307	|--------|-------|
+   308	| Users affected | {userCount} |
+   309	| Total occurrences | {count} |
+   310	| First seen | {firstSeen} |
+   311	| Last seen | {lastSeen} |
+   312	| Environment | production or development |
+   313	| Release | {release} |
+   314	
+   315	## Crash site
+   316	\`{filename}:{lineNo}\` in \`{function}\`
+   317	
+   318	## Source at crash
+   319	<details><summary>Code at {tag}</summary>
+   320	
+   321	[~20 lines centered on crash line]
+   322	
+   323	</details>
+   324	
+   325	## Hypothesis
+   326	> Unvalidated. Auto-generated from stack trace analysis only.
+   327	
+   328	[2 sentences OR fail-soft sentence per Step 6]
+   329	
+   330	## References
+   331	- [Sentry issue]({permalink})
+   332	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   333	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   334	
+   335	<!-- sentry-issue-id: {shortId} -->
+   336	<!-- auto-triaged: true -->
+   337	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   338	```
+   339	
+   340	**8. Parent the new issue under the Bugs epic (#317):**
+   341	
+   342	```
+   343	mcp__github__sub_issue_write(
+   344	  owner="saurabhav88",
+   345	  repo="EnviousWispr",
+   346	  issue_number=317,
+   347	  method="add",
+   348	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   349	)
+   350	```
+   351	
+   352	If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   353	
+   354	---
+   355	
+   356	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   357	
+   358	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   359	- Event count has at least doubled since last reported in any prior agent comment, OR
+   360	- New users affected since last comment, OR
+   361	- No `agent:sentry-triage` comment in the last 24h
+   362	
+   363	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   364	
+   365	Comment via `mcp__github__add_issue_comment`:
+   366	```
+   367	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   368	
+   369	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   370	```
+   371	
+   372	After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
+   373	
+   374	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   375	
+   376	---
+   377	
+   378	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   379	
+   380	**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+   381	
+   382	1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
+   383	2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+   384	3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
+   385	4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+   386	5. Post regression comment via `mcp__github__add_issue_comment`:
+   387	
+   388	   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+   389	```
+   390	**Regression detected** — This issue recurred after being closed.
+   391	| Metric | Value |
+   392	|--------|-------|
+   393	| Users now | {userCount} |
+   394	| Occurrences now | {count} |
+   395	| Release now | {release} |
+   396	
+   397	[View in Sentry]({permalink})
+   398	
+   399	**Fresh hypothesis** (current source at {tag}):
+   400	> [2 sentences — re-analyze, don't copy original.]
+   401	
+   402	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   403	```
+   404	
+   405	   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
+   406	```
+   407	**Regression detected** — This issue recurred after being closed.
+   408	| Metric | Value |
+   409	|--------|-------|
+   410	| Users now | {userCount} |
+   411	| Occurrences now | {count} |
+   412	| Last seen | {lastSeen} |
+   413	| Release now | {release} |
+   414	
+   415	[View in Sentry]({permalink})
+   416	
+   417	**Fresh hypothesis:**
+   418	> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+   419	
+   420	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   421	```
+   422	
+   423	   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+   424	6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   425	
+   426	---
+   427	
+   428	## Rules (Sentry Paths A/B/C)
+   429	
+   430	- Never write code or open PRs. Triage only.
+   431	- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
+   432	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+   433	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   434	- Use exact label names listed above.
+   435	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   436	- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+   437	
+   438	---
+   439	
+   440	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   441	
+   442	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   443	
+   444	### Path D HARD CONSTRAINTS
+   445	
+   446	- Read + triage only. Write allowlist:
+   447	  - Create GitHub issues (`mcp__github__issue_write`)
+   448	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   449	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   450	  - Edit issue body to APPEND the codex-source marker (append only)
+   451	  - Apply the `codex-review` label
+   452	  - Sub-issue link via `mcp__github__sub_issue_write`
+   453	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   454	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   455	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   456	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   457	
+   458	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   459	
+   460	```
+   461	mcp__github__list_pull_requests(
+   462	  owner="saurabhav88",
+   463	  repo="EnviousWispr",
+   464	  state="all",          # Codex reviews land on still-open PRs too
+   465	  sort="updated",
+   466	  direction="desc",
+   467	  perPage=20            # camelCase, NOT per_page
+   468	)
+   469	```
+   470	
+   471	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   472	
+   473	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   474	
+   475	For each returned PR, fetch its reviews via authenticated MCP:
+   476	
+   477	```
+   478	mcp__github__pull_request_read(
+   479	  owner="saurabhav88",
+   480	  repo="EnviousWispr",
+   481	  pull_number={pr_number},
+   482	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   483	)
+   484	```
+   485	
+   486	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   487	
+   488	**Filter reviews:**
+   489	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   490	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   491	
+   492	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   493	
+   494	### Step D2 — Dedup against prior triage (authenticated MCP)
+   495	
+   496	```
+   497	mcp__github__search_issues(
+   498	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   499	  perPage=100
+   500	)
+   501	```
+   502	
+   503	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   504	
+   505	For each returned issue, scan its `body` field for markers matching:
+   506	
+   507	```
+   508	<!-- codex-source: pr=<N>, review=<review_id> -->
+   509	```
+   510	
+   511	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   512	
+   513	### Step D3 — Per-event processing
+   514	
+   515	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   516	
+   517	**D3.1 Check merge state.**
+   518	
+   519	```
+   520	mcp__github__pull_request_read(
+   521	  owner="saurabhav88",
+   522	  repo="EnviousWispr",
+   523	  pull_number={pr_number},
+   524	  method="get"   # default; returns full PR object
+   525	)
+   526	```
+   527	
+   528	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   529	
+   530	**D3.2 Fetch the review body and inline comments.**
+   531	
+   532	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   533	
+   534	```
+   535	mcp__github__pull_request_read(
+   536	  owner="saurabhav88",
+   537	  repo="EnviousWispr",
+   538	  pull_number={pr_number},
+   539	  method="get_review_comments"   # or get_comments depending on MCP shape
+   540	)
+   541	```
+   542	
+   543	Filter comments by `pull_request_review_id == {review_id}`.
+   544	
+   545	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   546	
+   547	**D3.4 Consolidate findings.**
+   548	
+   549	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   550	- Each surviving inline comment is a candidate finding.
+   551	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   552	
+   553	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   554	
+   555	**D3.5 Resolve source issue.**
+   556	
+   557	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   558	
+   559	If non-null, fetch via authenticated MCP:
+   560	
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '560,760p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   560	
+   561	```
+   562	mcp__github__issue_read(
+   563	  owner="saurabhav88",
+   564	  repo="EnviousWispr",
+   565	  issue_number={source_issue},
+   566	  method="get"
+   567	)
+   568	```
+   569	
+   570	Extract `number`, `title`, `body`, `state`, labels.
+   571	
+   572	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   573	
+   574	```
+   575	mcp__github__get_file_contents(
+   576	  owner="saurabhav88",
+   577	  repo="EnviousWispr",
+   578	  path="{path}",
+   579	  ref="{head_sha}"
+   580	)
+   581	```
+   582	
+   583	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   584	
+   585	**D3.7 Triage decision.** For each finding, ONE of:
+   586	
+   587	---
+   588	
+   589	**(a) ATTACH to source issue.** ALL of these must hold:
+   590	
+   591	1. `source_issue` is non-null.
+   592	2. Source issue does NOT have the `sentry-triage` label.
+   593	3. Finding falls within the source issue's original scope (compare against title + body).
+   594	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   595	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   596	
+   597	If any condition fails, do NOT use ATTACH. Reclassify.
+   598	
+   599	Actions:
+   600	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   601	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   602	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   603	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   604	
+   605	Comment template:
+   606	
+   607	```
+   608	**Codex post-merge feedback — related to this issue.**
+   609	
+   610	<1-3 sentences summarizing the finding in plain English>
+   611	
+   612	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   613	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   614	
+   615	<details><summary>Codex's exact text</summary>
+   616	
+   617	<quoted review body or inline comment body>
+   618	
+   619	</details>
+   620	
+   621	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   622	<!-- auto-triaged: true -->
+   623	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   624	```
+   625	
+   626	---
+   627	
+   628	**(b) CREATE new issue.** Conditions:
+   629	
+   630	- `source_issue` is null, OR
+   631	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   632	- Finding is clearly out-of-scope for the source issue.
+   633	
+   634	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   635	
+   636	Actions:
+   637	1. Create a new issue via `mcp__github__issue_write`:
+   638	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   639	   - Labels: `codex-review`, `auto-triaged`
+   640	   - Body (template below)
+   641	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   642	   ```
+   643	   mcp__github__sub_issue_write(
+   644	     owner="saurabhav88",
+   645	     repo="EnviousWispr",
+   646	     issue_number=319,
+   647	     method="add",
+   648	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   649	   )
+   650	   ```
+   651	   422 means link already exists — fine. Other failure: log + continue.
+   652	
+   653	Issue body template:
+   654	
+   655	```
+   656	## Source
+   657	- PR: #{pr_number}
+   658	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   659	- Related issue (if any): #{source_issue}
+   660	
+   661	## Finding
+   662	<1-2 sentence plain-English summary>
+   663	
+   664	## Code location
+   665	`{file}:{line}`
+   666	
+   667	## Codex's full text
+   668	<quoted>
+   669	
+   670	## Source snippet
+   671	<code around the line, fetched via mcp__github__get_file_contents>
+   672	
+   673	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   674	<!-- auto-triaged: true -->
+   675	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   676	```
+   677	
+   678	---
+   679	
+   680	**(c) IGNORE.** Conditions (ANY):
+   681	
+   682	- Finding is vague, stylistic, or purely subjective.
+   683	- You cannot confidently state why the finding is valid against the current code.
+   684	- Finding references code that no longer exists at `head_sha`.
+   685	
+   686	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   687	
+   688	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   689	
+   690	### Path D error policy
+   691	
+   692	See the authoritative Failure-handling list at the top of the prompt for the canonical Path D recoveries. Summary by failure scope:
+   693	
+   694	- **Exit Path D entirely (non-auth):** Step D1 outer `mcp__github__list_pull_requests` failure, Step D2 dedup-search failure (shared setup — without it, dedup is broken across all reviews).
+   695	- **Auth-expiry on any GitHub MCP call (Path D scope):** trigger global MCP auth-expiry policy. Run terminates.
+   696	- **Skip one PR, continue Path D:** per-PR `pull_request_read` failure in Step D1's inner loop.
+   697	- **Skip the WHOLE review, continue Path D:** Step D3.1 (merge state), D3.2 (review body / inline comments), or D3.5 (source-issue resolve) failure. These run BEFORE any per-finding work; without them, downstream findings would be under-grounded.
+   698	- **Skip ONE finding, continue with the next finding on the same review:** D3.3, D3.4, D3.6, D3.7 per-finding failures, AND the create-issue sub-issue link failure.
+   699	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+   700	
+   701	### Path D rules
+   702	
+   703	- Process events in chronological order (oldest `submitted_at` first).
+   704	- All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+   705	- GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+   706	- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "git show b59d55a4cf8e1b4b9667baae194d9d061f697d4a:workers/sentry-triage/routine-prompt-v2.md | nl -ba | sed -n '1,460p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	-->
+    12	
+    13	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    14	
+    15	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    16	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    17	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    18	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    19	  - Adding labels (via `mcp__github__issue_write`)
+    20	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    21	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    22	
+    23	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    24	
+    25	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    26	
+    27	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    28	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    29	- Any tool that prompts the user to visit a URL or perform an action.
+    30	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    31	
+    32	If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
+    33	
+    34	## MCP auth-expiry policy (HARD)
+    35	
+    36	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    37	
+    38	1. STOP all GitHub writes for the rest of this run, immediately.
+    39	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    40	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    41	
+    42	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    43	
+    44	## Per-run idempotency
+    45	
+    46	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+    47	
+    48	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
+    49	
+    50	## Tool usage
+    51	
+    52	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    53	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    54	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    55	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    56	
+    57	## Step 0 — Fetch git tags
+    58	
+    59	```bash
+    60	git fetch --tags 2>/dev/null || true
+    61	```
+    62	
+    63	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    64	
+    65	## Step 1 — Query Sentry for recent activity
+    66	
+    67	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    68	
+    69	```bash
+    70	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    71	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    72	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    73	BODY=$(echo "$RESPONSE" | sed '$d')
+    74	if [ "$HTTP_CODE" != "200" ]; then
+    75	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+    76	  exit 0
+    77	fi
+    78	# JSON sanity check (Sentry returns HTML on 5xx)
+    79	if ! echo "$BODY" | jq empty 2>/dev/null; then
+    80	  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+    81	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+    82	  exit 0
+    83	fi
+    84	```
+    85	
+    86	Each issue object has these fields (use exact names):
+    87	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+    88	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+    89	- `count` — total event count (integer).
+    90	- `userCount` — distinct users affected (integer).
+    91	- `level` — "error" or "fatal".
+    92	- `firstSeen`, `lastSeen` — ISO timestamps.
+    93	- `permalink` — full Sentry URL to the issue.
+    94	
+    95	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+    96	
+    97	```python
+    98	from datetime import datetime, timezone, timedelta
+    99	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   100	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   101	```
+   102	
+   103	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   104	
+   105	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   106	
+   107	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   108	
+   109	```
+   110	mcp__github__search_issues(
+   111	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   112	  perPage=10
+   113	)
+   114	```
+   115	
+   116	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   117	
+   118	If the MCP call errors:
+   119	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   120	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   121	
+   122	Route based on result:
+   123	
+   124	---
+   125	
+   126	## Step 2.5 — Read prior agent decisions (durable memory)
+   127	
+   128	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   129	
+   130	```
+   131	mcp__github__issue_read(
+   132	  owner="saurabhav88",
+   133	  repo="EnviousWispr",
+   134	  issue_number=<N>,
+   135	  method="get_comments"  # or fetch issue + comments separately
+   136	)
+   137	```
+   138	
+   139	Grep the combined body+comments for markers matching:
+   140	
+   141	```
+   142	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   143	```
+   144	
+   145	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   146	
+   147	**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   148	
+   149	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   150	- New severity differs from prior severity, OR
+   151	- You're routing to a different `source_issue` than prior, OR
+   152	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   153	
+   154	---
+   155	
+   156	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   157	
+   158	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
+   159	
+   160	```
+   161	mcp__github__search_issues(
+   162	  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   163	  perPage=10
+   164	)
+   165	mcp__github__search_issues(
+   166	  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   167	  perPage=10
+   168	)
+   169	```
+   170	
+   171	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   172	1. Same crashing function name
+   173	2. Same source filename
+   174	3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
+   175	4. Same release range (issue's stated release vs Sentry's `release` field)
+   176	5. Same plausible precondition (issue's hypothesis vs new stack)
+   177	
+   178	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   179	
+   180	---
+   181	
+   182	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   183	
+   184	**1. Fetch full event with stack trace:**
+   185	
+   186	```bash
+   187	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   188	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   189	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   190	BODY=$(echo "$RESPONSE" | sed '$d')
+   191	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   192	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   193	  echo "Event response not JSON. Skipping this issue."
+   194	  continue
+   195	fi
+   196	```
+   197	
+   198	Use the numeric `id` field, NOT `shortId`.
+   199	
+   200	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   201	
+   202	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   203	
+   204	**3. Extract git tag from `release` field:**
+   205	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   206	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   207	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   208	- If release is null or missing, note it and use HEAD.
+   209	
+   210	**4. Read source at crash site:**
+   211	
+   212	```bash
+   213	git show {tag}:{filename} | sed -n '{start},{end}p'
+   214	```
+   215	
+   216	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   217	
+   218	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   219	- P0-critical: level=fatal OR userCount >= 10
+   220	- P1-high: userCount >= 3 OR count >= 20
+   221	- P2-medium: userCount >= 2 OR count >= 5
+   222	- P3-low: everything else
+   223	
+   224	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   225	
+   226	**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+   227	
+   228	Title: `P{n}: {area} — {symptom in plain English}`
+   229	
+   230	Labels (exact names — they exist in the repo):
+   231	- `bug`
+   232	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   233	- `sentry-triage`
+   234	- `auto-triaged`
+   235	- One of: `env-production`, `env-development`
+   236	
+   237	Body:
+   238	```
+   239	## Summary
+   240	[1-2 sentences: what error occurred, in plain English]
+   241	
+   242	## Impact
+   243	| Metric | Value |
+   244	|--------|-------|
+   245	| Users affected | {userCount} |
+   246	| Total occurrences | {count} |
+   247	| First seen | {firstSeen} |
+   248	| Last seen | {lastSeen} |
+   249	| Environment | production or development |
+   250	| Release | {release} |
+   251	
+   252	## Crash site
+   253	\`{filename}:{lineNo}\` in \`{function}\`
+   254	
+   255	## Source at crash
+   256	<details><summary>Code at {tag}</summary>
+   257	
+   258	[~20 lines centered on crash line]
+   259	
+   260	</details>
+   261	
+   262	## Hypothesis
+   263	> Unvalidated. Auto-generated from stack trace analysis only.
+   264	
+   265	[2 sentences OR fail-soft sentence per Step 6]
+   266	
+   267	## References
+   268	- [Sentry issue]({permalink})
+   269	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   270	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   271	
+   272	<!-- sentry-issue-id: {shortId} -->
+   273	<!-- auto-triaged: true -->
+   274	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   275	```
+   276	
+   277	**8. Parent the new issue under the Bugs epic (#317):**
+   278	
+   279	```
+   280	mcp__github__sub_issue_write(
+   281	  owner="saurabhav88",
+   282	  repo="EnviousWispr",
+   283	  issue_number=317,
+   284	  method="add",
+   285	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   286	)
+   287	```
+   288	
+   289	If the sub-issue link fails, log it and continue.
+   290	
+   291	---
+   292	
+   293	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   294	
+   295	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   296	- Event count has at least doubled since last reported in any prior agent comment, OR
+   297	- New users affected since last comment, OR
+   298	- No `agent:sentry-triage` comment in the last 24h
+   299	
+   300	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   301	
+   302	Comment via `mcp__github__add_issue_comment`:
+   303	```
+   304	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   305	
+   306	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   307	```
+   308	
+   309	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   310	
+   311	---
+   312	
+   313	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   314	
+   315	1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+   316	2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+   317	3. Fetch latest Sentry event (Path A Step 1).
+   318	4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+   319	5. Post regression comment via `mcp__github__add_issue_comment`:
+   320	```
+   321	**Regression detected** — This issue recurred after being closed.
+   322	| Metric | Value |
+   323	|--------|-------|
+   324	| Users now | {userCount} |
+   325	| Occurrences now | {count} |
+   326	| Release now | {release} |
+   327	
+   328	[View in Sentry]({permalink})
+   329	
+   330	**Fresh hypothesis** (current source at {tag}):
+   331	> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+   332	
+   333	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   334	```
+   335	6. Add label `regression`.
+   336	
+   337	---
+   338	
+   339	## Rules (Sentry Paths A/B/C)
+   340	
+   341	- Never write code or open PRs. Triage only.
+   342	- If Sentry API fails, log + stop. Do not retry.
+   343	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+   344	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   345	- Use exact label names listed above.
+   346	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   347	- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+   348	
+   349	---
+   350	
+   351	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   352	
+   353	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   354	
+   355	### Path D HARD CONSTRAINTS
+   356	
+   357	- Read + triage only. Write allowlist:
+   358	  - Create GitHub issues (`mcp__github__issue_write`)
+   359	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   360	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   361	  - Edit issue body to APPEND the codex-source marker (append only)
+   362	  - Apply the `codex-review` label
+   363	  - Sub-issue link via `mcp__github__sub_issue_write`
+   364	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   365	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   366	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   367	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   368	
+   369	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   370	
+   371	```
+   372	mcp__github__list_pull_requests(
+   373	  owner="saurabhav88",
+   374	  repo="EnviousWispr",
+   375	  state="all",          # Codex reviews land on still-open PRs too
+   376	  sort="updated",
+   377	  direction="desc",
+   378	  perPage=20            # camelCase, NOT per_page
+   379	)
+   380	```
+   381	
+   382	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   383	
+   384	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   385	
+   386	For each returned PR, fetch its reviews via authenticated MCP:
+   387	
+   388	```
+   389	mcp__github__pull_request_read(
+   390	  owner="saurabhav88",
+   391	  repo="EnviousWispr",
+   392	  pull_number={pr_number},
+   393	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   394	)
+   395	```
+   396	
+   397	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   398	
+   399	**Filter reviews:**
+   400	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   401	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   402	
+   403	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   404	
+   405	### Step D2 — Dedup against prior triage (authenticated MCP)
+   406	
+   407	```
+   408	mcp__github__search_issues(
+   409	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   410	  perPage=100
+   411	)
+   412	```
+   413	
+   414	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   415	
+   416	For each returned issue, scan its `body` field for markers matching:
+   417	
+   418	```
+   419	<!-- codex-source: pr=<N>, review=<review_id> -->
+   420	```
+   421	
+   422	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   423	
+   424	### Step D3 — Per-event processing
+   425	
+   426	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   427	
+   428	**D3.1 Check merge state.**
+   429	
+   430	```
+   431	mcp__github__pull_request_read(
+   432	  owner="saurabhav88",
+   433	  repo="EnviousWispr",
+   434	  pull_number={pr_number},
+   435	  method="get"   # default; returns full PR object
+   436	)
+   437	```
+   438	
+   439	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   440	
+   441	**D3.2 Fetch the review body and inline comments.**
+   442	
+   443	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   444	
+   445	```
+   446	mcp__github__pull_request_read(
+   447	  owner="saurabhav88",
+   448	  repo="EnviousWispr",
+   449	  pull_number={pr_number},
+   450	  method="get_review_comments"   # or get_comments depending on MCP shape
+   451	)
+   452	```
+   453	
+   454	Filter comments by `pull_request_review_id == {review_id}`.
+   455	
+   456	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   457	
+   458	**D3.4 Consolidate findings.**
+   459	
+   460	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+
+exec
+/bin/zsh -lc "head -80 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt && printf '\\n--- pass2 ---\\n' && head -80 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc535-cdd0-7bd1-942a-44a980f42959
+--------
+user
+# Grounded review — Sentry triage v3.1 prompt patch (issue #459)
+
+## What you're reviewing
+
+A v3.1 patch to `workers/sentry-triage/routine-prompt-v2.md` (the live Sentry triage Routine prompt at `trig_01Crr6qjS5HyQ1i3KbrezPfK`) that fixes three defects flagged by your prior review on PR #458 (review id 4175283434). The diff is in the worktree at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/` on branch `fix/issue-459-routine-prompt-v3.1` (vs `origin/main`).
+
+Run `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main -- workers/sentry-triage/routine-prompt-v2.md` to see the diff. Read the full file at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` for context.
+
+## The three v3 defects (your prior findings)
+
+1. **P1 — Global `If a step fails, log the failure and exit cleanly` rule at v3 line 32 conflicts with later per-step skip/continue policies** (Step 2 GH-search recovery, Step D1 per-PR continue). A model following the global rule terminates the whole run on any single transient error.
+
+2. **P1 — Step 2.5 default action applies Path B throttle without first checking issue state.** For closed issues with prior agent markers, the throttle silently swallows reopens (Path C never fires).
+
+3. **P2 — Step 2.6 cross-reference search references `<crashing-function-name>` and `<source-filename>`, which are only bound from the stack trace later in Path A.** Step 2.6 fires before Path A, so the placeholders are never bound, making the queries non-executable.
+
+## What v3.1 does
+
+- **Fix 1:** Replaced the absolute fail-fast rule (which lived under `## ABSOLUTELY FORBIDDEN`) with a new `## Failure handling (default vs per-step recovery)` section that enumerates ALL documented per-step recoveries (Step 1 Sentry HTTP guard, Step 2 GH-MCP non-auth, MCP auth-expiry, Path A Step 4 git-tag miss, Path A Step 8 sub-issue link, Path D Step D1 per-PR read failure, Path A Step 1 event-fetch failure). Default-vs-per-step distinction is explicit.
+- **Fix 2:** Step 2.5 default action now branches on issue state FIRST. Open → throttle. Closed → Path C (reopen + regression comment), throttle does NOT apply. Reversal-required rules unchanged.
+- **Fix 3:** Step 1 field documentation expanded to declare `culprit`, `metadata.function`, `metadata.filename`, `metadata.type`, `metadata.value` (verified empirically as bound at `is:unresolved` issue-list time via Sentry's GroupSerializer). Step 2.6 rewritten to use these fields by name with per-field `is non-empty` guards. Vacuous queries are now explicitly forbidden.
+
+## Your job — return a verdict
+
+Read the diff and the full file. Answer:
+
+1. **Does Fix 1 cleanly resolve the conflict between the global fail-fast and per-step recoveries?** Specifically: is the new `## Failure handling` section authoritative enough that a model reading the prompt top-to-bottom will follow per-step recoveries instead of bailing out at the first error? Are all per-step recoveries documented in the prompt actually listed in the new section (use grep to verify completeness — search for `skip`, `continue`, `fall back`, `log` patterns in the document and check each documented recovery is in the new list)?
+
+2. **Does Fix 2's open-vs-closed gate correctly route closed-issue regressions to Path C?** Verify that Path C (search later in the file) actually exists, accepts a reopen, and that the gate in Step 2.5 wires correctly to it. Watch for: any other clause downstream of Step 2.5 that could re-block the closed-issue path before it reaches Path C.
+
+3. **Does Fix 3's reliance on Sentry-list `culprit` / `metadata.*` fields hold up?** Specifically:
+   - Are these fields actually bound at `is:unresolved + sort=date` issue-list time? (You can verify against Sentry's API docs or by inspecting the past Sentry response shape — a real response from run 1 at session_018ucrzNMKKmxJTNoKypLkFu showed `id, shortId, count, userCount, level, firstSeen, lastSeen, permalink, title, release, status` because the prior jq stripped them, but the underlying Sentry response includes more.)
+   - Does the per-field `is non-empty` guard cleanly handle the case where, e.g., `metadata.function` is empty but `metadata.filename` is bound?
+   - Is the `elif culprit is non-empty` fallback's elif/if structure correct as written (will the prompt's natural-language pseudocode be parsed by the model the way it reads, or will the model hallucinate a different control flow)?
+
+4. **Anything else.** Bugs you notice in the diff that aren't covered above. Drift between the v3.1 changes and the rest of the prompt. Wording that's ambiguous. Be ruthless — this is a prompt that runs unattended on cron against a live Sentry account and live GitHub repo.
+
+## Output format
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Fix 1 (fail-fast)
+[your assessment]
+
+## Fix 2 (Step 2.5 state gate)
+[your assessment]
+
+## Fix 3 (Step 2.6 + Step 1 field doc)
+[your assessment]
+
+## Other findings
+[grep-verified file:line corrections, if any]
+
+## Recommendation
+[ship as-is | apply listed revisions before ship | do not ship]
+```
+
+Be grep-driven. Cite file:line for every claim. The repo root for the worktree is `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/`.
+codex
+I’ll treat this as a read-only review. I’m doing a quick memory check for any prior routine-prompt/Sentry triage context, then I’ll read the diff and full prompt with line numbers and grep the recovery language.
+exec
+/bin/zsh -lc 'rg -n "routine-prompt|sentry-triage|issue-459|issue #459|PR #458|4175283434|trig_01Crr6qjS5HyQ1i3KbrezPfK" /Users/m4pro_sv/.codex/memories/MEMORY.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ exited 1 in 0ms:
+exec
+/bin/zsh -lc 'git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 status --short --branch' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+
+--- pass2 ---
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2
+--------
+user
+# Grounded review pass 2 — Sentry triage v3.1 (post-revision)
+
+You did pass 1 and returned YES_WITH_REVISIONS with six concrete revisions:
+1. Failure list at top is incomplete — add Path C sub-issue, Step 2 ambiguous-search, Path D generic non-auth, D3.1-D3.7, Path D create-issue sub-link.
+2. Auth-expiry "writes only" contradicts the hard policy — remove the writes-only clause.
+3. Step 2.6 elif binds only to `metadata.type`; rewrite as explicit "all three empty AND culprit non-empty".
+4. Step 1 field doc says "fall back to culprit, then title" but Step 2.6 never uses title — drop title.
+5. Path C idempotency bug — `WRITTEN_THIS_RUN` add at step 1 (after reopen) blocks subsequent writes; move to end of sequence OR redefine as branch-entry check.
+6. Path C reopens before fetching Sentry event; on event-fetch failure the issue is reopened without a regression comment — fetch first OR fail-soft regression comment.
+
+All six revisions have been applied. The patch is now +110/-25 (was +58/-18).
+
+## Your job
+
+Re-read `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` (full file) and the diff `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main`. Confirm:
+
+A. Each of the 6 revisions is correctly applied.
+B. The revisions did not introduce new bugs (e.g., Path C reordering broke a downstream invariant; the idempotency rephrase broke Path A or Path D semantics; the failure list is now over-broad).
+C. There is nothing else in the diff that contradicts the rest of the file.
+
+Be ruthless. The same file:line citation rule applies. Output:
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Revision 1 (failure list completeness)
+[verified | issue at file:line]
+
+## Revision 2 (auth-expiry contradiction)
+[verified | issue]
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+[verified | issue]
+
+## Revision 4 (drop "then title")
+[verified | issue]
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+[verified | issue]
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+[verified | issue]
+
+## New issues introduced (if any)
+[file:line + description]
+
+## Recommendation
+[ship as-is | apply listed revisions before ship | do not ship]
+```
+codex
+I’ll treat this as a read-only review and re-ground it in the current file plus the `origin/main` diff. I’ll also do a quick memory lookup because this is in the EnviousLabs/Sentry review area, then rely on live file evidence for the verdict.
+exec
+/bin/zsh -lc 'wc -l workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     697 workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'rg -n "sentry-triage|routine-prompt|Sentry triage|wt-routine|routine-v3" /Users/m4pro_sv/.codex/memories/MEMORY.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+exec
+/bin/zsh -lc 'git diff --stat origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ exited 1 in 0ms:
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-rr8mlMZj' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-uNJr7RPC' (errno=Operation not permitted)
+ workers/sentry-triage/routine-prompt-v2.md | 135 +++++++++++++++++++++++------
+
+exec
+/bin/zsh -lc 'tail -120 docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+206:If metadata.filename is non-empty:
+208:    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+212:If metadata.type is non-empty AND distinct from metadata.function
+215:    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+219:# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+220:If metadata.function is empty
+221:   AND metadata.filename is empty
+222:   AND metadata.type is empty
+223:   AND culprit is non-empty:
+225:    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+230:If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+233:1. Same crashing function name (`metadata.function`)
+234:2. Same source filename (`metadata.filename`)
+235:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+237:5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+287:**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+350:If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+361:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+376:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+379:2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+419:   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+420:6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+427:- If Sentry API fails, log + stop. Do not retry.
+428:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+432:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+436:## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+438:Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+440:### Path D HARD CONSTRAINTS
+450:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+451:- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+452:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+488:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+524:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+566:Extract `number`, `title`, `body`, `state`, labels.
+589:3. Finding falls within the source issue's original scope (compare against title + body).
+686:### Path D error policy
+688:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+690:- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+692:### Path D rules
+697:- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc 'git diff --check origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Hg122DOX' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-tklw6S2w' (errno=Operation not permitted)
+
+exec
+/bin/zsh -lc 'git status --short' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Wrek7AHN' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-1mV6kdQA' (errno=Operation not permitted)
+ M workers/sentry-triage/routine-prompt-v2.md
+
+codex
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship
+2026-04-25T15:36:45.156185Z ERROR codex_core::session: failed to record rollout items: thread 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2 not found
+tokens used
+62,686
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship
+
+exec
+/bin/zsh -lc "rg -n \"exit 0|Path D still runs|Stopping Sentry Paths|Stopping\\.|log \\+ stop|before any write|Path C step 2|Path C step 3|WRITTEN_THIS_RUN\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+46:- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+48:- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+70:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+72:- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+102:  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+103:  exit 0
+107:  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+109:  exit 0
+289:**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+352:If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+363:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+372:After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
+380:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+424:6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+431:- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
+436:- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+456:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+706:- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc "git diff --unified=3 b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..f79ef58 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -8,6 +8,8 @@ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+@@ -29,7 +31,29 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
++- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
++- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
++- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
++- **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
++- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
++- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path D Step D2 dedup-search (`label:codex-review` issues fetch) non-auth failure**: this is a SHARED setup step, not per-PR. Without it the agent cannot tell which `(pr, review)` pairs are already triaged. Log + EXIT Path D cleanly. Do NOT continue retriaging without the dedup set. Auth-expiry triggers the hard policy.
++- **Path D Step D3.1, D3.2, or D3.5 failures** (PR merge-state read, review-body/comments fetch, source-issue resolution — these run BEFORE any per-finding work): log + skip the ENTIRE review (all findings on this `(pr, review)` together). Do NOT proceed to D3.6/D3.7 without merge-state, review-body, or source-issue context. Continue to the next un-triaged review.
++- **Path D Step D3.3, D3.4, D3.6, or D3.7 per-finding failures** (filter outdated, consolidate, fetch code context for one finding, single-finding `issue_write`/comment/label/sub-link): log + skip THAT one finding, continue with the next finding on the same review.
++- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue with the next finding.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+@@ -43,9 +67,12 @@ This protects against duplicate-issue creation when MCP search returns false-emp
+ 
+ ## Per-run idempotency
+ 
+-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
++Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
++
++- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
++- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+ 
+-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
++This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+ 
+ ## Tool usage
+ 
+@@ -72,12 +99,12 @@ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TO
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then
+-  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
++  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
+   exit 0
+ fi
+ # JSON sanity check (Sentry returns HTML on 5xx)
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+-  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
++  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
+   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   exit 0
+ fi
+@@ -91,6 +118,10 @@ Each issue object has these fields (use exact names):
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+@@ -144,7 +175,12 @@ Grep the combined body+comments for markers matching:
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+@@ -155,25 +191,52 @@ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ign
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+ 
+ ```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
++# Independent queries — run each one whose key field is non-empty.
++# Order does not matter; results are aggregated for the matching bar below.
++
++If metadata.function is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.type is non-empty AND distinct from metadata.function
++   (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
++If metadata.function is empty
++   AND metadata.filename is empty
++   AND metadata.type is empty
++   AND culprit is non-empty:
++  mcp__github__search_issues(
++    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
+ ```
+ 
++If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
++
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+@@ -223,7 +286,7 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
+ 
+ **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+ 
+-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
++**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+ 
+ Title: `P{n}: {area} — {symptom in plain English}`
+ 
+@@ -286,7 +349,7 @@ mcp__github__sub_issue_write(
+ )
+ ```
+ 
+-If the sub-issue link fails, log it and continue.
++If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+@@ -306,17 +369,23 @@ Comment via `mcp__github__add_issue_comment`:
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
++After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
++
+ If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+ 
+ ---
+ 
+ ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+ 
+-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+-3. Fetch latest Sentry event (Path A Step 1).
+-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
++**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
++
++1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
++2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
++3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
++4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+ 5. Post regression comment via `mcp__github__add_issue_comment`:
++
++   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+ ```
+ **Regression detected** — This issue recurred after being closed.
+ | Metric | Value |
+@@ -328,23 +397,43 @@ If new severity differs from prior agent comment's severity, prepend `**Reversin
+ [View in Sentry]({permalink})
+ 
+ **Fresh hypothesis** (current source at {tag}):
+-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
++> [2 sentences — re-analyze, don't copy original.]
++
++<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
++```
+
+exec
+/bin/zsh -lc "git diff --unified=3 b59d55a4cf8e1b4b9667baae194d9d061f697d4a -- workers/sentry-triage/routine-prompt-v2.md | sed -n '220,520p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
++```
++
++   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
++```
++**Regression detected** — This issue recurred after being closed.
++| Metric | Value |
++|--------|-------|
++| Users now | {userCount} |
++| Occurrences now | {count} |
++| Last seen | {lastSeen} |
++| Release now | {release} |
++
++[View in Sentry]({permalink})
++
++**Fresh hypothesis:**
++> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+-6. Add label `regression`.
++
++   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
++6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ## Rules (Sentry Paths A/B/C)
+ 
+ - Never write code or open PRs. Triage only.
+-- If Sentry API fails, log + stop. Do not retry.
+-- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
++- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
++- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
+ - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+ - Use exact label names listed above.
+ - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+-- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
++- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
+ 
+ ---
+ 
+@@ -600,8 +689,13 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
+ 
+ ### Path D error policy
+ 
+-- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+-- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
++See the authoritative Failure-handling list at the top of the prompt for the canonical Path D recoveries. Summary by failure scope:
++
++- **Exit Path D entirely (non-auth):** Step D1 outer `mcp__github__list_pull_requests` failure, Step D2 dedup-search failure (shared setup — without it, dedup is broken across all reviews).
++- **Auth-expiry on any GitHub MCP call (Path D scope):** trigger global MCP auth-expiry policy. Run terminates.
++- **Skip one PR, continue Path D:** per-PR `pull_request_read` failure in Step D1's inner loop.
++- **Skip the WHOLE review, continue Path D:** Step D3.1 (merge state), D3.2 (review body / inline comments), or D3.5 (source-issue resolve) failure. These run BEFORE any per-finding work; without them, downstream findings would be under-grounded.
++- **Skip ONE finding, continue with the next finding on the same review:** D3.3, D3.4, D3.6, D3.7 per-finding failures, AND the create-issue sub-issue link failure.
+ - **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+ 
+ ### Path D rules
+@@ -609,4 +703,4 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
+ - Process events in chronological order (oldest `submitted_at` first).
+ - All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+ - GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+-- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
++- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.
+
+exec
+/bin/zsh -lc 'rg -n "TOKEN|AUTH|Bearer|secret|api[_-]?key|password|SENTRY_AUTH_TOKEN|CLAUDE_CODE_REMOTE_SESSION_ID|session id" docs/audits/2026-04-25-routine-v3.1-grounded-review-pass*.txt' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:11:session id: 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:148:    61	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:164:    77	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:182:    95	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:339:   248	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:421:   330	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:426:   335	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:462:   367	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:493:   398	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:511:   416	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:718:   619	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:770:   671	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:856: RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:939: - [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:944: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:977: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1013: <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1099: 2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1117: - **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1135: RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt:1266:+<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:11:session id: 019dc535-cdd0-7bd1-942a-44a980f42959
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:161:    54	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:174:    67	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:192:    85	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:334:   227	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:416:   309	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:421:   314	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:453:   346	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:480:   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:681:   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:733:   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:905:373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:923:54:2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1056:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:314:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1058:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:346:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1060:/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1145:workers/crisp-kb/markdown/55-api-key-security.md
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1282:40:async function verifyHmac(body, sigHeader, secret) {
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1322:    54	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1562:   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1614:   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt:1667:   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+
+2026-04-25T15:52:32.843985Z ERROR codex_core::session: failed to record rollout items: thread 019dc554-eb48-7872-a727-336d445f1f88 not found
+codex
+The v3.1 failure policy says Step 1 Sentry failures should only stop Sentry paths and continue to Path D, but the Step 1 shell block still exits the entire run. This breaks an intended recovery path for routine operation.
+
+Review comment:
+
+- [P2] Let Sentry failures fall through to Path D — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:101-103
+  When Sentry returns a non-200 response, this block still runs `exit 0` immediately after the new “Path D still runs” message; the non-JSON guard below has the same pattern. In the scheduled routine, that terminates the whole run before Path D executes, so a Sentry outage/HTML response still drops Codex PR feedback triage despite the new recovery policy.
+2026-04-25T15:52:32.883635Z ERROR codex_core::session: failed to record rollout items: thread 019dc554-eac3-7542-8786-6c4563878fb9 not found
+The v3.1 failure policy says Step 1 Sentry failures should only stop Sentry paths and continue to Path D, but the Step 1 shell block still exits the entire run. This breaks an intended recovery path for routine operation.
+
+Review comment:
+
+- [P2] Let Sentry failures fall through to Path D — /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:101-103
+  When Sentry returns a non-200 response, this block still runs `exit 0` immediately after the new “Path D still runs” message; the non-JSON guard below has the same pattern. In the scheduled routine, that terminates the whole run before Path D executes, so a Sentry outage/HTML response still drops Codex PR feedback triage despite the new recovery policy.

--- a/docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt
+++ b/docs/audits/2026-04-25-routine-v3.1-grounded-review-pass1.txt
@@ -1,0 +1,1760 @@
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc535-cdd0-7bd1-942a-44a980f42959
+--------
+user
+# Grounded review — Sentry triage v3.1 prompt patch (issue #459)
+
+## What you're reviewing
+
+A v3.1 patch to `workers/sentry-triage/routine-prompt-v2.md` (the live Sentry triage Routine prompt at `trig_01Crr6qjS5HyQ1i3KbrezPfK`) that fixes three defects flagged by your prior review on PR #458 (review id 4175283434). The diff is in the worktree at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/` on branch `fix/issue-459-routine-prompt-v3.1` (vs `origin/main`).
+
+Run `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main -- workers/sentry-triage/routine-prompt-v2.md` to see the diff. Read the full file at `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` for context.
+
+## The three v3 defects (your prior findings)
+
+1. **P1 — Global `If a step fails, log the failure and exit cleanly` rule at v3 line 32 conflicts with later per-step skip/continue policies** (Step 2 GH-search recovery, Step D1 per-PR continue). A model following the global rule terminates the whole run on any single transient error.
+
+2. **P1 — Step 2.5 default action applies Path B throttle without first checking issue state.** For closed issues with prior agent markers, the throttle silently swallows reopens (Path C never fires).
+
+3. **P2 — Step 2.6 cross-reference search references `<crashing-function-name>` and `<source-filename>`, which are only bound from the stack trace later in Path A.** Step 2.6 fires before Path A, so the placeholders are never bound, making the queries non-executable.
+
+## What v3.1 does
+
+- **Fix 1:** Replaced the absolute fail-fast rule (which lived under `## ABSOLUTELY FORBIDDEN`) with a new `## Failure handling (default vs per-step recovery)` section that enumerates ALL documented per-step recoveries (Step 1 Sentry HTTP guard, Step 2 GH-MCP non-auth, MCP auth-expiry, Path A Step 4 git-tag miss, Path A Step 8 sub-issue link, Path D Step D1 per-PR read failure, Path A Step 1 event-fetch failure). Default-vs-per-step distinction is explicit.
+- **Fix 2:** Step 2.5 default action now branches on issue state FIRST. Open → throttle. Closed → Path C (reopen + regression comment), throttle does NOT apply. Reversal-required rules unchanged.
+- **Fix 3:** Step 1 field documentation expanded to declare `culprit`, `metadata.function`, `metadata.filename`, `metadata.type`, `metadata.value` (verified empirically as bound at `is:unresolved` issue-list time via Sentry's GroupSerializer). Step 2.6 rewritten to use these fields by name with per-field `is non-empty` guards. Vacuous queries are now explicitly forbidden.
+
+## Your job — return a verdict
+
+Read the diff and the full file. Answer:
+
+1. **Does Fix 1 cleanly resolve the conflict between the global fail-fast and per-step recoveries?** Specifically: is the new `## Failure handling` section authoritative enough that a model reading the prompt top-to-bottom will follow per-step recoveries instead of bailing out at the first error? Are all per-step recoveries documented in the prompt actually listed in the new section (use grep to verify completeness — search for `skip`, `continue`, `fall back`, `log` patterns in the document and check each documented recovery is in the new list)?
+
+2. **Does Fix 2's open-vs-closed gate correctly route closed-issue regressions to Path C?** Verify that Path C (search later in the file) actually exists, accepts a reopen, and that the gate in Step 2.5 wires correctly to it. Watch for: any other clause downstream of Step 2.5 that could re-block the closed-issue path before it reaches Path C.
+
+3. **Does Fix 3's reliance on Sentry-list `culprit` / `metadata.*` fields hold up?** Specifically:
+   - Are these fields actually bound at `is:unresolved + sort=date` issue-list time? (You can verify against Sentry's API docs or by inspecting the past Sentry response shape — a real response from run 1 at session_018ucrzNMKKmxJTNoKypLkFu showed `id, shortId, count, userCount, level, firstSeen, lastSeen, permalink, title, release, status` because the prior jq stripped them, but the underlying Sentry response includes more.)
+   - Does the per-field `is non-empty` guard cleanly handle the case where, e.g., `metadata.function` is empty but `metadata.filename` is bound?
+   - Is the `elif culprit is non-empty` fallback's elif/if structure correct as written (will the prompt's natural-language pseudocode be parsed by the model the way it reads, or will the model hallucinate a different control flow)?
+
+4. **Anything else.** Bugs you notice in the diff that aren't covered above. Drift between the v3.1 changes and the rest of the prompt. Wording that's ambiguous. Be ruthless — this is a prompt that runs unattended on cron against a live Sentry account and live GitHub repo.
+
+## Output format
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Fix 1 (fail-fast)
+[your assessment]
+
+## Fix 2 (Step 2.5 state gate)
+[your assessment]
+
+## Fix 3 (Step 2.6 + Step 1 field doc)
+[your assessment]
+
+## Other findings
+[grep-verified file:line corrections, if any]
+
+## Recommendation
+[ship as-is | apply listed revisions before ship | do not ship]
+```
+
+Be grep-driven. Cite file:line for every claim. The repo root for the worktree is `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/`.
+codex
+I’ll treat this as a read-only review. I’m doing a quick memory check for any prior routine-prompt/Sentry triage context, then I’ll read the diff and full prompt with line numbers and grep the recovery language.
+exec
+/bin/zsh -lc 'rg -n "routine-prompt|sentry-triage|issue-459|issue #459|PR #458|4175283434|trig_01Crr6qjS5HyQ1i3KbrezPfK" /Users/m4pro_sv/.codex/memories/MEMORY.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ exited 1 in 0ms:
+exec
+/bin/zsh -lc 'git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 status --short --branch' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-ytdO7b73' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-8UAUDaw6' (errno=Operation not permitted)
+## fix/issue-459-routine-prompt-v3.1...origin/main
+ M workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff --stat origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-YmiQIgn6' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-qiTW27aQ' (errno=Operation not permitted)
+ workers/sentry-triage/routine-prompt-v2.md | 76 +++++++++++++++++++++++-------
+ 1 file changed, 58 insertions(+), 18 deletions(-)
+
+codex
+Memory had no direct hits for this routine prompt or issue, so I’m staying with the live worktree evidence. The branch is dirty only for the prompt file under review, and the diff is scoped to that file.
+exec
+/bin/zsh -lc 'wc -l /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     652 /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'nl -ba /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	
+    12	v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+    13	-->
+    14	
+    15	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    16	
+    17	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    18	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    19	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    20	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    21	  - Adding labels (via `mcp__github__issue_write`)
+    22	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    23	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    24	
+    25	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    26	
+    27	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    28	
+    29	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    30	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    31	- Any tool that prompts the user to visit a URL or perform an action.
+    32	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    33	
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are:
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit cleanly *before* GitHub work, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+    41	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+    42	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat.
+    43	- **Path A Step 8 sub-issue link failure**: log and continue.
+    44	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    45	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    46	
+    47	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+    48	
+    49	## MCP auth-expiry policy (HARD)
+    50	
+    51	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    52	
+    53	1. STOP all GitHub writes for the rest of this run, immediately.
+    54	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    55	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    56	
+    57	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    58	
+    59	## Per-run idempotency
+    60	
+    61	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+    62	
+    63	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
+    64	
+    65	## Tool usage
+    66	
+    67	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    68	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    69	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    70	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    71	
+    72	## Step 0 — Fetch git tags
+    73	
+    74	```bash
+    75	git fetch --tags 2>/dev/null || true
+    76	```
+    77	
+    78	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    79	
+    80	## Step 1 — Query Sentry for recent activity
+    81	
+    82	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    83	
+    84	```bash
+    85	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    86	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    87	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    88	BODY=$(echo "$RESPONSE" | sed '$d')
+    89	if [ "$HTTP_CODE" != "200" ]; then
+    90	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+    91	  exit 0
+    92	fi
+    93	# JSON sanity check (Sentry returns HTML on 5xx)
+    94	if ! echo "$BODY" | jq empty 2>/dev/null; then
+    95	  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+    96	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+    97	  exit 0
+    98	fi
+    99	```
+   100	
+   101	Each issue object has these fields (use exact names):
+   102	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+   103	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+   104	- `count` — total event count (integer).
+   105	- `userCount` — distinct users affected (integer).
+   106	- `level` — "error" or "fatal".
+   107	- `firstSeen`, `lastSeen` — ISO timestamps.
+   108	- `permalink` — full Sentry URL to the issue.
+   109	- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+   110	- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
+   111	
+   112	When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+   113	
+   114	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+   115	
+   116	```python
+   117	from datetime import datetime, timezone, timedelta
+   118	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   119	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   120	```
+   121	
+   122	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   123	
+   124	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   125	
+   126	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   127	
+   128	```
+   129	mcp__github__search_issues(
+   130	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   131	  perPage=10
+   132	)
+   133	```
+   134	
+   135	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   136	
+   137	If the MCP call errors:
+   138	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   139	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   140	
+   141	Route based on result:
+   142	
+   143	---
+   144	
+   145	## Step 2.5 — Read prior agent decisions (durable memory)
+   146	
+   147	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   148	
+   149	```
+   150	mcp__github__issue_read(
+   151	  owner="saurabhav88",
+   152	  repo="EnviousWispr",
+   153	  issue_number=<N>,
+   154	  method="get_comments"  # or fetch issue + comments separately
+   155	)
+   156	```
+   157	
+   158	Grep the combined body+comments for markers matching:
+   159	
+   160	```
+   161	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   162	```
+   163	
+   164	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   165	
+   166	**Default action when prior agent marker exists — gate on issue state FIRST:**
+   167	
+   168	- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   169	- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+   170	
+   171	This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+   172	
+   173	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   174	- New severity differs from prior severity, OR
+   175	- You're routing to a different `source_issue` than prior, OR
+   176	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   177	
+   178	---
+   179	
+   180	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   181	
+   182	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+   183	
+   184	```
+   185	# Only run a query if its key field is non-empty for this Sentry issue.
+   186	if metadata.function is non-empty:
+   187	  mcp__github__search_issues(
+   188	    query="<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   189	    perPage=10
+   190	  )
+   191	if metadata.filename is non-empty:
+   192	  mcp__github__search_issues(
+   193	    query="<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   194	    perPage=10
+   195	  )
+   196	if metadata.type is non-empty AND distinct from metadata.function (e.g., an exception class like `audio_capture_failed`):
+   197	  mcp__github__search_issues(
+   198	    query="<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   199	    perPage=10
+   200	  )
+   201	# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
+   202	elif culprit is non-empty:
+   203	  mcp__github__search_issues(
+   204	    query="<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   205	    perPage=10
+   206	  )
+   207	```
+   208	
+   209	If NONE of those keys are bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+   210	
+   211	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   212	1. Same crashing function name (`metadata.function`)
+   213	2. Same source filename (`metadata.filename`)
+   214	3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+   215	4. Same release range (issue's stated release vs Sentry's `release` field)
+   216	5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+   217	
+   218	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   219	
+   220	---
+   221	
+   222	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   223	
+   224	**1. Fetch full event with stack trace:**
+   225	
+   226	```bash
+   227	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   228	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   229	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   230	BODY=$(echo "$RESPONSE" | sed '$d')
+   231	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   232	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   233	  echo "Event response not JSON. Skipping this issue."
+   234	  continue
+   235	fi
+   236	```
+   237	
+   238	Use the numeric `id` field, NOT `shortId`.
+   239	
+   240	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   241	
+   242	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   243	
+   244	**3. Extract git tag from `release` field:**
+   245	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   246	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   247	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   248	- If release is null or missing, note it and use HEAD.
+   249	
+   250	**4. Read source at crash site:**
+   251	
+   252	```bash
+   253	git show {tag}:{filename} | sed -n '{start},{end}p'
+   254	```
+   255	
+   256	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   257	
+   258	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   259	- P0-critical: level=fatal OR userCount >= 10
+   260	- P1-high: userCount >= 3 OR count >= 20
+   261	- P2-medium: userCount >= 2 OR count >= 5
+   262	- P3-low: everything else
+   263	
+   264	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   265	
+   266	**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+   267	
+   268	Title: `P{n}: {area} — {symptom in plain English}`
+   269	
+   270	Labels (exact names — they exist in the repo):
+   271	- `bug`
+   272	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   273	- `sentry-triage`
+   274	- `auto-triaged`
+   275	- One of: `env-production`, `env-development`
+   276	
+   277	Body:
+   278	```
+   279	## Summary
+   280	[1-2 sentences: what error occurred, in plain English]
+   281	
+   282	## Impact
+   283	| Metric | Value |
+   284	|--------|-------|
+   285	| Users affected | {userCount} |
+   286	| Total occurrences | {count} |
+   287	| First seen | {firstSeen} |
+   288	| Last seen | {lastSeen} |
+   289	| Environment | production or development |
+   290	| Release | {release} |
+   291	
+   292	## Crash site
+   293	\`{filename}:{lineNo}\` in \`{function}\`
+   294	
+   295	## Source at crash
+   296	<details><summary>Code at {tag}</summary>
+   297	
+   298	[~20 lines centered on crash line]
+   299	
+   300	</details>
+   301	
+   302	## Hypothesis
+   303	> Unvalidated. Auto-generated from stack trace analysis only.
+   304	
+   305	[2 sentences OR fail-soft sentence per Step 6]
+   306	
+   307	## References
+   308	- [Sentry issue]({permalink})
+   309	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   310	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   311	
+   312	<!-- sentry-issue-id: {shortId} -->
+   313	<!-- auto-triaged: true -->
+   314	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   315	```
+   316	
+   317	**8. Parent the new issue under the Bugs epic (#317):**
+   318	
+   319	```
+   320	mcp__github__sub_issue_write(
+   321	  owner="saurabhav88",
+   322	  repo="EnviousWispr",
+   323	  issue_number=317,
+   324	  method="add",
+   325	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   326	)
+   327	```
+   328	
+   329	If the sub-issue link fails, log it and continue.
+   330	
+   331	---
+   332	
+   333	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   334	
+   335	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   336	- Event count has at least doubled since last reported in any prior agent comment, OR
+   337	- New users affected since last comment, OR
+   338	- No `agent:sentry-triage` comment in the last 24h
+   339	
+   340	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   341	
+   342	Comment via `mcp__github__add_issue_comment`:
+   343	```
+   344	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   345	
+   346	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   347	```
+   348	
+   349	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   350	
+   351	---
+   352	
+   353	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   354	
+   355	1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+   356	2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+   357	3. Fetch latest Sentry event (Path A Step 1).
+   358	4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+   359	5. Post regression comment via `mcp__github__add_issue_comment`:
+   360	```
+   361	**Regression detected** — This issue recurred after being closed.
+   362	| Metric | Value |
+   363	|--------|-------|
+   364	| Users now | {userCount} |
+   365	| Occurrences now | {count} |
+   366	| Release now | {release} |
+   367	
+   368	[View in Sentry]({permalink})
+   369	
+   370	**Fresh hypothesis** (current source at {tag}):
+   371	> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+   372	
+   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   374	```
+   375	6. Add label `regression`.
+   376	
+   377	---
+   378	
+   379	## Rules (Sentry Paths A/B/C)
+   380	
+   381	- Never write code or open PRs. Triage only.
+   382	- If Sentry API fails, log + stop. Do not retry.
+   383	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+   384	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   385	- Use exact label names listed above.
+   386	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   387	- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+   388	
+   389	---
+   390	
+   391	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   392	
+   393	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   394	
+   395	### Path D HARD CONSTRAINTS
+   396	
+   397	- Read + triage only. Write allowlist:
+   398	  - Create GitHub issues (`mcp__github__issue_write`)
+   399	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   400	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   401	  - Edit issue body to APPEND the codex-source marker (append only)
+   402	  - Apply the `codex-review` label
+   403	  - Sub-issue link via `mcp__github__sub_issue_write`
+   404	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   405	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   406	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   407	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   408	
+   409	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   410	
+   411	```
+   412	mcp__github__list_pull_requests(
+   413	  owner="saurabhav88",
+   414	  repo="EnviousWispr",
+   415	  state="all",          # Codex reviews land on still-open PRs too
+   416	  sort="updated",
+   417	  direction="desc",
+   418	  perPage=20            # camelCase, NOT per_page
+   419	)
+   420	```
+   421	
+   422	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   423	
+   424	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   425	
+   426	For each returned PR, fetch its reviews via authenticated MCP:
+   427	
+   428	```
+   429	mcp__github__pull_request_read(
+   430	  owner="saurabhav88",
+   431	  repo="EnviousWispr",
+   432	  pull_number={pr_number},
+   433	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   434	)
+   435	```
+   436	
+   437	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   438	
+   439	**Filter reviews:**
+   440	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   441	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   442	
+   443	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   444	
+   445	### Step D2 — Dedup against prior triage (authenticated MCP)
+   446	
+   447	```
+   448	mcp__github__search_issues(
+   449	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   450	  perPage=100
+   451	)
+   452	```
+   453	
+   454	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   455	
+   456	For each returned issue, scan its `body` field for markers matching:
+   457	
+   458	```
+   459	<!-- codex-source: pr=<N>, review=<review_id> -->
+   460	```
+   461	
+   462	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   463	
+   464	### Step D3 — Per-event processing
+   465	
+   466	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   467	
+   468	**D3.1 Check merge state.**
+   469	
+   470	```
+   471	mcp__github__pull_request_read(
+   472	  owner="saurabhav88",
+   473	  repo="EnviousWispr",
+   474	  pull_number={pr_number},
+   475	  method="get"   # default; returns full PR object
+   476	)
+   477	```
+   478	
+   479	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   480	
+   481	**D3.2 Fetch the review body and inline comments.**
+   482	
+   483	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   484	
+   485	```
+   486	mcp__github__pull_request_read(
+   487	  owner="saurabhav88",
+   488	  repo="EnviousWispr",
+   489	  pull_number={pr_number},
+   490	  method="get_review_comments"   # or get_comments depending on MCP shape
+   491	)
+   492	```
+   493	
+   494	Filter comments by `pull_request_review_id == {review_id}`.
+   495	
+   496	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   497	
+   498	**D3.4 Consolidate findings.**
+   499	
+   500	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   501	- Each surviving inline comment is a candidate finding.
+   502	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   503	
+   504	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   505	
+   506	**D3.5 Resolve source issue.**
+   507	
+   508	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   509	
+   510	If non-null, fetch via authenticated MCP:
+   511	
+   512	```
+   513	mcp__github__issue_read(
+   514	  owner="saurabhav88",
+   515	  repo="EnviousWispr",
+   516	  issue_number={source_issue},
+   517	  method="get"
+   518	)
+   519	```
+   520	
+   521	Extract `number`, `title`, `body`, `state`, labels.
+   522	
+   523	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   524	
+   525	```
+   526	mcp__github__get_file_contents(
+   527	  owner="saurabhav88",
+   528	  repo="EnviousWispr",
+   529	  path="{path}",
+   530	  ref="{head_sha}"
+   531	)
+   532	```
+   533	
+   534	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   535	
+   536	**D3.7 Triage decision.** For each finding, ONE of:
+   537	
+   538	---
+   539	
+   540	**(a) ATTACH to source issue.** ALL of these must hold:
+   541	
+   542	1. `source_issue` is non-null.
+   543	2. Source issue does NOT have the `sentry-triage` label.
+   544	3. Finding falls within the source issue's original scope (compare against title + body).
+   545	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   546	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   547	
+   548	If any condition fails, do NOT use ATTACH. Reclassify.
+   549	
+   550	Actions:
+   551	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   552	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   553	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   554	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   555	
+   556	Comment template:
+   557	
+   558	```
+   559	**Codex post-merge feedback — related to this issue.**
+   560	
+   561	<1-3 sentences summarizing the finding in plain English>
+   562	
+   563	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   564	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   565	
+   566	<details><summary>Codex's exact text</summary>
+   567	
+   568	<quoted review body or inline comment body>
+   569	
+   570	</details>
+   571	
+   572	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   573	<!-- auto-triaged: true -->
+   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   575	```
+   576	
+   577	---
+   578	
+   579	**(b) CREATE new issue.** Conditions:
+   580	
+   581	- `source_issue` is null, OR
+   582	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   583	- Finding is clearly out-of-scope for the source issue.
+   584	
+   585	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   586	
+   587	Actions:
+   588	1. Create a new issue via `mcp__github__issue_write`:
+   589	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   590	   - Labels: `codex-review`, `auto-triaged`
+   591	   - Body (template below)
+   592	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   593	   ```
+   594	   mcp__github__sub_issue_write(
+   595	     owner="saurabhav88",
+   596	     repo="EnviousWispr",
+   597	     issue_number=319,
+   598	     method="add",
+   599	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   600	   )
+   601	   ```
+   602	   422 means link already exists — fine. Other failure: log + continue.
+   603	
+   604	Issue body template:
+   605	
+   606	```
+   607	## Source
+   608	- PR: #{pr_number}
+   609	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   610	- Related issue (if any): #{source_issue}
+   611	
+   612	## Finding
+   613	<1-2 sentence plain-English summary>
+   614	
+   615	## Code location
+   616	`{file}:{line}`
+   617	
+   618	## Codex's full text
+   619	<quoted>
+   620	
+   621	## Source snippet
+   622	<code around the line, fetched via mcp__github__get_file_contents>
+   623	
+   624	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   625	<!-- auto-triaged: true -->
+   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   627	```
+   628	
+   629	---
+   630	
+   631	**(c) IGNORE.** Conditions (ANY):
+   632	
+   633	- Finding is vague, stylistic, or purely subjective.
+   634	- You cannot confidently state why the finding is valid against the current code.
+   635	- Finding references code that no longer exists at `head_sha`.
+   636	
+   637	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   638	
+   639	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   640	
+   641	### Path D error policy
+   642	
+   643	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   644	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+   645	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+   646	
+   647	### Path D rules
+   648	
+   649	- Process events in chronological order (oldest `submitted_at` first).
+   650	- All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+   651	- GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+   652	- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc 'git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-WaO3ALeD' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-ts287Xa3' (errno=Operation not permitted)
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..3685d74 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -8,6 +8,8 @@ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+@@ -29,7 +31,20 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are:
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit cleanly *before* GitHub work, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat.
++- **Path A Step 8 sub-issue link failure**: log and continue.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+@@ -91,6 +106,10 @@ Each issue object has these fields (use exact names):
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+@@ -144,7 +163,12 @@ Grep the combined body+comments for markers matching:
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+@@ -155,25 +179,41 @@ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ign
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
+-
+-```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-```
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++```
++# Only run a query if its key field is non-empty for this Sentry issue.
++if metadata.function is non-empty:
++  mcp__github__search_issues(
++    query="<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage=10
++  )
++if metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query="<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage=10
++  )
++if metadata.type is non-empty AND distinct from metadata.function (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query="<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage=10
++  )
++# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
++elif culprit is non-empty:
++  mcp__github__search_issues(
++    query="<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage=10
++  )
++```
++
++If NONE of those keys are bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+ 
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+
+codex
+The prompt now has the new failure section at the top and the Step 2.5/2.6 edits in the expected places. I’m grepping every recovery verb now, because the likely remaining risk is whether the new authoritative list and the later local policies drift from each other.
+exec
+/bin/zsh -lc "rg -n \"\\b(skip|SKIP|continue|CONTINUE|fall back|fallback|log|Log|exit|Exit|fatal|Fatal|Recoverable|recoverable|fails?|errors?|retry|Stopping|Stopping\\.|stop|STOP)\\b\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+exec
+/bin/zsh -lc "rg -n \"Path C|REGRESSION|reopen|reopened|state == \\\"closed\\\"|CLOSED|closed|throttle|prior agent marker|Default action\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+82:Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+135:Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+147:Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+164:Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+166:**Default action when prior agent marker exists — gate on issue state FIRST:**
+168:- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+169:- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+171:This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+353:### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+361:**Regression detected** — This issue recurred after being closed.
+373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+551:1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+29:- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+36:If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+38:If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are:
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit cleanly *before* GitHub work, but Path D still runs.
+40:- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+41:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+42:- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat.
+43:- **Path A Step 8 sub-issue link failure**: log and continue.
+44:- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+45:- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+47:A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+51:If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+53:1. STOP all GitHub writes for the rest of this run, immediately.
+54:2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+55:3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+61:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+90:  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+91:  exit 0
+95:  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+97:  exit 0
+106:- `level` — "error" or "fatal".
+110:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
+122:If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+137:If the MCP call errors:
+138:- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+139:- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+168:- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+182:If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+201:# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
+209:If NONE of those keys are bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+214:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+231:if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+234:  continue
+259:- P0-critical: level=fatal OR userCount >= 10
+264:**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+280:[1-2 sentences: what error occurred, in plain English]
+305:[2 sentences OR fail-soft sentence per Step 6]
+329:If the sub-issue link fails, log it and continue.
+340:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+356:2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+371:> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+382:- If Sentry API fails, log + stop. Do not retry.
+383:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+387:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+405:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+424:**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+443:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+454:Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+466:For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+479:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+504:If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+548:If any condition fails, do NOT use ATTACH. Reclassify.
+602:   422 means link already exists — fine. Other failure: log + continue.
+641:### Path D error policy
+643:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+644:- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+
+exec
+/bin/zsh -lc "rg -n \"metadata\\.|culprit|Step 2\\.6|source-filename|crashing-function|placeholder|vacuous|elif|if .*non-empty|release|title\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+109:- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+110:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
+112:When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+135:Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+180:## Step 2.6 — Cross-reference search (catch fingerprint splits)
+182:If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+185:# Only run a query if its key field is non-empty for this Sentry issue.
+186:if metadata.function is non-empty:
+188:    query="<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+191:if metadata.filename is non-empty:
+193:    query="<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+196:if metadata.type is non-empty AND distinct from metadata.function (e.g., an exception class like `audio_capture_failed`):
+198:    query="<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+201:# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
+202:elif culprit is non-empty:
+204:    query="<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+209:If NONE of those keys are bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+212:1. Same crashing function name (`metadata.function`)
+213:2. Same source filename (`metadata.filename`)
+214:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+215:4. Same release range (issue's stated release vs Sentry's `release` field)
+216:5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+244:**3. Extract git tag from `release` field:**
+248:- If release is null or missing, note it and use HEAD.
+290:| Release | {release} |
+310:[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+344:**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+358:4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+366:| Release now | {release} |
+479:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+521:Extract `number`, `title`, `body`, `state`, labels.
+544:3. Finding falls within the source issue's original scope (compare against title + body).
+
+web search: 
+web search: Sentry API list project issues group metadata culprit fields issue object
+web search: 
+web search: https://docs.sentry.io/api/events/list-a-projects-issues/
+web search: 
+web search: https://docs.sentry.io/api/events/list-an-organizations-issues/
+web search: 
+web search: Sentry GroupSerializer metadata function filename culprit GroupSerializer source
+web search: 
+web search: github getsentry sentry serializers models group.py get_event_metadata metadata culprit SimpleGroupSerializer
+web search: 
+web search: 
+web search: 
+web search: https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/group.py
+web search: 
+web search: 'metadata' in https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/group.py
+codex
+External docs confirm the issue-list response includes `culprit` and a `metadata` object, but the exact subkeys are still optional by issue type. Locally, Step 2.6’s guards mostly handle that, with one control-flow wording problem I’m checking carefully.
+exec
+/bin/zsh -lc "rg -n \"session_018ucrzNMKKmxJTNoKypLkFu|ENVIOUSWISPR-|culprit|metadata\\.function|metadata\\.filename|metadata\\.type|GroupSerializer|Sentry response|shortId\" /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/src/index.js:113:  const culprit = issue.culprit ?? "";
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/src/index.js:234:    `culprit: ${culprit}`,
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:12:v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:40:- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:61:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:95:  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:103:- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:109:- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:110:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:112:When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:130:  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:139:- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:161:<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:182:If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:186:if metadata.function is non-empty:
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:188:    query="<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:191:if metadata.filename is non-empty:
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:193:    query="<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:196:if metadata.type is non-empty AND distinct from metadata.function (e.g., an exception class like `audio_capture_failed`):
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:198:    query="<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:201:# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:202:elif culprit is non-empty:
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:204:    query="<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:209:If NONE of those keys are bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:212:1. Same crashing function name (`metadata.function`)
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:213:2. Same source filename (`metadata.filename`)
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:214:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:216:5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:238:Use the numeric `id` field, NOT `shortId`.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:266:**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:312:<!-- sentry-issue-id: {shortId} -->
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:314:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:340:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:346:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:355:1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:373:<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:383:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md:387:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+
+exec
+/bin/zsh -lc "find /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 -maxdepth 5 -type f \\( -name '*sentry*' -o -name '*routine*' -o -name '*.json' -o -name '*.jsonl' -o -name '*.md' \\) | sed 's#"'^/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/##'"'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+website/README.md
+website/package-lock.json
+website/package.json
+website/tsconfig.json
+website/src/content/blog/meeting-notes-polished-summaries.md
+website/src/content/blog/dictation-for-developers-code-reviews.md
+website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+website/src/content/blog/switched-typing-to-dictating-git-commits.md
+website/src/content/blog/voice-coding-macos-without-cloud.md
+website/src/content/blog/dictate-emails-speed-of-thought.md
+website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+website/src/content/blog/essay-outline-by-talking-it-out.md
+website/src/content/blog/dictation-for-writers-skip-blank-page.md
+website/src/content/blog/dictation-remote-workers-tired-of-typing.md
+website/src/content/blog/async-communication-better-when-you-speak.md
+website/src/content/blog/hands-free-typing-toddler-climbs-you.md
+website/src/content/blog/welcome-to-enviouswispr.md
+website/src/content/blog/macos-dictation-offline-private.md
+website/src/content/blog/dictate-first-drafts-sound-like-you.md
+website/src/content/blog/voice-to-prose-writing-workflow.md
+website/src/content/blog/building-commercial-software-solo-with-claude-code.md
+website/src/content/blog/dictation-parents-type-one-handed.md
+website/src/content/blog/take-lecture-notes-by-speaking.md
+website/src/content/blog/podcast-show-notes-to-blog-posts.md
+benchmark-results/apple-polish-2026-04-12/baseline.jsonl
+benchmark-results/apple-polish-2026-04-12/postchange.jsonl
+benchmark-results/apple-polish-2026-04-12/RESULTS.md
+docs/feature-requests/multilingual-v1-followup.md
+docs/feature-requests/issue-381-2026-04-20-dual-mode-router.md
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+docs/feature-requests/issue-428-2026-04-20-phase-c-transcript-coordinator.md
+docs/feature-requests/ctc-vocabulary-boosting.md
+docs/feature-requests/issue-256-2026-04-16-remove-useRefreshedWhisperKitModel-flag.md
+docs/feature-requests/issue-388-2026-04-20-textprocessingrunner-polish-step-type.md
+docs/feature-requests/issue-396-2026-04-20-pastecascadeexecutor-di-seams.md
+docs/feature-requests/multilingual-v1.md
+docs/feature-requests/issue-385-2026-04-20-acceptance-gate-drift-options.md
+docs/feature-requests/apple-intelligence-lang-gate.md
+docs/feature-requests/issue-394-2026-04-20-transcriptionpipeline-di-seams.md
+docs/feature-requests/issue-398-2026-04-20-asrmanager-backend-injection.md
+docs/feature-requests/issue-389-2026-04-20-textprocessingrunner-logger-di.md
+docs/self-hosted-runner.md
+docs/apple-intelligence-diagnostics-spec.md
+README.md
+.codex/phase-g-grounded-review.md
+scripts/eval/corpus/ci_corpus.jsonl
+scripts/eval/apple_runner/README.md
+scripts/eval/golden_judge_scores.json
+scripts/eval/baselines/gpt-4o-mini.json
+.github/pull_request_template.md
+.github/ISSUE_TEMPLATE/sentry-triage.md
+.github/CI-GOVERNANCE.md
+workers/sentry-triage/routine-prompt-v2.md
+workers/crisp-kb/markdown/22-using-ollama-for-fully-offline-ai-polish.md
+workers/crisp-kb/markdown/27-paste-goes-to-the-wrong-app.md
+workers/crisp-kb/markdown/26-first-word-gets-cut-off.md
+workers/crisp-kb/markdown/37-supported-apps.md
+workers/crisp-kb/markdown/21-apple-intelligence-setup.md
+workers/crisp-kb/markdown/09-customizing-your-hotkey.md
+workers/crisp-kb/markdown/46-paste-not-working.md
+workers/crisp-kb/markdown/53-what-data-is-collected.md
+workers/crisp-kb/markdown/52-privacy-overview.md
+workers/crisp-kb/markdown/36-warm-engine-and-performance-tuning.md
+workers/crisp-kb/markdown/05-granting-permissions-microphone-and-accessibility.md
+workers/crisp-kb/markdown/13-multi-language-dictation.md
+workers/crisp-kb/markdown/18-writing-styles-and-custom-prompts.md
+workers/crisp-kb/markdown/30-apple-intelligence-not-available.md
+workers/crisp-kb/markdown/50-voice-activity-detection-and-auto-stop.md
+workers/crisp-kb/markdown/32-app-crashes-or-asr-engine-crashes.md
+workers/crisp-kb/markdown/04-your-first-dictation.md
+workers/crisp-kb/markdown/47-choosing-your-microphone.md
+workers/crisp-kb/markdown/56-is-enviouswispr-free.md
+workers/crisp-kb/markdown/38-use-cases.md
+workers/crisp-kb/markdown/19-how-smart-polish-works-context-aware.md
+workers/crisp-kb/markdown/28-bluetooth-audio-issues.md
+workers/crisp-kb/markdown/01-what-is-enviouswispr.md
+workers/crisp-kb/markdown/55-api-key-security.md
+workers/crisp-kb/markdown/44-how-text-gets-pasted-into-your-app.md
+workers/crisp-kb/markdown/14-model-downloads-and-management.md
+workers/crisp-kb/markdown/06-push-to-talk-mode.md
+workers/crisp-kb/markdown/25-empty-or-missing-transcription.md
+workers/crisp-kb/markdown/41-adding-custom-words.md
+workers/crisp-kb/markdown/10-canceling-a-recording.md
+workers/crisp-kb/markdown/40-source-code-and-contributing.md
+workers/crisp-kb/markdown/35-filler-word-removal.md
+workers/crisp-kb/markdown/49-noise-suppression.md
+workers/crisp-kb/markdown/33-transcript-history.md
+workers/crisp-kb/markdown/51-zero-first-word-clipping.md
+workers/crisp-kb/markdown/45-clipboard-preservation.md
+workers/crisp-kb/markdown/15-live-transcription-streaming-asr.md
+workers/crisp-kb/markdown/48-bluetooth-and-airpods.md
+workers/crisp-kb/markdown/43-ai-powered-alias-suggestions.md
+workers/crisp-kb/markdown/31-recording-won-t-stop-or-seems-stuck.md
+workers/crisp-kb/markdown/17-choosing-an-ai-provider-none-apple-intelligence-ol.md
+workers/crisp-kb/markdown/16-what-is-ai-polish.md
+workers/crisp-kb/markdown/42-how-custom-word-correction-works.md
+workers/crisp-kb/markdown/07-hands-free-mode-long-dictation.md
+workers/crisp-kb/markdown/20-extended-thinking-reasoning-mode.md
+workers/crisp-kb/markdown/34-re-polish-past-transcripts.md
+workers/crisp-kb/markdown/54-ai-polish-and-cloud-data.md
+workers/crisp-kb/markdown/03-download-and-install.md
+workers/crisp-kb/markdown/39-auto-updates.md
+workers/crisp-kb/markdown/02-system-requirements.md
+workers/crisp-kb/markdown/11-choosing-a-speech-engine-parakeet-vs-whisperkit.md
+workers/crisp-kb/markdown/23-hallucination-protection.md
+workers/crisp-kb/markdown/12-how-on-device-transcription-works.md
+workers/crisp-kb/markdown/24-accessibility-permission-not-working.md
+workers/crisp-kb/markdown/08-toggle-mode.md
+workers/crisp-kb/markdown/29-ollama-polish-not-working.md
+workers/crisp-kb/articles/categories-10-13.json
+workers/crisp-kb/articles/categories-5-9.json
+workers/crisp-kb/articles/categories-1-4.json
+periphery-baseline.json
+assets/artwork/DO_NOT_DELETE.md
+
+exec
+/bin/zsh -lc 'git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 branch --show-current' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-MxsLECxf' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-5LuuFuTs' (errno=Operation not permitted)
+fix/issue-459-routine-prompt-v3.1
+
+web search: 
+web search: 
+web search: 
+web search: https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/group.py
+web search: 
+web search: site:github.com/getsentry/sentry metadata.function metadata.filename metadata.type get_event_metadata
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/src/index.js | sed -n '90,135p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+    90	    return;
+    91	  }
+    92	
+    93	  // Replay protection: reject signatures seen in last 90 min
+    94	  const sigHash = await hashString(body);
+    95	  const replayKey = `replay:${sigHash}`;
+    96	  const seen = await env.SENTRY_DEDUP.get(replayKey);
+    97	  if (seen) {
+    98	    console.log("[sentry-triage] Duplicate delivery detected, skipping");
+    99	    return;
+   100	  }
+   101	  await env.SENTRY_DEDUP.put(replayKey, "1", { expirationTtl: 5400 }); // 90 min
+   102	
+   103	  // Validate payload shape — skip metric alerts (data.metric_alert) and malformed payloads
+   104	  const issue = payload?.data?.issue;
+   105	  if (!issue) {
+   106	    console.log("[sentry-triage] No data.issue — skipping (metric alert or unknown type)");
+   107	    return;
+   108	  }
+   109	
+   110	  const action = payload.action ?? "";
+   111	  const issueId = issue.id ?? "";
+   112	  const title = issue.title ?? "";
+   113	  const culprit = issue.culprit ?? "";
+   114	  const level = (issue.level ?? "").toLowerCase();
+   115	  const userCount = parseInt(issue.userCount, 10) || 0;
+   116	  const timesSeen = parseInt(issue.count, 10) || 0; // count is a string in Sentry payloads
+   117	  const substatus = issue.substatus ?? "";
+   118	  const permalink = issue.permalink ?? issue.web_url ?? "";
+   119	  const release = issue.release ?? null;
+   120	
+   121	  if (!issueId) {
+   122	    console.error("[sentry-triage] Missing issue ID, skipping");
+   123	    return;
+   124	  }
+   125	
+   126	  const kvKey = `sentry:${issueId}`;
+   127	
+   128	  // Handle terminal actions — update KV state and exit without firing Routine
+   129	  if (action === "resolved" || action === "archived") {
+   130	    // 90-day TTL — same as fired state, prevents unbounded KV growth.
+   131	    await env.SENTRY_DEDUP.put(
+   132	      kvKey,
+   133	      JSON.stringify({ state: "resolved", updatedAt: Date.now() }),
+   134	      { expirationTtl: 7776000 } // 90 days
+   135	    );
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/src/index.js | sed -n '220,245p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   220	
+   221	  // Write pending state before firing (self-healing TTL of 10 min in case Routine never responds)
+   222	  await env.SENTRY_DEDUP.put(
+   223	    kvKey,
+   224	    JSON.stringify({ state: "pending", intent, firedAt: Date.now(), priority }),
+   225	    { expirationTtl: 600 } // 10 min TTL — overwritten with permanent entry on success
+   226	  );
+   227	
+   228	  // Fire the Routine
+   229	  const textPayload = [
+   230	    `intent: ${intent}`,
+   231	    `sentry_issue_id: ${issueId}`,
+   232	    `sentry_url: ${permalink}`,
+   233	    `title: ${title}`,
+   234	    `culprit: ${culprit}`,
+   235	    `level: ${level}`,
+   236	    `user_count: ${userCount}`,
+   237	    `times_seen: ${timesSeen}`,
+   238	    `release: ${release ?? "null"}`,
+   239	    `environment: production`,
+   240	    `priority: ${priority}`,
+   241	  ].join("\n");
+   242	
+   243	  let sessionUrl = null;
+   244	  try {
+   245	    const fireRes = await fetch(
+
+exec
+/bin/zsh -lc "rg -n \"metadata|function|filename|type|value|culprit|issues/\\?query\" workers/sentry-triage/src/index.js" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+40:async function verifyHmac(body, sigHeader, secret) {
+84:async function handleTriage(body, env) {
+106:    console.log("[sentry-triage] No data.issue — skipping (metric alert or unknown type)");
+113:  const culprit = issue.culprit ?? "";
+234:    `culprit: ${culprit}`,
+305:function classifySeverity(userCount, timesSeen, level) {
+314:async function postDiscord(webhookUrl, embed) {
+326:function buildP3Embed(issueId, title, permalink, timesSeen, userCount) {
+331:      { name: "Impact", value: `${userCount} user(s), ${timesSeen} occurrences`, inline: true },
+332:      { name: "Sentry", value: `[${issueId}](${permalink})`, inline: true },
+339:function buildCapAlertEmbed(capCount, issueId, title, permalink) {
+345:      { name: "Missed Issue", value: `[${issueId}](${permalink}) — ${title}` },
+352:function buildFailureEmbed(issueId, title, permalink, priority, errMsg) {
+358:      { name: "Issue", value: title },
+359:      { name: "Error", value: errMsg.slice(0, 200) },
+368:async function hashString(str) {
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '34,57p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are:
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit cleanly *before* GitHub work, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+    41	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+    42	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat.
+    43	- **Path A Step 8 sub-issue link failure**: log and continue.
+    44	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    45	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    46	
+    47	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+    48	
+    49	## MCP auth-expiry policy (HARD)
+    50	
+    51	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    52	
+    53	1. STOP all GitHub writes for the rest of this run, immediately.
+    54	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    55	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    56	
+    57	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+
+exec
+/bin/zsh -lc "rg -n \"log \\+|log .*continue|Log \\+|skip \\+|SKIP|CONTINUE|continue to the next|continue\\.|continue;|fall back|fallback|Other failures|Recoverable|recoverable|fatal|Fatal|exit Path D|exit cleanly|exit with|proceed with what you have|proceed to Path D\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+12:v3.1 changes (2026-04-25, fixes #459): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, instead of stack-trace fields that were only bound later in Path A. Step 1 field doc expanded to document these.
+29:- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+38:If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are:
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit cleanly *before* GitHub work, but Path D still runs.
+40:- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one issue, continue with the next.
+41:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all GitHub writes for the rest of the run, log, exit cleanly. This applies to writes only; an in-flight Path D read may continue if it doesn't write.
+42:- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat.
+43:- **Path A Step 8 sub-issue link failure**: log and continue.
+44:- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+45:- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+47:A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+55:3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+106:- `level` — "error" or "fatal".
+110:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — fall back to `culprit`, then `title`, when a specific subfield is missing.
+122:If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+138:- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+139:- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+201:# If all three subfields are empty (rare — only `metadata.value`-only issues), fall back to one query on `culprit` if it is non-empty:
+231:if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+259:- P0-critical: level=fatal OR userCount >= 10
+329:If the sub-issue link fails, log it and continue.
+356:2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+382:- If Sentry API fails, log + stop. Do not retry.
+383:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+405:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+443:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+454:Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+466:For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+479:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+504:If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+602:   422 means link already exists — fine. Other failure: log + continue.
+643:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+644:- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '379,645p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   379	## Rules (Sentry Paths A/B/C)
+   380	
+   381	- Never write code or open PRs. Triage only.
+   382	- If Sentry API fails, log + stop. Do not retry.
+   383	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+   384	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   385	- Use exact label names listed above.
+   386	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   387	- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+   388	
+   389	---
+   390	
+   391	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   392	
+   393	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   394	
+   395	### Path D HARD CONSTRAINTS
+   396	
+   397	- Read + triage only. Write allowlist:
+   398	  - Create GitHub issues (`mcp__github__issue_write`)
+   399	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   400	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   401	  - Edit issue body to APPEND the codex-source marker (append only)
+   402	  - Apply the `codex-review` label
+   403	  - Sub-issue link via `mcp__github__sub_issue_write`
+   404	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   405	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   406	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   407	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   408	
+   409	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   410	
+   411	```
+   412	mcp__github__list_pull_requests(
+   413	  owner="saurabhav88",
+   414	  repo="EnviousWispr",
+   415	  state="all",          # Codex reviews land on still-open PRs too
+   416	  sort="updated",
+   417	  direction="desc",
+   418	  perPage=20            # camelCase, NOT per_page
+   419	)
+   420	```
+   421	
+   422	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   423	
+   424	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   425	
+   426	For each returned PR, fetch its reviews via authenticated MCP:
+   427	
+   428	```
+   429	mcp__github__pull_request_read(
+   430	  owner="saurabhav88",
+   431	  repo="EnviousWispr",
+   432	  pull_number={pr_number},
+   433	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   434	)
+   435	```
+   436	
+   437	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   438	
+   439	**Filter reviews:**
+   440	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   441	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   442	
+   443	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   444	
+   445	### Step D2 — Dedup against prior triage (authenticated MCP)
+   446	
+   447	```
+   448	mcp__github__search_issues(
+   449	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   450	  perPage=100
+   451	)
+   452	```
+   453	
+   454	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   455	
+   456	For each returned issue, scan its `body` field for markers matching:
+   457	
+   458	```
+   459	<!-- codex-source: pr=<N>, review=<review_id> -->
+   460	```
+   461	
+   462	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   463	
+   464	### Step D3 — Per-event processing
+   465	
+   466	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   467	
+   468	**D3.1 Check merge state.**
+   469	
+   470	```
+   471	mcp__github__pull_request_read(
+   472	  owner="saurabhav88",
+   473	  repo="EnviousWispr",
+   474	  pull_number={pr_number},
+   475	  method="get"   # default; returns full PR object
+   476	)
+   477	```
+   478	
+   479	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   480	
+   481	**D3.2 Fetch the review body and inline comments.**
+   482	
+   483	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   484	
+   485	```
+   486	mcp__github__pull_request_read(
+   487	  owner="saurabhav88",
+   488	  repo="EnviousWispr",
+   489	  pull_number={pr_number},
+   490	  method="get_review_comments"   # or get_comments depending on MCP shape
+   491	)
+   492	```
+   493	
+   494	Filter comments by `pull_request_review_id == {review_id}`.
+   495	
+   496	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   497	
+   498	**D3.4 Consolidate findings.**
+   499	
+   500	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   501	- Each surviving inline comment is a candidate finding.
+   502	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   503	
+   504	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   505	
+   506	**D3.5 Resolve source issue.**
+   507	
+   508	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   509	
+   510	If non-null, fetch via authenticated MCP:
+   511	
+   512	```
+   513	mcp__github__issue_read(
+   514	  owner="saurabhav88",
+   515	  repo="EnviousWispr",
+   516	  issue_number={source_issue},
+   517	  method="get"
+   518	)
+   519	```
+   520	
+   521	Extract `number`, `title`, `body`, `state`, labels.
+   522	
+   523	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   524	
+   525	```
+   526	mcp__github__get_file_contents(
+   527	  owner="saurabhav88",
+   528	  repo="EnviousWispr",
+   529	  path="{path}",
+   530	  ref="{head_sha}"
+   531	)
+   532	```
+   533	
+   534	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   535	
+   536	**D3.7 Triage decision.** For each finding, ONE of:
+   537	
+   538	---
+   539	
+   540	**(a) ATTACH to source issue.** ALL of these must hold:
+   541	
+   542	1. `source_issue` is non-null.
+   543	2. Source issue does NOT have the `sentry-triage` label.
+   544	3. Finding falls within the source issue's original scope (compare against title + body).
+   545	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   546	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   547	
+   548	If any condition fails, do NOT use ATTACH. Reclassify.
+   549	
+   550	Actions:
+   551	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   552	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   553	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   554	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   555	
+   556	Comment template:
+   557	
+   558	```
+   559	**Codex post-merge feedback — related to this issue.**
+   560	
+   561	<1-3 sentences summarizing the finding in plain English>
+   562	
+   563	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   564	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   565	
+   566	<details><summary>Codex's exact text</summary>
+   567	
+   568	<quoted review body or inline comment body>
+   569	
+   570	</details>
+   571	
+   572	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   573	<!-- auto-triaged: true -->
+   574	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   575	```
+   576	
+   577	---
+   578	
+   579	**(b) CREATE new issue.** Conditions:
+   580	
+   581	- `source_issue` is null, OR
+   582	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   583	- Finding is clearly out-of-scope for the source issue.
+   584	
+   585	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   586	
+   587	Actions:
+   588	1. Create a new issue via `mcp__github__issue_write`:
+   589	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   590	   - Labels: `codex-review`, `auto-triaged`
+   591	   - Body (template below)
+   592	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   593	   ```
+   594	   mcp__github__sub_issue_write(
+   595	     owner="saurabhav88",
+   596	     repo="EnviousWispr",
+   597	     issue_number=319,
+   598	     method="add",
+   599	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   600	   )
+   601	   ```
+   602	   422 means link already exists — fine. Other failure: log + continue.
+   603	
+   604	Issue body template:
+   605	
+   606	```
+   607	## Source
+   608	- PR: #{pr_number}
+   609	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   610	- Related issue (if any): #{source_issue}
+   611	
+   612	## Finding
+   613	<1-2 sentence plain-English summary>
+   614	
+   615	## Code location
+   616	`{file}:{line}`
+   617	
+   618	## Codex's full text
+   619	<quoted>
+   620	
+   621	## Source snippet
+   622	<code around the line, fetched via mcp__github__get_file_contents>
+   623	
+   624	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   625	<!-- auto-triaged: true -->
+   626	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   627	```
+   628	
+   629	---
+   630	
+   631	**(c) IGNORE.** Conditions (ANY):
+   632	
+   633	- Finding is vague, stylistic, or purely subjective.
+   634	- You cannot confidently state why the finding is valid against the current code.
+   635	- Finding references code that no longer exists at `head_sha`.
+   636	
+   637	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   638	
+   639	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   640	
+   641	### Path D error policy
+   642	
+   643	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   644	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+   645	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '59,63p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+    59	## Per-run idempotency
+    60	
+    61	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+    62	
+    63	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '353,376p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   353	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   354	
+   355	1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+   356	2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+   357	3. Fetch latest Sentry event (Path A Step 1).
+   358	4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+   359	5. Post regression comment via `mcp__github__add_issue_comment`:
+   360	```
+   361	**Regression detected** — This issue recurred after being closed.
+   362	| Metric | Value |
+   363	|--------|-------|
+   364	| Users now | {userCount} |
+   365	| Occurrences now | {count} |
+   366	| Release now | {release} |
+   367	
+   368	[View in Sentry]({permalink})
+   369	
+   370	**Fresh hypothesis** (current source at {tag}):
+   371	> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+   372	
+   373	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   374	```
+   375	6. Add label `regression`.
+   376	
+
+exec
+/bin/zsh -lc 'rg -n "WRITTEN_THIS_RUN|Before any GitHub write|Add `shortId`|Add label|Post regression|Create GitHub issue|sub-issue link" workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+zsh:1: command not found: shortId
+43:- **Path A Step 8 sub-issue link failure**: log and continue.
+61:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+266:**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+329:If the sub-issue link fails, log it and continue.
+340:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+355:1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+356:2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+359:5. Post regression comment via `mcp__github__add_issue_comment`:
+375:6. Add label `regression`.
+387:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+398:  - Create GitHub issues (`mcp__github__issue_write`)
+407:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+553:3. Add the `codex-review` label via `mcp__github__issue_write`.
+652:- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+codex
+VERDICT: YES_WITH_REVISIONS
+
+## Fix 1 (fail-fast)
+
+Partially fixed, but not clean enough to ship as written.
+
+The new section is authoritative in shape: it replaces the old absolute fail-fast rule with default-fatal only when no local recovery exists, and explicitly says documented recoveries must continue (`workers/sentry-triage/routine-prompt-v2.md:34-47`). That resolves the original Step 2 and D1 conflict for the listed cases (`:40`, `:44`).
+
+But grep shows the list is not complete. Documented recoveries omitted from the top list include Path C sub-issue failure (`:356`), ambiguous GitHub search log+skip (`:383`), Path D generic MCP non-auth skip+continue (`:405`), D3.1-D3.7 per-event recoveries (`:466`, `:643-644`), and Path D create-issue sub-issue link failure (`:602`). Because line `:38` says “The documented per-step recoveries are,” the list reads exhaustive.
+
+Also, line `:41` says auth expiry “applies to writes only” and a Path D read may continue, but the hard policy says any GitHub MCP auth error exits with no further GitHub interaction (`:51-55`). That contradiction should be removed.
+
+## Fix 2 (Step 2.5 state gate)
+
+The open-vs-closed routing fix is correct at the gate. Step 2 exposes GitHub `state` (`:135`), Step 2.5 now checks state before throttle (`:166-171`), and closed issues explicitly bypass throttle and route to Path C (`:169`). Path C exists, is for `state == "closed"`, reopens the issue, posts a regression comment, and adds `regression` (`:353-375`). Path B’s throttle is scoped to open issues (`:333-340`), so I do not see another downstream throttle re-blocking closed regressions before Path C.
+
+Separate Path C bug: global idempotency says before any GitHub write, skip if `shortId` is already in `WRITTEN_THIS_RUN` (`:61`). Path C adds `shortId` immediately after reopening (`:355`) before the sub-issue link, regression comment, and label (`:356-375`). A literal model could reopen and then skip the comment/label writes. Move the `WRITTEN_THIS_RUN` add to the end of the Path C write sequence, or define the key as branch-entry protection only.
+
+## Fix 3 (Step 2.6 + Step 1 field doc)
+
+The field-source direction is sound. Step 1 now documents `culprit` and `metadata` as issue-list fields (`:101-112`), and Step 2.6 no longer depends on Path A stack-trace variables (`:180-182`). Sentry’s own API docs for issue-list responses include `culprit` and `metadata` in the list response schema: [project issues](https://docs.sentry.io/api/events/list-a-projects-issues/) and [organization issues](https://docs.sentry.io/api/events/list-an-organizations-issues/). Specific `metadata.function` / `filename` / `type` keys are still issue-type dependent, but the prompt handles that with per-field non-empty guards (`:185-199`).
+
+The `elif` is the remaining defect. The code block has independent `if metadata.function`, independent `if metadata.filename`, then `if metadata.type` followed by `elif culprit` (`:185-202`). In code-shaped pseudocode, that `elif` binds only to `if metadata.type`, so `culprit` can run when function or filename already ran but type is empty. Replace it with explicit prose or pseudocode: `if all of metadata.function, metadata.filename, metadata.type are empty AND culprit is non-empty`.
+
+## Other findings
+
+`workers/sentry-triage/routine-prompt-v2.md:110` says fall back to `culprit`, then `title`, but Step 2.6 never uses `title`; it skips when `metadata.function/filename/type/culprit` are absent (`:209`). Either remove `title` from the field doc or add a guarded title query.
+
+`workers/sentry-triage/routine-prompt-v2.md:355-359` reopens before fetching the latest Sentry event (`:357`), while the reused event-fetch failure path skips the issue on failure (`:231-235`). That can leave a reopened issue without the regression comment if event fetch fails. Fetch first, or define a minimal fail-soft regression comment after reopen.
+
+## Recommendation
+
+Apply the listed revisions before ship. The three intended fixes are directionally right, but the failure list completeness, auth-policy contradiction, Step 2.6 `elif`, and Path C idempotency issue are enough to require one more prompt patch.
+2026-04-25T15:21:02.018114Z ERROR codex_core::session: failed to record rollout items: thread 019dc535-cdd0-7bd1-942a-44a980f42959 not found
+tokens used
+247,211
+VERDICT: YES_WITH_REVISIONS
+
+## Fix 1 (fail-fast)
+
+Partially fixed, but not clean enough to ship as written.
+
+The new section is authoritative in shape: it replaces the old absolute fail-fast rule with default-fatal only when no local recovery exists, and explicitly says documented recoveries must continue (`workers/sentry-triage/routine-prompt-v2.md:34-47`). That resolves the original Step 2 and D1 conflict for the listed cases (`:40`, `:44`).
+
+But grep shows the list is not complete. Documented recoveries omitted from the top list include Path C sub-issue failure (`:356`), ambiguous GitHub search log+skip (`:383`), Path D generic MCP non-auth skip+continue (`:405`), D3.1-D3.7 per-event recoveries (`:466`, `:643-644`), and Path D create-issue sub-issue link failure (`:602`). Because line `:38` says “The documented per-step recoveries are,” the list reads exhaustive.
+
+Also, line `:41` says auth expiry “applies to writes only” and a Path D read may continue, but the hard policy says any GitHub MCP auth error exits with no further GitHub interaction (`:51-55`). That contradiction should be removed.
+
+## Fix 2 (Step 2.5 state gate)
+
+The open-vs-closed routing fix is correct at the gate. Step 2 exposes GitHub `state` (`:135`), Step 2.5 now checks state before throttle (`:166-171`), and closed issues explicitly bypass throttle and route to Path C (`:169`). Path C exists, is for `state == "closed"`, reopens the issue, posts a regression comment, and adds `regression` (`:353-375`). Path B’s throttle is scoped to open issues (`:333-340`), so I do not see another downstream throttle re-blocking closed regressions before Path C.
+
+Separate Path C bug: global idempotency says before any GitHub write, skip if `shortId` is already in `WRITTEN_THIS_RUN` (`:61`). Path C adds `shortId` immediately after reopening (`:355`) before the sub-issue link, regression comment, and label (`:356-375`). A literal model could reopen and then skip the comment/label writes. Move the `WRITTEN_THIS_RUN` add to the end of the Path C write sequence, or define the key as branch-entry protection only.
+
+## Fix 3 (Step 2.6 + Step 1 field doc)
+
+The field-source direction is sound. Step 1 now documents `culprit` and `metadata` as issue-list fields (`:101-112`), and Step 2.6 no longer depends on Path A stack-trace variables (`:180-182`). Sentry’s own API docs for issue-list responses include `culprit` and `metadata` in the list response schema: [project issues](https://docs.sentry.io/api/events/list-a-projects-issues/) and [organization issues](https://docs.sentry.io/api/events/list-an-organizations-issues/). Specific `metadata.function` / `filename` / `type` keys are still issue-type dependent, but the prompt handles that with per-field non-empty guards (`:185-199`).
+
+The `elif` is the remaining defect. The code block has independent `if metadata.function`, independent `if metadata.filename`, then `if metadata.type` followed by `elif culprit` (`:185-202`). In code-shaped pseudocode, that `elif` binds only to `if metadata.type`, so `culprit` can run when function or filename already ran but type is empty. Replace it with explicit prose or pseudocode: `if all of metadata.function, metadata.filename, metadata.type are empty AND culprit is non-empty`.
+
+## Other findings
+
+`workers/sentry-triage/routine-prompt-v2.md:110` says fall back to `culprit`, then `title`, but Step 2.6 never uses `title`; it skips when `metadata.function/filename/type/culprit` are absent (`:209`). Either remove `title` from the field doc or add a guarded title query.
+
+`workers/sentry-triage/routine-prompt-v2.md:355-359` reopens before fetching the latest Sentry event (`:357`), while the reused event-fetch failure path skips the issue on failure (`:231-235`). That can leave a reopened issue without the regression comment if event fetch fails. Fetch first, or define a minimal fail-soft regression comment after reopen.
+
+## Recommendation
+
+Apply the listed revisions before ship. The three intended fixes are directionally right, but the failure list completeness, auth-policy contradiction, Step 2.6 `elif`, and Path C idempotency issue are enough to require one more prompt patch.

--- a/docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt
+++ b/docs/audits/2026-04-25-routine-v3.1-grounded-review-pass2.txt
@@ -1,0 +1,1505 @@
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2
+--------
+user
+# Grounded review pass 2 — Sentry triage v3.1 (post-revision)
+
+You did pass 1 and returned YES_WITH_REVISIONS with six concrete revisions:
+1. Failure list at top is incomplete — add Path C sub-issue, Step 2 ambiguous-search, Path D generic non-auth, D3.1-D3.7, Path D create-issue sub-link.
+2. Auth-expiry "writes only" contradicts the hard policy — remove the writes-only clause.
+3. Step 2.6 elif binds only to `metadata.type`; rewrite as explicit "all three empty AND culprit non-empty".
+4. Step 1 field doc says "fall back to culprit, then title" but Step 2.6 never uses title — drop title.
+5. Path C idempotency bug — `WRITTEN_THIS_RUN` add at step 1 (after reopen) blocks subsequent writes; move to end of sequence OR redefine as branch-entry check.
+6. Path C reopens before fetching Sentry event; on event-fetch failure the issue is reopened without a regression comment — fetch first OR fail-soft regression comment.
+
+All six revisions have been applied. The patch is now +110/-25 (was +58/-18).
+
+## Your job
+
+Re-read `/Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1/workers/sentry-triage/routine-prompt-v2.md` (full file) and the diff `git -C /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1 diff origin/main`. Confirm:
+
+A. Each of the 6 revisions is correctly applied.
+B. The revisions did not introduce new bugs (e.g., Path C reordering broke a downstream invariant; the idempotency rephrase broke Path A or Path D semantics; the failure list is now over-broad).
+C. There is nothing else in the diff that contradicts the rest of the file.
+
+Be ruthless. The same file:line citation rule applies. Output:
+
+```
+VERDICT: YES | YES_WITH_REVISIONS | NO
+
+## Revision 1 (failure list completeness)
+[verified | issue at file:line]
+
+## Revision 2 (auth-expiry contradiction)
+[verified | issue]
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+[verified | issue]
+
+## Revision 4 (drop "then title")
+[verified | issue]
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+[verified | issue]
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+[verified | issue]
+
+## New issues introduced (if any)
+[file:line + description]
+
+## Recommendation
+[ship as-is | apply listed revisions before ship | do not ship]
+```
+codex
+I’ll treat this as a read-only review and re-ground it in the current file plus the `origin/main` diff. I’ll also do a quick memory lookup because this is in the EnviousLabs/Sentry review area, then rely on live file evidence for the verdict.
+exec
+/bin/zsh -lc 'wc -l workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     697 workers/sentry-triage/routine-prompt-v2.md
+
+exec
+/bin/zsh -lc 'rg -n "sentry-triage|routine-prompt|Sentry triage|wt-routine|routine-v3" /Users/m4pro_sv/.codex/memories/MEMORY.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+exec
+/bin/zsh -lc 'git diff --stat origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ exited 1 in 0ms:
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-rr8mlMZj' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-uNJr7RPC' (errno=Operation not permitted)
+ workers/sentry-triage/routine-prompt-v2.md | 135 +++++++++++++++++++++++------
+ 1 file changed, 110 insertions(+), 25 deletions(-)
+
+codex
+Memory had no matching entry for this exact routine prompt, so I’m staying on the live file and diff. The diff stat matches your stated `+110/-25`; next I’m reading the file in numbered chunks and the patch text.
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '1,180p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+     1	<!--
+     2	Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+     3	
+     4	Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+     5	This file may drift from the live prompt. To sync, copy from the Routine
+     6	edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+     7	
+     8	Live schedule: every 4 hours on cron `7 */4 * * *`.
+     9	
+    10	v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+    11	
+    12	v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+    13	-->
+    14	
+    15	You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+    16	
+    17	HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+    18	  - Creating GitHub issues (via `mcp__github__issue_write`)
+    19	  - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+    20	  - Reopening GitHub issues (via `mcp__github__issue_write`)
+    21	  - Adding labels (via `mcp__github__issue_write`)
+    22	  - Linking sub-issues (via `mcp__github__sub_issue_write`)
+    23	  - Editing an issue body to APPEND a marker (Path D only; append-only)
+    24	
+    25	## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+    26	
+    27	You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+    28	
+    29	- `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+    30	- POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+    31	- Any tool that prompts the user to visit a URL or perform an action.
+    32	- `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+    33	
+    34	## Failure handling (default vs per-step recovery)
+    35	
+    36	If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+    37	
+    38	If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+    39	- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+    40	- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+    41	- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+    42	- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+    43	- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+    44	- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+    45	- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+    46	- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 2 sub-issue link.
+    47	- **Path C step 2 sub-issue link failure** (and any other Path C sub-step write failure between reopen and the regression comment): log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+    48	- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+    49	- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+    50	- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+    51	- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+    52	- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+    53	
+    54	A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+    55	
+    56	## MCP auth-expiry policy (HARD)
+    57	
+    58	If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+    59	
+    60	1. STOP all GitHub writes for the rest of this run, immediately.
+    61	2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+    62	3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+    63	
+    64	This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+    65	
+    66	## Per-run idempotency
+    67	
+    68	Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+    69	
+    70	- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C, OR Path D Step D3 decides ATTACH vs CREATE for a finding): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+    71	- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-finding sequence): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence.
+    72	
+    73	This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+    74	
+    75	## Tool usage
+    76	
+    77	- **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+    78	- **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+    79	- **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+    80	- **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+    81	
+    82	## Step 0 — Fetch git tags
+    83	
+    84	```bash
+    85	git fetch --tags 2>/dev/null || true
+    86	```
+    87	
+    88	Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+    89	
+    90	## Step 1 — Query Sentry for recent activity
+    91	
+    92	Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+    93	
+    94	```bash
+    95	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    96	  "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+    97	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    98	BODY=$(echo "$RESPONSE" | sed '$d')
+    99	if [ "$HTTP_CODE" != "200" ]; then
+   100	  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+   101	  exit 0
+   102	fi
+   103	# JSON sanity check (Sentry returns HTML on 5xx)
+   104	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   105	  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+   106	  echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   107	  exit 0
+   108	fi
+   109	```
+   110	
+   111	Each issue object has these fields (use exact names):
+   112	- `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+   113	- `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+   114	- `count` — total event count (integer).
+   115	- `userCount` — distinct users affected (integer).
+   116	- `level` — "error" or "fatal".
+   117	- `firstSeen`, `lastSeen` — ISO timestamps.
+   118	- `permalink` — full Sentry URL to the issue.
+   119	- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+   120	- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+   121	
+   122	When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+   123	
+   124	Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+   125	
+   126	```python
+   127	from datetime import datetime, timezone, timedelta
+   128	cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+   129	# Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+   130	```
+   131	
+   132	If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+   133	
+   134	## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+   135	
+   136	For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+   137	
+   138	```
+   139	mcp__github__search_issues(
+   140	  query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   141	  perPage=10
+   142	)
+   143	```
+   144	
+   145	Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+   146	
+   147	If the MCP call errors:
+   148	- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+   149	- If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+   150	
+   151	Route based on result:
+   152	
+   153	---
+   154	
+   155	## Step 2.5 — Read prior agent decisions (durable memory)
+   156	
+   157	Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+   158	
+   159	```
+   160	mcp__github__issue_read(
+   161	  owner="saurabhav88",
+   162	  repo="EnviousWispr",
+   163	  issue_number=<N>,
+   164	  method="get_comments"  # or fetch issue + comments separately
+   165	)
+   166	```
+   167	
+   168	Grep the combined body+comments for markers matching:
+   169	
+   170	```
+   171	<!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+   172	```
+   173	
+   174	Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+   175	
+   176	**Default action when prior agent marker exists — gate on issue state FIRST:**
+   177	
+   178	- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+   179	- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+   180	
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '181,360p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   181	This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+   182	
+   183	**If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+   184	- New severity differs from prior severity, OR
+   185	- You're routing to a different `source_issue` than prior, OR
+   186	- You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+   187	
+   188	---
+   189	
+   190	## Step 2.6 — Cross-reference search (catch fingerprint splits)
+   191	
+   192	If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+   193	
+   194	Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+   195	
+   196	```
+   197	# Independent queries — run each one whose key field is non-empty.
+   198	# Order does not matter; results are aggregated for the matching bar below.
+   199	
+   200	If metadata.function is non-empty:
+   201	  mcp__github__search_issues(
+   202	    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   203	    perPage = 10
+   204	  )
+   205	
+   206	If metadata.filename is non-empty:
+   207	  mcp__github__search_issues(
+   208	    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   209	    perPage = 10
+   210	  )
+   211	
+   212	If metadata.type is non-empty AND distinct from metadata.function
+   213	   (e.g., an exception class like `audio_capture_failed`):
+   214	  mcp__github__search_issues(
+   215	    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   216	    perPage = 10
+   217	  )
+   218	
+   219	# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+   220	If metadata.function is empty
+   221	   AND metadata.filename is empty
+   222	   AND metadata.type is empty
+   223	   AND culprit is non-empty:
+   224	  mcp__github__search_issues(
+   225	    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+   226	    perPage = 10
+   227	  )
+   228	```
+   229	
+   230	If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+   231	
+   232	For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+   233	1. Same crashing function name (`metadata.function`)
+   234	2. Same source filename (`metadata.filename`)
+   235	3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+   236	4. Same release range (issue's stated release vs Sentry's `release` field)
+   237	5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+   238	
+   239	If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+   240	
+   241	---
+   242	
+   243	### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+   244	
+   245	**1. Fetch full event with stack trace:**
+   246	
+   247	```bash
+   248	RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   249	  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+   250	HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+   251	BODY=$(echo "$RESPONSE" | sed '$d')
+   252	if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+   253	if ! echo "$BODY" | jq empty 2>/dev/null; then
+   254	  echo "Event response not JSON. Skipping this issue."
+   255	  continue
+   256	fi
+   257	```
+   258	
+   259	Use the numeric `id` field, NOT `shortId`.
+   260	
+   261	The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+   262	
+   263	**2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+   264	
+   265	**3. Extract git tag from `release` field:**
+   266	- Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+   267	- Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+   268	- Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+   269	- If release is null or missing, note it and use HEAD.
+   270	
+   271	**4. Read source at crash site:**
+   272	
+   273	```bash
+   274	git show {tag}:{filename} | sed -n '{start},{end}p'
+   275	```
+   276	
+   277	Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+   278	
+   279	**5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+   280	- P0-critical: level=fatal OR userCount >= 10
+   281	- P1-high: userCount >= 3 OR count >= 20
+   282	- P2-medium: userCount >= 2 OR count >= 5
+   283	- P3-low: everything else
+   284	
+   285	**6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+   286	
+   287	**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+   288	
+   289	Title: `P{n}: {area} — {symptom in plain English}`
+   290	
+   291	Labels (exact names — they exist in the repo):
+   292	- `bug`
+   293	- One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+   294	- `sentry-triage`
+   295	- `auto-triaged`
+   296	- One of: `env-production`, `env-development`
+   297	
+   298	Body:
+   299	```
+   300	## Summary
+   301	[1-2 sentences: what error occurred, in plain English]
+   302	
+   303	## Impact
+   304	| Metric | Value |
+   305	|--------|-------|
+   306	| Users affected | {userCount} |
+   307	| Total occurrences | {count} |
+   308	| First seen | {firstSeen} |
+   309	| Last seen | {lastSeen} |
+   310	| Environment | production or development |
+   311	| Release | {release} |
+   312	
+   313	## Crash site
+   314	\`{filename}:{lineNo}\` in \`{function}\`
+   315	
+   316	## Source at crash
+   317	<details><summary>Code at {tag}</summary>
+   318	
+   319	[~20 lines centered on crash line]
+   320	
+   321	</details>
+   322	
+   323	## Hypothesis
+   324	> Unvalidated. Auto-generated from stack trace analysis only.
+   325	
+   326	[2 sentences OR fail-soft sentence per Step 6]
+   327	
+   328	## References
+   329	- [Sentry issue]({permalink})
+   330	- [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+   331	[- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+   332	
+   333	<!-- sentry-issue-id: {shortId} -->
+   334	<!-- auto-triaged: true -->
+   335	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   336	```
+   337	
+   338	**8. Parent the new issue under the Bugs epic (#317):**
+   339	
+   340	```
+   341	mcp__github__sub_issue_write(
+   342	  owner="saurabhav88",
+   343	  repo="EnviousWispr",
+   344	  issue_number=317,
+   345	  method="add",
+   346	  sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+   347	)
+   348	```
+   349	
+   350	If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   351	
+   352	---
+   353	
+   354	### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+   355	
+   356	**Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+   357	- Event count has at least doubled since last reported in any prior agent comment, OR
+   358	- New users affected since last comment, OR
+   359	- No `agent:sentry-triage` comment in the last 24h
+   360	
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '361,540p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   361	If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+   362	
+   363	Comment via `mcp__github__add_issue_comment`:
+   364	```
+   365	**Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+   366	
+   367	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   368	```
+   369	
+   370	If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+   371	
+   372	---
+   373	
+   374	### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+   375	
+   376	**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+   377	
+   378	1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
+   379	2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+   380	3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
+   381	4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+   382	5. Post regression comment via `mcp__github__add_issue_comment`:
+   383	
+   384	   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+   385	```
+   386	**Regression detected** — This issue recurred after being closed.
+   387	| Metric | Value |
+   388	|--------|-------|
+   389	| Users now | {userCount} |
+   390	| Occurrences now | {count} |
+   391	| Release now | {release} |
+   392	
+   393	[View in Sentry]({permalink})
+   394	
+   395	**Fresh hypothesis** (current source at {tag}):
+   396	> [2 sentences — re-analyze, don't copy original.]
+   397	
+   398	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   399	```
+   400	
+   401	   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
+   402	```
+   403	**Regression detected** — This issue recurred after being closed.
+   404	| Metric | Value |
+   405	|--------|-------|
+   406	| Users now | {userCount} |
+   407	| Occurrences now | {count} |
+   408	| Last seen | {lastSeen} |
+   409	| Release now | {release} |
+   410	
+   411	[View in Sentry]({permalink})
+   412	
+   413	**Fresh hypothesis:**
+   414	> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+   415	
+   416	<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   417	```
+   418	
+   419	   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+   420	6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+   421	
+   422	---
+   423	
+   424	## Rules (Sentry Paths A/B/C)
+   425	
+   426	- Never write code or open PRs. Triage only.
+   427	- If Sentry API fails, log + stop. Do not retry.
+   428	- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+   429	- Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+   430	- Use exact label names listed above.
+   431	- GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+   432	- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+   433	
+   434	---
+   435	
+   436	## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+   437	
+   438	Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+   439	
+   440	### Path D HARD CONSTRAINTS
+   441	
+   442	- Read + triage only. Write allowlist:
+   443	  - Create GitHub issues (`mcp__github__issue_write`)
+   444	  - Reopen GitHub issues (`mcp__github__issue_write`)
+   445	  - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   446	  - Edit issue body to APPEND the codex-source marker (append only)
+   447	  - Apply the `codex-review` label
+   448	  - Sub-issue link via `mcp__github__sub_issue_write`
+   449	- Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+   450	- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+   451	- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+   452	- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+   453	
+   454	### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+   455	
+   456	```
+   457	mcp__github__list_pull_requests(
+   458	  owner="saurabhav88",
+   459	  repo="EnviousWispr",
+   460	  state="all",          # Codex reviews land on still-open PRs too
+   461	  sort="updated",
+   462	  direction="desc",
+   463	  perPage=20            # camelCase, NOT per_page
+   464	)
+   465	```
+   466	
+   467	**Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+   468	
+   469	**Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+   470	
+   471	For each returned PR, fetch its reviews via authenticated MCP:
+   472	
+   473	```
+   474	mcp__github__pull_request_read(
+   475	  owner="saurabhav88",
+   476	  repo="EnviousWispr",
+   477	  pull_number={pr_number},
+   478	  method="get_reviews"          # NOT summary="reviews" — that's not valid
+   479	)
+   480	```
+   481	
+   482	Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+   483	
+   484	**Filter reviews:**
+   485	- `user.login == "chatgpt-codex-connector[bot]"` — strict match
+   486	- AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+   487	
+   488	**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+   489	
+   490	### Step D2 — Dedup against prior triage (authenticated MCP)
+   491	
+   492	```
+   493	mcp__github__search_issues(
+   494	  query="label:codex-review repo:saurabhav88/EnviousWispr",
+   495	  perPage=100
+   496	)
+   497	```
+   498	
+   499	Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+   500	
+   501	For each returned issue, scan its `body` field for markers matching:
+   502	
+   503	```
+   504	<!-- codex-source: pr=<N>, review=<review_id> -->
+   505	```
+   506	
+   507	Build a set of already-triaged `(pr_number, review_id)` pairs. Drop reviews whose pair is in the set. Remaining reviews are un-triaged and proceed to Step D3.
+   508	
+   509	### Step D3 — Per-event processing
+   510	
+   511	For each un-triaged review, execute D3.1 through D3.7 in order. Per-event failures are recoverable: log + skip + continue.
+   512	
+   513	**D3.1 Check merge state.**
+   514	
+   515	```
+   516	mcp__github__pull_request_read(
+   517	  owner="saurabhav88",
+   518	  repo="EnviousWispr",
+   519	  pull_number={pr_number},
+   520	  method="get"   # default; returns full PR object
+   521	)
+   522	```
+   523	
+   524	Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+   525	
+   526	**D3.2 Fetch the review body and inline comments.**
+   527	
+   528	The review body is already in the result from Step D1's `get_reviews` call. For inline comments:
+   529	
+   530	```
+   531	mcp__github__pull_request_read(
+   532	  owner="saurabhav88",
+   533	  repo="EnviousWispr",
+   534	  pull_number={pr_number},
+   535	  method="get_review_comments"   # or get_comments depending on MCP shape
+   536	)
+   537	```
+   538	
+   539	Filter comments by `pull_request_review_id == {review_id}`.
+   540	
+
+exec
+/bin/zsh -lc "nl -ba workers/sentry-triage/routine-prompt-v2.md | sed -n '541,720p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+   541	**D3.3 Filter OUTDATED inline comments.** Drop any inline comment where `position` is null.
+   542	
+   543	**D3.4 Consolidate findings.**
+   544	
+   545	- Top-level review body: keep as a finding ONLY if it contains actionable content (names a file, function, line, or observable defect — not just acknowledgement).
+   546	- Each surviving inline comment is a candidate finding.
+   547	- If an inline comment restates the top-level body, treat as ONE finding (inline is authoritative).
+   548	
+   549	If after consolidation there are zero findings, SKIP this event silently. Do NOT stamp a marker, do NOT create an issue.
+   550	
+   551	**D3.5 Resolve source issue.**
+   552	
+   553	Parse the PR `body` for first case-insensitive match of `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. If no match, `source_issue = null`.
+   554	
+   555	If non-null, fetch via authenticated MCP:
+   556	
+   557	```
+   558	mcp__github__issue_read(
+   559	  owner="saurabhav88",
+   560	  repo="EnviousWispr",
+   561	  issue_number={source_issue},
+   562	  method="get"
+   563	)
+   564	```
+   565	
+   566	Extract `number`, `title`, `body`, `state`, labels.
+   567	
+   568	**D3.6 Fetch code context (authenticated MCP).** Budget: ~150 lines total across all findings for this event.
+   569	
+   570	```
+   571	mcp__github__get_file_contents(
+   572	  owner="saurabhav88",
+   573	  repo="EnviousWispr",
+   574	  path="{path}",
+   575	  ref="{head_sha}"
+   576	)
+   577	```
+   578	
+   579	For inline comments: extract ~20 lines centered on `line` (start = max(1, line-10), end = line+10). For top-level review body that references a specific file: same. Skip code context for reviews that don't reference a specific location.
+   580	
+   581	**D3.7 Triage decision.** For each finding, ONE of:
+   582	
+   583	---
+   584	
+   585	**(a) ATTACH to source issue.** ALL of these must hold:
+   586	
+   587	1. `source_issue` is non-null.
+   588	2. Source issue does NOT have the `sentry-triage` label.
+   589	3. Finding falls within the source issue's original scope (compare against title + body).
+   590	4. Finding is CONCRETE: references a specific function, file, line, or observable defect.
+   591	5. You can CONFIDENTLY explain in 1-2 sentences WHY the finding is valid against the code you read.
+   592	
+   593	If any condition fails, do NOT use ATTACH. Reclassify.
+   594	
+   595	Actions:
+   596	1. If source issue state is "closed", REOPEN via `mcp__github__issue_write`.
+   597	2. Post a comment via `mcp__github__add_issue_comment` (template below).
+   598	3. Add the `codex-review` label via `mcp__github__issue_write`.
+   599	4. APPEND the codex-source marker to the source issue body via `mcp__github__issue_write` (read existing body first, append marker line, write back). Preserve all existing content.
+   600	
+   601	Comment template:
+   602	
+   603	```
+   604	**Codex post-merge feedback — related to this issue.**
+   605	
+   606	<1-3 sentences summarizing the finding in plain English>
+   607	
+   608	**Code location:** `{file}:{line}` (from PR #{pr_number})
+   609	**Codex review:** https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   610	
+   611	<details><summary>Codex's exact text</summary>
+   612	
+   613	<quoted review body or inline comment body>
+   614	
+   615	</details>
+   616	
+   617	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   618	<!-- auto-triaged: true -->
+   619	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=attached run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   620	```
+   621	
+   622	---
+   623	
+   624	**(b) CREATE new issue.** Conditions:
+   625	
+   626	- `source_issue` is null, OR
+   627	- `source_issue` carries the `sentry-triage` label (off-limits), OR
+   628	- Finding is clearly out-of-scope for the source issue.
+   629	
+   630	AND the finding is CONCRETE and you can confidently explain why it is valid.
+   631	
+   632	Actions:
+   633	1. Create a new issue via `mcp__github__issue_write`:
+   634	   - Title: `Codex finding: <one-line summary> (from #{pr_number})`
+   635	   - Labels: `codex-review`, `auto-triaged`
+   636	   - Body (template below)
+   637	2. Sub-issue link to Epic: Hardening & Refactors (#319):
+   638	   ```
+   639	   mcp__github__sub_issue_write(
+   640	     owner="saurabhav88",
+   641	     repo="EnviousWispr",
+   642	     issue_number=319,
+   643	     method="add",
+   644	     sub_issue_id=<numeric .id of new issue, NOT .number>
+   645	   )
+   646	   ```
+   647	   422 means link already exists — fine. Other failure: log + continue.
+   648	
+   649	Issue body template:
+   650	
+   651	```
+   652	## Source
+   653	- PR: #{pr_number}
+   654	- Codex review: https://github.com/saurabhav88/EnviousWispr/pull/{pr_number}#pullrequestreview-{review_id}
+   655	- Related issue (if any): #{source_issue}
+   656	
+   657	## Finding
+   658	<1-2 sentence plain-English summary>
+   659	
+   660	## Code location
+   661	`{file}:{line}`
+   662	
+   663	## Codex's full text
+   664	<quoted>
+   665	
+   666	## Source snippet
+   667	<code around the line, fetched via mcp__github__get_file_contents>
+   668	
+   669	<!-- codex-source: pr={pr_number}, review={review_id} -->
+   670	<!-- auto-triaged: true -->
+   671	<!-- agent:sentry-triage v=3 source=codex pr={pr_number} review={review_id} decision=created run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+   672	```
+   673	
+   674	---
+   675	
+   676	**(c) IGNORE.** Conditions (ANY):
+   677	
+   678	- Finding is vague, stylistic, or purely subjective.
+   679	- You cannot confidently state why the finding is valid against the current code.
+   680	- Finding references code that no longer exists at `head_sha`.
+   681	
+   682	Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Move on.
+   683	
+   684	**Default to IGNORE when uncertain.** Less noise is better than false positives. This is an explicit founder decision.
+   685	
+   686	### Path D error policy
+   687	
+   688	- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+   689	- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+   690	- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+   691	
+   692	### Path D rules
+   693	
+   694	- Process events in chronological order (oldest `submitted_at` first).
+   695	- All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
+   696	- GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
+   697	- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc "git diff --unified=80 origin/main -- workers/sentry-triage/routine-prompt-v2.md | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+exec
+/bin/zsh -lc "git diff --unified=80 origin/main -- workers/sentry-triage/routine-prompt-v2.md | sed -n '221,440p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-w51Q2YWu' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-L0XZ6Llw' (errno=Operation not permitted)
++    perPage = 10
++  )
++
++If metadata.filename is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++If metadata.type is non-empty AND distinct from metadata.function
++   (e.g., an exception class like `audio_capture_failed`):
++  mcp__github__search_issues(
++    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
++
++# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
++If metadata.function is empty
++   AND metadata.filename is empty
++   AND metadata.type is empty
++   AND culprit is non-empty:
++  mcp__github__search_issues(
++    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
++    perPage = 10
++  )
+ ```
+ 
++If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
++
+ For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
+-1. Same crashing function name
+-2. Same source filename
+-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
++1. Same crashing function name (`metadata.function`)
++2. Same source filename (`metadata.filename`)
++3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+ 4. Same release range (issue's stated release vs Sentry's `release` field)
+-5. Same plausible precondition (issue's hypothesis vs new stack)
++5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+ 
+ If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
+ 
+ ---
+ 
+ ### Path A — `total_count == 0` AND no cross-reference hit (NEW SENTRY ISSUE)
+ 
+ **1. Fetch full event with stack trace:**
+ 
+ ```bash
+ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/latest/")
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then echo "Sentry event fetch failed: HTTP $HTTP_CODE. Skipping this issue."; continue; fi
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+   echo "Event response not JSON. Skipping this issue."
+   continue
+ fi
+ ```
+ 
+ Use the numeric `id` field, NOT `shortId`.
+ 
+ The response contains `entries[]` — look for the entry with `type: "exception"`. Inside: `values[].stacktrace.frames[]`. Each frame has `filename`, `function`, `lineNo`, `module`, `inApp`.
+ 
+ **2. Find the crash frame:** Walk frames from the END of the array (most recent call). Find the first frame where `inApp == true` AND `filename` starts with `Sources/`. Skip Apple framework frames.
+ 
+ **3. Extract git tag from `release` field:**
+ - Production: `com.enviouswispr.app@v1.9.3` — tag is `v1.9.3`
+ - Dev build: `com.enviouswispr.app@v1.9.3-4-gabcdef-dev` — base tag is `v1.9.3`
+ - Environment: contains `-dev` or `-N-g` = development. Otherwise = production.
+ - If release is null or missing, note it and use HEAD.
+ 
+ **4. Read source at crash site:**
+ 
+ ```bash
+ git show {tag}:{filename} | sed -n '{start},{end}p'
+ ```
+ 
+ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, use HEAD and note: "Source shown is HEAD (tag {tag} not found)".
+ 
+ **5. Classify severity (deterministic rules; you may override with explicit reason in body):**
+ - P0-critical: level=fatal OR userCount >= 10
+ - P1-high: userCount >= 3 OR count >= 20
+ - P2-medium: userCount >= 2 OR count >= 5
+ - P3-low: everything else
+ 
+ **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+ 
+-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
++**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+ 
+ Title: `P{n}: {area} — {symptom in plain English}`
+ 
+ Labels (exact names — they exist in the repo):
+ - `bug`
+ - One of: `P0-critical`, `P1-high`, `P2-medium`, `P3-low`
+ - `sentry-triage`
+ - `auto-triaged`
+ - One of: `env-production`, `env-development`
+ 
+ Body:
+ ```
+ ## Summary
+ [1-2 sentences: what error occurred, in plain English]
+ 
+ ## Impact
+ | Metric | Value |
+ |--------|-------|
+ | Users affected | {userCount} |
+ | Total occurrences | {count} |
+ | First seen | {firstSeen} |
+ | Last seen | {lastSeen} |
+ | Environment | production or development |
+ | Release | {release} |
+ 
+ ## Crash site
+ \`{filename}:{lineNo}\` in \`{function}\`
+ 
+ ## Source at crash
+ <details><summary>Code at {tag}</summary>
+ 
+ [~20 lines centered on crash line]
+ 
+ </details>
+ 
+ ## Hypothesis
+ > Unvalidated. Auto-generated from stack trace analysis only.
+ 
+ [2 sentences OR fail-soft sentence per Step 6]
+ 
+ ## References
+ - [Sentry issue]({permalink})
+ - [Triage session](https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID})
+ [- Possibly related: #N (single dimension match: <which>)  — if Step 2.6 found one]
+ 
+ <!-- sentry-issue-id: {shortId} -->
+ <!-- auto-triaged: true -->
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=created severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
+ **8. Parent the new issue under the Bugs epic (#317):**
+ 
+ ```
+ mcp__github__sub_issue_write(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   issue_number=317,
+   method="add",
+   sub_issue_id=<numeric DB id of newly-created issue (.id, NOT .number)>
+ )
+ ```
+ 
+-If the sub-issue link fails, log it and continue.
++If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ### Path B — GitHub issue found, `state == "open"` (ACCUMULATING)
+ 
+ **Throttle (KEEP STRICT — protects against update loops):** Only post a comment if AT LEAST ONE of:
+ - Event count has at least doubled since last reported in any prior agent comment, OR
+ - New users affected since last comment, OR
+ - No `agent:sentry-triage` comment in the last 24h
+ 
+ If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+ 
+ Comment via `mcp__github__add_issue_comment`:
+ ```
+ **Sentry update** — {userCount} users affected, {count} total occurrences as of {today}. Last event: {lastSeen}. Release: {release}. [View in Sentry]({permalink})
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+ 
+ If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
+ 
+ ---
+ 
+ ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+ 
+-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
+-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
+-3. Fetch latest Sentry event (Path A Step 1).
+-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
++**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
++
++1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
++2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
++3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
++4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
+ 5. Post regression comment via `mcp__github__add_issue_comment`:
++
++   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+ ```
+ **Regression detected** — This issue recurred after being closed.
+ | Metric | Value |
+ |--------|-------|
+ | Users now | {userCount} |
+ | Occurrences now | {count} |
+ | Release now | {release} |
+ 
+ [View in Sentry]({permalink})
+ 
+ **Fresh hypothesis** (current source at {tag}):
+-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
++> [2 sentences — re-analyze, don't copy original.]
+ 
+ <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+ ```
+-6. Add label `regression`.
++
++   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
++```
++**Regression detected** — This issue recurred after being closed.
++| Metric | Value |
++|--------|-------|
++| Users now | {userCount} |
++| Occurrences now | {count} |
++| Last seen | {lastSeen} |
++| Release now | {release} |
++
+
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-g3efxOvY' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-2Ve6GM9U' (errno=Operation not permitted)
+diff --git a/workers/sentry-triage/routine-prompt-v2.md b/workers/sentry-triage/routine-prompt-v2.md
+index a623d8b..1f02d8a 100644
+--- a/workers/sentry-triage/routine-prompt-v2.md
++++ b/workers/sentry-triage/routine-prompt-v2.md
+@@ -1,415 +1,500 @@
+ <!--
+ Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
+ 
+ Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
+ This file may drift from the live prompt. To sync, copy from the Routine
+ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+ 
+ Live schedule: every 4 hours on cron `7 */4 * * *`.
+ 
+ v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
++
++v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+ -->
+ 
+ You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
+ 
+ HARD CONSTRAINT: You are a read + triage agent only. You NEVER write code, NEVER open pull requests, NEVER commit files, NEVER edit source files. Your only write operations are:
+   - Creating GitHub issues (via `mcp__github__issue_write`)
+   - Commenting on GitHub issues (via `mcp__github__add_issue_comment` or `mcp__github__issue_write`)
+   - Reopening GitHub issues (via `mcp__github__issue_write`)
+   - Adding labels (via `mcp__github__issue_write`)
+   - Linking sub-issues (via `mcp__github__sub_issue_write`)
+   - Editing an issue body to APPEND a marker (Path D only; append-only)
+ 
+ ## ABSOLUTELY FORBIDDEN tool calls (ZERO EXCEPTIONS)
+ 
+ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
+ 
+ - `mcp__github__authenticate`, `mcp__github__complete_authentication` — these prompt the user to open a browser URL. Meaningless in unattended cron. If you see an "authorize" URL response from any tool, log it and exit cleanly.
+ - POSTs to `discord.com`, Slack webhooks, or any HTTP endpoint outside `api.github.com`, `us.sentry.io`, and the GitHub MCP tool surface. The sandbox blocks these. Three prior runs wasted turns hallucinating Discord recovery — don't repeat.
+ - Any tool that prompts the user to visit a URL or perform an action.
+ - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
+ 
+-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
++## Failure handling (default vs per-step recovery)
++
++If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
++
++If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
++- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
++- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
++- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
++- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
++- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
++- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
++- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
++- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 2 sub-issue link.
++- **Path C step 2 sub-issue link failure** (and any other Path C sub-step write failure between reopen and the regression comment): log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
++- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
++- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
++- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
++- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
++- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
++
++A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
+ 
+ ## MCP auth-expiry policy (HARD)
+ 
+ If any GitHub MCP call returns an error containing "authoriz", "token expired", "re-authorization required", or similar:
+ 
+ 1. STOP all GitHub writes for the rest of this run, immediately.
+ 2. Log: `GITHUB_MCP_AUTH_EXPIRED: <error text>. Manual re-auth required at claude.ai. Exiting cleanly.`
+ 3. Exit with no further GitHub interaction. Do NOT fall back to curl. Do NOT call authenticate tools. Do NOT retry.
+ 
+ This protects against duplicate-issue creation when MCP search returns false-empty mid-run.
+ 
+ ## Per-run idempotency
+ 
+-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
++Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
++
++- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C, OR Path D Step D3 decides ATTACH vs CREATE for a finding): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
++- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-finding sequence): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence.
+ 
+-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
++This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+ 
+ ## Tool usage
+ 
+ - **Sentry API:** Use `curl` with `$SENTRY_AUTH_TOKEN` (env var, available in your environment).
+ - **GitHub reads:** Use authenticated GitHub MCP tools (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`, `mcp__github__search_issues`, `mcp__github__issue_read`, `mcp__github__list_issue_comments`, `mcp__github__get_file_contents`). NO unauthenticated curl.
+ - **GitHub writes:** Use authenticated GitHub MCP tools (`mcp__github__issue_write`, `mcp__github__add_issue_comment`, `mcp__github__sub_issue_write`).
+ - **Source code:** Use `git show` on the local clone (available in your working directory) for the Path A crash-frame snippet. For Codex reviews on PRs whose head SHA may not exist in the local clone, use `mcp__github__get_file_contents` with `ref=<head_sha>`.
+ 
+ ## Step 0 — Fetch git tags
+ 
+ ```bash
+ git fetch --tags 2>/dev/null || true
+ ```
+ 
+ Ensures `git show v{tag}:{file}` works in Path A Step 4. Fallback-to-HEAD logic handles tag misses.
+ 
+ ## Step 1 — Query Sentry for recent activity
+ 
+ Fetch unresolved issues sorted by most recent activity. We query `is:unresolved` because the user does not resolve/archive issues in Sentry. GitHub is the source of truth for open/closed status.
+ 
+ ```bash
+ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+   "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
+ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+ BODY=$(echo "$RESPONSE" | sed '$d')
+ if [ "$HTTP_CODE" != "200" ]; then
+   echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+   exit 0
+ fi
+ # JSON sanity check (Sentry returns HTML on 5xx)
+ if ! echo "$BODY" | jq empty 2>/dev/null; then
+   echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
+   exit 0
+ fi
+ ```
+ 
+ Each issue object has these fields (use exact names):
+ - `id` — numeric string, e.g. "7406757774". Use this in Sentry API URLs.
+ - `shortId` — e.g. "ENVIOUSWISPR-D". Use this for the GitHub issue footer tag and idempotency key.
+ - `count` — total event count (integer).
+ - `userCount` — distinct users affected (integer).
+ - `level` — "error" or "fatal".
+ - `firstSeen`, `lastSeen` — ISO timestamps.
+ - `permalink` — full Sentry URL to the issue.
++- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
++- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
++
++When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+ 
+ Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
+ 
+ ```python
+ from datetime import datetime, timezone, timedelta
+ cutoff = datetime.now(timezone.utc) - timedelta(hours=5, minutes=10)
+ # Keep issue if datetime.fromisoformat(issue['lastSeen'].replace('Z','+00:00')) > cutoff
+ ```
+ 
+ If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+ 
+ ## Step 2 — For each Sentry issue, check GitHub state (authenticated MCP)
+ 
+ For each issue from Step 1, search GitHub via MCP for an existing tracking issue:
+ 
+ ```
+ mcp__github__search_issues(
+   query="sentry-issue-id {shortId} repo:saurabhav88/EnviousWispr",
+   perPage=10
+ )
+ ```
+ 
+ Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+ 
+ If the MCP call errors:
+ - If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+ - If other error: log the shortId + error and SKIP this Sentry issue (do NOT assume "no GitHub issue exists" — that creates duplicates).
+ 
+ Route based on result:
+ 
+ ---
+ 
+ ## Step 2.5 — Read prior agent decisions (durable memory)
+ 
+ Before deciding NEW vs RECURRING-OPEN vs RECURRING-CLOSED, fetch the issue body AND comments to see what the agent decided previously:
+ 
+ ```
+ mcp__github__issue_read(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   issue_number=<N>,
+   method="get_comments"  # or fetch issue + comments separately
+ )
+ ```
+ 
+ Grep the combined body+comments for markers matching:
+ 
+ ```
+ <!-- agent:sentry-triage v=3 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source=sentry run_id=<id> -->
+ ```
+ 
+ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
+ 
+-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++**Default action when prior agent marker exists — gate on issue state FIRST:**
++
++- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
++- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
++
++This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+ 
+ **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
+ - New severity differs from prior severity, OR
+ - You're routing to a different `source_issue` than prior, OR
+ - You're changing decision class (e.g., agent previously said `ignored` and you now say it's a real bug).
+ 
+ ---
+ 
+ ## Step 2.6 — Cross-reference search (catch fingerprint splits)
+ 
+-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
++If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
++
++Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+ 
+ ```
+-mcp__github__search_issues(
+-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
+-mcp__github__search_issues(
+-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+-  perPage=10
+-)
++# Independent queries — run each one whose key field is non-empty.
++# Order does not matter; results are aggregated for the matching bar below.
++
++If metadata.function is non-empty:
++  mcp__github__search_issues(
++    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+
+exec
+/bin/zsh -lc "git diff --unified=80 origin/main -- workers/sentry-triage/routine-prompt-v2.md | sed -n '441,700p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-6MCIB6Lv' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-1M6n2T1v' (errno=Operation not permitted)
++[View in Sentry]({permalink})
++
++**Fresh hypothesis:**
++> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
++
++<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
++```
++
++   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
++6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+ 
+ ---
+ 
+ ## Rules (Sentry Paths A/B/C)
+ 
+ - Never write code or open PRs. Triage only.
+ - If Sentry API fails, log + stop. Do not retry.
+ - If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+ - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
+ - Use exact label names listed above.
+ - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
+ - Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+ 
+ ---
+ 
+ ## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+ 
+ Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+ 
+ ### Path D HARD CONSTRAINTS
+ 
+ - Read + triage only. Write allowlist:
+   - Create GitHub issues (`mcp__github__issue_write`)
+   - Reopen GitHub issues (`mcp__github__issue_write`)
+   - Comment on GitHub issues (`mcp__github__add_issue_comment`)
+   - Edit issue body to APPEND the codex-source marker (append only)
+   - Apply the `codex-review` label
+   - Sub-issue link via `mcp__github__sub_issue_write`
+ - Before any write to a pre-existing issue, verify the issue does NOT have the `sentry-triage` label. If it does, OFF-LIMITS — reclassify the decision as CREATE.
+ - On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+ - Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+ - Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+ 
+ ### Step D1 — Fetch Codex review events (authenticated MCP, bounded recent-PR scan)
+ 
+ ```
+ mcp__github__list_pull_requests(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   state="all",          # Codex reviews land on still-open PRs too
+   sort="updated",
+   direction="desc",
+   perPage=20            # camelCase, NOT per_page
+ )
+ ```
+ 
+ **Bounded scan:** process the entire returned page. Stop fetching the next page when ANY returned PR on the current page has `updated_at < (now - 5h10m)`. Hard cap 5 pages (~100 PRs) for safety.
+ 
+ **Token-cap awareness:** `list_pull_requests` results may exceed the MCP per-tool token cap and be saved to a file. The MCP returns a "result file saved at /path/to/file" notice — read via `Read` with offsets in chunks. This is expected behavior, not a failure. Do NOT retry the call thinking it failed.
+ 
+ For each returned PR, fetch its reviews via authenticated MCP:
+ 
+ ```
+ mcp__github__pull_request_read(
+   owner="saurabhav88",
+   repo="EnviousWispr",
+   pull_number={pr_number},
+   method="get_reviews"          # NOT summary="reviews" — that's not valid
+ )
+ ```
+ 
+ Returned reviews JSON has fields: `id`, `state`, `body`, `user.login`, `commit_id`, `submitted_at`, `author_association`.
+ 
+ **Filter reviews:**
+ - `user.login == "chatgpt-codex-connector[bot]"` — strict match
+ - AND `submitted_at >= (now - 5h10m)` — only recent reviews; old Codex reviews on recently-updated PRs must NOT re-enter
+ 
+ **Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+ 
+ ### Step D2 — Dedup against prior triage (authenticated MCP)
+ 
+ ```
+ mcp__github__search_issues(
+   query="label:codex-review repo:saurabhav88/EnviousWispr",
+   perPage=100
+ )
+ ```
+ 
+ Response: `{total_count, incomplete_results, items[]}`. If `total_count > 100` OR `incomplete_results == true`: log a warning and proceed with what you have. Today's `codex-review` issue count is ~30, well below the cap. Revisit pagination when count approaches 100 (12+ months at current rate).
+ 
+
+codex
+The core revisions are present, but I’m seeing at least one remaining internal contradiction around Step 1 failure handling: the new recovery list says Sentry API failure should still allow Path D, while the Step 1 shell block and later Sentry rules still say to exit/stop. I’m checking for any other stale idempotency or title references before I write the verdict.
+exec
+/bin/zsh -lc "rg -n \"title|WRITTEN_THIS_RUN|auth-expiry|Sentry API fails|exit 0|Stopping|Path D|ambiguous|culprit|metadata\\.function|metadata\\.filename|metadata\\.type\" workers/sentry-triage/routine-prompt-v2.md" in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+10:v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+12:v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
+23:  - Editing an issue body to APPEND a marker (Path D only; append-only)
+39:- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+41:- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+42:- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+47:- **Path C step 2 sub-issue link failure** (and any other Path C sub-step write failure between reopen and the regression comment): log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+48:- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+49:- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+50:- **Path D Step D2 dedup-search non-auth failure**: log + skip that one PR, continue to the next.
+51:- **Path D Step D3.1–D3.7 per-finding failures** (e.g., `mcp__github__get_file_contents`, single-finding `issue_write`, comment write, label write, sub-issue link): log + skip that one finding, continue with the next finding on the same PR.
+52:- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue.
+56:## MCP auth-expiry policy (HARD)
+68:Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
+70:- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C, OR Path D Step D3 decides ATTACH vs CREATE for a finding): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+71:- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-finding sequence): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence.
+100:  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+101:  exit 0
+107:  exit 0
+119:- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+120:- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+122:When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
+132:If zero issues pass the filter, log a summary and proceed to Path D. Don't stop — Codex review triage still runs.
+145:Response: `{total_count, incomplete_results, items[]}`. Each item has `number`, `state` ("open" or "closed"), `title`, `body`.
+148:- If error indicates auth expired: trigger MCP auth-expiry policy above, exit cleanly.
+192:If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+194:Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
+200:If metadata.function is non-empty:
+202:    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+206:If metadata.filename is non-empty:
+208:    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+212:If metadata.type is non-empty AND distinct from metadata.function
+215:    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+219:# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+220:If metadata.function is empty
+221:   AND metadata.filename is empty
+222:   AND metadata.type is empty
+223:   AND culprit is non-empty:
+225:    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+230:If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
+233:1. Same crashing function name (`metadata.function`)
+234:2. Same source filename (`metadata.filename`)
+235:3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
+237:5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
+287:**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
+350:If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
+361:If none of those conditions hold, skip silently. Add `shortId` to `WRITTEN_THIS_RUN` to prevent re-evaluation.
+376:**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+379:2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+419:   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+420:6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+427:- If Sentry API fails, log + stop. Do not retry.
+428:- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+432:- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+436:## Path D — Codex PR feedback triage (additive, isolated from Sentry)
+438:Executes AFTER Sentry Paths A/B/C. Path D must NEVER modify any issue, comment, or state created by Sentry paths. Any issue carrying the `sentry-triage` label is Sentry-managed and OFF-LIMITS to Path D.
+440:### Path D HARD CONSTRAINTS
+450:- On any GitHub MCP error: trigger MCP auth-expiry policy if applicable, otherwise log + skip event + continue. Do NOT retry. Do NOT leave partial state.
+451:- Sentry output from Paths A/B/C is authoritative. Path D never modifies Sentry writes.
+452:- Per-run idempotency: track `(pr_number, review_id)` pairs in `WRITTEN_THIS_RUN`.
+488:**Per-PR error handling:** If `pull_request_read` errors for one PR, log the PR number + error, CONTINUE to the next PR. Only the outer `list_pull_requests` failing is fatal for Path D. Single-PR failures are NOT fatal.
+524:Extract `merged_at`, `title`, `body`, head SHA, labels. If `merged_at` is null, SKIP this event (open PRs are out of scope).
+566:Extract `number`, `title`, `body`, `state`, labels.
+589:3. Finding falls within the source issue's original scope (compare against title + body).
+686:### Path D error policy
+688:- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
+690:- **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
+692:### Path D rules
+697:- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+
+exec
+/bin/zsh -lc 'git diff --check origin/main -- workers/sentry-triage/routine-prompt-v2.md' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Hg122DOX' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-tklw6S2w' (errno=Operation not permitted)
+
+exec
+/bin/zsh -lc 'git status --short' in /Users/m4pro_sv/Developer/EnviousLabs/wt-routine-v3.1
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-Wrek7AHN' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-1mV6kdQA' (errno=Operation not permitted)
+ M workers/sentry-triage/routine-prompt-v2.md
+
+codex
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship
+2026-04-25T15:36:45.156185Z ERROR codex_core::session: failed to record rollout items: thread 019dc546-3b5b-7fd2-93ac-af3dcbcc25f2 not found
+tokens used
+62,686
+VERDICT: YES_WITH_REVISIONS
+
+## Revision 1 (failure list completeness)
+issue at `workers/sentry-triage/routine-prompt-v2.md:46-47`: Path C sub-issue recovery was added, but both bullets still call it “Path C step 2”; after the reorder, Path C step 2 is reopen and the sub-issue link is step 3 (`workers/sentry-triage/routine-prompt-v2.md:378-380`).
+
+Also issue at `workers/sentry-triage/routine-prompt-v2.md:39`: the new list says Step 1 Sentry HTTP/non-JSON failure still lets Path D run, but the Step 1 shell block exits the whole run (`workers/sentry-triage/routine-prompt-v2.md:99-107`) and the Sentry rules still say “log + stop” (`workers/sentry-triage/routine-prompt-v2.md:427`).
+
+## Revision 2 (auth-expiry contradiction)
+verified — the failure list now says auth expiry stops GitHub read AND write interaction (`workers/sentry-triage/routine-prompt-v2.md:42`), and the hard policy exits with no further GitHub interaction (`workers/sentry-triage/routine-prompt-v2.md:58-62`).
+
+## Revision 3 (Step 2.6 elif → explicit AND)
+verified — culprit fallback is now explicitly gated on all three metadata fields being empty AND culprit being non-empty (`workers/sentry-triage/routine-prompt-v2.md:219-227`).
+
+## Revision 4 (drop "then title")
+verified — Step 1 documents `culprit` and `metadata`, with fallback only to culprit when metadata function/filename/type are empty; no Sentry title fallback remains there (`workers/sentry-triage/routine-prompt-v2.md:119-122`).
+
+## Revision 5 (idempotency branch-entry semantics + Path A/C reorder)
+issue at `workers/sentry-triage/routine-prompt-v2.md:432`: stale Sentry rule still says “before any write, check `WRITTEN_THIS_RUN`,” contradicting the new branch-entry-only semantics at `workers/sentry-triage/routine-prompt-v2.md:68-72`.
+
+Path A/C reorder itself is applied: Path A delays add until after sub-link (`workers/sentry-triage/routine-prompt-v2.md:287`, `workers/sentry-triage/routine-prompt-v2.md:350`), and Path C delays add until step 6 (`workers/sentry-triage/routine-prompt-v2.md:376`, `workers/sentry-triage/routine-prompt-v2.md:420`).
+
+## Revision 6 (Path C event-fetch-before-reopen + fail-soft template)
+verified — Path C now fetches the event before reopen and falls through with `event = null` on fetch failure (`workers/sentry-triage/routine-prompt-v2.md:378-379`), then has a fail-soft regression comment template (`workers/sentry-triage/routine-prompt-v2.md:401-417`).
+
+## New issues introduced (if any)
+`workers/sentry-triage/routine-prompt-v2.md:68-72`, `workers/sentry-triage/routine-prompt-v2.md:581-648`, `workers/sentry-triage/routine-prompt-v2.md:697` — Path D idempotency is underspecified/broken after the branch-entry rewrite. The key is `(pr_number, review_id)`, but D3 processes multiple findings per review. The text says each branch states when its key is added, yet ATTACH/CREATE do not add it, and adding it per finding would skip later findings from the same review.
+
+## Recommendation
+apply listed revisions before ship

--- a/workers/sentry-triage/routine-prompt-v2.md
+++ b/workers/sentry-triage/routine-prompt-v2.md
@@ -8,6 +8,8 @@ edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
 Live schedule: every 4 hours on cron `7 */4 * * *`.
 
 v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+
+v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
 -->
 
 You are an automated Sentry triage agent for EnviousWispr (macOS voice-to-text app, repo: saurabhav88/EnviousWispr). You run every 4 hours on a schedule.
@@ -29,7 +31,29 @@ You MUST NOT call any of these. If `ToolSearch` surfaces them, ignore them.
 - Any tool that prompts the user to visit a URL or perform an action.
 - `curl` against `api.github.com` for READS — use the GitHub MCP. Writes already use the MCP. After v3, NO unauthenticated GitHub curl calls remain.
 
-If a step fails, log the failure and exit cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths.
+## Failure handling (default vs per-step recovery)
+
+If a step fails AND that step has no documented per-step recovery, log the failure and exit the run cleanly. Do NOT retry. Do NOT add backoff. Do NOT invent recovery paths not in this prompt.
+
+If the step DOES document a per-step recovery, follow that recovery and continue. The documented per-step recoveries are (this list is the source of truth — if the body of any step below contradicts a recovery clause stated here, this list wins for the question of "should I continue or exit"):
+- **Step 1 Sentry HTTP-status guard** (non-200 or non-JSON body): exit Sentry paths A/B/C cleanly, but Path D still runs.
+- **Step 2 GitHub MCP non-auth error** for one Sentry issue: log shortId + error and SKIP that one Sentry issue, continue with the next.
+- **Step 2 ambiguous GitHub search hit count** (e.g., multiple matches that could route to different existing issues): log + skip that Sentry issue, continue with the next.
+- **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
+- **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
+- **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+- **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
+- **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
+- **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
+- **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+- **Path D Step D1 outer `mcp__github__list_pull_requests` non-auth failure**: log + exit Path D cleanly (other Sentry paths in the same run are unaffected). Auth-expiry triggers the hard policy.
+- **Path D Step D1 per-PR `pull_request_read` failure**: log the PR number + error, continue to the next PR.
+- **Path D Step D2 dedup-search (`label:codex-review` issues fetch) non-auth failure**: this is a SHARED setup step, not per-PR. Without it the agent cannot tell which `(pr, review)` pairs are already triaged. Log + EXIT Path D cleanly. Do NOT continue retriaging without the dedup set. Auth-expiry triggers the hard policy.
+- **Path D Step D3.1, D3.2, or D3.5 failures** (PR merge-state read, review-body/comments fetch, source-issue resolution — these run BEFORE any per-finding work): log + skip the ENTIRE review (all findings on this `(pr, review)` together). Do NOT proceed to D3.6/D3.7 without merge-state, review-body, or source-issue context. Continue to the next un-triaged review.
+- **Path D Step D3.3, D3.4, D3.6, or D3.7 per-finding failures** (filter outdated, consolidate, fetch code context for one finding, single-finding `issue_write`/comment/label/sub-link): log + skip THAT one finding, continue with the next finding on the same review.
+- **Path D create-issue sub-issue link failure** (Path D's own sub-link to epic #319): log + continue with the next finding.
+
+A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues and PR reviews that should still be processed.
 
 ## MCP auth-expiry policy (HARD)
 
@@ -43,9 +67,12 @@ This protects against duplicate-issue creation when MCP search returns false-emp
 
 ## Per-run idempotency
 
-Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). Before any GitHub write, check the set. If the key is present, skip silently. If you write, add the key.
+Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId` (Sentry side) or `(pr_number, review_id)` pair (Codex side). The check is performed at **branch entry**, not on every individual write within a multi-step branch:
 
-This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run.
+- **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId, OR Path D enters Step D3 for a `(pr, review)` pair to process ALL its findings): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
+- **Within a branch** (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation processing all findings from that review): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — typically at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add; Path D: end of D3 after all findings from that `(pr, review)` are processed).
+
+This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
 
 ## Tool usage
 
@@ -71,13 +98,18 @@ RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $SENTRY_AUTH_TO
   "https://us.sentry.io/api/0/projects/envious-labs-llc/enviouswispr/issues/?query=is:unresolved&sort=date&limit=25")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
+# Note for the agent: `exit 0` below exits THIS bash subprocess only.
+# It does NOT terminate the routine run. After bash returns, you read the
+# stdout, see "Sentry Paths A/B/C only — Path D still runs", and proceed
+# directly to Path D. Empirically validated 2026-04-25 (run session_019VuL8TQB7fjgbjsY2Lyojn:
+# Sentry 503 → this exit 0 fired → Path D triaged Codex review of #458 → 0 errors).
 if [ "$HTTP_CODE" != "200" ]; then
-  echo "Sentry API error: HTTP $HTTP_CODE. Stopping."
+  echo "Sentry API error: HTTP $HTTP_CODE. Stopping Sentry Paths A/B/C only — Path D still runs."
   exit 0
 fi
 # JSON sanity check (Sentry returns HTML on 5xx)
 if ! echo "$BODY" | jq empty 2>/dev/null; then
-  echo "Sentry response is not valid JSON (likely upstream HTML error). Exiting cleanly."
+  echo "Sentry response is not valid JSON (likely upstream HTML error). Stopping Sentry Paths A/B/C only — Path D still runs."
   echo "BODY (first 500 chars): $(echo "$BODY" | head -c 500)"
   exit 0
 fi
@@ -91,6 +123,10 @@ Each issue object has these fields (use exact names):
 - `level` — "error" or "fatal".
 - `firstSeen`, `lastSeen` — ISO timestamps.
 - `permalink` — full Sentry URL to the issue.
+- `culprit` — Sentry's grouping locator, typically `"<function_name> (<filename>)"` or `"<function>"` or `"<filename>"`. Bound at issue-list time from the grouping fingerprint. Use for Step 2.6 cross-reference search.
+- `metadata` — object with grouping-derived fields, also bound at list time. Common keys for crash issues: `metadata.function` (string, crash function name), `metadata.filename` (string, source file), `metadata.type` (string, exception type or error symbol like `EXC_BREAKPOINT`, `audio_capture_failed`, `xpc_service_error`), `metadata.value` (string, error message). Some issues only have a subset (e.g., a `console.error` issue may only have `metadata.value`). Treat each subfield as optional — Step 2.6 falls back to `culprit` only when all three of `metadata.function` / `metadata.filename` / `metadata.type` are empty.
+
+When you preserve fields with jq for downstream use, include `culprit` and `metadata` in the projection. Otherwise Step 2.6's cross-reference search is non-executable.
 
 Filter to issues where `lastSeen` is within the last 5 hours (overlap window for the 4h cron + clock skew):
 
@@ -144,7 +180,12 @@ Grep the combined body+comments for markers matching:
 
 Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`.
 
-**Default action when prior agent marker exists:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+**Default action when prior agent marker exists — gate on issue state FIRST:**
+
+- **If the GitHub issue is OPEN:** apply Path B's existing throttle (event count doubled OR new users OR no Sentry update comment in last 24h). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
+- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply (severity / source_issue / decision-class changes still need an explicit `Reversing prior agent call from <date>:` opener).
+
+This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
 
 **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
 - New severity differs from prior severity, OR
@@ -155,25 +196,52 @@ Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ign
 
 ## Step 2.6 — Cross-reference search (catch fingerprint splits)
 
-If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location before creating:
+If Step 2's search returned `total_count == 0` (would route to Path A NEW), perform a SECOND search by code location BEFORE creating. **Use the Sentry-list fields already bound at this step** (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) — do NOT defer to Path A's stack-trace fetch (which runs after this step). If a specific subfield is missing on this Sentry issue, skip the query that needs it; do not synthesize a placeholder.
+
+Run each query only when its key field is non-empty on this Sentry issue. The four queries are independent — running one does NOT skip the others. The `culprit` query is a fallback that runs only when none of the three `metadata.*` keys is bound.
 
 ```
-mcp__github__search_issues(
-  query="<crashing-function-name> in:title,body repo:saurabhav88/EnviousWispr is:issue",
-  perPage=10
-)
-mcp__github__search_issues(
-  query="<source-filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
-  perPage=10
-)
+# Independent queries — run each one whose key field is non-empty.
+# Order does not matter; results are aggregated for the matching bar below.
+
+If metadata.function is non-empty:
+  mcp__github__search_issues(
+    query = "<metadata.function> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+    perPage = 10
+  )
+
+If metadata.filename is non-empty:
+  mcp__github__search_issues(
+    query = "<metadata.filename> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+    perPage = 10
+  )
+
+If metadata.type is non-empty AND distinct from metadata.function
+   (e.g., an exception class like `audio_capture_failed`):
+  mcp__github__search_issues(
+    query = "<metadata.type> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+    perPage = 10
+  )
+
+# Fallback. Only runs when NONE of metadata.function, metadata.filename, metadata.type is bound.
+If metadata.function is empty
+   AND metadata.filename is empty
+   AND metadata.type is empty
+   AND culprit is non-empty:
+  mcp__github__search_issues(
+    query = "<culprit> in:title,body repo:saurabhav88/EnviousWispr is:issue",
+    perPage = 10
+  )
 ```
+
+If NONE of `metadata.function`, `metadata.filename`, `metadata.type`, or `culprit` is bound on this Sentry issue (unusual), skip Step 2.6 entirely with a one-line log (`Step 2.6 skipped: no metadata.function/filename/type/culprit bound on shortId X`) and proceed to Path A NEW. Do NOT run vacuous queries with placeholder strings.
 
 For each candidate hit, decide whether to route to Path B (comment on existing) instead of Path A (create new). **Bar: at least TWO of these must match between the new Sentry data and the candidate issue:**
-1. Same crashing function name
-2. Same source filename
-3. Same exception type / error symbol (e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `asr_empty_result`)
+1. Same crashing function name (`metadata.function`)
+2. Same source filename (`metadata.filename`)
+3. Same exception type / error symbol (`metadata.type`, e.g., `EXC_BREAKPOINT`, `xpc_service_error`, `audio_capture_failed`)
 4. Same release range (issue's stated release vs Sentry's `release` field)
-5. Same plausible precondition (issue's hypothesis vs new stack)
+5. Same plausible precondition (issue's hypothesis vs Sentry `metadata.value` / `culprit`)
 
 If 2+ match: route as Path B. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**` If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
 
@@ -223,7 +291,7 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
 
 **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
 
-**7. Create GitHub issue** via `mcp__github__issue_write`. Add `shortId` to `WRITTEN_THIS_RUN` set.
+**7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
 
 Title: `P{n}: {area} — {symptom in plain English}`
 
@@ -286,7 +354,7 @@ mcp__github__sub_issue_write(
 )
 ```
 
-If the sub-issue link fails, log it and continue.
+If the sub-issue link fails, log it and continue. Then add `shortId` to `WRITTEN_THIS_RUN`.
 
 ---
 
@@ -306,17 +374,23 @@ Comment via `mcp__github__add_issue_comment`:
 <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=updated severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
 ```
 
+After the comment write completes, add `shortId` to `WRITTEN_THIS_RUN`.
+
 If new severity differs from prior agent comment's severity, prepend `**Reversing prior agent severity from {prior_severity} to {new_severity}: <reason>.**` per Step 2.5's reversal rule, and use `decision=reversed`.
 
 ---
 
 ### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
 
-1. Reopen via `mcp__github__issue_write` (set state=open). Add `shortId` to `WRITTEN_THIS_RUN`.
-2. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue.
-3. Fetch latest Sentry event (Path A Step 1).
-4. Read source at CURRENT release tag (`git show {tag}:{filename}`).
+**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+
+1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
+2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
+3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
+4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
 5. Post regression comment via `mcp__github__add_issue_comment`:
+
+   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
 ```
 **Regression detected** — This issue recurred after being closed.
 | Metric | Value |
@@ -328,23 +402,43 @@ If new severity differs from prior agent comment's severity, prepend `**Reversin
 [View in Sentry]({permalink})
 
 **Fresh hypothesis** (current source at {tag}):
-> [2 sentences — re-analyze, don't copy original. Use Step 6 fail-soft if evidence insufficient.]
+> [2 sentences — re-analyze, don't copy original.]
 
 <!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
 ```
-6. Add label `regression`.
+
+   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
+```
+**Regression detected** — This issue recurred after being closed.
+| Metric | Value |
+|--------|-------|
+| Users now | {userCount} |
+| Occurrences now | {count} |
+| Last seen | {lastSeen} |
+| Release now | {release} |
+
+[View in Sentry]({permalink})
+
+**Fresh hypothesis:**
+> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
+
+<!-- agent:sentry-triage v=3 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+```
+
+   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
+6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
 
 ---
 
 ## Rules (Sentry Paths A/B/C)
 
 - Never write code or open PRs. Triage only.
-- If Sentry API fails, log + stop. Do not retry.
-- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip.
+- If Sentry API fails (Step 1 HTTP guard or jq sanity check), log + stop **Sentry Paths A/B/C only**. Do not retry. Path D still runs (it is independent of Sentry).
+- If GitHub MCP search is ambiguous (multiple matches for one Sentry shortId), do NOT create a duplicate. Log + skip THAT Sentry issue, continue to the next.
 - Process Sentry issues in ORDER RECEIVED from Step 1 (FIFO). Do not reorder by severity — that risks dropping lower-severity items if turn budget runs out, and the per-issue idempotency key prevents duplicate work on next tick.
 - Use exact label names listed above.
 - GitHub issue email notifications are the user's signal channel for P1/P2/P3. P0 paging is handled OUTSIDE this Routine via the Sentry Issue Alert → Discord rule (configured 2026-04-25). Do not attempt Discord or other webhooks from inside this Routine.
-- Per-run idempotency: before any write, check `WRITTEN_THIS_RUN`. If shortId or (pr,review) pair is present, skip.
+- Per-run idempotency: branch-entry check only (see "Per-run idempotency" section above). The `WRITTEN_THIS_RUN` add happens at end of each path (Path A step 8, Path B end-of-comment, Path C step 6), NOT before each individual write within the path.
 
 ---
 
@@ -600,8 +694,13 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
 
 ### Path D error policy
 
-- **Fatal (exit Path D):** the Step D1 outer `mcp__github__list_pull_requests` call fails with auth-expiry → trigger global MCP auth-expiry policy. Other outer failures: log + exit Path D cleanly.
-- **Recoverable (skip this event/PR, continue):** per-PR `pull_request_read` failures in Step D1 inner loop, OR per-event failures in D3.1 through D3.7. Log, move to next item.
+See the authoritative Failure-handling list at the top of the prompt for the canonical Path D recoveries. Summary by failure scope:
+
+- **Exit Path D entirely (non-auth):** Step D1 outer `mcp__github__list_pull_requests` failure, Step D2 dedup-search failure (shared setup — without it, dedup is broken across all reviews).
+- **Auth-expiry on any GitHub MCP call (Path D scope):** trigger global MCP auth-expiry policy. Run terminates.
+- **Skip one PR, continue Path D:** per-PR `pull_request_read` failure in Step D1's inner loop.
+- **Skip the WHOLE review, continue Path D:** Step D3.1 (merge state), D3.2 (review body / inline comments), or D3.5 (source-issue resolve) failure. These run BEFORE any per-finding work; without them, downstream findings would be under-grounded.
+- **Skip ONE finding, continue with the next finding on the same review:** D3.3, D3.4, D3.6, D3.7 per-finding failures, AND the create-issue sub-issue link failure.
 - **Sentry protection:** Path D must never modify issues Sentry paths created (detected via `sentry-triage` label). If in doubt, do not write.
 
 ### Path D rules
@@ -609,4 +708,4 @@ Action: NONE. Do not create an issue, do not stamp a marker, do not comment. Mov
 - Process events in chronological order (oldest `submitted_at` first).
 - All GitHub interactions use authenticated MCP. NO unauthenticated curl. NO calls to `mcp__github__authenticate`.
 - GitHub issue email notifications are the user's signal channel. Do not attempt Discord or any external webhook from this Routine.
-- Per-run idempotency: track `(pr_number, review_id)` in `WRITTEN_THIS_RUN`.
+- Per-run idempotency for Path D: the key is `(pr_number, review_id)` and is checked at **branch entry to D3** for the WHOLE review (not per-finding). One review may produce multiple findings; all findings within the same `(pr, review)` are processed in a single D3 invocation. Add `(pr_number, review_id)` to `WRITTEN_THIS_RUN` AFTER the last finding from that review has been processed (ATTACH, CREATE, or IGNORE outcome stamped). This way later findings on the same review are NOT skipped, AND a logic-branch loop that re-encounters the same review on the same run skips it cleanly.


### PR DESCRIPTION
## Summary

Single-file patch to `workers/sentry-triage/routine-prompt-v2.md` (the live Sentry triage Routine prompt at `trig_01Crr6qjS5HyQ1i3KbrezPfK`). Closes #459 once paste-synced to live.

Three Codex post-merge findings on the v3 deploy (#458) plus four follow-on issues caught across two grounded-review passes and two code-diff review passes. Original v3 was deployed this morning and ran 2× cron cleanly (sessions `018ucrzNMKKmxJTNoKypLkFu`, `019VuL8TQB7fjgbjsY2Lyojn`) — no unauth GitHub 403s, no Discord, no auth-loops. Run 1 self-flagged the three v3 prompt defects this PR fixes.

## What changed

**#459 P0s:**

- Replaced absolute "exit cleanly on any failure" rule (line 32 of v3) with a typed default-vs-per-step recovery list. The list is authoritative — "if step body contradicts a recovery clause stated in the list, the list wins." Single transient errors no longer terminate the whole run when the prompt documents skip-and-continue. Auth-expiry is the one BROADER policy that still terminates the run.
- Step 2.5 default action now gates on issue-state BEFORE applying the throttle. Closed-issue regressions route to Path C (reopen + regression comment) instead of being silently swallowed by the throttle.
- Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) bound at issue-list time, instead of stack-trace fields only bound later in Path A. Step 1 field doc expanded to declare them. Per-field non-empty guards + explicit AND-gated `culprit` fallback (no elif scoping bug).

**Latent v3 bugs caught by review passes:**

- Per-run idempotency reframed as **branch-entry check**, not per-write. Multi-step branches (Path A's 8 steps, Path C's 6 steps, Path D's per-review D3 invocation) no longer self-block after the first write.
- Path A and Path C reordered to add the `WRITTEN_THIS_RUN` key at end-of-sequence (Path A step 8 after sub-link, Path B end-of-comment, Path C step 6 after label add, Path D after the last finding from the same `(pr, review)`).
- Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template (5b) when event fetch fails or evidence is insufficient. Reopens never leave an issue without a regression comment.
- Path D recovery scope tightened: D2 dedup-search failure exits Path D entirely (shared setup); D3.1/D3.2/D3.5 failures skip the WHOLE review (they run before per-finding work); D3.3/D3.4/D3.6/D3.7 failures skip ONE finding and continue with the next on the same review.
- Sentry rules section reconciled with the new branch-entry idempotency semantics.
- Step 1 bash block's `exit 0` annotated with empirically-validated comment ("exits subshell only, agent continues to Path D" — verified by run 2).

## Process

- Workflow §1 narrow exception: LLM prompt strings, single file, no new APIs, single-commit revert. Council-skip tag: `council-skip: zero-blast-radius (LLM prompt strings — grounded-review-validated)`.
- Two Codex grounded-review passes against the v3.1 plan. Both verdicts applied (audits at `docs/audits/2026-04-25-routine-v3.1-grounded-review-pass{1,2}.txt`).
- Two Codex code-diff review passes on the uncommitted diff. Both verdicts applied (audits at `docs/audits/2026-04-25-routine-v3.1-code-diff-review-pass{1,2}.txt`). Pass-2 sole finding was a false positive on `exit 0` semantics; clarifying comment added.
- Diff: +12X/-3X across one prompt file, +0 source. No code touched.
- Live Routine paste-sync separate at deploy time per #458 procedure (Chrome subagent path).

## Validation

- [x] No Swift / build / test impact (prompt file only)
- [x] Two grounded-review passes converged (pass-2 verified all pass-1 revisions applied + caught 4 new issues, all fixed)
- [x] Two code-diff review passes converged (pass-2 found one false positive on bash `exit 0`, clarified inline)
- [ ] CI build-check green
- [ ] Live paste-sync verified via Chrome devtools
- [ ] Next 3 cron runs (16:07Z, 20:07Z tonight) show: no premature run termination, no closed-issue regressions silently swallowed, Step 2.6 produces non-vacuous queries when a NEW Path A issue surfaces

## Council-skip rationale

Tag: `council-skip: zero-blast-radius (LLM prompt strings — grounded-review-validated)`

Single-file LLM prompt patch addressing already-flagged Codex findings on a deployed routine. No new code, no new APIs, no schema/migration. Two grounded-review + two code-diff Codex passes substitute for council on this surface (council reviews plan design; the design here is "fix the three #459 findings" — every iteration was grounded against the actual code).
