### PR TITLE
docs: align stale plan/comment text with shipped code (#399, #413, #419, #420, #421)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -144,7 +144,7 @@ public final class ASRManager: ASRManagerInterface {
     try await activeBackend.feedAudio(buffer)
   }
 
-  /// Finalize streaming and return the transcript. Falls back to batch if streaming was not active.
+  /// Finalize streaming and return the transcript. Throws `ASRError.streamingNotSupported` if no streaming session is active.
   public func finalizeStreaming() async throws -> ASRResult {
     guard isStreaming else {
       throw ASRError.streamingNotSupported

--- a/docs/feature-requests/issue-385-2026-04-20-acceptance-gate-drift-options.md
+++ b/docs/feature-requests/issue-385-2026-04-20-acceptance-gate-drift-options.md
@@ -2,7 +2,7 @@
 
 ## 1. Problem recap
 
-Today the offline eval in [scripts/eval/acceptance_gate.py](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/acceptance_gate.py) rebuilds production polish prompts in Python, while the user-facing logic lives in Swift under [Sources/EnviousWisprLLM/Prompting/](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/) and [Sources/EnviousWisprPostProcessing/CustomWordsManager.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift). That creates a predictable drift risk: prompt changes land in Swift first, and the eval harness can silently keep testing an older prompt shape.
+Today the offline eval in [scripts/eval/acceptance_gate.py](scripts/eval/acceptance_gate.py) rebuilds production polish prompts in Python, while the user-facing logic lives in Swift under [Sources/EnviousWisprLLM/Prompting/](Sources/EnviousWisprLLM/Prompting/) and [Sources/EnviousWisprPostProcessing/CustomWordsManager.swift](Sources/EnviousWisprPostProcessing/CustomWordsManager.swift). That creates a predictable drift risk: prompt changes land in Swift first, and the eval harness can silently keep testing an older prompt shape.
 
 ## 2. Options
 
@@ -10,19 +10,19 @@ Today the offline eval in [scripts/eval/acceptance_gate.py](/Users/m4pro_sv/Deve
 
 **Architecture sketch**
 
-Add a small Swift CLI whose only job is to render the production prompt envelope and return it as JSON. It should call the same production path the app already uses for cloud providers: [DefaultPromptPlanner.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift), [OpenAIPromptBuilder.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift), [GeminiPromptBuilder.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift), [GemmaPromptBuilder.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift), and [TranscriptAnalyzer.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/TranscriptAnalyzer.swift). For Apple Intelligence, the same CLI can expose the enriched production instruction from [LLMPolishStep.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprPipeline/LLMPolishStep.swift) instead of requiring Python to assemble `PolishInstructions.default + enrichment + custom vocab`. Python stays as the orchestration and judging layer, but stops owning prompt text.
+Add a small Swift CLI whose only job is to render the production prompt envelope and return it as JSON. It should call the same production path the app already uses for cloud providers: [DefaultPromptPlanner.swift](Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift), [OpenAIPromptBuilder.swift](Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift), [GeminiPromptBuilder.swift](Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift), [GemmaPromptBuilder.swift](Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift), and [TranscriptAnalyzer.swift](Sources/EnviousWisprLLM/Prompting/TranscriptAnalyzer.swift). For Apple Intelligence, the same CLI can expose the enriched production instruction from [LLMPolishStep.swift](Sources/EnviousWisprPipeline/LLMPolishStep.swift) instead of requiring Python to assemble `PolishInstructions.default + enrichment + custom vocab`. Python stays as the orchestration and judging layer, but stops owning prompt text.
 
 **Tradeoffs**
 
 - Latency: one subprocess call per case is acceptable for 1,590 cases if batched; one call per prompt would be too slow, so the CLI should accept many rows in one input file.
-- Binary-size impact: low. This is a developer-only tool, similar in spirit to the existing [scripts/eval/apple_runner/](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/apple_runner/) package.
+- Binary-size impact: low. This is a developer-only tool, similar in spirit to the existing [scripts/eval/apple_runner/](scripts/eval/apple_runner/) package.
 - Build-time coupling: moderate. Eval now depends on a built Swift helper, but only at dev/CI time, not in the shipped app.
 - Debuggability: good. JSON prompt artifacts can be written alongside eval outputs, which makes “what prompt did we actually send?” easy to inspect.
 - Ability to run eval without a full Swift build: reduced. Python-only eval disappears for prompt rendering; however, the build can stay scoped to a small helper package rather than the whole app product.
 
 **Migration cost**
 
-In [acceptance_gate.py](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/acceptance_gate.py), the mirrored prompt constants and builders would be removed or bypassed: `OPENAI_BASE`, `OPENAI_FORMATTING`, `OPENAI_TAIL`, `GEMINI_BASE`, `GEMINI_FORMATTING`, `USER_TEMPLATE`, `DEFAULT_CUSTOM_VOCAB`, `render_custom_vocab()`, `build_openai_system()`, `build_gemini_system()`, and the Apple `_build_afm_system_prompt()` path. The Python side would instead call the Swift dumper with transcript, provider, model, app context, language, and custom words, then pass the returned prompt straight to OpenAI/Gemini APIs. In [scripts/eval/apple_runner/](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/apple_runner/), either add a sibling executable or extend the existing package with a non-Apple mode that can emit prompts without invoking the connector.
+In [acceptance_gate.py](scripts/eval/acceptance_gate.py), the mirrored prompt constants and builders would be removed or bypassed: `OPENAI_BASE`, `OPENAI_FORMATTING`, `OPENAI_TAIL`, `GEMINI_BASE`, `GEMINI_FORMATTING`, `USER_TEMPLATE`, `DEFAULT_CUSTOM_VOCAB`, `render_custom_vocab()`, `build_openai_system()`, `build_gemini_system()`, and the Apple `_build_afm_system_prompt()` path. The Python side would instead call the Swift dumper with transcript, provider, model, app context, language, and custom words, then pass the returned prompt straight to OpenAI/Gemini APIs. In [scripts/eval/apple_runner/](scripts/eval/apple_runner/), either add a sibling executable or extend the existing package with a non-Apple mode that can emit prompts without invoking the connector.
 
 **Verdict**
 
@@ -46,7 +46,7 @@ Instead of a one-shot CLI, run a long-lived Swift helper process that accepts JS
 
 **Migration cost**
 
-[acceptance_gate.py](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/acceptance_gate.py) would change more deeply than in Option A because it would need bridge lifecycle management: start process, stream requests, handle partial failures, retry, and fall back if the helper dies mid-run. [scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift) would likely stop being “Apple-only bench runner” and become a more general eval bridge package with subcommands or protocol modes. This is still manageable, but it is real systems work, not just a helper command.
+[acceptance_gate.py](scripts/eval/acceptance_gate.py) would change more deeply than in Option A because it would need bridge lifecycle management: start process, stream requests, handle partial failures, retry, and fall back if the helper dies mid-run. [scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift](scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift) would likely stop being “Apple-only bench runner” and become a more general eval bridge package with subcommands or protocol modes. This is still manageable, but it is real systems work, not just a helper command.
 
 **Verdict**
 
@@ -70,7 +70,7 @@ Package the production prompt renderer as a Swift dynamic library or Python exte
 
 **Migration cost**
 
-[acceptance_gate.py](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/acceptance_gate.py) would need a new native integration layer and packaging assumptions that do not exist today. [scripts/eval/apple_runner/](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/apple_runner/) would either become obsolete or need to coexist with an even more complex native bridge. This is a larger infrastructure change than the drift problem justifies.
+[acceptance_gate.py](scripts/eval/acceptance_gate.py) would need a new native integration layer and packaging assumptions that do not exist today. [scripts/eval/apple_runner/](scripts/eval/apple_runner/) would either become obsolete or need to coexist with an even more complex native bridge. This is a larger infrastructure change than the drift problem justifies.
 
 **Verdict**
 
@@ -95,7 +95,7 @@ Package the production prompt renderer as a Swift dynamic library or Python exte
 
 **Current-best bet: Option A, the hidden Swift CLI prompt dumper.**
 
-It fits the codebase as it exists today. The repo already has a working pattern for a Swift sidecar tool in [scripts/eval/apple_runner/Package.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/scripts/eval/apple_runner/Package.swift), and the actual prompt source of truth is already centralized in Swift in [DefaultPromptPlanner.swift](/Users/m4pro_sv/Developer/EnviousLabs/worktrees/target-6-drift-research/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift) plus the provider builders. That means the team can remove the risky Python mirror without redesigning the whole eval harness.
+It fits the codebase as it exists today. The repo already has a working pattern for a Swift sidecar tool in [scripts/eval/apple_runner/Package.swift](scripts/eval/apple_runner/Package.swift), and the actual prompt source of truth is already centralized in Swift in [DefaultPromptPlanner.swift](Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift) plus the provider builders. That means the team can remove the risky Python mirror without redesigning the whole eval harness.
 
 It also keeps the architecture honest. Swift continues to own prompt construction; Python continues to own corpus iteration, API calling, judging, and reporting. That is a clean boundary, easy to explain to a founder and easy to debug in CI.
 

--- a/docs/feature-requests/issue-394-2026-04-20-transcriptionpipeline-di-seams.md
+++ b/docs/feature-requests/issue-394-2026-04-20-transcriptionpipeline-di-seams.md
@@ -92,12 +92,12 @@ No `TranscriptFinalizer` visibility change. No new public surface. No dependency
 
 **Why NOT go through `TranscriptFinalizer`'s closure seam directly at the pipeline level:** That would duplicate the finalizer-level injection and create two truthy paths to the same seam. Reuse the existing finalizer path; only open one new door at the pipeline level.
 
-## 4. MANDATORY Contract deltas
+## 4. MANDATORY Contract deltas — revised 2026-04-20 after grounded review
 
-- **Changed `TranscriptionPipeline.init(...)` signature** — added one optional parameter `finalizer: TranscriptFinalizer? = nil`.
-  - Semantics: Dependency injection seam. Nil = "use production default"; non-nil = "use this one."
-  - Invariant: production callers omitting the arg get identical behavior to today. Tests passing a mock-backed finalizer observe paste delivery through their mock, not through the real paste path.
-- **No new public types.** `TranscriptFinalizer` is already public (grep-verify — if not, promote only the minimal surface the pipeline's init needs, or go Option B).
+- **Added `internal init` overload on `TranscriptionPipeline`** that accepts a pre-built `TranscriptFinalizer`. The existing `public init(...)` at `:107` is **UNCHANGED**.
+  - Semantics: Dependency injection seam reachable only from same-module code or `@testable import EnviousWisprPipeline`.
+  - Invariant: production callers continue to use the existing `public init` and get identical behavior to today. Tests construct the internal overload with a mock-backed finalizer and observe paste delivery through their mock.
+- **No public surface change.** `TranscriptFinalizer` remains `internal` (declared at `TranscriptFinalizer.swift:53`). The `internal` overload keeps the type's narrow access discipline per `architecture-rules.md` §Access Control.
 
 No persisted fields. No legacy data.
 
@@ -125,8 +125,8 @@ No persisted fields. No legacy data.
 
 | Contract delta | Consumer | Current | Required | Change? | Verified by |
 |---|---|---|---|---|---|
-| `TranscriptionPipeline.init(finalizer:)` | `AppState` (production) | omits param | omits param, gets default | No | compile |
-| (same) | `HeartPathIntegrationTests` | constructs ad-hoc harness | constructs pipeline with mock finalizer | **Yes (test)** | new test file |
+| `TranscriptionPipeline.init(...)` (existing public) | `AppState` (production) | calls existing public init | calls existing public init, identical signature | No | compile |
+| `internal init(..., transcriptFinalizer:)` | `HeartPathIntegrationTests` | constructs ad-hoc harness | constructs pipeline via `@testable import` with mock finalizer | **Yes (test)** | new test file |
 | Future test scenarios (streaming, backend switch) | (not yet written) | blocked | unblocked | Yes (future) | follow-on tests |
 
 Discovery method:
@@ -162,9 +162,9 @@ No new fallback branch. If the mock finalizer throws in a test, the test is the 
 
 ## 10. File-by-file changes
 
-- **`Sources/EnviousWisprPipeline/TranscriptionPipeline.swift`**: add optional `finalizer:` init param; assign internal `self.finalizer = finalizer ?? TranscriptFinalizer(...)`.
-- **Possibly** `Sources/EnviousWisprPipeline/TranscriptFinalizer.swift`: promote visibility on any member the new init needs. Prefer not to widen; if a widening is required, disclose in PR per `architecture-rules.md` §Access Control.
-- **New tests** in `Tests/EnviousWisprPipelineTests/TranscriptionPipelineInjectionTests.swift`: construction sanity + one heart-path scenario that was previously NOT_TESTABLE.
+- **`Sources/EnviousWisprPipeline/TranscriptionPipeline.swift`**: add a second `internal init` overload that accepts `transcriptFinalizer: TranscriptFinalizer`. The existing `public init(...)` at `:107` is unchanged.
+- **No visibility change** to `Sources/EnviousWisprPipeline/TranscriptFinalizer.swift`. The new init is `internal`, so an `internal` finalizer parameter type is fine without promotion.
+- **New tests** in `Tests/EnviousWisprPipelineTests/TranscriptionPipelineInjectionTests.swift` (uses `@testable import EnviousWisprPipeline`): construction sanity + one heart-path scenario that was previously NOT_TESTABLE.
 
 ## 11. Testing
 

--- a/docs/feature-requests/issue-396-2026-04-20-pastecascadeexecutor-di-seams.md
+++ b/docs/feature-requests/issue-396-2026-04-20-pastecascadeexecutor-di-seams.md
@@ -54,7 +54,7 @@ public protocol PasteServiceProtocol {
   func isTextFieldRole(_ element: AXUIElement) -> Bool
   func insertViaAccessibility(_ text: String, element: AXUIElement) -> Bool
   func forceActivateApp(pid: pid_t) -> Bool
-  func pasteToActiveApp(_ text: String) -> Bool
+  func pasteToActiveApp(_ text: String) -> PasteDispatchResult
   func pasteViaAppleScript(pid: pid_t) -> Bool
   func saveClipboard() -> ClipboardSnapshot
   func restoreClipboard(_ snapshot: ClipboardSnapshot, changeCountAfterPaste: Int)

--- a/docs/feature-requests/issue-398-2026-04-20-asrmanager-backend-injection.md
+++ b/docs/feature-requests/issue-398-2026-04-20-asrmanager-backend-injection.md
@@ -43,11 +43,12 @@ The same blind spot blocks `switchBackend` reset-branch testing and any future c
 
 ### 2.2 Non-goals
 
-- Changing the backend protocol `ASRBackend`.
 - Refactoring `ParakeetBackend` or `WhisperKitBackend` internals.
 - Changing `ASRManagerInterface`.
 - Adding test-only initializers that accept preset flag state (Option A from issue body) — rejected because it masks the real issue (backends are the seam, flags are derived state).
 - `#if DEBUG` helpers (Option B) — rejected because "exposes state for testing" is an anti-pattern when the real fix is composable DI.
+
+**Note:** §3 widens `ASRBackend` to expose the progress-reporting variant. This is the minimum surface change required to keep production progress UI working when backend properties become `any ASRBackend`. The original v1 plan had "Changing the backend protocol `ASRBackend`" listed as a non-goal — grounded review (2026-04-20) overrode that, and the corrected design in §3 is now the canonical scope. `ASRProtocol.swift` is in scope.
 
 ## 3. Design — revised 2026-04-20 after grounded review
 
@@ -189,13 +190,17 @@ No new fallback branch.
 
 ## 10. File-by-file changes
 
+- **`Sources/EnviousWisprASR/ASRProtocol.swift`** (in scope per §3 design correction):
+  - Add `func prepare(progressCallback: ProgressCallback?) async throws` to `ASRBackend`.
+  - Add a default-implementation extension that delegates to `prepare()`.
+  - Move `ProgressCallback` typealias next to the protocol if it currently lives on `ParakeetBackend` (grep-verify during implementation).
 - **`Sources/EnviousWisprASR/ASRManager.swift`**:
   - Lines 23-24: change property types from concrete to `any ASRBackend`.
   - Line 26: change `public init()` to `public init(parakeetBackend: (any ASRBackend)? = nil, whisperKitBackend: (any ASRBackend)? = nil)`; assign via `??` defaults.
 - **New test file** `Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift`:
   - `FakeASRBackend` (records calls, controllable `isReady`, controllable `unload()` / `prepare()` throws).
   - Three scenario tests per §11.
-- **No other file changes**. `ASRManagerProxy` and `ASRManagerInterface` untouched.
+- **No other file changes**. `ParakeetBackend`'s concrete `prepare(progressCallback:)` at `:46` is unchanged (still serves as the override). `WhisperKitBackend` inherits the default. `ASRManagerProxy` and `ASRManagerInterface` untouched.
 
 ## 11. Testing
 


### PR DESCRIPTION
## Summary

Five doc/comment drift fixes. Codex findings on prior PRs flagged that planning docs and one Swift doc comment didn't match shipped code. No behavior change.

- **#399** — `ASRManager.swift:147` doc comment claimed `finalizeStreaming()` falls back to batch; it actually throws `ASRError.streamingNotSupported`. Comment now matches behavior.
- **#413** — Drift research doc (`issue-385-...`) had absolute filesystem paths (`/Users/m4pro_sv/...`) baked into all cross-reference links. Replaced with repo-relative paths.
- **#419** — G3 plan (`issue-394-...`) §4 / §6 / §10 still described the v1 single-init-with-optional-param strategy; §3's revised design uses a separate `internal init` overload. Aligned mandatory sections to §3.
- **#420** — G5 plan (`issue-398-...`) §2.2 listed "Changing `ASRBackend`" as a non-goal, but §3's corrected design widens the protocol with a default-implemented progress variant. Removed the contradicting non-goal and added `ASRProtocol.swift` to §10 file-by-file.
- **#421** — G4 plan (`issue-396-...`) §3 PasteServiceProtocol snippet showed `pasteToActiveApp(_:) -> Bool`; §4 contract uses `PasteDispatchResult`. Updated §3 to match.

#447 and #448 (Phase C plan goals) were already corrected via PR #435 (commit 0a132ae). Closing those separately with a pointer.

`council-skip: zero-blast-radius (doc comment + planning-artifact text only — no Swift logic, no API, no test changes)`

## Test plan
- [x] `swift build` — succeeds
- [x] No code logic changed; the only Swift edit is a doc comment
- [x] Closes #399, #413, #419, #420, #421
