### PR TITLE
seo(homepage): link all 11 compare pages from homepage compare section (#376)

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -684,6 +684,14 @@ const jsonLdFaq = JSON.stringify({
         <a href="/compare/otter-ai/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs Otter.ai</a>
         <a href="/compare/macwhisper/" style="padding:10px 20px;border-radius:100px;font-size:14px;font-weight:600;color:var(--text-2);border:1px solid var(--border-hover);text-decoration:none;transition:all 0.2s;">vs MacWhisper</a>
       </div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px 18px;justify-content:center;margin-top:14px;font-size:13px;color:var(--text-3);" class="reveal">
+        <span style="color:var(--text-3);">Also:</span>
+        <a href="/compare/voiceink/" style="color:var(--text-3);text-decoration:none;border-bottom:1px solid var(--border);">VoiceInk</a>
+        <a href="/compare/whisper-cpp/" style="color:var(--text-3);text-decoration:none;border-bottom:1px solid var(--border);">whisper.cpp</a>
+        <a href="/compare/willow-voice/" style="color:var(--text-3);text-decoration:none;border-bottom:1px solid var(--border);">Willow Voice</a>
+        <a href="/compare/notta/" style="color:var(--text-3);text-decoration:none;border-bottom:1px solid var(--border);">Notta</a>
+        <a href="/compare/google-docs-voice-typing/" style="color:var(--text-3);text-decoration:none;border-bottom:1px solid var(--border);">Google Docs Voice Typing</a>
+      </div>
       <div style="text-align:center;margin-top:20px;" class="reveal">
         <a href="/compare/" style="font-size:14px;font-weight:600;color:var(--accent);text-decoration:none;">View all comparisons &rarr;</a>
       </div>


### PR DESCRIPTION
## Summary

Homepage previously linked 6 of 11 compare pages (WisprFlow, Superwhisper, Dragon, Apple Dictation, Otter.ai, MacWhisper). The other 5 — VoiceInk, whisper.cpp, Willow Voice, Notta, Google Docs Voice Typing — were reachable only via the /compare/ index, which sits at Google position ~29.5 and gets little PageRank flow. The unlinked subset is also the unindexed-by-Google subset.

Hybrid of issue Options A and B: keep the curated 6-pill marquee as the visual primary, add a smaller secondary "Also:" row of text-only links underneath in `var(--text-3)` so each page now has a direct homepage link without competing with the main pills. "View all comparisons →" preserved.

Astro build succeeded; all 5 new links verified present in `dist/index.html`.

## Test plan
- [x] `npm run build` (Astro) exits 0
- [x] All 5 new compare-page links confirmed in built HTML
- [x] No design noise: secondary row uses muted color + thin underline so curated 6-pill row stays visually primary
- [ ] Closes #376
