### PR TITLE
fix(logger): #if DEBUG-gate AppLogger sinks (#361, R3)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -100,6 +100,31 @@ jobs:
           PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
           echo "==> $STARTED test entries started, $PASSED reported passed, 0 failures"
 
+      - name: Run logic tests (release config)
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          set +e
+          OUTPUT=$(scripts/swift-test.sh -c release 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::scripts/swift-test.sh -c release exited $STATUS"
+            exit "$STATUS"
+          fi
+          if echo "$OUTPUT" | grep -q "✘"; then
+            echo "::error::Swift tests have failures (release config)"
+            exit 1
+          fi
+          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
+          if [ "$STARTED" -eq 0 ]; then
+            echo "::error::No tests started in release config — possible compilation failure"
+            exit 1
+          fi
+          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
+          echo "==> release: $STARTED test entries started, $PASSED reported passed, 0 failures"
+
       - name: Verify FoundationModels compile probe
         if: steps.changes.outputs.needs_build == 'true'
         run: |

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -749,10 +749,15 @@ struct AIPolishSettingsView: View {
         .foregroundStyle(Color.stTextTertiary)
     }
 
-    // Debug section — dev builds only
-    if appState.settings.isDebugModeEnabled, let report = appState.aiAvailability.latestReport {
-      aiDebugSection(report: report)
-    }
+    #if DEBUG
+      // Debug section — dev builds only. Wrapped with `#if DEBUG` (not just the
+      // `isDebugModeEnabled` runtime check) so a release binary inheriting a
+      // persisted-true flag from a prior dev session cannot reach
+      // `aiDebugSection`.
+      if appState.settings.isDebugModeEnabled, let report = appState.aiAvailability.latestReport {
+        aiDebugSection(report: report)
+      }
+    #endif
   }
 
   @ViewBuilder
@@ -780,74 +785,76 @@ struct AIPolishSettingsView: View {
     }
   }
 
-  @ViewBuilder
-  private func aiDebugSection(report: AppleIntelligenceAvailabilityReport) -> some View {
-    DisclosureGroup("Diagnostics") {
-      VStack(alignment: .leading, spacing: 4) {
-        ForEach(report.gates.allGates, id: \.name) { gate in
-          HStack(spacing: 6) {
-            gateStatusIcon(gate.result.status)
-            Text(gate.name)
-              .font(.caption)
-              .fontWeight(.medium)
-            Spacer()
-            Text(gate.result.summary)
-              .font(.caption2)
-              .foregroundStyle(Color.stTextTertiary)
-              .lineLimit(1)
-            if let ms = gate.result.durationMs {
-              Text("\(ms)ms")
+  #if DEBUG
+    @ViewBuilder
+    private func aiDebugSection(report: AppleIntelligenceAvailabilityReport) -> some View {
+      DisclosureGroup("Diagnostics") {
+        VStack(alignment: .leading, spacing: 4) {
+          ForEach(report.gates.allGates, id: \.name) { gate in
+            HStack(spacing: 6) {
+              gateStatusIcon(gate.result.status)
+              Text(gate.name)
+                .font(.caption)
+                .fontWeight(.medium)
+              Spacer()
+              Text(gate.result.summary)
                 .font(.caption2)
                 .foregroundStyle(Color.stTextTertiary)
+                .lineLimit(1)
+              if let ms = gate.result.durationMs {
+                Text("\(ms)ms")
+                  .font(.caption2)
+                  .foregroundStyle(Color.stTextTertiary)
+              }
             }
           }
-        }
-        HStack {
-          Text("OS: \(report.osVersion)")
-          Spacer()
-          Text("HW: \(report.hardwareClass)")
-          Spacer()
-          Text("Total: \(report.checkDurationMs)ms")
-        }
-        .font(.caption2)
-        .foregroundStyle(Color.stTextTertiary)
+          HStack {
+            Text("OS: \(report.osVersion)")
+            Spacer()
+            Text("HW: \(report.hardwareClass)")
+            Spacer()
+            Text("Total: \(report.checkDurationMs)ms")
+          }
+          .font(.caption2)
+          .foregroundStyle(Color.stTextTertiary)
 
-        Button("Copy Diagnostics") {
-          appState.aiAvailability.copyDiagnosticsToClipboard()
+          Button("Copy Diagnostics") {
+            appState.aiAvailability.copyDiagnosticsToClipboard()
+          }
+          .font(.caption)
+          .buttonStyle(.borderless)
         }
-        .font(.caption)
-        .buttonStyle(.borderless)
+        .padding(.vertical, 4)
       }
-      .padding(.vertical, 4)
+      .font(.caption)
     }
-    .font(.caption)
-  }
 
-  @ViewBuilder
-  private func gateStatusIcon(_ status: AIGateStatus) -> some View {
-    switch status {
-    case .passed:
-      Image(systemName: "checkmark.circle.fill")
-        .foregroundStyle(.stSuccess)
-        .font(.caption2)
-    case .failed:
-      Image(systemName: "xmark.circle.fill")
-        .foregroundStyle(.stError)
-        .font(.caption2)
-    case .skipped:
-      Image(systemName: "minus.circle")
-        .foregroundStyle(Color.stTextTertiary)
-        .font(.caption2)
-    case .timedOut:
-      Image(systemName: "clock.badge.exclamationmark")
-        .foregroundStyle(.stWarning)
-        .font(.caption2)
-    case .unknown:
-      Image(systemName: "questionmark.circle")
-        .foregroundStyle(Color.stTextTertiary)
-        .font(.caption2)
+    @ViewBuilder
+    private func gateStatusIcon(_ status: AIGateStatus) -> some View {
+      switch status {
+      case .passed:
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(.stSuccess)
+          .font(.caption2)
+      case .failed:
+        Image(systemName: "xmark.circle.fill")
+          .foregroundStyle(.stError)
+          .font(.caption2)
+      case .skipped:
+        Image(systemName: "minus.circle")
+          .foregroundStyle(Color.stTextTertiary)
+          .font(.caption2)
+      case .timedOut:
+        Image(systemName: "clock.badge.exclamationmark")
+          .foregroundStyle(.stWarning)
+          .font(.caption2)
+      case .unknown:
+        Image(systemName: "questionmark.circle")
+          .foregroundStyle(Color.stTextTertiary)
+          .font(.caption2)
+      }
     }
-  }
+  #endif
 
   // MARK: - Ollama Model Catalog
 

--- a/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsSection.swift
@@ -12,7 +12,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case clipboard
   case memory
   case permissions
-  case diagnostics
+  #if DEBUG
+    case diagnostics
+  #endif
 
   var id: String { rawValue }
 
@@ -28,7 +30,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .clipboard: return "Clipboard"
     case .memory: return "Performance"
     case .permissions: return "Permissions"
-    case .diagnostics: return "Diagnostics"
+    #if DEBUG
+      case .diagnostics: return "Diagnostics"
+    #endif
     }
   }
 
@@ -44,7 +48,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .clipboard: return "clipboard"
     case .memory: return "memorychip"
     case .permissions: return "lock.shield"
-    case .diagnostics: return "ladybug"
+    #if DEBUG
+      case .diagnostics: return "ladybug"
+    #endif
     }
   }
 
@@ -54,7 +60,10 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .speechEngine, .audio, .shortcuts: return .record
     case .aiPolish, .wordCorrection: return .process
     case .clipboard: return .output
-    case .memory, .permissions, .diagnostics: return .system
+    case .memory, .permissions: return .system
+    #if DEBUG
+      case .diagnostics: return .system
+    #endif
     }
   }
 }

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -73,8 +73,10 @@ struct UnifiedWindowView: View {
       MemorySettingsView()
     case .permissions:
       PermissionsSettingsView()
-    case .diagnostics:
-      DiagnosticsSettingsView()
+    #if DEBUG
+      case .diagnostics:
+        DiagnosticsSettingsView()
+    #endif
     }
   }
 }

--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -3,53 +3,66 @@ import OSLog
 
 /// Centralised logging for EnviousWispr.
 ///
-/// - OSLog entries are always emitted (at the appropriate level) and are
-///   visible in Console.app under subsystem "com.enviouswispr.app".
-/// - File logging to ~/Library/Logs/EnviousWispr/ is active only while
-///   isDebugModeEnabled is true.
-/// - API keys and secrets are never logged — callers must redact before passing.
+/// **Release builds: dead code.** The entire log pipeline (OSLog + file sink)
+/// is gated behind `#if DEBUG`. Call sites compile unchanged but produce no
+/// output, no Console.app entries, and no `~/Library/Logs/EnviousWispr/` files
+/// in shipped binaries. Production diagnostics route via
+/// `SentryBreadcrumb.captureError` (errors) and `TelemetryService` (PostHog
+/// opt-in events) — NOT through AppLogger.
+///
+/// **Debug builds:** OSLog entries appear in Console.app under subsystem
+/// "com.enviouswispr.app", and file logging to `~/Library/Logs/EnviousWispr/`
+/// is active when `isDebugModeEnabled` is true. API keys and secrets are never
+/// logged — callers must redact before passing.
 public actor AppLogger {
   public static let shared = AppLogger()
 
+  // State preserved in both configs so Settings UI compiles unchanged.
+  // In release the setters update internal state harmlessly; log() is a no-op
+  // so the state is never observed by any sink.
   public private(set) var isDebugModeEnabled: Bool = false
   public private(set) var logLevel: DebugLogLevel = .info
 
-  private let oslog = Logger(subsystem: "com.enviouswispr.app", category: "pipeline")
+  #if DEBUG
+    private let oslog = Logger(subsystem: "com.enviouswispr.app", category: "pipeline")
 
-  /// Cached date formatter to avoid allocation per log line.
-  /// Instance property is safe since AppLogger is an actor with serialized access.
-  /// Uses the user's local time zone so `[2026-04-15T19:11:22-04:00]` in the
-  /// file log matches their wall clock, not UTC.
-  private let timestampFormatter: ISO8601DateFormatter = {
-    let formatter = ISO8601DateFormatter()
-    // autoupdatingCurrent tracks DST transitions and travel; .current would
-    // snapshot the offset at init and go stale in long-running sessions.
-    formatter.timeZone = TimeZone.autoupdatingCurrent
-    return formatter
-  }()
+    /// Cached date formatter to avoid allocation per log line.
+    /// Instance property is safe since AppLogger is an actor with serialized access.
+    /// Uses the user's local time zone so `[2026-04-15T19:11:22-04:00]` in the
+    /// file log matches their wall clock, not UTC.
+    private let timestampFormatter: ISO8601DateFormatter = {
+      let formatter = ISO8601DateFormatter()
+      // autoupdatingCurrent tracks DST transitions and travel; .current would
+      // snapshot the offset at init and go stale in long-running sessions.
+      formatter.timeZone = TimeZone.autoupdatingCurrent
+      return formatter
+    }()
 
-  private let maxFileSize: Int = 10 * 1024 * 1024
-  private let maxFileCount: Int = 5
+    private let maxFileSize: Int = 10 * 1024 * 1024
+    private let maxFileCount: Int = 5
 
-  private var logDirectory: URL {
-    let lib = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-    return lib.appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
-  }
-  private var currentLogURL: URL { logDirectory.appendingPathComponent("app.log") }
-  private var fileHandle: FileHandle?
+    private var logDirectory: URL {
+      let lib = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+      return lib.appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
+    }
+    private var currentLogURL: URL { logDirectory.appendingPathComponent("app.log") }
+    private var fileHandle: FileHandle?
+  #endif
 
   private init() {}
 
   public func setDebugMode(_ enabled: Bool) {
     isDebugModeEnabled = enabled
-    if enabled {
-      openFileHandleIfNeeded()
-      log("Debug mode enabled", level: .info, category: "AppLogger")
-    } else {
-      log("Debug mode disabled", level: .info, category: "AppLogger")
-      fileHandle?.closeFile()
-      fileHandle = nil
-    }
+    #if DEBUG
+      if enabled {
+        openFileHandleIfNeeded()
+        log("Debug mode enabled", level: .info, category: "AppLogger")
+      } else {
+        log("Debug mode disabled", level: .info, category: "AppLogger")
+        fileHandle?.closeFile()
+        fileHandle = nil
+      }
+    #endif
   }
 
   public func setLogLevel(_ level: DebugLogLevel) {
@@ -57,85 +70,104 @@ public actor AppLogger {
   }
 
   public func log(_ message: String, level: DebugLogLevel = .info, category: String = "App") {
-    switch level {
-    case .info: oslog.info("[\(category)] \(message)")
-    case .verbose: oslog.debug("[\(category)] \(message)")
     #if DEBUG
+      switch level {
+      case .info: oslog.info("[\(category)] \(message)")
+      case .verbose: oslog.debug("[\(category)] \(message)")
       case .debug: oslog.debug("[\(category, privacy: .public)] \(message, privacy: .public)")
-    #else
-      case .debug: oslog.debug("[\(category)] \(message)")
+      }
+
+      guard isDebugModeEnabled, level <= logLevel else { return }
+
+      let timestamp = timestampFormatter.string(from: Date())
+      let line = "[\(timestamp)] [\(level.rawValue.uppercased())] [\(category)] \(message)\n"
+
+      guard let data = line.data(using: .utf8) else { return }
+      writeToFile(data)
     #endif
+    // Release: no-op. The 148 call sites still pay the actor-hop cost of
+    // `await AppLogger.shared.log(...)`; the privacy win is removing all sink
+    // output, not eliminating call-site overhead.
+  }
+
+  #if DEBUG
+
+    // MARK: - File management (debug-only)
+
+    private func openFileHandleIfNeeded() {
+      guard fileHandle == nil else { return }
+      let dir = logDirectory
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      if !FileManager.default.fileExists(atPath: currentLogURL.path) {
+        FileManager.default.createFile(atPath: currentLogURL.path, contents: nil)
+      }
+      fileHandle = try? FileHandle(forWritingTo: currentLogURL)
+      fileHandle?.seekToEndOfFile()
     }
 
-    guard isDebugModeEnabled, level <= logLevel else { return }
-
-    let timestamp = timestampFormatter.string(from: Date())
-    let line = "[\(timestamp)] [\(level.rawValue.uppercased())] [\(category)] \(message)\n"
-
-    guard let data = line.data(using: .utf8) else { return }
-    writeToFile(data)
-  }
-
-  // MARK: - File management
-
-  private func openFileHandleIfNeeded() {
-    guard fileHandle == nil else { return }
-    let dir = logDirectory
-    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    if !FileManager.default.fileExists(atPath: currentLogURL.path) {
-      FileManager.default.createFile(atPath: currentLogURL.path, contents: nil)
+    private func writeToFile(_ data: Data) {
+      guard let fh = fileHandle else { return }
+      fh.write(data)
+      rotateIfNeeded()
     }
-    fileHandle = try? FileHandle(forWritingTo: currentLogURL)
-    fileHandle?.seekToEndOfFile()
-  }
 
-  private func writeToFile(_ data: Data) {
-    guard let fh = fileHandle else { return }
-    fh.write(data)
-    rotateIfNeeded()
-  }
+    private func rotateIfNeeded() {
+      guard let attrs = try? FileManager.default.attributesOfItem(atPath: currentLogURL.path),
+        let size = attrs[.size] as? Int,
+        size >= maxFileSize
+      else { return }
 
-  private func rotateIfNeeded() {
-    guard let attrs = try? FileManager.default.attributesOfItem(atPath: currentLogURL.path),
-      let size = attrs[.size] as? Int,
-      size >= maxFileSize
-    else { return }
+      fileHandle?.closeFile()
+      fileHandle = nil
 
-    fileHandle?.closeFile()
-    fileHandle = nil
+      let dir = logDirectory
+      for i in stride(from: maxFileCount - 1, through: 1, by: -1) {
+        let old = dir.appendingPathComponent("app.\(i).log")
+        let new = dir.appendingPathComponent("app.\(i + 1).log")
+        try? FileManager.default.moveItem(at: old, to: new)
+      }
+      try? FileManager.default.moveItem(
+        at: currentLogURL,
+        to: dir.appendingPathComponent("app.1.log"))
 
-    let dir = logDirectory
-    for i in stride(from: maxFileCount - 1, through: 1, by: -1) {
-      let old = dir.appendingPathComponent("app.\(i).log")
-      let new = dir.appendingPathComponent("app.\(i + 1).log")
-      try? FileManager.default.moveItem(at: old, to: new)
+      let oldest = dir.appendingPathComponent("app.\(maxFileCount).log")
+      try? FileManager.default.removeItem(at: oldest)
+
+      openFileHandleIfNeeded()
     }
-    try? FileManager.default.moveItem(
-      at: currentLogURL,
-      to: dir.appendingPathComponent("app.1.log"))
 
-    let oldest = dir.appendingPathComponent("app.\(maxFileCount).log")
-    try? FileManager.default.removeItem(at: oldest)
-
-    openFileHandleIfNeeded()
-  }
+  #endif
 
   // MARK: - Utilities
 
-  public func logDirectoryURL() -> URL { logDirectory }
+  public func logDirectoryURL() -> URL {
+    #if DEBUG
+      return logDirectory
+    #else
+      // API-shape preservation only. Settings UI's "Open log folder" button is
+      // hidden in release via the Diagnostics tab `#if DEBUG` wrap; this URL
+      // never gets opened. No file is ever created here.
+      let lib = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+      return lib.appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
+    #endif
+  }
 
   public func clearLogs() throws {
-    fileHandle?.closeFile()
-    fileHandle = nil
-    let dir = logDirectory
-    guard
-      let files = try? FileManager.default.contentsOfDirectory(
-        at: dir, includingPropertiesForKeys: nil
-      )
-    else { return }
-    for file in files where file.pathExtension == "log" {
-      try FileManager.default.removeItem(at: file)
-    }
-    if isDebugModeEnabled { openFileHandleIfNeeded() }
+    #if DEBUG
+      fileHandle?.closeFile()
+      fileHandle = nil
+      let dir = logDirectory
+      guard
+        let files = try? FileManager.default.contentsOfDirectory(
+          at: dir, includingPropertiesForKeys: nil
+        )
+      else { return }
+      for file in files where file.pathExtension == "log" {
+        try FileManager.default.removeItem(at: file)
+      }
+      if isDebugModeEnabled { openFileHandleIfNeeded() }
+    #endif
+    // Release: no-op. The Diagnostics tab's "Clear logs" button is hidden via
+    // `#if DEBUG`; this method exists only to keep the public API stable.
   }
 }

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// Validates Phase R3 compile-out: `AppLogger` is dev-only, release sinks are dead code.
+///
+/// In debug builds, enabling debug mode + logging must produce content on disk under
+/// `~/Library/Logs/EnviousWispr/app.log`. In release builds, the same call sequence
+/// must NOT emit the marker — the sink machinery is gated behind `#if DEBUG`.
+///
+/// Tests are non-destructive: each assertion uses a unique-per-run marker token and
+/// inspects the existing log file (or its absence) without deleting or truncating
+/// the developer's real logs. Running the suite locally never wipes
+/// `~/Library/Logs/EnviousWispr/`.
+@Suite("AppLogger R3 compile-out")
+struct AppLoggerCompileOutTests {
+
+  /// Resolves the file URL the (debug-build) sink would write to. Mirrors the actor
+  /// implementation but stays out of process so we can inspect the filesystem
+  /// regardless of which config we're compiled in.
+  private static var expectedLogURL: URL {
+    let lib = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+    return
+      lib
+      .appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
+      .appendingPathComponent("app.log")
+  }
+
+  /// Returns true if the file at `url` contains `marker` as a UTF-8 substring.
+  /// Returns false if the file does not exist or cannot be read.
+  private static func fileContains(_ url: URL, marker: String) -> Bool {
+    guard let data = try? Data(contentsOf: url),
+      let s = String(data: data, encoding: .utf8)
+    else { return false }
+    return s.contains(marker)
+  }
+
+  /// Generates a one-shot marker that cannot collide with any prior log line.
+  private static func uniqueMarker(_ tag: String) -> String {
+    "R3-test-\(tag)-\(UUID().uuidString)"
+  }
+
+  #if DEBUG
+
+    @Test("Debug build: log() emits the marker into the file sink")
+    func debugBuildEmitsMarkerIntoFileSink() async throws {
+      let marker = Self.uniqueMarker("debug")
+      let priorMode = await AppLogger.shared.isDebugModeEnabled
+
+      await AppLogger.shared.setDebugMode(true)
+      await AppLogger.shared.log(marker, level: .info, category: "Test")
+      // Drain in-flight actor work before reading the file.
+      _ = await AppLogger.shared.logDirectoryURL()
+
+      let url = Self.expectedLogURL
+      #expect(FileManager.default.fileExists(atPath: url.path))
+      #expect(Self.fileContains(url, marker: marker))
+
+      // Restore prior debug-mode state — never assume default false, so suite
+      // ordering does not change behavior.
+      await AppLogger.shared.setDebugMode(priorMode)
+    }
+
+  #else
+
+    @Test("Release build: log() does NOT emit the marker (sink is dead code)")
+    func releaseBuildSinkIsDeadCode() async throws {
+      let marker = Self.uniqueMarker("release")
+      let priorMode = await AppLogger.shared.isDebugModeEnabled
+      let url = Self.expectedLogURL
+      let priorExists = FileManager.default.fileExists(atPath: url.path)
+
+      await AppLogger.shared.setDebugMode(true)
+      await AppLogger.shared.log(marker, level: .info, category: "Test")
+      // Drain in-flight actor work before checking the filesystem.
+      _ = await AppLogger.shared.logDirectoryURL()
+
+      // The marker MUST NOT appear anywhere in the (possibly pre-existing) file.
+      // Existence/size of the file are not asserted because a developer running
+      // the suite locally may have a populated app.log from prior dev work.
+      #expect(!Self.fileContains(url, marker: marker))
+      #expect(FileManager.default.fileExists(atPath: url.path) == priorExists)
+
+      // Internal state still updates harmlessly even though the sink is dead.
+      let isEnabled = await AppLogger.shared.isDebugModeEnabled
+      #expect(isEnabled == true)
+
+      await AppLogger.shared.setDebugMode(priorMode)
+    }
+
+  #endif
+}


### PR DESCRIPTION
## Summary

Phase R3 of #319 Hardening Bible. Compiles out the `AppLogger` log pipeline in release builds via `#if DEBUG` gating; release binaries emit nothing under subsystem `com.enviouswispr.app` and create no `~/Library/Logs/EnviousWispr/app.log`.

- `AppLogger.log()` body, OSLog instance, file-sink helpers, and timestamp formatter wrapped in `#if DEBUG`. 152 call sites compile unchanged.
- Diagnostics tab gated in 5 sites (`SettingsSection.swift` enum case + label/icon/group + `SettingsView.swift` render) so it is absent from the release Settings sidebar entirely.
- `AIPolishSettingsView` debug section also `#if DEBUG`-wrapped (not just runtime-flag-gated) so a release binary inheriting persisted `isDebugModeEnabled=true` cannot reach `aiDebugSection`.
- Production diagnostics route remains `SentryBreadcrumb` + `TelemetryService` (PostHog) — independent of AppLogger (grep-verified).

Plan reference: `docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md` §13.

## Test plan

- [x] `swift build -c release` succeeds
- [x] `swift build` (debug) succeeds
- [x] `scripts/swift-test.sh` passes (475 tests)
- [x] `scripts/swift-test.sh -c release` passes (475 tests)
- [x] New `AppLoggerCompileOutTests` covers both configs
  - debug: `setDebugMode(true) + log(marker)` → file contains marker
  - release: same call sequence → file does NOT contain marker (non-destructive: marker is per-run UUID, no log files deleted)
- [x] CI gains `Run logic tests (release config)` step so the release-only test is actually exercised; status code is preserved and the step fails on any non-zero exit
- [x] Codex code review clean (2 rounds: P2 destructive-test fix + P2 CI exit-status fix, both addressed)

## Architecture Closeout

- Module: `EnviousWisprCore` (AppLogger), `EnviousWispr` (Settings views). No new module dependencies.
- Heart path: untouched. AppLogger was already a developer affordance; Sentry / PostHog stay live in release.
- Public API: preserved exactly. `AppLogger.shared`, `log`, `setDebugMode`, `setLogLevel`, `clearLogs`, `logDirectoryURL` all callable in both configs; release-side bodies are no-ops.
- Privacy posture strengthened: 152 call sites' sink output is dead code in shipped binaries.
