### PR TITLE
fix(audio): rotate bt-route.log via RotatingFileSink (#362, R4)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,6 +130,7 @@ let package = Package(
         "EnviousWisprLLM",
         "EnviousWisprPipeline",
         "EnviousWisprStorage",
+        "EnviousWisprAudio",
         "EnviousWispr",
       ],
       path: "Tests/EnviousWisprTests"

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -520,26 +520,27 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   // MARK: - BT Route Logging (Step 6 instrumentation)
 
+  /// Default sink path; cross-process write target shared by main app + XPC service.
+  /// Phase R4: bounded by `RotatingFileSink` at 5 MB × 3 files = 15 MB ceiling.
+  nonisolated private static let btRouteLogURL: URL = FileManager.default
+    .homeDirectoryForCurrentUser
+    .appendingPathComponent("Library/Logs/EnviousWispr/bt-route.log")
+
+  /// Bounded sink for BT route diagnostics. `nonisolated static` matches the
+  /// prior surface so existing sync callers keep their call shape; the sink
+  /// itself uses `OSAllocatedUnfairLock` + `flock` for safety across the main
+  /// app and XPC service writing concurrently.
+  nonisolated static let btRouteSink = RotatingFileSink(
+    path: btRouteLogURL,
+    maxSize: 5 * 1_024 * 1_024,
+    maxFiles: 3)
+
   /// Direct file write for BT route diagnostics. os_log info level is suppressed on macOS 26 beta,
   /// and AppLogger.shared is process-local (XPC service has its own instance).
   nonisolated static func btRouteLog(_ message: String) {
     let timestamp = ISO8601DateFormatter().string(from: Date())
     let line = "[\(timestamp)] [BTRoute] \(message)\n"
-    let url = FileManager.default.homeDirectoryForCurrentUser
-      .appendingPathComponent("Library/Logs/EnviousWispr/bt-route.log")
-    try? FileManager.default.createDirectory(
-      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-    if let data = line.data(using: .utf8) {
-      if FileManager.default.fileExists(atPath: url.path) {
-        if let handle = try? FileHandle(forWritingTo: url) {
-          handle.seekToEndOfFile()
-          handle.write(data)
-          handle.closeFile()
-        }
-      } else {
-        try? data.write(to: url)
-      }
-    }
+    btRouteSink.append(line)
   }
 
   // MARK: - VAD Interface (Step 5)

--- a/Sources/EnviousWisprAudio/RotatingFileSink.swift
+++ b/Sources/EnviousWisprAudio/RotatingFileSink.swift
@@ -1,0 +1,171 @@
+import Darwin
+import Foundation
+import os
+
+/// Synchronous, lock-guarded file sink with append-with-rotation semantics.
+///
+/// Designed for diagnostic logs that must remain bounded on disk. Callers are
+/// frequently in audio-thread-adjacent or RT-sensitive contexts that cannot
+/// `await`, so this sink is intentionally NOT an actor — write operations are
+/// nonisolated, lock-guarded syscalls.
+///
+/// ## Concurrency model
+///
+/// - In-process: `OSAllocatedUnfairLock` serializes `append` calls so the
+///   open-write-rotate sequence is atomic.
+/// - Cross-process: `flock(LOCK_EX)` on a *separate, stable* lock file
+///   (`<base>.lock`) serializes writes from sibling processes. The lock is
+///   intentionally NOT taken on the active log file's descriptor, since
+///   rotation renames that file mid-sequence — flock follows the inode, so a
+///   waiter that acquired before rename would still hold a lock on the rolled
+///   file while another process opened a fresh active and proceeded. Using a
+///   stable lock file avoids that race.
+/// - The class is `@unchecked Sendable` because Swift 6 cannot prove the
+///   safety automatically. The path/maxSize/maxFiles are immutable; the only
+///   mutable state is the on-disk file itself, which is protected by the two
+///   locks above.
+///
+/// ## Rotation policy
+///
+/// `maxFiles` is the **total file count** retained on disk (active +
+/// rolled), so the disk ceiling is `maxSize * maxFiles`. After a rotation:
+///
+/// - `maxFiles == 1` → active is truncated (no archive kept).
+/// - `maxFiles == 2` → active becomes `<base>.1`; total = 2 files.
+/// - `maxFiles == 3` → `.1` becomes `.2`; active becomes `.1`; total = 3 files.
+///
+/// On `append`, post-write file size is checked. If it exceeds `maxSize`,
+/// rotation runs synchronously while the cross-process lock is held.
+///
+/// ## Constraints (from architecture-rules)
+///
+/// Callers must NOT invoke `append` while holding the RT audio lock — see
+/// `architecture-rules.md` Audio/ASR Danger Zones. Capture the message
+/// outside the RT lock and emit afterwards.
+public final class RotatingFileSink: @unchecked Sendable {
+  private let path: URL
+  private let lockFilePath: URL
+  private let maxSize: Int
+  private let maxFiles: Int
+  private let lock = OSAllocatedUnfairLock()
+
+  public init(path: URL, maxSize: Int = 5 * 1_024 * 1_024, maxFiles: Int = 3) {
+    self.path = path
+    // Stable companion file for cross-process flock. Never renamed, never
+    // touched by rotation logic — its only role is to host an OS file lock
+    // that survives renames of the active log.
+    self.lockFilePath = path.deletingLastPathComponent()
+      .appendingPathComponent("\(path.lastPathComponent).lock")
+    self.maxSize = maxSize
+    self.maxFiles = maxFiles
+  }
+
+  /// Append a single message to the sink. Synchronous and nonisolated; safe to
+  /// call from non-RT audio paths. Failures are silent (best-effort logging).
+  public func append(_ message: String) {
+    let data = Data(message.utf8)
+    lock.withLock {
+      Self.atomicAppendWithRotation(
+        path: path,
+        lockFilePath: lockFilePath,
+        data: data,
+        maxSize: maxSize,
+        maxFiles: maxFiles)
+    }
+  }
+
+  // MARK: - File helpers (BSD syscalls)
+
+  /// Opens a stable lock file, takes `flock(LOCK_EX)`, then opens the active
+  /// log with O_APPEND and writes. If the post-write size exceeds `maxSize`,
+  /// rotation runs while the cross-process lock is still held. The active-log
+  /// fd is closed before rotation so its rename can proceed.
+  ///
+  /// All errors swallowed — diagnostic logs must not propagate failure.
+  private static func atomicAppendWithRotation(
+    path: URL,
+    lockFilePath: URL,
+    data: Data,
+    maxSize: Int,
+    maxFiles: Int
+  ) {
+    try? FileManager.default.createDirectory(
+      at: path.deletingLastPathComponent(),
+      withIntermediateDirectories: true)
+
+    // 1. Stable lock file — never renamed, immune to rotation churn.
+    let lockFd = lockFilePath.path.withCString {
+      open($0, O_WRONLY | O_CREAT, 0o644)
+    }
+    guard lockFd >= 0 else { return }
+    defer { close(lockFd) }
+
+    guard flock(lockFd, LOCK_EX) == 0 else { return }
+    defer { _ = flock(lockFd, LOCK_UN) }
+
+    // 2. Active log: open separately and write.
+    let logFd = path.path.withCString { open($0, O_WRONLY | O_APPEND | O_CREAT, 0o644) }
+    guard logFd >= 0 else { return }
+
+    _ = data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Int in
+      guard let base = buf.baseAddress else { return 0 }
+      return write(logFd, base, buf.count)
+    }
+
+    var st = stat()
+    let sizeOk = fstat(logFd, &st) == 0
+    let oversize = sizeOk && Int(st.st_size) > maxSize
+
+    // 3. Close the active fd BEFORE rotation so rename can proceed cleanly.
+    close(logFd)
+
+    if oversize {
+      rotate(path: path, maxFiles: maxFiles)
+    }
+  }
+
+  /// Drops the oldest archive, shifts each `.i` → `.i+1`, and renames the
+  /// active file to `.1`. `maxFiles` is the total count INCLUDING the active
+  /// file: so `maxFiles == N` keeps `path` plus `.1` through `.(N - 1)`,
+  /// for `N` files on disk.
+  ///
+  /// Caller must hold both the in-process lock and the cross-process lock.
+  private static func rotate(path: URL, maxFiles: Int) {
+    let fm = FileManager.default
+    let dir = path.deletingLastPathComponent()
+    let base = path.lastPathComponent
+
+    // Total = active + (maxFiles - 1) archives.
+    let archiveCount = max(0, maxFiles - 1)
+
+    // Drop the oldest archive if it exists.
+    if archiveCount >= 1 {
+      let oldest = dir.appendingPathComponent("\(base).\(archiveCount)")
+      try? fm.removeItem(at: oldest)
+    }
+
+    // Shift each `.i` → `.i+1`, walking from highest archive index downward.
+    if archiveCount >= 2 {
+      for i in stride(from: archiveCount - 1, through: 1, by: -1) {
+        let src = dir.appendingPathComponent("\(base).\(i)")
+        let dst = dir.appendingPathComponent("\(base).\(i + 1)")
+        if fm.fileExists(atPath: src.path) {
+          try? fm.moveItem(at: src, to: dst)
+        }
+      }
+    }
+
+    // Active → `.1` if there's any archive budget; otherwise truncate.
+    if archiveCount >= 1 {
+      let firstRolled = dir.appendingPathComponent("\(base).1")
+      try? fm.moveItem(at: path, to: firstRolled)
+      // Recreate an empty active file so consumers tailing the documented
+      // path do not lose their target between rotation and the next append.
+      fm.createFile(atPath: path.path, contents: nil)
+    } else {
+      // maxFiles == 1 — caller wants size-cap-and-truncate behaviour.
+      // Truncate the active file in-place so the path keeps existing.
+      try? Data().write(to: path)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift
+++ b/Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+/// Validates Phase R4: `RotatingFileSink` enforces a bounded disk ceiling and
+/// stays correct under concurrent writers (in-process and cross-process).
+///
+/// Tests use a unique per-test directory under `NSTemporaryDirectory()` so
+/// parallel tests cannot collide and the developer's real
+/// `~/Library/Logs/EnviousWispr/` is never touched.
+@Suite("RotatingFileSink")
+struct RotatingFileSinkTests {
+
+  /// Builds a fresh isolated directory for one test. Cleaned via the
+  /// per-test cleanup callback — never assumes a specific path.
+  private static func makeIsolatedDirectory(_ tag: String) throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent(
+        "RotatingFileSinkTests-\(tag)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private static func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  // MARK: - Basic append
+
+  @Test("Writes are appended in order and visible on disk")
+  func appendOrderPreserved() throws {
+    let dir = try Self.makeIsolatedDirectory("append-order")
+    defer { Self.cleanup(dir) }
+
+    let path = dir.appendingPathComponent("sink.log")
+    let sink = RotatingFileSink(path: path, maxSize: 1_000_000, maxFiles: 3)
+
+    sink.append("first\n")
+    sink.append("second\n")
+    sink.append("third\n")
+
+    let contents = try String(contentsOf: path, encoding: .utf8)
+    #expect(contents == "first\nsecond\nthird\n")
+  }
+
+  // MARK: - Rotation
+
+  @Test("Rotation caps total retention at maxFiles (active + archives)")
+  func rotationCapsRetention() throws {
+    let dir = try Self.makeIsolatedDirectory("rotate-cap")
+    defer { Self.cleanup(dir) }
+
+    let path = dir.appendingPathComponent("sink.log")
+    // 1 KB ceiling, 3-file retention. Each line is roughly 64 bytes; ~24
+    // appends will produce multiple rotations before the test ends.
+    let sink = RotatingFileSink(path: path, maxSize: 1_024, maxFiles: 3)
+
+    let line = String(repeating: "x", count: 60) + "\n"
+    for _ in 0..<60 { sink.append(line) }
+
+    let active = path
+    let one = dir.appendingPathComponent("sink.log.1")
+    let two = dir.appendingPathComponent("sink.log.2")
+    let three = dir.appendingPathComponent("sink.log.3")
+
+    // maxFiles = TOTAL file count: active + .1 + .2 = 3 files. Archive .3
+    // must NEVER appear — oldest is dropped on each rotation.
+    #expect(FileManager.default.fileExists(atPath: active.path))
+    #expect(FileManager.default.fileExists(atPath: one.path))
+    #expect(FileManager.default.fileExists(atPath: two.path))
+    #expect(!FileManager.default.fileExists(atPath: three.path))
+
+    // Ceiling check: total bytes on disk are bounded by maxFiles * maxSize
+    // (each file just under the cap when it rolled), plus a small slack for
+    // the post-write size check that triggered the most recent rotation.
+    let urls = [active, one, two]
+    let totalBytes = urls.reduce(0) { acc, url in
+      let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+      return acc + ((attrs?[.size] as? Int) ?? 0)
+    }
+    #expect(totalBytes <= 3 * 1_024 + 1_024)
+  }
+
+  // MARK: - Concurrent writers (in-process)
+
+  @Test("Concurrent in-process writers do not produce torn lines")
+  func concurrentInProcessWritersAreAtomic() async throws {
+    let dir = try Self.makeIsolatedDirectory("concurrent")
+    defer { Self.cleanup(dir) }
+
+    let path = dir.appendingPathComponent("sink.log")
+    let sink = RotatingFileSink(path: path, maxSize: 10_000_000, maxFiles: 1)
+
+    // Each writer task emits a distinct full line. After all tasks finish,
+    // every emitted line must appear intact on disk.
+    let writers = 8
+    let perWriter = 100
+    await withTaskGroup(of: Void.self) { group in
+      for w in 0..<writers {
+        group.addTask {
+          for n in 0..<perWriter {
+            sink.append("writer-\(w)-msg-\(n)\n")
+          }
+        }
+      }
+    }
+
+    let contents = try String(contentsOf: path, encoding: .utf8)
+    let lines = contents.split(separator: "\n", omittingEmptySubsequences: true)
+
+    #expect(lines.count == writers * perWriter)
+    // Every line matches the expected shape — no torn writes from interleaving.
+    for line in lines {
+      #expect(line.hasPrefix("writer-"))
+      #expect(line.contains("-msg-"))
+    }
+  }
+
+  // MARK: - Cross-process safety smoke
+
+  @Test("Sibling process appends survive a rotation triggered by us")
+  func siblingProcessAppendsSurviveRotation() throws {
+    let dir = try Self.makeIsolatedDirectory("cross-process")
+    defer { Self.cleanup(dir) }
+
+    let path = dir.appendingPathComponent("sink.log")
+    // 256-byte cap, 3-file retention. Sibling write + bounded filler triggers
+    // at most one rotation; total bytes written stay under maxFiles × maxSize
+    // so the sibling line cannot be evicted past retention.
+    let sink = RotatingFileSink(path: path, maxSize: 256, maxFiles: 3)
+
+    // Simulate a sibling-process write by hand: open with O_APPEND outside the
+    // sink. The sibling line must appear in the active file or one of the
+    // rolled files when we're done — never lost.
+    let siblingMarker = "SIBLING-\(UUID().uuidString)"
+    let siblingLine = "\(siblingMarker)\n"
+    let cPath = path.path
+    let fd = cPath.withCString { open($0, O_WRONLY | O_APPEND | O_CREAT, 0o644) }
+    #expect(fd >= 0)
+    if fd >= 0 {
+      _ = siblingLine.withCString { ptr in
+        write(fd, ptr, strlen(ptr))
+      }
+      close(fd)
+    }
+
+    // 6 × ~50-byte filler keeps total bytes under (maxFiles × maxSize), so
+    // the sibling line lands in the active file or `.1` after one rotation.
+    let filler = String(repeating: "f", count: 48) + "\n"
+    for _ in 0..<6 { sink.append(filler) }
+
+    let candidates = [
+      path,
+      dir.appendingPathComponent("sink.log.1"),
+      dir.appendingPathComponent("sink.log.2"),
+      dir.appendingPathComponent("sink.log.3"),
+    ]
+
+    let foundSomewhere = candidates.contains { url in
+      guard let s = try? String(contentsOf: url, encoding: .utf8) else { return false }
+      return s.contains(siblingMarker)
+    }
+    #expect(foundSomewhere)
+  }
+}


### PR DESCRIPTION
## Summary

Phase R4 of #319 Hardening Bible. \`bt-route.log\` was append-only across the main app and XPC audio service with no cap or rotation — grew unbounded for the lifetime of the install. New \`RotatingFileSink\` enforces a 5 MB × 3 file ceiling (15 MB total) with append-with-rotation semantics.

- \`nonisolated\` class with \`OSAllocatedUnfairLock\` (in-process) + \`flock(LOCK_EX)\` on a separate stable lock file (cross-process). An actor would force \`async\` and break every existing call site, including audio-thread-adjacent contexts.
- Stable lock file (\`bt-route.log.lock\`) is intentionally NOT the active log itself — flock follows the inode, so a waiter that acquired before rename would still hold a lock on the rolled file while a sibling process opened a fresh active log and proceeded. Using a stable lock file avoids the cross-process race.
- \`maxFiles\` is the **total file count** retained on disk (active + archives), so the disk ceiling is \`maxSize × maxFiles\`. After rotation, an empty active file is recreated so consumers tailing \`bt-route.log\` never lose their target.
- Existing \`nonisolated static AudioCaptureManager.btRouteLog(_:)\` surface preserved — the 16 call sites across AudioCaptureManager, AVCaptureSessionSource, and PreRollForwarder keep their shape.

Plan reference: \`docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md\` §15.

## Test plan

- [x] \`scripts/swift-test.sh\` passes (478 tests)
- [x] \`scripts/swift-test.sh -c release\` passes (478 tests)
- [x] New \`RotatingFileSinkTests\`:
  - append order preserved
  - rotation caps total retention at maxFiles (active + archives = N files exactly)
  - 8 concurrent in-process writers × 100 messages each: no torn lines
  - sibling-process O_APPEND write survives one rotation
- [x] Tests use isolated tmp dirs — developer's \`~/Library/Logs/EnviousWispr/\` never touched
- [x] Codex code review clean (3 rounds: stable-lock-file fix + retention-budget off-by-one fix + active-file-recreation-after-rotation fix, all addressed)

## Architecture Closeout

- Module: \`EnviousWisprAudio\` (RotatingFileSink + AudioCaptureManager change). No new module dependencies for production code; \`EnviousWisprTests\` test target gains \`EnviousWisprAudio\` dep.
- Heart path: untouched. RotatingFileSink is sync nonisolated — call sites (audio capture / route changes / pre-roll) keep their existing call shape with no new actor hops.
- Disk: \`bt-route.log\` ceiling now bounded; the prior unbounded-append diagnostic risk is fixed.
