### PR TITLE
refactor(pipeline): TextProcessingRunner DI bundle (#388 G1, #389 G2)

### DIFF
--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -8,6 +8,11 @@ import Foundation
 public final class LLMPolishStep: TextProcessingStep {
   public let name = "LLM Polish"
 
+  /// LLM polish failures are user-visible: surface them to `polishError` so
+  /// the runner shows the "AI polish failed" banner. All other steps inherit
+  /// the default `.swallow` from the protocol extension.
+  internal var errorSurfacePolicy: ErrorSurfacePolicy { .surface }
+
   public var llmProvider: LLMProvider = .none
   public var llmModel: String = LLMProvider.defaultModel(for: .openAI)
   public var polishInstructions: PolishInstructions = .default

--- a/Sources/EnviousWisprPipeline/PipelineLogging.swift
+++ b/Sources/EnviousWisprPipeline/PipelineLogging.swift
@@ -1,0 +1,23 @@
+import EnviousWisprCore
+import Foundation
+
+/// Dependency-injection seam for the post-ASR text-processing chain's log sink.
+///
+/// `TextProcessingRunner` uses this to keep its log calls testable (the
+/// production default routes to `AppLogger.shared`; tests pass a recorder that
+/// captures entries in memory). Internal to `EnviousWisprPipeline` — there is
+/// no cross-module conformer today, so promoting it to `Core` would expand
+/// surface area without payoff.
+internal protocol PipelineLogging: Sendable {
+  func log(_ message: String, level: DebugLogLevel, category: String) async
+}
+
+/// Production conformer: routes every call to the existing
+/// `AppLogger.shared` actor. Stateless adapter — adding a default-init
+/// keeps `TextProcessingRunner.init(logger:)` ergonomic.
+internal struct AppLoggerAdapter: PipelineLogging {
+  init() {}
+  func log(_ message: String, level: DebugLogLevel, category: String) async {
+    await AppLogger.shared.log(message, level: level, category: category)
+  }
+}

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -16,8 +16,18 @@ internal struct TextProcessingRunResult {
 /// ownership for PipelineSettingsSync mutation.
 /// The runner owns only the execution algorithm: ordering, timeout, cancellation,
 /// failure continuation (heart & limbs), and CORRECTION_DEBUG logging.
+///
+/// Phase G1+G2: error-surface dispatch reads `step.errorSurfacePolicy` instead
+/// of matching `step.name == "LLM Polish"`, and the log sink is injectable via
+/// `PipelineLogging` so tests can verify side effects without disk reads.
 @MainActor
 internal final class TextProcessingRunner {
+
+  private let logger: any PipelineLogging
+
+  init(logger: any PipelineLogging = AppLoggerAdapter()) {
+    self.logger = logger
+  }
 
   func run(
     rawText: String,
@@ -29,8 +39,9 @@ internal final class TextProcessingRunner {
     context.targetAppName = targetAppName
     var polishError: String?
 
+    let logger = self.logger
     Task {
-      await AppLogger.shared.log(
+      await logger.log(
         "CORRECTION_DEBUG [RAW ASR] \(rawText)",
         level: .info, category: "CorrectionDebug"
       )
@@ -55,21 +66,21 @@ internal final class TextProcessingRunner {
         let outputText = context.polishedText ?? context.text
         let changed = inputText != outputText
         Task {
-          await AppLogger.shared.log(
+          await logger.log(
             "\(stepName) completed in \(String(format: "%.1f", stepMs))ms (budget: \(String(format: "%.0f", budgetSeconds * 1000))ms)",
             level: .info, category: "PipelineTiming"
           )
           if changed {
-            await AppLogger.shared.log(
+            await logger.log(
               "CORRECTION_DEBUG [\(stepName)] IN:  \(inputText)",
               level: .info, category: "CorrectionDebug"
             )
-            await AppLogger.shared.log(
+            await logger.log(
               "CORRECTION_DEBUG [\(stepName)] OUT: \(outputText)",
               level: .info, category: "CorrectionDebug"
             )
           } else {
-            await AppLogger.shared.log(
+            await logger.log(
               "CORRECTION_DEBUG [\(stepName)] no change",
               level: .info, category: "CorrectionDebug"
             )
@@ -96,11 +107,11 @@ internal final class TextProcessingRunner {
         } else {
           isLanguageGateSkip = false
         }
-        if stepName == "LLM Polish" && !isLanguageGateSkip {
+        if step.errorSurfacePolicy == .surface && !isLanguageGateSkip {
           polishError = error.localizedDescription
         }
         Task {
-          await AppLogger.shared.log(
+          await logger.log(
             "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping",
             level: .info, category: "TextProcessing"
           )

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -21,6 +21,19 @@ public struct TextProcessingContext: Sendable {
   }
 }
 
+/// Whether a step's thrown error should reach the user as `polishError`
+/// (e.g. the "AI polish failed" banner) or be silently absorbed by the heart.
+///
+/// Default conformance is `.swallow`: limb failures stay invisible. Only
+/// `LLMPolishStep` overrides to `.surface` today. Adding the property as a
+/// protocol requirement (with a default extension) replaces the prior
+/// string-literal branch on `step.name == "LLM Polish"`, so renaming a step
+/// can never silently mute the user-visible failure path.
+internal enum ErrorSurfacePolicy {
+  case surface
+  case swallow
+}
+
 /// A single step in the post-ASR text processing chain.
 ///
 /// Steps run in order after transcription. Each step receives the context
@@ -35,4 +48,11 @@ protocol TextProcessingStep {
   var maxDuration: Duration { get }
   /// Process the text and return an updated context.
   func process(_ context: TextProcessingContext) async throws -> TextProcessingContext
+  /// How `TextProcessingRunner` should treat an error thrown by `process`.
+  /// Defaults to `.swallow` — only LLM polish overrides to `.surface`.
+  var errorSurfacePolicy: ErrorSurfacePolicy { get }
+}
+
+extension TextProcessingStep {
+  var errorSurfacePolicy: ErrorSurfacePolicy { .swallow }
 }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -639,6 +639,7 @@ private final class MockPolishStep: TextProcessingStep {
   let name = "LLM Polish"
   let isEnabled = true
   let maxDuration: Duration
+  let errorSurfacePolicy: ErrorSurfacePolicy = .surface
 
   private let mode: Mode
 

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
@@ -1,8 +1,8 @@
-
 import EnviousWisprCore
 import EnviousWisprLLM
 import Foundation
 import Testing
+import os
 
 @testable import EnviousWisprPipeline
 
@@ -165,7 +165,7 @@ struct TextProcessingRunnerTests {
       return next
     }
 
-    let llm = RecordingStep(name: "LLM Polish") { _ in
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
       throw LLMError.requestFailed("service unavailable")
     }
 
@@ -183,14 +183,15 @@ struct TextProcessingRunnerTests {
     )
 
     #expect(result.context.text == "start-A-C")
-    #expect(result.polishError == LLMError.requestFailed("service unavailable").localizedDescription)
+    #expect(
+      result.polishError == LLMError.requestFailed("service unavailable").localizedDescription)
   }
 
   @Test("suppresses polishError for unsupported input language skips from LLM Polish")
   func suppressesPolishErrorForUnsupportedInputLanguage() async throws {
     let runner = TextProcessingRunner()
 
-    let llm = RecordingStep(name: "LLM Polish") { _ in
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
       throw LLMError.unsupportedInputLanguage("de")
     }
 
@@ -219,7 +220,7 @@ struct TextProcessingRunnerTests {
   func suppressesPolishErrorForOutputLanguageDrift() async throws {
     let runner = TextProcessingRunner()
 
-    let llm = RecordingStep(name: "LLM Polish") { _ in
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
       throw LLMError.outputLanguageDrift(expected: "de", actual: "en")
     }
 
@@ -293,7 +294,9 @@ struct TextProcessingRunnerTests {
       return next
     }
 
-    let slowLLM = RecordingStep(name: "LLM Polish", maxDuration: .milliseconds(50)) { context in
+    let slowLLM = RecordingStep(
+      name: "LLM Polish", maxDuration: .milliseconds(50), errorSurfacePolicy: .surface
+    ) { context in
       try await Task.sleep(for: .milliseconds(300))
       var next = context
       next.text += "-slow"
@@ -358,10 +361,138 @@ struct TextProcessingRunnerTests {
     }
   }
 
-  // TODO: production bug — add a contract test once fixed.
-  // `TextProcessingRunner` decides whether to surface `polishError` by matching
-  // the literal step name "LLM Polish". That is brittle: renaming the polish step
-  // silently changes user-visible error behavior.
+  // MARK: - Phase G1 — error-surface policy contract tests
+
+  @Test(
+    "Renaming the polish step does NOT affect polishError when the policy stays .surface"
+  )
+  func policyDispatchSurvivesRename() async throws {
+    let runner = TextProcessingRunner()
+
+    let renamed = RecordingStep(
+      name: "Polish",  // intentionally NOT "LLM Polish"
+      errorSurfacePolicy: .surface
+    ) { _ in
+      throw StepFailure(message: "renamed surface step exploded")
+    }
+
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [renamed]
+    )
+
+    #expect(result.polishError == "renamed surface step exploded")
+  }
+
+  @Test(".swallow policy never sets polishError, even for a step named 'LLM Polish'")
+  func swallowPolicyHidesErrorEvenForCollidingName() async throws {
+    let runner = TextProcessingRunner()
+
+    // Same legacy name but explicit .swallow policy: the runner must read the
+    // policy, not the name. This is the symmetric guarantee for
+    // policyDispatchSurvivesRename.
+    let collide = RecordingStep(
+      name: "LLM Polish",
+      errorSurfacePolicy: .swallow
+    ) { _ in
+      throw StepFailure(message: "should be swallowed")
+    }
+
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [collide]
+    )
+
+    #expect(result.polishError == nil)
+  }
+
+  @Test("LLMPolishStep declares .surface error policy")
+  func llmPolishStepDeclaresSurfacePolicy() async throws {
+    let llmStep = LLMPolishStep(keychainManager: KeychainManager())
+    #expect(llmStep.errorSurfacePolicy == .surface)
+  }
+
+  // MARK: - Phase G2 — injectable logger contract tests
+
+  @Test("Step success emits a PipelineTiming entry into the injected logger")
+  func successLogsPipelineTimingEntry() async throws {
+    let recorder = RecordingPipelineLogger()
+    let runner = TextProcessingRunner(logger: recorder)
+
+    let step = RecordingStep(name: "A") { context in
+      var next = context
+      next.text += "-A"
+      return next
+    }
+
+    _ = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [step]
+    )
+
+    // Logger work runs in fire-and-forget Task envelopes; bounded-poll for it.
+    let entries = await recorder.awaitEntry(
+      category: "PipelineTiming", messageContains: "A completed in")
+    #expect(
+      entries.contains { $0.category == "PipelineTiming" && $0.message.hasPrefix("A completed in") }
+    )
+  }
+
+  @Test("Step that mutates text emits CorrectionDebug IN/OUT lines via injected logger")
+  func mutatingStepLogsCorrectionDebug() async throws {
+    let recorder = RecordingPipelineLogger()
+    let runner = TextProcessingRunner(logger: recorder)
+
+    let step = RecordingStep(name: "Renamer") { context in
+      var next = context
+      next.text = "polished"
+      return next
+    }
+
+    _ = try await runner.run(
+      rawText: "raw",
+      language: "en",
+      targetAppName: nil,
+      steps: [step]
+    )
+
+    // OUT is emitted right after IN inside the same Task envelope; awaiting OUT
+    // implicitly drains until both have landed.
+    let entries = await recorder.awaitEntry(
+      category: "CorrectionDebug", messageContains: "[Renamer] OUT: polished")
+    let cd = entries.filter { $0.category == "CorrectionDebug" }
+    #expect(cd.contains { $0.message.contains("[Renamer] IN:  raw") })
+    #expect(cd.contains { $0.message.contains("[Renamer] OUT: polished") })
+  }
+
+  @Test("Step timeout emits a TextProcessing 'timed out' entry via injected logger")
+  func timeoutLogsTextProcessingWarning() async throws {
+    let recorder = RecordingPipelineLogger()
+    let runner = TextProcessingRunner(logger: recorder)
+
+    let slow = RecordingStep(name: "Slow", maxDuration: .milliseconds(50)) { context in
+      try await Task.sleep(for: .milliseconds(300))
+      return context
+    }
+
+    _ = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [slow]
+    )
+
+    let entries = await recorder.awaitEntry(
+      category: "TextProcessing", messageContains: "Slow timed out")
+    #expect(
+      entries.contains { $0.category == "TextProcessing" && $0.message.contains("Slow timed out") })
+  }
 }
 
 @MainActor
@@ -369,6 +500,7 @@ private final class RecordingStep: TextProcessingStep {
   let name: String
   let isEnabled: Bool
   let maxDuration: Duration
+  let errorSurfacePolicy: ErrorSurfacePolicy
 
   private let transform: @MainActor (TextProcessingContext) async throws -> TextProcessingContext
 
@@ -379,11 +511,13 @@ private final class RecordingStep: TextProcessingStep {
     name: String,
     isEnabled: Bool = true,
     maxDuration: Duration = .seconds(5),
+    errorSurfacePolicy: ErrorSurfacePolicy = .swallow,
     transform: @escaping @MainActor (TextProcessingContext) async throws -> TextProcessingContext
   ) {
     self.name = name
     self.isEnabled = isEnabled
     self.maxDuration = maxDuration
+    self.errorSurfacePolicy = errorSurfacePolicy
     self.transform = transform
   }
 
@@ -391,6 +525,48 @@ private final class RecordingStep: TextProcessingStep {
     runCount += 1
     seenInputs.append(context)
     return try await transform(context)
+  }
+}
+
+/// Test-only PipelineLogging conformer. Records every log call in memory so
+/// G2 tests can assert log side effects that the prior global-singleton
+/// `AppLogger.shared` design hid behind disk-only writes.
+final class RecordingPipelineLogger: PipelineLogging, @unchecked Sendable {
+  struct Entry: Equatable {
+    let message: String
+    let level: DebugLogLevel
+    let category: String
+  }
+
+  // OSAllocatedUnfairLock rather than NSLock — Swift 6 strict concurrency
+  // forbids NSLock.lock/unlock from async contexts.
+  private let storage = OSAllocatedUnfairLock<[Entry]>(initialState: [])
+
+  func log(_ message: String, level: DebugLogLevel, category: String) async {
+    storage.withLock { state in
+      state.append(Entry(message: message, level: level, category: category))
+    }
+  }
+
+  func snapshot() -> [Entry] {
+    storage.withLock { $0 }
+  }
+
+  /// Waits up to ~500ms for an entry whose category matches `category` and
+  /// whose message contains `messageContains` to appear. Returns the full
+  /// recorded buffer afterwards. The runner emits log calls from inside
+  /// fire-and-forget `Task { ... }` envelopes; cooperative yield alone is
+  /// not deterministic because the detached Tasks have no parent the test
+  /// can await. A bounded poll is a robust and cheap workaround.
+  func awaitEntry(category: String, messageContains needle: String) async -> [Entry] {
+    for _ in 0..<50 {
+      let current = snapshot()
+      if current.contains(where: { $0.category == category && $0.message.contains(needle) }) {
+        return current
+      }
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+    return snapshot()
   }
 }
 


### PR DESCRIPTION
## Summary

Phase G1+G2 of #319 Hardening Bible (sequencing-locked bundle per PR #418).

**G1 — error-surface policy (#388, ~25 LOC):** runner reads \`step.errorSurfacePolicy\` instead of matching the literal \`"LLM Polish"\`. Renaming a polish step can no longer silently mute the user-visible "AI polish failed" banner. Default is \`.swallow\`; only \`LLMPolishStep\` overrides to \`.surface\`.

**G2 — injectable logger (#389, ~30 LOC):** new internal \`PipelineLogging\` protocol + \`AppLoggerAdapter\` default. Tests inject a recorder; production behavior unchanged. Fire-and-forget \`Task { ... }\` envelope shape preserved at every site so logging stays heart-path-non-blocking.

Plan reference: \`docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md\` §17A.

## Test plan

- [x] \`scripts/swift-test.sh\` passes (481 tests)
- [x] \`scripts/swift-test.sh -c release\` passes (481 tests)
- [x] Six new tests cover G1 + G2:
  - rename-survives-policy, swallow-collides-with-name, LLMPolishStep self-declares \`.surface\`
  - timing/correction-debug/timeout entries flow through injected logger
- [x] \`MockPolishStep\` in HeartPathIntegrationTests now declares \`.surface\` policy explicitly (was relying on the legacy string match)
- [x] \`RecordingPipelineLogger\` uses \`OSAllocatedUnfairLock\` (NSLock unavailable from async contexts under Swift 6)
- [x] Bounded-poll drain on the recorder so fire-and-forget Task envelopes drain before assertions run
- [x] Codex code-diff review clean (1 round, no findings)

## Architecture Closeout

- Module: \`EnviousWisprPipeline\` only. No new module dependencies.
- Heart path: untouched. Both changes are internal restructuring of the existing post-ASR text-processing chain.
- Public API: unchanged. \`TextProcessingRunner.init(logger:)\` adds an optional defaulted parameter; existing callers compile without edits.
