### PR TITLE
refactor(asr): inject ASRManager backends for testability (#398, G5)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -20,10 +20,20 @@ public final class ASRManager: ASRManagerInterface {
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
   private var inFlightLoadTask: Task<Void, any Error>?
 
-  private var parakeetBackend = ParakeetBackend()
-  private var whisperKitBackend = WhisperKitBackend()
+  // Phase G5: existential-typed for test injection. Production callers pass
+  // nothing; the defaults preserve today's wiring exactly. Tests pass fakes
+  // that report `isReady=true` without a real model load, unblocking
+  // reset-branch coverage in `setInitialBackendType` and `switchBackend`.
+  private var parakeetBackend: any ASRBackend
+  private var whisperKitBackend: any ASRBackend
 
-  public init() {}
+  public init(
+    parakeetBackend: (any ASRBackend)? = nil,
+    whisperKitBackend: (any ASRBackend)? = nil
+  ) {
+    self.parakeetBackend = parakeetBackend ?? ParakeetBackend()
+    self.whisperKitBackend = whisperKitBackend ?? WhisperKitBackend()
+  }
 
   /// The currently active backend.
   public var activeBackend: any ASRBackend {

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -2,6 +2,11 @@
 import EnviousWisprCore
 import Foundation
 
+/// Progress callback shape: (fractionCompleted, phaseString, detailString).
+/// Lives at the protocol scope so any backend with download progress can
+/// surface it through the shared `prepare(progressCallback:)` entry point.
+public typealias ProgressCallback = @Sendable (Double, String, String) -> Void
+
 /// Unified protocol for all ASR backends.
 ///
 /// Both WhisperKit and Parakeet/FluidAudio conform to this protocol,
@@ -12,6 +17,11 @@ public protocol ASRBackend: Actor {
 
   /// Load/initialize the model. Call once before transcription.
   func prepare() async throws
+
+  /// Load/initialize the model with optional progress reporting.
+  /// Default implementation delegates to `prepare()`; backends that report
+  /// progress (Parakeet via FluidAudio download) override directly.
+  func prepare(progressCallback: ProgressCallback?) async throws
 
   /// Batch transcription from raw Float32 samples (16kHz mono).
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
@@ -54,6 +64,13 @@ extension ASRBackend {
   }
 
   public func cancelStreaming() async {}
+
+  /// Default delegates to plain `prepare()` — backends without progress
+  /// reporting ignore the callback. ParakeetBackend overrides directly to
+  /// report FluidAudio download progress.
+  public func prepare(progressCallback: ProgressCallback?) async throws {
+    try await prepare()
+  }
 }
 
 /// Errors that can occur during ASR operations.

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -25,9 +25,6 @@ public actor ParakeetBackend: ASRBackend {
 
   public init() {}
 
-  /// Progress callback type: (fractionCompleted, phaseString, detailString)
-  public typealias ProgressCallback = @Sendable (Double, String, String) -> Void
-
   public func prepare() async throws {
     try await prepare(progressCallback: nil)
   }

--- a/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
@@ -1,0 +1,138 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+import Testing
+import os
+
+@testable import EnviousWisprASR
+
+/// Phase G5 — exercises reset-branch behavior in `setInitialBackendType` and
+/// `switchBackend` from a synthetic loaded state. Previously NOT_TESTABLE
+/// because driving a real `ParakeetBackend` / `WhisperKitBackend` to
+/// `isReady=true` requires a real model download/compile on CI.
+///
+/// `FakeASRBackend` is an actor (matches `ASRBackend: Actor` requirement)
+/// that reports a controllable `isReady` and records `unload` / `prepare`
+/// calls for assertions.
+@Suite("ASRManager backend injection (Phase G5)")
+@MainActor
+struct ASRManagerBackendInjectionTests {
+
+  // MARK: - switchBackend reset branch
+
+  @Test("switchBackend from a loaded state resets isModelLoaded to false")
+  func switchBackendFromLoadedResetsIsModelLoaded() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: true)
+    let whisperKit = FakeASRBackend(initiallyReady: true)
+
+    let manager = ASRManager(
+      parakeetBackend: parakeet,
+      whisperKitBackend: whisperKit
+    )
+
+    // Drive the manager to "loaded" via the public loadModel path. Because
+    // FakeASRBackend reports ready, loadModel completes synchronously after
+    // the actor hop and isModelLoaded becomes true.
+    try await manager.loadModel()
+    #expect(manager.isModelLoaded == true)
+
+    await manager.switchBackend(to: .whisperKit)
+    #expect(manager.isModelLoaded == false)
+    #expect(manager.activeBackendType == .whisperKit)
+  }
+
+  @Test("switchBackend unloads the previous backend exactly once")
+  func switchBackendUnloadsPreviousBackend() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: true)
+    let whisperKit = FakeASRBackend(initiallyReady: true)
+
+    let manager = ASRManager(
+      parakeetBackend: parakeet,
+      whisperKitBackend: whisperKit
+    )
+    try await manager.loadModel()
+
+    await manager.switchBackend(to: .whisperKit)
+
+    let parakeetUnloads = await parakeet.unloadCount
+    let whisperKitUnloads = await whisperKit.unloadCount
+    #expect(parakeetUnloads == 1)
+    #expect(whisperKitUnloads == 0)
+  }
+
+  @Test("switchBackend to the same type is a no-op (no unload, flags preserved)")
+  func switchBackendSameTypeIsNoOp() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: true)
+    let whisperKit = FakeASRBackend(initiallyReady: true)
+
+    let manager = ASRManager(
+      parakeetBackend: parakeet,
+      whisperKitBackend: whisperKit
+    )
+    try await manager.loadModel()
+
+    await manager.switchBackend(to: .parakeet)
+
+    let parakeetUnloads = await parakeet.unloadCount
+    #expect(parakeetUnloads == 0)
+    #expect(manager.activeBackendType == .parakeet)
+    #expect(manager.isModelLoaded == true)
+  }
+
+  // MARK: - setInitialBackendType reset branch
+
+  @Test("setInitialBackendType after a load resets isModelLoaded and isStreaming")
+  func setInitialBackendTypeAfterLoadResetsFlags() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: true)
+    let whisperKit = FakeASRBackend(initiallyReady: true)
+
+    let manager = ASRManager(
+      parakeetBackend: parakeet,
+      whisperKitBackend: whisperKit
+    )
+    try await manager.loadModel()
+    #expect(manager.isModelLoaded == true)
+
+    manager.setInitialBackendType(.whisperKit)
+    #expect(manager.isModelLoaded == false)
+    #expect(manager.isStreaming == false)
+    #expect(manager.activeBackendType == .whisperKit)
+  }
+}
+
+// MARK: - Fake
+
+/// Minimal `ASRBackend` actor for tests. Reports controllable readiness and
+/// records lifecycle calls. Does NOT implement transcription or streaming —
+/// G5 scope is the manager's reset branches, not real ASR work.
+final actor FakeASRBackend: ASRBackend {
+  private var ready: Bool
+  private(set) var unloadCount: Int = 0
+  private(set) var prepareCount: Int = 0
+
+  init(initiallyReady: Bool) {
+    self.ready = initiallyReady
+  }
+
+  // MARK: ASRBackend
+
+  var isReady: Bool { ready }
+
+  var supportsStreaming: Bool { false }
+
+  func prepare() async throws {
+    prepareCount += 1
+    ready = true
+  }
+
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions)
+    async throws -> ASRResult
+  {
+    fatalError("FakeASRBackend.transcribe is not used by Phase G5 tests")
+  }
+
+  func unload() async {
+    unloadCount += 1
+    ready = false
+  }
+}


### PR DESCRIPTION
## Summary

Phase G5 of #319 Hardening Bible §17A. \`ASRManager\` no longer constructs its backends inline — production callers still use \`ASRManager()\` (defaults preserve today's wiring); tests can pass fakes that report \`isReady=true\` without a real model load. Unblocks reset-branch coverage in \`setInitialBackendType\` and \`switchBackend\` that PR #400 had to drop as SUBTLE_THEATER.

- \`ASRBackend\` protocol gains \`prepare(progressCallback:)\` with a default extension that delegates to plain \`prepare()\`. ParakeetBackend keeps its concrete progress-reporting override; WhisperKitBackend inherits the no-op default. Without this widening, switching the manager's stored backends to \`any ASRBackend\` would lose Parakeet's download UI (per grounded review 2026-04-20).
- \`ProgressCallback\` typealias moves from ParakeetBackend to the protocol scope so any future backend with download progress reuses the same shape.
- \`ASRManager\` properties become \`any ASRBackend\`. New \`init(parakeetBackend:whisperKitBackend:)\` with both params optional; production callers (AppState, etc.) keep zero-arg \`ASRManager()\`.

Plan reference: \`docs/feature-requests/issue-398-2026-04-20-asrmanager-backend-injection.md\`.

Sequencing: G1+G2 (#477) → **G5 (this PR)** → G3 (#394) → G4 (#396) per Bible §17A lock.

## Test plan

- [x] \`scripts/swift-test.sh\` passes (483 tests)
- [x] \`scripts/swift-test.sh -c release\` passes (483 tests)
- [x] Four new tests in \`ASRManagerBackendInjectionTests\`:
  - switchBackend from loaded resets isModelLoaded
  - switchBackend unloads previous backend exactly once
  - switchBackend to same type is a no-op (locks the early-return guard)
  - setInitialBackendType after a load resets both flags
- [x] \`FakeASRBackend\` is a \`final actor\` (matches \`ASRBackend: Actor\`); records lifecycle calls
- [x] Existing \`ASRManagerColdStateContractTests\` continue to pass — default init preserves cold-manager behavior
- [x] Codex code-diff review clean (1 round, no findings)

## Architecture Closeout

- Module: \`EnviousWisprASR\` only. No new module dependencies.
- Heart path: ASR is heart. The protocol widening + existential indirection adds zero new actor hops at runtime — every \`activeBackend.foo()\` call already \`await\`ed across the actor boundary.
- Public API: \`ASRManager.init\` adds optional defaulted params; existing callers compile unchanged. \`ASRBackend\` gains one method with a default impl; existing conformers continue to compile.
