### PR TITLE
refactor(pipeline): inject TranscriptFinalizer into TranscriptionPipeline (#394, G3)

### DIFF
--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -137,19 +137,41 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// `currentCaptureSessionID`) is not torn down by stale cleanup.
   private var pendingStallRecoveryToken: UInt64?
 
-  public init(
+  public convenience init(
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
     transcriptStore: TranscriptStore,
     keychainManager: KeychainManager = KeychainManager(),
     captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
   ) {
+    self.init(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      captureTelemetry: captureTelemetry,
+      transcriptFinalizer: TranscriptFinalizer(transcriptStore: transcriptStore))
+  }
+
+  /// Phase G3 — `internal` overload that accepts a pre-built finalizer so
+  /// `@testable` callers can drive the heart path with a mock paste seam.
+  /// Production callers use the zero-arg-finalizer `public init` above and
+  /// get identical wiring; only the construction of `transcriptFinalizer`
+  /// is parameterized.
+  internal init(
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    transcriptStore: TranscriptStore,
+    keychainManager: KeychainManager = KeychainManager(),
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState(),
+    transcriptFinalizer: TranscriptFinalizer
+  ) {
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.transcriptStore = transcriptStore
     self.keychainManager = keychainManager
     self.captureTelemetry = captureTelemetry
-    self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
+    self.transcriptFinalizer = transcriptFinalizer
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: makes the Parakeet path non-inferred. The
     // planner will force the legacy English-centric path for Parakeet

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -283,7 +283,7 @@ private final class HeartPathHarness {
 
 // MARK: - Fixture generation
 
-private struct SyntheticAudioFixture {
+internal struct SyntheticAudioFixture {
   let url: URL
   let durationSeconds: TimeInterval
 
@@ -402,7 +402,7 @@ extension Data {
 // MARK: - Test doubles
 
 @MainActor
-private final class FixtureAudioCapture: AudioCaptureInterface {
+internal final class FixtureAudioCapture: AudioCaptureInterface {
   var isCapturing: Bool = false
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
@@ -550,7 +550,7 @@ private final class FixtureAudioCapture: AudioCaptureInterface {
 }
 
 @MainActor
-private final class MockASRManager: ASRManagerInterface {
+internal final class MockASRManager: ASRManagerInterface {
   enum TranscribeBehavior {
     case success(ASRResult)
     case failure(Error)
@@ -676,7 +676,7 @@ private final class MockPolishStep: TextProcessingStep {
 
 // MARK: - Helpers
 
-private enum FixtureError: Error {
+internal enum FixtureError: Error {
   case malformedWAV
   case unsupportedFormat
 }

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptionPipelineInjectionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptionPipelineInjectionTests.swift
@@ -1,0 +1,111 @@
+@preconcurrency import AVFoundation
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Phase G3 — locks the new `internal init` overload on `TranscriptionPipeline`.
+/// The seam lets `@testable` callers swap in a `TranscriptFinalizer` built from
+/// closure mocks, so future heart-path tests can drive end-to-end through the
+/// pipeline (paste, persistence, finalization) instead of around it via the
+/// HeartPathHarness side-channel that PR #391 was forced to use.
+///
+/// Full state-machine scenarios stay in `HeartPathIntegrationTests`. G3 only
+/// needs to demonstrate the seam is reachable from `@testable import`.
+@MainActor
+@Suite("TranscriptionPipeline injection (Phase G3)")
+struct TranscriptionPipelineInjectionTests {
+
+  @Test("Internal init wires an injected TranscriptFinalizer instead of the default one")
+  func internalInitWiresInjectedFinalizer() async throws {
+    let fixture = try SyntheticAudioFixture.make(
+      fileName: "g3-injection-smoke.wav",
+      pattern: .toneBurst
+    )
+    let audioCapture = try FixtureAudioCapture(fixtureURL: fixture.url)
+    let asrManager = MockASRManager(
+      transcribeBehavior: .success(
+        ASRResult(
+          text: "hello",
+          language: "en",
+          duration: fixture.durationSeconds,
+          processingTime: 0.01,
+          backendType: .parakeet
+        )
+      )
+    )
+
+    // Closure-mocked finalizer — same shape as TranscriptFinalizerTests uses.
+    // The init only needs to ACCEPT this; verifying the pipeline drives it
+    // end-to-end is HeartPathIntegrationTests' job.
+    let saved = SavedBox()
+    let pasteCount = CountBox()
+    let finalizer = TranscriptFinalizer(
+      save: { saved.append($0) },
+      deliverPaste: { _ in
+        pasteCount.increment()
+        return PasteDeliveryResult(
+          tier: .axDirect,
+          durationMs: 0,
+          outcome: .delivered(tier: .axDirect, durationMs: 0))
+      }
+    )
+
+    let pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: TranscriptStore(),
+      transcriptFinalizer: finalizer
+    )
+
+    // Pipeline starts idle; no transcription/paste invoked yet.
+    #expect(pipeline.state == .idle)
+    #expect(pipeline.currentTranscript == nil)
+    #expect(saved.count == 0)
+    #expect(pasteCount.value == 0)
+  }
+
+  @Test("Public convenience init still produces a working default-finalizer pipeline")
+  func publicInitStillWorksAfterG3Split() async throws {
+    let fixture = try SyntheticAudioFixture.make(
+      fileName: "g3-public-init-smoke.wav",
+      pattern: .toneBurst
+    )
+    let audioCapture = try FixtureAudioCapture(fixtureURL: fixture.url)
+    let asrManager = MockASRManager(
+      transcribeBehavior: .success(
+        ASRResult(
+          text: "hello",
+          language: "en",
+          duration: fixture.durationSeconds,
+          processingTime: 0.01,
+          backendType: .parakeet
+        )
+      )
+    )
+
+    let pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: TranscriptStore()
+    )
+    #expect(pipeline.state == .idle)
+    #expect(pipeline.currentTranscript == nil)
+  }
+}
+
+@MainActor
+private final class SavedBox {
+  private(set) var transcripts: [Transcript] = []
+  var count: Int { transcripts.count }
+  func append(_ t: Transcript) { transcripts.append(t) }
+}
+
+@MainActor
+private final class CountBox {
+  private(set) var value: Int = 0
+  func increment() { value += 1 }
+}


### PR DESCRIPTION
## Summary

Phase G3 of #319 Hardening Bible §17A. \`TranscriptionPipeline\` now exposes an \`internal init\` overload accepting a pre-built \`TranscriptFinalizer\`, reachable from \`@testable import EnviousWisprPipeline\`. Production callers continue to use the existing \`public init(...)\` (now a \`convenience\` initializer that delegates to the new designated init with the existing \`TranscriptFinalizer(transcriptStore:)\` default).

- The seam unblocks future heart-path tests that need to drive end-to-end through the pipeline (paste, persistence, finalization) without building a parallel \`HeartPathHarness\` side-channel as PR #391 had to do.
- No public surface change: \`TranscriptFinalizer\` stays \`internal\`. The new init is \`internal\`-visibility-matched.
- Promotes existing test fixtures (\`FixtureAudioCapture\`, \`MockASRManager\`, \`SyntheticAudioFixture\`, \`FixtureError\`) from \`private\` to \`internal\` so the new test file can drive a real-shape pipeline construction without duplicating fixture code.

Plan reference: \`docs/feature-requests/issue-394-2026-04-20-transcriptionpipeline-di-seams.md\`.

Sequencing: G1+G2 (#477) → G5 (#479) → **G3 (this PR)** → G4 (#396) per Bible §17A lock.

## Test plan

- [x] \`scripts/swift-test.sh\` passes (491 tests)
- [x] \`scripts/swift-test.sh -c release\` passes
- [x] New \`TranscriptionPipelineInjectionTests\` (2 tests):
  - Internal init accepts an injected closure-mocked \`TranscriptFinalizer\` (the seam)
  - Public convenience init still produces a working default-finalizer pipeline (no behavior drift)
- [x] All existing \`HeartPathIntegrationTests\` continue to pass after fixture-promotion
- [x] Codex code-diff review clean (1 round, no findings)

## Architecture Closeout

- Module: \`EnviousWisprPipeline\` only. No new module dependencies.
- Heart path: untouched. Production wiring is the same TranscriptStore-backed default; the only runtime change is one extra constructor delegation.
- Public API: unchanged. \`TranscriptionPipeline.init(...)\` callers compile with no edits; the convenience init has the same signature as before.
- Access control: \`TranscriptFinalizer\` stays \`internal\` per architecture-rules.md §Access Control.
