### PR TITLE
seo: remove em-dashes from meta layer (titles, og alts, RSS, 404)

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const {
   description,
   activePage = 'home',
   ogImage = '/og-image.png',
-  ogImageAlt = 'EnviousWispr — Private AI dictation for macOS',
+  ogImageAlt = 'EnviousWispr: Private AI dictation for macOS',
   ogType = 'website',
   canonicalPath,
   noindex = false,

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -34,7 +34,7 @@ const formatDate = (d: Date) =>
 const siteUrl = 'https://enviouswispr.com';
 const canonicalUrl = Astro.url.href;
 const ogImage = image || '/og-image.png';
-const ogImageAlt = `${title} — EnviousWispr`;
+const ogImageAlt = `${title} | EnviousWispr`;
 
 const articleJsonLd = JSON.stringify({
   "@context": "https://schema.org",
@@ -129,7 +129,7 @@ const breadcrumbJsonLd = JSON.stringify({
 });
 ---
 
-<BaseLayout title={`${title} — EnviousWispr`} description={description} activePage="blog" ogType="article" ogImage={ogImage} ogImageAlt={ogImageAlt}>
+<BaseLayout title={`${title} | EnviousWispr`} description={description} activePage="blog" ogType="article" ogImage={ogImage} ogImageAlt={ogImageAlt}>
   <Fragment slot="head">
     <meta property="article:published_time" content={pubDate.toISOString()} />
     {updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="Page Not Found — EnviousWispr"
+  title="Page Not Found | EnviousWispr"
   description="This page doesn't exist. Head back to EnviousWispr to download the app or read the blog."
   noindex
 >

--- a/website/src/pages/rss.xml.ts
+++ b/website/src/pages/rss.xml.ts
@@ -8,7 +8,7 @@ export async function GET(context: APIContext) {
   return rss({
     title: 'EnviousWispr Blog',
     description:
-      'Updates, release notes, and deep dives from the EnviousWispr team — private AI dictation for macOS.',
+      'Updates, release notes, and deep dives from the EnviousWispr team: private AI dictation for macOS.',
     site: context.site ?? 'https://enviouswispr.com',
     items: sorted.map(post => ({
       title: post.data.title,


### PR DESCRIPTION
## Summary
Continuation of #489's Rule 6 work, sweeping the remaining em-dashes in the meta layer (titles, og:image alts, RSS feed) where they leak into search snippets and social cards.

## Files
- `BaseLayout.astro:23` — default og:image:alt `EnviousWispr — Private AI dictation for macOS` -> colon (every page that does not override it)
- `404.astro:6` — title `Page Not Found — EnviousWispr` -> pipe
- `BlogPost.astro:37, :132` — `\`${title} — EnviousWispr\`` -> pipe in both `<title>` and og:image:alt (sweeps all 22 blog post pages in one shot)
- `rss.xml.ts:11` — channel `<description>` `... team — private ...` -> colon

Pipe (`|`) for site-name suffixes (standard SEO separator), colon for descriptive copy. All edits are 1:1 character swaps; no length impact.

## Out of scope
Body-copy em-dashes remain on:
- Home: 6 instances (in-page demo text, mode hints)
- /compare/wisprflow/: 4 instances (citation prose)
- Various blog posts: many instances in body copy

Those are a content sweep, not a meta sweep, and warrant their own PR pass with brand-voice review per `.claude/rules/content-brand.md`.

## Test plan
- [x] `npm run build` clean
- [x] Verified rendered `<title>`, `og:image:alt`, RSS `<description>` show pipe/colon (no `—`) in /404, /blog/getting-started.../, /index, /rss.xml

`council-skip: zero-blast-radius (User-facing copy in website/src/)`
