### PR TITLE
seo: homepage → privacy blog anchor + body em-dash sweep

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -186,7 +186,7 @@ const jsonLdFaq = JSON.stringify({
           <span class="chrome-dot red"></span>
           <span class="chrome-dot yellow"></span>
           <span class="chrome-dot green"></span>
-          <span class="chrome-title">EnviousWispr — AI Polish</span>
+          <span class="chrome-title">EnviousWispr: AI Polish</span>
         </div>
         <div class="tone-body">
           <!-- Raw voice input -->
@@ -227,7 +227,7 @@ const jsonLdFaq = JSON.stringify({
             </div>
             <div class="tone-output" id="tone-out-casual" role="tabpanel" aria-labelledby="tone-tab-casual">
               <div class="tone-output-badge badge-casual">Casual</div>
-              <div>Hey! Quick follow-up from yesterday — we gotta lock down those budget numbers before Friday. Oh and Sarah thinks the Q3 projections might be off.</div>
+              <div>Hey! Quick follow-up from yesterday: we gotta lock down those budget numbers before Friday. Oh and Sarah thinks the Q3 projections might be off.</div>
             </div>
           </div>
 
@@ -280,7 +280,7 @@ const jsonLdFaq = JSON.stringify({
             Coder
           </div>
           <h3 class="uc-card-headline">Ship code without<br/>leaving flow.</h3>
-          <p class="uc-card-desc">Narrate your thoughts while you work. Your IDE, your pace — no keyboard-switching required.</p>
+          <p class="uc-card-desc">Narrate your thoughts while you work. Your IDE, your pace, no keyboard-switching required.</p>
           <ul class="uc-task-list">
             <li>PR descriptions &amp; review notes</li>
             <li>Commit messages on the fly</li>
@@ -380,7 +380,7 @@ const jsonLdFaq = JSON.stringify({
             Remote Worker
           </div>
           <h3 class="uc-card-headline">Stay responsive without<br/>breaking focus.</h3>
-          <p class="uc-card-desc">Answer Slack, update tickets, post standups — all without switching mental contexts.</p>
+          <p class="uc-card-desc">Answer Slack, update tickets, post standups, all without switching mental contexts.</p>
           <ul class="uc-task-list">
             <li>Slack replies &amp; threads</li>
             <li>Daily standup updates</li>
@@ -400,7 +400,7 @@ const jsonLdFaq = JSON.stringify({
             Accessibility
           </div>
           <h3 class="uc-card-headline">Your voice,<br/>your primary input.</h3>
-          <p class="uc-card-desc">Hands-free and reliable all day. Dictate anything, anywhere — no mode-switching, no limits.</p>
+          <p class="uc-card-desc">Hands-free and reliable all day. Dictate anything, anywhere. No mode-switching, no limits.</p>
           <ul class="uc-task-list">
             <li>Hands-free writing &amp; editing</li>
             <li>Form filling &amp; web navigation</li>
@@ -440,7 +440,7 @@ const jsonLdFaq = JSON.stringify({
             Healthcare Pro
           </div>
           <h3 class="uc-card-headline">Chart notes without<br/>the keyboard.</h3>
-          <p class="uc-card-desc">Dictate patient notes, referral letters, and discharge summaries between rounds. Fully on-device — no cloud, no WiFi needed, no patient data leaves your Mac.</p>
+          <p class="uc-card-desc">Dictate patient notes, referral letters, and discharge summaries between rounds. Fully on-device. No cloud, no WiFi needed, no patient data leaves your Mac.</p>
           <ul class="uc-task-list">
             <li>Patient case notes</li>
             <li>Referral letters</li>
@@ -494,11 +494,11 @@ const jsonLdFaq = JSON.stringify({
           </div>
           <span class="mode-tag">Push-to-Talk</span>
           <h3>Hold to record.<br/>Release to paste.</h3>
-          <p>Perfect for quick messages, replies, and search queries. Hold your hotkey while you speak — the moment you release, polished text appears exactly where you're typing.</p>
+          <p>Perfect for quick messages, replies, and search queries. Hold your hotkey while you speak. The moment you release, polished text appears exactly where you're typing.</p>
           <div class="mode-hint">
             <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Command, hold">
               <span class="key-cap held" aria-hidden="true">&#8984;</span>
-              <span class="key-sep" aria-hidden="true">— hold</span>
+              <span class="key-sep" aria-hidden="true">· hold</span>
             </div>
             <span class="mode-hint-label">Hold Right Command while speaking, release to paste</span>
           </div>
@@ -509,7 +509,7 @@ const jsonLdFaq = JSON.stringify({
           </div>
           <span class="mode-tag">Hands-Free</span>
           <h3>Double-press to start.<br/>Press once to stop.</h3>
-          <p>Built for long-form writing — emails, documents, meeting notes. Double-press your hotkey to start recording, then press once to finish. Your hands stay free the whole time.</p>
+          <p>Built for long-form writing: emails, documents, meeting notes. Double-press your hotkey to start recording, then press once to finish. Your hands stay free the whole time.</p>
           <div class="mode-hint">
             <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Command double-press">
               <span class="key-cap tap" aria-hidden="true">&#8984;</span>
@@ -546,14 +546,14 @@ const jsonLdFaq = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#4169e1" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           </div>
           <h3>Works Everywhere</h3>
-          <p>Dictate into any app — email, Slack, docs, notes, terminals. Text appears right where you're typing. Your previous clipboard is preserved.</p>
+          <p>Dictate into any app: email, Slack, docs, notes, terminals. Text appears right where you're typing. Your previous clipboard is preserved.</p>
         </div>
         <div class="benefit-card reveal" style="--i:2">
           <div class="benefit-icon cyan" aria-hidden="true">
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#0099aa" stroke-width="2" stroke-linecap="round"><path d="M12 2L15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2z"/></svg>
           </div>
           <h3>Cleans Up Your Words</h3>
-          <p>Removes ums, fixes grammar, and polishes your text automatically. Choose from clean, formal, or casual styles — or write your own custom prompt.</p>
+          <p>Removes ums, fixes grammar, and polishes your text automatically. Choose from clean, formal, or casual styles, or write your own custom prompt.</p>
         </div>
         <div class="benefit-card reveal" style="--i:3">
           <div class="benefit-icon amber" aria-hidden="true">
@@ -567,7 +567,7 @@ const jsonLdFaq = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="2" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
           </div>
           <h3>Your AI, Your Choice</h3>
-          <p>Works with OpenAI, Google Gemini, Apple Intelligence, or fully offline with Ollama. Bring your own API key — or go completely local, no internet required.</p>
+          <p>Works with OpenAI, Google Gemini, Apple Intelligence, or fully offline with Ollama. Bring your own API key, or go completely local with no internet required.</p>
         </div>
         <div class="benefit-card reveal" style="--i:5">
           <div class="benefit-icon orange" aria-hidden="true">
@@ -588,24 +588,24 @@ const jsonLdFaq = JSON.stringify({
       <div class="section-head reveal">
         <div class="section-label-pill green">Privacy</div>
         <h2 class="section-title" id="privacy-heading">Your voice stays<br/>on your Mac.</h2>
-        <p class="section-sub">No cloud ASR. No voice data servers. No account required. What you say is yours alone.</p>
+        <p class="section-sub">No cloud ASR. No voice data servers. No account required. What you say is yours alone. <a href="/blog/on-device-vs-cloud-dictation-privacy/">Read the full breakdown of on-device vs cloud dictation.</a></p>
       </div>
 
       <div class="privacy-grid-3 reveal-stagger">
         <div class="privacy-card-3 reveal" style="--i:0">
           <div class="privacy-icon" style="background:rgba(0,200,128,0.1);" aria-hidden="true">&#128274;</div>
           <h3>On-Device by Default</h3>
-          <p>Speech recognition runs entirely on your Mac using Apple Neural Engine. Audio bytes never leave your device — not even in transit.</p>
+          <p>Speech recognition runs entirely on your Mac using Apple Neural Engine. Audio bytes never leave your device, not even in transit.</p>
         </div>
         <div class="privacy-card-3 reveal" style="--i:1">
           <div class="privacy-icon" style="background:rgba(30,144,255,0.1);" aria-hidden="true">&#128584;</div>
           <h3>Your Words Stay Yours</h3>
-          <p>We never see, store, or log your transcriptions. Your voice recordings and text are never tracked or used to train models. What you say is your business — not ours.</p>
+          <p>We never see, store, or log your transcriptions. Your voice recordings and text are never tracked or used to train models. What you say is your business, not ours.</p>
         </div>
         <div class="privacy-card-3 reveal" style="--i:2">
           <div class="privacy-icon" style="background:rgba(124,58,237,0.1);" aria-hidden="true">&#128230;</div>
           <h3>Open Source</h3>
-          <p>The full codebase is on GitHub. Audit it yourself. Every privacy claim is verifiable — no trust required, only code.</p>
+          <p>The full codebase is on GitHub. Audit it yourself. Every privacy claim is verifiable. No trust required, only code.</p>
         </div>
       </div>
     </div>
@@ -619,7 +619,7 @@ const jsonLdFaq = JSON.stringify({
       <div class="section-head reveal">
         <div class="section-label-pill amber">Early Users</div>
         <h2 class="section-title" id="testimonials-heading">What people are saying</h2>
-        <p class="section-sub">From professionals to students — EnviousWispr fits every workflow.</p>
+        <p class="section-sub">From professionals to students, EnviousWispr fits every workflow.</p>
       </div>
 
       <div class="testimonials-grid reveal-stagger">


### PR DESCRIPTION
## Summary
The homepage already pill-links all 11 /compare/* slugs and links to /how-it-works/, but it had no inbound link to the privacy blog (which is doing 64% of total site impressions). Adding one inline anchor in the privacy section sub passes site-wide authority into the highest-traffic blog post, since every page on the site links to /.

While in the file, completed the Rule 6 (no em-dashes) sweep on home body copy that was scoped out of #492.

## Changes
- **Privacy section sub** extended with: \"Read the full breakdown of on-device vs cloud dictation.\" → /blog/on-device-vs-cloud-dictation-privacy/
- **16 customer-facing em-dashes** converted to colons, periods, or commas across:
  - Demo tone-tab input
  - Window chrome title (EnviousWispr — AI Polish → colon)
  - 4 use case cards (Devs/Comms/Mobility/Healthcare)
  - PTT and Hands-Free mode descriptions
  - Key-cap separator (decorative — → ·)
  - Universal Paste / AI Polish / BYOM cards
  - 3 privacy cards
  - Testimonials sub
- **Remaining em-dashes** in `dist/index.html` are HTML/CSS comments only, not customer-visible

## Why this matters
- Highest-leverage internal link change still available: home is the most-linked page on the site (every page → / via Nav). One anchor from home = sitewide PageRank distribution.
- Privacy blog is at pos 7.2 (clicks=1, imp=434 last 28d) and represents 64% of total impressions. Strengthening its inbound profile is direct ROI on the audit's #488 finding.

## Test plan
- [x] `npm run build` clean (42 pages)
- [x] Verified rendered \`<a href=\"/blog/on-device-vs-cloud-dictation-privacy/\">\` in dist/index.html
- [x] Verified 0 em-dashes left in customer-visible HTML body of dist/index.html (only 1 HTML comment remains)

`council-skip: zero-blast-radius (User-facing copy in website/src/)`
