### PR TITLE
seo: FAQPage on macos-dictation-offline-private (#379)

### DIFF
--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -2,10 +2,21 @@
 title: "macOS Dictation That Works Offline and Stays Private"
 description: "Fully private, on-device dictation for macOS that never sends your voice to the cloud. How EnviousWispr delivers offline speech-to-text you can trust."
 pubDate: 2026-03-11
-updatedDate: 2026-04-04
+updatedDate: 2026-04-28
 tags: ["accessibility", "privacy", "dictation", "offline"]
 draft: false
 author: "Saurabh Vaish"
+faqs:
+  - question: "Does macOS have a built-in offline dictation option?"
+    answer: "Yes, but with caveats. Apple Dictation can download an Enhanced Dictation model that runs locally, but the experience is dated, post-processing is minimal, and accuracy on long-form dictation lags purpose-built tools. EnviousWispr runs entirely on-device using newer speech models (Parakeet for English, Whisper for multilingual) plus optional AI polish, so the transcript you paste is closer to what you actually meant to write."
+  - question: "Can dictation software really work without an internet connection?"
+    answer: "Yes, when the speech model runs locally. EnviousWispr ships with Core ML models that execute on your Mac's Neural Engine, so the entire transcribe-and-polish pipeline runs offline after the first download. There is no API call out, no server round-trip, and no graceful degradation when the Wi-Fi drops."
+  - question: "Is on-device dictation accurate enough for medical or accessibility use?"
+    answer: "On Apple Silicon Macs, on-device speech recognition reaches word error rates competitive with leading cloud APIs for English dictation. For accessibility users who rely on voice input as a primary modality, that accuracy plus the predictability of no network failures is usually the deciding factor. For medical dictation, accuracy matters but the on-device privacy story usually matters more."
+  - question: "What happens if I dictate while completely offline?"
+    answer: "Everything works the same. EnviousWispr captures audio, runs transcription via Core ML, and pastes polished text into your app. The only feature that needs network is optional cloud AI polish (OpenAI, Gemini); on-device polish via Apple Intelligence or Ollama still works offline, as does raw transcription with no polish at all."
+  - question: "Is there a free offline dictation app for Mac?"
+    answer: "Yes. EnviousWispr is free to download, requires no account, and runs entirely on your Mac. There is no usage cap, no trial period, and no subscription tier. You can use it indefinitely without ever creating an account or connecting to a server."
 ---
 
 What happens to your primary input method when the Wi-Fi goes down? If voice input is how you write (because typing hurts, or because it's simply not an option) that's not a hypothetical question. It's the difference between a tool you can depend on and one that fails when you need it most.


### PR DESCRIPTION
## Summary
Continues blog FAQPage rollout (#491 added 5 FAQs to getting-started). This post covers the offline + accessibility + privacy intent cluster and is the next-most-likely-to-rank candidate based on observed GSC queries:
- \"apple dictation on-device processing privacy\" — pos 6.5
- \"free dictation software for mac\" — pos 88 (#483)

5 FAQs added to the post frontmatter. Each targets a real query intent:
1. Does macOS have built-in offline dictation? (Apple Dictation comparison)
2. Can dictation software work without an internet connection?
3. Is on-device dictation accurate for medical/accessibility use?
4. What happens if I dictate while completely offline?
5. Is there a free offline dictation app for Mac? (direct pos-88 target)

Answers: 2-4 sentences, plain English, no em-dashes, no \"open source\" claims (content-brand rules 2 and 6 followed).

## GSC snapshot context (just pulled)
| Metric | 28d as of 2026-04-28 | Audit baseline (12hr ago) |
|---|---|---|
| Clicks | 7 | 7 |
| Impressions | 634 | 677 |
| Avg pos | 9.0 | n/a |
| /compare/ pos | 24.3 | 25.5 |

Indexing/ranking has not moved (expected — Google takes days to weeks to reflect link/schema changes). Today's PRs are the stake in the ground for the next pull.

## Author bio (#3 from priority list)
Audited and **no work needed**. Author page already has Person + BreadcrumbList JSON-LD, all 22 blog posts already link via visible \`rel=\"author\"\` byline, all 11 compare pages link 2× each. The page is just unindexed because nobody is searching the name yet, not because of missing on-page SEO.

## Test plan
- [x] \`npm run build\` clean
- [x] FAQPage JSON-LD renders 5 mainEntity entries in dist
- [ ] Validate via [Google Rich Results Test](https://search.google.com/test/rich-results) once live

\`council-skip: zero-blast-radius (User-facing copy in website/src/)\`
