### PR TITLE
refactor(app): Phase F — SetupCoordinator extraction (#319, #501)

### DIFF
--- a/.validation/runs/20260430T142205Z-5d732f7/codex-review.txt
+++ b/.validation/runs/20260430T142205Z-5d732f7/codex-review.txt
@@ -1,0 +1,1 @@
+Codex code-diff review: PASS (no actionable regressions). Output: docs/audits/2026-04-30-phase-f-code-diff-review.txt

--- a/.validation/runs/20260430T142205Z-5d732f7/live-uat.json
+++ b/.validation/runs/20260430T142205Z-5d732f7/live-uat.json
@@ -1,0 +1,14 @@
+{
+  "executor": "manual-human (founder, in-office)",
+  "expected_token": "Dallas",
+  "observed_transcript": "She was just getting ready to watch this program. And at this point, she was able to take a lot of feedback that we got last year in Dallas, but also some of the other events that we've done and we drew out last year as well.",
+  "manual_paths_confirmed": [
+    {"path": "Parakeet dictation", "result": "pass — heart-path baseline"},
+    {"path": "Apple Intelligence polish", "result": "pass"},
+    {"path": "WhisperKit (Speech Engine tab + dictation)", "result": "pass"},
+    {"path": "Ollama (AI Polish tab)", "result": "pass"},
+    {"path": "PTT dictation (long-form free-speech, in-office)", "result": "pass — full sentence transcribed, polished, pasted; matches what was spoken"}
+  ],
+  "log_scan": "clean — no errors / fatals / crashes in app.log or bt-route.log; bt-route shows healthy warm-engine reuse during UAT",
+  "notes": "R3 #if DEBUG gating means release-build app.log is sparse by design, not a regression"
+}

--- a/.validation/runs/20260430T142205Z-5d732f7/run.json
+++ b/.validation/runs/20260430T142205Z-5d732f7/run.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "head_sha": "5d732f7b5f4251b94f002ce20819f89cdc3cb2b6",
+  "branch": "feat/issue-501-phase-f-setup-coordinator",
+  "declared_lane": "Code",
+  "detected_lanes": ["Code", "Docs/dev-tooling"],
+  "is_mixed_pr": false,
+  "started_at": "2026-04-30T13:50:00Z",
+  "completed_at": "2026-04-30T14:22:00Z",
+  "obligations_satisfied": ["tests", "smoke", "live-uat", "codex-review"],
+  "obligations_skipped": [],
+  "skip_notes": []
+}

--- a/.validation/runs/20260430T142205Z-5d732f7/smoke.json
+++ b/.validation/runs/20260430T142205Z-5d732f7/smoke.json
@@ -1,0 +1,9 @@
+{
+  "build_config": "release",
+  "build_status": "success",
+  "build_time_seconds": 83.19,
+  "bundle_path": "/tmp/EnviousWispr Local.app",
+  "version": "v1.9.4-74-gbc445a1-dev",
+  "launch_status": "running",
+  "launch_pid_at_smoke": 68055
+}

--- a/.validation/runs/20260430T142205Z-5d732f7/tests.log
+++ b/.validation/runs/20260430T142205Z-5d732f7/tests.log
@@ -1,0 +1,1 @@
+tests: 498 passed, 0 failed (scripts/swift-test.sh, see commit message + plan)

--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -414,7 +414,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       NotificationCenter.default.removeObserver(observer)
       onboardingCloseObserver = nil
     }
-    appState.ollamaSetup.cleanup()
+    appState.setup.ollamaSetup.cleanup()
     appState.hotkeyService.stop()
     LLMNetworkSession.shared.invalidate()
   }

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -22,13 +22,13 @@ final class AppState {
   let hotkeyService = HotkeyService()
   let benchmark = BenchmarkSuite()
   let recordingOverlay = RecordingOverlayPanel()
-  let ollamaSetup = OllamaSetupService()
-  let whisperKitSetup = WhisperKitSetupService()
+  // Phase F (#501) — setup-orchestration cluster moved out of AppState.
+  // Holds ollamaSetup, whisperKitSetup, and the WhisperKit preload-observation
+  // task. Constructed in init() after asrManager and whisperKitPipeline exist
+  // (it needs both to drive the preload observer).
+  let setup: SetupCoordinator
   let audioDeviceList = AudioDeviceList()
   let captureTelemetry = CaptureTelemetryState()
-
-  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
-  private var whisperKitPreloadTask: Task<Void, Never>?
 
   /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
   /// Cancelled when a new recording starts or a higher-priority notification is shown.
@@ -206,6 +206,17 @@ final class AppState {
       transcriptStore: transcriptStore
     )
 
+    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
+    // exist (it needs both — asrManager for activeBackendType reads, the pipeline
+    // closure for prepareBackendSilently()). The capture is [weak whisperKitPipeline]
+    // so the coordinator does not retain the pipeline.
+    setup = SetupCoordinator(
+      asrManager: asrManager,
+      preloadAction: { [weak whisperKitPipeline] in
+        await whisperKitPipeline?.prepareBackendSilently()
+      }
+    )
+
     // Initialize settingsSync and apply initial settings to all targets
     settingsSync = PipelineSettingsSync(
       pipeline: pipeline,
@@ -214,7 +225,7 @@ final class AppState {
       audioCapture: audioCapture,
       asrManager: asrManager,
       hotkeyService: hotkeyService,
-      whisperKitSetup: whisperKitSetup
+      whisperKitSetup: setup.whisperKitSetup
     )
     settingsSync.applyInitialSettings(settings)
 
@@ -372,8 +383,8 @@ final class AppState {
         Task { await self.whisperKitPipeline.stopAndTranscribe() }
       }
     }
-    settingsSync.onNeedsPreloadObservation = { [weak self] in
-      self?.startWhisperKitPreloadObservation()
+    settingsSync.onNeedsPreloadObservation = { [weak setup] in
+      setup?.startPreloadObservation()
     }
 
     // Wire custom-words propagator. The exact ordering (seed → register all
@@ -616,8 +627,8 @@ final class AppState {
       }
     }
     Task { [weak self] in
-      await self?.whisperKitSetup.detectState()
-      self?.startWhisperKitPreloadObservation()
+      await self?.setup.whisperKitSetup.detectState()
+      self?.setup.startPreloadObservation()
     }
 
     // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
@@ -631,39 +642,6 @@ final class AppState {
   func startHotkeyServiceIfEnabled() {
     if settings.hotkeyEnabled {
       hotkeyService.start()
-    }
-  }
-
-  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
-  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
-  private func startWhisperKitPreloadObservation() {
-    whisperKitPreloadTask?.cancel()
-    whisperKitPreloadTask = Task { [weak self] in
-      while !Task.isCancelled {
-        guard let self else { return }
-
-        // Exit immediately when WhisperKit isn't the active backend. Parakeet
-        // users shouldn't pay CPU/memory cost warming a backend they never use.
-        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
-        // restarts this observer; the re-entry sees the new activeBackendType.
-        guard self.asrManager.activeBackendType == .whisperKit else { return }
-
-        // Check current state — if already .ready, trigger pre-load
-        let currentState = self.whisperKitSetup.setupState
-        if currentState == .ready {
-          await self.whisperKitPipeline.prepareBackendSilently()
-          return  // Model loaded — no need to keep observing
-        }
-
-        // Wait for the next change to setupState
-        await withCheckedContinuation { continuation in
-          withObservationTracking {
-            _ = self.whisperKitSetup.setupState
-          } onChange: {
-            continuation.resume()
-          }
-        }
-      }
     }
   }
 

--- a/Sources/EnviousWispr/App/SetupCoordinator.swift
+++ b/Sources/EnviousWispr/App/SetupCoordinator.swift
@@ -1,0 +1,63 @@
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprLLM
+import Observation
+
+/// Owns setup-orchestration concerns previously held directly on AppState:
+/// the Ollama setup service, the WhisperKit setup service, and the background
+/// observation task that pre-loads WhisperKit when its setup state becomes ready.
+///
+/// Heart path does not consult this object. If setup services fail, dictation
+/// still completes — the user just sees broken status in Settings tabs.
+@MainActor
+@Observable
+final class SetupCoordinator {
+  let ollamaSetup = OllamaSetupService()
+  let whisperKitSetup = WhisperKitSetupService()
+
+  @ObservationIgnored
+  private var whisperKitPreloadTask: Task<Void, Never>?
+
+  private let asrManager: any ASRManagerInterface
+  private let preloadAction: @MainActor () async -> Void
+
+  init(
+    asrManager: any ASRManagerInterface,
+    preloadAction: @escaping @MainActor () async -> Void
+  ) {
+    self.asrManager = asrManager
+    self.preloadAction = preloadAction
+  }
+
+  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
+  /// `.ready` and the active backend is WhisperKit. Cancels any prior observation
+  /// task; safe to call repeatedly (e.g. on backend switch).
+  func startPreloadObservation() {
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+
+        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+        // users shouldn't pay CPU/memory cost warming a backend they never use.
+        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+        // restarts this observer; the re-entry sees the new activeBackendType.
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+
+        let currentState = self.whisperKitSetup.setupState
+        if currentState == .ready {
+          await self.preloadAction()
+          return
+        }
+
+        await withCheckedContinuation { continuation in
+          withObservationTracking {
+            _ = self.whisperKitSetup.setupState
+          } onChange: {
+            continuation.resume()
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -24,7 +24,7 @@ struct AIPolishSettingsView: View {
   }
 
   private var ollamaShowsManageModels: Bool {
-    switch appState.ollamaSetup.setupState {
+    switch appState.setup.ollamaSetup.setupState {
     case .ready, .pullingModel, .runningNoModels: return true
     default: return false
     }
@@ -225,8 +225,8 @@ struct AIPolishSettingsView: View {
       if appState.settings.llmProvider == .ollama {
         appState.llmDiscovery.loadCachedModels(for: .ollama)
         Task {
-          await appState.ollamaSetup.detectState()
-          if case .ready = appState.ollamaSetup.setupState {
+          await appState.setup.ollamaSetup.detectState()
+          if case .ready = appState.setup.ollamaSetup.setupState {
             await appState.llmDiscovery.validateKeyAndDiscoverModels(
               provider: .ollama, settings: appState.settings)
           }
@@ -244,8 +244,8 @@ struct AIPolishSettingsView: View {
 
       // Clean up Ollama state when switching away
       if newProvider != .ollama {
-        appState.ollamaSetup.cancelPull()
-        appState.ollamaSetup.resetWarmup()
+        appState.setup.ollamaSetup.cancelPull()
+        appState.setup.ollamaSetup.resetWarmup()
       }
 
       switch newProvider {
@@ -254,7 +254,7 @@ struct AIPolishSettingsView: View {
       case .ollama:
         // detectState() will set setupState, which triggers the onChange handler
         // for discovery + warm-up. Don't duplicate that work here.
-        Task { await appState.ollamaSetup.detectState() }
+        Task { await appState.setup.ollamaSetup.detectState() }
       case .appleIntelligence:
         Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
       default:
@@ -265,7 +265,7 @@ struct AIPolishSettingsView: View {
         }
       }
     }
-    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
+    .onChange(of: appState.setup.ollamaSetup.setupState) { _, newState in
       if case .ready = newState, appState.settings.llmProvider == .ollama {
         Task {
           await appState.llmDiscovery.validateKeyAndDiscoverModels(
@@ -273,20 +273,20 @@ struct AIPolishSettingsView: View {
         }
         // Warm up the selected model when Ollama becomes ready
         if !appState.settings.llmModel.isEmpty {
-          appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+          appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
         }
       } else if appState.settings.llmProvider == .ollama {
         // Reset warmup when Ollama leaves .ready (server died, etc.)
-        appState.ollamaSetup.resetWarmup()
+        appState.setup.ollamaSetup.resetWarmup()
       }
     }
     .onChange(of: appState.settings.llmModel) { _, newModel in
       // Warm up when user switches Ollama model
       if appState.settings.llmProvider == .ollama,
-        case .ready = appState.ollamaSetup.setupState,
+        case .ready = appState.setup.ollamaSetup.setupState,
         !newModel.isEmpty
       {
-        appState.ollamaSetup.warmUpModel(newModel)
+        appState.setup.ollamaSetup.warmUpModel(newModel)
       }
     }
   }
@@ -570,7 +570,7 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var ollamaSetupContent: some View {
-    switch appState.ollamaSetup.setupState {
+    switch appState.setup.ollamaSetup.setupState {
     case .detecting:
       HStack {
         ProgressView()
@@ -616,7 +616,7 @@ struct AIPolishSettingsView: View {
 
         HStack {
           Button("Start Ollama") {
-            appState.ollamaSetup.startServer()
+            appState.setup.ollamaSetup.startServer()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -639,7 +639,7 @@ struct AIPolishSettingsView: View {
 
         HStack {
           Button("Download \(appState.settings.ollamaModel)") {
-            appState.ollamaSetup.pullModel(appState.settings.ollamaModel)
+            appState.setup.ollamaSetup.pullModel(appState.settings.ollamaModel)
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -672,7 +672,7 @@ struct AIPolishSettingsView: View {
               .foregroundStyle(Color.stTextTertiary)
           }
           Button("Cancel") {
-            appState.ollamaSetup.cancelPull()
+            appState.setup.ollamaSetup.cancelPull()
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -705,8 +705,8 @@ struct AIPolishSettingsView: View {
 
         Button("Try Again") {
           Task {
-            await appState.ollamaSetup.detectState()
-            if case .ready = appState.ollamaSetup.setupState {
+            await appState.setup.ollamaSetup.detectState()
+            if case .ready = appState.setup.ollamaSetup.setupState {
               await appState.llmDiscovery.validateKeyAndDiscoverModels(
                 provider: .ollama, settings: appState.settings)
             }
@@ -860,9 +860,9 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var ollamaModelCatalogView: some View {
-    let catalog = appState.ollamaSetup.dynamicCatalog
+    let catalog = appState.setup.ollamaSetup.dynamicCatalog
     let isPulling: Bool = {
-      if case .pullingModel = appState.ollamaSetup.setupState { return true }
+      if case .pullingModel = appState.setup.ollamaSetup.setupState { return true }
       return false
     }()
 
@@ -887,15 +887,15 @@ struct AIPolishSettingsView: View {
 
           Spacer()
 
-          if appState.ollamaSetup.currentPullingModel == entry.name {
+          if appState.setup.ollamaSetup.currentPullingModel == entry.name {
             // Active pull for THIS row: show progress + Cancel.
             HStack(spacing: 8) {
-              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
+              Text("Downloading… \(Int(appState.setup.ollamaSetup.pullProgress * 100))%")
                 .font(.caption)
                 .foregroundStyle(Color.secondary)
                 .monospacedDigit()
               Button {
-                appState.ollamaSetup.cancelPull()
+                appState.setup.ollamaSetup.cancelPull()
               } label: {
                 Text("Cancel")
                   .foregroundStyle(.stError)
@@ -905,7 +905,7 @@ struct AIPolishSettingsView: View {
             }
           } else if entry.isDownloaded {
             Button {
-              appState.ollamaSetup.deleteModel(name: entry.name)
+              appState.setup.ollamaSetup.deleteModel(name: entry.name)
             } label: {
               Text("Delete")
                 .foregroundStyle(.stError)
@@ -915,7 +915,7 @@ struct AIPolishSettingsView: View {
             .disabled(isPulling)
           } else {
             Button {
-              appState.ollamaSetup.pullModel(entry.name)
+              appState.setup.ollamaSetup.pullModel(entry.name)
             } label: {
               Text("Download")
             }
@@ -983,8 +983,8 @@ struct AIPolishSettingsView: View {
   private func ollamaRefreshButton() -> some View {
     Button {
       Task {
-        await appState.ollamaSetup.detectState()
-        if case .ready = appState.ollamaSetup.setupState {
+        await appState.setup.ollamaSetup.detectState()
+        if case .ready = appState.setup.ollamaSetup.setupState {
           await appState.llmDiscovery.validateKeyAndDiscoverModels(
             provider: .ollama, settings: appState.settings)
         }
@@ -1001,7 +1001,7 @@ struct AIPolishSettingsView: View {
   @ViewBuilder
   private var ollamaWarmupIndicator: some View {
     let currentModel = OllamaSetupService.canonicalModelName(appState.settings.llmModel)
-    switch appState.ollamaSetup.warmupState {
+    switch appState.setup.ollamaSetup.warmupState {
     case .warming(let model) where model == currentModel:
       ProgressView()
         .controlSize(.small)
@@ -1012,7 +1012,7 @@ struct AIPolishSettingsView: View {
         .help("Model is ready")
     case .failed(let model) where model == currentModel:
       Button {
-        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
       } label: {
         Image(systemName: "exclamationmark.triangle")
           .foregroundStyle(.stWarning)
@@ -1022,7 +1022,7 @@ struct AIPolishSettingsView: View {
     default:
       Button {
         guard !appState.settings.llmModel.isEmpty else { return }
-        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
       } label: {
         Image(systemName: "arrow.clockwise")
       }

--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
@@ -44,7 +44,7 @@ struct SpeechEngineSettingsView: View {
 
       // ── Section 3: Language Selection (only when model is ready) ──
       if appState.settings.selectedBackend == .whisperKit,
-        case .ready = appState.whisperKitSetup.setupState
+        case .ready = appState.setup.whisperKitSetup.setupState
       {
         BrandedSection(header: "Language") {
           BrandedRow {
@@ -162,12 +162,12 @@ struct SpeechEngineSettingsView: View {
     }
     .onAppear {
       if appState.settings.selectedBackend == .whisperKit {
-        Task { await appState.whisperKitSetup.detectState() }
+        Task { await appState.setup.whisperKitSetup.detectState() }
       }
     }
     .onChange(of: appState.settings.selectedBackend) { _, newBackend in
       if newBackend == .whisperKit {
-        Task { await appState.whisperKitSetup.detectState() }
+        Task { await appState.setup.whisperKitSetup.detectState() }
       }
     }
     .sheet(isPresented: $showLanguageLockSheet) {
@@ -203,7 +203,7 @@ struct SpeechEngineSettingsView: View {
 
   @ViewBuilder
   private var whisperKitSetupContent: some View {
-    switch appState.whisperKitSetup.setupState {
+    switch appState.setup.whisperKitSetup.setupState {
     case .checking:
       HStack {
         ProgressView()
@@ -225,7 +225,7 @@ struct SpeechEngineSettingsView: View {
 
         HStack {
           Button("Download WhisperKit Model") {
-            appState.whisperKitSetup.downloadModel()
+            appState.setup.whisperKitSetup.downloadModel()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -254,7 +254,7 @@ struct SpeechEngineSettingsView: View {
               .foregroundStyle(.stTextTertiary)
           }
           Button("Cancel") {
-            appState.whisperKitSetup.cancelDownload()
+            appState.setup.whisperKitSetup.cancelDownload()
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -281,7 +281,7 @@ struct SpeechEngineSettingsView: View {
           .fixedSize(horizontal: false, vertical: true)
 
         Button("Try Again") {
-          Task { await appState.whisperKitSetup.detectState() }
+          Task { await appState.setup.whisperKitSetup.detectState() }
         }
         .controlSize(.small)
       }
@@ -298,7 +298,7 @@ struct SpeechEngineSettingsView: View {
   @ViewBuilder
   private var whisperKitRefreshButton: some View {
     Button {
-      Task { await appState.whisperKitSetup.forceDetectState() }
+      Task { await appState.setup.whisperKitSetup.forceDetectState() }
     } label: {
       Image(systemName: "arrow.clockwise")
     }

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -1,0 +1,107 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWispr
+
+/// Unit tests for SetupCoordinator's preload observation behavior.
+///
+/// SetupCoordinator owns the WhisperKit preload observer that previously lived
+/// on AppState. The observer is gated by two signals: `asrManager.activeBackendType`
+/// (must be `.whisperKit`) and `whisperKitSetup.setupState` (must reach `.ready`).
+/// When both are satisfied, the injected `preloadAction` closure fires once.
+///
+/// These tests exercise the gating without touching any real WhisperKit / Ollama
+/// state — the closure-based seam is the whole point of moving this code off
+/// AppState.
+@Suite @MainActor
+struct SetupCoordinatorTests {
+
+  /// Active backend = parakeet → preload action must NOT fire even if the user
+  /// later flips WhisperKit to .ready (no observation should be running).
+  @Test func parakeetBackendSkipsPreload() async throws {
+    let fakeASR = FakeASRManager(backend: .parakeet)
+    let counter = InvocationCounter()
+    let coord = SetupCoordinator(
+      asrManager: fakeASR,
+      preloadAction: { @MainActor in counter.increment() }
+    )
+
+    coord.startPreloadObservation()
+
+    // Yield once so the observation Task gets a chance to run and bail out
+    // on the .parakeet guard.
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(counter.count == 0, "preloadAction must not fire when active backend is parakeet")
+  }
+
+  /// startPreloadObservation can be called repeatedly; each call cancels the
+  /// prior observation Task. Verify the invocation completes without crashing
+  /// (cancellation correctness — the task body uses `[weak self]` and a
+  /// while-not-cancelled loop).
+  @Test func repeatedStartCancelsPrior() async throws {
+    let fakeASR = FakeASRManager(backend: .parakeet)
+    let counter = InvocationCounter()
+    let coord = SetupCoordinator(
+      asrManager: fakeASR,
+      preloadAction: { @MainActor in counter.increment() }
+    )
+
+    coord.startPreloadObservation()
+    coord.startPreloadObservation()
+    coord.startPreloadObservation()
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(counter.count == 0)
+  }
+}
+
+@MainActor
+private final class InvocationCounter {
+  var count: Int = 0
+  func increment() { count += 1 }
+}
+
+/// Minimal ASRManagerInterface fake. SetupCoordinator only reads
+/// `activeBackendType`; everything else traps to make accidental use loud.
+@MainActor
+private final class FakeASRManager: ASRManagerInterface {
+  let activeBackendType: ASRBackendType
+  init(backend: ASRBackendType) { self.activeBackendType = backend }
+
+  var isModelLoaded: Bool { false }
+  var isStreaming: Bool { false }
+  var downloadProgress: Double { 0 }
+  var downloadPhase: String { "" }
+  var downloadDetail: String { "" }
+  var activeBackendSupportsStreaming: Bool { false }
+  var onServiceInterrupted: (() -> Void)?
+
+  func loadModel() async throws { fatalError("not used in SetupCoordinatorTests") }
+  func loadModelSilently() async { fatalError("not used in SetupCoordinatorTests") }
+  func unloadModel() async { fatalError("not used in SetupCoordinatorTests") }
+  func setInitialBackendType(_: ASRBackendType) { fatalError("not used in SetupCoordinatorTests") }
+  func switchBackend(to _: ASRBackendType) async { fatalError("not used in SetupCoordinatorTests") }
+  func transcribe(audioSamples _: [Float], options _: TranscriptionOptions) async throws
+    -> ASRResult
+  {
+    fatalError("not used in SetupCoordinatorTests")
+  }
+  func startStreaming(options _: TranscriptionOptions) async throws {
+    fatalError("not used in SetupCoordinatorTests")
+  }
+  func feedAudio(_: AVAudioPCMBuffer) async throws {
+    fatalError("not used in SetupCoordinatorTests")
+  }
+  func finalizeStreaming() async throws -> ASRResult {
+    fatalError("not used in SetupCoordinatorTests")
+  }
+  func cancelStreaming() async { fatalError("not used in SetupCoordinatorTests") }
+  func noteTranscriptionComplete(policy _: ModelUnloadPolicy) {
+    fatalError("not used in SetupCoordinatorTests")
+  }
+  func cancelIdleTimer() { fatalError("not used in SetupCoordinatorTests") }
+}

--- a/docs/audits/2026-04-30-phase-f-code-diff-review.stderr.log
+++ b/docs/audits/2026-04-30-phase-f-code-diff-review.stderr.log
@@ -1,0 +1,4243 @@
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/m4pro_sv/.codex/memories]
+reasoning effort: high
+reasoning summaries: none
+session id: 019ddec0-9ce9-7463-9902-b480f7becff5
+--------
+user
+changes against 'origin/main'
+exec
+/bin/zsh -lc 'git diff bc445a1dc817c48db543f818b28c16eabc7e313e --stat && git diff bc445a1dc817c48db543f818b28c16eabc7e313e --' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+ Sources/EnviousWispr/App/AppDelegate.swift         |   2 +-
+ Sources/EnviousWispr/App/AppState.swift            |  64 ++++--------
+ Sources/EnviousWispr/App/SetupCoordinator.swift    |  63 ++++++++++++
+ .../Views/Settings/AIPolishSettingsView.swift      |  58 +++++------
+ .../Views/Settings/SpeechEngineSettingsView.swift  |  16 +--
+ .../Architecture/SetupCoordinatorTests.swift       | 107 +++++++++++++++++++++
+ .../issue-319-2026-04-18-q2-hardening-epic.md      |   2 +-
+ 7 files changed, 230 insertions(+), 82 deletions(-)
+diff --git a/Sources/EnviousWispr/App/AppDelegate.swift b/Sources/EnviousWispr/App/AppDelegate.swift
+index b31cf38..4883ad9 100644
+--- a/Sources/EnviousWispr/App/AppDelegate.swift
++++ b/Sources/EnviousWispr/App/AppDelegate.swift
+@@ -414,7 +414,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
+       NotificationCenter.default.removeObserver(observer)
+       onboardingCloseObserver = nil
+     }
+-    appState.ollamaSetup.cleanup()
++    appState.setup.ollamaSetup.cleanup()
+     appState.hotkeyService.stop()
+     LLMNetworkSession.shared.invalidate()
+   }
+diff --git a/Sources/EnviousWispr/App/AppState.swift b/Sources/EnviousWispr/App/AppState.swift
+index 6e8ec4a..2b161ab 100644
+--- a/Sources/EnviousWispr/App/AppState.swift
++++ b/Sources/EnviousWispr/App/AppState.swift
+@@ -22,14 +22,14 @@ final class AppState {
+   let hotkeyService = HotkeyService()
+   let benchmark = BenchmarkSuite()
+   let recordingOverlay = RecordingOverlayPanel()
+-  let ollamaSetup = OllamaSetupService()
+-  let whisperKitSetup = WhisperKitSetupService()
++  // Phase F (#501) — setup-orchestration cluster moved out of AppState.
++  // Holds ollamaSetup, whisperKitSetup, and the WhisperKit preload-observation
++  // task. Constructed in init() after asrManager and whisperKitPipeline exist
++  // (it needs both to drive the preload observer).
++  let setup: SetupCoordinator
+   let audioDeviceList = AudioDeviceList()
+   let captureTelemetry = CaptureTelemetryState()
+ 
+-  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
+-  private var whisperKitPreloadTask: Task<Void, Never>?
+-
+   /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+   /// Cancelled when a new recording starts or a higher-priority notification is shown.
+   private var postCompletionWarningTask: Task<Void, Never>?
+@@ -206,6 +206,17 @@ final class AppState {
+       transcriptStore: transcriptStore
+     )
+ 
++    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
++    // exist (it needs both — asrManager for activeBackendType reads, the pipeline
++    // closure for prepareBackendSilently()). The capture is [weak whisperKitPipeline]
++    // so the coordinator does not retain the pipeline.
++    setup = SetupCoordinator(
++      asrManager: asrManager,
++      preloadAction: { [weak whisperKitPipeline] in
++        await whisperKitPipeline?.prepareBackendSilently()
++      }
++    )
++
+     // Initialize settingsSync and apply initial settings to all targets
+     settingsSync = PipelineSettingsSync(
+       pipeline: pipeline,
+@@ -214,7 +225,7 @@ final class AppState {
+       audioCapture: audioCapture,
+       asrManager: asrManager,
+       hotkeyService: hotkeyService,
+-      whisperKitSetup: whisperKitSetup
++      whisperKitSetup: setup.whisperKitSetup
+     )
+     settingsSync.applyInitialSettings(settings)
+ 
+@@ -372,8 +383,8 @@ final class AppState {
+         Task { await self.whisperKitPipeline.stopAndTranscribe() }
+       }
+     }
+-    settingsSync.onNeedsPreloadObservation = { [weak self] in
+-      self?.startWhisperKitPreloadObservation()
++    settingsSync.onNeedsPreloadObservation = { [weak setup] in
++      setup?.startPreloadObservation()
+     }
+ 
+     // Wire custom-words propagator. The exact ordering (seed → register all
+@@ -616,8 +627,8 @@ final class AppState {
+       }
+     }
+     Task { [weak self] in
+-      await self?.whisperKitSetup.detectState()
+-      self?.startWhisperKitPreloadObservation()
++      await self?.setup.whisperKitSetup.detectState()
++      self?.setup.startPreloadObservation()
+     }
+ 
+     // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
+@@ -634,39 +645,6 @@ final class AppState {
+     }
+   }
+ 
+-  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
+-  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
+-  private func startWhisperKitPreloadObservation() {
+-    whisperKitPreloadTask?.cancel()
+-    whisperKitPreloadTask = Task { [weak self] in
+-      while !Task.isCancelled {
+-        guard let self else { return }
+-
+-        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+-        // users shouldn't pay CPU/memory cost warming a backend they never use.
+-        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+-        // restarts this observer; the re-entry sees the new activeBackendType.
+-        guard self.asrManager.activeBackendType == .whisperKit else { return }
+-
+-        // Check current state — if already .ready, trigger pre-load
+-        let currentState = self.whisperKitSetup.setupState
+-        if currentState == .ready {
+-          await self.whisperKitPipeline.prepareBackendSilently()
+-          return  // Model loaded — no need to keep observing
+-        }
+-
+-        // Wait for the next change to setupState
+-        await withCheckedContinuation { continuation in
+-          withObservationTracking {
+-            _ = self.whisperKitSetup.setupState
+-          } onChange: {
+-            continuation.resume()
+-          }
+-        }
+-      }
+-    }
+-  }
+-
+   /// Active dictation pipeline — routes based on selected backend.
+   var activePipeline: any DictationPipeline {
+     asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
+diff --git a/Sources/EnviousWispr/App/SetupCoordinator.swift b/Sources/EnviousWispr/App/SetupCoordinator.swift
+new file mode 100644
+index 0000000..829b615
+--- /dev/null
++++ b/Sources/EnviousWispr/App/SetupCoordinator.swift
+@@ -0,0 +1,63 @@
++import EnviousWisprASR
++import EnviousWisprCore
++import EnviousWisprLLM
++import Observation
++
++/// Owns setup-orchestration concerns previously held directly on AppState:
++/// the Ollama setup service, the WhisperKit setup service, and the background
++/// observation task that pre-loads WhisperKit when its setup state becomes ready.
++///
++/// Heart path does not consult this object. If setup services fail, dictation
++/// still completes — the user just sees broken status in Settings tabs.
++@MainActor
++@Observable
++final class SetupCoordinator {
++  let ollamaSetup = OllamaSetupService()
++  let whisperKitSetup = WhisperKitSetupService()
++
++  @ObservationIgnored
++  private var whisperKitPreloadTask: Task<Void, Never>?
++
++  private let asrManager: any ASRManagerInterface
++  private let preloadAction: @MainActor () async -> Void
++
++  init(
++    asrManager: any ASRManagerInterface,
++    preloadAction: @escaping @MainActor () async -> Void
++  ) {
++    self.asrManager = asrManager
++    self.preloadAction = preloadAction
++  }
++
++  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
++  /// `.ready` and the active backend is WhisperKit. Cancels any prior observation
++  /// task; safe to call repeatedly (e.g. on backend switch).
++  func startPreloadObservation() {
++    whisperKitPreloadTask?.cancel()
++    whisperKitPreloadTask = Task { [weak self] in
++      while !Task.isCancelled {
++        guard let self else { return }
++
++        // Exit immediately when WhisperKit isn't the active backend. Parakeet
++        // users shouldn't pay CPU/memory cost warming a backend they never use.
++        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
++        // restarts this observer; the re-entry sees the new activeBackendType.
++        guard self.asrManager.activeBackendType == .whisperKit else { return }
++
++        let currentState = self.whisperKitSetup.setupState
++        if currentState == .ready {
++          await self.preloadAction()
++          return
++        }
++
++        await withCheckedContinuation { continuation in
++          withObservationTracking {
++            _ = self.whisperKitSetup.setupState
++          } onChange: {
++            continuation.resume()
++          }
++        }
++      }
++    }
++  }
++}
+diff --git a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+index 0a642de..0f888b7 100644
+--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
++++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+@@ -24,7 +24,7 @@ struct AIPolishSettingsView: View {
+   }
+ 
+   private var ollamaShowsManageModels: Bool {
+-    switch appState.ollamaSetup.setupState {
++    switch appState.setup.ollamaSetup.setupState {
+     case .ready, .pullingModel, .runningNoModels: return true
+     default: return false
+     }
+@@ -225,8 +225,8 @@ struct AIPolishSettingsView: View {
+       if appState.settings.llmProvider == .ollama {
+         appState.llmDiscovery.loadCachedModels(for: .ollama)
+         Task {
+-          await appState.ollamaSetup.detectState()
+-          if case .ready = appState.ollamaSetup.setupState {
++          await appState.setup.ollamaSetup.detectState()
++          if case .ready = appState.setup.ollamaSetup.setupState {
+             await appState.llmDiscovery.validateKeyAndDiscoverModels(
+               provider: .ollama, settings: appState.settings)
+           }
+@@ -244,8 +244,8 @@ struct AIPolishSettingsView: View {
+ 
+       // Clean up Ollama state when switching away
+       if newProvider != .ollama {
+-        appState.ollamaSetup.cancelPull()
+-        appState.ollamaSetup.resetWarmup()
++        appState.setup.ollamaSetup.cancelPull()
++        appState.setup.ollamaSetup.resetWarmup()
+       }
+ 
+       switch newProvider {
+@@ -254,7 +254,7 @@ struct AIPolishSettingsView: View {
+       case .ollama:
+         // detectState() will set setupState, which triggers the onChange handler
+         // for discovery + warm-up. Don't duplicate that work here.
+-        Task { await appState.ollamaSetup.detectState() }
++        Task { await appState.setup.ollamaSetup.detectState() }
+       case .appleIntelligence:
+         Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
+       default:
+@@ -265,7 +265,7 @@ struct AIPolishSettingsView: View {
+         }
+       }
+     }
+-    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
++    .onChange(of: appState.setup.ollamaSetup.setupState) { _, newState in
+       if case .ready = newState, appState.settings.llmProvider == .ollama {
+         Task {
+           await appState.llmDiscovery.validateKeyAndDiscoverModels(
+@@ -273,20 +273,20 @@ struct AIPolishSettingsView: View {
+         }
+         // Warm up the selected model when Ollama becomes ready
+         if !appState.settings.llmModel.isEmpty {
+-          appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
++          appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+         }
+       } else if appState.settings.llmProvider == .ollama {
+         // Reset warmup when Ollama leaves .ready (server died, etc.)
+-        appState.ollamaSetup.resetWarmup()
++        appState.setup.ollamaSetup.resetWarmup()
+       }
+     }
+     .onChange(of: appState.settings.llmModel) { _, newModel in
+       // Warm up when user switches Ollama model
+       if appState.settings.llmProvider == .ollama,
+-        case .ready = appState.ollamaSetup.setupState,
++        case .ready = appState.setup.ollamaSetup.setupState,
+         !newModel.isEmpty
+       {
+-        appState.ollamaSetup.warmUpModel(newModel)
++        appState.setup.ollamaSetup.warmUpModel(newModel)
+       }
+     }
+   }
+@@ -570,7 +570,7 @@ struct AIPolishSettingsView: View {
+ 
+   @ViewBuilder
+   private var ollamaSetupContent: some View {
+-    switch appState.ollamaSetup.setupState {
++    switch appState.setup.ollamaSetup.setupState {
+     case .detecting:
+       HStack {
+         ProgressView()
+@@ -616,7 +616,7 @@ struct AIPolishSettingsView: View {
+ 
+         HStack {
+           Button("Start Ollama") {
+-            appState.ollamaSetup.startServer()
++            appState.setup.ollamaSetup.startServer()
+           }
+           .buttonStyle(.borderedProminent)
+           .controlSize(.small)
+@@ -639,7 +639,7 @@ struct AIPolishSettingsView: View {
+ 
+         HStack {
+           Button("Download \(appState.settings.ollamaModel)") {
+-            appState.ollamaSetup.pullModel(appState.settings.ollamaModel)
++            appState.setup.ollamaSetup.pullModel(appState.settings.ollamaModel)
+           }
+           .buttonStyle(.borderedProminent)
+           .controlSize(.small)
+@@ -672,7 +672,7 @@ struct AIPolishSettingsView: View {
+               .foregroundStyle(Color.stTextTertiary)
+           }
+           Button("Cancel") {
+-            appState.ollamaSetup.cancelPull()
++            appState.setup.ollamaSetup.cancelPull()
+           }
+           .controlSize(.small)
+           .buttonStyle(.borderless)
+@@ -705,8 +705,8 @@ struct AIPolishSettingsView: View {
+ 
+         Button("Try Again") {
+           Task {
+-            await appState.ollamaSetup.detectState()
+-            if case .ready = appState.ollamaSetup.setupState {
++            await appState.setup.ollamaSetup.detectState()
++            if case .ready = appState.setup.ollamaSetup.setupState {
+               await appState.llmDiscovery.validateKeyAndDiscoverModels(
+                 provider: .ollama, settings: appState.settings)
+             }
+@@ -860,9 +860,9 @@ struct AIPolishSettingsView: View {
+ 
+   @ViewBuilder
+   private var ollamaModelCatalogView: some View {
+-    let catalog = appState.ollamaSetup.dynamicCatalog
++    let catalog = appState.setup.ollamaSetup.dynamicCatalog
+     let isPulling: Bool = {
+-      if case .pullingModel = appState.ollamaSetup.setupState { return true }
++      if case .pullingModel = appState.setup.ollamaSetup.setupState { return true }
+       return false
+     }()
+ 
+@@ -887,15 +887,15 @@ struct AIPolishSettingsView: View {
+ 
+           Spacer()
+ 
+-          if appState.ollamaSetup.currentPullingModel == entry.name {
++          if appState.setup.ollamaSetup.currentPullingModel == entry.name {
+             // Active pull for THIS row: show progress + Cancel.
+             HStack(spacing: 8) {
+-              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
++              Text("Downloading… \(Int(appState.setup.ollamaSetup.pullProgress * 100))%")
+                 .font(.caption)
+                 .foregroundStyle(Color.secondary)
+                 .monospacedDigit()
+               Button {
+-                appState.ollamaSetup.cancelPull()
++                appState.setup.ollamaSetup.cancelPull()
+               } label: {
+                 Text("Cancel")
+                   .foregroundStyle(.stError)
+@@ -905,7 +905,7 @@ struct AIPolishSettingsView: View {
+             }
+           } else if entry.isDownloaded {
+             Button {
+-              appState.ollamaSetup.deleteModel(name: entry.name)
++              appState.setup.ollamaSetup.deleteModel(name: entry.name)
+             } label: {
+               Text("Delete")
+                 .foregroundStyle(.stError)
+@@ -915,7 +915,7 @@ struct AIPolishSettingsView: View {
+             .disabled(isPulling)
+           } else {
+             Button {
+-              appState.ollamaSetup.pullModel(entry.name)
++              appState.setup.ollamaSetup.pullModel(entry.name)
+             } label: {
+               Text("Download")
+             }
+@@ -983,8 +983,8 @@ struct AIPolishSettingsView: View {
+   private func ollamaRefreshButton() -> some View {
+     Button {
+       Task {
+-        await appState.ollamaSetup.detectState()
+-        if case .ready = appState.ollamaSetup.setupState {
++        await appState.setup.ollamaSetup.detectState()
++        if case .ready = appState.setup.ollamaSetup.setupState {
+           await appState.llmDiscovery.validateKeyAndDiscoverModels(
+             provider: .ollama, settings: appState.settings)
+         }
+@@ -1001,7 +1001,7 @@ struct AIPolishSettingsView: View {
+   @ViewBuilder
+   private var ollamaWarmupIndicator: some View {
+     let currentModel = OllamaSetupService.canonicalModelName(appState.settings.llmModel)
+-    switch appState.ollamaSetup.warmupState {
++    switch appState.setup.ollamaSetup.warmupState {
+     case .warming(let model) where model == currentModel:
+       ProgressView()
+         .controlSize(.small)
+@@ -1012,7 +1012,7 @@ struct AIPolishSettingsView: View {
+         .help("Model is ready")
+     case .failed(let model) where model == currentModel:
+       Button {
+-        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
++        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+       } label: {
+         Image(systemName: "exclamationmark.triangle")
+           .foregroundStyle(.stWarning)
+@@ -1022,7 +1022,7 @@ struct AIPolishSettingsView: View {
+     default:
+       Button {
+         guard !appState.settings.llmModel.isEmpty else { return }
+-        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
++        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+       } label: {
+         Image(systemName: "arrow.clockwise")
+       }
+diff --git a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+index daeb6af..097f08a 100644
+--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
++++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+@@ -44,7 +44,7 @@ struct SpeechEngineSettingsView: View {
+ 
+       // ── Section 3: Language Selection (only when model is ready) ──
+       if appState.settings.selectedBackend == .whisperKit,
+-        case .ready = appState.whisperKitSetup.setupState
++        case .ready = appState.setup.whisperKitSetup.setupState
+       {
+         BrandedSection(header: "Language") {
+           BrandedRow {
+@@ -162,12 +162,12 @@ struct SpeechEngineSettingsView: View {
+     }
+     .onAppear {
+       if appState.settings.selectedBackend == .whisperKit {
+-        Task { await appState.whisperKitSetup.detectState() }
++        Task { await appState.setup.whisperKitSetup.detectState() }
+       }
+     }
+     .onChange(of: appState.settings.selectedBackend) { _, newBackend in
+       if newBackend == .whisperKit {
+-        Task { await appState.whisperKitSetup.detectState() }
++        Task { await appState.setup.whisperKitSetup.detectState() }
+       }
+     }
+     .sheet(isPresented: $showLanguageLockSheet) {
+@@ -203,7 +203,7 @@ struct SpeechEngineSettingsView: View {
+ 
+   @ViewBuilder
+   private var whisperKitSetupContent: some View {
+-    switch appState.whisperKitSetup.setupState {
++    switch appState.setup.whisperKitSetup.setupState {
+     case .checking:
+       HStack {
+         ProgressView()
+@@ -225,7 +225,7 @@ struct SpeechEngineSettingsView: View {
+ 
+         HStack {
+           Button("Download WhisperKit Model") {
+-            appState.whisperKitSetup.downloadModel()
++            appState.setup.whisperKitSetup.downloadModel()
+           }
+           .buttonStyle(.borderedProminent)
+           .controlSize(.small)
+@@ -254,7 +254,7 @@ struct SpeechEngineSettingsView: View {
+               .foregroundStyle(.stTextTertiary)
+           }
+           Button("Cancel") {
+-            appState.whisperKitSetup.cancelDownload()
++            appState.setup.whisperKitSetup.cancelDownload()
+           }
+           .controlSize(.small)
+           .buttonStyle(.borderless)
+@@ -281,7 +281,7 @@ struct SpeechEngineSettingsView: View {
+           .fixedSize(horizontal: false, vertical: true)
+ 
+         Button("Try Again") {
+-          Task { await appState.whisperKitSetup.detectState() }
++          Task { await appState.setup.whisperKitSetup.detectState() }
+         }
+         .controlSize(.small)
+       }
+@@ -298,7 +298,7 @@ struct SpeechEngineSettingsView: View {
+   @ViewBuilder
+   private var whisperKitRefreshButton: some View {
+     Button {
+-      Task { await appState.whisperKitSetup.forceDetectState() }
++      Task { await appState.setup.whisperKitSetup.forceDetectState() }
+     } label: {
+       Image(systemName: "arrow.clockwise")
+     }
+diff --git a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+new file mode 100644
+index 0000000..f5e3e4e
+--- /dev/null
++++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+@@ -0,0 +1,107 @@
++@preconcurrency import AVFoundation
++import EnviousWisprASR
++import EnviousWisprCore
++import Testing
++
++@testable import EnviousWispr
++
++/// Unit tests for SetupCoordinator's preload observation behavior.
++///
++/// SetupCoordinator owns the WhisperKit preload observer that previously lived
++/// on AppState. The observer is gated by two signals: `asrManager.activeBackendType`
++/// (must be `.whisperKit`) and `whisperKitSetup.setupState` (must reach `.ready`).
++/// When both are satisfied, the injected `preloadAction` closure fires once.
++///
++/// These tests exercise the gating without touching any real WhisperKit / Ollama
++/// state — the closure-based seam is the whole point of moving this code off
++/// AppState.
++@Suite @MainActor
++struct SetupCoordinatorTests {
++
++  /// Active backend = parakeet → preload action must NOT fire even if the user
++  /// later flips WhisperKit to .ready (no observation should be running).
++  @Test func parakeetBackendSkipsPreload() async throws {
++    let fakeASR = FakeASRManager(backend: .parakeet)
++    let counter = InvocationCounter()
++    let coord = SetupCoordinator(
++      asrManager: fakeASR,
++      preloadAction: { @MainActor in counter.increment() }
++    )
++
++    coord.startPreloadObservation()
++
++    // Yield once so the observation Task gets a chance to run and bail out
++    // on the .parakeet guard.
++    try await Task.sleep(nanoseconds: 50_000_000)
++
++    #expect(counter.count == 0, "preloadAction must not fire when active backend is parakeet")
++  }
++
++  /// startPreloadObservation can be called repeatedly; each call cancels the
++  /// prior observation Task. Verify the invocation completes without crashing
++  /// (cancellation correctness — the task body uses `[weak self]` and a
++  /// while-not-cancelled loop).
++  @Test func repeatedStartCancelsPrior() async throws {
++    let fakeASR = FakeASRManager(backend: .parakeet)
++    let counter = InvocationCounter()
++    let coord = SetupCoordinator(
++      asrManager: fakeASR,
++      preloadAction: { @MainActor in counter.increment() }
++    )
++
++    coord.startPreloadObservation()
++    coord.startPreloadObservation()
++    coord.startPreloadObservation()
++
++    try await Task.sleep(nanoseconds: 50_000_000)
++
++    #expect(counter.count == 0)
++  }
++}
++
++@MainActor
++private final class InvocationCounter {
++  var count: Int = 0
++  func increment() { count += 1 }
++}
++
++/// Minimal ASRManagerInterface fake. SetupCoordinator only reads
++/// `activeBackendType`; everything else traps to make accidental use loud.
++@MainActor
++private final class FakeASRManager: ASRManagerInterface {
++  let activeBackendType: ASRBackendType
++  init(backend: ASRBackendType) { self.activeBackendType = backend }
++
++  var isModelLoaded: Bool { false }
++  var isStreaming: Bool { false }
++  var downloadProgress: Double { 0 }
++  var downloadPhase: String { "" }
++  var downloadDetail: String { "" }
++  var activeBackendSupportsStreaming: Bool { false }
++  var onServiceInterrupted: (() -> Void)?
++
++  func loadModel() async throws { fatalError("not used in SetupCoordinatorTests") }
++  func loadModelSilently() async { fatalError("not used in SetupCoordinatorTests") }
++  func unloadModel() async { fatalError("not used in SetupCoordinatorTests") }
++  func setInitialBackendType(_: ASRBackendType) { fatalError("not used in SetupCoordinatorTests") }
++  func switchBackend(to _: ASRBackendType) async { fatalError("not used in SetupCoordinatorTests") }
++  func transcribe(audioSamples _: [Float], options _: TranscriptionOptions) async throws
++    -> ASRResult
++  {
++    fatalError("not used in SetupCoordinatorTests")
++  }
++  func startStreaming(options _: TranscriptionOptions) async throws {
++    fatalError("not used in SetupCoordinatorTests")
++  }
++  func feedAudio(_: AVAudioPCMBuffer) async throws {
++    fatalError("not used in SetupCoordinatorTests")
++  }
++  func finalizeStreaming() async throws -> ASRResult {
++    fatalError("not used in SetupCoordinatorTests")
++  }
++  func cancelStreaming() async { fatalError("not used in SetupCoordinatorTests") }
++  func noteTranscriptionComplete(policy _: ModelUnloadPolicy) {
++    fatalError("not used in SetupCoordinatorTests")
++  }
++  func cancelIdleTimer() { fatalError("not used in SetupCoordinatorTests") }
++}
+diff --git a/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md b/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+index 4f750cc..7eb8306 100644
+--- a/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
++++ b/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+@@ -620,7 +620,7 @@ Each refactor pattern carries its own test strategy.
+ | 3 | **C** | TranscriptCoordinator owns history | 1 | MEDIUM | #428 | SHIPPED (PR #432, 2026-04-21) | +283/−39 actual |
+ | 4 | **D** | CustomWordsPropagator replaces 5-way fanout | 1 | MEDIUM | to open | PLANNED §10 | ~180 |
+ | 5 | **E** | Architecture regression tests | 1 | SMALL | to open | PLANNED §11 | ~65 |
+-| **F** | SetupCoordinator extraction (NEW v1.3) | 1 | MEDIUM | to open | PLANNED §17 | ~+90 net |
++| **F** | SetupCoordinator extraction (NEW v1.3) | 1 | MEDIUM | #501 | IN-FLIGHT (F-Exec, Codex grounded review 2026-04-30) | ~+135 net |
+ | 6 | **R2** | WhisperKitBackend adapter | 1 | MEDIUM | #360 | PLANNED §12 | ~120 |
+ | 7 | **R3** | Transcript out of logs | 1 | SMALL | #361 | PLANNED §13 | ~40 |
+ | 8 | **R4** | BT route log rotation | 1 | SMALL | #362 | PLANNED §15 | ~45 |
+
+exec
+/bin/zsh -lc "rg \"\\bollamaSetup\\b|\\bwhisperKitSetup\\b|whisperKitPreloadTask|SetupCoordinator\" -n Sources Tests | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:8:/// Unit tests for SetupCoordinator's preload observation behavior.
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:10:/// SetupCoordinator owns the WhisperKit preload observer that previously lived
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:12:/// (must be `.whisperKit`) and `whisperKitSetup.setupState` (must reach `.ready`).
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:19:struct SetupCoordinatorTests {
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:26:    let coord = SetupCoordinator(
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:47:    let coord = SetupCoordinator(
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:68:/// Minimal ASRManagerInterface fake. SetupCoordinator only reads
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:83:  func loadModel() async throws { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:84:  func loadModelSilently() async { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:85:  func unloadModel() async { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:86:  func setInitialBackendType(_: ASRBackendType) { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:87:  func switchBackend(to _: ASRBackendType) async { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:91:    fatalError("not used in SetupCoordinatorTests")
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:94:    fatalError("not used in SetupCoordinatorTests")
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:97:    fatalError("not used in SetupCoordinatorTests")
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:100:    fatalError("not used in SetupCoordinatorTests")
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:102:  func cancelStreaming() async { fatalError("not used in SetupCoordinatorTests") }
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:104:    fatalError("not used in SetupCoordinatorTests")
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:106:  func cancelIdleTimer() { fatalError("not used in SetupCoordinatorTests") }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:47:        case .ready = appState.setup.whisperKitSetup.setupState
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:165:        Task { await appState.setup.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:170:        Task { await appState.setup.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:206:    switch appState.setup.whisperKitSetup.setupState {
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:228:            appState.setup.whisperKitSetup.downloadModel()
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:257:            appState.setup.whisperKitSetup.cancelDownload()
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:284:          Task { await appState.setup.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:301:      Task { await appState.setup.whisperKitSetup.forceDetectState() }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:27:    switch appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:228:          await appState.setup.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:229:          if case .ready = appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:247:        appState.setup.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:248:        appState.setup.ollamaSetup.resetWarmup()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:257:        Task { await appState.setup.ollamaSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:268:    .onChange(of: appState.setup.ollamaSetup.setupState) { _, newState in
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:276:          appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:280:        appState.setup.ollamaSetup.resetWarmup()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:286:        case .ready = appState.setup.ollamaSetup.setupState,
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:289:        appState.setup.ollamaSetup.warmUpModel(newModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:573:    switch appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:619:            appState.setup.ollamaSetup.startServer()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:642:            appState.setup.ollamaSetup.pullModel(appState.settings.ollamaModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:675:            appState.setup.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:708:            await appState.setup.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:709:            if case .ready = appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:863:    let catalog = appState.setup.ollamaSetup.dynamicCatalog
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:865:      if case .pullingModel = appState.setup.ollamaSetup.setupState { return true }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:890:          if appState.setup.ollamaSetup.currentPullingModel == entry.name {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:893:              Text("Downloading… \(Int(appState.setup.ollamaSetup.pullProgress * 100))%")
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:898:                appState.setup.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:908:              appState.setup.ollamaSetup.deleteModel(name: entry.name)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:918:              appState.setup.ollamaSetup.pullModel(entry.name)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:986:        await appState.setup.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:987:        if case .ready = appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1004:    switch appState.setup.ollamaSetup.warmupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1015:        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1025:        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+Sources/EnviousWispr/App/AppDelegate.swift:417:    appState.setup.ollamaSetup.cleanup()
+Sources/EnviousWispr/App/SetupCoordinator.swift:14:final class SetupCoordinator {
+Sources/EnviousWispr/App/SetupCoordinator.swift:15:  let ollamaSetup = OllamaSetupService()
+Sources/EnviousWispr/App/SetupCoordinator.swift:16:  let whisperKitSetup = WhisperKitSetupService()
+Sources/EnviousWispr/App/SetupCoordinator.swift:19:  private var whisperKitPreloadTask: Task<Void, Never>?
+Sources/EnviousWispr/App/SetupCoordinator.swift:32:  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
+Sources/EnviousWispr/App/SetupCoordinator.swift:36:    whisperKitPreloadTask?.cancel()
+Sources/EnviousWispr/App/SetupCoordinator.swift:37:    whisperKitPreloadTask = Task { [weak self] in
+Sources/EnviousWispr/App/SetupCoordinator.swift:47:        let currentState = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/SetupCoordinator.swift:55:            _ = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/AppState.swift:26:  // Holds ollamaSetup, whisperKitSetup, and the WhisperKit preload-observation
+Sources/EnviousWispr/App/AppState.swift:29:  let setup: SetupCoordinator
+Sources/EnviousWispr/App/AppState.swift:209:    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
+Sources/EnviousWispr/App/AppState.swift:213:    setup = SetupCoordinator(
+Sources/EnviousWispr/App/AppState.swift:228:      whisperKitSetup: setup.whisperKitSetup
+Sources/EnviousWispr/App/AppState.swift:630:      await self?.setup.whisperKitSetup.detectState()
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:20:  private let whisperKitSetup: WhisperKitSetupService
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:38:    whisperKitSetup: WhisperKitSetupService
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:46:    self.whisperKitSetup = whisperKitSetup
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:109:          await self?.whisperKitSetup.detectState()
+
+exec
+/bin/zsh -lc "sed -n '1,280p' Sources/EnviousWispr/App/AppState.swift && sed -n '1,160p' Sources/EnviousWispr/App/PipelineSettingsSync.swift && sed -n '1,120p' Sources/EnviousWispr/App/SetupCoordinator.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
+import EnviousWisprServices
+import EnviousWisprStorage
+import SwiftUI
+
+/// Root observable state for the entire application.
+@MainActor
+@Observable
+final class AppState {
+  // Settings
+  var settings = SettingsManager()
+
+  // Sub-systems
+  let permissions = PermissionsService()
+  let audioCapture: any AudioCaptureInterface
+  let asrManager: any ASRManagerInterface
+  let keychainManager = KeychainManager()
+  let hotkeyService = HotkeyService()
+  let benchmark = BenchmarkSuite()
+  let recordingOverlay = RecordingOverlayPanel()
+  // Phase F (#501) — setup-orchestration cluster moved out of AppState.
+  // Holds ollamaSetup, whisperKitSetup, and the WhisperKit preload-observation
+  // task. Constructed in init() after asrManager and whisperKitPipeline exist
+  // (it needs both to drive the preload observer).
+  let setup: SetupCoordinator
+  let audioDeviceList = AudioDeviceList()
+  let captureTelemetry = CaptureTelemetryState()
+
+  /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+  /// Cancelled when a new recording starts or a higher-priority notification is shown.
+  private var postCompletionWarningTask: Task<Void, Never>?
+
+  // Pipelines — initialized after sub-systems
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
+
+  // Phase A (#196) — per-pipeline state-change behavior absorbed from the
+  // onStateChange closures. Each handler owns the effect execution; AppState
+  // still owns the cross-pipeline warning Task + tiebreaker + hotkey ordering.
+  // Lazy so the callback closures can capture `self` after stored-property
+  // assignment completes. First access is inside `onStateChange`, well after
+  // `init()` returns.
+  @ObservationIgnored
+  private lazy var parakeetStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "parakeet")
+  }()
+  @ObservationIgnored
+  private lazy var whisperKitStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "whisperKit")
+  }()
+
+  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { [weak self] intent in
+        guard let self else { return }
+        self.recordingOverlay.show(
+          intent: intent,
+          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+          isRecordingLocked: self.isRecordingLocked
+        )
+      },
+      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+      schedulePolishFailedWarning: { [weak self] in
+        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+      },
+      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
+      reportDictationCompleted: { [weak self] t in
+        guard let self else { return }
+        TelemetryService.shared.reportDictationCompleted(
+          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+      },
+      reportPipelineFailed: { msg in
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backendLabel)
+      }
+    )
+  }
+
+  /// Standalone service for re-polishing saved transcripts from the detail view.
+  /// Completely decoupled from pipeline state machines.
+  let polishService: TranscriptPolishService
+
+  /// Forwards settings changes to pipelines and subsystems.
+  private let settingsSync: PipelineSettingsSync
+
+  /// Called when pipeline state changes — set by AppDelegate for icon updates.
+  var onPipelineStateChange: ((PipelineState) -> Void)?
+
+  // Transcript history — delegated to coordinator
+  let transcriptCoordinator: TranscriptCoordinator
+  var pendingNavigationSection: SettingsSection?
+
+  /// True when recording is in hands-free (locked) mode via double-press.
+  /// Read by the overlay to switch to the expanded lips visual.
+  var isRecordingLocked: Bool = false
+
+  /// Multilingual v1: latest passive-chip trigger emitted by LanguageDetector,
+  /// if any. Observed by settings/overlay UI to offer a "Detected X. Lock it?"
+  /// or "Language unstable. Lock language?" CTA. Nil when no chip is pending.
+  /// UI consumers set this to nil after dismissing.
+  /// TODO: wire a settings-level banner that presents this; current v1 ship is
+  /// callback-only so chip events are not silently dropped.
+  var pendingPassiveChip: PassiveChipTrigger?
+
+  // Feature #8: custom word management — delegated to coordinator
+  let customWordsCoordinator = CustomWordsCoordinator()
+
+  /// Broadcasts custom-words changes to all registered consumers (pipelines'
+  /// word-correction + polish steps, plus the re-polish service). Initialized
+  /// at property declaration (no ctor dependencies); seeded with
+  /// `customWordsCoordinator.customWords` in `init` before consumer
+  /// registrations.
+  let customWordsPropagator = CustomWordsPropagator()
+
+  // Model discovery — delegated to coordinator
+  let llmDiscovery: LLMModelDiscoveryCoordinator
+
+  // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
+  let aiAvailability = AIAvailabilityCoordinator()
+
+  init() {
+    // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
+    // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
+    // Read directly from UserDefaults because `settings` is not yet available (stored
+    // properties must all be initialized before `self` is accessible).
+    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern
+    // so existing installs (no key written) get the new default.
+    let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
+    if useXPC {
+      audioCapture = AudioCaptureProxy()
+    } else {
+      audioCapture = AudioCaptureManager()
+    }
+
+    // Phase 5: XPC ASR service — default ON (Stage F). ASR inference runs in a separate
+    // XPC service process for memory isolation. Escape hatch: `defaults write ... useXPCASRService -bool false`
+    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern.
+    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
+    if useXPCASR {
+      asrManager = ASRManagerProxy()
+    } else {
+      asrManager = ASRManager()
+    }
+
+    // Phase C (#428) — composition-root for transcript storage.
+    // One `TranscriptStore` instance is constructed here and threaded
+    // into every consumer (coordinator + both pipelines + polish service).
+    // AppState does NOT retain this as a property; each consumer keeps
+    // the reference it received via init. No accessor is exposed on the
+    // coordinator; no consumer constructs its own. The shared-store
+    // invariant is verifiable by grep: exactly one `TranscriptStore(`
+    // call in `Sources/` outside `EnviousWisprStorage/TranscriptStore.swift`.
+    let transcriptStore = TranscriptStore()
+    // Production invariant: the app has always written transcripts to
+    // AppConstants.appSupportURL/transcripts. Verified via grep 2026-04-20.
+    // No legacy path, no group container, no iCloud. Phase C Invariant
+    // safeguard #4 (Option B — plan §11): a concrete migrator would be a
+    // no-op, so we rely on the default init's directory-create-on-miss
+    // plus founder dogfood (safeguard #3) to catch any future path shift.
+    transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
+
+    // Both pipeline properties must be initialized before `self` can be used.
+    // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
+    pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      captureTelemetry: captureTelemetry
+    )
+    // W6: wire language-flip telemetry into the detector via a closure so
+    // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
+    // The detector fires this inline from an actor; we hop to MainActor to
+    // call `TelemetryService` (which is @MainActor isolated).
+    // The chip handler is wired AFTER init completes (see setPassiveChipHandler
+    // call below) because it needs to capture self, and Swift does not allow
+    // that before all stored properties are initialized.
+    let languageDetector = LanguageDetector(
+      onLanguageFlip: { @Sendable event in
+        Task { @MainActor in
+          TelemetryService.shared.trackLanguageFlip(
+            fromLang: event.fromLang,
+            toLang: event.toLang,
+            confidenceBoth: event.confidenceBoth
+          )
+        }
+      }
+    )
+    whisperKitPipeline = WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      languageDetector: languageDetector,
+      captureTelemetry: captureTelemetry
+    )
+    // Transcript polish service (re-polish from detail view, decoupled from pipelines)
+    polishService = TranscriptPolishService(
+      keychainManager: keychainManager,
+      transcriptStore: transcriptStore
+    )
+
+    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
+    // exist (it needs both — asrManager for activeBackendType reads, the pipeline
+    // closure for prepareBackendSilently()). The capture is [weak whisperKitPipeline]
+    // so the coordinator does not retain the pipeline.
+    setup = SetupCoordinator(
+      asrManager: asrManager,
+      preloadAction: { [weak whisperKitPipeline] in
+        await whisperKitPipeline?.prepareBackendSilently()
+      }
+    )
+
+    // Initialize settingsSync and apply initial settings to all targets
+    settingsSync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: hotkeyService,
+      whisperKitSetup: setup.whisperKitSetup
+    )
+    settingsSync.applyInitialSettings(settings)
+
+    // Wire dictation activity provider (after all stored properties initialized)
+    polishService.setDictationActivity(self)
+
+    // Wire the passive-chip handler on the LanguageDetector actor now that
+    // self is fully constructed. The handler hops back to the MainActor
+    // to publish the chip on `pendingPassiveChip` so UI can observe it.
+    Task { [weak self] in
+      await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
+        Task { @MainActor in
+          self?.pendingPassiveChip = trigger
+        }
+      }
+    }
+
+    // Unified engine interruption handler — routes to whichever pipeline is actively recording.
+    // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
+    // is interrupted, we must notify the pipeline that's currently recording, not the one
+    // that happened to set onEngineInterrupted last.
+    audioCapture.onEngineInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
+        )
+      }
+      SentryBreadcrumb.add(
+        stage: "audio", message: "Audio XPC interrupted", level: .error,
+        data: [
+          "parakeet_state": "\(pState)",
+          "whisperkit_state": "\(wkState)",
+        ])
+      // Issue #285 — route to the pipeline that owns the shared capture
+      // right now. Uses the same owner-selection as `activeTelemetryTarget()`
+      // so the two paths cannot drift when both pipelines are active
+      // (overlap during backend switch: one polishing while the other starts
+      // a new recording).
+      switch self.activeCaptureBackend() {
+      case .parakeet:
+        self.pipeline.handleEngineInterruption()
+      case .whisperKit:
+        self.whisperKitPipeline.handleEngineInterruption()
+      case nil:
+        break  // neither pipeline active — nothing to clean up
+      }
+      // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
+      // sets state = .error(...), which fires onStateChange and shows the error
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// Forwards live-mutable settings changes. Per-recording values are frozen
+/// via `DictationSessionConfig` at `startRecording` and do not flow here —
+/// see #195 plan for the full frozen/live classification.
+@MainActor
+final class PipelineSettingsSync {
+  private let pipeline: TranscriptionPipeline
+  private let whisperKitPipeline: WhisperKitPipeline
+  private let polishService: TranscriptPolishService
+  private let audioCapture: any AudioCaptureInterface
+  private let asrManager: any ASRManagerInterface
+  private let hotkeyService: HotkeyService
+  private let whisperKitSetup: WhisperKitSetupService
+
+  /// Set by AppState so backend/model changes can retrigger preload observation
+  /// without coupling this layer to AppState.
+  var onNeedsPreloadObservation: (() -> Void)?
+
+  /// Tracks the last evictable Ollama model for #295. Independent of
+  /// `polishService.llmPolishStep` because SettingsManager's cascading didSet
+  /// can corrupt a pre-snapshot read from the polish step.
+  private var lastEvictableOllamaModel: String?
+
+  init(
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    polishService: TranscriptPolishService,
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    hotkeyService: HotkeyService,
+    whisperKitSetup: WhisperKitSetupService
+  ) {
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.polishService = polishService
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.hotkeyService = hotkeyService
+    self.whisperKitSetup = whisperKitSetup
+  }
+
+  /// Seed live-mutable subsystems. Per-recording values are captured fresh
+  /// at each `startRecording` and are not seeded here.
+  ///
+  /// Custom words are NOT seeded here — `CustomWordsPropagator` (registered
+  /// in AppState init) owns that fanout. See Phase D (#496).
+  func applyInitialSettings(_ settings: SettingsManager) {
+    pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+
+    syncPolishServiceSettings(settings)
+
+    if settings.noiseSuppression {
+      audioCapture.buildEngine(noiseSuppression: true)
+    } else {
+      audioCapture.noiseSuppressionEnabled = false
+    }
+    audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
+    audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    audioCapture.warmEnginePolicy = settings.warmEnginePolicy
+    audioCapture.configureVAD(
+      autoStop: settings.vadAutoStop,
+      silenceTimeout: settings.vadSilenceTimeout,
+      sensitivity: settings.vadSensitivity,
+      energyGate: settings.vadEnergyGate
+    )
+
+    // #295: seed eviction tracker. No initial eviction on app launch.
+    lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
+      provider: settings.llmProvider, model: resolvedModel(settings)
+    )
+  }
+
+  /// Handle a settings change by forwarding to the appropriate subsystem.
+  func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
+    switch key {
+    case .selectedBackend:
+      // Don't switch backends while a pipeline is actively recording/transcribing
+      let parakeetActive = pipeline.state.isActive
+      let whisperKitActive = whisperKitPipeline.state.isActive
+      if parakeetActive || whisperKitActive {
+        Task {
+          await AppLogger.shared.log(
+            "Backend switch blocked — pipeline is active",
+            level: .info, category: "PipelineSettingsSync"
+          )
+        }
+        break
+      }
+      let backend = settings.selectedBackend
+      // Issue #289: invalidate any stall-recovery token on either pipeline
+      // so a deferred cleanup from a pre-switch stall doesn't tear down
+      // the pipeline that's about to become active.
+      pipeline.clearPendingStallRecovery()
+      whisperKitPipeline.clearPendingStallRecovery()
+      Task { [weak self] in
+        await self?.asrManager.switchBackend(to: backend)
+        SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
+        if backend == .whisperKit {
+          await self?.whisperKitSetup.detectState()
+          self?.onNeedsPreloadObservation?()
+        }
+      }
+    case .recordingMode:
+      hotkeyService.recordingMode = settings.recordingMode
+    case .llmProvider:
+      // Live mirror to re-polish path; eviction fires for RAM management (#295).
+      // Pipeline polish uses the frozen value from `DictationSessionConfig`.
+      polishService.llmPolishStep.llmProvider = settings.llmProvider
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+      reconcileOllamaEviction(settings: settings)
+    case .llmModel:
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+      if settings.llmProvider == .ollama {
+        settings.ollamaModel = settings.llmModel
+      }
+      reconcileOllamaEviction(settings: settings)
+    case .ollamaModel:
+      if settings.llmProvider == .ollama {
+        polishService.llmPolishStep.llmModel = settings.ollamaModel
+      }
+      reconcileOllamaEviction(settings: settings)
+    case .hotkeyEnabled:
+      if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
+    case .environmentPreset:
+      // Cascade into `vadSensitivity` for the next recording's snapshot.
+      settings.vadSensitivity = settings.environmentPreset.vadSensitivity
+    case .writingStylePreset, .customSystemPrompt:
+      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+    case .cancelKeyCode:
+      hotkeyService.cancelKeyCode = settings.cancelKeyCode
+    case .cancelModifiers:
+      hotkeyService.cancelModifiers = settings.cancelModifiers
+    case .toggleKeyCode:
+      hotkeyService.toggleKeyCode = settings.toggleKeyCode
+      reregisterHotkeys()
+    case .toggleModifiers:
+      hotkeyService.toggleModifiers = settings.toggleModifiers
+      reregisterHotkeys()
+    case .pushToTalkKeyCode, .pushToTalkModifiers:
+      // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
+      break
+    case .modelUnloadPolicy:
+      // Frozen per recording; cancel idle timer live when switched to .never.
+      if settings.modelUnloadPolicy == .never {
+        asrManager.cancelIdleTimer()
+      }
+    case .wordCorrectionEnabled:
+      pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+      whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprLLM
+import Observation
+
+/// Owns setup-orchestration concerns previously held directly on AppState:
+/// the Ollama setup service, the WhisperKit setup service, and the background
+/// observation task that pre-loads WhisperKit when its setup state becomes ready.
+///
+/// Heart path does not consult this object. If setup services fail, dictation
+/// still completes — the user just sees broken status in Settings tabs.
+@MainActor
+@Observable
+final class SetupCoordinator {
+  let ollamaSetup = OllamaSetupService()
+  let whisperKitSetup = WhisperKitSetupService()
+
+  @ObservationIgnored
+  private var whisperKitPreloadTask: Task<Void, Never>?
+
+  private let asrManager: any ASRManagerInterface
+  private let preloadAction: @MainActor () async -> Void
+
+  init(
+    asrManager: any ASRManagerInterface,
+    preloadAction: @escaping @MainActor () async -> Void
+  ) {
+    self.asrManager = asrManager
+    self.preloadAction = preloadAction
+  }
+
+  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
+  /// `.ready` and the active backend is WhisperKit. Cancels any prior observation
+  /// task; safe to call repeatedly (e.g. on backend switch).
+  func startPreloadObservation() {
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+
+        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+        // users shouldn't pay CPU/memory cost warming a backend they never use.
+        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+        // restarts this observer; the re-entry sees the new activeBackendType.
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+
+        let currentState = self.whisperKitSetup.setupState
+        if currentState == .ready {
+          await self.preloadAction()
+          return
+        }
+
+        await withCheckedContinuation { continuation in
+          withObservationTracking {
+            _ = self.whisperKitSetup.setupState
+          } onChange: {
+            continuation.resume()
+          }
+        }
+      }
+    }
+  }
+}
+
+exec
+/bin/zsh -lc 'swift test --filter SetupCoordinatorTests' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ exited 1 in 6265ms:
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/configuration is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/security is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/Caches/org.swift.swiftpm is not accessible or not writable, disabling user-level cache features.
+error: 'wt-phase-f': Invalid manifest (compiled with: ["/Library/Developer/CommandLineTools/usr/bin/swiftc", "-vfsoverlay", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.3JWBJV/vfs.yaml", "-L", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx14.0", "-I", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-L", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-plugin-path", "/Library/Developer/CommandLineTools/usr/lib/swift/host/plugins/testing", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-swift-version", "6", "-I", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-package-description-version", "6.0.0", "/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Package.swift", "-o", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.jZYMZs/wt-phase-f-manifest"])
+<unknown>:0: error: unable to open output file '/Users/m4pro_sv/.cache/clang/ModuleCache/16FE8S6R1GMN7/SwiftShims-JX1COEH18DAN.pcm': 'Operation not permitted'
+/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface:5:8: error: could not build Objective-C module 'SwiftShims'
+    3 | // swift-module-flags: -target arm64e-apple-macosx26.4 -target-variant arm64e-apple-ios26.4-macabi -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -enable-experimental-concise-pound-file -disable-objc-attr-requires-foundation-module -enable-experimental-feature NoncopyableGenerics2 -enable-experimental-feature SuppressedAssociatedTypes -enable-experimental-feature SE427NoInferenceOnExtension -enable-experimental-feature NonescapableTypes -enable-experimental-feature LifetimeDependence -enable-experimental-feature InoutLifetimeDependence -enable-experimental-feature LifetimeDependenceMutableAccessors -enable-experimental-feature MemberImportVisibility -enable-experimental-feature TypedThrows -enable-experimental-feature Macros -enable-experimental-feature FreestandingMacros -enable-experimental-feature BitwiseCopyable -enable-experimental-feature Extern -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature ValueGenerics -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes -user-module-version 6.3.0.123.11 -module-name Swift
+    4 | // swift-module-flags-ignorable: -enable-lexical-lifetimes=false -strict-memory-safety -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3
+    5 | import SwiftShims
+      |        `- error: could not build Objective-C module 'SwiftShims'
+    6 | @inlinable public func min<T>(_ x: T, _ y: T) -> T where T : Swift.Comparable {
+    7 |    
+
+/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface:1:1: error: failed to build module 'Swift'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)', while this compiler is 'Apple Swift version 6.3.1 effective-5.10 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)'). Please select a toolchain which matches the SDK.
+    1 | // swift-interface-format-version: 1.0
+      | `- error: failed to build module 'Swift'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)', while this compiler is 'Apple Swift version 6.3.1 effective-5.10 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)'). Please select a toolchain which matches the SDK.
+    2 | // swift-compiler-version: Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)
+    3 | // swift-module-flags: -target arm64e-apple-macosx26.4 -target-variant arm64e-apple-ios26.4-macabi -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -enable-experimental-concise-pound-file -disable-objc-attr-requires-foundation-module -enable-experimental-feature NoncopyableGenerics2 -enable-experimental-feature SuppressedAssociatedTypes -enable-experimental-feature SE427NoInferenceOnExtension -enable-experimental-feature NonescapableTypes -enable-experimental-feature LifetimeDependence -enable-experimental-feature InoutLifetimeDependence -enable-experimental-feature LifetimeDependenceMutableAccessors -enable-experimental-feature MemberImportVisibility -enable-experimental-feature TypedThrows -enable-experimental-feature Macros -enable-experimental-feature FreestandingMacros -enable-experimental-feature BitwiseCopyable -enable-experimental-feature Extern -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature ValueGenerics -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes -user-module-version 6.3.0.123.11 -module-name Swift
+error: 'wt-phase-f': Invalid manifest (compiled with: ["/Library/Developer/CommandLineTools/usr/bin/swiftc", "-vfsoverlay", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.6lMHxf/vfs.yaml", "-L", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx14.0", "-I", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-L", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-plugin-path", "/Library/Developer/CommandLineTools/usr/lib/swift/host/plugins/testing", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-swift-version", "6", "-I", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-package-description-version", "6.0.0", "/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Package.swift", "-o", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.HRBDcJ/wt-phase-f-manifest"])
+<unknown>:0: error: unable to open output file '/Users/m4pro_sv/.cache/clang/ModuleCache/16FE8S6R1GMN7/SwiftShims-JX1COEH18DAN.pcm': 'Operation not permitted'
+/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface:5:8: error: could not build Objective-C module 'SwiftShims'
+    3 | // swift-module-flags: -target arm64e-apple-macosx26.4 -target-variant arm64e-apple-ios26.4-macabi -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -enable-experimental-concise-pound-file -disable-objc-attr-requires-foundation-module -enable-experimental-feature NoncopyableGenerics2 -enable-experimental-feature SuppressedAssociatedTypes -enable-experimental-feature SE427NoInferenceOnExtension -enable-experimental-feature NonescapableTypes -enable-experimental-feature LifetimeDependence -enable-experimental-feature InoutLifetimeDependence -enable-experimental-feature LifetimeDependenceMutableAccessors -enable-experimental-feature MemberImportVisibility -enable-experimental-feature TypedThrows -enable-experimental-feature Macros -enable-experimental-feature FreestandingMacros -enable-experimental-feature BitwiseCopyable -enable-experimental-feature Extern -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature ValueGenerics -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes -user-module-version 6.3.0.123.11 -module-name Swift
+    4 | // swift-module-flags-ignorable: -enable-lexical-lifetimes=false -strict-memory-safety -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3
+    5 | import SwiftShims
+      |        `- error: could not build Objective-C module 'SwiftShims'
+    6 | @inlinable public func min<T>(_ x: T, _ y: T) -> T where T : Swift.Comparable {
+    7 |    
+
+/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface:1:1: error: failed to build module 'Swift'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)', while this compiler is 'Apple Swift version 6.3.1 effective-5.10 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)'). Please select a toolchain which matches the SDK.
+    1 | // swift-interface-format-version: 1.0
+      | `- error: failed to build module 'Swift'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)', while this compiler is 'Apple Swift version 6.3.1 effective-5.10 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)'). Please select a toolchain which matches the SDK.
+    2 | // swift-compiler-version: Apple Swift version 6.3 effective-5.10 (swiftlang-6.3.0.123.4 clang-2100.0.123.2)
+    3 | // swift-module-flags: -target arm64e-apple-macosx26.4 -target-variant arm64e-apple-ios26.4-macabi -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -library-level api -enforce-exclusivity=unchecked -target-min-inlining-version min -enable-experimental-concise-pound-file -disable-objc-attr-requires-foundation-module -enable-experimental-feature NoncopyableGenerics2 -enable-experimental-feature SuppressedAssociatedTypes -enable-experimental-feature SE427NoInferenceOnExtension -enable-experimental-feature NonescapableTypes -enable-experimental-feature LifetimeDependence -enable-experimental-feature InoutLifetimeDependence -enable-experimental-feature LifetimeDependenceMutableAccessors -enable-experimental-feature MemberImportVisibility -enable-experimental-feature TypedThrows -enable-experimental-feature Macros -enable-experimental-feature FreestandingMacros -enable-experimental-feature BitwiseCopyable -enable-experimental-feature Extern -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature ValueGenerics -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes -user-module-version 6.3.0.123.11 -module-name Swift
+error: ExitCode(rawValue: 1)
+[0/1] Planning build
+
+exec
+/bin/zsh -lc 'rg "protocol ASRManagerInterface|ASRManagerInterface" -n Sources | head -20 && rg "class WhisperKitSetupService|enum.*WhisperKit.*Setup|setupState" -n Sources/EnviousWispr* | head -100' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:18:  private let asrManager: any ASRManagerInterface
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:36:    asrManager: any ASRManagerInterface,
+Sources/EnviousWispr/App/SetupCoordinator.swift:21:  private let asrManager: any ASRManagerInterface
+Sources/EnviousWispr/App/SetupCoordinator.swift:25:    asrManager: any ASRManagerInterface,
+Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:41:  /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:88:  func startSetup(asrManager: any ASRManagerInterface, settings: SettingsManager) async {
+Sources/EnviousWisprASR/ASRManagerProxy.swift:5:/// XPC-backed implementation of `ASRManagerInterface`.
+Sources/EnviousWisprASR/ASRManagerProxy.swift:13:public final class ASRManagerProxy: ASRManagerInterface {
+Sources/EnviousWisprASR/ASRManagerProxy.swift:45:  // MARK: - ASRManagerInterface: Model lifecycle
+Sources/EnviousWisprASR/ASRManagerProxy.swift:163:  // MARK: - ASRManagerInterface: Capability
+Sources/EnviousWisprASR/ASRManagerProxy.swift:179:  // MARK: - ASRManagerInterface: Batch transcription
+Sources/EnviousWisprASR/ASRManagerProxy.swift:213:  // MARK: - ASRManagerInterface: Streaming
+Sources/EnviousWisprASR/ASRManagerProxy.swift:275:  // MARK: - ASRManagerInterface: Pipeline lifecycle
+Sources/EnviousWisprASR/ASRManager.swift:8:public final class ASRManager: ASRManagerInterface {
+Sources/EnviousWisprASR/ASRManagerInterface.swift:9:public protocol ASRManagerInterface: AnyObject {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:15:  private let asrManager: any ASRManagerInterface
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:142:    asrManager: any ASRManagerInterface,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:163:    asrManager: any ASRManagerInterface,
+Sources/EnviousWispr/App/BenchmarkSuite.swift:33:  private func ensureModelLoaded(using asrManager: any ASRManagerInterface) async -> Bool {
+Sources/EnviousWispr/App/BenchmarkSuite.swift:46:  func run(using asrManager: any ASRManagerInterface) async {
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:22:public enum WhisperKitSetupState: Equatable {
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:34:public final class WhisperKitSetupService {
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:38:  public private(set) var setupState: WhisperKitSetupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:62:  /// Sets setupState to .ready or .notDownloaded (never triggers a download).
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:67:      setupState != .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:72:    setupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:74:    setupState = isDownloaded ? .ready : .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:95:  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:131:    setupState = .downloading(progress: 0, status: "Starting download...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:154:        self.setupState = .downloading(progress: fraction, status: "Downloading model files...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:160:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:168:        self.setupState = .ready
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:170:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:173:        self?.setupState = .error(
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:184:    setupState = .notDownloaded
+Sources/EnviousWisprLLM/OllamaSetupService.swift:91:  public private(set) var setupState: OllamaSetupState = .detecting
+Sources/EnviousWisprLLM/OllamaSetupService.swift:317:    setupState = .detecting
+Sources/EnviousWisprLLM/OllamaSetupService.swift:323:          setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:326:        setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:333:      setupState = .notInstalled
+Sources/EnviousWisprLLM/OllamaSetupService.swift:340:      if case .error = setupState { return }
+Sources/EnviousWisprLLM/OllamaSetupService.swift:341:      setupState = .installedNotRunning
+Sources/EnviousWisprLLM/OllamaSetupService.swift:346:      setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:349:      setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:412:      setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:502:            setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:535:        setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:541:      setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:556:            self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:559:            self.setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:565:      self?.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:591:    setupState = .pullingModel(progress: 0, status: "Starting download...")
+Sources/EnviousWisprLLM/OllamaSetupService.swift:600:        // setupState = .pullingModel(1.0, "success") from the last stream chunk
+Sources/EnviousWisprLLM/OllamaSetupService.swift:610:        // its own setupState; overwriting with .ready would clobber it.
+Sources/EnviousWisprLLM/OllamaSetupService.swift:613:        self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:619:          self.setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:621:          self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:626:        self.setupState = .error(self.friendlyMessage(for: urlError))
+Sources/EnviousWisprLLM/OllamaSetupService.swift:632:          self.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:636:          self.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:657:        setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:659:        setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:666:      //      await) bails and does NOT overwrite setupState. Otherwise a
+Sources/EnviousWisprLLM/OllamaSetupService.swift:672:      //   3. Commit setupState = .ready here. The stream reported success, so
+Sources/EnviousWisprLLM/OllamaSetupService.swift:675:      //      Task's bail (step 1) would leave setupState stuck at
+Sources/EnviousWisprLLM/OllamaSetupService.swift:681:      setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:811:        setupState = .pullingModel(progress: progress, status: status)
+Sources/EnviousWisprLLM/OllamaSetupService.swift:814:        setupState = .pullingModel(progress: pullProgress, status: status)
+Sources/EnviousWisprLLM/OllamaSetupService.swift:820:        setupState = .pullingModel(progress: 1.0, status: status)
+Sources/EnviousWispr/App/AppState.swift:623:    // WhisperKit: observation-based (waits for setupState to become .ready first).
+Sources/EnviousWispr/App/SetupCoordinator.swift:32:  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
+Sources/EnviousWispr/App/SetupCoordinator.swift:47:        let currentState = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/SetupCoordinator.swift:55:            _ = self.whisperKitSetup.setupState
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:47:        case .ready = appState.setup.whisperKitSetup.setupState
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:206:    switch appState.setup.whisperKitSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:27:    switch appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:229:          if case .ready = appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:255:        // detectState() will set setupState, which triggers the onChange handler
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:268:    .onChange(of: appState.setup.ollamaSetup.setupState) { _, newState in
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:286:        case .ready = appState.setup.ollamaSetup.setupState,
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:573:    switch appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:709:            if case .ready = appState.setup.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:865:      if case .pullingModel = appState.setup.ollamaSetup.setupState { return true }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:987:        if case .ready = appState.setup.ollamaSetup.setupState {
+
+exec
+/bin/zsh -lc "cat Sources/EnviousWisprASR/ASRManagerInterface.swift && sed -n '1,220p' Sources/EnviousWisprASR/WhisperKitSetupService.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+
+/// Abstraction over ASR management — enables swapping between in-process and XPC implementations.
+///
+/// `ASRManager` (in-process) and `ASRManagerProxy` (XPC) both conform to this protocol.
+/// Pipelines and AppState interact through this interface only.
+@MainActor
+public protocol ASRManagerInterface: AnyObject {
+  // Observable state
+  var activeBackendType: ASRBackendType { get }
+  var isModelLoaded: Bool { get }
+  var isStreaming: Bool { get }  // periphery:ignore - read via existential type (ASRManagerProxy)
+
+  // Download progress (0.0–1.0), phase description, and detail string.
+  // Updated during loadModel() when model download is in progress.
+  // periphery:ignore:all - read via existential type in OnboardingV2View progress polling
+  var downloadProgress: Double { get }
+  var downloadPhase: String { get }
+  var downloadDetail: String { get }
+
+  // Model lifecycle
+  func loadModel() async throws
+  func loadModelSilently() async
+  func unloadModel() async  // periphery:ignore - called via existential type (ASRManager idle timer)
+  func setInitialBackendType(_ type: ASRBackendType)
+  func switchBackend(to type: ASRBackendType) async
+
+  // Capability
+  var activeBackendSupportsStreaming: Bool { get async }
+
+  // Batch transcription
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
+
+  // Streaming transcription
+  func startStreaming(options: TranscriptionOptions) async throws
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws
+  func finalizeStreaming() async throws -> ASRResult
+  func cancelStreaming() async
+
+  // Pipeline lifecycle hooks
+  func noteTranscriptionComplete(policy: ModelUnloadPolicy)
+  func cancelIdleTimer()
+
+  // Crash notification — fires when XPC ASR service dies during an active session.
+  // Wired by AppState to route to the active pipeline (same pattern as AudioCaptureProxy.onEngineInterrupted).
+  var onServiceInterrupted: (() -> Void)? { get set }
+}
+import Foundation
+@preconcurrency import WhisperKit
+
+/// Free function (nonisolated) that wraps WhisperKit.download() and relays progress
+/// via an AsyncStream continuation. The continuation is Sendable, so this avoids
+/// Swift 6 data-race diagnostics around sending a MainActor-captured closure
+/// to a nonisolated function.
+private func whisperKitDownload(
+  variant: String,
+  progressContinuation: AsyncStream<Double>.Continuation
+) async throws {
+  defer { progressContinuation.finish() }
+  _ = try await WhisperKit.download(
+    variant: variant,
+    progressCallback: { progress in
+      progressContinuation.yield(progress.fractionCompleted)
+    }
+  )
+}
+
+/// States in the WhisperKit model setup flow.
+public enum WhisperKitSetupState: Equatable {
+  case checking  // initial detection
+  case notDownloaded  // model not on disk
+  case downloading(progress: Double, status: String)  // actively downloading
+  case ready  // model cached locally, ready to use
+  case error(String)
+}
+
+/// Guides users through WhisperKit model download.
+/// Downloads happen in Settings — NOT auto-triggered on first record.
+@MainActor
+@Observable
+public final class WhisperKitSetupService {
+
+  // MARK: - Public State
+
+  public private(set) var setupState: WhisperKitSetupState = .checking
+
+  /// Model variant to download. Source of truth: `WhisperKitBackend.defaultModelVariant()`.
+  // BRAIN: gotcha id=model-name-format
+  public let modelVariant: String = WhisperKitBackend.defaultModelVariant()
+
+  public init() {}
+
+  // MARK: - Private
+
+  private var downloadTask: Task<Void, Never>?
+
+  /// WhisperKit model storage directory.
+  /// WhisperKit 0.12+ downloads models to ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/
+  /// nonisolated(unsafe) is required: the class is @MainActor but nonisolated static methods reference this.
+  nonisolated(unsafe) private static let whisperKitModelRoot: URL? = FileManager.default
+    .homeDirectoryForCurrentUser
+    .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+
+  // MARK: - Detection
+
+  private var lastDetectTime: Date?
+
+  /// Check whether the model is already cached locally.
+  /// Sets setupState to .ready or .notDownloaded (never triggers a download).
+  /// Caches result for 5 seconds to avoid redundant file I/O on tab switches.
+  public func detectState() async {
+    if let lastTime = lastDetectTime,
+      Date().timeIntervalSince(lastTime) < 5.0,
+      setupState != .checking
+    {
+      return
+    }
+
+    setupState = .checking
+    let isDownloaded = WhisperKitSetupService.isModelCached(variant: modelVariant)
+    setupState = isDownloaded ? .ready : .notDownloaded
+    lastDetectTime = Date()
+  }
+
+  /// Force a fresh state check, ignoring cache.
+  public func forceDetectState() async {
+    lastDetectTime = nil
+    await detectState()
+  }
+
+  /// Returns true if a folder matching the given model variant exists in the HF cache.
+  public nonisolated static func isModelCached(variant: String) -> Bool {
+    return getLocalModelPath(variant: variant) != nil
+  }
+
+  /// Returns the local path to a fully-cached WhisperKit model, or nil if not
+  /// downloaded OR if the cache is incomplete (missing one of the required
+  /// `.mlmodelc` artifacts — e.g. an interrupted download).
+  /// WhisperKit 0.12+ stores models as direct subdirectories like
+  /// `openai_whisper-large-v3`. Partial-download semantics (issue #329):
+  /// treating an incomplete folder as "not cached" keeps `detectState` →
+  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+  /// back to `WhisperKit.download(...)` instead of trying to load a
+  /// corrupt path.
+  public nonisolated static func getLocalModelPath(variant: String) -> String? {
+    guard let root = whisperKitModelRoot else { return nil }
+
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: root.path) else { return nil }
+
+    let variantLower = variant.lowercased()
+    let sanitizedLower = variant.replacingOccurrences(of: "-", with: "_").lowercased()
+
+    guard let contents = try? fm.contentsOfDirectory(atPath: root.path) else {
+      return nil
+    }
+
+    for dir in contents {
+      let lower = dir.lowercased()
+      if lower.contains(variantLower) || lower.contains(sanitizedLower) {
+        let fullPath = root.appendingPathComponent(dir).path
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: fullPath, isDirectory: &isDir), isDir.boolValue else {
+          continue
+        }
+        guard WhisperKitBackend.hasRequiredArtifacts(at: fullPath) else { continue }
+        return fullPath
+      }
+    }
+    return nil
+  }
+
+  // MARK: - Download
+
+  /// Start downloading the model with progress tracking.
+  public func downloadModel() {
+    downloadTask?.cancel()
+    setupState = .downloading(progress: 0, status: "Starting download...")
+
+    let variant = modelVariant
+    downloadTask = Task { [weak self] in
+      // Run the actual network download on a detached task (nonisolated context).
+      // Progress fractions are relayed back via an AsyncStream so there is no
+      // actor-isolated closure sent to a nonisolated function (Swift 6 safe).
+      let (progressStream, progressContinuation) = AsyncStream<Double>.makeStream()
+
+      let downloadResult: Task<Void, Error> = Task.detached {
+        // The progress callback runs on whatever thread URLSession uses.
+        // It feeds into the stream (safe — AsyncStream continuation is Sendable).
+        try await whisperKitDownload(
+          variant: variant,
+          progressContinuation: progressContinuation
+        )
+      }
+
+      // Consume progress updates on the MainActor while the download runs.
+      // If outer Task is cancelled, exit the loop and cancel the inner download.
+      for await fraction in progressStream {
+        if Task.isCancelled { break }
+        guard let self else { break }
+        self.setupState = .downloading(progress: fraction, status: "Downloading model files...")
+      }
+
+      // If the outer Task was cancelled, cancel the inner detached download too.
+      if Task.isCancelled {
+        downloadResult.cancel()
+        self?.setupState = .notDownloaded
+        return
+      }
+
+      do {
+        try await downloadResult.value
+        guard let self else { return }
+        self.lastDetectTime = Date()
+        self.setupState = .ready
+      } catch is CancellationError {
+        self?.setupState = .notDownloaded
+        downloadResult.cancel()
+      } catch {
+        self?.setupState = .error(
+          "Download failed — check your internet connection and try again."
+        )
+      }
+    }
+  }
+
+  /// Cancel an in-progress download.
+  public func cancelDownload() {
+    downloadTask?.cancel()
+    downloadTask = nil
+    setupState = .notDownloaded
+  }
+}
+
+exec
+/bin/zsh -lc "git show bc445a1dc817c48db543f818b28c16eabc7e313e:Sources/EnviousWispr/App/AppState.swift | sed -n '1,90p;180,245p;350,400p;600,675p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
+import EnviousWisprServices
+import EnviousWisprStorage
+import SwiftUI
+
+/// Root observable state for the entire application.
+@MainActor
+@Observable
+final class AppState {
+  // Settings
+  var settings = SettingsManager()
+
+  // Sub-systems
+  let permissions = PermissionsService()
+  let audioCapture: any AudioCaptureInterface
+  let asrManager: any ASRManagerInterface
+  let keychainManager = KeychainManager()
+  let hotkeyService = HotkeyService()
+  let benchmark = BenchmarkSuite()
+  let recordingOverlay = RecordingOverlayPanel()
+  let ollamaSetup = OllamaSetupService()
+  let whisperKitSetup = WhisperKitSetupService()
+  let audioDeviceList = AudioDeviceList()
+  let captureTelemetry = CaptureTelemetryState()
+
+  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
+  private var whisperKitPreloadTask: Task<Void, Never>?
+
+  /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+  /// Cancelled when a new recording starts or a higher-priority notification is shown.
+  private var postCompletionWarningTask: Task<Void, Never>?
+
+  // Pipelines — initialized after sub-systems
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
+
+  // Phase A (#196) — per-pipeline state-change behavior absorbed from the
+  // onStateChange closures. Each handler owns the effect execution; AppState
+  // still owns the cross-pipeline warning Task + tiebreaker + hotkey ordering.
+  // Lazy so the callback closures can capture `self` after stored-property
+  // assignment completes. First access is inside `onStateChange`, well after
+  // `init()` returns.
+  @ObservationIgnored
+  private lazy var parakeetStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "parakeet")
+  }()
+  @ObservationIgnored
+  private lazy var whisperKitStateHandler: PipelineStateChangeHandler = {
+    makeStateChangeHandler(backendLabel: "whisperKit")
+  }()
+
+  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { [weak self] intent in
+        guard let self else { return }
+        self.recordingOverlay.show(
+          intent: intent,
+          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+          isRecordingLocked: self.isRecordingLocked
+        )
+      },
+      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+      schedulePolishFailedWarning: { [weak self] in
+        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+      },
+      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
+      reportDictationCompleted: { [weak self] t in
+        guard let self else { return }
+        TelemetryService.shared.reportDictationCompleted(
+          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+      },
+      reportPipelineFailed: { msg in
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backendLabel)
+      }
+    )
+  }
+
+  /// Standalone service for re-polishing saved transcripts from the detail view.
+  /// Completely decoupled from pipeline state machines.
+  let polishService: TranscriptPolishService
+
+  /// Forwards settings changes to pipelines and subsystems.
+  private let settingsSync: PipelineSettingsSync
+
+    // call `TelemetryService` (which is @MainActor isolated).
+    // The chip handler is wired AFTER init completes (see setPassiveChipHandler
+    // call below) because it needs to capture self, and Swift does not allow
+    // that before all stored properties are initialized.
+    let languageDetector = LanguageDetector(
+      onLanguageFlip: { @Sendable event in
+        Task { @MainActor in
+          TelemetryService.shared.trackLanguageFlip(
+            fromLang: event.fromLang,
+            toLang: event.toLang,
+            confidenceBoth: event.confidenceBoth
+          )
+        }
+      }
+    )
+    whisperKitPipeline = WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      languageDetector: languageDetector,
+      captureTelemetry: captureTelemetry
+    )
+    // Transcript polish service (re-polish from detail view, decoupled from pipelines)
+    polishService = TranscriptPolishService(
+      keychainManager: keychainManager,
+      transcriptStore: transcriptStore
+    )
+
+    // Initialize settingsSync and apply initial settings to all targets
+    settingsSync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: hotkeyService,
+      whisperKitSetup: whisperKitSetup
+    )
+    settingsSync.applyInitialSettings(settings)
+
+    // Wire dictation activity provider (after all stored properties initialized)
+    polishService.setDictationActivity(self)
+
+    // Wire the passive-chip handler on the LanguageDetector actor now that
+    // self is fully constructed. The handler hops back to the MainActor
+    // to publish the chip on `pendingPassiveChip` so UI can observe it.
+    Task { [weak self] in
+      await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
+        Task { @MainActor in
+          self?.pendingPassiveChip = trigger
+        }
+      }
+    }
+
+    // Unified engine interruption handler — routes to whichever pipeline is actively recording.
+    // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
+    // is interrupted, we must notify the pipeline that's currently recording, not the one
+    // that happened to set onEngineInterrupted last.
+    audioCapture.onEngineInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+        await AppLogger.shared.log(
+          "[AppState] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
+        )
+      }
+      if pState == .loadingModel || pState == .recording || pState == .transcribing {
+        self.pipeline.handleASRServiceInterruption()
+      } else if wkState == .recording || wkState == .transcribing {
+        self.whisperKitPipeline.handleASRServiceInterruption()
+      }
+      // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
+      // the pipeline sets .error(...) state which shows the error overlay via
+      // onStateChange. The error overlay auto-dismisses after 3 seconds.
+    }
+
+    // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
+    // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
+    audioCapture.onVADAutoStop = { [weak self] in
+      guard let self else { return }
+      if self.pipeline.state == .recording {
+        Task { await self.pipeline.stopAndTranscribe() }
+      } else if self.whisperKitPipeline.state == .recording {
+        Task { await self.whisperKitPipeline.stopAndTranscribe() }
+      }
+    }
+    settingsSync.onNeedsPreloadObservation = { [weak self] in
+      self?.startWhisperKitPreloadObservation()
+    }
+
+    // Wire custom-words propagator. The exact ordering (seed → register all
+    // consumers → install onWordsChanged) lives in `wireCustomWords` so
+    // tests can drive the same path with spy consumers + a real
+    // `CustomWordsCoordinator`. Phase D (#496) replaces the prior 5-way
+    // fanout in AppState plus 5 mirror sites in `PipelineSettingsSync`.
+    wireCustomWords(
+      propagator: customWordsPropagator,
+      initialWords: customWordsCoordinator.customWords,
+      consumers: [
+        pipeline.wordCorrection,
+        pipeline.llmPolish,
+        whisperKitPipeline.wordCorrection,
+        whisperKitPipeline.llmPolish,
+        polishService.llmPolishStep,
+      ],
+      coordinator: customWordsCoordinator
+    )
+
+    // Initialize logger
+    Task {
+      await AppLogger.shared.setLogLevel(settings.debugLogLevel)
+      await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
+      self.isRecordingLocked = true
+      self.recordingOverlay.updateLockState(true)
+      Task {
+        await AppLogger.shared.log(
+          "Hands-free mode activated — overlay expanding",
+          level: .info, category: "AppState"
+        )
+      }
+    }
+
+    // Pre-load the selected backend's model in the background to eliminate cold-start delay.
+    // Parakeet: direct silent load (model files already downloaded during onboarding).
+    // WhisperKit: observation-based (waits for setupState to become .ready first).
+    if settings.selectedBackend == .parakeet {
+      Task { [weak self] in
+        await self?.asrManager.loadModelSilently()
+      }
+    }
+    Task { [weak self] in
+      await self?.whisperKitSetup.detectState()
+      self?.startWhisperKitPreloadObservation()
+    }
+
+    // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
+    // called from applicationDidFinishLaunching. Carbon RegisterEventHotKey
+    // requires the NSApplication event loop to be running for event delivery.
+  }
+
+  /// Start the hotkey service. Must be called after the NSApplication event loop
+  /// is running (e.g., from applicationDidFinishLaunching), because Carbon
+  /// RegisterEventHotKey events are only delivered once the run loop is active.
+  func startHotkeyServiceIfEnabled() {
+    if settings.hotkeyEnabled {
+      hotkeyService.start()
+    }
+  }
+
+  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
+  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
+  private func startWhisperKitPreloadObservation() {
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+
+        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+        // users shouldn't pay CPU/memory cost warming a backend they never use.
+        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+        // restarts this observer; the re-entry sees the new activeBackendType.
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+
+        // Check current state — if already .ready, trigger pre-load
+        let currentState = self.whisperKitSetup.setupState
+        if currentState == .ready {
+          await self.whisperKitPipeline.prepareBackendSilently()
+          return  // Model loaded — no need to keep observing
+        }
+
+        // Wait for the next change to setupState
+        await withCheckedContinuation { continuation in
+          withObservationTracking {
+            _ = self.whisperKitSetup.setupState
+          } onChange: {
+            continuation.resume()
+          }
+        }
+      }
+    }
+  }
+
+  /// Active dictation pipeline — routes based on selected backend.
+  var activePipeline: any DictationPipeline {
+    asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
+  }
+
+  /// Convenience: current pipeline state — routes through active backend.
+
+exec
+/bin/zsh -lc "mkdir -p .build/clang-cache .build/module-cache /tmp/swifttest && cat > /tmp/swifttest/test.swift <<'EOF'
+final class P { func f() {} }
+final class C {
+ let p: P
+ let c: () -> Void
+ init() {
+  p = P()
+  c = { [weak p] in p?.f() }
+ }
+}
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/test.swift -o /tmp/swifttest/test' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 11611ms:
+exec
+/bin/zsh -lc 'CLANG_MODULE_CACHE_PATH="$PWD/.build/clang-cache" swift test --filter SetupCoordinatorTests' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ exited 1 in 814ms:
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/configuration is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/security is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/Caches/org.swift.swiftpm is not accessible or not writable, disabling user-level cache features.
+error: 'wt-phase-f': Invalid manifest (compiled with: ["/Library/Developer/CommandLineTools/usr/bin/swiftc", "-vfsoverlay", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.zjcmSv/vfs.yaml", "-L", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx14.0", "-I", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-L", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-plugin-path", "/Library/Developer/CommandLineTools/usr/lib/swift/host/plugins/testing", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-swift-version", "6", "-I", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-package-description-version", "6.0.0", "/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Package.swift", "-o", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.Iv4WVy/wt-phase-f-manifest"])
+sandbox-exec: sandbox_apply: Operation not permitted
+error: 'wt-phase-f': Invalid manifest (compiled with: ["/Library/Developer/CommandLineTools/usr/bin/swiftc", "-vfsoverlay", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.xFMpPe/vfs.yaml", "-L", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx14.0", "-I", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-L", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks", "-plugin-path", "/Library/Developer/CommandLineTools/usr/lib/swift/host/plugins/testing", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-swift-version", "6", "-I", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-package-description-version", "6.0.0", "/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Package.swift", "-o", "/var/folders/t0/1pnvt1n158gfwl6vbb4fb0v40000gn/T/TemporaryDirectory.Exe9s0/wt-phase-f-manifest"])
+sandbox-exec: sandbox_apply: Operation not permitted
+error: ExitCode(rawValue: 1)
+[0/1] Planning build
+
+exec
+/bin/zsh -lc "ls && sed -n '1,220p' Package.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+LICENSE
+Package.resolved
+Package.swift
+README.md
+Sources
+Tests
+assets
+benchmark-results
+build
+docs
+periphery-baseline.json
+scripts
+website
+workers
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "EnviousWispr",
+  platforms: [
+    .macOS(.v14)
+  ],
+  products: [
+    // Exposed so the multilingual polish-quality harness (a separate
+    // SwiftPM package at scripts/multilingual-eval/polisher-runner) can
+    // depend on the real planner + connectors via a path-based package
+    // dependency. Purely additive — no production code imports these.
+    .library(name: "EnviousWisprCore", targets: ["EnviousWisprCore"]),
+    .library(name: "EnviousWisprLLM", targets: ["EnviousWisprLLM"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
+    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
+    .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
+    .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+    .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),
+  ],
+  targets: [
+    .target(
+      name: "EnviousWisprCore",
+      path: "Sources/EnviousWisprCore"
+    ),
+    .target(
+      name: "EnviousWisprStorage",
+      dependencies: ["EnviousWisprCore"],
+      path: "Sources/EnviousWisprStorage"
+    ),
+    .target(
+      name: "EnviousWisprPostProcessing",
+      dependencies: ["EnviousWisprCore"],
+      path: "Sources/EnviousWisprPostProcessing"
+    ),
+    .target(
+      name: "EnviousWisprAudio",
+      dependencies: [
+        "EnviousWisprCore",
+        "FluidAudio",
+      ],
+      path: "Sources/EnviousWisprAudio"
+    ),
+    .target(
+      name: "EnviousWisprServices",
+      dependencies: [
+        "EnviousWisprCore",
+        .product(name: "PostHog", package: "posthog-ios"),
+        .product(name: "Sentry", package: "sentry-cocoa"),
+      ],
+      path: "Sources/EnviousWisprServices"
+    ),
+    .target(
+      name: "EnviousWisprASR",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprAudio",
+        "WhisperKit",
+        "FluidAudio",
+      ],
+      path: "Sources/EnviousWisprASR"
+    ),
+    .target(
+      name: "EnviousWisprLLM",
+      dependencies: ["EnviousWisprCore"],
+      path: "Sources/EnviousWisprLLM"
+    ),
+    .target(
+      name: "EnviousWisprPipeline",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprASR",
+        "EnviousWisprAudio",
+        "EnviousWisprLLM",
+        "EnviousWisprPostProcessing",
+        "EnviousWisprServices",
+        "EnviousWisprStorage",
+        "WhisperKit",
+      ],
+      path: "Sources/EnviousWisprPipeline"
+    ),
+    .executableTarget(
+      name: "EnviousWisprAudioService",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprAudio",
+      ],
+      path: "Sources/EnviousWisprAudioService",
+      exclude: ["Resources"]
+    ),
+    .executableTarget(
+      name: "EnviousWisprASRService",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprASR",
+        "EnviousWisprAudio",
+        "WhisperKit",
+        "FluidAudio",
+      ],
+      path: "Sources/EnviousWisprASRService",
+      exclude: ["Resources"]
+    ),
+    .executableTarget(
+      name: "EnviousWispr",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprStorage",
+        "EnviousWisprPostProcessing",
+        "EnviousWisprAudio",
+        "EnviousWisprServices",
+        "EnviousWisprASR",
+        "EnviousWisprLLM",
+        "EnviousWisprPipeline",
+        "WhisperKit",
+        "FluidAudio",
+        "Sparkle",
+      ],
+      path: "Sources/EnviousWispr",
+      exclude: ["Resources"]
+    ),
+    .testTarget(
+      name: "EnviousWisprTests",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprPostProcessing",
+        "EnviousWisprLLM",
+        "EnviousWisprPipeline",
+        "EnviousWisprStorage",
+        "EnviousWisprAudio",
+        "EnviousWispr",
+      ],
+      path: "Tests/EnviousWisprTests"
+    ),
+    .testTarget(
+      name: "EnviousWisprASRTests",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprASR",
+      ],
+      path: "Tests/EnviousWisprASRTests"
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)
+
+exec
+/bin/zsh -lc 'rg "import EnviousWisprASR" Tests/EnviousWisprTests -n | head -50 && rg "import EnviousWisprAudio|import EnviousWisprServices" Tests/EnviousWisprTests -n | head -50' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift:2:import EnviousWisprASR
+Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift:3:import EnviousWisprASR
+Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift:5:@testable import EnviousWisprServices
+Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift:5:@testable import EnviousWisprServices
+Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift:5:@testable import EnviousWisprServices
+Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift:4:@testable import EnviousWisprServices
+Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift:4:@testable import EnviousWisprAudio
+Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift:2:import EnviousWisprServices
+Tests/EnviousWisprTests/Pipeline/TranscriptionPipelineInjectionTests.swift:2:import EnviousWisprAudio
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:2:import EnviousWisprAudio
+Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift:4:import EnviousWisprAudio
+
+exec
+/bin/zsh -lc "sed -n '60,115p' Sources/EnviousWisprLLM/OllamaSetupService.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+    parameterCount: String,
+    qualityTier: OllamaQualityTier,
+    downloadSize: String,
+    isDownloaded: Bool = false
+  ) {
+    self.name = name
+    self.displayName = displayName
+    self.parameterCount = parameterCount
+    self.qualityTier = qualityTier
+    self.downloadSize = downloadSize
+    self.isDownloaded = isDownloaded
+  }
+}
+
+/// A model parsed from Ollama's /api/tags response.
+public struct OllamaDownloadedModel: Sendable {
+  public let exactName: String
+  public let canonicalName: String
+  public let parameterSize: String?
+  public let parameterBillions: Double?
+  public let fileSizeBytes: Int64
+  public let displayName: String
+}
+
+/// Guides users through Ollama installation, server startup, and model pulling.
+@MainActor
+@Observable
+public final class OllamaSetupService {
+
+  // MARK: - Public State
+
+  public private(set) var setupState: OllamaSetupState = .detecting
+  public private(set) var pullProgress: Double = 0
+  public private(set) var pullStatusText: String = ""
+  public private(set) var currentPullingModel: String?
+  public private(set) var downloadedModels: [OllamaDownloadedModel] = []
+  public private(set) var warmupState: OllamaWarmupState = .idle
+
+  // Per-pull generation token. Bumped on every pullModel/cancelPull call so stale
+  // tasks can no-op their writes (Swift Task cancellation is cooperative; without
+  // this, a late chunk or terminal-branch cleanup from an old task could clobber
+  // the newer pull's state, most acutely on cancel-then-re-download-same-model).
+  private var pullEpoch: UInt64 = 0
+
+  /// Canonical names of downloaded models. Backward-compatible with old Set<String> consumers.
+  public var downloadedModelNames: Set<String> {
+    Set(downloadedModels.map(\.canonicalName))
+  }
+
+  // MARK: - Model Catalog
+
+  /// Curated suggestions for users who haven't downloaded models yet.
+  public static let modelCatalog: [OllamaModelCatalogEntry] = [
+    OllamaModelCatalogEntry(
+      name: "gemma3n:e4b", displayName: "Gemma 3 Nano (4B)", parameterCount: "4B",
+      qualityTier: .best, downloadSize: "~6 GB"),
+
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/asyncprop.swift <<'EOF'
+protocol P { var x: Bool { get async } }
+struct S: P { var x: Bool { false } }
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/asyncprop.swift -o /tmp/swifttest/asyncprop' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/SetupCoordinator.swift | sed -n '1,90p'; nl -ba Sources/EnviousWispr/App/AppState.swift | sed -n '206,235p;376,390p;622,633p'; nl -ba Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift | sed -n '1,115p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+     1	import EnviousWisprASR
+     2	import EnviousWisprCore
+     3	import EnviousWisprLLM
+     4	import Observation
+     5	
+     6	/// Owns setup-orchestration concerns previously held directly on AppState:
+     7	/// the Ollama setup service, the WhisperKit setup service, and the background
+     8	/// observation task that pre-loads WhisperKit when its setup state becomes ready.
+     9	///
+    10	/// Heart path does not consult this object. If setup services fail, dictation
+    11	/// still completes — the user just sees broken status in Settings tabs.
+    12	@MainActor
+    13	@Observable
+    14	final class SetupCoordinator {
+    15	  let ollamaSetup = OllamaSetupService()
+    16	  let whisperKitSetup = WhisperKitSetupService()
+    17	
+    18	  @ObservationIgnored
+    19	  private var whisperKitPreloadTask: Task<Void, Never>?
+    20	
+    21	  private let asrManager: any ASRManagerInterface
+    22	  private let preloadAction: @MainActor () async -> Void
+    23	
+    24	  init(
+    25	    asrManager: any ASRManagerInterface,
+    26	    preloadAction: @escaping @MainActor () async -> Void
+    27	  ) {
+    28	    self.asrManager = asrManager
+    29	    self.preloadAction = preloadAction
+    30	  }
+    31	
+    32	  /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
+    33	  /// `.ready` and the active backend is WhisperKit. Cancels any prior observation
+    34	  /// task; safe to call repeatedly (e.g. on backend switch).
+    35	  func startPreloadObservation() {
+    36	    whisperKitPreloadTask?.cancel()
+    37	    whisperKitPreloadTask = Task { [weak self] in
+    38	      while !Task.isCancelled {
+    39	        guard let self else { return }
+    40	
+    41	        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+    42	        // users shouldn't pay CPU/memory cost warming a backend they never use.
+    43	        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+    44	        // restarts this observer; the re-entry sees the new activeBackendType.
+    45	        guard self.asrManager.activeBackendType == .whisperKit else { return }
+    46	
+    47	        let currentState = self.whisperKitSetup.setupState
+    48	        if currentState == .ready {
+    49	          await self.preloadAction()
+    50	          return
+    51	        }
+    52	
+    53	        await withCheckedContinuation { continuation in
+    54	          withObservationTracking {
+    55	            _ = self.whisperKitSetup.setupState
+    56	          } onChange: {
+    57	            continuation.resume()
+    58	          }
+    59	        }
+    60	      }
+    61	    }
+    62	  }
+    63	}
+   206	      transcriptStore: transcriptStore
+   207	    )
+   208	
+   209	    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
+   210	    // exist (it needs both — asrManager for activeBackendType reads, the pipeline
+   211	    // closure for prepareBackendSilently()). The capture is [weak whisperKitPipeline]
+   212	    // so the coordinator does not retain the pipeline.
+   213	    setup = SetupCoordinator(
+   214	      asrManager: asrManager,
+   215	      preloadAction: { [weak whisperKitPipeline] in
+   216	        await whisperKitPipeline?.prepareBackendSilently()
+   217	      }
+   218	    )
+   219	
+   220	    // Initialize settingsSync and apply initial settings to all targets
+   221	    settingsSync = PipelineSettingsSync(
+   222	      pipeline: pipeline,
+   223	      whisperKitPipeline: whisperKitPipeline,
+   224	      polishService: polishService,
+   225	      audioCapture: audioCapture,
+   226	      asrManager: asrManager,
+   227	      hotkeyService: hotkeyService,
+   228	      whisperKitSetup: setup.whisperKitSetup
+   229	    )
+   230	    settingsSync.applyInitialSettings(settings)
+   231	
+   232	    // Wire dictation activity provider (after all stored properties initialized)
+   233	    polishService.setDictationActivity(self)
+   234	
+   235	    // Wire the passive-chip handler on the LanguageDetector actor now that
+   376	    // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
+   377	    // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
+   378	    audioCapture.onVADAutoStop = { [weak self] in
+   379	      guard let self else { return }
+   380	      if self.pipeline.state == .recording {
+   381	        Task { await self.pipeline.stopAndTranscribe() }
+   382	      } else if self.whisperKitPipeline.state == .recording {
+   383	        Task { await self.whisperKitPipeline.stopAndTranscribe() }
+   384	      }
+   385	    }
+   386	    settingsSync.onNeedsPreloadObservation = { [weak setup] in
+   387	      setup?.startPreloadObservation()
+   388	    }
+   389	
+   390	    // Wire custom-words propagator. The exact ordering (seed → register all
+   622	    // Parakeet: direct silent load (model files already downloaded during onboarding).
+   623	    // WhisperKit: observation-based (waits for setupState to become .ready first).
+   624	    if settings.selectedBackend == .parakeet {
+   625	      Task { [weak self] in
+   626	        await self?.asrManager.loadModelSilently()
+   627	      }
+   628	    }
+   629	    Task { [weak self] in
+   630	      await self?.setup.whisperKitSetup.detectState()
+   631	      self?.setup.startPreloadObservation()
+   632	    }
+   633	
+     1	@preconcurrency import AVFoundation
+     2	import EnviousWisprASR
+     3	import EnviousWisprCore
+     4	import Testing
+     5	
+     6	@testable import EnviousWispr
+     7	
+     8	/// Unit tests for SetupCoordinator's preload observation behavior.
+     9	///
+    10	/// SetupCoordinator owns the WhisperKit preload observer that previously lived
+    11	/// on AppState. The observer is gated by two signals: `asrManager.activeBackendType`
+    12	/// (must be `.whisperKit`) and `whisperKitSetup.setupState` (must reach `.ready`).
+    13	/// When both are satisfied, the injected `preloadAction` closure fires once.
+    14	///
+    15	/// These tests exercise the gating without touching any real WhisperKit / Ollama
+    16	/// state — the closure-based seam is the whole point of moving this code off
+    17	/// AppState.
+    18	@Suite @MainActor
+    19	struct SetupCoordinatorTests {
+    20	
+    21	  /// Active backend = parakeet → preload action must NOT fire even if the user
+    22	  /// later flips WhisperKit to .ready (no observation should be running).
+    23	  @Test func parakeetBackendSkipsPreload() async throws {
+    24	    let fakeASR = FakeASRManager(backend: .parakeet)
+    25	    let counter = InvocationCounter()
+    26	    let coord = SetupCoordinator(
+    27	      asrManager: fakeASR,
+    28	      preloadAction: { @MainActor in counter.increment() }
+    29	    )
+    30	
+    31	    coord.startPreloadObservation()
+    32	
+    33	    // Yield once so the observation Task gets a chance to run and bail out
+    34	    // on the .parakeet guard.
+    35	    try await Task.sleep(nanoseconds: 50_000_000)
+    36	
+    37	    #expect(counter.count == 0, "preloadAction must not fire when active backend is parakeet")
+    38	  }
+    39	
+    40	  /// startPreloadObservation can be called repeatedly; each call cancels the
+    41	  /// prior observation Task. Verify the invocation completes without crashing
+    42	  /// (cancellation correctness — the task body uses `[weak self]` and a
+    43	  /// while-not-cancelled loop).
+    44	  @Test func repeatedStartCancelsPrior() async throws {
+    45	    let fakeASR = FakeASRManager(backend: .parakeet)
+    46	    let counter = InvocationCounter()
+    47	    let coord = SetupCoordinator(
+    48	      asrManager: fakeASR,
+    49	      preloadAction: { @MainActor in counter.increment() }
+    50	    )
+    51	
+    52	    coord.startPreloadObservation()
+    53	    coord.startPreloadObservation()
+    54	    coord.startPreloadObservation()
+    55	
+    56	    try await Task.sleep(nanoseconds: 50_000_000)
+    57	
+    58	    #expect(counter.count == 0)
+    59	  }
+    60	}
+    61	
+    62	@MainActor
+    63	private final class InvocationCounter {
+    64	  var count: Int = 0
+    65	  func increment() { count += 1 }
+    66	}
+    67	
+    68	/// Minimal ASRManagerInterface fake. SetupCoordinator only reads
+    69	/// `activeBackendType`; everything else traps to make accidental use loud.
+    70	@MainActor
+    71	private final class FakeASRManager: ASRManagerInterface {
+    72	  let activeBackendType: ASRBackendType
+    73	  init(backend: ASRBackendType) { self.activeBackendType = backend }
+    74	
+    75	  var isModelLoaded: Bool { false }
+    76	  var isStreaming: Bool { false }
+    77	  var downloadProgress: Double { 0 }
+    78	  var downloadPhase: String { "" }
+    79	  var downloadDetail: String { "" }
+    80	  var activeBackendSupportsStreaming: Bool { false }
+    81	  var onServiceInterrupted: (() -> Void)?
+    82	
+    83	  func loadModel() async throws { fatalError("not used in SetupCoordinatorTests") }
+    84	  func loadModelSilently() async { fatalError("not used in SetupCoordinatorTests") }
+    85	  func unloadModel() async { fatalError("not used in SetupCoordinatorTests") }
+    86	  func setInitialBackendType(_: ASRBackendType) { fatalError("not used in SetupCoordinatorTests") }
+    87	  func switchBackend(to _: ASRBackendType) async { fatalError("not used in SetupCoordinatorTests") }
+    88	  func transcribe(audioSamples _: [Float], options _: TranscriptionOptions) async throws
+    89	    -> ASRResult
+    90	  {
+    91	    fatalError("not used in SetupCoordinatorTests")
+    92	  }
+    93	  func startStreaming(options _: TranscriptionOptions) async throws {
+    94	    fatalError("not used in SetupCoordinatorTests")
+    95	  }
+    96	  func feedAudio(_: AVAudioPCMBuffer) async throws {
+    97	    fatalError("not used in SetupCoordinatorTests")
+    98	  }
+    99	  func finalizeStreaming() async throws -> ASRResult {
+   100	    fatalError("not used in SetupCoordinatorTests")
+   101	  }
+   102	  func cancelStreaming() async { fatalError("not used in SetupCoordinatorTests") }
+   103	  func noteTranscriptionComplete(policy _: ModelUnloadPolicy) {
+   104	    fatalError("not used in SetupCoordinatorTests")
+   105	  }
+   106	  func cancelIdleTimer() { fatalError("not used in SetupCoordinatorTests") }
+   107	}
+
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/obs.swift <<'EOF'
+import Observation
+@MainActor
+@Observable
+final class Coord {
+  private let action: @MainActor () async -> Void
+  init(action: @escaping @MainActor () async -> Void) { self.action = action }
+}
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/obs.swift -o /tmp/swifttest/obs' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 1162ms:
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/obs2.swift <<'EOF'
+import Observation
+@MainActor protocol P: AnyObject { var x: Int { get } }
+@MainActor
+@Observable
+final class Coord {
+  private let p: any P
+  init(p: any P) { self.p = p }
+  func f() { _ = p.x }
+}
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/obs2.swift -o /tmp/swifttest/obs2' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 130ms:
+exec
+/bin/zsh -lc "sed -n '80,160p' Sources/EnviousWispr/App/PipelineSettingsSync.swift && rg \"selectedBackend|setInitialBackendType\" -n Sources/EnviousWispr/App/PipelineSettingsSync.swift Sources/EnviousWispr" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+    )
+  }
+
+  /// Handle a settings change by forwarding to the appropriate subsystem.
+  func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
+    switch key {
+    case .selectedBackend:
+      // Don't switch backends while a pipeline is actively recording/transcribing
+      let parakeetActive = pipeline.state.isActive
+      let whisperKitActive = whisperKitPipeline.state.isActive
+      if parakeetActive || whisperKitActive {
+        Task {
+          await AppLogger.shared.log(
+            "Backend switch blocked — pipeline is active",
+            level: .info, category: "PipelineSettingsSync"
+          )
+        }
+        break
+      }
+      let backend = settings.selectedBackend
+      // Issue #289: invalidate any stall-recovery token on either pipeline
+      // so a deferred cleanup from a pre-switch stall doesn't tear down
+      // the pipeline that's about to become active.
+      pipeline.clearPendingStallRecovery()
+      whisperKitPipeline.clearPendingStallRecovery()
+      Task { [weak self] in
+        await self?.asrManager.switchBackend(to: backend)
+        SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
+        if backend == .whisperKit {
+          await self?.whisperKitSetup.detectState()
+          self?.onNeedsPreloadObservation?()
+        }
+      }
+    case .recordingMode:
+      hotkeyService.recordingMode = settings.recordingMode
+    case .llmProvider:
+      // Live mirror to re-polish path; eviction fires for RAM management (#295).
+      // Pipeline polish uses the frozen value from `DictationSessionConfig`.
+      polishService.llmPolishStep.llmProvider = settings.llmProvider
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+      reconcileOllamaEviction(settings: settings)
+    case .llmModel:
+      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+      if settings.llmProvider == .ollama {
+        settings.ollamaModel = settings.llmModel
+      }
+      reconcileOllamaEviction(settings: settings)
+    case .ollamaModel:
+      if settings.llmProvider == .ollama {
+        polishService.llmPolishStep.llmModel = settings.ollamaModel
+      }
+      reconcileOllamaEviction(settings: settings)
+    case .hotkeyEnabled:
+      if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
+    case .environmentPreset:
+      // Cascade into `vadSensitivity` for the next recording's snapshot.
+      settings.vadSensitivity = settings.environmentPreset.vadSensitivity
+    case .writingStylePreset, .customSystemPrompt:
+      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+    case .cancelKeyCode:
+      hotkeyService.cancelKeyCode = settings.cancelKeyCode
+    case .cancelModifiers:
+      hotkeyService.cancelModifiers = settings.cancelModifiers
+    case .toggleKeyCode:
+      hotkeyService.toggleKeyCode = settings.toggleKeyCode
+      reregisterHotkeys()
+    case .toggleModifiers:
+      hotkeyService.toggleModifiers = settings.toggleModifiers
+      reregisterHotkeys()
+    case .pushToTalkKeyCode, .pushToTalkModifiers:
+      // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
+      break
+    case .modelUnloadPolicy:
+      // Frozen per recording; cancel idle timer live when switched to .never.
+      if settings.modelUnloadPolicy == .never {
+        asrManager.cancelIdleTimer()
+      }
+    case .wordCorrectionEnabled:
+      pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+      whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:86:    case .selectedBackend:
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:99:      let backend = settings.selectedBackend
+Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:266:      asrBackend: settings.selectedBackend.rawValue, recordingMode: settings.recordingMode.rawValue)
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:22:            selection: $state.settings.selectedBackend
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:27:            appState.settings.selectedBackend == .parakeet
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:37:      if appState.settings.selectedBackend == .whisperKit {
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:46:      if appState.settings.selectedBackend == .whisperKit,
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:130:      if appState.settings.selectedBackend == .parakeet {
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:164:      if appState.settings.selectedBackend == .whisperKit {
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:168:    .onChange(of: appState.settings.selectedBackend) { _, newBackend in
+Sources/EnviousWispr/App/AppDelegate.swift:94:        asrBackend: s.selectedBackend.rawValue,
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:86:    case .selectedBackend:
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:99:      let backend = settings.selectedBackend
+Sources/EnviousWispr/App/AppState.swift:415:    // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
+Sources/EnviousWispr/App/AppState.swift:416:    asrManager.setInitialBackendType(settings.selectedBackend)
+Sources/EnviousWispr/App/AppState.swift:418:      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+Sources/EnviousWispr/App/AppState.swift:624:    if settings.selectedBackend == .parakeet {
+Sources/EnviousWispr/App/AppState.swift:760:    settings.selectedBackend == .parakeet ? "Parakeet v3" : "WhisperKit"
+
+exec
+/bin/zsh -lc "sed -n '400,425p' Sources/EnviousWispr/App/AppState.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+        pipeline.llmPolish,
+        whisperKitPipeline.wordCorrection,
+        whisperKitPipeline.llmPolish,
+        polishService.llmPolishStep,
+      ],
+      coordinator: customWordsCoordinator
+    )
+
+    // Initialize logger
+    Task {
+      await AppLogger.shared.setLogLevel(settings.debugLogLevel)
+      await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
+    }
+
+    // Restore persisted backend selection synchronously (no race with first record).
+    // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
+    asrManager.setInitialBackendType(settings.selectedBackend)
+    SentryBreadcrumb.updateASRBackend(
+      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+
+    // Wire settings change handler
+    settings.onChange = { [weak self] key in
+      guard let self else { return }
+      self.settingsSync.handleSettingChanged(key, settings: self.settings)
+    }
+
+
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/nestedobs.swift <<'EOF'
+import Observation
+import Foundation
+@Observable @MainActor final class Inner { var x=0 }
+@Observable @MainActor final class Outer { let inner=Inner() }
+@MainActor func test() {
+ let o=Outer(); var hits=0
+ withObservationTracking { _ = o.inner.x } onChange: { hits += 1; print(\"changed\") }
+ o.inner.x=1
+ print(\"hits\", hits)
+}
+Task { @MainActor in test(); exit(0)}
+RunLoop.main.run()
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/nestedobs.swift -o /tmp/swifttest/nestedobs && /tmp/swifttest/nestedobs' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 4744ms:
+/tmp/swifttest/nestedobs.swift:7:56: warning: mutation of captured var 'hits' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
+ 5 | @MainActor func test() {
+ 6 |  let o=Outer(); var hits=0
+ 7 |  withObservationTracking { _ = o.inner.x } onChange: { hits += 1; print("changed") }
+   |                                                        `- warning: mutation of captured var 'hits' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
+ 8 |  o.inner.x=1
+ 9 |  print("hits", hits)
+
+[#SendableClosureCaptures]: <https://docs.swift.org/compiler/documentation/diagnostics/sendable-closure-captures>
+changed
+hits 1
+
+exec
+/bin/zsh -lc "git show bc445a1dc817c48db543f818b28c16eabc7e313e:Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift | sed -n '1,10p' && git show bc445a1dc817c48db543f818b28c16eabc7e313e:Package.swift | sed -n '105,130p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+@preconcurrency import AVFoundation
+import AppKit
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+      exclude: ["Resources"]
+    ),
+    .executableTarget(
+      name: "EnviousWispr",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprStorage",
+        "EnviousWisprPostProcessing",
+        "EnviousWisprAudio",
+        "EnviousWisprServices",
+        "EnviousWisprASR",
+        "EnviousWisprLLM",
+        "EnviousWisprPipeline",
+        "WhisperKit",
+        "FluidAudio",
+        "Sparkle",
+      ],
+      path: "Sources/EnviousWispr",
+      exclude: ["Resources"]
+    ),
+    .testTarget(
+      name: "EnviousWisprTests",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprPostProcessing",
+        "EnviousWisprLLM",
+
+exec
+/bin/zsh -lc "git show bc445a1dc817c48db543f818b28c16eabc7e313e:Package.swift | sed -n '130,155p'" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+        "EnviousWisprLLM",
+        "EnviousWisprPipeline",
+        "EnviousWisprStorage",
+        "EnviousWisprAudio",
+        "EnviousWispr",
+      ],
+      path: "Tests/EnviousWisprTests"
+    ),
+    .testTarget(
+      name: "EnviousWisprASRTests",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprASR",
+      ],
+      path: "Tests/EnviousWisprASRTests"
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)
+
+exec
+/bin/zsh -lc 'git diff --check bc445a1dc817c48db543f818b28c16eabc7e313e' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/closureasync.swift <<'EOF'
+@MainActor func takes(_ f: @escaping @MainActor () async -> Void) {}
+@MainActor func test() { takes({ @MainActor in print(\"x\") }) }
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/closureasync.swift -o /tmp/swifttest/closureasync' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+exec
+/bin/zsh -lc "cat >/tmp/swifttest/initobs.swift <<'EOF'
+import Observation
+final class S { let x = 1 }
+final class T { init(_ x: Int){} }
+@Observable final class A {
+ let s: S
+ let t: T
+ init(){
+  s = S()
+  t = T(s.x)
+ }
+}
+EOF
+CLANG_MODULE_CACHE_PATH=\""'$PWD/.build/clang-cache" swiftc /tmp/swifttest/initobs.swift -o /tmp/swifttest/initobs' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 130ms:
+exec
+/bin/zsh -lc "sed -n '1,60p' Sources/EnviousWispr/App/AppDelegate.swift && sed -n '390,425p' Sources/EnviousWispr/App/AppDelegate.swift" in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 0ms:
+import AppKit
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+@preconcurrency import Sparkle
+import SwiftUI
+
+/// AppDelegate that manages the menu bar status item using NSStatusItem.
+///
+/// SwiftUI's MenuBarExtra has known click-routing issues when launched
+/// outside Xcode or as a bare binary. NSStatusItem is the battle-tested
+/// native approach that reliably handles clicks on all macOS versions.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+  private var statusItem: NSStatusItem?
+  private(set) var updaterController: SPUStandardUpdaterController?
+  private let iconAnimator = MenuBarIconAnimator()
+  private weak var mainWindow: NSWindow?
+  private var windowCloseObserver: (any NSObjectProtocol)?
+
+  /// Shared app state — created here so it's available before any SwiftUI scene loads.
+  let appState = AppState()
+
+  /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
+  var openMainWindowAction: (() -> Void)?
+
+  /// Callback set by SwiftUI to open the onboarding window.
+  var openOnboardingAction: (() -> Void)?
+
+  /// Callback set by SwiftUI to dismiss the onboarding window (state-driven).
+  var dismissOnboardingAction: (() -> Void)?
+
+  /// Weak reference to the onboarding window so we can detect when user closes it early.
+  private weak var onboardingWindow: NSWindow?
+  private var onboardingCloseObserver: (any NSObjectProtocol)?
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    // Hide dock icon on launch — we're a menu bar utility.
+    // If onboarding is needed, stay .regular so SwiftUI creates the main window hierarchy
+    // and ActionWirer can wire callbacks before opening the onboarding window.
+    if appState.settings.onboardingState == .completed {
+      NSApp.setActivationPolicy(.accessory)
+    }
+
+    // When the unified window closes, revert to .accessory immediately.
+    // There's only one window now, so no need for the 200ms re-check delay.
+    // Store token so we can remove on termination (H11 observer leak fix).
+    windowCloseObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] notification in
+      guard let window = notification.object as? NSWindow else { return }
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        // Capture the main window reference on first titled window appearance.
+        if self.mainWindow == nil, window.styleMask.contains(.titled),
+          window.title == AppConstants.appName
+        {
+          self.mainWindow = window
+        window.makeKeyAndOrderFront(nil)
+        break
+      }
+    }
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  @objc private func openSettings() {
+    appState.pendingNavigationSection = .speechEngine
+    showWindow()
+  }
+
+  @objc private func openPermissionsSettings() {
+    appState.pendingNavigationSection = .permissions
+    showWindow()
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    if let observer = windowCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      windowCloseObserver = nil
+    }
+    if let observer = onboardingCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      onboardingCloseObserver = nil
+    }
+    appState.setup.ollamaSetup.cleanup()
+    appState.hotkeyService.stop()
+    LLMNetworkSession.shared.invalidate()
+  }
+
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // Menu bar app — keep running when windows close.
+    // User quits via "Quit EnviousWispr" in the status bar menu.
+    return false
+
+exec
+/bin/zsh -lc 'CLANG_MODULE_CACHE_PATH="$PWD/.build/clang-cache" swift test --disable-sandbox --filter SetupCoordinatorTests' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ exited 1 in 15333ms:
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/configuration is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/security is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/Caches/org.swift.swiftpm is not accessible or not writable, disabling user-level cache features.
+warning: 'wt-phase-f': failed storing manifest for 'wt-phase-f' in cache: attempt to write a readonly database
+warning: 'posthog-ios': failed storing manifest for 'posthog-ios' in cache: attempt to write a readonly database
+warning: 'sentry-cocoa': failed storing manifest for 'sentry-cocoa' in cache: attempt to write a readonly database
+warning: 'whisperkit': failed storing manifest for 'whisperkit' in cache: attempt to write a readonly database
+warning: 'sparkle': failed storing manifest for 'sparkle' in cache: attempt to write a readonly database
+warning: 'fluidaudio': failed storing manifest for 'fluidaudio' in cache: attempt to write a readonly database
+warning: 'plcrashreporter': failed storing manifest for 'plcrashreporter' in cache: attempt to write a readonly database
+warning: 'swift-transformers': failed storing manifest for 'swift-transformers' in cache: attempt to write a readonly database
+warning: 'swift-argument-parser': failed storing manifest for 'swift-argument-parser' in cache: attempt to write a readonly database
+warning: 'swift-jinja': failed storing manifest for 'swift-jinja' in cache: attempt to write a readonly database
+warning: 'swift-collections': failed storing manifest for 'swift-collections' in cache: attempt to write a readonly database
+warning: 'yyjson': failed storing manifest for 'yyjson' in cache: attempt to write a readonly database
+warning: 'swift-crypto': failed storing manifest for 'swift-crypto' in cache: attempt to write a readonly database
+warning: 'swift-asn1': failed storing manifest for 'swift-asn1' in cache: attempt to write a readonly database
+[0/1] Planning build
+[1/1] Compiling plugin GenerateManual
+[2/2] Compiling plugin GenerateDoccReference
+Building for debugging...
+[2/14] Write swift-version--1AB21518FC5DEDBE.txt
+[4/65] Compiling SentryCppHelper SentryCppHelper.swift
+[5/65] Emitting module SentryCppHelper
+[6/277] Compiling PostHog ApplicationLifecyclePublisher.swift
+[7/277] Compiling PostHog PostHogAppLifeCycleIntegration.swift
+[8/278] Compiling PostHog PostHogRemoteConfig.swift
+[9/278] Compiling PostHog PostHogSDK.swift
+[10/313] Compiling InternalCollectionsUtilities UnsafeMutableRawBufferPointer+Extras.swift
+[11/313] Compiling FluidAudio AsrTranscription.swift
+[12/313] Compiling FluidAudio AsrTypes.swift
+[13/313] Compiling FluidAudio AudioBuffer.swift
+[14/313] Compiling FluidAudio ChunkProcessor.swift
+[15/313] Compiling FluidAudio EncoderFrameView.swift
+[16/313] Compiling FluidAudio TdtConfig.swift
+[17/313] Compiling FluidAudio TdtDecoderState.swift
+[18/313] Compiling FluidAudio TdtDecoderV2.swift
+[19/313] Compiling FluidAudio NemotronStreamingAsrManager+Pipeline.swift
+[20/313] Compiling FluidAudio NemotronStreamingAsrManager.swift
+[21/313] Compiling FluidAudio NemotronStreamingConfig.swift
+[22/328] Compiling FluidAudio AsrManager.swift
+[23/328] Compiling FluidAudio AsrModels.swift
+[28/328] Compiling FluidAudio BlasIndex.swift
+[29/366] Compiling InternalCollectionsUtilities _UniqueCollection.swift
+[30/391] Emitting module Crypto
+[31/410] Compiling InternalCollectionsUtilities _UnsafeBitSet.swift
+[32/410] Compiling InternalCollectionsUtilities UnsafeMutableBufferPointer+Extras.swift
+[35/415] Compiling InternalCollectionsUtilities _SortedCollection.swift
+[36/415] Compiling InternalCollectionsUtilities UnsafeRawBufferPointer+Extras.swift
+[37/415] Compiling InternalCollectionsUtilities _UnsafeBitSet+Index.swift
+[38/420] Compiling InternalCollectionsUtilities UnsafeBufferPointer+Extras.swift
+[41/420] Compiling InternalCollectionsUtilities _UnsafeBitSet+_Word.swift
+[42/426] Compiling FluidAudio StreamingEouAsrManager.swift
+[43/426] Compiling FluidAudio NemotronChunkSize.swift
+[44/426] Compiling FluidAudio OfflineEmbeddingExtractor.swift
+[45/426] Compiling FluidAudio PLDATransform.swift
+[46/426] Compiling FluidAudio WeightInterpolation.swift
+[47/426] Compiling FluidAudio OfflineSegmentationProcessor.swift
+[48/426] Compiling FluidAudio OfflineReconstruction.swift
+[49/426] Compiling FluidAudio Qwen3AsrModels.swift
+[50/426] Compiling FluidAudio TdtDecoderV3.swift
+[51/426] Compiling FluidAudio TdtHypothesis.swift
+[52/426] Compiling FluidAudio ARPALanguageModel.swift
+[53/426] Compiling FluidAudio CtcDecoder.swift
+[54/426] Compiling FluidAudio BKTree.swift
+[55/426] Compiling FluidAudio VocabularyRescorer+CandidateMatching.swift
+[56/426] Compiling FluidAudio ParakeetModelVariant.swift
+[57/426] Compiling FluidAudio RnntDecoder.swift
+[58/426] Compiling FluidAudio StreamingAsrEngine.swift
+[59/426] Compiling FluidAudio StreamingAsrEngineFactory.swift
+[60/426] Compiling FluidAudio Tokenizer.swift
+[61/426] Compiling FluidAudio Qwen3AsrConfig.swift
+[62/426] Compiling FluidAudio Qwen3AsrManager.swift
+[63/426] Compiling FluidAudio VDSPOperations.swift
+[64/426] Compiling FluidAudio AudioValidation.swift
+[65/426] Compiling FluidAudio SegmentationProcessor.swift
+[66/426] Compiling FluidAudio SlidingWindow.swift
+[67/426] Compiling FluidAudio SortformerDiarizer.swift
+[68/426] Compiling FluidAudio SortformerModelInference.swift
+[69/426] Compiling FluidAudio Qwen3RoPE.swift
+[78/426] Compiling FluidAudio ContextBiasingConstants.swift
+[79/426] Compiling FluidAudio CustomVocabularyContext.swift
+[80/426] Compiling FluidAudio VocabularyRescorer+TokenEvaluation.swift
+[81/426] Compiling FluidAudio VocabularyRescorer+TokenRescoring.swift
+[82/426] Compiling FluidAudio VocabularyRescorer+Utilities.swift
+[83/426] Compiling FluidAudio VocabularyRescorer.swift
+[84/426] Compiling FluidAudio BpeTokenizer.swift
+[85/426] Compiling FluidAudio CtcDPAlgorithm.swift
+[86/426] Compiling FluidAudio CtcKeywordSpotter+Inference.swift
+[87/426] Compiling FluidAudio CtcKeywordSpotter.swift
+[88/426] Compiling FluidAudio CtcModels.swift
+[89/426] Compiling FluidAudio CtcTokenizer.swift
+[90/426] Compiling FluidAudio SlidingWindowAsrManager.swift
+[91/426] Compiling FluidAudio SlidingWindowAsrSession.swift
+[92/426] Compiling FluidAudio AHCClustering.swift
+[93/426] Compiling FluidAudio KMeansClustering.swift
+[94/426] Compiling FluidAudio SpeakerCountConstraints.swift
+[95/426] Compiling FluidAudio VBxClustering.swift
+[96/426] Compiling FluidAudio OfflineDiarizerManager.swift
+[97/426] Compiling FluidAudio OfflineDiarizerModels.swift
+[98/426] Compiling FluidAudio OfflineDiarizerTypes.swift
+[99/426] Compiling FluidAudio AudioMelSpectrogram.swift
+[100/426] Compiling FluidAudio AudioSampleSource.swift
+[101/426] Compiling FluidAudio AudioSource.swift
+[102/426] Compiling FluidAudio AudioSourceFactory.swift
+[103/426] Compiling FluidAudio AudioStream.swift
+[104/426] Compiling FluidAudio MLArrayCache.swift
+[105/426] Compiling FluidAudio MLModel+Prediction.swift
+[106/426] Compiling FluidAudio Qwen3StreamingManager.swift
+[107/426] Compiling FluidAudio WhisperMelSpectrogram.swift
+[108/426] Compiling FluidAudio SpeakerManager.swift
+[109/426] Compiling FluidAudio SpeakerOperations.swift
+[110/426] Compiling FluidAudio SpeakerTypes.swift
+[111/426] Compiling FluidAudio DiarizerManager.swift
+[112/426] Compiling FluidAudio DiarizerModels.swift
+[113/426] Compiling FluidAudio DiarizerTypes.swift
+[114/426] Compiling FluidAudio DiarizerTimeline.swift
+[115/426] Compiling FluidAudio EmbeddingExtractor.swift
+[116/426] Compiling FluidAudio AssetDownloader.swift
+[117/426] Compiling FluidAudio AudioConverter.swift
+[127/426] Emitting module EnviousWisprCore
+[128/426] Emitting module InternalCollectionsUtilities
+[129/426] Compiling FluidAudio MLModelConfigurationUtils.swift
+[130/426] Compiling FluidAudio ModelWarmup.swift
+[131/426] Compiling FluidAudio LSEENDDatatypes.swift
+[132/426] Compiling FluidAudio LSEENDDiarizer.swift
+[133/426] Compiling FluidAudio LSEENDModelInference.swift
+[134/426] Compiling FluidAudio LSEENDPreprocessor.swift
+[156/435] Compiling FluidAudio PocketTtsManager.swift
+[157/435] Compiling FluidAudio SentencePieceProto.swift
+[158/435] Compiling FluidAudio SentencePieceTokenizer.swift
+[159/435] Compiling FluidAudio SSMLProcessor.swift
+[160/435] Compiling FluidAudio SSMLTagParser.swift
+[161/435] Compiling FluidAudio LexiconAssetManager.swift
+[162/435] Compiling FluidAudio TtsResourceDownloader.swift
+[163/435] Compiling FluidAudio KokoroTtsManager.swift
+[164/435] Compiling FluidAudio KokoroSynthesizer+Types.swift
+[185/435] Compiling FluidAudio PerformanceMetrics.swift
+[186/435] Compiling FluidAudio ProgressEmitter.swift
+[187/435] Compiling FluidAudio StringUtils.swift
+[188/435] Compiling FluidAudio SystemInfo.swift
+[189/435] Compiling FluidAudio ZeroCopyFeatureProvider.swift
+[190/435] Compiling FluidAudio MultilingualG2PError.swift
+[191/435] Compiling FluidAudio MultilingualG2PLanguage.swift
+[217/523] Compiling EnviousWisprLLM LLMTaskMetricsCollector.swift
+[218/523] Compiling EnviousWisprLLM OllamaConnector.swift
+[219/523] Compiling EnviousWisprLLM CustomVocabularyFormatter.swift
+[220/523] Compiling EnviousWisprLLM DefaultPromptPlanner.swift
+[221/527] Compiling EnviousWisprPostProcessing WordSuggestionService.swift
+[222/527] Compiling OrderedCollections OrderedSet+ReserveCapacity.swift
+[223/527] Compiling OrderedCollections OrderedSet+Sendable.swift
+[224/527] Compiling OrderedCollections OrderedSet+SubSequence.swift
+[225/527] Compiling OrderedCollections OrderedSet+Testing.swift
+[226/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isSubset.swift
+[227/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isSuperset.swift
+[228/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra subtract.swift
+[229/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra subtracting.swift
+[230/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isDisjoint.swift
+[231/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isEqualSet.swift
+[232/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isStrictSubset.swift
+[233/527] Compiling OrderedCollections OrderedSet+Partial SetAlgebra isStrictSuperset.swift
+[234/527] Compiling OrderedCollections OrderedSet+Equatable.swift
+[235/527] Compiling OrderedCollections OrderedSet+ExpressibleByArrayLiteral.swift
+[236/527] Compiling OrderedCollections OrderedSet+Hashable.swift
+[237/527] Compiling OrderedCollections OrderedSet+Initializers.swift
+[238/527] Compiling EnviousWisprLLM OllamaSetupService.swift
+[239/527] Compiling EnviousWisprLLM OpenAIConnector.swift
+[240/527] Compiling EnviousWisprLLM GeminiPromptBuilder.swift
+[241/527] Compiling EnviousWisprLLM GemmaPromptBuilder.swift
+[242/527] Emitting module EnviousWisprPostProcessing
+[243/527] Emitting module PostHog
+[244/527] Compiling OrderedCollections OrderedDictionary+Deprecations.swift
+[245/527] Compiling OrderedCollections OrderedDictionary+Descriptions.swift
+[246/527] Compiling OrderedCollections OrderedDictionary+Elements.SubSequence.swift
+[247/527] Compiling OrderedCollections OrderedDictionary+Elements.swift
+[248/527] Compiling OrderedCollections OrderedDictionary+Equatable.swift
+[249/527] Compiling OrderedCollections OrderedSet+Codable.swift
+[250/527] Compiling OrderedCollections OrderedSet+CustomReflectable.swift
+[251/527] Compiling OrderedCollections OrderedSet+Descriptions.swift
+[252/527] Compiling OrderedCollections OrderedSet+Diffing.swift
+[253/527] Compiling FluidAudio MultilingualG2PModel.swift
+[254/527] Compiling FluidAudio G2PModel.swift
+[255/527] Compiling FluidAudio KokoroVocabulary.swift
+[256/527] Compiling FluidAudio KokoroSynthesizer+ModelUtils.swift
+[257/527] Compiling FluidAudio KokoroSynthesizer+VoiceEmbeddings.swift
+[258/527] Compiling FluidAudio KokoroSynthesizer.swift
+[259/527] Compiling FluidAudio TtsCustomLexicon.swift
+[260/527] Compiling FluidAudio PocketTtsConstantsLoader.swift
+[261/527] Compiling FluidAudio PocketTtsResourceDownloader.swift
+[262/527] Compiling OrderedCollections OrderedSet+Insertions.swift
+[263/527] Emitting module EnviousWisprStorage
+[264/527] Compiling OrderedCollections OrderedSet+Invariants.swift
+[265/527] Compiling EnviousWisprStorage TranscriptStore.swift
+[266/527] Compiling OrderedCollections OrderedSet+Partial MutableCollection.swift
+[267/527] Compiling OrderedCollections OrderedSet+Partial RangeReplaceableCollection.swift
+[268/527] Compiling OrderedCollections OrderedDictionary+ExpressibleByDictionaryLiteral.swift
+[269/527] Compiling OrderedCollections OrderedDictionary+Hashable.swift
+[270/527] Compiling OrderedCollections OrderedDictionary+Initializers.swift
+[271/527] Compiling OrderedCollections OrderedDictionary+Invariants.swift
+[272/527] Compiling OrderedCollections OrderedDictionary+Partial MutableCollection.swift
+[273/527] Compiling EnviousWisprLLM AppleIntelligenceConnector.swift
+[274/527] Compiling EnviousWisprLLM AppleIntelligenceDiagnosticsService.swift
+[275/527] Compiling EnviousWisprLLM ApplePolishRouter.swift
+[276/527] Compiling EnviousWisprLLM EnviousOutputFilter.swift
+[277/527] Compiling EnviousWisprLLM LLMModelDiscovery.swift
+[278/527] Compiling EnviousWisprLLM PromptPlanning.swift
+[279/527] Compiling EnviousWisprLLM PromptV2Support.swift
+[280/528] Compiling EnviousWisprLLM LLMNetworkSession.swift
+[281/528] Compiling EnviousWisprLLM GeminiConnector.swift
+[282/528] Compiling EnviousWisprLLM KeychainManager.swift
+[283/528] Compiling EnviousWisprLLM LLMProtocol.swift
+[284/528] Compiling EnviousWisprLLM LLMRetryPolicy.swift
+[295/528] Compiling EnviousWisprLLM PromptFamily.swift
+[296/528] Compiling EnviousWisprLLM OpenAIPromptBuilder.swift
+[297/528] Compiling EnviousWisprLLM PromptBuilder.swift
+[298/528] Compiling FluidAudio PocketTtsModelStore.swift
+[299/528] Compiling FluidAudio PocketTtsSynthesizer+Flow.swift
+[300/528] Compiling FluidAudio PocketTtsSynthesizer+KVCache.swift
+[301/528] Compiling FluidAudio PocketTtsSynthesizer+Mimi.swift
+[302/528] Compiling FluidAudio PocketTtsSynthesizer+Types.swift
+[303/528] Compiling FluidAudio PocketTtsSynthesizer.swift
+[304/528] Compiling FluidAudio PocketTtsVoiceCloner.swift
+[305/528] Compiling FluidAudio PocketTTSError.swift
+[306/528] Compiling FluidAudio PocketTtsConstants.swift
+[307/528] Compiling PostHog Hedgelog.swift
+[308/528] Compiling PostHog PostHogMulticastCallback.swift
+[309/528] Compiling PostHog Reachability.swift
+[310/528] Compiling PostHog TimeBasedEpochGenerator.swift
+[311/528] Compiling PostHog UIApplication+.swift
+[312/528] Compiling PostHog UIImage+WebP.swift
+[313/528] Compiling PostHog UIWindow+.swift
+[314/528] Compiling PostHog UUIDUtils.swift
+[315/528] Compiling PostHog resource_bundle_accessor.swift
+[318/528] Compiling OrderedCollections _Hashtable+Header.swift
+[319/528] Compiling OrderedCollections OrderedDictionary+Codable.swift
+[320/528] Compiling OrderedCollections OrderedDictionary+CustomReflectable.swift
+[321/528] Compiling OrderedCollections OrderedSet+UnorderedView.swift
+[322/528] Compiling OrderedCollections OrderedSet+UnstableInternals.swift
+[323/528] Compiling OrderedCollections OrderedSet.swift
+[324/528] Compiling OrderedCollections _UnsafeBitset.swift
+[325/528] Compiling EnviousWisprLLM TranscriptAnalyzer.swift
+[330/528] Compiling EnviousWisprPostProcessing CustomWordsManager.swift
+[331/528] Compiling EnviousWisprPostProcessing WordCorrector.swift
+[342/528] Emitting module EnviousWisprLLM
+[365/528] Emitting module OrderedCollections
+[419/564] Emitting module FluidAudio
+[431/564] Compiling Jinja Tests.swift
+[432/564] Compiling Jinja Utilities.swift
+[433/564] Compiling Jinja Template.swift
+[434/564] Compiling Jinja PropertyMembers.swift
+[435/564] Compiling Jinja Token.swift
+[436/565] Compiling EnviousWisprServices HeartPathError.swift
+[437/565] Compiling EnviousWisprServices KeySymbols.swift
+[449/565] Compiling EnviousWisprServices SentryBreadcrumb.swift
+[450/565] Compiling EnviousWisprServices CaptureTelemetryState.swift
+[451/565] Compiling EnviousWisprServices PasteService.swift
+[463/565] Compiling Jinja Value.swift
+[474/565] Compiling Jinja AST.swift
+[475/565] Compiling Jinja Lexer.swift
+[476/565] Compiling Jinja Globals.swift
+[477/565] Compiling Jinja Parser.swift
+[478/565] Compiling Jinja Error.swift
+[479/565] Compiling Jinja Macro.swift
+[480/565] Compiling Jinja Interpreter.swift
+[481/565] Emitting module Jinja
+[482/565] Compiling Jinja Filters.swift
+[486/565] Compiling FluidAudio FluidAudioSwift.swift
+[487/565] Compiling FluidAudio TextNormalizer.swift
+[488/565] Compiling FluidAudio ModelNames.swift
+[489/565] Compiling FluidAudio ModelRegistry.swift
+[490/565] Compiling FluidAudio ANEMemoryOptimizer.swift
+[491/565] Compiling FluidAudio ANEMemoryUtils.swift
+[492/565] Compiling FluidAudio ASRConstants.swift
+[493/565] Compiling FluidAudio AppLogger.swift
+[505/573] Compiling EnviousWisprServices TelemetryService.swift
+[506/573] Compiling EnviousWisprServices SentryAudioExtras.swift
+[507/573] Compiling FluidAudio SSMLTypes.swift
+[508/573] Compiling FluidAudio SayAsInterpreter.swift
+[509/573] Compiling FluidAudio AudioPostProcessor.swift
+[510/573] Compiling FluidAudio TtsBackend.swift
+[511/573] Compiling FluidAudio TtsConstants.swift
+[512/573] Compiling FluidAudio TtsModels.swift
+[513/573] Compiling FluidAudio VadManager+SpeechSegmentation.swift
+[514/573] Compiling FluidAudio VadManager+Streaming.swift
+[515/573] Compiling FluidAudio VadManager.swift
+[516/573] Compiling FluidAudio VadTypes.swift
+[517/573] Emitting module EnviousWisprServices
+[518/573] Compiling EnviousWisprServices PermissionsService.swift
+[519/573] Compiling EnviousWisprServices ObservabilityBootstrap.swift
+[520/573] Compiling EnviousWisprServices HotkeyService.swift
+[521/573] Compiling EnviousWisprServices SettingsManager.swift
+[522/573] Compiling Hub YYJSONParser.swift
+[523/573] Compiling Hub resource_bundle_accessor.swift
+[546/573] Compiling Hub Hub.swift
+[547/573] Compiling Hub Downloader.swift
+[548/573] Compiling Hub Config.swift
+[549/573] Compiling Hub BinaryDistinct.swift
+[550/573] Emitting module Hub
+[551/573] Compiling Hub HubApi.swift
+[552/600] Compiling Tokenizers ByteEncoder.swift
+[553/600] Compiling Tokenizers TokenLattice.swift
+[554/600] Compiling Tokenizers BertTokenizer.swift
+[555/600] Compiling Tokenizers String+PreTokenization.swift
+[556/600] Compiling ArgmaxCore ModelUtilities.swift
+[557/600] Compiling ArgmaxCore ModelManager.swift
+[558/600] Compiling ArgmaxCore ModelState.swift
+[559/600] Compiling Tokenizers PostProcessor.swift
+[560/600] Compiling Tokenizers PreTokenizer.swift
+[561/600] Compiling Tokenizers Trie.swift
+[562/600] Compiling Tokenizers UnigramTokenizer.swift
+[563/600] Compiling ArgmaxCore MLTensorExtensions.swift
+[564/600] Compiling ArgmaxCore ModelDownloader.swift
+[565/600] Compiling Tokenizers Decoder.swift
+[566/600] Compiling Tokenizers BPETokenizer.swift
+[567/600] Emitting module Tokenizers
+[568/600] Compiling ArgmaxCore MLModelLoading.swift
+[569/600] Compiling ArgmaxCore MLMultiArrayExtensions.swift
+[570/600] Compiling Tokenizers Normalizer.swift
+[571/600] Compiling ArgmaxCore MLModelExtensions.swift
+[572/600] Compiling ArgmaxCore Logging.swift
+[573/600] Compiling ArgmaxCore FloatType.swift
+[574/600] Compiling ArgmaxCore ConcurrencyUtilities.swift
+[575/600] Emitting module ArgmaxCore
+[576/600] Compiling ArgmaxCore FoundationExtensions.swift
+[577/600] Compiling ArgmaxCore ArgmaxCoreError.swift
+[578/600] Compiling Tokenizers Tokenizer.swift
+[579/624] Compiling WhisperKit SegmentSeeker.swift
+[580/624] Compiling WhisperKit TokenSampler.swift
+[581/624] Compiling WhisperKit TextUtilities.swift
+[582/625] Compiling WhisperKit Logging.swift
+[583/625] Compiling WhisperKit ModelUtilities.swift
+[584/625] Compiling WhisperKit ResultWriter.swift
+[585/625] Compiling WhisperKit WhisperKit.swift
+[586/625] Compiling WhisperKit Concurrency.swift
+[587/625] Compiling WhisperKit Extensions+Internal.swift
+[588/625] Compiling WhisperKit Extensions+Public.swift
+[589/625] Compiling WhisperKit TranscriptionUtilities.swift
+[590/625] Compiling WhisperKit TextDecoder.swift
+[591/625] Compiling WhisperKit TranscribeTask.swift
+[592/625] Compiling WhisperKit WhisperError.swift
+[593/625] Compiling WhisperKit Configurations.swift
+[594/625] Compiling WhisperKit FeatureExtractor.swift
+[595/625] Compiling WhisperKit Models.swift
+[596/625] Compiling WhisperKit LogitsFilter.swift
+[597/625] Compiling WhisperKit VoiceActivityDetector.swift
+[598/625] Compiling WhisperKit AudioEncoder.swift
+[599/625] Compiling WhisperKit AudioStreamTranscriber.swift
+[600/625] Compiling WhisperKit EnergyVAD.swift
+[601/625] Emitting module WhisperKit
+[602/625] Compiling WhisperKit AudioChunker.swift
+[603/625] Compiling WhisperKit AudioProcessor.swift
+[615/638] Compiling EnviousWisprAudio AudioDeviceManager.swift
+[616/638] Compiling EnviousWisprAudio CaptureRouteResolver.swift
+[617/638] Compiling EnviousWisprAudio SilenceDetector.swift
+[618/638] Compiling EnviousWisprAudio RotatingFileSink.swift
+[619/638] Compiling EnviousWisprAudio PreRollForwarder.swift
+[620/638] Compiling EnviousWisprAudio AudioCaptureManager.swift
+[621/638] Compiling EnviousWisprAudio AudioInputSource.swift
+[622/638] Compiling EnviousWisprAudio AudioBufferProcessor.swift
+[623/638] Compiling EnviousWisprAudio AudioCaptureInterface.swift
+[624/638] Emitting module EnviousWisprAudio
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprAudio/AudioCaptureProxy.swift:107:3: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'AVAudioFormat', consider removing it
+105 |   /// 16kHz mono Float32 format used for buffer reconstruction.
+106 |   /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
+107 |   nonisolated(unsafe) private static let targetFormat = AVAudioFormat(
+    |   `- warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'AVAudioFormat', consider removing it
+108 |     commonFormat: .pcmFormatFloat32,
+109 |     sampleRate: 16000,
+[625/638] Compiling EnviousWisprAudio AVCaptureSessionSource.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift:367:14: warning: sending 'notification' risks causing data races [#SendingRisksDataRace]
+365 |       MainActor.assumeIsolated {
+366 |         guard let self else { return }
+367 |         self.emitCaptureSessionInterruption(kind: .wasInterrupted, notification: notification)
+    |              |- warning: sending 'notification' risks causing data races [#SendingRisksDataRace]
+    |              `- note: task-isolated 'notification' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses
+368 |         self.onInterrupted?()
+369 |       }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift:379:14: warning: sending 'notification' risks causing data races [#SendingRisksDataRace]
+377 |       MainActor.assumeIsolated {
+378 |         guard let self else { return }
+379 |         self.emitCaptureSessionInterruption(kind: .runtimeError, notification: notification)
+    |              |- warning: sending 'notification' risks causing data races [#SendingRisksDataRace]
+    |              `- note: task-isolated 'notification' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses
+380 |         self.onInterrupted?()
+381 |       }
+
+[#SendingRisksDataRace]: <https://docs.swift.org/compiler/documentation/diagnostics/sending-risks-data-race>
+[626/638] Compiling EnviousWisprAudio AudioCaptureProxy.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprAudio/AudioCaptureProxy.swift:107:3: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'AVAudioFormat', consider removing it
+105 |   /// 16kHz mono Float32 format used for buffer reconstruction.
+106 |   /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
+107 |   nonisolated(unsafe) private static let targetFormat = AVAudioFormat(
+    |   `- warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'AVAudioFormat', consider removing it
+108 |     commonFormat: .pcmFormatFloat32,
+109 |     sampleRate: 16000,
+[627/638] Compiling EnviousWisprAudio AVAudioEngineSource.swift
+[628/653] Compiling EnviousWisprASR ModelDownloadManager.swift
+[629/653] Compiling EnviousWisprASR ParakeetBackend.swift
+[630/653] Compiling EnviousWisprASR WhisperKitSetupService.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/WhisperKitSetupService.swift:53:3: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'URL?', consider removing it
+ 51 |   /// WhisperKit 0.12+ downloads models to ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/
+ 52 |   /// nonisolated(unsafe) is required: the class is @MainActor but nonisolated static methods reference this.
+ 53 |   nonisolated(unsafe) private static let whisperKitModelRoot: URL? = FileManager.default
+    |   `- warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'URL?', consider removing it
+ 54 |     .homeDirectoryForCurrentUser
+ 55 |     .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+[631/653] Compiling EnviousWisprASR WhisperKitIncrementalWorker.swift
+[632/653] Compiling EnviousWisprASR WhisperKitBackend.swift
+[633/653] Compiling EnviousWisprAudioService AudioServiceHandler.swift
+[634/653] Compiling EnviousWisprAudioService main.swift
+[635/653] Emitting module EnviousWisprAudioService
+[636/653] Compiling EnviousWisprAudioService AudioServiceDelegate.swift
+[637/652] Compiling EnviousWisprASR ASRProtocol.swift
+[638/652] Compiling EnviousWisprASR ASRManagerInterface.swift
+[639/652] Emitting module EnviousWisprASR
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/WhisperKitSetupService.swift:53:3: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'URL?', consider removing it
+ 51 |   /// WhisperKit 0.12+ downloads models to ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/
+ 52 |   /// nonisolated(unsafe) is required: the class is @MainActor but nonisolated static methods reference this.
+ 53 |   nonisolated(unsafe) private static let whisperKitModelRoot: URL? = FileManager.default
+    |   `- warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'URL?', consider removing it
+ 54 |     .homeDirectoryForCurrentUser
+ 55 |     .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+[640/652] Compiling EnviousWisprASR LanguageDetector.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/LanguageDetector.swift:283:9: warning: initialization of immutable value 'runnerUp' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
+281 |     // branches keep their concise spelling.
+282 |     let top = (key: topLang, value: topProb)
+283 |     let runnerUp = runnerUpVoteShare
+    |         `- warning: initialization of immutable value 'runnerUp' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
+284 | 
+285 |     switch decision {
+[641/652] Compiling EnviousWisprASR ASRManager.swift
+[642/652] Compiling EnviousWisprASR ASRManagerProxy.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/ASRManagerProxy.swift:118:29: warning: main actor-isolated property 'isModelLoaded' can not be referenced from a Sendable closure
+ 16 | 
+ 17 |   public private(set) var activeBackendType: ASRBackendType = .parakeet
+ 18 |   public private(set) var isModelLoaded = false
+    |                           `- note: property declared here
+ 19 |   public private(set) var isStreaming = false
+ 20 | 
+    :
+116 |     let progressFile = ProgressFile.shared
+117 |     let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
+118 |       guard let self, !self.isModelLoaded else { return }
+    |                             `- warning: main actor-isolated property 'isModelLoaded' can not be referenced from a Sendable closure
+119 |       if let state = progressFile.read() {
+120 |         self.downloadProgress = state.fraction
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/ASRManagerProxy.swift:120:14: warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+ 20 | 
+ 21 |   // Download progress — updated via XPC callback from ASR service.
+ 22 |   public private(set) var downloadProgress: Double = 0
+    |                           `- note: mutation of this property is only permitted within the actor
+ 23 |   public private(set) var downloadPhase: String = ""
+ 24 |   public private(set) var downloadDetail: String = ""
+    :
+118 |       guard let self, !self.isModelLoaded else { return }
+119 |       if let state = progressFile.read() {
+120 |         self.downloadProgress = state.fraction
+    |              `- warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+121 |         self.downloadPhase = state.phase
+122 |         self.downloadDetail = state.detail
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/ASRManagerProxy.swift:121:14: warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+ 21 |   // Download progress — updated via XPC callback from ASR service.
+ 22 |   public private(set) var downloadProgress: Double = 0
+ 23 |   public private(set) var downloadPhase: String = ""
+    |                           `- note: mutation of this property is only permitted within the actor
+ 24 |   public private(set) var downloadDetail: String = ""
+ 25 | 
+    :
+119 |       if let state = progressFile.read() {
+120 |         self.downloadProgress = state.fraction
+121 |         self.downloadPhase = state.phase
+    |              `- warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+122 |         self.downloadDetail = state.detail
+123 |       }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWisprASR/ASRManagerProxy.swift:122:14: warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+ 22 |   public private(set) var downloadProgress: Double = 0
+ 23 |   public private(set) var downloadPhase: String = ""
+ 24 |   public private(set) var downloadDetail: String = ""
+    |                           `- note: mutation of this property is only permitted within the actor
+ 25 | 
+ 26 |   // MARK: - XPC connection
+    :
+120 |         self.downloadProgress = state.fraction
+121 |         self.downloadPhase = state.phase
+122 |         self.downloadDetail = state.detail
+    |              `- warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+123 |       }
+124 |     }
+[643/677] Compiling EnviousWisprASRTests WhisperKitBackendArtifactsTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift:4:8: error: no such module 'Testing'
+  2 | import EnviousWisprCore
+  3 | import Foundation
+  4 | import Testing
+    |        `- error: no such module 'Testing'
+  5 | import os
+  6 | 
+error: emit-module command failed with exit code 1 (use -v to see invocation)
+[644/677] Emitting module EnviousWisprASRTests
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift:4:8: error: no such module 'Testing'
+  2 | import EnviousWisprCore
+  3 | import Foundation
+  4 | import Testing
+    |        `- error: no such module 'Testing'
+  5 | import os
+  6 | 
+[645/677] Compiling EnviousWisprASRTests ASRManagerColdStateContractTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift:4:8: error: no such module 'Testing'
+  2 | import EnviousWisprCore
+  3 | import Foundation
+  4 | import Testing
+    |        `- error: no such module 'Testing'
+  5 | import os
+  6 | 
+[646/677] Compiling EnviousWisprASRTests ASRManagerBackendInjectionTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift:4:8: error: no such module 'Testing'
+  2 | import EnviousWisprCore
+  3 | import Foundation
+  4 | import Testing
+    |        `- error: no such module 'Testing'
+  5 | import os
+  6 | 
+[647/677] Compiling EnviousWisprASRTests LanguageDetectorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift:4:8: error: no such module 'Testing'
+  2 | import EnviousWisprCore
+  3 | import Foundation
+  4 | import Testing
+    |        `- error: no such module 'Testing'
+  5 | import os
+  6 | 
+[648/677] Compiling EnviousWisprASRService main.swift
+[649/677] Compiling EnviousWisprASRService ASRServiceDelegate.swift
+[649/677] Linking EnviousWisprAudioService
+[650/677] Emitting module EnviousWisprASRService
+error: fatalError
+
+exec
+/bin/zsh -lc 'CLANG_MODULE_CACHE_PATH="$PWD/.build/clang-cache" swift build --disable-sandbox --target EnviousWispr' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ succeeded in 8988ms:
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/configuration is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/security is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/Caches/org.swift.swiftpm is not accessible or not writable, disabling user-level cache features.
+warning: 'wt-phase-f': failed storing manifest for 'wt-phase-f' in cache: attempt to write a readonly database
+warning: 'posthog-ios': failed storing manifest for 'posthog-ios' in cache: attempt to write a readonly database
+warning: 'sentry-cocoa': failed storing manifest for 'sentry-cocoa' in cache: attempt to write a readonly database
+warning: 'sparkle': failed storing manifest for 'sparkle' in cache: attempt to write a readonly database
+warning: 'fluidaudio': failed storing manifest for 'fluidaudio' in cache: attempt to write a readonly database
+warning: 'whisperkit': failed storing manifest for 'whisperkit' in cache: attempt to write a readonly database
+warning: 'plcrashreporter': failed storing manifest for 'plcrashreporter' in cache: attempt to write a readonly database
+warning: 'swift-transformers': failed storing manifest for 'swift-transformers' in cache: attempt to write a readonly database
+warning: 'swift-argument-parser': failed storing manifest for 'swift-argument-parser' in cache: attempt to write a readonly database
+warning: 'swift-collections': failed storing manifest for 'swift-collections' in cache: attempt to write a readonly database
+warning: 'yyjson': failed storing manifest for 'yyjson' in cache: attempt to write a readonly database
+warning: 'swift-jinja': failed storing manifest for 'swift-jinja' in cache: attempt to write a readonly database
+warning: 'swift-crypto': failed storing manifest for 'swift-crypto' in cache: attempt to write a readonly database
+warning: 'swift-asn1': failed storing manifest for 'swift-asn1' in cache: attempt to write a readonly database
+[0/1] Planning build
+Building for debugging...
+[0/1] Write swift-version--1AB21518FC5DEDBE.txt
+[2/17] Compiling EnviousWisprPipeline SampleFilter.swift
+[3/17] Compiling EnviousWisprPipeline TranscriptionPipeline.swift
+[4/17] Compiling EnviousWisprPipeline TranscriptPolishService.swift
+[5/17] Compiling EnviousWisprPipeline PipelineLogging.swift
+[6/17] Compiling EnviousWisprPipeline TextProcessingRunner.swift
+[7/17] Compiling EnviousWisprPipeline TextProcessingStep.swift
+[8/17] Compiling EnviousWisprPipeline TranscriptFinalizer.swift
+[9/17] Compiling EnviousWisprPipeline PipelineStateChangePlanner.swift
+[10/17] Compiling EnviousWisprPipeline VADMonitorLoop.swift
+[11/17] Compiling EnviousWisprPipeline PipelineStateChangeHandler.swift
+[12/17] Compiling EnviousWisprPipeline LLMPolishStep.swift
+[13/17] Compiling EnviousWisprPipeline PasteCascadeExecutor.swift
+[14/17] Compiling EnviousWisprPipeline DictationPipeline.swift
+[15/17] Compiling EnviousWisprPipeline FillerRemovalStep.swift
+[16/17] Emitting module EnviousWisprPipeline
+[17/17] Compiling EnviousWisprPipeline WhisperKitPipeline.swift
+[18/18] Compiling EnviousWisprPipeline WordCorrectionStep.swift
+[19/58] Compiling EnviousWispr SettingsDesignTokens.swift
+[20/58] Compiling EnviousWispr SettingsSection.swift
+[21/58] Compiling EnviousWispr SettingsView.swift
+[22/60] Compiling EnviousWispr ShortcutsSettingsView.swift
+[23/60] Compiling EnviousWispr SpeechEngineSettingsView.swift
+[24/60] Compiling EnviousWispr WhatsNewContent.swift
+[25/60] Compiling EnviousWispr HotkeyRecorderView.swift
+[26/60] Compiling EnviousWispr HistoryContentView.swift
+[27/60] Compiling EnviousWispr MainWindowView.swift
+[28/60] Compiling EnviousWispr MemorySettingsView.swift
+[29/60] Compiling EnviousWispr PermissionsSettingsView.swift
+[30/60] Compiling EnviousWispr SettingsComponents.swift
+[31/60] Compiling EnviousWispr AudioDeviceList.swift
+[32/60] Compiling EnviousWispr BenchmarkSuite.swift
+[33/60] Compiling EnviousWispr CustomWordsCoordinator.swift
+[34/60] Compiling EnviousWispr WhatsNewSettingsView.swift
+[35/60] Compiling EnviousWispr WordFixSettingsView.swift
+[36/60] Compiling EnviousWispr AIAvailabilityCoordinator.swift
+[37/60] Compiling EnviousWispr AppDelegate.swift
+[38/60] Compiling EnviousWispr AppState.swift
+[39/60] Compiling EnviousWispr SetupCoordinator.swift
+[40/60] Compiling EnviousWispr TranscriptCoordinator.swift
+[41/60] Compiling EnviousWispr AccessibilityWarningBanner.swift
+[42/60] Compiling EnviousWispr AIPolishSettingsView.swift
+[43/60] Compiling EnviousWispr AudioSettingsView.swift
+[44/60] Compiling EnviousWispr ClipboardSettingsView.swift
+[45/60] Compiling EnviousWispr DiagnosticsSettingsView.swift
+[46/60] Compiling EnviousWispr LanguageCatalog.swift
+[47/60] Compiling EnviousWispr LanguageLockSheet.swift
+[48/60] Compiling EnviousWispr CustomWordsPropagator.swift
+[49/60] Compiling EnviousWispr EnviousWisprApp.swift
+[50/60] Compiling EnviousWispr LLMModelDiscoveryCoordinator.swift
+[51/60] Compiling EnviousWispr SidebarStatsHeader.swift
+[52/60] Compiling EnviousWispr TranscriptDetailView.swift
+[53/60] Compiling EnviousWispr TranscriptHistoryView.swift
+[54/60] Compiling EnviousWispr OnboardingDesignTokens.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:167:14: warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+  40 |   /// SwiftUI can't observe @Observable properties through protocol existentials
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+     |       `- note: mutation of this property is only permitted within the actor
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     :
+ 165 |       guard let self else { return }
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+     |              `- warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:168:14: warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  44 |   var downloadDetail: String = ""
+  45 |   private var progressPollTimer: Timer?
+     :
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+     |              `- warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+ 169 |         self.downloadDetail = state.detail
+ 170 | 
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:169:14: warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  45 |   private var progressPollTimer: Timer?
+  46 | 
+     :
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+     |              `- warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:172:42: warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+     |               `- note: property declared here
+  50 |   private var quipIndex: Int = 0
+  51 | 
+     :
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+     |                                          `- warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+ 173 |           self.startQuipTimer()
+ 174 |         }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:173:16: warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+ 173 |           self.startQuipTimer()
+     |                `- warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 174 |         }
+ 175 |       }
+     :
+ 187 |   // MARK: - Installation Quips
+ 188 | 
+ 189 |   private func startQuipTimer() {
+     |                `- note: calls to instance method 'startQuipTimer()' from outside of its actor context are implicitly asynchronous
+ 190 |     quipIndex = 0
+ 191 |     installQuip = Self.installQuips[0]
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:12: warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: mutation of this property is only permitted within the actor
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |            `- warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:30: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                              `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:52: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                                                    `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:12: warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+  46 | 
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |            `- warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:31: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                               `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:49: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                                                 `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+[#ActorIsolatedCall]: <https://docs.swift.org/compiler/documentation/diagnostics/actor-isolated-call>
+[55/60] Compiling EnviousWispr OnboardingV2View.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:167:14: warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+  40 |   /// SwiftUI can't observe @Observable properties through protocol existentials
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+     |       `- note: mutation of this property is only permitted within the actor
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     :
+ 165 |       guard let self else { return }
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+     |              `- warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:168:14: warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  44 |   var downloadDetail: String = ""
+  45 |   private var progressPollTimer: Timer?
+     :
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+     |              `- warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+ 169 |         self.downloadDetail = state.detail
+ 170 | 
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:169:14: warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  45 |   private var progressPollTimer: Timer?
+  46 | 
+     :
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+     |              `- warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:172:42: warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+     |               `- note: property declared here
+  50 |   private var quipIndex: Int = 0
+  51 | 
+     :
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+     |                                          `- warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+ 173 |           self.startQuipTimer()
+ 174 |         }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:173:16: warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+ 173 |           self.startQuipTimer()
+     |                `- warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 174 |         }
+ 175 |       }
+     :
+ 187 |   // MARK: - Installation Quips
+ 188 | 
+ 189 |   private func startQuipTimer() {
+     |                `- note: calls to instance method 'startQuipTimer()' from outside of its actor context are implicitly asynchronous
+ 190 |     quipIndex = 0
+ 191 |     installQuip = Self.installQuips[0]
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:12: warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: mutation of this property is only permitted within the actor
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |            `- warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:30: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                              `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:52: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                                                    `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:12: warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+  46 | 
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |            `- warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:31: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                               `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:49: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                                                 `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+[#ActorIsolatedCall]: <https://docs.swift.org/compiler/documentation/diagnostics/actor-isolated-call>
+[56/60] Compiling EnviousWispr RainbowLipsView.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:167:14: warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+  40 |   /// SwiftUI can't observe @Observable properties through protocol existentials
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+     |       `- note: mutation of this property is only permitted within the actor
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     :
+ 165 |       guard let self else { return }
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+     |              `- warning: main actor-isolated property 'downloadProgress' can not be mutated from a Sendable closure
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:168:14: warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+  41 |   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  44 |   var downloadDetail: String = ""
+  45 |   private var progressPollTimer: Timer?
+     :
+ 166 |       if let state = progressFile.read() {
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+     |              `- warning: main actor-isolated property 'downloadPhase' can not be mutated from a Sendable closure
+ 169 |         self.downloadDetail = state.detail
+ 170 | 
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:169:14: warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+  42 |   var downloadProgress: Double = 0
+  43 |   var downloadPhase: String = ""
+  44 |   var downloadDetail: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  45 |   private var progressPollTimer: Timer?
+  46 | 
+     :
+ 167 |         self.downloadProgress = state.fraction
+ 168 |         self.downloadPhase = state.phase
+ 169 |         self.downloadDetail = state.detail
+     |              `- warning: main actor-isolated property 'downloadDetail' can not be mutated from a Sendable closure
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:172:42: warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+     |               `- note: property declared here
+  50 |   private var quipIndex: Int = 0
+  51 | 
+     :
+ 170 | 
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+     |                                          `- warning: main actor-isolated property 'quipTimer' can not be referenced from a nonisolated autoclosure
+ 173 |           self.startQuipTimer()
+ 174 |         }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:173:16: warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 171 |         // Start quip timer when compilation begins (fraction >= 0.5)
+ 172 |         if state.fraction >= 0.5 && self.quipTimer == nil {
+ 173 |           self.startQuipTimer()
+     |                `- warning: call to main actor-isolated instance method 'startQuipTimer()' in a synchronous nonisolated context [#ActorIsolatedCall]
+ 174 |         }
+ 175 |       }
+     :
+ 187 |   // MARK: - Installation Quips
+ 188 | 
+ 189 |   private func startQuipTimer() {
+     |                `- note: calls to instance method 'startQuipTimer()' from outside of its actor context are implicitly asynchronous
+ 190 |     quipIndex = 0
+ 191 |     installQuip = Self.installQuips[0]
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:12: warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: mutation of this property is only permitted within the actor
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |            `- warning: main actor-isolated property 'quipIndex' can not be mutated from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:30: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                              `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:194:52: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 192 |     let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+     |                                                    `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+ 196 |     }
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:12: warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+  46 | 
+  47 |   /// Quirky installation message, cycled during the compilation phase.
+  48 |   var installQuip: String = ""
+     |       `- note: mutation of this property is only permitted within the actor
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |            `- warning: main actor-isolated property 'installQuip' can not be mutated from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:31: warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+  53 |   private static let installQuips = [
+     |                      `- note: static property declared here
+  54 |     "Tuning the neural ears...",
+  55 |     "Teaching AI to listen politely...",
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                               `- warning: main actor-isolated static property 'installQuips' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:195:49: warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+  48 |   var installQuip: String = ""
+  49 |   private var quipTimer: Timer?
+  50 |   private var quipIndex: Int = 0
+     |               `- note: property declared here
+  51 | 
+  52 |   /// Fun status messages shown during model compilation (~20-30s wait).
+     :
+ 193 |       guard let self else { return }
+ 194 |       self.quipIndex = (self.quipIndex + 1) % Self.installQuips.count
+ 195 |       self.installQuip = Self.installQuips[self.quipIndex]
+     |                                                 `- warning: main actor-isolated property 'quipIndex' can not be referenced from a Sendable closure
+ 196 |     }
+ 197 |     RunLoop.main.add(timer, forMode: .common)
+
+[#ActorIsolatedCall]: <https://docs.swift.org/compiler/documentation/diagnostics/actor-isolated-call>
+[57/60] Compiling EnviousWispr MenuBarIconAnimator.swift
+[58/60] Compiling EnviousWispr PipelineSettingsSync.swift
+[59/60] Compiling EnviousWispr RecordingOverlayPanel.swift
+[60/60] Emitting module EnviousWispr
+Build of target: 'EnviousWispr' complete! (7.03s)
+
+exec
+/bin/zsh -lc 'CLANG_MODULE_CACHE_PATH="$PWD/.build/clang-cache" swift build --disable-sandbox --target EnviousWisprTests' in /Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f
+ exited 1 in 4769ms:
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/configuration is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/org.swift.swiftpm/security is not accessible or not writable, disabling user-level cache features.
+warning: /Users/m4pro_sv/Library/Caches/org.swift.swiftpm is not accessible or not writable, disabling user-level cache features.
+warning: 'wt-phase-f': failed storing manifest for 'wt-phase-f' in cache: attempt to write a readonly database
+Building for debugging...
+warning: 'sentry-cocoa': failed storing manifest for 'sentry-cocoa' in cache: attempt to write a readonly database
+warning: 'whisperkit': failed storing manifest for 'whisperkit' in cache: attempt to write a readonly database
+warning: 'sparkle': failed storing manifest for 'sparkle' in cache: attempt to write a readonly database
+warning: 'fluidaudio': failed storing manifest for 'fluidaudio' in cache: attempt to write a readonly database
+warning: 'posthog-ios': failed storing manifest for 'posthog-ios' in cache: attempt to write a readonly database
+warning: 'plcrashreporter': failed storing manifest for 'plcrashreporter' in cache: attempt to write a readonly database
+warning: 'swift-transformers': failed storing manifest for 'swift-transformers' in cache: attempt to write a readonly database
+warning: 'swift-argument-parser': failed storing manifest for 'swift-argument-parser' in cache: attempt to write a readonly database
+warning: 'swift-collections': failed storing manifest for 'swift-collections' in cache: attempt to write a readonly database
+warning: 'yyjson': failed storing manifest for 'yyjson' in cache: attempt to write a readonly database
+warning: 'swift-jinja': failed storing manifest for 'swift-jinja' in cache: attempt to write a readonly database
+warning: 'swift-crypto': failed storing manifest for 'swift-crypto' in cache: attempt to write a readonly database
+warning: 'swift-asn1': failed storing manifest for 'swift-asn1' in cache: attempt to write a readonly database
+[0/3] Write swift-version--1AB21518FC5DEDBE.txt
+[1/3] Write Objects.LinkFileList
+[2/3] Linking EnviousWispr
+[4/43] Compiling EnviousWisprTests EnviousOutputFilterTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[5/43] Compiling EnviousWisprTests GeminiPromptBuilderTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[6/43] Compiling EnviousWisprTests GemmaPromptBuilderTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[7/45] Compiling EnviousWisprTests AppLoggerCompileOutTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[8/45] Compiling EnviousWisprTests CustomWordTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[9/45] Compiling EnviousWisprTests HeartPathContextsTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[10/45] Compiling EnviousWisprTests PreambleStrippingTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[11/45] Compiling EnviousWisprTests PromptPlannerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[12/45] Compiling EnviousWisprTests TranscriptAnalyzerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[13/45] Compiling EnviousWisprTests CustomWordsPropagatorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[14/45] Compiling EnviousWisprTests TranscriptCoordinatorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[15/45] Compiling EnviousWisprTests SetupCoordinatorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+error: emit-module command failed with exit code 1 (use -v to see invocation)
+[16/45] Emitting module EnviousWisprTests
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[17/45] Compiling EnviousWisprTests RotatingFileSinkTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[18/45] Compiling EnviousWisprTests XPCErrorSanitizerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[19/45] Compiling EnviousWisprTests EnviousWisprTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[20/45] Compiling EnviousWisprTests PipelineStateChangePlannerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[21/45] Compiling EnviousWisprTests PreWarmThrowsTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[22/45] Compiling EnviousWisprTests SampleFilterTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[23/45] Compiling EnviousWisprTests AppleIntelligencePolishTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[24/45] Compiling EnviousWisprTests ApplePolishRouterTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[25/45] Compiling EnviousWisprTests ConnectorContractTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[26/45] Compiling EnviousWisprTests LLMRetryPolicyTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[27/45] Compiling EnviousWisprTests LLMTaskMetricsCollectorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[28/45] Compiling EnviousWisprTests LanguageAwarePromptInjectionTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[29/45] Compiling EnviousWisprTests TranscriptionPipelineInjectionTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[30/45] Compiling EnviousWisprTests CaptureTelemetryStateTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[31/45] Compiling EnviousWisprTests HeartPathErrorTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[32/45] Compiling EnviousWisprTests OllamaConnectorRequestBodyTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[33/45] Compiling EnviousWisprTests OllamaModelCatalogTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[34/45] Compiling EnviousWisprTests OpenAIPromptBuilderTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[35/45] Compiling EnviousWisprTests TextProcessingChainRacesTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[36/45] Compiling EnviousWisprTests TextProcessingRunnerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[37/45] Compiling EnviousWisprTests TranscriptFinalizerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[38/45] Compiling EnviousWisprTests TranscriptPolishServiceTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[39/45] Compiling EnviousWisprTests DictationSessionConfig+TestDefault.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[40/45] Compiling EnviousWisprTests DictationSessionConfigTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[41/45] Compiling EnviousWisprTests HeartPathIntegrationTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[42/45] Compiling EnviousWisprTests PasteFocusClassificationTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[43/45] Compiling EnviousWisprTests PipelineStateChangeHandlerTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[44/45] Compiling EnviousWisprTests PasteServiceClipboardTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+[45/45] Compiling EnviousWisprTests SentryAudioExtrasTests.swift
+/Users/m4pro_sv/Developer/EnviousLabs/wt-phase-f/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift:3:8: error: no such module 'Testing'
+  1 | import EnviousWisprCore
+  2 | import Foundation
+  3 | import Testing
+    |        `- error: no such module 'Testing'
+  4 | 
+  5 | @testable import EnviousWispr
+
+codex
+I did not identify any actionable regressions in the refactor. The EnviousWispr target builds successfully; the full test target could not be run in this environment due an unrelated missing Swift Testing module.
+2026-04-30T14:21:40.561341Z ERROR codex_core::session: failed to record rollout items: thread 019ddec0-9d78-7832-a6e1-8dd526a2e5f6 not found
+2026-04-30T14:21:40.603735Z ERROR codex_core::session: failed to record rollout items: thread 019ddec0-9ce9-7463-9902-b480f7becff5 not found

--- a/docs/audits/2026-04-30-phase-f-code-diff-review.txt
+++ b/docs/audits/2026-04-30-phase-f-code-diff-review.txt
@@ -1,0 +1,1 @@
+I did not identify any actionable regressions in the refactor. The EnviousWispr target builds successfully; the full test target could not be run in this environment due an unrelated missing Swift Testing module.

--- a/docs/audits/2026-04-30-phase-f-grounded-review.stderr.log
+++ b/docs/audits/2026-04-30-phase-f-grounded-review.stderr.log
@@ -1,0 +1,4716 @@
+Reading additional input from stdin...
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019dde88-178d-7d51-9b65-cbd2a0bd75a6
+--------
+user
+# Grounded Review — Phase F (SetupCoordinator extraction, #501)
+
+You are an independent reviewer with full read-only access to the EnviousWispr codebase at `/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr`. Scope: Phase F ONLY. Do NOT review unrelated phases (E, R2, R5, V1-V4, G4) except as needed to answer Q3 below. You may grep, read, and traverse anywhere in the repo to verify claims; do NOT propose changes outside the Phase F surface.
+
+## Context — what this is and why I want your read
+
+EnviousWispr is a 2-person macOS voice-to-text company. Heart path = audio capture → ASR → text → paste; must never fail. Limbs (LLM polish, custom words, filler removal, language hints) may degrade. Roughly 5 active users today, no client pressure, no release schedule. Two ASR backends kept intentionally isolated. Calibrate review to this scale; no enterprise process advice.
+
+The plan at `docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md` proposes extracting three setup-related fields from AppState (`ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` plus the observation method) into a new `SetupCoordinator` class living in a new SPM library target `EnviousWisprAppCore`. The decision to use a library target (not just put SetupCoordinator alongside AppState in the executable target) traces to a 2026-04-18 decisions-lock entry D7 in `docs/feature-requests/issue-319-open-decisions-2026-04-18.md`. The locked rationale was test-target access — but that rationale appears to be stale: `Package.swift:138` already includes `"EnviousWispr"` as a dependency of `EnviousWisprTests`. So the locked decision now stands on a weaker secondary rationale ("build to right shape day-one, avoid future re-extraction").
+
+Parent epic context lives in `docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md` §17 (Phase F design) and §4.13 (AppState property disposition matrix). Bible §6.1 is the phase index.
+
+Other key files to ground on (read these directly, do not summarize from the plan):
+- `Sources/EnviousWispr/App/AppState.swift` — the type being decomposed (currently 976 lines, 19 file-scope `let` declarations)
+- `Sources/EnviousWispr/App/AppDelegate.swift:417` — the `ollamaSetup.cleanup()` quit hook
+- `Sources/EnviousWispr/App/PipelineSettingsSync.swift` — takes `whisperKitSetup` directly via init
+- `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` — 31 read sites for `appState.ollamaSetup.*`
+- `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift` — 8 read sites for `appState.whisperKitSetup.*`
+- `Sources/EnviousWisprLLM/OllamaSetupService.swift` — the leaf service (already public, MainActor, Observable)
+- `Sources/EnviousWisprASR/WhisperKitSetupService.swift` — the leaf service (already public, MainActor, Observable)
+- `Package.swift` — current target graph
+- `.claude/rules/architecture-rules.md` — the in-house architecture doctrine this phase claims to advance
+
+## What I need
+
+Direct prose review, **800–1500 words**. Your engineering judgment on whether Phase F is genuine hardening or ceremonial decomposition. Range further into the codebase if context demands; sometimes the immediate vicinity has blinders, and you can see the full picture.
+
+The two primary questions I want answered, with grep-verified evidence:
+
+### Q1 — Is Phase F a genuine value-add, or does it add fragility?
+
+The plan claims this hardens the system by:
+(a) reducing AppState's owned-property count toward an architectural target,
+(b) clustering a cohesive concern (setup orchestration) under a single owner,
+(c) enabling future testability via the injected `asrManager` + `preloadAction` seams,
+(d) calibrating Phase E's regression-test ceilings.
+
+Pressure-test each claim against the actual code:
+
+1. **Cohesion claim.** Is "setup of Ollama" + "setup of WhisperKit" + "preload observation when WhisperKit becomes ready" actually one cohesive concern, or three loosely related things bundled together because they share the word "setup"? Specifically: does the preload-observation method belong with `whisperKitSetup` (its trigger), with `whisperKitPipeline` (its action), or in its own owner? Read `AppState.swift:637-668` and decide.
+
+2. **Decoupling claim.** Does extraction actually reduce coupling, or does it move coupling from "AppState directly owns three fields" to "AppState owns a SetupCoordinator that owns three fields and reaches back into AppState's collaborators (`asrManager`, `whisperKitPipeline`) via injected closures"? Is the injection dance a real seam or a vanity seam? Verify against the proposed init shape in plan §3.2 and the current call sites in `AppState.swift:619, 620, 375, 217`.
+
+3. **Observation chain risk.** SwiftUI's @Observable tracking traverses `appState → setup → ollamaSetup → setupState`. Today it's `appState → ollamaSetup → setupState`. The plan claims SwiftUI handles deeper paths fine. Is there a real risk this lengthening introduces stale-render bugs, observation-graph cycles, or unnecessary re-renders? Look at how other multi-level @Observable paths are handled in the codebase (search for similar patterns) and form an opinion.
+
+4. **Heart-path safety.** The plan claims Phase F doesn't touch the heart path. Verify: does anything in `Sources/EnviousWisprPipeline/`, `Sources/EnviousWisprASR/`, or `Sources/EnviousWisprAudio/` depend on `AppState.ollamaSetup` or `AppState.whisperKitSetup` being directly readable? Or does the heart path consult these objects through some other path that the plan missed? Specifically check the streaming, recording-start, and finalize paths. If anything reads from `appState.ollamaSetup` or `appState.whisperKitSetup` outside the Settings views and AppDelegate, flag it.
+
+5. **Library-target choice (D7 staleness).** The plan flags that D7's primary rationale (test access) is stale because `Package.swift:138` already includes the executable in `EnviousWisprTests.dependencies`. Verify this is correct. If true: is the secondary rationale ("build to right shape day-one") strong enough to justify the new SPM target on its own, or is putting `SetupCoordinator` in the existing executable target the cleaner choice? Consider build-time impact, future extraction cost, and the architecture-rules.md "convenience is not justification" rule.
+
+6. **Phase E ceiling honesty.** The plan notes that the Bible's "≤ 12 concrete deps after A+C+D+F" target is unreachable from the current 19-property baseline (post-F: 17). Is that a Phase E problem or a sign Phase F is undersized? Specifically: are there OTHER properties on AppState that should be folded into SetupCoordinator (or into a parallel coordinator extraction in the same PR) to actually hit the architectural target?
+
+### Q2 — Is there a better-shaped intervention I'm missing?
+
+You have full repo access. If you see an intervention that would yield more hardening per unit of churn — for instance, extracting a different cluster on AppState that is louder god-object signal than this one — name it. Bible §17.7 mentions BenchmarkCoordinator and TelemetryObservationCoordinator as post-epic candidates. Are those genuinely smaller targets, or is one of them actually the bigger-bang refactor? Read `AppState.swift` end-to-end before answering. If Phase F as scoped is the right move, say so explicitly.
+
+### Q3 — Falsifiability anchors
+
+For each of these claims in the plan, return a verdict (TRUE / FALSE / PARTIAL / JUDGMENT-CALL) with grep-verified `file:line` evidence:
+
+- Plan §3.3 claims `AppState.startWhisperKitPreloadObservation()` body lives at lines 639–668 today. Verify.
+- Plan §6 claims 31 sites in `AIPolishSettingsView.swift`, 8 in `SpeechEngineSettingsView.swift`, 1 in `AppDelegate.swift:417`. Verify exact counts.
+- Plan §3.4 claims `Package.swift:138` includes `"EnviousWispr"` in `EnviousWisprTests.dependencies`. Verify.
+- Plan §3.2 claims the proposed `SetupCoordinator` init takes `asrManager: any ASRManagerInterface` + `preloadAction: @MainActor () async -> Void` and that this captures everything `startWhisperKitPreloadObservation()` currently needs. Verify by walking the body at `AppState.swift:639-668`.
+- Plan §4 contract delta table — flag any contract delta missing.
+- Plan §10 file-by-file LOC estimates — sanity-check against the actual files (don't be precise; flag only if off by 2x or more).
+
+## Sign-off
+
+End with one of:
+
+- **PROCEED-AS-PLANNED** — Phase F is a genuine value-add as scoped; ship it.
+- **PROCEED-WITH-REVISIONS** — Phase F is the right direction but the scope, target choice, or design needs adjustment. Name the revisions.
+- **PIVOT** — Phase F as scoped is ceremonial / introduces fragility / is not the highest-leverage refactor; here is what to do instead.
+
+Followed by one paragraph rationale.
+
+## Rules
+
+- Spot-check every numerical and structural claim against actual code.
+- If a claim is correct, say so. If wrong, name `file:line`.
+- No hedging ("possibly", "might"). State your call.
+- Founder is non-coder; rationale paragraph reads in plain English.
+codex
+I’ll ground this in the current checkout, then keep the answer scoped to Phase F and the specific falsifiability anchors. I’m also doing a quick memory pass because this repo has prior AppState/architecture review context that can keep me from re-litigating settled history.
+exec
+/bin/zsh -lc 'rg -n "AppState|issue-319|SetupCoordinator|Phase F|BenchmarkCoordinator|TelemetryObservationCoordinator|architecture" /Users/m4pro_sv/.codex/memories/MEMORY.md' in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+82:- The durable architecture pattern from the workflow discussion was "clean source of truth first, AI second." Suggested entities were `Agents`, `Fee Types`, `Charges`, `Payments`, `Balances`, `Email Log`, and `Follow-up Status`. [Task 3]
+307:- Bad delegation targets for this repo were architecture calls, repo-wide root-cause analysis, subtle concurrency judgments, and high-trust completion claims. Keep OpenCode on bounded labor while Claude handles judgment. [Task 3]
+421:- when real evals made the classifier direction weaker, the user accepted holding it off; future similar work should favor practical shipping evidence over architecture theater or synthetic-only wins [Task 2]
+441:applies_to: cwd=/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-worktrees/issue-289-review; reuse_rule=safe when reviewing the same audio-capture architecture or nearby revisions, but verify line numbers and blame against the checked-out commit before reusing
+452:- issue-289, heart-path, preWarm, isPreWarmed, AudioCaptureInterface, AudioCaptureProxy, AudioCaptureManager, AppState, TranscriptionPipeline, WhisperKitPipeline, captureStallWatchdogFired, stallEventAlreadyCaptured, xpcReplyFailedThisSession, b8345c2, 7b78898, 18640f7
+474:- The core wedge is source-backed: `AppState` unconditionally goes from `await active.handle(event: .preWarm)` to `await active.handle(event: .toggleRecording)`, while both pipelines call `await audioCapture.preWarm()` and then set `isPreWarmed = true` unconditionally. Because `AudioCaptureProxy.preWarm()` catches XPC/engine failures and only logs them, the pipeline can believe warm-up succeeded when it did not. [Task 1][Task 2]
+584:- cold boot, first record, AppState.activePipeline, ASRManager.switchBackend, WhisperKitPipeline backend, WhisperKitBackend.prepare, WhisperKit.download, loadingModel, RecordButton, menu bar icon
+605:- when the user asks for a full path trace like launch warmup, first record, loading UI, and model management, inspect the handoff across `AppState`, both pipelines, and manager/backend ownership rather than auditing one file in isolation [Task 9]
+620:- The cold-start path splits ownership: `AppState` routes visible state through `ASRManager.activeBackendType`, but `WhisperKitPipeline` owns its own private `WhisperKitBackend()`, and `WhisperKitBackend.prepare()` can silently fall back to `WhisperKit.download(...)` on first record. [Task 9]
+638:applies_to: cwd=/Users/m4pro_sv/Desktop/EnviousWispr or sibling prompt-planner worktrees; reuse_rule=safe for the same prompt architecture family, but check checkout-specific contract changes before reusing exact guidance
+675:- when the user said "Only flag issues you can prove from the code you read. No speculative bugs.", keep prompt reviews tightly evidence-backed and do not elevate architecture guesses into findings [Task 1][Task 2][Task 3]
+718:- The main spec drift risks were not "missing WhisperKit in XPC" but stale state and wiring gaps: decode options can be snapshotted before LID settles, the rollback flag is effectively cold in runtime wiring, migration normalization is lax, the anti-flap logic is weaker than the spec, passive-chip callbacks are not fully wired into `AppState`, and saved-transcript re-polish does not forward backend provenance. [Task 1]
+798:- when the user asks for an "Adversarial code review" with code-level specificity and names concrete regressions, prioritize those failure classes first instead of broad architecture commentary [Task 1]
+872:- rollout_summaries/2026-04-07T21-26-14-5OBJ-transcript_polish_service_architecture_review.md (cwd=/Users/m4pro_sv/Desktop/EnviousWispr-polish-service, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/07/rollout-2026-04-07T17-26-14-019d69d6-bdb0-78f2-86df-4ac5ae780323.jsonl, updated_at=2026-04-07T21:28:48+00:00, thread_id=019d69d6-bdb0-78f2-86df-4ac5ae780323, integration review)
+891:- when reviewing these kinds of features, the user said "Only flag issues you can trace to specific lines or patterns in the actual code. No speculative warnings." -> keep reviews evidence-first and avoid architecture speculation [Task 1]
+912:## Task 1: Repo code-quality and Sentry issue audits, main remaining debt is AppState and pipeline orchestration
+923:- AppState, PipelineSettingsSync, TranscriptionPipeline, WhisperKitPipeline, TranscriptFinalizer, TextProcessingRunner, PasteCascadeExecutor, VADMonitorLoop, Sentry, model_load_failed, negative VAD duration, transcribeWithStreamingRescue, v1.7.1, v1.8.0, v1.9.1
+943:- Repo-level audits consistently found the package boundary cleaner than the behavior boundary: extracted helpers (`TranscriptFinalizer`, `TextProcessingRunner`, `PasteCascadeExecutor`, `VADMonitorLoop`) reduced duplication, but `AppState` and the two pipelines remain the main orchestration debt center. [Task 1]
+950:- Symptom: an audit overstates regressions after a refactor. Cause: it ignores intentional exceptions or already-extracted helper ownership. Fix: compare against the user’s accepted tradeoffs and the before/after architecture, not an abstract ideal. [Task 1]
+955:scope: read-only security, architecture, UX/DX, and full-flow reviews for the local demo-platform pnpm monorepo
+958:## Task 1: Initial architecture and security review, found export XSS, SSRF, and builder create/save blocker
+962:- rollout_summaries/2026-04-03T01-59-48-baTW-demo_platform_code_review_security_and_architecture.md (cwd=/Users/m4pro_sv/Documents/Code/demo-platform, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/02/rollout-2026-04-02T21-59-48-019d5111-676e-7573-8de9-1cc3591d02ac.jsonl, updated_at=2026-04-03T02:04:01+00:00, thread_id=019d5111-676e-7573-8de9-1cc3591d02ac, broad first-pass review)
+1033:scope: architecture and targeted-fix reviews for the local single-process llm-council MCP server
+1036:## Task 1: Adversarial architecture review, serviceable for local workflow but brittle under stronger assumptions
+1040:- rollout_summaries/2026-04-10T07-40-44-MUaV-llm_council_adversarial_design_review.md (cwd=/Users/m4pro_sv/.claude/mcp-servers/llm-council, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/10/rollout-2026-04-10T03-40-44-019d7656-0fdd-7941-b627-06b6a1dead75.jsonl, updated_at=2026-04-10T07:43:03+00:00, thread_id=019d7656-0fdd-7941-b627-06b6a1dead75, architecture critique)
+1059:- for the adversarial review, the user said "**NOT a bug-hunt**" and asked to challenge architecture, assumptions, session model, error handling, and timeouts -> default to design critique rather than defect enumeration when they frame the task that way [Task 1]
+1063:- The architecture review’s core tension was session semantics: `SessionStore.get_or_create()` originally refreshed config on an existing session, making sessions mutable scratchpads, while the later targeted fix pinned config at creation and silently ignored later config changes except `system_prompt`. [Task 1][Task 2]
+
+exec
+/bin/zsh -lc "pwd && git status --short && rg --files | rg '("'^Package.swift$|AppState.swift$|AppDelegate.swift$|PipelineSettingsSync.swift$|AIPolishSettingsView.swift$|SpeechEngineSettingsView.swift$|OllamaSetupService.swift$|WhisperKitSetupService.swift$|architecture-rules.md$|issue-501-2026-04-30-phase-f-setup-coordinator.md$|issue-319-open-decisions-2026-04-18.md$|issue-319-2026-04-18-q2-hardening-epic.md$)'"'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-0v460T0O' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-D0B3Pi2r' (errno=Operation not permitted)
+ M docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+?? .agents/
+?? .codex/a-review-prompt.md
+?? .codex/adversarial-test-review-template.md
+?? .codex/audit-prompt.md
+?? .codex/audit-schema.json
+?? .codex/b-review-prompt.md
+?? .codex/c-review-prompt.md
+?? .codex/config.toml
+?? .codex/d-review-prompt.md
+?? .codex/decisions-lock-review-prompt.md
+?? .codex/f-review-prompt.md
+?? .codex/grounded-review-template.md
+?? .codex/plan-review-prompt.md
+?? .codex/plan-review-schema.json
+?? .codex/r2-review-prompt.md
+?? .codex/r3-review-prompt.md
+?? .codex/truth-audit-test-template.md
+Package.swift
+Sources/EnviousWisprLLM/OllamaSetupService.swift
+Sources/EnviousWisprASR/WhisperKitSetupService.swift
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+Sources/EnviousWispr/App/AppDelegate.swift
+Sources/EnviousWispr/App/PipelineSettingsSync.swift
+Sources/EnviousWispr/App/AppState.swift
+
+codex
+The memory hit is only a guardrail: prior audits already identified AppState and pipeline orchestration as the real debt center, but I’ll verify all current Phase F claims from this checkout rather than relying on old conclusions. Next I’m reading the plan, the parent docs, and the actual owner/call-site files.
+exec
+/bin/zsh -lc "nl -ba docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md | sed -n '1,260p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+exec
+/bin/zsh -lc "nl -ba docs/feature-requests/issue-319-open-decisions-2026-04-18.md | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	# Phase F — SetupCoordinator extraction (#501)
+     2	
+     3	Parent epic: #319 (Hardening & Refactors). Bible §17. Depends on: nothing (independent). Blocks: Phase E (#502 — ceiling calibration).
+     4	
+     5	## Preface — Lane + Live UAT declaration (PR #498 — MANDATORY)
+     6	
+     7	- **Declared lane:** code (mixed_pr: false)
+     8	- **Phase 3 obligations:** logic tests + smoke + Live UAT (synthetic dictation through real speakers + Settings tab visual confirmation) + Codex code-diff
+     9	- **Live UAT:** Y — manual-human required for the Settings UI portion (no synthetic AX path covers Settings tabs cycling through setup states); synthetic dictation covers the heart-path regression check
+    10	
+    11	## Preface — User Rubric
+    12	
+    13	User Rubric: N/A — Hardening & Refactors is internal-only (Bible §0.7). No user-visible surface change. Settings tabs must look and behave identically.
+    14	
+    15	## 0. TL;DR
+    16	
+    17	Bundle three setup-related concerns currently owned by AppState (`ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` plus the observation wiring) into a new `SetupCoordinator` class living in a new SPM library target `EnviousWisprAppCore`. AppState owns one `setup` property instead of three. View call sites change `appState.X` → `appState.setup.X` (40 mechanical rewrites across 3 files). Net: AppState concrete-property count drops from 19 → 17. Pre-loaded for Phase E ceiling calibration.
+    18	
+    19	## 1. Problem
+    20	
+    21	AppState owns 19 file-scope concrete properties. Three of them — `ollamaSetup` (Ollama for cloud-style polish), `whisperKitSetup` (WhisperKit model lifecycle), `whisperKitPreloadTask` (background observation that triggers a model preload when WhisperKit becomes ready) — form a single cohesive concern (initial setup of optional limbs) that does not need to live on the central state object. Phase A+C+D shaved AppState to its current shape; Phase F removes the next-cohesive-cluster. Without F, Phase E's regression-test ceilings cannot be calibrated honestly because the post-A+C+D state is not the architectural target.
+    22	
+    23	## 2. Goals & non-goals
+    24	
+    25	### 2.1 Goals
+    26	
+    27	- AppState's three setup properties consolidated into one new owner.
+    28	- New `SetupCoordinator` lives in a new SPM library target (per locked decision D7, with the caveat documented in §3.4).
+    29	- All view consumers continue observing the same `OllamaSetupService` / `WhisperKitSetupService` instances (Option A passthrough — no semantic-API wrapper).
+    30	- `PipelineSettingsSync.onNeedsPreloadObservation` callback rerouted to call SetupCoordinator instead of AppState.
+    31	- Settings tabs (AI Polish, Speech Engine) render and respond identically to current behavior.
+    32	- Heart path is unaffected (raw transcription does not depend on setup services).
+    33	
+    34	### 2.2 Non-goals
+    35	
+    36	- No semantic-API wrapping (Option B per Bible §17.3 substep 2). Property-passthrough only. If a future phase needs `setup.ollamaReady`-style accessors, that is a separate phase.
+    37	- No `reset()` method on the protocol (per Bible §17.3.1; no caller exists).
+    38	- No extraction of `BenchmarkCoordinator` or `TelemetryObservationCoordinator` (Bible §17.7 — post-epic).
+    39	- No move of `OllamaSetupService` or `WhisperKitSetupService` themselves; they already live in `EnviousWisprLLM` and `EnviousWisprASR` respectively.
+    40	
+    41	## 3. Design
+    42	
+    43	### 3.1 New SPM library target
+    44	
+    45	```swift
+    46	// Package.swift — new target between Pipeline and the executable
+    47	.target(
+    48	  name: "EnviousWisprAppCore",
+    49	  dependencies: [
+    50	    "EnviousWisprCore",
+    51	    "EnviousWisprASR",
+    52	    "EnviousWisprLLM",
+    53	    "EnviousWisprPipeline",
+    54	  ],
+    55	  path: "Sources/EnviousWisprAppCore"
+    56	),
+    57	```
+    58	
+    59	Executable `EnviousWispr` adds `EnviousWisprAppCore` to its dependency list. Tests `EnviousWisprTests` adds `EnviousWisprAppCore`.
+    60	
+    61	Dependency direction (per architecture-rules.md): App-shell-equivalent → Pipeline → Features → Core. The new `EnviousWisprAppCore` sits at the App-shell level (above Pipeline, below the executable). No upward edges.
+    62	
+    63	### 3.2 SetupCoordinator class
+    64	
+    65	```swift
+    66	// Sources/EnviousWisprAppCore/SetupCoordinator.swift
+    67	import EnviousWisprASR
+    68	import EnviousWisprCore
+    69	import EnviousWisprLLM
+    70	
+    71	@MainActor
+    72	public protocol SetupCoordinating: AnyObject {
+    73	  var ollamaSetup: OllamaSetupService { get }
+    74	  var whisperKitSetup: WhisperKitSetupService { get }
+    75	  func startPreloadObservation()
+    76	}
+    77	
+    78	@MainActor
+    79	@Observable
+    80	public final class SetupCoordinator: SetupCoordinating {
+    81	  public let ollamaSetup = OllamaSetupService()
+    82	  public let whisperKitSetup = WhisperKitSetupService()
+    83	
+    84	  @ObservationIgnored
+    85	  private var whisperKitPreloadTask: Task<Void, Never>?
+    86	
+    87	  private let asrManager: any ASRManagerInterface
+    88	  private let preloadAction: @MainActor () async -> Void
+    89	
+    90	  public init(
+    91	    asrManager: any ASRManagerInterface,
+    92	    preloadAction: @escaping @MainActor () async -> Void
+    93	  ) {
+    94	    self.asrManager = asrManager
+    95	    self.preloadAction = preloadAction
+    96	  }
+    97	
+    98	  public func startPreloadObservation() {
+    99	    whisperKitPreloadTask?.cancel()
+   100	    whisperKitPreloadTask = Task { [weak self] in
+   101	      while !Task.isCancelled {
+   102	        guard let self else { return }
+   103	        guard self.asrManager.activeBackendType == .whisperKit else { return }
+   104	        let currentState = self.whisperKitSetup.setupState
+   105	        if currentState == .ready {
+   106	          await self.preloadAction()
+   107	          return
+   108	        }
+   109	        await withCheckedContinuation { continuation in
+   110	          withObservationTracking {
+   111	            _ = self.whisperKitSetup.setupState
+   112	          } onChange: {
+   113	            continuation.resume()
+   114	          }
+   115	        }
+   116	      }
+   117	    }
+   118	  }
+   119	}
+   120	```
+   121	
+   122	The body of `startPreloadObservation()` is a verbatim move of `AppState.startWhisperKitPreloadObservation()` (currently lines 639–668), with `self.asrManager` and `self.preloadAction` substituted for the AppState-bound references.
+   123	
+   124	### 3.3 AppState shape change
+   125	
+   126	```swift
+   127	// Sources/EnviousWispr/App/AppState.swift — diff sketch
+   128	
+   129	// REMOVED (lines 25, 26, 31 today):
+   130	// let ollamaSetup = OllamaSetupService()
+   131	// let whisperKitSetup = WhisperKitSetupService()
+   132	// private var whisperKitPreloadTask: Task<Void, Never>?
+   133	
+   134	// ADDED at file scope (in same region):
+   135	let setup: SetupCoordinator
+   136	
+   137	// REMOVED (lines 637–668 today): startWhisperKitPreloadObservation() body
+   138	// — entire method moves to SetupCoordinator.
+   139	
+   140	// CHANGED in init() after asrManager + whisperKitPipeline are constructed:
+   141	self.setup = SetupCoordinator(
+   142	  asrManager: asrManager,
+   143	  preloadAction: { [weak whisperKitPipeline] in
+   144	    await whisperKitPipeline?.prepareBackendSilently()
+   145	  }
+   146	)
+   147	
+   148	// CHANGED at line 375:
+   149	settingsSync.onNeedsPreloadObservation = { [weak setup = self.setup] in
+   150	  setup?.startPreloadObservation()
+   151	}
+   152	
+   153	// CHANGED at line 619 (the "kick the tires" call right after init):
+   154	Task { [weak self] in
+   155	  await self?.setup.whisperKitSetup.detectState()
+   156	  self?.setup.startPreloadObservation()
+   157	}
+   158	```
+   159	
+   160	`PipelineSettingsSync` keeps taking `whisperKitSetup: WhisperKitSetupService` directly. AppState passes `setup.whisperKitSetup` instead of the old top-level property at the construction site (line 217).
+   161	
+   162	### 3.4 Note on D7 lock-in
+   163	
+   164	D7 (decisions doc 2026-04-18) said "build SetupCoordinator in a library target from day one." Its primary rationale was test-target access — `Package.swift:107` was claimed not to include the executable as a test dep. **Verified 2026-04-30: Package.swift today (line 138) DOES include `EnviousWispr` in `EnviousWisprTests.dependencies`.** The test-access argument is gone. D7's secondary rationale (build to the right shape day-one, avoid future re-extraction churn) stands. Plan ships F-Lib (library target) under that secondary rationale plus `feedback_no_shortcuts_mode.md` ("structure properly") — but if council or grounded review challenges this, F-Exec (everything in the executable target) is a one-day-cheaper fallback.
+   165	
+   166	### 3.5 Edge cases (per workflow-process §10)
+   167	
+   168	- **Interrupted:** SetupCoordinator deinit has `whisperKitPreloadTask?.cancel()` not explicitly written but the Task captures `[weak self]` so cancellation propagates when the coordinator is freed. AppState owns it for the app lifetime, so this is theoretical.
+   169	- **Deleted:** N/A — `setup` is a `let` on AppState, no deletion path.
+   170	- **Mutated:** Backend-switch settings change calls `onNeedsPreloadObservation` → `setup.startPreloadObservation()`, which cancels the prior task and restarts. Identical behavior to today.
+   171	- **Concurrent:** Two backend switches in fast succession → both fire `startPreloadObservation()` → first task cancels, second proceeds. Identical to today.
+   172	- **Nil:** `[weak setup = self.setup]` capture in the `onNeedsPreloadObservation` closure handles AppState death (theoretical) without keeping setup alive.
+   173	- **Stale:** Views observe `setup.ollamaSetup` and `setup.whisperKitSetup` directly. SwiftUI's @Observable change tracking sees the underlying service's properties changing because the path `appState.setup.ollamaSetup.setupState` traverses two `@Observable` boundaries (AppState and SetupCoordinator both are @Observable, the leaf service is @Observable). Spot-check during Live UAT.
+   174	
+   175	## 4. **MANDATORY** Contract deltas
+   176	
+   177	| Symbol | Before | After | Visibility | Notes |
+   178	|---|---|---|---|---|
+   179	| `AppState.ollamaSetup` | `let ollamaSetup: OllamaSetupService` | removed | — | replaced by `appState.setup.ollamaSetup` |
+   180	| `AppState.whisperKitSetup` | `let whisperKitSetup: WhisperKitSetupService` | removed | — | replaced by `appState.setup.whisperKitSetup` |
+   181	| `AppState.whisperKitPreloadTask` | `private var Task<Void, Never>?` | removed | — | moves to `SetupCoordinator` |
+   182	| `AppState.startWhisperKitPreloadObservation()` | `private func` | removed | — | body moves to `SetupCoordinator.startPreloadObservation()` |
+   183	| `AppState.setup` | — | `let setup: SetupCoordinator` | internal | new owned property |
+   184	| `SetupCoordinator` | — | `public final class @MainActor @Observable` | public | new |
+   185	| `SetupCoordinating` | — | `public protocol @MainActor : AnyObject` | public | new — exists for test seam, not currently used by views |
+   186	
+   187	No public API on SetupCoordinator beyond the protocol. No `reset()`.
+   188	
+   189	## 5. **MANDATORY** E2E state & lifecycle audit
+   190	
+   191	State that lives in SetupCoordinator: the two service instances + the preload task handle. State that lives elsewhere and is read by SetupCoordinator: `asrManager.activeBackendType` (read-only via interface), `whisperKitPipeline.prepareBackendSilently()` (call-only via injected closure). No new persisted state. No new app-lifecycle hooks.
+   192	
+   193	App-quit cleanup: `appState.ollamaSetup.cleanup()` at `AppDelegate.swift:417` becomes `appState.setup.ollamaSetup.cleanup()`. No new cleanup needed for SetupCoordinator itself; the Task is owned and will be cancelled when the coordinator deinits at app termination.
+   194	
+   195	## 6. **MANDATORY** Downstream consumer matrix
+   196	
+   197	| Consumer | File | Sites | Migration |
+   198	|---|---|---|---|
+   199	| AI Polish Settings tab | `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` | 31 | `appState.ollamaSetup.X` → `appState.setup.ollamaSetup.X` |
+   200	| Speech Engine Settings tab | `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift` | 8 | `appState.whisperKitSetup.X` → `appState.setup.whisperKitSetup.X` |
+   201	| AppDelegate quit hook | `Sources/EnviousWispr/App/AppDelegate.swift:417` | 1 | `appState.ollamaSetup.cleanup()` → `appState.setup.ollamaSetup.cleanup()` |
+   202	| PipelineSettingsSync init | `Sources/EnviousWispr/App/AppState.swift:217` | 1 | pass `setup.whisperKitSetup` instead of `whisperKitSetup` |
+   203	| AppState.init internal | `Sources/EnviousWispr/App/AppState.swift:619, 620, 375` | 3 | route through `self.setup` |
+   204	
+   205	Total: **44 sites** (40 view + 4 internal). All mechanical rewrites.
+   206	
+   207	## 7. **MANDATORY** Failure-mode × caller table
+   208	
+   209	| Failure | Caller | Behavior before | Behavior after | Heart-path impact |
+   210	|---|---|---|---|---|
+   211	| OllamaSetupService unreachable | AI Polish view | Status shows "not running", buttons reflect state | Identical (same instance, same observation path) | None — limb |
+   212	| WhisperKitSetupService download fails | Speech Engine view | Status shows error, retry button enabled | Identical | None — limb |
+   213	| Backend switch during preload | settingsSync | Old preload task cancels, new starts | Identical (cancellation logic moves verbatim) | None — limb |
+   214	| App quit during pull | AppDelegate | `ollamaSetup.cleanup()` cancels active pull | Identical | None |
+   215	
+   216	No failure mode changes. Heart path (audio capture → ASR → paste) does not consult either setup service.
+   217	
+   218	## 8. **MANDATORY** Caller-visible signals audit
+   219	
+   220	Settings tabs subscribe to `@Observable` property changes via SwiftUI's tracking. The change `appState.ollamaSetup.setupState` → `appState.setup.ollamaSetup.setupState` lengthens the keypath but does not change the observation graph: SwiftUI walks `appState` (Observable) → `setup` (Observable, new) → `ollamaSetup` (Observable, same) → `setupState`. All three boundaries are tracked. Live UAT must confirm that state transitions still re-render the views without lag or stuck state.
+   221	
+   222	## 9. **MANDATORY** Fallback source-of-truth audit
+   223	
+   224	No fallbacks. If SetupCoordinator misbehaves, the user sees broken Settings tabs but heart-path dictation continues. Per heart/limbs doctrine, this is acceptable — Settings UI for limb configuration is itself a limb.
+   225	
+   226	## 10. File-by-file changes
+   227	
+   228	| File | Change | Est. LOC delta |
+   229	|---|---|---|
+   230	| `Package.swift` | Add `EnviousWisprAppCore` target; add it as dep on `EnviousWispr` and `EnviousWisprTests` | +12 |
+   231	| `Sources/EnviousWisprAppCore/SetupCoordinator.swift` | NEW | +95 |
+   232	| `Sources/EnviousWispr/App/AppState.swift` | Remove 3 properties + 1 method; add 1 property; rewire 3 call sites | −40, +12 |
+   233	| `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` | 31 mechanical renames | ±31 (no net LOC) |
+   234	| `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift` | 8 mechanical renames | ±8 (no net LOC) |
+   235	| `Sources/EnviousWispr/App/AppDelegate.swift` | 1 mechanical rename | ±1 |
+   236	| `Sources/EnviousWispr/App/PipelineSettingsSync.swift` | No change to sync itself; AppState passes `setup.whisperKitSetup` at construction site | 0 |
+   237	| `Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift` | NEW — preload observation start/cancel/fire test with fake `ASRManagerInterface` + recording closure | +75 |
+   238	
+   239	**Net: +154 lines.** Closer to the v1.6 estimate (+200 to +250 was generous) but in the right ballpark.
+   240	
+   241	## 11. Testing
+   242	
+   243	### 11.1 Live UAT spec
+   244	
+   245	**Pre-build:** `scripts/swift-test.sh` green.
+   246	
+   247	**Build:** `/wispr-rebuild-and-relaunch`.
+   248	
+   249	**Synthetic dictation regression (Code-lane default):**
+   250	- `Tests/UITests/wispr_eyes.py test_recording(audio=tts("Phase F regression check sample one"), sentence="Phase F regression check sample one", hold=2.5, expect="Phase F", timeout=15)`. Expected: clipboard contains the transcribed sentence within 15 seconds. Confirms heart path unaffected.
+   251	
+   252	**Settings UI manual-human (cannot be synthesized):**
+   253	1. Open Settings → Speech Engine. Confirm WhisperKit setup state matches current backend (ready/downloading/etc.).
+   254	2. Trigger a backend switch (toggle Speech Engine selection if WhisperKit is selectable). Confirm preload observation re-fires (look for `[AppState]`-or-`[SetupCoordinator]` log line about preload starting).
+   255	3. Open Settings → AI Polish. Confirm Ollama status renders. Click "Detect" → state cycles through detect/ready/error as expected.
+   256	4. Quit the app. Confirm log line for `ollamaSetup.cleanup()` fires once.
+   257	
+   258	Output: `live-uat.json` in run dir with `{tts_sentence, expected_token, observed_clipboard, exit_code, app_path, settings_uat_pass: true|false}`.
+   259	
+   260	### 11.2 Other test obligations
+
+ succeeded in 0ms:
+     1	# Epic Hardening & Refactors (#319) — Founder Decisions Snapshot (2026-04-18)
+     2	
+     3	User Rubric: N/A — Hardening & Refactors is internal-only per workflow-process §1.
+     4	
+     5	Snapshot of founder decisions for Epic #319. Lives alongside the bible (`issue-319-2026-04-18-q2-hardening-epic.md`). Purpose: survive conversation compaction and new sessions so these don't get lost.
+     6	
+     7	Update protocol: when a decision is made, move it from OPEN to LOCKED with the date + choice. Don't delete — the record is the point.
+     8	
+     9	---
+    10	
+    11	## LOCKED (for the record)
+    12	
+    13	### Doctrine
+    14	
+    15	- **Polish is a limb, not heart.** Polish settings (`llmProvider`, `llmModel`, `ollamaModel`, `polishInstructions`, `writingStylePreset`, `customSystemPrompt`, `useExtendedThinking`) stay live-mutable mid-recording. If the user changes provider mid-recording and polish runs with the new provider at end of recording, that is acceptable behavior per Heart/Limbs doctrine.
+    16	- **Freeze policy umbrella: Heart = freeze, Limbs = live.** Any settings changes during an active recording apply to the NEXT recording (for heart-path settings). Limb settings can change live; limbs are allowed to fail or degrade.
+    17	- **VAD sensitivity + energy gate are moot for Phase B.** Verified no UI surface in `Sources/EnviousWispr/Views/`. Users cannot reach these settings, so freeze behavior doesn't matter for them.
+    18	- **No shortcuts refactor discipline (2026-04-18).** Epic #319 has no client pressure, no release schedule. Every "defer this to a follow-on" lean was re-evaluated; correct scoping was preserved, deferrals-as-debt were rejected. The goal is structurally correct Phase B / Phase C, not fast Phase B / Phase C.
+    19	
+    20	### Phase B decisions
+    21	
+    22	- **D1 (2026-04-18, revised post-Codex) — Six active fields + one legacy.** `DictationSessionConfig` freezes at recording start. Six active heart-path fields: `autoCopyToClipboard` (clipboard flag read during finalization), `restoreClipboardAfterPaste` (same), `vadAutoStop` (VAD monitoring read), `vadSilenceTimeout` (VAD monitoring read), `noiseSuppression` (engine rebuild/config), `languageMode` (WhisperKit worker-start + stop-time LID). One legacy field `whisperKitLanguage` has no active heart-path read today per Codex grep-verification — kept in config only for session-consistent UI helper fallback in `SpeechEngineSettingsView.swift:185-193`, documented as legacy rather than heart-path.
+    23	
+    24	- **D2 (2026-04-18, revised post-Codex) — Include in Phase B (full fix, three coordinated changes).** Not just removing WhisperKit's `didSet` at `WhisperKitPipeline.swift:62-79`. Three coordinated changes:
+    25	  1. **Stop live writes from settings sync during active session.** `PipelineSettingsSync.swift:261-266` pushes live mode changes on every setting mutation; must guard behind "session active" check.
+    26	  2. **Snapshot worker-start gate.** `WhisperKitPipeline.swift:497-505` reads `languageMode` at recording start to decide whether the worker should exist; must read from frozen config.
+    27	  3. **Snapshot stop-time LID.** `WhisperKitPipeline.swift:715-720` reads `languageMode` again at stop time for LID; must read from frozen config so post-stop decode doesn't observe a latest UI setting.
+    28	  
+    29	  Removing the `didSet` is necessary but not sufficient. Codex caught the original description understated the work.
+    30	
+    31	- **D3 (2026-04-18, confirmed post-Codex) — Stays live.** `modelUnloadPolicy` consumed AFTER transcription completes: `WhisperKitPipeline.scheduleModelUnloadIfNeeded()` at `:1027-1028, 1289-1307`; `asrManager.noteTranscriptionComplete(policy:)` at `TranscriptionPipeline.swift:908-909`. Live write at `PipelineSettingsSync.swift:229-233` affects post-recording teardown only, not capture/transcription semantics. Correctly scoped as post-heart cleanup, not a hidden deferral.
+    32	
+    33	- **D4 (2026-04-18, revised post-Codex) — Complete fix, broader than original description.** Beyond removing `configureVAD(...)` calls at `PipelineSettingsSync.swift:173-178, 182-187, 201-206, 210-215`, this requires coordinated changes across three abstraction layers:
+    34	  1. **`AudioCaptureInterface` protocol change** — current `startEnginePhase()` has no config payload and exposes separate mutable `configureVAD(...)` (`Sources/EnviousWisprAudio/AudioCaptureInterface.swift:83-95`). Add config-accepting start API OR pass config to existing methods.
+    35	  2. **XPC protocol change** — `Sources/EnviousWisprCore/AudioServiceProtocol.swift:43-68` mirrors the mutable shape; must accept session config.
+    36	  3. **XPC service handler change** — `AudioServiceHandler.swift:27-30, 234-245, 283-330` stores mutable VAD state updatable mid-session; must be REMOVED (not just unused), or live path survives accidentally.
+    37	  
+    38	  Also fix `noiseSuppression` live-rebuild leak at `PipelineSettingsSync.swift:274-280` (guards only `pipeline.state == .recording`, allowing engine rebuild mid-recording when WhisperKit is active).
+    39	  
+    40	  Bundled XPC service ships with the app, so no backwards-compatibility burden. The founder's call: "no shortcuts, complete." Real Phase B: ~2-3 weeks of work.
+    41	
+    42	- **D5 (2026-04-18) — Tooltip.** Frozen-field Settings rows display a passive "Applies on next recording" tooltip. No toast, no popup. Minimal surface, discoverable, non-intrusive.
+    43	
+    44	### Pre-existing decisions
+    45	
+    46	- **D6 (2026-04-18, confirmed post-Codex) — Stays in HotkeyService.** `recordingMode` (PTT vs toggle vs hands-free) is owned by `HotkeyService` at `:443-449, 487-498, 527` for toggle vs press/release semantics. Not in `DictationSessionConfig` — correctly scoped as pre-recording choice. Caveat: the mode is also read by `AppState` telemetry at `:397-398, 454-455, 868-870` post-invocation; if user flips mode mid-session, reported `inputMode` on invocation/completion events can drift from how the session actually started. Analytics drift, not heart-path control flow. See D9 for the session-telemetry freeze that addresses this adjacency.
+    47	
+    48	- **D7 (2026-04-18, revised post-Codex) — Extract to library targets, re-scoped.** Under-bounded in the original lock-in. Codex flagged as the single decision most likely to regret. Corrections:
+    49	  - `SetupCoordinator` (Phase F) does NOT exist in the current tree. It is NEW code to be built in Phase F. "Extract" is wrong framing; this is a "build in a library target" decision.
+    50	  - WhisperKit bridge types (`WhisperKitBackend`, `WhisperKitSetupService`, `ASRManagerProxy`) ALREADY live in `EnviousWisprASR`, a non-executable target. No extraction needed.
+    51	  - The real extraction candidate is `TranscriptCoordinator` at `Sources/EnviousWispr/App/TranscriptCoordinator.swift:7-27`, still app-target-only.
+    52	  - Visibility: since app and tests share one SPM package, `package` access can keep visibility narrower than `public` for many types. Do not over-export.
+    53	  
+    54	  Revised scope: Phase F builds `SetupCoordinator` in a library target from day one (not "extract later"). Phase C may extract `TranscriptCoordinator` if coordinator-level characterization testing requires it. WhisperKit bridge types: no action needed.
+    55	
+    56	- **D8 (2026-04-18, revised post-Codex) — Directory-injectable init, corrected rationale.** `TranscriptStore` gains `public init(directory: URL)` alongside existing parameterless `init()`. `TranscriptStore` already lives in `EnviousWisprStorage` library target (`Package.swift:30-34, Sources/EnviousWisprStorage/TranscriptStore.swift:6-17`); tests are separate targets (`Package.swift:125-142`). **The safety argument is NOT "tests separate from production" — it's "default initializer is the only production wiring in AppState."** A future production call site could mis-point the store if someone wired `init(directory:)` incorrectly; the guarantee is that `AppState` holds the only production construction point, and it uses the default init. Document this invariant in the Phase C plan.
+    57	
+    58	### New decision (post-Codex)
+    59	
+    60	- **D9 (2026-04-18) — Session-scoped telemetry metadata freezing.** Codex surfaced the missed decision: `AppState` live-reads `recordingMode` AFTER invocation/completion at `:397-398, 454-455, 868-870`. If user flips mode mid-session, the invocation-time and completion-time telemetry events report different `inputMode` values for the same session. Not a heart-path bug, but an inconsistency in the "freeze what belongs to the session" doctrine. Decision: at invocation time, snapshot `inputMode` onto the session/invocation telemetry context; completion-time events read the snapshot, not the live setting. Lightweight — a single `String` freeze per session. Lands with Phase B session config (natural home: extend `DictationSessionConfig` or add a sibling telemetry snapshot).
+    61	
+    62	---
+    63	
+    64	## Phase C Invariant — Zero production history loss (revised post-Codex)
+    65	
+    66	Non-negotiable requirement on any Phase C change. Sparkle update recipients must never lose transcript history.
+    67	
+    68	**Three safeguards (was two):**
+    69	
+    70	1. **Read-compat characterization test (fixture-based, pinned to pre-refactor code).** Generate a corpus directory with the pre-refactor `TranscriptStore` implementation, check it in as a fixture (or generate it with a baseline script pinned to the pre-refactor commit). Refactored code loads that exact folder and decodes every `Transcript` field. Asserts identical results. Fixture approach, not "run old code and new code in the same test."
+    71	
+    72	2. **Write-after-read characterization test.** Load the old fixture corpus with refactored code, append or rewrite via the new implementation, relaunch/reload, verify nothing pre-existing changed unexpectedly. This covers the class of bugs where read succeeds but a subsequent write corrupts the pre-existing file. Without this, safeguards 1 and 3 can both pass while write-path regressions destroy real user data.
+    73	
+    74	3. **Pre-release dogfood.** Before tagging a release with Phase C changes: fresh dev build points at founder's real `~/Library/Application Support/EnviousWispr/` folder. Verify full load + search works, record three new transcripts, confirm they persist across relaunch.
+    75	
+    76	**Upgrade-time folder copy: reinstated.** Codex pushed back on the original rejection — dogfooding is one corpus and observationally weak (may miss older schema variants, partially corrupt files, silent first-launch rewrites). Recommended minimum: on first launch after a version bump, copy the transcript folder to `~/Library/Application Support/EnviousWispr/backup-<old-version>/` before any new code touches it. Cheap insurance for a non-negotiable invariant. One-time per version bump.
+    77	
+    78	---
+    79	
+    80	## Changelog
+    81	
+    82	- **2026-04-18** — Initial file. Five Phase B brainstorm decisions (D1-D5), three pre-existing (D6-D8). Three doctrine locks recorded.
+    83	- **2026-04-18** — All 8 decisions locked. No-shortcuts discipline applied: D1 expanded to seven fields, D2 included in Phase B full fix, D4 complete fix (founder's call), D7 extract to library targets. D3 and D6 confirmed as correctly scoped (not deferrals). D5 tooltip. D8 directory-injectable init.
+    84	- **2026-04-18** — Phase C Invariant added: zero production history loss. Characterization test + pre-release dogfood mandatory; upgrade-time backup declined.
+    85	- **2026-04-18** — Codex review of the lock-in. D3/D6 confirmed correctly scoped. D1 revised: 6 active + 1 legacy (`whisperKitLanguage` has no heart-path read today). D2 revised: 3 coordinated changes, not just `didSet` removal. D4 revised: touches 3 abstraction layers (`AudioCaptureInterface` protocol, XPC protocol, `AudioServiceHandler`); mutable setters must be REMOVED. D7 re-scoped: `SetupCoordinator` doesn't exist yet (build in library target from day one); WhisperKit bridge types already in non-exec target (no action). D8 rationale corrected: safety from "default init only production wiring," not "tests separate." D9 added: session-scoped telemetry metadata freezing (addresses `recordingMode` telemetry drift). Phase C Invariant expanded to 3 safeguards (read-compat, write-after-read, dogfood) + reinstated upgrade-time folder copy.
+
+exec
+/bin/zsh -lc "nl -ba docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md | sed -n '1,260p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	# The Hardening & Refactors Bible — Epic #319 — 2026-04-18
+     2	
+     3	**Status:** DRAFT · **Tier:** REFACTOR (aggregate) · **Parent:** none (standing epic) · **Ultraplan:** YES
+     4	**Supersedes:** in-session framework comment on #319 (2026-04-18). This file is the canonical, long-lived handbook for the epic.
+     5	
+     6	---
+     7	
+     8	## 0. Reader and map
+     9	
+    10	### 0.1 Reader
+    11	
+    12	This document is written for Claude Code. Saurabh reads plain-English summaries in chat; he does not read 2000-line plan files. There is no human engineer on this project; Claude Code is the engineer. External contributors do not exist.
+    13	
+    14	Implication: skip human-oriented optimizations (reading-time estimates, prose flourishes, motivational framing). Optimize for accurate fact retrieval and unambiguous execution instructions.
+    15	
+    16	### 0.2 What this is
+    17	
+    18	Epic Hardening & Refactors (#319) — EnviousWispr's Q2 structural hardening pass. This document is the single source of truth for every phase inside it. Every GitHub sub-issue (#196, #195, #290, #291, #360, #361, #362, #363, #364, #365, #366) is a phase of this plan. When an issue body and this doc disagree, this doc wins; update the issue body to cite the relevant section.
+    19	
+    20	### 0.3 Load map — what to read for what task
+    21	
+    22	Per-task minimum load (read only these sections; skip the rest unless the phase blocks):
+    23	
+    24	| Task | Required sections |
+    25	|---|---|
+    26	| Execute Phase A (#196) | §2, §3.1, §4.1, §4.9, §5, §7, §24 rows #12/#16 touching A |
+    27	| Execute Phase B (#195) | §2, §3 where relevant, §4.4, §5, §8, §27.1 + §27.7 (UX decision record — STOP until decision made) |
+    28	| Execute Phase C | §2, §3.1 + §3.5, §4.1, §4.2, §4.3, §4.9, §5, §9, §27.2 (persistence boundary decision), §24 rows #12/#18/#19 |
+    29	| Execute Phase D | §2, §3.1, §4.1, §4.8 (CustomWordsCoordinator), §4.11, §5, §10, §27.3 (event model decision — STOP until decision made), §24 rows #12/#18 |
+    30	| Execute Phase E | §3 (audit meta-rec #1), §4.9 + §4.13, §11, §24 rows #15/#20, §25.3 |
+    31	| Execute Phase F (NEW v1.3) | §2, §4.1, §4.13 disposition matrix, §5, §17, §24 rows #12/#18 |
+    32	| Execute Phase G sub-phase G1 (#388) | §2, §4.6, §17A, `docs/feature-requests/issue-388-*` |
+    33	| Execute Phase G sub-phase G2 (#389) | §2, §4.6, §17A, `docs/feature-requests/issue-389-*` |
+    34	| Execute Phase G sub-phase G3 (#394) | §2, §2.3 (intentional duplication), §17A, `docs/feature-requests/issue-394-*` |
+    35	| Execute Phase G sub-phase G4 (#396) | §2.4 (access control), §17A, `docs/feature-requests/issue-396-*` |
+    36	| Execute Phase G sub-phase G5 (#398) | §2.1 (heart), §4.5, §17A, `docs/feature-requests/issue-398-*` |
+    37	| Execute R2 (#360) | §2.4, §3.2, §4.5, §5, §12, §27.4 (approach A vs B — STOP until decision made), §24 |
+    38	| Execute R3 (#361) | §3.3, §4.6, §5, §13, §22.1, §20 (V3 verifies the fix) |
+    39	| Execute R4 (#362) | §3.6, §4.7, §5, §15 |
+    40	| Execute R5 (#290) | §2, §3.7 strengths, §4.1 telemetry callouts, §5, §14 (references standalone plan file issue-290-*) |
+    41	| Execute R6 (#363) | §3.4, §5, §16, §21 (V4 prerequisite results — STOP unless V4 confirms failure) |
+    42	| Run V1 (#364) | §3.10 item 1 + 3, §18, §22.3 audit rerun protocol |
+    43	| Run V2 (#291) | §3.9 Red Team top gap, §19 |
+    44	| Run V3 (#365) | §3.10 item 4, §20 |
+    45	| Run V4 (#366) | §3.4 Low-confidence rationale, §21 |
+    46	| Close the epic | §22, §25 (all 5 subsections), §26.1 protocol, §30 Changelog |
+    47	| Resume after a gap | §30 Changelog bottom to top + §6.1 phase table |
+    48	
+    49	If a phase says "read file X" as a substep, that overrides this map.
+    50	
+    51	### 0.4 Gate 0 discipline — always read before acting
+    52	
+    53	Before starting ANY phase work, run the bible's own Gate 0:
+    54	
+    55	1. Read the phase's section (from §0.3 map above).
+    56	2. For every `file:line` citation and code snippet in that section, verify it against current code (grep + Read). Line numbers drift; snippets drift.
+    57	3. If a citation is stale, substep 0 of the phase is: refresh the citations inline in the bible, commit, THEN start the code work. See §26.2 for protocol.
+    58	4. Run `gh issue view <phase-issue-N> --comments` and grep `.claude/knowledge/session-log.md` for `#<N>` per `validation-discipline.md §3`.
+    59	
+    60	Hooks enforce some of this (`check-issue-prior-context.sh`, `gate-gh-issue-view.sh`). The bible adds the snippet-verification step on top.
+    61	
+    62	### 0.5 Rule of this document
+    63	
+    64	One plan file. One epic. All phases live here. Per-phase plans previously kept as standalone files (#196, #195, #290) are referenced and kept for council audit trail, but their canonical content now lives in §7 / §8 / §14. If a phase grows past ~400 lines of bible section, extract to a standalone file per §26.3.
+    65	
+    66	### 0.6 Rule inheritance
+    67	
+    68	Every phase inherits `.claude/rules/workflow-process.md`, `validation-discipline.md`, `architecture-rules.md`, `swift-patterns.md`, `session-behavior.md`, `tools-and-apps.md`. This document cites the sections that govern each phase, does not restate them. Workflow gates (Gate 0 prior-context, Gate 0.5 user rubric, Gate 1 intent, council, Gate 2 sign-off, codex) apply per phase unless the enumerated zero-blast-radius exception in `workflow-process.md §1` fires.
+    69	
+    70	### 0.7 User Rubric scope
+    71	
+    72	Hardening & Refactors is internal; no user-visible surface. User Rubric is N/A for every phase except Phase B (§8), which introduces the visible "applies on next recording" behavior shift and MUST answer the rubric locally before ship.
+    73	
+    74	---
+    75	
+    76	## 1. Executive context
+    77	
+    78	### 1.1 What drove this epic
+    79	
+    80	The 2026-04-18 senior audit (Codex CLI, `gpt-5-class` model, `reasoning_effort="high"`, structured JSON output via JSON Schema; full artifact at `docs/audits/2026-04-18-senior-audit.json`, full mechanics at `.claude/knowledge/codex-audit.md`). The audit answered one question: **is this production-grade senior engineering, or AI slop?** Verdict: **grade C, Medium confidence, "not AI slop"**, with six concrete refactor targets and a Red Team self-critique flagging a runtime validation gap the static audit could not close.
+    81	
+    82	### 1.2 What grade C means
+    83	
+    84	Operationally, per the anchored scoring rubric established in round-1 council review:
+    85	
+    86	- **A** Exemplary, template-quality, would pass review at a top-tier Swift product org.
+    87	- **B** Production-ready. Solid work; minor non-blocking suggestions only.
+    88	- **C** Shippable with follow-up. Works, but tracked tech debt that must be addressed.
+    89	- **D** Conditional. Significant flaws. Do not merge without addressing.
+    90	- **F** Blocked. Fundamentally unsafe or broken. Rewrite or redesign required.
+    91	
+    92	Grade C is acceptable for a shipping product; it is not acceptable as a ceiling. This epic moves the grade upward by resolving the enumerated debts, and closes with a re-run of the same audit under the same conditions so the delta is measurable (per `.claude/knowledge/codex-audit.md` `RULE: diff-across-runs`).
+    93	
+    94	### 1.3 What "done" looks like
+    95	
+    96	Epic close requires all ship criteria in §25 to hold, including a re-run audit showing movement on Architecture integrity, Code Hygiene & Maintainability, and API surface (the three letter-graded dimensions that carried findings), and confirmation or downgrade of the three Static Risk dimensions (Performance, Resource lifecycle, Security & privacy) via Track 2 runtime validation.
+    97	
+    98	### 1.4 What the audit found, in brief
+    99	
+   100	Per-dimension grades and worst violations are reproduced in full in §3. Summary:
+   101	
+   102	| Dimension | Grade | Worst violation |
+   103	|---|---|---|
+   104	| Architecture integrity | B | `AppState.swift:316-321` — 5-way custom-words fanout |
+   105	| Concurrency discipline | B | None found (best example: `PreRollForwarder` RT lock discipline) |
+   106	| Error handling & observability | **A** | None found (best example: Sentry breadcrumb redaction) |
+   107	| Testability | B | `AppState.swift:18-23` — 11 direct concrete-type property declarations |
+   108	| Code Hygiene & Maintainability | C | Same `AppState.swift:316-321` fanout |
+   109	| API surface | C | `WhisperKitBackend.swift:155-158` — confessed-temporary public widening |
+   110	| Performance & latency (Static Risk) | Medium Risk | `AppState.swift:394-398` — transcript reload on every `.complete` |
+   111	| Resource lifecycle (Static Risk) | Medium Risk | `AudioCaptureManager.swift:525-530` — unbounded `bt-route.log` append |
+   112	| Security & privacy (Static Risk) | Medium Risk | `TextProcessingRunner.swift:32-36` — raw transcript in always-on log |
+   113	
+   114	`AppState` (965 lines) carries the worst violation in three letter-graded dimensions; decomposing it is the structural centerpiece of the epic. Every other finding is smaller and local.
+   115	
+   116	### 1.5 Why the founder opened this
+   117	
+   118	Saurabh's phrasing: *"limbs have grown pretty large, act as their own little mini hearts with their own mini limbs."* The audit independently confirmed the instinct. The epic turns instinct into plan.
+   119	
+   120	---
+   121	
+   122	## 2. Philosophy — the laws this epic protects
+   123	
+   124	These laws come from `.claude/rules/architecture-rules.md`. Repeating the short form here for navigation; the rule file is canonical.
+   125	
+   126	### 2.1 Heart and Limbs
+   127	
+   128	**Heart:** `trigger → audio capture (including pre-roll drain when engine is warm) → ASR → text finalization → clipboard/paste`. Must always complete.
+   129	
+   130	**Limbs:** custom words, filler removal, LLM polish, any post-processing not required for raw transcription. May improve output. MUST NOT block output. Fail-open with timeout + fallback to raw text.
+   131	
+   132	**Every refactor in this epic preserves heart completion.** No phase's rollback may leave the heart broken. Each phase has its own Rollback subsection that restates this (e.g., §7.5 for Phase A, §9.5 for Phase C, §10.5 for Phase D).
+   133	
+   134	### 2.2 Anti-god-object
+   135	
+   136	A type is at risk if it:
+   137	- knows too many unrelated domains
+   138	- is imported almost everywhere
+   139	- becomes the default location for new logic
+   140	- owns state AND orchestration AND business rules
+   141	- grows mainly because it is convenient
+   142	- is hard to describe in one sentence
+   143	
+   144	`AppState` hits all six. This epic resolves it.
+   145	
+   146	### 2.3 Intentional duplication
+   147	
+   148	`TranscriptionPipeline` and `WhisperKitPipeline` stay separate. This is a deliberate stability decision; the rule file explicitly forbids collapsing them. Phase D (custom-words propagator) honors this by broadcasting to both, not unifying them.
+   149	
+   150	### 2.4 Access control — narrow by default
+   151	
+   152	`public` is expensive. Any widening must be justified. `WhisperKitBackend.makeDecodeOptions` (the R2 finding) is a TODO-confessed violation. R2 narrows it.
+   153	
+   154	### 2.5 State ownership
+   155	
+   156	State lives near the domain that owns it — not centralized because many layers read it. Phase C moves transcript history ownership to `TranscriptCoordinator` where it belongs, not `AppState`.
+   157	
+   158	### 2.6 Module dependency direction
+   159	
+   160	```
+   161	App / Views / top-level coordination
+   162	        ↓
+   163	Pipeline / feature orchestration
+   164	        ↓
+   165	Features / LLM / ASR / Audio
+   166	        ↓
+   167	Core (shared models, constants, value types, narrow protocols)
+   168	```
+   169	
+   170	Historical script `scripts/check-dependency-direction.sh` existed under the now-deprecated brain system; verified removed as of 2026-04-18. `.git/hooks/pre-commit` is a no-op stub (`exit 0`) carrying the deletion's historical comment. No CI workflow or Claude-level hook enforces dep direction today.
+   171	
+   172	Until Phase E (§11) re-introduces automated enforcement, dep direction is enforced by: (a) manual review on architecture-touching PRs, and (b) Swift Package Manager's implicit module-graph errors (cyclic imports fail to compile). Every new type in this epic's phase plans justifies its module placement.
+   173	
+   174	---
+   175	
+   176	## 3. The 2026-04-18 Senior Audit — reproduced for fresh sessions
+   177	
+   178	Full artifact at `docs/audits/2026-04-18-senior-audit.json`. This section reproduces the six refactor findings with complete evidence contracts so a fresh session can work without re-reading the JSON. The evidence contract was round-2 council-hardened (quoted snippet + severity + confidence + counterfactual + rationale + falsifiability + interleaving-if-concurrency).
+   179	
+   180	### 3.1 REF-01 — Decompose AppState into focused coordinators
+   181	
+   182	- **Title:** Decompose AppState into focused coordinators and remove manual cross-domain fanout
+   183	- **Dimension:** Architecture integrity
+   184	- **Tier:** REFACTOR · **Severity:** HIGH · **Confidence:** High · **Est. LOC delta:** 450
+   185	- **Rule violated:** `.claude/rules/architecture-rules.md §Anti-God-Object / Hard rule; §Architecture Definition of Done / Anti-god-object`
+   186	- **Worst-violation location (architecture + code hygiene):** `Sources/EnviousWispr/App/AppState.swift:316-321`
+   187	- **Snippet (verbatim):**
+   188	
+   189	  ```swift
+   190	  customWordsCoordinator.onWordsChanged = { [weak self] words in
+   191	    guard let self else { return }
+   192	    self.pipeline.wordCorrection.customWords = words
+   193	    self.pipeline.llmPolish.customWords = words
+   194	    self.whisperKitPipeline.wordCorrection.customWords = words
+   195	    self.whisperKitPipeline.llmPolish.customWords = words
+   196	  ```
+   197	
+   198	  (Closure continues through `polishService.llmPolishStep.customWords = words`. Five consumers total.)
+   199	
+   200	- **Testability worst violation (same root cause):** `AppState.swift:18-23`, 11 direct concrete-type property declarations (`PermissionsService`, `TranscriptStore`, `KeychainManager`, `HotkeyService`, `BenchmarkSuite`, `RecordingOverlayPanel`, `OllamaSetupService`, `WhisperKitSetupService`, `AudioDeviceList`, `CaptureTelemetryState`, plus the interface-typed `audioCapture` and `asrManager`).
+   201	- **Counterfactual:** Extract custom-word propagation into one pipeline-owned configuration object or broadcaster. Give `AppState` one high-level write instead of four direct mutations. Keep per-backend wiring inside the pipeline layer where the backend differences already live.
+   202	- **Counterfactual rationale:** Matches the thin-coordinator pattern already used in `Sources/EnviousWisprAudio/AudioCaptureManager.swift:L6-L15`.
+   203	- **Falsifiability:** Add one more custom-word-aware post-processing step, update only the Parakeet branch, then record once with Parakeet and once with WhisperKit. Divergent word-correction behavior exposes the architectural split-brain immediately.
+   204	- **Audit `depends_on`:** none upstream; REF-05 depends on REF-01.
+   205	- **Phase(s) addressing:** A (#196, already drafted), B (#195, already drafted), C (new §9), D (new §10), E (new §11).
+   206	
+   207	### 3.2 REF-02 — Hide WhisperKit internals behind a narrow adapter
+   208	
+   209	- **Title:** Hide WhisperKit internals behind a narrow adapter and remove convenience public API
+   210	- **Dimension:** API surface
+   211	- **Tier:** MEDIUM · **Severity:** HIGH · **Confidence:** High · **Est. LOC delta:** 120
+   212	- **Rule violated:** `.claude/rules/architecture-rules.md §Access Control; §Architecture Definition of Done / API surface`
+   213	- **Worst-violation location:** `Sources/EnviousWisprASR/WhisperKitBackend.swift:155-158`
+   214	- **Snippet (verbatim):**
+   215	
+   216	  ```swift
+   217	  // public: called by WhisperKitPipeline in EnviousWisprPipeline (cross-module boundary).
+   218	  // TODO: Phase 2 — narrow to package once Pipeline moves into the same SPM package.
+   219	  public func makeDecodeOptions(from options: TranscriptionOptions, sampleCount: Int)
+   220	    -> DecodingOptions
+   221	  ```
+   222	
+   223	- **Actual cross-module reach (grep confirmed):** `Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1150`, `1154`, `1155`.
+   224	  - Line 1150: `await backend.makeDecodeOptions(from: transcriptionOptions, sampleCount: 0)`
+   225	  - Line 1154: `await backend.whisperKitTokenizer`
+   226	  - Line 1155: `WhisperKitIncrementalWorker(whisperKit: kit, decodingOptions: opts, tokenizer: tokenizer)`
+   227	- **Note (new, not in audit):** `WhisperKitIncrementalWorker` already lives in `Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift` as a `public actor`. The leak is three `public` items on `WhisperKitBackend` + the worker's public constructor, all consumed at the same call site in `WhisperKitPipeline`.
+   228	- **Counterfactual:** Move the tail-decode helper behind an internal adapter in the same package as the pipeline, or relocate the incremental worker into the ASR module. Remove public access to backend internals and expose only the operation the pipeline actually needs.
+   229	- **Counterfactual rationale:** Restores the narrow-boundary style already present in `Sources/EnviousWisprASR/ASRManagerInterface.swift:L4-L9`.
+   230	- **Falsifiability:** Make `makeDecodeOptions` internal and rebuild `EnviousWisprPipeline`. The compile break pinpoints every place where cross-module convenience exposure hardened into dependency.
+   231	- **Phase addressing:** R2 (#360, new §12).
+   232	
+   233	### 3.3 REF-03 — Remove raw transcript from always-on logs
+   234	
+   235	- **Title:** Remove raw transcript content from the always-on logging path
+   236	- **Dimension:** Security & privacy (Static Risk Assessment)
+   237	- **Tier:** SMALL · **Severity:** HIGH · **Confidence:** Medium · **Est. LOC delta:** 40
+   238	- **Rule violated:** No-PII policy (`.claude/knowledge/accounts-licensing.md §Analytics Privacy / Events Never Collected`)
+   239	- **Worst-violation location:** `Sources/EnviousWisprPipeline/TextProcessingRunner.swift:32-36`
+   240	- **Snippet (verbatim):**
+   241	
+   242	  ```swift
+   243	  Task {
+   244	    await AppLogger.shared.log(
+   245	      "CORRECTION_DEBUG [RAW ASR] \(rawText)",
+   246	      level: .info, category: "CorrectionDebug"
+   247	    )
+   248	  ```
+   249	
+   250	- **Confidence caveat from audit:** "The code logs raw transcript text, and `AppLogger` documents that OSLog entries are always emitted and visible in Console.app. Static review does not prove release-log collection policy or OSLog presentation details on every macOS build." (Hence Medium.)
+   251	- **Counterfactual:** Strip transcript bodies from always-on logs and replace them with lengths, hashes, and step names. Gate full text behind an explicit local debug-only sink with a hard-off default. Put redaction in `AppLogger` so call sites cannot bypass it by accident.
+   252	- **Counterfactual rationale:** Follows the redact-before-export pattern already used in `Sources/EnviousWisprServices/ObservabilityBootstrap.swift:L101-L106`.
+   253	- **Falsifiability:** Dictate a unique secret-like string, run a build with correction logging enabled, then inspect Console.app or `log stream` for subsystem `com.enviouswispr.app`. If the dictated text appears verbatim, the privacy boundary is broken.
+   254	- **Phase addressing:** R3 (#361, new §13).
+   255	
+   256	### 3.4 REF-04 — Harden prompt delimiter escaping (LOW confidence, gated)
+   257	
+   258	- **Title:** Harden prompt transcript delimiter escaping and add adversarial corpus coverage
+   259	- **Dimension:** Security & privacy (Static Risk Assessment)
+   260	- **Tier:** SMALL · **Severity:** MEDIUM · **Confidence:** **Low** · **Est. LOC delta:** 60
+
+exec
+/bin/zsh -lc "nl -ba .claude/rules/architecture-rules.md | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	---
+     2	paths:
+     3	  - "Sources/**"
+     4	  - "Package.swift"
+     5	---
+     6	
+     7	# Architecture Rules — EnviousWispr
+     8	
+     9	## The Laws (always apply)
+    10	
+    11	1. **Heart path is sacred** — no optional feature may prevent raw transcription from completing.
+    12	2. **Modules are real boundaries** — not folder decoration. Do not treat them as suggestions.
+    13	3. **Convenience is not justification** — "easy to wire here" is not a valid placement reason.
+    14	4. **New shared objects are guilty until proven innocent** — any new manager/coordinator/container/context/singleton must justify its existence.
+    15	5. **Duplication is allowed when it protects independence** — do not force-unify intentionally separate components.
+    16	6. **Structural drift is a bug** — architecture regression is correctness debt, not style debt.
+    17	7. **Shortcuts must be declared** — temporary compromises must be called out in the change summary.
+    18	
+    19	## Module Boundaries
+    20	
+    21	### Dependency direction
+    22	
+    23	```
+    24	App / Views / top-level coordination
+    25	        ↓
+    26	Pipeline / feature orchestration
+    27	        ↓
+    28	Features / LLM / ASR / Audio
+    29	        ↓
+    30	Core (shared models, constants, value types, narrow protocols)
+    31	```
+    32	
+    33	Low-level code must NOT import upward. No exceptions.
+    34	
+    35	### Core rules
+    36	
+    37	Core is for: shared models, constants, value types, small utilities, narrow protocols.
+    38	
+    39	Core must NOT contain: business logic, feature logic, UI state, app wiring, "shared for now" hacks.
+    40	
+    41	Red flag — reject a Core addition if it: imports UI frameworks, knows about AppState, knows about views, coordinates multiple domains, or exists mainly because two higher layers want easy access.
+    42	
+    43	### App shell rules
+    44	
+    45	- DO: compose subsystems, own top-level startup/lifecycle, coordinate user-triggered flows.
+    46	- DO NOT: absorb domain logic for convenience, directly implement feature logic that belongs in modules, take ownership of audio/ASR/LLM internals.
+    47	
+    48	### Pipeline rules
+    49	
+    50	- DO: sequence work, enforce timing/fallback contracts, choose flow branches, gather telemetry.
+    51	- DO NOT: become a junk drawer for unrelated business logic, absorb feature implementation details, become the new god object after AppState is slimmed.
+    52	
+    53	### Feature module rules
+    54	
+    55	- Features own their internal behavior.
+    56	- Features must NOT: reach upward into AppState/view state, manipulate clipboard/paste unless explicitly designated, depend on unrelated feature internals.
+    57	
+    58	## Anti-God-Object
+    59	
+    60	God objects reappear as: coordinator, manager, container, runtime, environment, context, registry, service hub.
+    61	
+    62	### Smell test — a type is at risk if it:
+    63	- knows too many unrelated domains
+    64	- is imported almost everywhere
+    65	- becomes the default location for new logic
+    66	- owns state AND orchestration AND business rules
+    67	- grows mainly because it is convenient
+    68	- is hard to describe in one sentence
+    69	
+    70	### Hard rule
+    71	If a type coordinates more than one domain, it must stay thin: delegates real work downward, owns minimal state, exposes narrow surface, has a crisp reason to exist.
+    72	
+    73	If a central file grew meaningfully, the reason must be explicit. Create a follow-up bead with extraction target if deferring.
+    74	
+    75	## Heart & Limbs
+    76	
+    77	**Heart** = `trigger → audio capture (including pre-roll drain when engine is warm) → ASR → text finalization → clipboard/paste`. Must always complete.
+    78	
+    79	**Limbs** = custom words, filler removal, LLM polish, any post-processing not required for raw transcription. May improve output. May NOT block output.
+    80	
+    81	### Placement questions (answer before adding any feature)
+    82	1. Is this heart or limb?
+    83	2. Which module owns it?
+    84	3. What does it depend on?
+    85	4. What is its failure mode?
+    86	5. Can the heart continue if it fails?
+    87	
+    88	If answers are fuzzy, placement is not ready.
+    89	
+    90	### Limb constraints
+    91	- Must not root into app-wide state, windowing/UI state, or paste orchestration.
+    92	- Must support: timeout budget, failure isolation, unchanged-text fallback.
+    93	- Must not consume system resources (RAM, GPU, Metal) in a way that can degrade heart infrastructure. Discovered 2026-04-15: Ollama dual-model residency (17 GB) collapsed the BT CoreAudio HAL, zombying our AVAudioEngine tap. Fix: evict the previous model (`keep_alive: 0`) before loading the new one.
+    94	
+    95	## Intentional Duplication
+    96	
+    97	`TranscriptionPipeline` and `WhisperKitPipeline` staying separate is an intentional stability decision.
+    98	
+    99	Do NOT collapse intentionally separate pipelines into a "cleaner" abstraction unless:
+   100	- new evidence proves the old risk is gone
+   101	- migration plan is explicit
+   102	- rollback is clear
+   103	- validation scope is defined in advance
+   104	
+   105	**Abstraction is not automatically an improvement.** If separation protects runtime stability, separation wins.
+   106	
+   107	## State Ownership
+   108	
+   109	- State lives near the domain that owns it — do not centralize just because many layers read it.
+   110	- Keep clear separation: UI/view state, workflow coordination state, domain runtime state, persisted settings, historical data.
+   111	- `AppState` must not become the permanent destination for new unrelated logic.
+   112	
+   113	Before adding to AppState, ask: Is this truly top-level coordination? Can it move to a more local owner? Does this increase coupling? Does this make AppState the easiest place to keep adding things? If the last two are yes — stop and redesign.
+   114	
+   115	## Access Control
+   116	
+   117	- Use the narrowest visibility that works. `public` is expensive.
+   118	- Any visibility widening must be justified in the change summary.
+   119	- Do NOT expose deep engine internals just because cross-module access is inconvenient. Wrap, adapt, or relocate.
+   120	
+   121	## Audio/ASR Danger Zones
+   122	
+   123	Audio is crash-prone and device-sensitive. ASR is memory-heavy and lifecycle-sensitive.
+   124	
+   125	When touching Audio or ASR code, optimize for:
+   126	- **Stability over elegance**
+   127	- **Blast-radius reduction** — minimize what breaks if this change fails
+   128	- **Rollback clarity** — can this be reverted cleanly?
+   129	- **Measured performance impact** — attach evidence where feasible
+   130	
+   131	If a change increases coupling between app shell and volatile engine internals, that is a warning sign.
+   132	
+   133	`PreRollForwarder.route()` runs on the audio thread under `OSAllocatedUnfairLock`. Lock hold time must stay minimal (memcpy or pointer copy only). Never run callbacks, logging, or allocations under the lock. Getting this wrong causes priority inversion and audio glitches.
+   134	
+   135	## Temporary Shortcuts
+   136	
+   137	A temporary architecture compromise must be disclosed. Change summary must include:
+   138	- What the shortcut is
+   139	- Why it was taken now
+   140	- The intended future placement or extraction
+   141	- Whether it increases coupling or API surface
+   142	
+   143	No invisible debt. Do not bury shortcuts inside otherwise clean summaries.
+   144	
+   145	## Architecture Definition of Done
+   146	
+   147	Applies when work: adds/changes modules or targets, changes dependency direction, introduces a new coordinator/manager/container/context, adds a feature step, changes state ownership, touches AppState/Pipeline/Audio/ASR/LLM/service boundaries, changes cross-module visibility, or moves logic across layers.
+   148	
+   149	### Checklist
+   150	
+   151	**Placement and ownership**
+   152	- [ ] New/changed logic lives in the correct module
+   153	- [ ] Ownership choice explained in 1-2 sentences
+   154	- [ ] No lower-level module imports upward
+   155	
+   156	**Heart protection**
+   157	- [ ] Critical path still completes if optional work fails
+   158	- [ ] Optional features have defined failure behavior
+   159	- [ ] No new enhancement can silently block raw output
+   160	
+   161	**Anti-god-object**
+   162	- [ ] No coordinator/manager/container absorbed domain logic for convenience
+   163	- [ ] No central file became the default dumping ground
+   164	- [ ] If a central file grew meaningfully, reason is explicit
+   165	
+   166	**API surface**
+   167	- [ ] Access control is the narrowest practical level
+   168	- [ ] New `public` exposure is justified
+   169	- [ ] No deep internals leaked for cross-module convenience
+   170	
+   171	**Boundary integrity**
+   172	- [ ] Dependency direction remains valid
+   173	- [ ] No circular target dependency introduced
+   174	- [ ] App/view types did not leak downward
+   175	
+   176	**Validation**
+   177	- [ ] Build / relaunch / UAT checks were run
+   178	- [ ] Architecture-sensitive changes include brief audit note
+   179	- [ ] Any untested edge is named honestly
+   180	- [ ] If change crosses module boundaries or introduces new coordinator/manager: `/ask-gpt` architecture review completed
+   181	
+   182	**Debt disclosure**
+   183	- [ ] Any temporary shortcut is stated explicitly
+   184	- [ ] Any follow-up extraction or tightening work is named
+   185	
+   186	## Architecture Closeout Format
+   187	
+   188	For architecture-relevant work, include in bead closure:
+   189	
+   190	```
+   191	### Architecture Closeout
+   192	- Module/owner chosen: ...
+   193	- Why this placement is correct: ...
+   194	- Whether any central type grew: ...
+   195	- Whether access control widened: ...
+   196	- Whether any temporary compromise remains: ...
+   197	- Whether dependency direction remains clean: ...
+   198	```
+   199	
+   200	## Self-review before finalizing
+   201	
+   202	Work through the DoD Checklist above as a questionnaire. If any section feels uncertain, invoke `/ask-gpt` for architecture feedback before proceeding.
+
+exec
+/bin/zsh -lc "rg -n \"4\\.13|17\\.|BenchmarkCoordinator|TelemetryObservationCoordinator|concrete deps|≤ 12|SetupCoordinator\" docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+30:| Execute Phase E | §3 (audit meta-rec #1), §4.9 + §4.13, §11, §24 rows #15/#20, §25.3 |
+31:| Execute Phase F (NEW v1.3) | §2, §4.1, §4.13 disposition matrix, §5, §17, §24 rows #12/#18 |
+499:**Target after Phases A + C + D:** ≤ 8 direct concrete-type property declarations. Larger reduction if the epic decides to delegate setup services (ollamaSetup, whisperKitSetup) into a new `SetupCoordinator` — track that as a Phase E candidate (§11).
+517:### 4.13 AppState disposition matrix — every owned dependency's fate
+530:| 8 | `benchmark = BenchmarkSuite()` | 24 | **STAYS (post-epic candidate)** | Could move to a BenchmarkCoordinator; not in this epic. |
+532:| 10 | `ollamaSetup = OllamaSetupService()` | 26 | **MOVES → SetupCoordinator** (Phase F, new in v1.3) | Setup orchestration is a cohesive domain; extracting gets AppState closer to target. |
+533:| 11 | `whisperKitSetup = WhisperKitSetupService()` | 27 | **MOVES → SetupCoordinator** (Phase F) | Same. Co-owned by SetupCoordinator with ollamaSetup. |
+539:Plus architectural fixtures that aren't counted in "direct concrete deps" because they are either pipelines (peers, not owned state) or injected via composition:
+546:- **Before epic:** 15 owned concrete deps.
+548:- **After Phase F:** 12 (ollamaSetup + whisperKitSetup → SetupCoordinator, but add 1 dep on the new SetupCoordinator itself; net -1).
+549:- **Target:** ≤ 12 direct concrete deps (Phase E regression test calibrated here).
+551:Phase E previously targeted ≤ 8. That target was wrong given the disposition matrix. Revised target ≤ 12 documented in §11.
+623:| **F** | SetupCoordinator extraction (NEW v1.3) | 1 | MEDIUM | #501 | PLANNED §17 | ~+200 net (revised v1.6) |
+1373:1. **AppState property-count ceiling.** Number of direct concrete-type stored properties on `AppState` exceeds the target. Verified 2026-04-18 baseline: 15 (§4.13). Target after Phases A+C+D+F: ≤ 12. This is the *architectural* signal, not the line count. Target revised from ≤ 8 in v1.2 because the §4.13 disposition matrix made the original target unachievable without unbundling stable concerns. A ≤ 10 target is reachable with post-epic BenchmarkCoordinator + TelemetryObservationCoordinator extractions (not in this epic).
+1411:    #expect(count <= 12, "AppState has \(count) direct owned concrete dependencies; epic target is ≤ 12 after Phases A+C+D+F (§4.13 matrix).")
+1469:1. After Phase A lands, measure baselines (line count, concrete-dep count). Expect ~760 lines, 11 concrete deps.
+1470:2. After Phases C+D land, measure again. Expect ~500-550 lines, ≤ 8 concrete deps.
+2068:## 17. Phase F — SetupCoordinator extraction (NEW v1.3)
+2071:**Pattern:** Extract Class (Fowler) — cohesive cluster of setup-orchestration concerns moves out of AppState · **Tier:** MEDIUM · **Est. LOC delta:** +~200 net (SetupCoordinator ~100, AppState −~30, view migrations +~100-150 across 5+ files). Original v1.3 estimate of +~90 undercounted view migration; corrected 2026-04-18 after adversarial view-surface grep.
+2073:### 17.1 Why this phase exists
+2075:Added in v1.3 after the §4.13 disposition matrix made clear that Phases A+C+D alone would take AppState from 15 deps to 14 — nowhere near meaningful testability improvement. Extracting the setup-service cluster (`ollamaSetup`, `whisperKitSetup`, plus the `whisperKitPreloadTask` observation wiring that drives them) into a dedicated coordinator takes the count to 12 and clusters a genuinely cohesive domain.
+2079:### 17.2 Scope
+2081:New `@MainActor final class SetupCoordinator` in `Sources/EnviousWispr/App/SetupCoordinator.swift`. Owns:
+2090:The current preload observer at `AppState.swift:647` reads `asrManager.activeBackendType` at line 657 and calls `whisperKitPipeline.prepareBackendSilently()` at line 662. `SetupCoordinator` as zero-arg `let setup = SetupCoordinator()` is INSUFFICIENT — it needs these collaborators injected. Corrected init shape:
+2094:final class SetupCoordinator {
+2111:AppState constructs it AFTER `asrManager` and `whisperKitPipeline` are ready (init-order constraint documented). The preload action is a closure so `SetupCoordinator` doesn't need to know about the pipeline's full interface — just one method.
+2126:AppState drops `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` direct properties and gains one: `let setup = SetupCoordinator()` (or injected via composition for test seams).
+2128:### 17.3 Substeps (ordered)
+2153:3. Define `SetupCoordinator` concrete class. Move `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` ownership. Preserve their current `@Observable` surfaces intact.
+2154:4. Update AppState: replace three fields with one `setup = SetupCoordinator()` field.
+2158:8. Unit test: `SetupCoordinator` can be constructed without AppState; `startWhisperKitPreloadObservation` starts and can be cancelled. **Codex F-review 2026-04-18 prerequisite:** `Package.swift:107` does NOT include the `EnviousWispr` executable target as a test dependency; `EnviousWisprTests` cannot import `SetupCoordinator` as-is. The test requires either (a) adding `EnviousWispr` to test target deps in `Package.swift`, OR (b) extracting `SetupCoordinator` into a library target that tests can depend on. Recommendation: (a) — smaller blast radius. With the seam (injectable `asrManager` + `preloadAction` closure per §17.2), the test can force a fake non-ready state, assert observer start/cancel, and assert `preloadAction` is invoked. No real HTTP or model downloads.
+2161:### 17.3.1 Protocol surface — RESOLVED (no `reset()`)
+2163:Codex plan review 2026-04-18 flagged self-contradiction between §17.2 (earlier draft included `reset()` in the protocol sketch) and §17.3.1 (dropped `reset()`). Locked in v1.6: the `SetupCoordinating` protocol does NOT expose `reset()`. No current caller needs it. §17.2 sketch above is the canonical protocol shape. If future work needs reset-on-account-switch or similar, add it then with a concrete caller.
+2165:### 17.4 DoD
+2168:- [ ] `SetupCoordinator.swift` + `SetupCoordinating` protocol committed.
+2175:### 17.5 Rollback
+2179:### 17.6 Dependencies
+2183:### 17.7 Post-epic candidates (not in Phase F scope)
+2185:§4.13 identified two other extraction candidates that are NOT in this epic:
+2186:- **BenchmarkCoordinator** absorbing `benchmark = BenchmarkSuite()`.
+2187:- **TelemetryObservationCoordinator** absorbing `captureTelemetry = CaptureTelemetryState()` observer wiring.
+2538:**Sequencing collision — B × F (Codex plan review 2026-04-18):** Phase B and Phase F BOTH edit `AppState.swift` AND `PipelineSettingsSync.swift`. Phase B removes settings cases (frozen-per-recording move to `DictationSessionConfig`). Phase F extracts setup services — and `PipelineSettingsSync` has an `onNeedsPreloadObservation` callback Phase F rewires through `SetupCoordinator`. Running them in parallel worktrees creates near-certain conflicts on both files. **B ships first; F branches off post-B main. Not parallel.** Prior v1.3-v1.5 marked these as parallel; that was wrong.
+2541:- After Phase B main-green: ship Phase F (SetupCoordinator extraction). Sequential, not parallel.
+2668:- [ ] Phase F merged — SetupCoordinator extracted; AppState sheds ollamaSetup + whisperKitSetup + preload task ownership.
+2936:  **Unblocked next.** Per §6.3 dependency graph: Phase E (architecture-regression tests) ready — should add a fitness test asserting AppState init wires all 5 known custom-words consumers via the new `wireCustomWords` helper. Phase F (SetupCoordinator) independent of Phase D; available. R2 (WhisperKitBackend adapter) independent.
+2991:  - **D7 re-scoped.** Codex flagged as single decision most likely to regret — under-bounded. `SetupCoordinator` does not exist in current tree (Phase F will build it; decision should be "build in library target from day one," not "extract"). WhisperKit bridge types already in `EnviousWisprASR` non-exec target — no action needed. Real extraction candidate is `TranscriptCoordinator` in Phase C if coordinator-level testing requires.
+3005:  - **D7 — Extract to library targets.** Rather than adding executable-target deps to `EnviousWisprTests` in `Package.swift`, extract `SetupCoordinator` (Phase F) and WhisperKit bridge types (Phase R2) into library targets. Correct SPM architecture; importing app executable into tests is an anti-pattern.
+3065:  - `SetupCoordinator` MUST accept two collaborators as init params: `asrManager: any ASRManagerInterface` (for `activeBackendType` reads) and `preloadAction: @MainActor () async -> Void` (wraps `whisperKitPipeline.prepareBackendSilently()`). Zero-arg init was wrong. Documented init shape in §17.2.
+3066:  - Init-order constraint: `SetupCoordinator` must be constructed AFTER `asrManager` and `whisperKitPipeline` are ready.
+3067:  - Test prerequisite: `Package.swift:107` doesn't include `EnviousWispr` executable target in `EnviousWisprTests` deps. Tests can't import `SetupCoordinator` as-is. Either (a) add `EnviousWispr` to test deps, OR (b) extract coordinator into a library target. Recommend (a). Without one of these, substep 8's unit test can't run.
+3110:  - §17.2 Phase F — self-contradicting protocol sketch (§17.2 had `reset()` + semantic accessors, §17.3.1 removed `reset()`). Locked in v1.6 as property-passthrough protocol without `reset()`. Matches §17.3 substep 2 Option A (recommended).
+3153:  - All custom types the bible claims as NEW (`PipelineStateChangeHandler`, `CustomWordsPropagator`, `CustomWordsConsumer`, `RotatingFileSink`, `SetupCoordinator`, `WhisperKitDecodeBridge`, `DictationSessionConfig`, `PromptDelimiterSanitizer`, `HeartPathTelemetryEmitter`, `PipelineStateProtocol`, `PipelineActivity`, `SetupCoordinating`) are verified ABSENT — no name collisions.
+3165:  - §11.2 Phase E — property-count regex `^  let x = Type()` missed arg-bearing constructors like `let x = Type(arg: value)`. Regex expanded to match both forms. Also: file path resolution switched from bare relative path (broken under different test runners) to `#filePath`-based resolution. Concrete-dep count target held at ≤12 per §4.13 disposition matrix.
+3170:  - §17.3 Phase F — substep 1 rewritten to require full view-surface grep BEFORE protocol design. Protocol surface follows inventory, not vice versa. §17.3.1 dropped `reset()` method (scope creep without caller).
+3177:  - §4.13 Disposition matrix.
+3186:  - §4.13 NEW — AppState disposition matrix. Every one of the 15 owned concrete-type deps now has an explicit fate (STAYS / MOVES-to-X / post-epic-candidate). Prior bible was vague; fresh session had to reverse-engineer from other sections. Fate trajectory: 15 → 14 (Phase C) → 12 (Phase F).
+3190:  - §17 NEW — Phase F, SetupCoordinator extraction. Extracts `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` out of AppState. Added because §4.13 revealed that Phases A+C+D alone only take AppState from 15 deps to 14 — nowhere near meaningful Testability improvement. Phase F gets to 12.
+3191:  - §11.2 Phase E target revised from ≤ 8 (unachievable per matrix) to ≤ 12 (honest, reachable by Phases A+C+D+F). Added note about post-epic BenchmarkCoordinator + TelemetryObservationCoordinator reaching ≤ 10 if needed.
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/AppState.swift | sed -n '1,760p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	import EnviousWisprASR
+     2	import EnviousWisprAudio
+     3	import EnviousWisprCore
+     4	import EnviousWisprLLM
+     5	import EnviousWisprPipeline
+     6	import EnviousWisprServices
+     7	import EnviousWisprStorage
+     8	import SwiftUI
+     9	
+    10	/// Root observable state for the entire application.
+    11	@MainActor
+    12	@Observable
+    13	final class AppState {
+    14	  // Settings
+    15	  var settings = SettingsManager()
+    16	
+    17	  // Sub-systems
+    18	  let permissions = PermissionsService()
+    19	  let audioCapture: any AudioCaptureInterface
+    20	  let asrManager: any ASRManagerInterface
+    21	  let keychainManager = KeychainManager()
+    22	  let hotkeyService = HotkeyService()
+    23	  let benchmark = BenchmarkSuite()
+    24	  let recordingOverlay = RecordingOverlayPanel()
+    25	  let ollamaSetup = OllamaSetupService()
+    26	  let whisperKitSetup = WhisperKitSetupService()
+    27	  let audioDeviceList = AudioDeviceList()
+    28	  let captureTelemetry = CaptureTelemetryState()
+    29	
+    30	  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
+    31	  private var whisperKitPreloadTask: Task<Void, Never>?
+    32	
+    33	  /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
+    34	  /// Cancelled when a new recording starts or a higher-priority notification is shown.
+    35	  private var postCompletionWarningTask: Task<Void, Never>?
+    36	
+    37	  // Pipelines — initialized after sub-systems
+    38	  let pipeline: TranscriptionPipeline
+    39	  let whisperKitPipeline: WhisperKitPipeline
+    40	
+    41	  // Phase A (#196) — per-pipeline state-change behavior absorbed from the
+    42	  // onStateChange closures. Each handler owns the effect execution; AppState
+    43	  // still owns the cross-pipeline warning Task + tiebreaker + hotkey ordering.
+    44	  // Lazy so the callback closures can capture `self` after stored-property
+    45	  // assignment completes. First access is inside `onStateChange`, well after
+    46	  // `init()` returns.
+    47	  @ObservationIgnored
+    48	  private lazy var parakeetStateHandler: PipelineStateChangeHandler = {
+    49	    makeStateChangeHandler(backendLabel: "parakeet")
+    50	  }()
+    51	  @ObservationIgnored
+    52	  private lazy var whisperKitStateHandler: PipelineStateChangeHandler = {
+    53	    makeStateChangeHandler(backendLabel: "whisperKit")
+    54	  }()
+    55	
+    56	  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
+    57	    PipelineStateChangeHandler(
+    58	      showOverlay: { [weak self] intent in
+    59	        guard let self else { return }
+    60	        self.recordingOverlay.show(
+    61	          intent: intent,
+    62	          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
+    63	          isRecordingLocked: self.isRecordingLocked
+    64	        )
+    65	      },
+    66	      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+    67	      schedulePolishFailedWarning: { [weak self] in
+    68	        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+    69	      },
+    70	      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
+    71	      reportDictationCompleted: { [weak self] t in
+    72	        guard let self else { return }
+    73	        TelemetryService.shared.reportDictationCompleted(
+    74	          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+    75	      },
+    76	      reportPipelineFailed: { msg in
+    77	        TelemetryService.shared.pipelineFailed(
+    78	          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+    79	          recoverable: false, backend: backendLabel)
+    80	      }
+    81	    )
+    82	  }
+    83	
+    84	  /// Standalone service for re-polishing saved transcripts from the detail view.
+    85	  /// Completely decoupled from pipeline state machines.
+    86	  let polishService: TranscriptPolishService
+    87	
+    88	  /// Forwards settings changes to pipelines and subsystems.
+    89	  private let settingsSync: PipelineSettingsSync
+    90	
+    91	  /// Called when pipeline state changes — set by AppDelegate for icon updates.
+    92	  var onPipelineStateChange: ((PipelineState) -> Void)?
+    93	
+    94	  // Transcript history — delegated to coordinator
+    95	  let transcriptCoordinator: TranscriptCoordinator
+    96	  var pendingNavigationSection: SettingsSection?
+    97	
+    98	  /// True when recording is in hands-free (locked) mode via double-press.
+    99	  /// Read by the overlay to switch to the expanded lips visual.
+   100	  var isRecordingLocked: Bool = false
+   101	
+   102	  /// Multilingual v1: latest passive-chip trigger emitted by LanguageDetector,
+   103	  /// if any. Observed by settings/overlay UI to offer a "Detected X. Lock it?"
+   104	  /// or "Language unstable. Lock language?" CTA. Nil when no chip is pending.
+   105	  /// UI consumers set this to nil after dismissing.
+   106	  /// TODO: wire a settings-level banner that presents this; current v1 ship is
+   107	  /// callback-only so chip events are not silently dropped.
+   108	  var pendingPassiveChip: PassiveChipTrigger?
+   109	
+   110	  // Feature #8: custom word management — delegated to coordinator
+   111	  let customWordsCoordinator = CustomWordsCoordinator()
+   112	
+   113	  /// Broadcasts custom-words changes to all registered consumers (pipelines'
+   114	  /// word-correction + polish steps, plus the re-polish service). Initialized
+   115	  /// at property declaration (no ctor dependencies); seeded with
+   116	  /// `customWordsCoordinator.customWords` in `init` before consumer
+   117	  /// registrations.
+   118	  let customWordsPropagator = CustomWordsPropagator()
+   119	
+   120	  // Model discovery — delegated to coordinator
+   121	  let llmDiscovery: LLMModelDiscoveryCoordinator
+   122	
+   123	  // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
+   124	  let aiAvailability = AIAvailabilityCoordinator()
+   125	
+   126	  init() {
+   127	    // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
+   128	    // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
+   129	    // Read directly from UserDefaults because `settings` is not yet available (stored
+   130	    // properties must all be initialized before `self` is accessible).
+   131	    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern
+   132	    // so existing installs (no key written) get the new default.
+   133	    let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
+   134	    if useXPC {
+   135	      audioCapture = AudioCaptureProxy()
+   136	    } else {
+   137	      audioCapture = AudioCaptureManager()
+   138	    }
+   139	
+   140	    // Phase 5: XPC ASR service — default ON (Stage F). ASR inference runs in a separate
+   141	    // XPC service process for memory isolation. Escape hatch: `defaults write ... useXPCASRService -bool false`
+   142	    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern.
+   143	    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
+   144	    if useXPCASR {
+   145	      asrManager = ASRManagerProxy()
+   146	    } else {
+   147	      asrManager = ASRManager()
+   148	    }
+   149	
+   150	    // Phase C (#428) — composition-root for transcript storage.
+   151	    // One `TranscriptStore` instance is constructed here and threaded
+   152	    // into every consumer (coordinator + both pipelines + polish service).
+   153	    // AppState does NOT retain this as a property; each consumer keeps
+   154	    // the reference it received via init. No accessor is exposed on the
+   155	    // coordinator; no consumer constructs its own. The shared-store
+   156	    // invariant is verifiable by grep: exactly one `TranscriptStore(`
+   157	    // call in `Sources/` outside `EnviousWisprStorage/TranscriptStore.swift`.
+   158	    let transcriptStore = TranscriptStore()
+   159	    // Production invariant: the app has always written transcripts to
+   160	    // AppConstants.appSupportURL/transcripts. Verified via grep 2026-04-20.
+   161	    // No legacy path, no group container, no iCloud. Phase C Invariant
+   162	    // safeguard #4 (Option B — plan §11): a concrete migrator would be a
+   163	    // no-op, so we rely on the default init's directory-create-on-miss
+   164	    // plus founder dogfood (safeguard #3) to catch any future path shift.
+   165	    transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+   166	    llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
+   167	
+   168	    // Both pipeline properties must be initialized before `self` can be used.
+   169	    // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
+   170	    pipeline = TranscriptionPipeline(
+   171	      audioCapture: audioCapture,
+   172	      asrManager: asrManager,
+   173	      transcriptStore: transcriptStore,
+   174	      keychainManager: keychainManager,
+   175	      captureTelemetry: captureTelemetry
+   176	    )
+   177	    // W6: wire language-flip telemetry into the detector via a closure so
+   178	    // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
+   179	    // The detector fires this inline from an actor; we hop to MainActor to
+   180	    // call `TelemetryService` (which is @MainActor isolated).
+   181	    // The chip handler is wired AFTER init completes (see setPassiveChipHandler
+   182	    // call below) because it needs to capture self, and Swift does not allow
+   183	    // that before all stored properties are initialized.
+   184	    let languageDetector = LanguageDetector(
+   185	      onLanguageFlip: { @Sendable event in
+   186	        Task { @MainActor in
+   187	          TelemetryService.shared.trackLanguageFlip(
+   188	            fromLang: event.fromLang,
+   189	            toLang: event.toLang,
+   190	            confidenceBoth: event.confidenceBoth
+   191	          )
+   192	        }
+   193	      }
+   194	    )
+   195	    whisperKitPipeline = WhisperKitPipeline(
+   196	      audioCapture: audioCapture,
+   197	      backend: WhisperKitBackend(),
+   198	      transcriptStore: transcriptStore,
+   199	      keychainManager: keychainManager,
+   200	      languageDetector: languageDetector,
+   201	      captureTelemetry: captureTelemetry
+   202	    )
+   203	    // Transcript polish service (re-polish from detail view, decoupled from pipelines)
+   204	    polishService = TranscriptPolishService(
+   205	      keychainManager: keychainManager,
+   206	      transcriptStore: transcriptStore
+   207	    )
+   208	
+   209	    // Initialize settingsSync and apply initial settings to all targets
+   210	    settingsSync = PipelineSettingsSync(
+   211	      pipeline: pipeline,
+   212	      whisperKitPipeline: whisperKitPipeline,
+   213	      polishService: polishService,
+   214	      audioCapture: audioCapture,
+   215	      asrManager: asrManager,
+   216	      hotkeyService: hotkeyService,
+   217	      whisperKitSetup: whisperKitSetup
+   218	    )
+   219	    settingsSync.applyInitialSettings(settings)
+   220	
+   221	    // Wire dictation activity provider (after all stored properties initialized)
+   222	    polishService.setDictationActivity(self)
+   223	
+   224	    // Wire the passive-chip handler on the LanguageDetector actor now that
+   225	    // self is fully constructed. The handler hops back to the MainActor
+   226	    // to publish the chip on `pendingPassiveChip` so UI can observe it.
+   227	    Task { [weak self] in
+   228	      await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
+   229	        Task { @MainActor in
+   230	          self?.pendingPassiveChip = trigger
+   231	        }
+   232	      }
+   233	    }
+   234	
+   235	    // Unified engine interruption handler — routes to whichever pipeline is actively recording.
+   236	    // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
+   237	    // is interrupted, we must notify the pipeline that's currently recording, not the one
+   238	    // that happened to set onEngineInterrupted last.
+   239	    audioCapture.onEngineInterrupted = { [weak self] in
+   240	      guard let self else { return }
+   241	      let pState = self.pipeline.state
+   242	      let wkState = self.whisperKitPipeline.state
+   243	      Task {
+   244	        await AppLogger.shared.log(
+   245	          "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+   246	          level: .info, category: "XPC"
+   247	        )
+   248	      }
+   249	      SentryBreadcrumb.add(
+   250	        stage: "audio", message: "Audio XPC interrupted", level: .error,
+   251	        data: [
+   252	          "parakeet_state": "\(pState)",
+   253	          "whisperkit_state": "\(wkState)",
+   254	        ])
+   255	      // Issue #285 — route to the pipeline that owns the shared capture
+   256	      // right now. Uses the same owner-selection as `activeTelemetryTarget()`
+   257	      // so the two paths cannot drift when both pipelines are active
+   258	      // (overlap during backend switch: one polishing while the other starts
+   259	      // a new recording).
+   260	      switch self.activeCaptureBackend() {
+   261	      case .parakeet:
+   262	        self.pipeline.handleEngineInterruption()
+   263	      case .whisperKit:
+   264	        self.whisperKitPipeline.handleEngineInterruption()
+   265	      case nil:
+   266	        break  // neither pipeline active — nothing to clean up
+   267	      }
+   268	      // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
+   269	      // sets state = .error(...), which fires onStateChange and shows the error
+   270	      // overlay. Calling hide() immediately after would dismiss it before the
+   271	      // user can read it. The error overlay auto-dismisses after 3 seconds.
+   272	    }
+   273	
+   274	    // Issue #285 — XPC transport telemetry. Proxy fires this from its
+   275	    // interruption and invalidation handlers; idle interrupts stay silent.
+   276	    // We emit a single captureError per channel with enough context for
+   277	    // Sentry to classify and alert.
+   278	    audioCapture.onXPCServiceError = { [weak self] ctx in
+   279	      guard let self else { return }
+   280	      let handlerKind: XPCHandlerKind = {
+   281	        switch ctx.kind {
+   282	        case .interruptCapturing: return .interrupt
+   283	        case .invalidateCapturing, .invalidateIdle: return .invalidate
+   284	        }
+   285	      }()
+   286	      let wasCapturing = ctx.kind != .invalidateIdle
+   287	      let extras: [String: Any] = [
+   288	        "xpc.handler": handlerKind.rawValue,
+   289	        "xpc.was_capturing": wasCapturing,
+   290	        "xpc.kind": ctx.kind.rawValue,
+   291	        "capture_session_id": ctx.sessionID.map { Int($0) } ?? NSNull(),
+   292	        "capture.route": self.audioCapture.currentAudioRoute,
+   293	      ]
+   294	      SentryBreadcrumb.captureError(
+   295	        HeartPathError.audioXPCInterrupted(
+   296	          handler: handlerKind, wasCapturing: wasCapturing),
+   297	        category: .xpcServiceError,
+   298	        stage: "audio",
+   299	        extra: extras
+   300	      )
+   301	    }
+   302	
+   303	    // (see `activeTelemetryTarget()` at end of init for dispatch logic).
+   304	    // Issue #285 — centralized routing for heart-path telemetry callbacks.
+   305	    // `audioCapture` is a single instance shared by both pipelines, so these
+   306	    // closure properties are single-owner — per-pipeline wiring would let the
+   307	    // last-initialized pipeline silently steal the callbacks. Same pattern as
+   308	    // `onEngineInterrupted` above: route to whichever pipeline is currently
+   309	    // recording so the right backend's dedup flags get set.
+   310	    audioCapture.onCaptureStalled = { [weak self] ctx in
+   311	      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+   312	      self.activeTelemetryTarget()?.handleCaptureStall(ctx)
+   313	    }
+   314	    audioCapture.onXPCReplyFailed = { [weak self] ctx in
+   315	      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+   316	      self.activeTelemetryTarget()?.handleXPCReplyFailed(ctx)
+   317	    }
+   318	    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
+   319	      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+   320	      self.activeTelemetryTarget()?.handleCaptureSessionInterruption(ctx)
+   321	    }
+   322	
+   323	    // Observe audio route changes for Sentry context enrichment.
+   324	    // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
+   325	    // recovery, but breadcrumbs live in EnviousWisprServices (unavailable in the audio module).
+   326	    // AppState observes here to stay within module boundary rules.
+   327	    NotificationCenter.default.addObserver(
+   328	      forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
+   329	    ) { [weak self] _ in
+   330	      Task { @MainActor in
+   331	        guard let self else { return }
+   332	        self.captureTelemetry.incrementConfigChange()
+   333	        let route = self.audioCapture.currentAudioRoute
+   334	        SentryBreadcrumb.add(
+   335	          stage: "audio", message: "Audio route changed", level: .warning,
+   336	          data: [
+   337	            "audio_route": route
+   338	          ])
+   339	        SentryBreadcrumb.updateAudioRoute(route)
+   340	      }
+   341	    }
+   342	
+   343	    // Unified ASR service crash handler — routes to whichever pipeline is active.
+   344	    // Fires when the XPC ASR service dies mid-session (streaming or batch).
+   345	    asrManager.onServiceInterrupted = { [weak self] in
+   346	      guard let self else { return }
+   347	      let pState = self.pipeline.state
+   348	      let wkState = self.whisperKitPipeline.state
+   349	      Task {
+   350	        await AppLogger.shared.log(
+   351	          "[AppState] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+   352	          level: .info, category: "XPC"
+   353	        )
+   354	      }
+   355	      if pState == .loadingModel || pState == .recording || pState == .transcribing {
+   356	        self.pipeline.handleASRServiceInterruption()
+   357	      } else if wkState == .recording || wkState == .transcribing {
+   358	        self.whisperKitPipeline.handleASRServiceInterruption()
+   359	      }
+   360	      // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
+   361	      // the pipeline sets .error(...) state which shows the error overlay via
+   362	      // onStateChange. The error overlay auto-dismisses after 3 seconds.
+   363	    }
+   364	
+   365	    // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
+   366	    // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
+   367	    audioCapture.onVADAutoStop = { [weak self] in
+   368	      guard let self else { return }
+   369	      if self.pipeline.state == .recording {
+   370	        Task { await self.pipeline.stopAndTranscribe() }
+   371	      } else if self.whisperKitPipeline.state == .recording {
+   372	        Task { await self.whisperKitPipeline.stopAndTranscribe() }
+   373	      }
+   374	    }
+   375	    settingsSync.onNeedsPreloadObservation = { [weak self] in
+   376	      self?.startWhisperKitPreloadObservation()
+   377	    }
+   378	
+   379	    // Wire custom-words propagator. The exact ordering (seed → register all
+   380	    // consumers → install onWordsChanged) lives in `wireCustomWords` so
+   381	    // tests can drive the same path with spy consumers + a real
+   382	    // `CustomWordsCoordinator`. Phase D (#496) replaces the prior 5-way
+   383	    // fanout in AppState plus 5 mirror sites in `PipelineSettingsSync`.
+   384	    wireCustomWords(
+   385	      propagator: customWordsPropagator,
+   386	      initialWords: customWordsCoordinator.customWords,
+   387	      consumers: [
+   388	        pipeline.wordCorrection,
+   389	        pipeline.llmPolish,
+   390	        whisperKitPipeline.wordCorrection,
+   391	        whisperKitPipeline.llmPolish,
+   392	        polishService.llmPolishStep,
+   393	      ],
+   394	      coordinator: customWordsCoordinator
+   395	    )
+   396	
+   397	    // Initialize logger
+   398	    Task {
+   399	      await AppLogger.shared.setLogLevel(settings.debugLogLevel)
+   400	      await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
+   401	    }
+   402	
+   403	    // Restore persisted backend selection synchronously (no race with first record).
+   404	    // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
+   405	    asrManager.setInitialBackendType(settings.selectedBackend)
+   406	    SentryBreadcrumb.updateASRBackend(
+   407	      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+   408	
+   409	    // Wire settings change handler
+   410	    settings.onChange = { [weak self] key in
+   411	      guard let self else { return }
+   412	      self.settingsSync.handleSettingChanged(key, settings: self.settings)
+   413	    }
+   414	
+   415	    // Wire pipeline state changes to overlay and icon.
+   416	    // The behavioral contract (overlay resolution, warning scheduling /
+   417	    // cancellation, telemetry, history reload) is owned by the per-pipeline
+   418	    // PipelineStateChangeHandler. The closure still owns AppState-local
+   419	    // concerns: external observer fan-out, hotkey register/unregister,
+   420	    // isRecordingLocked reset, and the inactive→active tiebreaker (#285).
+   421	    pipeline.onStateChange = { [weak self] newState in
+   422	      guard let self else { return }
+   423	      self.onPipelineStateChange?(newState)
+   424	      switch newState {
+   425	      case .recording:
+   426	        self.hotkeyService.registerCancelHotkey()
+   427	      case .loadingModel, .transcribing, .polishing:
+   428	        self.isRecordingLocked = false
+   429	        self.hotkeyService.unregisterCancelHotkey()
+   430	      case .error, .idle, .complete:
+   431	        self.isRecordingLocked = false
+   432	        self.hotkeyService.unregisterCancelHotkey()
+   433	        // Session ended — retry any Ollama eviction deferred because the
+   434	        // frozen session pinned the old model.
+   435	        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
+   436	      }
+   437	      let nowActive = newState.isActive
+   438	      if nowActive && !self.prevParakeetActive {
+   439	        self.lastCapturingBackend = .parakeet
+   440	      }
+   441	      self.prevParakeetActive = nowActive
+   442	      self.parakeetStateHandler.handle(
+   443	        to: newState,
+   444	        pipelineOverlayIntent: self.pipeline.overlayIntent,
+   445	        lastPolishError: self.pipeline.lastPolishError,
+   446	        currentTranscript: self.pipeline.currentTranscript
+   447	      )
+   448	    }
+   449	
+   450	    // Wire WhisperKit pipeline state changes to overlay and icon.
+   451	    whisperKitPipeline.onStateChange = { [weak self] newState in
+   452	      guard let self else { return }
+   453	      self.onPipelineStateChange?(self.pipelineState)
+   454	      switch newState {
+   455	      case .recording:
+   456	        self.hotkeyService.registerCancelHotkey()
+   457	      case .startingUp, .loadingModel, .transcribing, .polishing:
+   458	        self.isRecordingLocked = false
+   459	        self.hotkeyService.unregisterCancelHotkey()
+   460	      case .error, .idle, .ready, .complete:
+   461	        self.isRecordingLocked = false
+   462	        self.hotkeyService.unregisterCancelHotkey()
+   463	        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
+   464	      }
+   465	      let nowActive = newState.isActive
+   466	      if nowActive && !self.prevWhisperKitActive {
+   467	        self.lastCapturingBackend = .whisperKit
+   468	      }
+   469	      self.prevWhisperKitActive = nowActive
+   470	      self.whisperKitStateHandler.handle(
+   471	        to: newState,
+   472	        pipelineOverlayIntent: self.whisperKitPipeline.overlayIntent,
+   473	        lastPolishError: self.whisperKitPipeline.lastPolishError,
+   474	        currentTranscript: self.whisperKitPipeline.currentTranscript
+   475	      )
+   476	    }
+   477	
+   478	    // Wire hotkey callbacks
+   479	    hotkeyService.recordingMode = settings.recordingMode
+   480	    hotkeyService.cancelKeyCode = settings.cancelKeyCode
+   481	    hotkeyService.cancelModifiers = settings.cancelModifiers
+   482	    hotkeyService.toggleKeyCode = settings.toggleKeyCode
+   483	    hotkeyService.toggleModifiers = settings.toggleModifiers
+   484	    hotkeyService.onToggleRecording = { [weak self] in
+   485	      guard let self else { return }
+   486	      await self.toggleRecording()
+   487	    }
+   488	    hotkeyService.onStartRecording = { [weak self] in
+   489	      guard let self else { return }
+   490	      // Cancel any pending post-completion warning from the previous session
+   491	      // before showing the new recording overlay.
+   492	      self.postCompletionWarningTask?.cancel()
+   493	      let isWhisperKit = self.asrManager.activeBackendType == .whisperKit
+   494	      let active = self.activePipeline
+   495	
+   496	      if isWhisperKit {
+   497	        guard !self.whisperKitPipeline.state.isActive else { return }
+   498	      } else {
+   499	        guard !self.pipelineState.isActive else { return }
+   500	      }
+   501	
+   502	      // Refresh AX status so `makeDictationSessionConfig` sees the right
+   503	      // paste capability. The session snapshot is captured fresh at
+   504	      // `.toggleRecording` dispatch below.
+   505	      self.permissions.refreshAccessibilityStatus()
+   506	      if !self.permissions.hasAccessibilityPermission {
+   507	        self.permissions.restartMonitoringIfNeeded()
+   508	      }
+   509	
+   510	      // Show recording overlay IMMEDIATELY for instant visual feedback.
+   511	      // The pipeline hasn't started yet, but the user needs to see the
+   512	      // overlay now — especially for double-press detection where they
+   513	      // need visual confirmation before tapping again.
+   514	      self.recordingOverlay.show(
+   515	        intent: .recording(audioLevel: 0),
+   516	        audioLevelProvider: { self.audioCapture.audioLevel },
+   517	        isRecordingLocked: false
+   518	      )
+   519	
+   520	      let pttStart = ContinuousClock.now
+   521	      do {
+   522	        try await active.handle(event: .preWarm)
+   523	      } catch is CancellationError {
+   524	        // Issue #289: PTT release mid-preWarm threw CancellationError (silent
+   525	        // unwind). Not a user-visible failure — just clean up. The existing
+   526	        // `Task.isCancelled` guard below no longer fires because the throw
+   527	        // short-circuits past it, so this catch is load-bearing.
+   528	        self.audioCapture.abortPreWarm()
+   529	        self.recordingOverlay.show(intent: .hidden)
+   530	        self.isRecordingLocked = false
+   531	        return
+   532	      } catch {
+   533	        // Issue #289: real preWarm failure (XPC transport dead, AVAudioEngine
+   534	        // `'what?'`, etc.). Abort the start cleanly — never call
+   535	        // `.toggleRecording` against a dead capture path — and surface a brief
+   536	        // user-visible error. Telemetry-free here: the lower layers already
+   537	        // breadcrumbed the root cause; this is the user-facing UX.
+   538	        self.audioCapture.abortPreWarm()
+   539	        self.recordingOverlay.show(intent: .hidden)
+   540	        self.isRecordingLocked = false
+   541	        SentryBreadcrumb.add(
+   542	          stage: "recording", message: "preWarm failed — start aborted",
+   543	          level: .warning, data: ["error": String(describing: error)]
+   544	        )
+   545	        active.setExternalError("Microphone unavailable — try again.")
+   546	        return
+   547	      }
+   548	      guard !Task.isCancelled else {
+   549	        // Non-throwing cancellation path (e.g. outer Task cancel between
+   550	        // preWarm return and .toggleRecording dispatch).
+   551	        self.audioCapture.abortPreWarm()
+   552	        self.recordingOverlay.show(intent: .hidden)
+   553	        self.isRecordingLocked = false
+   554	        return
+   555	      }
+   556	      let preWarmMs = {
+   557	        let (s, a) = (ContinuousClock.now - pttStart).components
+   558	        return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+   559	      }()
+   560	      // `.toggleRecording` is declared throws on the protocol, but today the
+   561	      // underlying implementation doesn't throw. `try?` keeps the surface
+   562	      // unchanged. If a future event grows a meaningful throw we revisit here.
+   563	      try? await active.handle(event: .toggleRecording(makeDictationSessionConfig()))
+   564	      let totalMs = {
+   565	        let (s, a) = (ContinuousClock.now - pttStart).components
+   566	        return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+   567	      }()
+   568	      Task {
+   569	        await AppLogger.shared.log(
+   570	          "COLD-START [AppState] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet")",
+   571	          level: .info, category: "Pipeline"
+   572	        )
+   573	      }
+   574	    }
+   575	    hotkeyService.onStopRecording = { [weak self] in
+   576	      guard let self else { return }
+   577	      self.isRecordingLocked = false
+   578	      try? await self.activePipeline.handle(event: .requestStop)
+   579	    }
+   580	
+   581	    hotkeyService.onCancelRecording = { [weak self] in
+   582	      self?.isRecordingLocked = false
+   583	      await self?.cancelRecording()
+   584	    }
+   585	
+   586	    hotkeyService.onIsProcessing = { [weak self] in
+   587	      guard let self else { return false }
+   588	      // Block during any state that means "still working on the last recording"
+   589	      if self.asrManager.activeBackendType == .whisperKit {
+   590	        let state = self.whisperKitPipeline.state
+   591	        return state == .transcribing || state == .polishing
+   592	      } else {
+   593	        let state = self.pipeline.state
+   594	        return state == .transcribing || state == .polishing
+   595	      }
+   596	    }
+   597	
+   598	    hotkeyService.onLocked = { [weak self] in
+   599	      guard let self else { return }
+   600	      self.isRecordingLocked = true
+   601	      self.recordingOverlay.updateLockState(true)
+   602	      Task {
+   603	        await AppLogger.shared.log(
+   604	          "Hands-free mode activated — overlay expanding",
+   605	          level: .info, category: "AppState"
+   606	        )
+   607	      }
+   608	    }
+   609	
+   610	    // Pre-load the selected backend's model in the background to eliminate cold-start delay.
+   611	    // Parakeet: direct silent load (model files already downloaded during onboarding).
+   612	    // WhisperKit: observation-based (waits for setupState to become .ready first).
+   613	    if settings.selectedBackend == .parakeet {
+   614	      Task { [weak self] in
+   615	        await self?.asrManager.loadModelSilently()
+   616	      }
+   617	    }
+   618	    Task { [weak self] in
+   619	      await self?.whisperKitSetup.detectState()
+   620	      self?.startWhisperKitPreloadObservation()
+   621	    }
+   622	
+   623	    // NOTE: hotkey registration is deferred to startHotkeyServiceIfEnabled(),
+   624	    // called from applicationDidFinishLaunching. Carbon RegisterEventHotKey
+   625	    // requires the NSApplication event loop to be running for event delivery.
+   626	  }
+   627	
+   628	  /// Start the hotkey service. Must be called after the NSApplication event loop
+   629	  /// is running (e.g., from applicationDidFinishLaunching), because Carbon
+   630	  /// RegisterEventHotKey events are only delivered once the run loop is active.
+   631	  func startHotkeyServiceIfEnabled() {
+   632	    if settings.hotkeyEnabled {
+   633	      hotkeyService.start()
+   634	    }
+   635	  }
+   636	
+   637	  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
+   638	  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
+   639	  private func startWhisperKitPreloadObservation() {
+   640	    whisperKitPreloadTask?.cancel()
+   641	    whisperKitPreloadTask = Task { [weak self] in
+   642	      while !Task.isCancelled {
+   643	        guard let self else { return }
+   644	
+   645	        // Exit immediately when WhisperKit isn't the active backend. Parakeet
+   646	        // users shouldn't pay CPU/memory cost warming a backend they never use.
+   647	        // Backend switches fire settingsSync.onNeedsPreloadObservation, which
+   648	        // restarts this observer; the re-entry sees the new activeBackendType.
+   649	        guard self.asrManager.activeBackendType == .whisperKit else { return }
+   650	
+   651	        // Check current state — if already .ready, trigger pre-load
+   652	        let currentState = self.whisperKitSetup.setupState
+   653	        if currentState == .ready {
+   654	          await self.whisperKitPipeline.prepareBackendSilently()
+   655	          return  // Model loaded — no need to keep observing
+   656	        }
+   657	
+   658	        // Wait for the next change to setupState
+   659	        await withCheckedContinuation { continuation in
+   660	          withObservationTracking {
+   661	            _ = self.whisperKitSetup.setupState
+   662	          } onChange: {
+   663	            continuation.resume()
+   664	          }
+   665	        }
+   666	      }
+   667	    }
+   668	  }
+   669	
+   670	  /// Active dictation pipeline — routes based on selected backend.
+   671	  var activePipeline: any DictationPipeline {
+   672	    asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
+   673	  }
+   674	
+   675	  /// Convenience: current pipeline state — routes through active backend.
+   676	  var pipelineState: PipelineState {
+   677	    if asrManager.activeBackendType == .whisperKit {
+   678	      return whisperKitPipeline.state.asPipelineState
+   679	    }
+   680	    return pipeline.state
+   681	  }
+   682	
+   683	  /// Last polish error from the active pipeline.
+   684	  var lastPolishError: String? {
+   685	    if asrManager.activeBackendType == .whisperKit {
+   686	      return whisperKitPipeline.lastPolishError
+   687	    }
+   688	    return pipeline.lastPolishError
+   689	  }
+   690	
+   691	  /// Convenience: the transcript from the latest recording.
+   692	  var activeTranscript: Transcript? {
+   693	    if let selected = transcriptCoordinator.selectedTranscriptID {
+   694	      return transcriptCoordinator.transcripts.first { $0.id == selected }
+   695	    }
+   696	    if asrManager.activeBackendType == .whisperKit {
+   697	      return whisperKitPipeline.currentTranscript
+   698	    }
+   699	    return pipeline.currentTranscript
+   700	  }
+   701	
+   702	  /// Schedule a deferred post-completion warning overlay. Cancellable and session-scoped:
+   703	  /// cancelled if a new recording starts (any non-complete state change cancels it).
+   704	  /// Uses the pipeline's current state as a guard to avoid showing stale warnings.
+   705	  /// Issue #285 — which backend most recently entered an active state
+   706	  /// (startup, loading, or recording). Used as a tiebreaker when both
+   707	  /// pipelines are active simultaneously (e.g. one still polishing while the
+   708	  /// other begins a new capture). Updated on any active-state entry, not just
+   709	  /// `.recording`, so stall watchdog and interruption callbacks that fire
+   710	  /// pre-recording resolve to the correct backend.
+   711	  private enum LastCapturingBackend { case parakeet, whisperKit }
+   712	  private var lastCapturingBackend: LastCapturingBackend = .parakeet
+   713	  // Previous active-state of each pipeline, tracked so we flip
+   714	  // `lastCapturingBackend` only on inactive→active transitions. Without this,
+   715	  // `.transcribing → .polishing` (active → active) would re-steal ownership
+   716	  // after a different backend acquired the shared capture.
+   717	  private var prevParakeetActive: Bool = false
+   718	  private var prevWhisperKitActive: Bool = false
+   719	
+   720	  /// Issue #285 — resolve which backend owns the shared audio capture right
+   721	  /// now. Returns nil when both pipelines are fully idle. Shared helper for
+   722	  /// both telemetry routing and engine-interrupt routing so the two paths
+   723	  /// cannot drift.
+   724	  private func activeCaptureBackend() -> LastCapturingBackend? {
+   725	    let pActive = pipeline.state.isActive
+   726	    let wkActive = whisperKitPipeline.state.isActive
+   727	    if pActive && wkActive { return lastCapturingBackend }
+   728	    if pActive { return .parakeet }
+   729	    if wkActive { return .whisperKit }
+   730	    return nil
+   731	  }
+   732	
+   733	  /// Issue #285 — belt-and-suspenders filter for late callbacks that somehow
+   734	  /// slip past the per-source `isCapturing` / observer-removal guards during a
+   735	  /// backend switch. Dropping a stale callback is safer than misrouting it to
+   736	  /// a new session's dedup state. Source-level guards normally catch this;
+   737	  /// this is a second line of defense for the backend-overlap window.
+   738	  private func isCurrentSession(_ sessionID: UInt64) -> Bool {
+   739	    sessionID == audioCapture.currentCaptureSessionID
+   740	  }
+   741	
+   742	  private func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
+   743	    switch activeCaptureBackend() {
+   744	    case .whisperKit: return whisperKitPipeline
+   745	    case .parakeet: return pipeline
+   746	    case nil:
+   747	      // Idle → attribute to the backend that most recently owned a session.
+   748	      return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
+   749	    }
+   750	  }
+   751	
+   752	  private func schedulePostCompletionWarning(message: String) {
+   753	    postCompletionWarningTask?.cancel()
+   754	    postCompletionWarningTask = Task { @MainActor [weak self] in
+   755	      try? await Task.sleep(for: .milliseconds(400))
+   756	      guard !Task.isCancelled, let self else { return }
+   757	      // Only show if we're still in the completed state (no new recording started)
+   758	      let parakeetComplete = self.pipeline.state == .complete
+   759	      let whisperKitComplete =
+   760	        self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
+
+exec
+/bin/zsh -lc "nl -ba Package.swift | sed -n '1,180p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	// swift-tools-version: 6.0
+     2	
+     3	import PackageDescription
+     4	
+     5	let package = Package(
+     6	  name: "EnviousWispr",
+     7	  platforms: [
+     8	    .macOS(.v14)
+     9	  ],
+    10	  products: [
+    11	    // Exposed so the multilingual polish-quality harness (a separate
+    12	    // SwiftPM package at scripts/multilingual-eval/polisher-runner) can
+    13	    // depend on the real planner + connectors via a path-based package
+    14	    // dependency. Purely additive — no production code imports these.
+    15	    .library(name: "EnviousWisprCore", targets: ["EnviousWisprCore"]),
+    16	    .library(name: "EnviousWisprLLM", targets: ["EnviousWisprLLM"]),
+    17	  ],
+    18	  dependencies: [
+    19	    .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
+    20	    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
+    21	    .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
+    22	    .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+    23	    .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),
+    24	  ],
+    25	  targets: [
+    26	    .target(
+    27	      name: "EnviousWisprCore",
+    28	      path: "Sources/EnviousWisprCore"
+    29	    ),
+    30	    .target(
+    31	      name: "EnviousWisprStorage",
+    32	      dependencies: ["EnviousWisprCore"],
+    33	      path: "Sources/EnviousWisprStorage"
+    34	    ),
+    35	    .target(
+    36	      name: "EnviousWisprPostProcessing",
+    37	      dependencies: ["EnviousWisprCore"],
+    38	      path: "Sources/EnviousWisprPostProcessing"
+    39	    ),
+    40	    .target(
+    41	      name: "EnviousWisprAudio",
+    42	      dependencies: [
+    43	        "EnviousWisprCore",
+    44	        "FluidAudio",
+    45	      ],
+    46	      path: "Sources/EnviousWisprAudio"
+    47	    ),
+    48	    .target(
+    49	      name: "EnviousWisprServices",
+    50	      dependencies: [
+    51	        "EnviousWisprCore",
+    52	        .product(name: "PostHog", package: "posthog-ios"),
+    53	        .product(name: "Sentry", package: "sentry-cocoa"),
+    54	      ],
+    55	      path: "Sources/EnviousWisprServices"
+    56	    ),
+    57	    .target(
+    58	      name: "EnviousWisprASR",
+    59	      dependencies: [
+    60	        "EnviousWisprCore",
+    61	        "EnviousWisprAudio",
+    62	        "WhisperKit",
+    63	        "FluidAudio",
+    64	      ],
+    65	      path: "Sources/EnviousWisprASR"
+    66	    ),
+    67	    .target(
+    68	      name: "EnviousWisprLLM",
+    69	      dependencies: ["EnviousWisprCore"],
+    70	      path: "Sources/EnviousWisprLLM"
+    71	    ),
+    72	    .target(
+    73	      name: "EnviousWisprPipeline",
+    74	      dependencies: [
+    75	        "EnviousWisprCore",
+    76	        "EnviousWisprASR",
+    77	        "EnviousWisprAudio",
+    78	        "EnviousWisprLLM",
+    79	        "EnviousWisprPostProcessing",
+    80	        "EnviousWisprServices",
+    81	        "EnviousWisprStorage",
+    82	        "WhisperKit",
+    83	      ],
+    84	      path: "Sources/EnviousWisprPipeline"
+    85	    ),
+    86	    .executableTarget(
+    87	      name: "EnviousWisprAudioService",
+    88	      dependencies: [
+    89	        "EnviousWisprCore",
+    90	        "EnviousWisprAudio",
+    91	      ],
+    92	      path: "Sources/EnviousWisprAudioService",
+    93	      exclude: ["Resources"]
+    94	    ),
+    95	    .executableTarget(
+    96	      name: "EnviousWisprASRService",
+    97	      dependencies: [
+    98	        "EnviousWisprCore",
+    99	        "EnviousWisprASR",
+   100	        "EnviousWisprAudio",
+   101	        "WhisperKit",
+   102	        "FluidAudio",
+   103	      ],
+   104	      path: "Sources/EnviousWisprASRService",
+   105	      exclude: ["Resources"]
+   106	    ),
+   107	    .executableTarget(
+   108	      name: "EnviousWispr",
+   109	      dependencies: [
+   110	        "EnviousWisprCore",
+   111	        "EnviousWisprStorage",
+   112	        "EnviousWisprPostProcessing",
+   113	        "EnviousWisprAudio",
+   114	        "EnviousWisprServices",
+   115	        "EnviousWisprASR",
+   116	        "EnviousWisprLLM",
+   117	        "EnviousWisprPipeline",
+   118	        "WhisperKit",
+   119	        "FluidAudio",
+   120	        "Sparkle",
+   121	      ],
+   122	      path: "Sources/EnviousWispr",
+   123	      exclude: ["Resources"]
+   124	    ),
+   125	    .testTarget(
+   126	      name: "EnviousWisprTests",
+   127	      dependencies: [
+   128	        "EnviousWisprCore",
+   129	        "EnviousWisprPostProcessing",
+   130	        "EnviousWisprLLM",
+   131	        "EnviousWisprPipeline",
+   132	        "EnviousWisprStorage",
+   133	        "EnviousWisprAudio",
+   134	        "EnviousWispr",
+   135	      ],
+   136	      path: "Tests/EnviousWisprTests"
+   137	    ),
+   138	    .testTarget(
+   139	      name: "EnviousWisprASRTests",
+   140	      dependencies: [
+   141	        "EnviousWisprCore",
+   142	        "EnviousWisprASR",
+   143	      ],
+   144	      path: "Tests/EnviousWisprASRTests"
+   145	    ),
+   146	  ],
+   147	  swiftLanguageModes: [.v6]
+   148	)
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/AppState.swift | sed -n '760,1040p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   760	        self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
+   761	      guard parakeetComplete || whisperKitComplete else { return }
+   762	      self.recordingOverlay.show(intent: .warning(message: message))
+   763	    }
+   764	  }
+   765	
+   766	  /// Reset the currently active pipeline to idle. Used by UI "dismiss" actions.
+   767	  func resetActivePipeline() {
+   768	    if asrManager.activeBackendType == .whisperKit {
+   769	      whisperKitPipeline.reset()
+   770	    } else {
+   771	      pipeline.reset()
+   772	    }
+   773	  }
+   774	
+   775	  /// Convenience: audio level for UI visualization.
+   776	  var audioLevel: Float {
+   777	    audioCapture.audioLevel
+   778	  }
+   779	
+   780	  /// Human-readable model name for display.
+   781	  var activeModelName: String {
+   782	    settings.selectedBackend == .parakeet ? "Parakeet v3" : "WhisperKit"
+   783	  }
+   784	
+   785	  var activeLLMDisplayName: String {
+   786	    guard settings.llmProvider != .none else { return "LLM Deactivated" }
+   787	    let model = settings.llmProvider == .ollama ? settings.ollamaModel : settings.llmModel
+   788	    if model.isEmpty { return settings.llmProvider.displayName }
+   789	    // Use discoveredModels displayName if available, otherwise raw model ID
+   790	    if let info = llmDiscovery.discoveredModels.first(where: { $0.id == model }) {
+   791	      return info.displayName
+   792	    }
+   793	    return model
+   794	  }
+   795	
+   796	  /// Model status text for sidebar display.
+   797	  var modelStatusText: String {
+   798	    if asrManager.activeBackendType == .whisperKit {
+   799	      switch whisperKitPipeline.state {
+   800	      case .loadingModel: return "Loading Model"
+   801	      case .recording: return "Recording"
+   802	      case .transcribing: return "Transcribing"
+   803	      case .polishing: return "Polishing"
+   804	      case .error: return "Error"
+   805	      default: break
+   806	      }
+   807	    } else {
+   808	      if pipelineState == .recording { return "Recording" }
+   809	      if pipelineState == .transcribing { return "Transcribing" }
+   810	      if pipelineState == .polishing { return "Polishing" }
+   811	      if case .error = pipelineState { return "Error" }
+   812	    }
+   813	    return asrManager.isModelLoaded ? "Loaded" : "Unloaded"
+   814	  }
+   815	
+   816	  /// Toggle recording on/off (plain, no forced LLM).
+   817	  func toggleRecording() async {
+   818	    postCompletionWarningTask?.cancel()
+   819	    let active = activePipeline
+   820	
+   821	    // Refresh AX status before snapshotting — `makeDictationSessionConfig`
+   822	    // derives `autoPasteToActiveApp` from the active pipeline's idle state
+   823	    // plus the current AX permission.
+   824	    permissions.refreshAccessibilityStatus()
+   825	    if !permissions.hasAccessibilityPermission {
+   826	      permissions.restartMonitoringIfNeeded()
+   827	    }
+   828	
+   829	    // Fire dictation.invoked telemetry when starting (not stopping).
+   830	    // Intent event: captures user action before engine/ASR work begins.
+   831	    // Check that the active pipeline is NOT already in a recording/processing state.
+   832	    let alreadyActive: Bool
+   833	    if active is WhisperKitPipeline {
+   834	      let s = whisperKitPipeline.state
+   835	      alreadyActive =
+   836	        s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
+   837	        || s == .startingUp
+   838	    } else {
+   839	      let s = pipeline.state
+   840	      alreadyActive = s == .recording || s == .transcribing || s == .polishing || s == .loadingModel
+   841	    }
+   842	    if !alreadyActive {
+   843	      let targetApp = NSWorkspace.shared.frontmostApplication?.localizedName
+   844	      TelemetryService.shared.dictationInvoked(
+   845	        triggerSource: settings.recordingMode.rawValue,
+   846	        inputMode: settings.recordingMode.rawValue,
+   847	        targetApp: targetApp
+   848	      )
+   849	    }
+   850	
+   851	    try? await active.handle(event: .toggleRecording(makeDictationSessionConfig()))
+   852	  }
+   853	
+   854	  /// Build the per-recording `DictationSessionConfig` snapshot. Captures the
+   855	  /// current `SettingsManager` state plus the input-mode-derived paste intent.
+   856	  /// Called at `.toggleRecording` dispatch; the recording's pipeline freezes
+   857	  /// the snapshot for its lifetime via `startRecording(config:)`.
+   858	  private func makeDictationSessionConfig() -> DictationSessionConfig {
+   859	    let isWhisperKit = asrManager.activeBackendType == .whisperKit
+   860	    let activePipelineIdle: Bool = {
+   861	      if isWhisperKit {
+   862	        switch whisperKitPipeline.state {
+   863	        case .idle, .ready, .complete, .error: return true
+   864	        default: return false
+   865	        }
+   866	      } else {
+   867	        switch pipeline.state {
+   868	        case .idle, .complete, .error: return true
+   869	        default: return false
+   870	        }
+   871	      }
+   872	    }()
+   873	    let autoPaste = activePipelineIdle && permissions.hasAccessibilityPermission
+   874	    let resolvedModel: String = {
+   875	      switch settings.llmProvider {
+   876	      case .appleIntelligence: return "apple-intelligence"
+   877	      case .ollama: return settings.ollamaModel
+   878	      default: return settings.llmModel
+   879	      }
+   880	    }()
+   881	    return DictationSessionConfig(
+   882	      autoCopyToClipboard: settings.autoCopyToClipboard,
+   883	      autoPasteToActiveApp: autoPaste,
+   884	      restoreClipboardAfterPaste: settings.restoreClipboardAfterPaste,
+   885	      vadAutoStop: settings.vadAutoStop,
+   886	      vadSilenceTimeout: settings.vadSilenceTimeout,
+   887	      vadSensitivity: settings.vadSensitivity,
+   888	      vadEnergyGate: settings.vadEnergyGate,
+   889	      languageMode: settings.languageMode,
+   890	      useStreamingASR: settings.useStreamingASR,
+   891	      modelUnloadPolicy: settings.modelUnloadPolicy,
+   892	      llmProvider: settings.llmProvider,
+   893	      llmModel: resolvedModel,
+   894	      polishInstructions: settings.activePolishInstructions,
+   895	      styleConfig: settings.activePolishStyleConfig,
+   896	      useExtendedThinking: settings.useExtendedThinking,
+   897	      selectedInputDeviceUID: settings.selectedInputDeviceUID,
+   898	      preferredInputDeviceIDOverride: settings.preferredInputDeviceIDOverride
+   899	    )
+   900	  }
+   901	
+   902	  /// Cancel an active recording, discarding all captured audio.
+   903	  func cancelRecording() async {
+   904	    TelemetryService.shared.dictationCanceled(
+   905	      stage: "recording", reason: "user_cancel", durationSeconds: nil)
+   906	    isRecordingLocked = false
+   907	    recordingOverlay.hide()
+   908	    let isWhisperKit = asrManager.activeBackendType == .whisperKit
+   909	    if isWhisperKit {
+   910	      let wkState = whisperKitPipeline.state
+   911	      guard wkState == .recording || wkState == .loadingModel || wkState == .startingUp else {
+   912	        return
+   913	      }
+   914	      try? await whisperKitPipeline.handle(event: .cancelRecording)
+   915	    } else {
+   916	      guard pipelineState == .recording || pipelineState == .loadingModel else { return }
+   917	      await pipeline.cancelRecording()
+   918	    }
+   919	  }
+   920	
+   921	  /// Enhancement error from the transcript detail view's re-polish service.
+   922	  /// Separate from `lastPolishError` which tracks live-dictation polish failures.
+   923	  var lastEnhancementError: EnhancementError? {
+   924	    polishService.lastEnhancementError
+   925	  }
+   926	
+   927	  /// Re-polish an existing transcript via the standalone polish service.
+   928	  /// Decoupled from pipeline state: does not touch pipeline.state, currentTranscript, or lastPolishError.
+   929	  func polishTranscript(_ transcript: Transcript) async {
+   930	    do {
+   931	      let updated = try await polishService.polish(transcript)
+   932	      if let idx = transcriptCoordinator.transcripts.firstIndex(where: { $0.id == updated.id }) {
+   933	        transcriptCoordinator.transcripts[idx] = updated
+   934	      }
+   935	      // Ensure detail view refreshes even when activeTranscript falls back to pipeline.currentTranscript
+   936	      transcriptCoordinator.selectedTranscriptID = updated.id
+   937	    } catch {
+   938	      // Error already captured in polishService.lastEnhancementError
+   939	      Task {
+   940	        await AppLogger.shared.log(
+   941	          "Transcript enhancement failed: \(error.localizedDescription)",
+   942	          level: .info, category: "Enhancement"
+   943	        )
+   944	      }
+   945	    }
+   946	  }
+   947	
+   948	  // Phase 5 B.1 validated 2026-03-16: batch round-trip 51-60ms across XPC.
+   949	  // Cold model load: 13,966ms. 3 warm back-to-back runs stable.
+   950	  // Test function in git history.
+   951	}
+   952	
+   953	// MARK: - DictationActivityProviding
+   954	
+   955	extension AppState: DictationActivityProviding {
+   956	  /// True when either pipeline is actively recording, transcribing, or polishing.
+   957	  /// Used by TranscriptPolishService to prevent concurrent re-polish + live dictation.
+   958	  var isDictationActive: Bool {
+   959	    pipeline.state.isActive || whisperKitPipeline.state.isActive
+   960	  }
+   961	}
+   962	
+   963	extension WhisperKitPipelineState {
+   964	  /// One authoritative mapping from WhisperKit's 9-state enum to unified PipelineState.
+   965	  var asPipelineState: PipelineState {
+   966	    switch self {
+   967	    case .idle, .ready: return .idle
+   968	    case .startingUp, .loadingModel: return .loadingModel
+   969	    case .recording: return .recording
+   970	    case .transcribing: return .transcribing
+   971	    case .polishing: return .polishing
+   972	    case .complete: return .complete
+   973	    case .error(let msg): return .error(msg)
+   974	    }
+   975	  }
+   976	}
+
+exec
+/bin/zsh -lc "nl -ba docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md | sed -n '480,560p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   480	### 4.9 AppState concrete-type dependencies — verified count
+   481	
+   482	Verified 2026-04-18 via grep of `^\s+let [a-zA-Z]+ = [A-Z][a-zA-Z]*\(\)` against `AppState.swift`. Twelve direct concrete-type property declarations at file scope:
+   483	
+   484	1. `permissions = PermissionsService()`
+   485	2. `transcriptStore = TranscriptStore()` — moved into `TranscriptCoordinator` ownership in Phase C.
+   486	3. `keychainManager = KeychainManager()`
+   487	4. `hotkeyService = HotkeyService()`
+   488	5. `benchmark = BenchmarkSuite()`
+   489	6. `recordingOverlay = RecordingOverlayPanel()`
+   490	7. `ollamaSetup = OllamaSetupService()`
+   491	8. `whisperKitSetup = WhisperKitSetupService()`
+   492	9. `audioDeviceList = AudioDeviceList()`
+   493	10. `captureTelemetry = CaptureTelemetryState()`
+   494	11. `customWordsCoordinator = CustomWordsCoordinator()` — Phase D wires a propagator as its subscriber but this property stays.
+   495	12. `aiAvailability = AIAvailabilityCoordinator()`
+   496	
+   497	Plus `settings = SettingsManager()`. Audit reported 11 (close; count includes interface-typed slots).
+   498	
+   499	**Target after Phases A + C + D:** ≤ 8 direct concrete-type property declarations. Larger reduction if the epic decides to delegate setup services (ollamaSetup, whisperKitSetup) into a new `SetupCoordinator` — track that as a Phase E candidate (§11).
+   500	
+   501	### 4.10 Tool existence — verified (2026-04-18)
+   502	
+   503	Both scripts referenced by the bible exist:
+   504	- `scripts/heart-path-bench.sh` — present; runs cold/hot bench per `validation-discipline.md §9`.
+   505	- `Tests/UITests/wispr_eyes.py` — present; `test_recording`, `tts`, etc. per `tools-and-apps.md §2`.
+   506	
+   507	No hallucinated tool paths.
+   508	
+   509	### 4.11 Custom-words consumer types — verified MainActor (2026-04-18)
+   510	
+   511	Both primary custom-words consumer types are already `@MainActor`:
+   512	- `Sources/EnviousWisprPipeline/WordCorrectionStep.swift` — `@MainActor public final class WordCorrectionStep`.
+   513	- `Sources/EnviousWisprPipeline/LLMPolishStep.swift` — `@MainActor public final class LLMPolishStep`.
+   514	
+   515	Phase D's `CustomWordsConsumer` protocol can safely require `@MainActor` isolation without forcing a new actor on consumers.
+   516	
+   517	### 4.13 AppState disposition matrix — every owned dependency's fate
+   518	
+   519	Enumerated 2026-04-18. Every `let X = TypeName()` or injected interface property on `AppState`. Fate after this epic:
+   520	
+   521	| # | Property | Line | Disposition | Reason |
+   522	|---|---|---|---|---|
+   523	| 1 | `settings = SettingsManager()` | ~15 | **STAYS** | Composition root owns settings. Shape stable. |
+   524	| 2 | `permissions = PermissionsService()` | 18 | **STAYS** | Top-level permission flow. Low coupling. |
+   525	| 3 | `audioCapture: any AudioCaptureInterface` | 19 | **STAYS** | Composition root injects audio. Stable. |
+   526	| 4 | `asrManager: any ASRManagerInterface` | 20 | **STAYS** | Composition root injects ASR. Stable. |
+   527	| 5 | `transcriptStore = TranscriptStore()` | 21 | **MOVES → TranscriptCoordinator** (Phase C) | REF-05. Ownership belongs to the coordinator that serves views. |
+   528	| 6 | `keychainManager = KeychainManager()` | 22 | **STAYS** | Low-coupling utility. Not a decomposition target. |
+   529	| 7 | `hotkeyService = HotkeyService()` | 23 | **STAYS** | Carbon timing sensitive; do NOT touch. |
+   530	| 8 | `benchmark = BenchmarkSuite()` | 24 | **STAYS (post-epic candidate)** | Could move to a BenchmarkCoordinator; not in this epic. |
+   531	| 9 | `recordingOverlay = RecordingOverlayPanel()` | 25 | **STAYS** | Overlay window owner. Size is decoration, not debt. |
+   532	| 10 | `ollamaSetup = OllamaSetupService()` | 26 | **MOVES → SetupCoordinator** (Phase F, new in v1.3) | Setup orchestration is a cohesive domain; extracting gets AppState closer to target. |
+   533	| 11 | `whisperKitSetup = WhisperKitSetupService()` | 27 | **MOVES → SetupCoordinator** (Phase F) | Same. Co-owned by SetupCoordinator with ollamaSetup. |
+   534	| 12 | `audioDeviceList = AudioDeviceList()` | 28 | **STAYS** | 20-line view adapter. Not debt. |
+   535	| 13 | `captureTelemetry = CaptureTelemetryState()` | 29 | **STAYS (post-epic candidate)** | Could absorb into R5's HeartPathTelemetryEmitter eventually; not in this epic. |
+   536	| 14 | `customWordsCoordinator = CustomWordsCoordinator()` | 69 | **STAYS** | Phase D adds `CustomWordsPropagator` as its subscriber; the coordinator itself remains the publisher. |
+   537	| 15 | `aiAvailability = AIAvailabilityCoordinator()` | 75 | **STAYS** | 209-line AI availability checks. Own domain already. |
+   538	
+   539	Plus architectural fixtures that aren't counted in "direct concrete deps" because they are either pipelines (peers, not owned state) or injected via composition:
+   540	- `pipeline: TranscriptionPipeline`, `whisperKitPipeline: WhisperKitPipeline` — pipeline layer peers
+   541	- `polishService: TranscriptPolishService` — peer service
+   542	- `settingsSync: PipelineSettingsSync` — shrinks in Phase B
+   543	- Ephemeral task slots: `whisperKitPreloadTask`, `postCompletionWarningTask` — not deps
+   544	
+   545	**Count trajectory:**
+   546	- **Before epic:** 15 owned concrete deps.
+   547	- **After Phase C:** 14 (transcriptStore → TranscriptCoordinator).
+   548	- **After Phase F:** 12 (ollamaSetup + whisperKitSetup → SetupCoordinator, but add 1 dep on the new SetupCoordinator itself; net -1).
+   549	- **Target:** ≤ 12 direct concrete deps (Phase E regression test calibrated here).
+   550	
+   551	Phase E previously targeted ≤ 8. That target was wrong given the disposition matrix. Revised target ≤ 12 documented in §11.
+   552	
+   553	### 4.12 Rules files that govern each phase
+   554	
+   555	Single quick-reference table. Details in `.claude/rules/`.
+   556	
+   557	| Rule file | Phases it governs primarily |
+   558	|---|---|
+   559	| `architecture-rules.md` | A, B, C, D, E, R2 (anti-god-object, access control, state ownership, intentional duplication) |
+   560	| `swift-patterns.md` | All Swift phases (Swift 6 concurrency, `@preconcurrency` imports, actor isolation) |
+
+exec
+/bin/zsh -lc "nl -ba docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md | sed -n '1360,1420p' && nl -ba docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md | sed -n '2068,2190p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+  1360	## 11. Phase E — Architecture regression tests (new)
+  1361	
+  1362	**Issue:** to open · **Plan:** inline below · **Status:** PLANNED
+  1363	**Pattern:** Self-testing code (Feathers) / Architecture fitness functions (Building Evolutionary Architectures) · **Tier:** SMALL · **Est. LOC delta:** ~65 (mostly test code)
+  1364	
+  1365	### 11.1 Why this phase exists
+  1366	
+  1367	Without guardrails, Phases A/C/D will re-accrete. A future session adding "just one more coordinator to AppState for convenience" is the next god-object. Test-enforced limits prevent silent regression.
+  1368	
+  1369	### 11.2 Design summary — three fitness functions
+  1370	
+  1371	Lightweight Swift-Testing suite that fails CI if any of the following regress. Council review flagged brittle-line-count as weak; the property-count and public-surface checks below are the architectural teeth of the phase.
+  1372	
+  1373	1. **AppState property-count ceiling.** Number of direct concrete-type stored properties on `AppState` exceeds the target. Verified 2026-04-18 baseline: 15 (§4.13). Target after Phases A+C+D+F: ≤ 12. This is the *architectural* signal, not the line count. Target revised from ≤ 8 in v1.2 because the §4.13 disposition matrix made the original target unachievable without unbundling stable concerns. A ≤ 10 target is reachable with post-epic BenchmarkCoordinator + TelemetryObservationCoordinator extractions (not in this epic).
+  1374	2. **AppState line count ceiling.** Soft backstop to catch unexpected bloat. Pick ceiling = measured-after-C+D+F + 10%, rounded. Expectation: ~500-550. Rationale: line count alone is gameable (add comments, reformat), but serves as a cheap early-warning tripwire. Paired with the property-count check, not standalone.
+  1375	3. **Cross-module `public` guard on non-App modules.** Implements audit meta-recommendation #1. Grep-based test that fails if any new `public` symbol appears in a non-App module that was not in a snapshot baseline — OR that contains a `TODO: ... narrow` / `TODO: ... Phase N` comment on a `public` declaration. Prevents another `WhisperKitBackend.makeDecodeOptions`-style confessional-TODO widening.
+  1376	
+  1377	Optional fourth (stretch, not required for Phase E close):
+  1378	4. **Dependency direction** via `scripts/check-dependency-direction.sh`. Verified 2026-04-18: the script existed historically under the brain system, was deleted when that system was deprecated, and has not been replaced. `.git/hooks/pre-commit` is a no-op stub confirming the deletion. Phase E RE-INTRODUCES automated dep-direction enforcement. See §11.3 substep 6.
+  1379	
+  1380	```swift
+  1381	// Tests/EnviousWisprTests/Architecture/AppStateSizeTests.swift
+  1382	import Testing
+  1383	import Foundation
+  1384	
+  1385	@Suite struct AppStateArchitectureTests {
+  1386	
+  1387	  /// Resolve the path to AppState.swift robustly. `#filePath` points to THIS test file;
+  1388	  /// walk up to package root and join the known path. Works under `swift test` and `xcodebuild test`.
+  1389	  private static func appStateURL() -> URL {
+  1390	    let testFile = URL(fileURLWithPath: #filePath)
+  1391	    // Tests/EnviousWisprTests/Architecture/AppStateSizeTests.swift → walk up 3 levels to package root.
+  1392	    let packageRoot = testFile.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+  1393	    return packageRoot
+  1394	      .appendingPathComponent("Sources/EnviousWispr/App/AppState.swift")
+  1395	  }
+  1396	
+  1397	  /// Count direct owned concrete-type declarations at file scope on AppState.
+  1398	  /// Matches BOTH zero-arg and arg-bearing initializers at indent depth 2.
+  1399	  /// Examples matched: `  let foo = Foo()`, `  let foo = Foo(arg: bar)`, `  let foo: Foo = .init(arg: bar)`.
+  1400	  /// Does NOT match interface-typed properties (`let foo: any FooInterface`) — those are injected, not owned.
+  1401	  @Test func appStateDirectConcreteDependencyCount() throws {
+  1402	    let url = Self.appStateURL()
+  1403	    let src = try String(contentsOf: url)
+  1404	    // Pattern intent: file-scope `let IDENT = TypeName(`...`)` where TypeName is capitalized.
+  1405	    // Captures `let foo = Foo()` and `let foo = Foo(arg: bar)` and `let foo: Foo = Foo(...)`.
+  1406	    // Does NOT capture `let foo: any Interface` (injected, not owned).
+  1407	    let pattern = #"^  let [a-zA-Z_][a-zA-Z0-9_]*(?:\s*:\s*[A-Z][a-zA-Z0-9_<>, ]*)?\s*=\s*[A-Z][a-zA-Z0-9_]*\("#
+  1408	    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+  1409	    let range = NSRange(src.startIndex..., in: src)
+  1410	    let count = regex.numberOfMatches(in: src, range: range)
+  1411	    #expect(count <= 12, "AppState has \(count) direct owned concrete dependencies; epic target is ≤ 12 after Phases A+C+D+F (§4.13 matrix).")
+  1412	  }
+  1413	
+  1414	  @Test func appStateLineCount() throws {
+  1415	    let url = Self.appStateURL()
+  1416	    let lines = try String(contentsOf: url).components(separatedBy: .newlines).count
+  1417	    #expect(lines <= 550, "AppState has \(lines) lines; decomposition ceiling is 550.")
+  1418	  }
+  1419	}
+  1420	
+  2068	## 17. Phase F — SetupCoordinator extraction (NEW v1.3)
+  2069	
+  2070	**Issue:** to open · **Plan:** inline below · **Status:** PLANNED
+  2071	**Pattern:** Extract Class (Fowler) — cohesive cluster of setup-orchestration concerns moves out of AppState · **Tier:** MEDIUM · **Est. LOC delta:** +~200 net (SetupCoordinator ~100, AppState −~30, view migrations +~100-150 across 5+ files). Original v1.3 estimate of +~90 undercounted view migration; corrected 2026-04-18 after adversarial view-surface grep.
+  2072	
+  2073	### 17.1 Why this phase exists
+  2074	
+  2075	Added in v1.3 after the §4.13 disposition matrix made clear that Phases A+C+D alone would take AppState from 15 deps to 14 — nowhere near meaningful testability improvement. Extracting the setup-service cluster (`ollamaSetup`, `whisperKitSetup`, plus the `whisperKitPreloadTask` observation wiring that drives them) into a dedicated coordinator takes the count to 12 and clusters a genuinely cohesive domain.
+  2076	
+  2077	Without Phase F, Phase E's regression test would need to be calibrated to a ≤ 14 target, which does not move the Testability grade.
+  2078	
+  2079	### 17.2 Scope
+  2080	
+  2081	New `@MainActor final class SetupCoordinator` in `Sources/EnviousWispr/App/SetupCoordinator.swift`. Owns:
+  2082	
+  2083	- `let ollamaSetup = OllamaSetupService()`
+  2084	- `let whisperKitSetup = WhisperKitSetupService()`
+  2085	- `private var whisperKitPreloadTask: Task<Void, Never>?`
+  2086	- `func startWhisperKitPreloadObservation()`
+  2087	- Any setup-progress reporting surface currently on AppState.
+  2088	
+  2089	**Required collaborators (Codex F-review 2026-04-18 — missing from v1.6 design):**
+  2090	The current preload observer at `AppState.swift:647` reads `asrManager.activeBackendType` at line 657 and calls `whisperKitPipeline.prepareBackendSilently()` at line 662. `SetupCoordinator` as zero-arg `let setup = SetupCoordinator()` is INSUFFICIENT — it needs these collaborators injected. Corrected init shape:
+  2091	
+  2092	```swift
+  2093	@MainActor
+  2094	final class SetupCoordinator {
+  2095	  let ollamaSetup = OllamaSetupService()
+  2096	  let whisperKitSetup = WhisperKitSetupService()
+  2097	  private var whisperKitPreloadTask: Task<Void, Never>?
+  2098	  private let asrManager: any ASRManagerInterface
+  2099	  private let preloadAction: @MainActor () async -> Void  // wraps whisperKitPipeline.prepareBackendSilently()
+  2100	
+  2101	  init(asrManager: any ASRManagerInterface,
+  2102	       preloadAction: @escaping @MainActor () async -> Void) {
+  2103	    self.asrManager = asrManager
+  2104	    self.preloadAction = preloadAction
+  2105	  }
+  2106	
+  2107	  func startPreloadObservation() { /* same logic, uses injected collaborators */ }
+  2108	}
+  2109	```
+  2110	
+  2111	AppState constructs it AFTER `asrManager` and `whisperKitPipeline` are ready (init-order constraint documented). The preload action is a closure so `SetupCoordinator` doesn't need to know about the pipeline's full interface — just one method.
+  2112	
+  2113	Owns internally, exposes a narrow protocol to AppState:
+  2114	
+  2115	```swift
+  2116	@MainActor
+  2117	protocol SetupCoordinating: AnyObject {
+  2118	  var ollamaSetup: OllamaSetupService { get }      // passthrough — views observe @Observable properties directly
+  2119	  var whisperKitSetup: WhisperKitSetupService { get }
+  2120	  func startPreloadObservation()
+  2121	}
+  2122	```
+  2123	
+  2124	v1.6 correction (Codex plan review 2026-04-18): the earlier draft included `reset()` AND semantic accessors `ollamaReady` / `whisperKitReady`. The semantic accessors lose SwiftUI's @Observable change tracking for `appState.ollamaSetup.setupState` in views. Substep 2 (Option A) documents the property-passthrough pattern; the protocol shape above must match that. `reset()` dropped — no caller.
+  2125	
+  2126	AppState drops `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` direct properties and gains one: `let setup = SetupCoordinator()` (or injected via composition for test seams).
+  2127	
+  2128	### 17.3 Substeps (ordered)
+  2129	
+  2130	**Exact view-migration surface (Codex F-review 2026-04-18, precise counts):**
+  2131	- `appState.ollamaSetup.*` — **29 sites** in `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift`.
+  2132	- `appState.whisperKitSetup.*` — **8 sites** in `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift`.
+  2133	- `appState.ollamaSetup.cleanup()` — **1 site** in `Sources/EnviousWispr/App/AppDelegate.swift:417`.
+  2134	- **Total: 38 sites across 3 files** (plus AppDelegate shutdown hook). The v1.3 "~20-30 sites across ~5 files" estimate was BOTH too-few (sites) AND too-many (files). LOC delta revised: +200 to +250 (mostly mechanical rename of `appState.ollamaSetup.X` → `appState.setup.ollamaSetup.X` in 29 places + `appState.whisperKitSetup.X` → `appState.setup.whisperKitSetup.X` in 8 places).
+  2135	
+  2136	1. **Inventory pass (substep 1 — DO THIS BEFORE WRITING CODE).** Grep every read site:
+  2137	   ```bash
+  2138	   grep -rn "appState\.ollamaSetup\." Sources/ Tests/
+  2139	   grep -rn "appState\.whisperKitSetup\." Sources/ Tests/
+  2140	   grep -rn "\.whisperKitPreloadTask\b" Sources/
+  2141	   ```
+  2142	   Expected hits include at minimum:
+  2143	   - `Sources/EnviousWispr/App/AppDelegate.swift:417` — `ollamaSetup.cleanup()`.
+  2144	   - `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` — 15+ sites (setupState reads, onChange, method calls: detectState, cancelPull, resetWarmup, startServer, pullModel, warmUpModel).
+  2145	   - Likely more view sites for WhisperKit setup.
+  2146	   
+  2147	   Build a full inventory BEFORE designing the `SetupCoordinating` protocol. The protocol surface is whatever this inventory demands plus safe margin.
+  2148	2. Design `SetupCoordinating` protocol. At minimum it must expose the underlying `@Observable` services for SwiftUI's property-observation tracking to keep working. Options:
+  2149	   - **Option A (simplest):** `setupCoordinator.ollamaSetup` and `setupCoordinator.whisperKitSetup` passthrough properties. Views change `appState.ollamaSetup` → `appState.setup.ollamaSetup`. Protocol surface = two properties. Simplest migration.
+  2150	   - **Option B (encapsulating):** Protocol exposes semantic methods (`setup.ollamaReady`, `setup.startOllamaDetect()`, etc.). Views deeply migrate. More work, cleaner end state, but larger blast radius.
+  2151	   
+  2152	   **Recommendation for this epic: Option A.** Ship the property-passthrough version. Post-epic, if the encapsulation is genuinely needed, do a smaller follow-on.
+  2153	3. Define `SetupCoordinator` concrete class. Move `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` ownership. Preserve their current `@Observable` surfaces intact.
+  2154	4. Update AppState: replace three fields with one `setup = SetupCoordinator()` field.
+  2155	5. Update `PipelineSettingsSync.onNeedsPreloadObservation` callback to call into `setup` instead of AppState.
+  2156	6. **View migration (substep 6 — mechanical, from inventory in substep 1).** Every read `appState.ollamaSetup.X` becomes `appState.setup.ollamaSetup.X` (Option A). Every `appState.whisperKitSetup.X` → `appState.setup.whisperKitSetup.X`. Every `.onChange(of: appState.ollamaSetup.setupState)` still observes the SAME `OllamaSetupService` instance; the observation path changes string, not the object graph.
+  2157	7. Test pass: `AIPolishSettingsView` + WhisperKit-setup-touching views still render and respond to state changes live. Use `wispr-eyes` to verify the Settings > AI Polish tab cycles through setupState transitions correctly.
+  2158	8. Unit test: `SetupCoordinator` can be constructed without AppState; `startWhisperKitPreloadObservation` starts and can be cancelled. **Codex F-review 2026-04-18 prerequisite:** `Package.swift:107` does NOT include the `EnviousWispr` executable target as a test dependency; `EnviousWisprTests` cannot import `SetupCoordinator` as-is. The test requires either (a) adding `EnviousWispr` to test target deps in `Package.swift`, OR (b) extracting `SetupCoordinator` into a library target that tests can depend on. Recommendation: (a) — smaller blast radius. With the seam (injectable `asrManager` + `preloadAction` closure per §17.2), the test can force a fake non-ready state, assert observer start/cancel, and assert `preloadAction` is invoked. No real HTTP or model downloads.
+  2159	9. Live smoke: Ollama and WhisperKit setup still report status correctly in Settings UI; preload fires on new model selection; cleanup fires on app quit.
+  2160	
+  2161	### 17.3.1 Protocol surface — RESOLVED (no `reset()`)
+  2162	
+  2163	Codex plan review 2026-04-18 flagged self-contradiction between §17.2 (earlier draft included `reset()` in the protocol sketch) and §17.3.1 (dropped `reset()`). Locked in v1.6: the `SetupCoordinating` protocol does NOT expose `reset()`. No current caller needs it. §17.2 sketch above is the canonical protocol shape. If future work needs reset-on-account-switch or similar, add it then with a concrete caller.
+  2164	
+  2165	### 17.4 DoD
+  2166	
+  2167	- [ ] `AppState.swift` grep returns zero hits for `ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` as owned properties.
+  2168	- [ ] `SetupCoordinator.swift` + `SetupCoordinating` protocol committed.
+  2169	- [ ] PipelineSettingsSync + views route through the protocol.
+  2170	- [ ] Unit test exercises preload observation.
+  2171	- [ ] Live smoke: both setup services work as before.
+  2172	- [ ] Architecture Closeout — ownership moved, no widening.
+  2173	- [ ] Codex clean + Periphery clean.
+  2174	
+  2175	### 17.5 Rollback
+  2176	
+  2177	`git revert`. Properties return to AppState. No persisted state; no migration.
+  2178	
+  2179	### 17.6 Dependencies
+  2180	
+  2181	After Phase A (cleaner AppState to operate on). Can land in Session 3 with or adjacent to Phase C+D+E, or Session 4 if time constrained. No dependency on R2.
+  2182	
+  2183	### 17.7 Post-epic candidates (not in Phase F scope)
+  2184	
+  2185	§4.13 identified two other extraction candidates that are NOT in this epic:
+  2186	- **BenchmarkCoordinator** absorbing `benchmark = BenchmarkSuite()`.
+  2187	- **TelemetryObservationCoordinator** absorbing `captureTelemetry = CaptureTelemetryState()` observer wiring.
+  2188	
+  2189	If the post-epic audit rerun grades Testability below A, open these as follow-on issues under #319. Do not expand this epic to absorb them.
+  2190	
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/AppDelegate.swift | sed -n '400,425p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   400	    showWindow()
+   401	  }
+   402	
+   403	  @objc private func openPermissionsSettings() {
+   404	    appState.pendingNavigationSection = .permissions
+   405	    showWindow()
+   406	  }
+   407	
+   408	  func applicationWillTerminate(_ notification: Notification) {
+   409	    if let observer = windowCloseObserver {
+   410	      NotificationCenter.default.removeObserver(observer)
+   411	      windowCloseObserver = nil
+   412	    }
+   413	    if let observer = onboardingCloseObserver {
+   414	      NotificationCenter.default.removeObserver(observer)
+   415	      onboardingCloseObserver = nil
+   416	    }
+   417	    appState.ollamaSetup.cleanup()
+   418	    appState.hotkeyService.stop()
+   419	    LLMNetworkSession.shared.invalidate()
+   420	  }
+   421	
+   422	  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+   423	    // Menu bar app — keep running when windows close.
+   424	    // User quits via "Quit EnviousWispr" in the status bar menu.
+   425	    return false
+
+codex
+I’ve confirmed the current `AppState` is already post-Phase A/C/D-ish: `TranscriptStore` is now constructed locally and `CustomWordsPropagator` exists, so the old bible count trajectory has drifted. That matters for the Phase E ceiling and for whether this is a meaningful decomposition versus just lowering a counter.
+exec
+/bin/zsh -lc "rg -n \"appState\\.ollamaSetup\\.\" Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+27:    switch appState.ollamaSetup.setupState {
+228:          await appState.ollamaSetup.detectState()
+229:          if case .ready = appState.ollamaSetup.setupState {
+247:        appState.ollamaSetup.cancelPull()
+248:        appState.ollamaSetup.resetWarmup()
+257:        Task { await appState.ollamaSetup.detectState() }
+268:    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
+276:          appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+280:        appState.ollamaSetup.resetWarmup()
+286:        case .ready = appState.ollamaSetup.setupState,
+289:        appState.ollamaSetup.warmUpModel(newModel)
+573:    switch appState.ollamaSetup.setupState {
+619:            appState.ollamaSetup.startServer()
+642:            appState.ollamaSetup.pullModel(appState.settings.ollamaModel)
+675:            appState.ollamaSetup.cancelPull()
+708:            await appState.ollamaSetup.detectState()
+709:            if case .ready = appState.ollamaSetup.setupState {
+863:    let catalog = appState.ollamaSetup.dynamicCatalog
+865:      if case .pullingModel = appState.ollamaSetup.setupState { return true }
+890:          if appState.ollamaSetup.currentPullingModel == entry.name {
+893:              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
+898:                appState.ollamaSetup.cancelPull()
+908:              appState.ollamaSetup.deleteModel(name: entry.name)
+918:              appState.ollamaSetup.pullModel(entry.name)
+986:        await appState.ollamaSetup.detectState()
+987:        if case .ready = appState.ollamaSetup.setupState {
+1004:    switch appState.ollamaSetup.warmupState {
+1015:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+1025:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+
+exec
+/bin/zsh -lc "rg -n \"appState\\.whisperKitSetup\\.\" Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+47:        case .ready = appState.whisperKitSetup.setupState
+165:        Task { await appState.whisperKitSetup.detectState() }
+170:        Task { await appState.whisperKitSetup.detectState() }
+206:    switch appState.whisperKitSetup.setupState {
+228:            appState.whisperKitSetup.downloadModel()
+257:            appState.whisperKitSetup.cancelDownload()
+284:          Task { await appState.whisperKitSetup.detectState() }
+301:      Task { await appState.whisperKitSetup.forceDetectState() }
+
+exec
+/bin/zsh -lc "rg -n \"appState\\.(ollamaSetup|whisperKitSetup)\\.|\\bollamaSetup\\b|\\bwhisperKitSetup\\b|whisperKitPreloadTask|startWhisperKitPreloadObservation\" Sources Tests Package.swift" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:47:        case .ready = appState.whisperKitSetup.setupState
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:165:        Task { await appState.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:170:        Task { await appState.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:206:    switch appState.whisperKitSetup.setupState {
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:228:            appState.whisperKitSetup.downloadModel()
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:257:            appState.whisperKitSetup.cancelDownload()
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:284:          Task { await appState.whisperKitSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:301:      Task { await appState.whisperKitSetup.forceDetectState() }
+Sources/EnviousWispr/App/AppDelegate.swift:417:    appState.ollamaSetup.cleanup()
+Sources/EnviousWispr/App/AppState.swift:25:  let ollamaSetup = OllamaSetupService()
+Sources/EnviousWispr/App/AppState.swift:26:  let whisperKitSetup = WhisperKitSetupService()
+Sources/EnviousWispr/App/AppState.swift:31:  private var whisperKitPreloadTask: Task<Void, Never>?
+Sources/EnviousWispr/App/AppState.swift:217:      whisperKitSetup: whisperKitSetup
+Sources/EnviousWispr/App/AppState.swift:376:      self?.startWhisperKitPreloadObservation()
+Sources/EnviousWispr/App/AppState.swift:619:      await self?.whisperKitSetup.detectState()
+Sources/EnviousWispr/App/AppState.swift:620:      self?.startWhisperKitPreloadObservation()
+Sources/EnviousWispr/App/AppState.swift:639:  private func startWhisperKitPreloadObservation() {
+Sources/EnviousWispr/App/AppState.swift:640:    whisperKitPreloadTask?.cancel()
+Sources/EnviousWispr/App/AppState.swift:641:    whisperKitPreloadTask = Task { [weak self] in
+Sources/EnviousWispr/App/AppState.swift:652:        let currentState = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/AppState.swift:661:            _ = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:20:  private let whisperKitSetup: WhisperKitSetupService
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:38:    whisperKitSetup: WhisperKitSetupService
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:46:    self.whisperKitSetup = whisperKitSetup
+Sources/EnviousWispr/App/PipelineSettingsSync.swift:109:          await self?.whisperKitSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:27:    switch appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:228:          await appState.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:229:          if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:247:        appState.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:248:        appState.ollamaSetup.resetWarmup()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:257:        Task { await appState.ollamaSetup.detectState() }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:268:    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:276:          appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:280:        appState.ollamaSetup.resetWarmup()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:286:        case .ready = appState.ollamaSetup.setupState,
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:289:        appState.ollamaSetup.warmUpModel(newModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:573:    switch appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:619:            appState.ollamaSetup.startServer()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:642:            appState.ollamaSetup.pullModel(appState.settings.ollamaModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:675:            appState.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:708:            await appState.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:709:            if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:863:    let catalog = appState.ollamaSetup.dynamicCatalog
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:865:      if case .pullingModel = appState.ollamaSetup.setupState { return true }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:890:          if appState.ollamaSetup.currentPullingModel == entry.name {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:893:              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:898:                appState.ollamaSetup.cancelPull()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:908:              appState.ollamaSetup.deleteModel(name: entry.name)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:918:              appState.ollamaSetup.pullModel(entry.name)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:986:        await appState.ollamaSetup.detectState()
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:987:        if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1004:    switch appState.ollamaSetup.warmupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1015:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1025:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+
+exec
+/bin/zsh -lc "rg -n \"setupState|withObservationTracking|@Observable|\\.setup\\.[A-Za-z]+\\.|appState\\.[A-Za-z]+\\.[A-Za-z]+\\.\" Sources/EnviousWispr Sources/EnviousWisprASR Sources/EnviousWisprLLM Sources/EnviousWisprPipeline | head -n 200" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWisprPipeline/TranscriptPolishService.swift:16:@Observable
+Sources/EnviousWisprASR/ASRManagerProxy.swift:12:@Observable
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:33:@Observable
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:38:  public private(set) var setupState: WhisperKitSetupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:62:  /// Sets setupState to .ready or .notDownloaded (never triggers a download).
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:67:      setupState != .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:72:    setupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:74:    setupState = isDownloaded ? .ready : .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:95:  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:131:    setupState = .downloading(progress: 0, status: "Starting download...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:154:        self.setupState = .downloading(progress: fraction, status: "Downloading model files...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:160:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:168:        self.setupState = .ready
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:170:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:173:        self?.setupState = .error(
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:184:    setupState = .notDownloaded
+Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:11:@Observable
+Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift:40:  /// SwiftUI can't observe @Observable properties through protocol existentials
+Sources/EnviousWisprASR/ASRManager.swift:7:@Observable
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:12:@Observable
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:53:@Observable
+Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift:29:        if appState.transcriptCoordinator.transcripts.isEmpty {
+Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift:38:      if !appState.transcriptCoordinator.transcripts.isEmpty {
+Sources/EnviousWisprLLM/OllamaSetupService.swift:86:@Observable
+Sources/EnviousWisprLLM/OllamaSetupService.swift:91:  public private(set) var setupState: OllamaSetupState = .detecting
+Sources/EnviousWisprLLM/OllamaSetupService.swift:317:    setupState = .detecting
+Sources/EnviousWisprLLM/OllamaSetupService.swift:323:          setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:326:        setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:333:      setupState = .notInstalled
+Sources/EnviousWisprLLM/OllamaSetupService.swift:340:      if case .error = setupState { return }
+Sources/EnviousWisprLLM/OllamaSetupService.swift:341:      setupState = .installedNotRunning
+Sources/EnviousWisprLLM/OllamaSetupService.swift:346:      setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:349:      setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:412:      setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:502:            setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:535:        setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:541:      setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:556:            self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:559:            self.setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:565:      self?.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:591:    setupState = .pullingModel(progress: 0, status: "Starting download...")
+Sources/EnviousWisprLLM/OllamaSetupService.swift:600:        // setupState = .pullingModel(1.0, "success") from the last stream chunk
+Sources/EnviousWisprLLM/OllamaSetupService.swift:610:        // its own setupState; overwriting with .ready would clobber it.
+Sources/EnviousWisprLLM/OllamaSetupService.swift:613:        self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:619:          self.setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:621:          self.setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:626:        self.setupState = .error(self.friendlyMessage(for: urlError))
+Sources/EnviousWisprLLM/OllamaSetupService.swift:632:          self.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:636:          self.setupState = .error(
+Sources/EnviousWisprLLM/OllamaSetupService.swift:657:        setupState = .runningNoModels
+Sources/EnviousWisprLLM/OllamaSetupService.swift:659:        setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:666:      //      await) bails and does NOT overwrite setupState. Otherwise a
+Sources/EnviousWisprLLM/OllamaSetupService.swift:672:      //   3. Commit setupState = .ready here. The stream reported success, so
+Sources/EnviousWisprLLM/OllamaSetupService.swift:675:      //      Task's bail (step 1) would leave setupState stuck at
+Sources/EnviousWisprLLM/OllamaSetupService.swift:681:      setupState = .ready
+Sources/EnviousWisprLLM/OllamaSetupService.swift:811:        setupState = .pullingModel(progress: progress, status: status)
+Sources/EnviousWisprLLM/OllamaSetupService.swift:814:        setupState = .pullingModel(progress: pullProgress, status: status)
+Sources/EnviousWisprLLM/OllamaSetupService.swift:820:        setupState = .pullingModel(progress: 1.0, status: status)
+Sources/EnviousWispr/App/LLMModelDiscoveryCoordinator.swift:7:@MainActor @Observable
+Sources/EnviousWispr/App/AppState.swift:12:@Observable
+Sources/EnviousWispr/App/AppState.swift:30:  /// Background task that observes WhisperKitSetupService.setupState and pre-loads the model when ready.
+Sources/EnviousWispr/App/AppState.swift:612:    // WhisperKit: observation-based (waits for setupState to become .ready first).
+Sources/EnviousWispr/App/AppState.swift:637:  /// Observe WhisperKitSetupService.setupState and pre-load the model when it becomes .ready.
+Sources/EnviousWispr/App/AppState.swift:638:  /// Uses withObservationTracking to react to @Observable property changes outside SwiftUI.
+Sources/EnviousWispr/App/AppState.swift:652:        let currentState = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/AppState.swift:658:        // Wait for the next change to setupState
+Sources/EnviousWispr/App/AppState.swift:660:          withObservationTracking {
+Sources/EnviousWispr/App/AppState.swift:661:            _ = self.whisperKitSetup.setupState
+Sources/EnviousWispr/App/AIAvailabilityCoordinator.swift:11:@MainActor @Observable
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:47:        case .ready = appState.whisperKitSetup.setupState
+Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift:206:    switch appState.whisperKitSetup.setupState {
+Sources/EnviousWispr/App/CustomWordsCoordinator.swift:7:@MainActor @Observable
+Sources/EnviousWispr/App/BenchmarkSuite.swift:9:@Observable
+Sources/EnviousWispr/App/TranscriptCoordinator.swift:7:@MainActor @Observable
+Sources/EnviousWispr/App/AppDelegate.swift:99:        customWordsCount: appState.customWordsCoordinator.customWords.count,
+Sources/EnviousWispr/App/AudioDeviceList.swift:5:@MainActor @Observable
+Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift:32:        header: "Custom Word List (\(appState.customWordsCoordinator.customWords.count) words)"
+Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift:60:        if appState.customWordsCoordinator.customWords.isEmpty {
+Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift:72:                appState.customWordsCoordinator.customWords.sorted {
+Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift:125:    // layout pass to process the @Observable array mutation
+Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift:129:      if let added = appState.customWordsCoordinator.customWords.first(where: {
+Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift:23:          if appState.settings.preferredInputDeviceIDOverride.isEmpty,
+Sources/EnviousWispr/App/RecordingOverlayPanel.swift:13:@Observable
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:126:        if !appState.benchmark.results.isEmpty {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:19:    appState.settings.llmProvider.supportsReasoning(model: appState.settings.llmModel)
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:27:    switch appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:125:                if appState.llmDiscovery.discoveredModels.isEmpty
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:129:                    appState.settings.llmModel.isEmpty
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:170:          if let selectedModel = appState.llmDiscovery.discoveredModels.first(where: {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:229:          if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:255:        // detectState() will set setupState, which triggers the onChange handler
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:268:    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:275:        if !appState.settings.llmModel.isEmpty {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:286:        case .ready = appState.ollamaSetup.setupState,
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:573:    switch appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:709:            if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:865:      if case .pullingModel = appState.ollamaSetup.setupState { return true }
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:987:        if case .ready = appState.ollamaSetup.setupState {
+Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift:1024:        guard !appState.settings.llmModel.isEmpty else { return }
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprASR/WhisperKitSetupService.swift | sed -n '1,220p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/PipelineSettingsSync.swift | sed -n '1,180p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	import Foundation
+     2	@preconcurrency import WhisperKit
+     3	
+     4	/// Free function (nonisolated) that wraps WhisperKit.download() and relays progress
+     5	/// via an AsyncStream continuation. The continuation is Sendable, so this avoids
+     6	/// Swift 6 data-race diagnostics around sending a MainActor-captured closure
+     7	/// to a nonisolated function.
+     8	private func whisperKitDownload(
+     9	  variant: String,
+    10	  progressContinuation: AsyncStream<Double>.Continuation
+    11	) async throws {
+    12	  defer { progressContinuation.finish() }
+    13	  _ = try await WhisperKit.download(
+    14	    variant: variant,
+    15	    progressCallback: { progress in
+    16	      progressContinuation.yield(progress.fractionCompleted)
+    17	    }
+    18	  )
+    19	}
+    20	
+    21	/// States in the WhisperKit model setup flow.
+    22	public enum WhisperKitSetupState: Equatable {
+    23	  case checking  // initial detection
+    24	  case notDownloaded  // model not on disk
+    25	  case downloading(progress: Double, status: String)  // actively downloading
+    26	  case ready  // model cached locally, ready to use
+    27	  case error(String)
+    28	}
+    29	
+    30	/// Guides users through WhisperKit model download.
+    31	/// Downloads happen in Settings — NOT auto-triggered on first record.
+    32	@MainActor
+    33	@Observable
+    34	public final class WhisperKitSetupService {
+    35	
+    36	  // MARK: - Public State
+    37	
+    38	  public private(set) var setupState: WhisperKitSetupState = .checking
+    39	
+    40	  /// Model variant to download. Source of truth: `WhisperKitBackend.defaultModelVariant()`.
+    41	  // BRAIN: gotcha id=model-name-format
+    42	  public let modelVariant: String = WhisperKitBackend.defaultModelVariant()
+    43	
+    44	  public init() {}
+    45	
+    46	  // MARK: - Private
+    47	
+    48	  private var downloadTask: Task<Void, Never>?
+    49	
+    50	  /// WhisperKit model storage directory.
+    51	  /// WhisperKit 0.12+ downloads models to ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/
+    52	  /// nonisolated(unsafe) is required: the class is @MainActor but nonisolated static methods reference this.
+    53	  nonisolated(unsafe) private static let whisperKitModelRoot: URL? = FileManager.default
+    54	    .homeDirectoryForCurrentUser
+    55	    .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+    56	
+    57	  // MARK: - Detection
+    58	
+    59	  private var lastDetectTime: Date?
+    60	
+    61	  /// Check whether the model is already cached locally.
+    62	  /// Sets setupState to .ready or .notDownloaded (never triggers a download).
+    63	  /// Caches result for 5 seconds to avoid redundant file I/O on tab switches.
+    64	  public func detectState() async {
+    65	    if let lastTime = lastDetectTime,
+    66	      Date().timeIntervalSince(lastTime) < 5.0,
+    67	      setupState != .checking
+    68	    {
+    69	      return
+    70	    }
+    71	
+    72	    setupState = .checking
+    73	    let isDownloaded = WhisperKitSetupService.isModelCached(variant: modelVariant)
+    74	    setupState = isDownloaded ? .ready : .notDownloaded
+    75	    lastDetectTime = Date()
+    76	  }
+    77	
+    78	  /// Force a fresh state check, ignoring cache.
+    79	  public func forceDetectState() async {
+    80	    lastDetectTime = nil
+    81	    await detectState()
+    82	  }
+    83	
+    84	  /// Returns true if a folder matching the given model variant exists in the HF cache.
+    85	  public nonisolated static func isModelCached(variant: String) -> Bool {
+    86	    return getLocalModelPath(variant: variant) != nil
+    87	  }
+    88	
+    89	  /// Returns the local path to a fully-cached WhisperKit model, or nil if not
+    90	  /// downloaded OR if the cache is incomplete (missing one of the required
+    91	  /// `.mlmodelc` artifacts — e.g. an interrupted download).
+    92	  /// WhisperKit 0.12+ stores models as direct subdirectories like
+    93	  /// `openai_whisper-large-v3`. Partial-download semantics (issue #329):
+    94	  /// treating an incomplete folder as "not cached" keeps `detectState` →
+    95	  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+    96	  /// back to `WhisperKit.download(...)` instead of trying to load a
+    97	  /// corrupt path.
+    98	  public nonisolated static func getLocalModelPath(variant: String) -> String? {
+    99	    guard let root = whisperKitModelRoot else { return nil }
+   100	
+   101	    let fm = FileManager.default
+   102	    guard fm.fileExists(atPath: root.path) else { return nil }
+   103	
+   104	    let variantLower = variant.lowercased()
+   105	    let sanitizedLower = variant.replacingOccurrences(of: "-", with: "_").lowercased()
+   106	
+   107	    guard let contents = try? fm.contentsOfDirectory(atPath: root.path) else {
+   108	      return nil
+   109	    }
+   110	
+   111	    for dir in contents {
+   112	      let lower = dir.lowercased()
+   113	      if lower.contains(variantLower) || lower.contains(sanitizedLower) {
+   114	        let fullPath = root.appendingPathComponent(dir).path
+   115	        var isDir: ObjCBool = false
+   116	        guard fm.fileExists(atPath: fullPath, isDirectory: &isDir), isDir.boolValue else {
+   117	          continue
+   118	        }
+   119	        guard WhisperKitBackend.hasRequiredArtifacts(at: fullPath) else { continue }
+   120	        return fullPath
+   121	      }
+   122	    }
+   123	    return nil
+   124	  }
+   125	
+   126	  // MARK: - Download
+   127	
+   128	  /// Start downloading the model with progress tracking.
+   129	  public func downloadModel() {
+   130	    downloadTask?.cancel()
+   131	    setupState = .downloading(progress: 0, status: "Starting download...")
+   132	
+   133	    let variant = modelVariant
+   134	    downloadTask = Task { [weak self] in
+   135	      // Run the actual network download on a detached task (nonisolated context).
+   136	      // Progress fractions are relayed back via an AsyncStream so there is no
+   137	      // actor-isolated closure sent to a nonisolated function (Swift 6 safe).
+   138	      let (progressStream, progressContinuation) = AsyncStream<Double>.makeStream()
+   139	
+   140	      let downloadResult: Task<Void, Error> = Task.detached {
+   141	        // The progress callback runs on whatever thread URLSession uses.
+   142	        // It feeds into the stream (safe — AsyncStream continuation is Sendable).
+   143	        try await whisperKitDownload(
+   144	          variant: variant,
+   145	          progressContinuation: progressContinuation
+   146	        )
+   147	      }
+   148	
+   149	      // Consume progress updates on the MainActor while the download runs.
+   150	      // If outer Task is cancelled, exit the loop and cancel the inner download.
+   151	      for await fraction in progressStream {
+   152	        if Task.isCancelled { break }
+   153	        guard let self else { break }
+   154	        self.setupState = .downloading(progress: fraction, status: "Downloading model files...")
+   155	      }
+   156	
+   157	      // If the outer Task was cancelled, cancel the inner detached download too.
+   158	      if Task.isCancelled {
+   159	        downloadResult.cancel()
+   160	        self?.setupState = .notDownloaded
+   161	        return
+   162	      }
+   163	
+   164	      do {
+   165	        try await downloadResult.value
+   166	        guard let self else { return }
+   167	        self.lastDetectTime = Date()
+   168	        self.setupState = .ready
+   169	      } catch is CancellationError {
+   170	        self?.setupState = .notDownloaded
+   171	        downloadResult.cancel()
+   172	      } catch {
+   173	        self?.setupState = .error(
+   174	          "Download failed — check your internet connection and try again."
+   175	        )
+   176	      }
+   177	    }
+   178	  }
+   179	
+   180	  /// Cancel an in-progress download.
+   181	  public func cancelDownload() {
+   182	    downloadTask?.cancel()
+   183	    downloadTask = nil
+   184	    setupState = .notDownloaded
+   185	  }
+   186	}
+
+ succeeded in 0ms:
+     1	import EnviousWisprASR
+     2	import EnviousWisprAudio
+     3	import EnviousWisprCore
+     4	import EnviousWisprLLM
+     5	import EnviousWisprPipeline
+     6	import EnviousWisprServices
+     7	import Foundation
+     8	
+     9	/// Forwards live-mutable settings changes. Per-recording values are frozen
+    10	/// via `DictationSessionConfig` at `startRecording` and do not flow here —
+    11	/// see #195 plan for the full frozen/live classification.
+    12	@MainActor
+    13	final class PipelineSettingsSync {
+    14	  private let pipeline: TranscriptionPipeline
+    15	  private let whisperKitPipeline: WhisperKitPipeline
+    16	  private let polishService: TranscriptPolishService
+    17	  private let audioCapture: any AudioCaptureInterface
+    18	  private let asrManager: any ASRManagerInterface
+    19	  private let hotkeyService: HotkeyService
+    20	  private let whisperKitSetup: WhisperKitSetupService
+    21	
+    22	  /// Set by AppState so backend/model changes can retrigger preload observation
+    23	  /// without coupling this layer to AppState.
+    24	  var onNeedsPreloadObservation: (() -> Void)?
+    25	
+    26	  /// Tracks the last evictable Ollama model for #295. Independent of
+    27	  /// `polishService.llmPolishStep` because SettingsManager's cascading didSet
+    28	  /// can corrupt a pre-snapshot read from the polish step.
+    29	  private var lastEvictableOllamaModel: String?
+    30	
+    31	  init(
+    32	    pipeline: TranscriptionPipeline,
+    33	    whisperKitPipeline: WhisperKitPipeline,
+    34	    polishService: TranscriptPolishService,
+    35	    audioCapture: any AudioCaptureInterface,
+    36	    asrManager: any ASRManagerInterface,
+    37	    hotkeyService: HotkeyService,
+    38	    whisperKitSetup: WhisperKitSetupService
+    39	  ) {
+    40	    self.pipeline = pipeline
+    41	    self.whisperKitPipeline = whisperKitPipeline
+    42	    self.polishService = polishService
+    43	    self.audioCapture = audioCapture
+    44	    self.asrManager = asrManager
+    45	    self.hotkeyService = hotkeyService
+    46	    self.whisperKitSetup = whisperKitSetup
+    47	  }
+    48	
+    49	  /// Seed live-mutable subsystems. Per-recording values are captured fresh
+    50	  /// at each `startRecording` and are not seeded here.
+    51	  ///
+    52	  /// Custom words are NOT seeded here — `CustomWordsPropagator` (registered
+    53	  /// in AppState init) owns that fanout. See Phase D (#496).
+    54	  func applyInitialSettings(_ settings: SettingsManager) {
+    55	    pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    56	    pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    57	    whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    58	    whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    59	
+    60	    syncPolishServiceSettings(settings)
+    61	
+    62	    if settings.noiseSuppression {
+    63	      audioCapture.buildEngine(noiseSuppression: true)
+    64	    } else {
+    65	      audioCapture.noiseSuppressionEnabled = false
+    66	    }
+    67	    audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
+    68	    audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    69	    audioCapture.warmEnginePolicy = settings.warmEnginePolicy
+    70	    audioCapture.configureVAD(
+    71	      autoStop: settings.vadAutoStop,
+    72	      silenceTimeout: settings.vadSilenceTimeout,
+    73	      sensitivity: settings.vadSensitivity,
+    74	      energyGate: settings.vadEnergyGate
+    75	    )
+    76	
+    77	    // #295: seed eviction tracker. No initial eviction on app launch.
+    78	    lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
+    79	      provider: settings.llmProvider, model: resolvedModel(settings)
+    80	    )
+    81	  }
+    82	
+    83	  /// Handle a settings change by forwarding to the appropriate subsystem.
+    84	  func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
+    85	    switch key {
+    86	    case .selectedBackend:
+    87	      // Don't switch backends while a pipeline is actively recording/transcribing
+    88	      let parakeetActive = pipeline.state.isActive
+    89	      let whisperKitActive = whisperKitPipeline.state.isActive
+    90	      if parakeetActive || whisperKitActive {
+    91	        Task {
+    92	          await AppLogger.shared.log(
+    93	            "Backend switch blocked — pipeline is active",
+    94	            level: .info, category: "PipelineSettingsSync"
+    95	          )
+    96	        }
+    97	        break
+    98	      }
+    99	      let backend = settings.selectedBackend
+   100	      // Issue #289: invalidate any stall-recovery token on either pipeline
+   101	      // so a deferred cleanup from a pre-switch stall doesn't tear down
+   102	      // the pipeline that's about to become active.
+   103	      pipeline.clearPendingStallRecovery()
+   104	      whisperKitPipeline.clearPendingStallRecovery()
+   105	      Task { [weak self] in
+   106	        await self?.asrManager.switchBackend(to: backend)
+   107	        SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
+   108	        if backend == .whisperKit {
+   109	          await self?.whisperKitSetup.detectState()
+   110	          self?.onNeedsPreloadObservation?()
+   111	        }
+   112	      }
+   113	    case .recordingMode:
+   114	      hotkeyService.recordingMode = settings.recordingMode
+   115	    case .llmProvider:
+   116	      // Live mirror to re-polish path; eviction fires for RAM management (#295).
+   117	      // Pipeline polish uses the frozen value from `DictationSessionConfig`.
+   118	      polishService.llmPolishStep.llmProvider = settings.llmProvider
+   119	      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+   120	      reconcileOllamaEviction(settings: settings)
+   121	    case .llmModel:
+   122	      polishService.llmPolishStep.llmModel = resolvedModel(settings)
+   123	      if settings.llmProvider == .ollama {
+   124	        settings.ollamaModel = settings.llmModel
+   125	      }
+   126	      reconcileOllamaEviction(settings: settings)
+   127	    case .ollamaModel:
+   128	      if settings.llmProvider == .ollama {
+   129	        polishService.llmPolishStep.llmModel = settings.ollamaModel
+   130	      }
+   131	      reconcileOllamaEviction(settings: settings)
+   132	    case .hotkeyEnabled:
+   133	      if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
+   134	    case .environmentPreset:
+   135	      // Cascade into `vadSensitivity` for the next recording's snapshot.
+   136	      settings.vadSensitivity = settings.environmentPreset.vadSensitivity
+   137	    case .writingStylePreset, .customSystemPrompt:
+   138	      polishService.llmPolishStep.polishInstructions = settings.activePolishInstructions
+   139	      polishService.llmPolishStep.styleConfig = settings.activePolishStyleConfig
+   140	    case .cancelKeyCode:
+   141	      hotkeyService.cancelKeyCode = settings.cancelKeyCode
+   142	    case .cancelModifiers:
+   143	      hotkeyService.cancelModifiers = settings.cancelModifiers
+   144	    case .toggleKeyCode:
+   145	      hotkeyService.toggleKeyCode = settings.toggleKeyCode
+   146	      reregisterHotkeys()
+   147	    case .toggleModifiers:
+   148	      hotkeyService.toggleModifiers = settings.toggleModifiers
+   149	      reregisterHotkeys()
+   150	    case .pushToTalkKeyCode, .pushToTalkModifiers:
+   151	      // PTT mirrors toggle — single hotkey, mode determines behavior. No separate registration needed.
+   152	      break
+   153	    case .modelUnloadPolicy:
+   154	      // Frozen per recording; cancel idle timer live when switched to .never.
+   155	      if settings.modelUnloadPolicy == .never {
+   156	        asrManager.cancelIdleTimer()
+   157	      }
+   158	    case .wordCorrectionEnabled:
+   159	      pipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+   160	      whisperKitPipeline.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+   161	    case .fillerRemovalEnabled:
+   162	      pipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+   163	      whisperKitPipeline.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+   164	    case .isDebugModeEnabled:
+   165	      Task { await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled) }
+   166	    case .debugLogLevel:
+   167	      Task { await AppLogger.shared.setLogLevel(settings.debugLogLevel) }
+   168	    case .useExtendedThinking:
+   169	      polishService.llmPolishStep.useExtendedThinking = settings.useExtendedThinking
+   170	    case .selectedInputDeviceUID:
+   171	      // Rebuilds next recording's capture source; in-flight recordings unaffected.
+   172	      audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
+   173	    case .preferredInputDeviceIDOverride:
+   174	      audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+   175	    case .noiseSuppression:
+   176	      // Runtime voice-processing toggling is unreliable — full engine rebuild.
+   177	      // Cancel active recording first to avoid corrupted state.
+   178	      if pipeline.state == .recording {
+   179	        Task { [weak self] in
+   180	          await self?.pipeline.cancelRecording()
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprLLM/OllamaSetupService.swift | sed -n '70,130p' && nl -ba Sources/EnviousWisprLLM/OllamaSetupService.swift | sed -n '300,360p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+    70	    self.isDownloaded = isDownloaded
+    71	  }
+    72	}
+    73	
+    74	/// A model parsed from Ollama's /api/tags response.
+    75	public struct OllamaDownloadedModel: Sendable {
+    76	  public let exactName: String
+    77	  public let canonicalName: String
+    78	  public let parameterSize: String?
+    79	  public let parameterBillions: Double?
+    80	  public let fileSizeBytes: Int64
+    81	  public let displayName: String
+    82	}
+    83	
+    84	/// Guides users through Ollama installation, server startup, and model pulling.
+    85	@MainActor
+    86	@Observable
+    87	public final class OllamaSetupService {
+    88	
+    89	  // MARK: - Public State
+    90	
+    91	  public private(set) var setupState: OllamaSetupState = .detecting
+    92	  public private(set) var pullProgress: Double = 0
+    93	  public private(set) var pullStatusText: String = ""
+    94	  public private(set) var currentPullingModel: String?
+    95	  public private(set) var downloadedModels: [OllamaDownloadedModel] = []
+    96	  public private(set) var warmupState: OllamaWarmupState = .idle
+    97	
+    98	  // Per-pull generation token. Bumped on every pullModel/cancelPull call so stale
+    99	  // tasks can no-op their writes (Swift Task cancellation is cooperative; without
+   100	  // this, a late chunk or terminal-branch cleanup from an old task could clobber
+   101	  // the newer pull's state, most acutely on cancel-then-re-download-same-model).
+   102	  private var pullEpoch: UInt64 = 0
+   103	
+   104	  /// Canonical names of downloaded models. Backward-compatible with old Set<String> consumers.
+   105	  public var downloadedModelNames: Set<String> {
+   106	    Set(downloadedModels.map(\.canonicalName))
+   107	  }
+   108	
+   109	  // MARK: - Model Catalog
+   110	
+   111	  /// Curated suggestions for users who haven't downloaded models yet.
+   112	  public static let modelCatalog: [OllamaModelCatalogEntry] = [
+   113	    OllamaModelCatalogEntry(
+   114	      name: "gemma3n:e4b", displayName: "Gemma 3 Nano (4B)", parameterCount: "4B",
+   115	      qualityTier: .best, downloadSize: "~6 GB"),
+   116	    OllamaModelCatalogEntry(
+   117	      name: "llama3.2", displayName: "Llama 3.2", parameterCount: "3B", qualityTier: .best,
+   118	      downloadSize: "~2 GB"),
+   119	    OllamaModelCatalogEntry(
+   120	      name: "llama3.2:1b", displayName: "Llama 3.2 (1B)", parameterCount: "1B",
+   121	      qualityTier: .medium, downloadSize: "~800 MB"),
+   122	    OllamaModelCatalogEntry(
+   123	      name: "mistral", displayName: "Mistral", parameterCount: "7B", qualityTier: .best,
+   124	      downloadSize: "~4 GB"),
+   125	    OllamaModelCatalogEntry(
+   126	      name: "phi3", displayName: "Phi-3 Mini", parameterCount: "3.8B", qualityTier: .medium,
+   127	      downloadSize: "~2.3 GB"),
+   128	    OllamaModelCatalogEntry(
+   129	      name: "gemma2:2b", displayName: "Gemma 2 (2B)", parameterCount: "2B", qualityTier: .medium,
+   130	      downloadSize: "~1.6 GB"),
+   300	
+   301	  // MARK: - Private
+   302	
+   303	  private var ollamaProcess: Process?
+   304	  private var pullTask: Task<Void, Never>?
+   305	  private var warmupTask: Task<Void, Never>?
+   306	
+   307	  private static let binaryPaths = ["/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"]
+   308	  private static let baseURL = "http://localhost:11434"
+   309	  private static let lastKnownStateKey = "OllamaSetupService.lastKnownReady"
+   310	
+   311	  // MARK: - Detection Pipeline
+   312	
+   313	  public init() {}
+   314	
+   315	  /// Run the full detection pipeline: binary -> server -> models.
+   316	  public func detectState() async {
+   317	    setupState = .detecting
+   318	
+   319	    // Fast path: if the user previously reached .ready, try the server directly.
+   320	    if UserDefaults.standard.bool(forKey: Self.lastKnownStateKey) {
+   321	      if await isServerRunning() {
+   322	        if await hasAnyModels() {
+   323	          setupState = .ready
+   324	          return
+   325	        }
+   326	        setupState = .runningNoModels
+   327	        return
+   328	      }
+   329	    }
+   330	
+   331	    // Full detection
+   332	    guard findOllamaBinary() != nil else {
+   333	      setupState = .notInstalled
+   334	      UserDefaults.standard.set(false, forKey: Self.lastKnownStateKey)
+   335	      return
+   336	    }
+   337	
+   338	    guard await isServerRunning() else {
+   339	      // isServerRunning may have already set an .error state (port conflict)
+   340	      if case .error = setupState { return }
+   341	      setupState = .installedNotRunning
+   342	      return
+   343	    }
+   344	
+   345	    if await hasAnyModels() {
+   346	      setupState = .ready
+   347	      UserDefaults.standard.set(true, forKey: Self.lastKnownStateKey)
+   348	    } else {
+   349	      setupState = .runningNoModels
+   350	    }
+   351	  }
+   352	
+   353	  // MARK: - Binary Discovery
+   354	
+   355	  /// Locate the Ollama binary on disk. Returns the path or nil.
+   356	  public func findOllamaBinary() -> String? {
+   357	    // Check well-known paths first
+   358	    for path in Self.binaryPaths {
+   359	      if FileManager.default.isExecutableFile(atPath: path) {
+   360	        return path
+
+exec
+/bin/zsh -lc "rg -n \"ollamaSetup|whisperKitSetup|setupState|prepareBackendSilently|startWhisperKitPreloadObservation|detectState\\(\" Sources/EnviousWisprPipeline Sources/EnviousWisprASR Sources/EnviousWisprAudio Sources/EnviousWisprCore Sources/EnviousWisprPostProcessing Sources/EnviousWisprServices Sources/EnviousWisprStorage" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:38:  public private(set) var setupState: WhisperKitSetupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:62:  /// Sets setupState to .ready or .notDownloaded (never triggers a download).
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:64:  public func detectState() async {
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:67:      setupState != .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:72:    setupState = .checking
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:74:    setupState = isDownloaded ? .ready : .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:81:    await detectState()
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:95:  /// `setupState` accurate (UI offers Download) and lets `prepare()` fall
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:131:    setupState = .downloading(progress: 0, status: "Starting download...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:154:        self.setupState = .downloading(progress: fraction, status: "Downloading model files...")
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:160:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:168:        self.setupState = .ready
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:170:        self?.setupState = .notDownloaded
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:173:        self?.setupState = .error(
+Sources/EnviousWisprASR/WhisperKitSetupService.swift:184:    setupState = .notDownloaded
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:386:  public func prepareBackendSilently() async {
+
+exec
+/bin/zsh -lc "rg -n \"func (startRecording|stopAndTranscribe|finalize|prepareBackendSilently|transcribeWithStreamingRescue)|handle\\(event|stream|streaming|finalize|finish|paste|clipboard\" Sources/EnviousWisprPipeline/TranscriptionPipeline.swift Sources/EnviousWisprPipeline/WhisperKitPipeline.swift | head -n 240" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:48:/// Independent WhisperKit dictation pipeline — batch record → transcribe → polish → paste.
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:51:/// with the Parakeet highway (TranscriptionPipeline). No streaming — batch only.
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:183:    // Activate SSE streaming for Gemini
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:262:      await self?.finishStallRecovery(for: sessionID)
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:267:  /// See TranscriptionPipeline.finishStallRecovery for the sessionID-stale
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:270:  private func finishStallRecovery(for sessionID: UInt64) async {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:354:  public func handle(event: PipelineEvent) async throws {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:385:  /// If user presses record before this finishes, startRecording() handles it with its own .loadingModel flow.
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:386:  public func prepareBackendSilently() async {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:457:  public func startRecording(config: DictationSessionConfig) async {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:495:    // Capture target app for paste-back
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:499:    // No streaming buffer forwarding for batch mode
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:530:      // Skip the worker in .auto mode; batch decode at finalize picks up the
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:583:  public func stopAndTranscribe() async {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:673:      await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:827:        let result = await worker.finalize(finalSamples: rawSamples, speechSegments: segments)
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:844:              "WhisperKit finalize: strategy=\(result.strategy), mode=\(result.mode), "
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:853:              "WhisperKit finalize: strategy=\(result.strategy), "
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:869:              "WhisperKit finalize: strategy=\(result.strategy), batchMs=\(batchMs), "
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:966:      // Post-ASR finalization: text processing -> store -> paste
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:970:        finalizationResult = try await transcriptFinalizer.finalize(
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1018:      let pasteTargetApp = targetApp?.bundleIdentifier
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1024:      let pasteDuration = finalizationResult.pasteDurationSeconds
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1030:            + "paste=\(String(format: "%.3f", pasteDuration))s)",
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1039:        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1040:        pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1041:        targetApp: pasteTargetApp,
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1043:        streamingMode: false,
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:1053:          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:10:/// Orchestrates the full dictation pipeline: record → transcribe → (correct) → (polish) → store → copy/paste.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:25:      // just-finished recording as still pinning a model. (#426 — Codex)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:99:  /// User preference: use streaming ASR during recording (lower latency) or batch after stop (cleaner text).
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:102:  /// Whether streaming ASR was successfully started for the current recording.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:103:  private var streamingASRActive = false
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:104:  /// Counters for diagnosing streaming buffer delivery (tail-cutoff instrumentation).
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:105:  private var streamingBuffersDispatched = 0
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:106:  private var streamingBuffersFed = 0
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:134:  /// `reset`, engine interruption). `finishStallRecovery` bails unless the
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:156:  /// Phase G3 — `internal` overload that accepts a pre-built finalizer so
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:157:  /// `@testable` callers can drive the heart path with a mock paste seam.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:158:  /// Production callers use the zero-arg-finalizer `public init` above and
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:187:    // Activate SSE streaming for Gemini — a non-nil onToken causes GeminiConnector
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:188:    // to use streamGenerateContent instead of batch generateContent.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:272:      await self?.finishStallRecovery(for: sessionID)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:282:  private func finishStallRecovery(for sessionID: UInt64) async {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:292:    if streamingASRActive {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:400:  /// settings (auto-paste, VAD config, polish provider/model, etc.) for the
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:403:  public func startRecording(config: DictationSessionConfig) async {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:456:    // Remember the frontmost app and focused text field so we can paste back
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:462:    // Start streaming ASR if the backend supports it — feed audio buffers
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:464:    var streamingSetupSucceeded = false
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:465:    defer { if !streamingSetupSucceeded { deactivateStreamingForwarding() } }
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:471:        streamingASRActive = true
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:472:        streamingBuffersDispatched = 0
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:473:        streamingBuffersFed = 0
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:478:        // Wire audio buffer forwarding: each converted buffer goes to streaming ASR.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:479:        // The streamingASRActive flag gates delivery — deactivateStreamingForwarding()
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:491:            self.streamingBuffersDispatched += 1
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:492:            guard self.streamingASRActive, self.state == .recording else { return }
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:494:            self.streamingBuffersFed += 1
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:543:      streamingSetupSucceeded = true
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:551:          "streaming": streamingASRActive,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:554:        active: true, backend: "parakeet", isStreaming: streamingASRActive)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:565:          "Recording started. Backend: \(asrManager.activeBackendType.rawValue), streaming=\(streamingASRActive)",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:573:      // startCapture() failed — cancel any streaming session we started
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:574:      if streamingASRActive {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:614:      // Pipeline is past the point of no return or already finished — ignore.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:620:  public func stopAndTranscribe() async {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:633:        if streamingASRActive {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:655:      wasStreaming: streamingASRActive,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:667:    let wasStreaming = streamingASRActive
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:671:    // These tasks check streamingASRActive (still true) and deliver their buffers
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:685:      let targetDispatched = streamingBuffersDispatched
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:687:      while streamingBuffersFed < targetDispatched,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:692:      if streamingBuffersFed >= targetDispatched {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:695:            "Streaming drain: clean (\(self.streamingBuffersFed)/\(targetDispatched) fed)",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:702:            "Streaming drain: TIMEOUT (\(self.streamingBuffersFed)/\(targetDispatched) fed — \(targetDispatched - self.streamingBuffersFed) lost)",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:722:      // Cancel streaming if it was active — empty samples means no useful audio
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:759:      await detector.finalizeSegments(totalSampleCount: rawSamples.count)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:795:          "mode": wasStreaming ? "streaming" : "batch",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:828:        "mode": wasStreaming ? "streaming" : "batch",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:835:      // Use streaming finalize when available for lowest latency.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:837:      // to eliminate the ~12% text loss that affected upstream SlidingWindowAsrManager.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:838:      // Streaming mode includes batch rescue: if finalize fails or returns empty
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:866:              "mode": wasStreaming ? "streaming" : "batch",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:889:              "mode": wasStreaming ? "streaming" : "batch",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:907:          "mode": wasStreaming ? "streaming" : "batch",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:915:            + "(mode=\(wasStreaming ? "streaming" : "batch"), \(asrText.count) chars, lang=\(result.language ?? "?"))",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:920:      // Post-ASR finalization: text processing -> store -> paste
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:923:        finalizationResult = try await transcriptFinalizer.finalize(
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:973:      // Build metrics (pipeline-specific: uses ASR timing, streaming mode)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:974:      let pasteTargetApp = targetApp?.bundleIdentifier
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:980:      let pasteDuration = finalizationResult.pasteDurationSeconds
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:986:            + "paste=\(String(format: "%.3f", pasteDuration))s)",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:995:        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:996:        pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:997:        targetApp: pasteTargetApp,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:999:        streamingMode: wasStreaming,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1009:          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1081:    // Cancel any active streaming ASR session to prevent orphaned sessions.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1082:    let wasStreaming = streamingASRActive
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1111:    if streamingASRActive {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1147:    if streamingASRActive {
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1168:      wasStreaming: streamingASRActive,
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1198:    // Deactivate streaming forwarding FIRST to prevent new buffer dispatches
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1199:    let wasStreaming = streamingASRActive
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1210:    // Now cancel streaming ASR session (safe to await — engine is stopped)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1215:    // Clear target app/element reference — nothing will be pasted
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1224:  /// Deactivate streaming ASR buffer forwarding. Does not cancel the backend session.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1226:    streamingASRActive = false
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1285:  /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1287:  /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1288:  private func transcribeWithStreamingRescue(
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1292:    // 1. Try streaming finalize (happy path)
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1294:      let result = try await asrManager.finalizeStreaming()
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1304:        "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1316:    // 3. Batch rescue: speech was detected but streaming failed to decode it.
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1355:  public func handle(event: PipelineEvent) async throws {
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprPipeline/WhisperKitPipeline.swift | sed -n '360,430p' && nl -ba Sources/EnviousWisprPipeline/WhisperKitPipeline.swift | sed -n '470,540p' && nl -ba Sources/EnviousWisprPipeline/WhisperKitPipeline.swift | sed -n '680,760p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   360	    case .requestStop:
+   361	      await requestStop()
+   362	    case .cancelRecording:
+   363	      await cancelRecording()
+   364	    case .reset:
+   365	      reset()
+   366	    }
+   367	  }
+   368	
+   369	  /// Issue #289: dumb external-error sink (mirrors `TranscriptionPipeline`).
+   370	  public func setExternalError(_ message: String) {
+   371	    currentTranscript = nil
+   372	    state = .error(message)
+   373	  }
+   374	
+   375	  /// Issue #289: see `DictationPipeline.clearPendingStallRecovery`.
+   376	  public func clearPendingStallRecovery() {
+   377	    pendingStallRecoveryToken = nil
+   378	  }
+   379	
+   380	  // MARK: - Background Pre-load
+   381	
+   382	  /// Silently load the WhisperKit model into RAM without changing pipeline state.
+   383	  /// Called after model download completes or on launch if model is already cached.
+   384	  /// Uses prepareIfCached() to avoid triggering a silent network download.
+   385	  /// If user presses record before this finishes, startRecording() handles it with its own .loadingModel flow.
+   386	  public func prepareBackendSilently() async {
+   387	    let isBackendReady = await backend.isReady
+   388	    guard !isBackendReady else { return }
+   389	    do {
+   390	      let loaded = try await backend.prepareIfCached()
+   391	      if loaded {
+   392	        Task {
+   393	          await AppLogger.shared.log(
+   394	            "WhisperKit model pre-loaded successfully (background)",
+   395	            level: .info, category: "WhisperKitPipeline"
+   396	          )
+   397	        }
+   398	      } else {
+   399	        Task {
+   400	          await AppLogger.shared.log(
+   401	            "WhisperKit model not cached, skipping silent pre-load",
+   402	            level: .info, category: "WhisperKitPipeline"
+   403	          )
+   404	        }
+   405	      }
+   406	    } catch {
+   407	      Task {
+   408	        await AppLogger.shared.log(
+   409	          "WhisperKit model pre-load failed: \(error.localizedDescription)",
+   410	          level: .info, category: "WhisperKitPipeline"
+   411	        )
+   412	      }
+   413	    }
+   414	  }
+   415	
+   416	  // MARK: - Recording Lifecycle
+   417	
+   418	  public func preWarmAudioInput() async throws {
+   419	    guard !state.isActive, state != .recording else { return }
+   420	    // Issue #289: earliest new-attempt signal — see TranscriptionPipeline
+   421	    // for rationale. Clearing in `startRecording` alone left a race window.
+   422	    pendingStallRecoveryToken = nil
+   423	    let start = ContinuousClock.now
+   424	    // Issue #289: propagate preWarm failures (see TranscriptionPipeline).
+   425	    try await audioCapture.preWarm()
+   426	    guard !Task.isCancelled else { return }
+   427	    isPreWarmed = true
+   428	    let totalMs = PipelineUtils.durationMs(ContinuousClock.now - start)
+   429	    Task {
+   430	      await AppLogger.shared.log(
+   470	    modelUnloadTask = nil
+   471	
+   472	    state = .startingUp
+   473	    lastPolishError = nil
+   474	    SentryBreadcrumb.add(stage: "whisperkit", message: "Pipeline starting up")
+   475	
+   476	    // Load model if not ready
+   477	    let isBackendReady = await backend.isReady
+   478	    guard state == .startingUp else { return }  // cancelled during await
+   479	
+   480	    if !isBackendReady {
+   481	      state = .loadingModel
+   482	      SentryBreadcrumb.add(stage: "asr", message: "WhisperKit model loading")
+   483	      do {
+   484	        try await backend.prepare()
+   485	      } catch {
+   486	        SentryBreadcrumb.captureError(
+   487	          error, category: .modelLoadFailed, stage: "asr", extra: ["backend": "whisperKit"])
+   488	        state = .error("Model load failed: \(error.localizedDescription)")
+   489	        return
+   490	      }
+   491	      guard state == .loadingModel else { return }  // cancelled during model load
+   492	      state = .startingUp  // back to startingUp for engine setup
+   493	    }
+   494	
+   495	    // Capture target app for paste-back
+   496	    targetApp = NSWorkspace.shared.frontmostApplication
+   497	    targetElement = PasteService.captureFocusedElement()
+   498	
+   499	    // No streaming buffer forwarding for batch mode
+   500	    audioCapture.onBufferCaptured = nil
+   501	
+   502	    do {
+   503	      if !isPreWarmed {
+   504	        try await audioCapture.startEnginePhase()
+   505	        let stabilized = await audioCapture.waitForFormatStabilization(
+   506	          maxWait: 1.5,
+   507	          pollInterval: 0.2
+   508	        )
+   509	        guard state == .startingUp else { return }  // cancelled during stabilization
+   510	        if !stabilized {
+   511	          audioCapture.rebuildEngine()
+   512	          try await audioCapture.startEnginePhase()
+   513	        }
+   514	      }
+   515	      isPreWarmed = false
+   516	
+   517	      _ = try await audioCapture.beginCapturePhase()
+   518	      state = .recording
+   519	      recordingStartTime = Date()
+   520	      currentTranscript = nil
+   521	      SentryBreadcrumb.add(
+   522	        stage: "recording", message: "WhisperKit recording started", data: ["backend": "whisperKit"]
+   523	      )
+   524	      SentryBreadcrumb.updateRecordingState(active: true, backend: "whisperkit")
+   525	      SentryBreadcrumb.updateAudioRoute(audioCapture.currentAudioRoute)
+   526	      startVADMonitoring()
+   527	      // Multilingual v1: the incremental worker snapshots transcriptionOptions.language
+   528	      // at recording start. In .auto mode, language is unknown until LID runs at
+   529	      // recording stop, so the worker would decode with the stale/legacy language.
+   530	      // Skip the worker in .auto mode; batch decode at finalize picks up the
+   531	      // post-LID language. .locked mode is safe because the language is known upfront.
+   532	      let workerEnabled: Bool
+   533	      if case .locked = languageMode {
+   534	        workerEnabled = true
+   535	        await startIncrementalWorker()
+   536	      } else {
+   537	        workerEnabled = false
+   538	      }
+   539	
+   540	      Task { [workerEnabled] in
+   680	      let pct = String(
+   681	        format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
+   682	      Task {
+   683	        await AppLogger.shared.log(
+   684	          "WhisperKit VAD filtered to \(samples.count) samples (\(pct)% voiced)",
+   685	          level: .info, category: "WhisperKitPipeline"
+   686	        )
+   687	      }
+   688	    } else {
+   689	      samples = rawSamples
+   690	      // No VAD detector available -- default to true so empty ASR results
+   691	      // still fire Sentry errors (fail toward visibility).
+   692	      hasSpeechEvidence = true
+   693	    }
+   694	    let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
+   695	
+   696	    // VAD gate: if no speech was detected, skip ASR entirely.
+   697	    // Prevents noise-induced hallucinations from ambient sounds.
+   698	    if !hasSpeechEvidence {
+   699	      if let worker = incrementalWorker {
+   700	        await worker.cancel()
+   701	        incrementalWorker = nil
+   702	      }
+   703	      SentryBreadcrumb.add(
+   704	        stage: "asr", message: "VAD gate: no speech detected, skipping WhisperKit ASR",
+   705	        level: .info,
+   706	        data: [
+   707	          "backend": "whisperKit",
+   708	          "raw_sample_count": rawSamples.count,
+   709	          "peak_audio_level": peakAudioLevel,
+   710	        ]
+   711	      )
+   712	      emitZombieEngineEventIfNeeded(rawSamples: rawSamples, peakAudioLevel: peakAudioLevel)
+   713	      frozenSnapshot = nil
+   714	      state = .idle
+   715	      Task {
+   716	        await AppLogger.shared.log(
+   717	          "VAD gate: no speech, skipping WhisperKit ASR (samples=\(rawSamples.count), peak=\(String(format: "%.4f", peakAudioLevel)))",
+   718	          level: .info, category: "WhisperKitPipeline"
+   719	        )
+   720	      }
+   721	      return
+   722	    }
+   723	
+   724	    // Fallback: if VAD was too aggressive, use raw
+   725	    let minimumSamples = AudioConstants.minimumTranscriptionSamples
+   726	    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
+   727	      samples = rawSamples
+   728	    }
+   729	
+   730	    // Pad short recordings
+   731	    if samples.count > 0 && samples.count < minimumSamples {
+   732	      samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
+   733	    }
+   734	
+   735	    // Multilingual v1 (W2): detect language on voiced audio before transcribe.
+   736	    // Heart protection: detector never throws; if it abstains, pass nil to
+   737	    // TranscriptionOptions.language so WhisperKit's internal LID runs.
+   738	    // languageMode is captured lazily so a user toggling Auto<->Locked
+   739	    // mid-recording is respected.
+   740	    let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
+   741	    // nonisolated(unsafe): WhisperKit is an actor/reference-typed handle that is
+   742	    // not Sendable. Safe to pass to the detector actor because the backend owns
+   743	    // it for its lifetime and the detector only calls read-only detectLanguage.
+   744	    nonisolated(unsafe) let kitForLID = await backend.whisperKitInstance
+   745	    let lidResult = await languageDetector.detect(
+   746	      samples: samples,
+   747	      voicedDuration: voicedDurationSec,
+   748	      whisperKit: kitForLID,
+   749	      mode: languageMode
+   750	    )
+   751	    lastLanguageDetection = lidResult
+   752	    // Multilingual v1 (W3): forward the detection to the polish step so the
+   753	    // prompt planner can apply confidence-tiered, language-aware vocab
+   754	    // injection. Heart-protected: the planner degrades gracefully when the
+   755	    // detection is abstained or low-confidence.
+   756	    llmPolishStep.languageDetection = lidResult
+   757	    if let lang = lidResult.lang, !lidResult.abstained {
+   758	      transcriptionOptions.language = lang
+   759	    } else {
+   760	      // Abstain: let WhisperKit's own LID run. Heart still completes.
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprPipeline/TranscriptionPipeline.swift | sed -n '430,520p' && nl -ba Sources/EnviousWisprPipeline/TranscriptionPipeline.swift | sed -n '620,720p' && nl -ba Sources/EnviousWisprPipeline/TranscriptionPipeline.swift | sed -n '840,930p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   430	      }
+   431	      modelLoadTask = loadTask
+   432	      do {
+   433	        try await loadTask.value
+   434	      } catch is CancellationError {
+   435	        // User cancelled during model load. Return to idle.
+   436	        stopRequested = false
+   437	        modelLoadTask = nil
+   438	        state = .idle
+   439	        return
+   440	      } catch {
+   441	        SentryBreadcrumb.captureError(
+   442	          error, category: .modelLoadFailed, stage: "asr",
+   443	          extra: ["backend": asrManager.activeBackendType.rawValue])
+   444	        stopRequested = false
+   445	        modelLoadTask = nil
+   446	        state = .error("Model load failed: \(error.localizedDescription)")
+   447	        return
+   448	      }
+   449	      modelLoadTask = nil
+   450	      // Late-completion guard: if state changed while we were loading (e.g., cancel),
+   451	      // do not proceed. The cancel handler already set state to .idle.
+   452	      guard state == .loadingModel else { return }
+   453	      guard !Task.isCancelled else { return }
+   454	    }
+   455	
+   456	    // Remember the frontmost app and focused text field so we can paste back
+   457	    // (LLM polishing can take seconds, during which focus may shift)
+   458	    targetApp = NSWorkspace.shared.frontmostApplication
+   459	    targetElement = PasteService.captureFocusedElement()
+   460	
+   461	    // BRAIN: gotcha id=pipeline-timing-misconception
+   462	    // Start streaming ASR if the backend supports it — feed audio buffers
+   463	    // to the ASR model during recording so transcription overlaps with capture.
+   464	    var streamingSetupSucceeded = false
+   465	    defer { if !streamingSetupSucceeded { deactivateStreamingForwarding() } }
+   466	
+   467	    let supportsStreaming = await asrManager.activeBackendSupportsStreaming
+   468	    if supportsStreaming && useStreamingASR {
+   469	      do {
+   470	        try await asrManager.startStreaming(options: transcriptionOptions)
+   471	        streamingASRActive = true
+   472	        streamingBuffersDispatched = 0
+   473	        streamingBuffersFed = 0
+   474	        SentryBreadcrumb.add(
+   475	          stage: "asr", message: "Streaming ASR started",
+   476	          data: ["backend": asrManager.activeBackendType.rawValue])
+   477	
+   478	        // Wire audio buffer forwarding: each converted buffer goes to streaming ASR.
+   479	        // The streamingASRActive flag gates delivery — deactivateStreamingForwarding()
+   480	        // sets it to false and nils onBufferCaptured, so in-flight tasks exit quickly.
+   481	        //
+   482	        // NOTE: This callback runs on the real-time audio thread. The TapStoppedFlag
+   483	        // in AudioCaptureManager prevents this from being called after teardown starts.
+   484	        // The nonisolated(unsafe) is safe because the buffer is created on the audio
+   485	        // thread, transferred to the main thread via Task, and never accessed from
+   486	        // both threads simultaneously.
+   487	        audioCapture.onBufferCaptured = { [weak self] buffer in
+   488	          guard let self else { return }
+   489	          nonisolated(unsafe) let safeBuffer = buffer
+   490	          Task { @MainActor in
+   491	            self.streamingBuffersDispatched += 1
+   492	            guard self.streamingASRActive, self.state == .recording else { return }
+   493	            try? await self.asrManager.feedAudio(safeBuffer)
+   494	            self.streamingBuffersFed += 1
+   495	          }
+   496	        }
+   497	
+   498	        Task {
+   499	          await AppLogger.shared.log(
+   500	            "Streaming ASR started during recording",
+   501	            level: .info, category: "Pipeline"
+   502	          )
+   503	        }
+   504	      } catch {
+   505	        // Streaming init failed — fall back to batch after recording
+   506	        deactivateStreamingForwarding()
+   507	        SentryBreadcrumb.add(
+   508	          stage: "asr", message: "Streaming start failed, will use batch", level: .warning)
+   509	        Task {
+   510	          await AppLogger.shared.log(
+   511	            "Streaming ASR failed to start, will use batch: \(error.localizedDescription)",
+   512	            level: .info, category: "Pipeline"
+   513	          )
+   514	        }
+   515	      }
+   516	    }
+   517	
+   518	    do {
+   519	      // Two-phase start: phase 1 triggers any Bluetooth codec switch
+   520	      if !isPreWarmed {
+   620	  public func stopAndTranscribe() async {
+   621	    guard state == .recording, !isStopping else { return }
+   622	    isStopping = true
+   623	    defer { isStopping = false }
+   624	
+   625	    let pipelineStart = CFAbsoluteTimeGetCurrent()
+   626	
+   627	    // Silently discard recordings shorter than minimum duration (accidental taps)
+   628	    if let startTime = recordingStartTime {
+   629	      let elapsed = Date().timeIntervalSince(startTime)
+   630	      if elapsed < TimingConstants.minimumRecordingDuration {
+   631	        vadMonitorTask?.cancel()
+   632	        vadMonitorTask = nil
+   633	        if streamingASRActive {
+   634	          await asrManager.cancelStreaming()
+   635	        }
+   636	        deactivateStreamingForwarding()
+   637	        _ = await audioCapture.stopCapture()
+   638	        recordingStartTime = nil
+   639	        state = .idle
+   640	        Task {
+   641	          await AppLogger.shared.log(
+   642	            "Recording too short (\(String(format: "%.2f", elapsed))s), discarded silently",
+   643	            level: .info, category: "Pipeline"
+   644	          )
+   645	        }
+   646	        return
+   647	      }
+   648	    }
+   649	    // Freeze snapshot BEFORE teardown — post-recording errors use this instead of live scope.
+   650	    let snapshotStartTime = recordingStartTime ?? Date()
+   651	    let durationMs = Int(Date().timeIntervalSince(snapshotStartTime) * 1000)
+   652	    frozenSnapshot = SentryBreadcrumb.RecordingSnapshot(
+   653	      backend: "parakeet",
+   654	      audioRoute: audioCapture.currentAudioRoute,
+   655	      wasStreaming: streamingASRActive,
+   656	      startTime: snapshotStartTime,
+   657	      durationMs: durationMs,
+   658	      targetAppBundleID: targetApp?.bundleIdentifier
+   659	    )
+   660	
+   661	    recordingStartTime = nil
+   662	
+   663	    // Cancel VAD monitoring
+   664	    vadMonitorTask?.cancel()
+   665	    vadMonitorTask = nil
+   666	
+   667	    let wasStreaming = streamingASRActive
+   668	
+   669	    // Stop the audio tap FIRST — prevents new buffer-feed tasks from being dispatched.
+   670	    // Then yield to drain any in-flight feed tasks already queued on @MainActor.
+   671	    // These tasks check streamingASRActive (still true) and deliver their buffers
+   672	    // to the Parakeet actor before we deactivate forwarding.
+   673	    // Without this reorder, deactivateStreamingForwarding() sets the flag to false
+   674	    // and all queued tasks drop their buffers — losing ~250-500ms of trailing audio.
+   675	    let captureResult = await audioCapture.stopCapture()
+   676	    let rawSamples = captureResult.samples
+   677	    SentryBreadcrumb.add(
+   678	      stage: "recording", message: "Recording stopped", data: ["sample_count": rawSamples.count])
+   679	    SentryBreadcrumb.updateRecordingState(active: false)
+   680	
+   681	    if wasStreaming {
+   682	      // Deterministic drain: freeze the dispatch count after stopCapture (no new buffers
+   683	      // will be dispatched since the tap/session is stopped). Wait for all queued buffer-feed
+   684	      // tasks to complete before deactivating forwarding. Bounded by 500ms deadline.
+   685	      let targetDispatched = streamingBuffersDispatched
+   686	      let drainDeadline = ContinuousClock.now + .milliseconds(500)
+   687	      while streamingBuffersFed < targetDispatched,
+   688	        ContinuousClock.now < drainDeadline
+   689	      {
+   690	        await Task.yield()
+   691	      }
+   692	      if streamingBuffersFed >= targetDispatched {
+   693	        Task {
+   694	          await AppLogger.shared.log(
+   695	            "Streaming drain: clean (\(self.streamingBuffersFed)/\(targetDispatched) fed)",
+   696	            level: .info, category: "PipelineTiming"
+   697	          )
+   698	        }
+   699	      } else {
+   700	        Task {
+   701	          await AppLogger.shared.log(
+   702	            "Streaming drain: TIMEOUT (\(self.streamingBuffersFed)/\(targetDispatched) fed — \(targetDispatched - self.streamingBuffersFed) lost)",
+   703	            level: .info, category: "PipelineTiming"
+   704	          )
+   705	        }
+   706	      }
+   707	    }
+   708	
+   709	    deactivateStreamingForwarding()
+   710	
+   711	    // Defense: if cancelRecording() ran during yield, bail out
+   712	    guard state == .recording else { return }
+   713	
+   714	    // Pre-warm the LLM backend while ASR is still running (fire-and-forget).
+   715	    LLMNetworkSession.shared.preWarmModel(
+   716	      provider: llmPolishStep.llmProvider,
+   717	      model: llmPolishStep.llmModel,
+   718	      keychainManager: keychainManager
+   719	    )
+   720	
+   840	      let result: ASRResult
+   841	      if wasStreaming {
+   842	        result = try await transcribeWithStreamingRescue(
+   843	          samples: samples,
+   844	          hasSpeechEvidence: hasSpeechEvidence
+   845	        )
+   846	      } else {
+   847	        result = try await asrManager.transcribe(
+   848	          audioSamples: samples, options: transcriptionOptions)
+   849	      }
+   850	
+   851	      let asrEnd = CFAbsoluteTimeGetCurrent()
+   852	
+   853	      let asrText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+   854	      guard !asrText.isEmpty else {
+   855	        if hasSpeechEvidence {
+   856	          // Real ASR failure: VAD detected speech but decoder returned nothing
+   857	          SentryBreadcrumb.captureError(
+   858	            NSError(
+   859	              domain: "EnviousWispr", code: -1,
+   860	              userInfo: [
+   861	                NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"
+   862	              ]),
+   863	            category: .asrEmptyResult, stage: "asr",
+   864	            extra: [
+   865	              "backend": asrManager.activeBackendType.rawValue,
+   866	              "mode": wasStreaming ? "streaming" : "batch",
+   867	              "has_speech_evidence": true,
+   868	              "raw_sample_count": rawSamples.count,
+   869	              "vad_segment_count": vadSegmentCount,
+   870	              "vad_speech_duration_ms": vadSpeechDurationMs,
+   871	              "peak_audio_level": peakAudioLevel,
+   872	            ],
+   873	            snapshot: frozenSnapshot
+   874	          )
+   875	          state = .error("Couldn't catch that -- try again")
+   876	          Task {
+   877	            await AppLogger.shared.log(
+   878	              "ASR empty despite speech evidence (segments=\(vadSegmentCount), speechMs=\(vadSpeechDurationMs), peak=\(peakAudioLevel))",
+   879	              level: .info, category: "Pipeline"
+   880	            )
+   881	          }
+   882	        } else {
+   883	          // Expected: user held button without speaking
+   884	          SentryBreadcrumb.add(
+   885	            stage: "asr", message: "ASR empty (no speech detected)",
+   886	            level: .info,
+   887	            data: [
+   888	              "backend": asrManager.activeBackendType.rawValue,
+   889	              "mode": wasStreaming ? "streaming" : "batch",
+   890	            ]
+   891	          )
+   892	          state = .idle
+   893	          Task {
+   894	            await AppLogger.shared.log(
+   895	              "No speech detected, returning to idle",
+   896	              level: .info, category: "Pipeline"
+   897	            )
+   898	          }
+   899	        }
+   900	        frozenSnapshot = nil
+   901	        return
+   902	      }
+   903	
+   904	      SentryBreadcrumb.add(
+   905	        stage: "asr", message: "ASR completed",
+   906	        data: [
+   907	          "mode": wasStreaming ? "streaming" : "batch",
+   908	          "backend": asrManager.activeBackendType.rawValue,
+   909	          "duration_s": String(format: "%.3f", asrEnd - asrStart),
+   910	          "char_count": asrText.count,
+   911	        ])
+   912	      Task {
+   913	        await AppLogger.shared.log(
+   914	          "Pipeline timing: ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s "
+   915	            + "(mode=\(wasStreaming ? "streaming" : "batch"), \(asrText.count) chars, lang=\(result.language ?? "?"))",
+   916	          level: .info, category: "PipelineTiming"
+   917	        )
+   918	      }
+   919	
+   920	      // Post-ASR finalization: text processing -> store -> paste
+   921	      let finalizationResult: FinalizationResult
+   922	      do {
+   923	        finalizationResult = try await transcriptFinalizer.finalize(
+   924	          FinalizationRequest(
+   925	            asrText: asrText,
+   926	            language: result.language,
+   927	            duration: result.duration,
+   928	            processingTime: result.processingTime,
+   929	            backendType: result.backendType,
+   930	            targetApp: targetApp,
+
+exec
+/bin/zsh -lc 'wc -l Sources/EnviousWispr/App/AppState.swift Sources/EnviousWispr/App/AppDelegate.swift Sources/EnviousWispr/App/PipelineSettingsSync.swift Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift Sources/EnviousWisprLLM/OllamaSetupService.swift Sources/EnviousWisprASR/WhisperKitSetupService.swift Package.swift docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md' in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     976 Sources/EnviousWispr/App/AppState.swift
+     461 Sources/EnviousWispr/App/AppDelegate.swift
+     272 Sources/EnviousWispr/App/PipelineSettingsSync.swift
+    1033 Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+     394 Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+     869 Sources/EnviousWisprLLM/OllamaSetupService.swift
+     186 Sources/EnviousWisprASR/WhisperKitSetupService.swift
+     148 Package.swift
+     302 docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md
+    4641 total
+
+exec
+/bin/zsh -lc 'rg -n "''^  (private )?let |''^  let " Sources/EnviousWispr/App/AppState.swift' in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+18:  let permissions = PermissionsService()
+19:  let audioCapture: any AudioCaptureInterface
+20:  let asrManager: any ASRManagerInterface
+21:  let keychainManager = KeychainManager()
+22:  let hotkeyService = HotkeyService()
+23:  let benchmark = BenchmarkSuite()
+24:  let recordingOverlay = RecordingOverlayPanel()
+25:  let ollamaSetup = OllamaSetupService()
+26:  let whisperKitSetup = WhisperKitSetupService()
+27:  let audioDeviceList = AudioDeviceList()
+28:  let captureTelemetry = CaptureTelemetryState()
+38:  let pipeline: TranscriptionPipeline
+39:  let whisperKitPipeline: WhisperKitPipeline
+86:  let polishService: TranscriptPolishService
+89:  private let settingsSync: PipelineSettingsSync
+95:  let transcriptCoordinator: TranscriptCoordinator
+111:  let customWordsCoordinator = CustomWordsCoordinator()
+118:  let customWordsPropagator = CustomWordsPropagator()
+121:  let llmDiscovery: LLMModelDiscoveryCoordinator
+124:  let aiAvailability = AIAvailabilityCoordinator()
+
+exec
+/bin/zsh -lc "rg -n \"appState\\.benchmark|benchmark\\.|captureTelemetry|onCaptureStalled|onXPCReplyFailed|onCaptureSessionInterruption|AVAudioEngineConfigurationChange|TelemetryObservation|BenchmarkCoordinator\" Sources/EnviousWispr Tests/EnviousWisprTests docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:391:- `captureTelemetry = CaptureTelemetryState()`
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:493:10. `captureTelemetry = CaptureTelemetryState()`
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:530:| 8 | `benchmark = BenchmarkSuite()` | 24 | **STAYS (post-epic candidate)** | Could move to a BenchmarkCoordinator; not in this epic. |
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:535:| 13 | `captureTelemetry = CaptureTelemetryState()` | 29 | **STAYS (post-epic candidate)** | Could absorb into R5's HeartPathTelemetryEmitter eventually; not in this epic. |
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:1373:1. **AppState property-count ceiling.** Number of direct concrete-type stored properties on `AppState` exceeds the target. Verified 2026-04-18 baseline: 15 (§4.13). Target after Phases A+C+D+F: ≤ 12. This is the *architectural* signal, not the line count. Target revised from ≤ 8 in v1.2 because the §4.13 disposition matrix made the original target unachievable without unbundling stable concerns. A ≤ 10 target is reachable with post-epic BenchmarkCoordinator + TelemetryObservationCoordinator extractions (not in this epic).
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:2186:- **BenchmarkCoordinator** absorbing `benchmark = BenchmarkSuite()`.
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:2187:- **TelemetryObservationCoordinator** absorbing `captureTelemetry = CaptureTelemetryState()` observer wiring.
+docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md:3191:  - §11.2 Phase E target revised from ≤ 8 (unachievable per matrix) to ≤ 12 (honest, reachable by Phases A+C+D+F). Added note about post-epic BenchmarkCoordinator + TelemetryObservationCoordinator reaching ≤ 10 if needed.
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:50:  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:51:  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:53:  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:96:  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:97:  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift:99:  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+Sources/EnviousWispr/App/AppState.swift:28:  let captureTelemetry = CaptureTelemetryState()
+Sources/EnviousWispr/App/AppState.swift:175:      captureTelemetry: captureTelemetry
+Sources/EnviousWispr/App/AppState.swift:201:      captureTelemetry: captureTelemetry
+Sources/EnviousWispr/App/AppState.swift:310:    audioCapture.onCaptureStalled = { [weak self] ctx in
+Sources/EnviousWispr/App/AppState.swift:314:    audioCapture.onXPCReplyFailed = { [weak self] ctx in
+Sources/EnviousWispr/App/AppState.swift:318:    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
+Sources/EnviousWispr/App/AppState.swift:324:    // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
+Sources/EnviousWispr/App/AppState.swift:328:      forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
+Sources/EnviousWispr/App/AppState.swift:332:        self.captureTelemetry.incrementConfigChange()
+Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift:413:  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift:414:  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift:416:  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:104:        if appState.benchmark.isRunning {
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:109:              Text(appState.benchmark.progress)
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:117:                Task { await appState.benchmark.run(using: appState.asrManager) }
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:120:                Task { await appState.benchmark.runPipelineBenchmark(using: appState.asrManager) }
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:126:        if !appState.benchmark.results.isEmpty {
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:128:            ForEach(appState.benchmark.results) { result in
+Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift:145:        if let pipeline = appState.benchmark.pipelineResult {
+
+exec
+/bin/zsh -lc "printf 'ollama_view_occurrences '; rg -o \"appState\\.ollamaSetup\\.\" Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift | wc -l; printf 'whisper_view_occurrences '; rg -o \"appState\\.whisperKitSetup\\.\" Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift | wc -l; printf 'appdelegate_occurrences '; rg -o \"appState\\.ollamaSetup\\.cleanup\\(\" Sources/EnviousWispr/App/AppDelegate.swift | wc -l; printf 'sources_appstate_setup_occurrences '; rg -o \"appState\\.(ollamaSetup|whisperKitSetup)\\.\" Sources | wc -l" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+ollama_view_occurrences       29
+whisper_view_occurrences        8
+appdelegate_occurrences        1
+sources_appstate_setup_occurrences       38
+
+exec
+/bin/zsh -lc 'rg -n "ollamaSetup" Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift && rg -n "whisperKitSetup" Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift' in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+27:    switch appState.ollamaSetup.setupState {
+74:              ollamaSetupContent
+228:          await appState.ollamaSetup.detectState()
+229:          if case .ready = appState.ollamaSetup.setupState {
+247:        appState.ollamaSetup.cancelPull()
+248:        appState.ollamaSetup.resetWarmup()
+257:        Task { await appState.ollamaSetup.detectState() }
+268:    .onChange(of: appState.ollamaSetup.setupState) { _, newState in
+276:          appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+280:        appState.ollamaSetup.resetWarmup()
+286:        case .ready = appState.ollamaSetup.setupState,
+289:        appState.ollamaSetup.warmUpModel(newModel)
+572:  private var ollamaSetupContent: some View {
+573:    switch appState.ollamaSetup.setupState {
+619:            appState.ollamaSetup.startServer()
+642:            appState.ollamaSetup.pullModel(appState.settings.ollamaModel)
+675:            appState.ollamaSetup.cancelPull()
+708:            await appState.ollamaSetup.detectState()
+709:            if case .ready = appState.ollamaSetup.setupState {
+863:    let catalog = appState.ollamaSetup.dynamicCatalog
+865:      if case .pullingModel = appState.ollamaSetup.setupState { return true }
+890:          if appState.ollamaSetup.currentPullingModel == entry.name {
+893:              Text("Downloading… \(Int(appState.ollamaSetup.pullProgress * 100))%")
+898:                appState.ollamaSetup.cancelPull()
+908:              appState.ollamaSetup.deleteModel(name: entry.name)
+918:              appState.ollamaSetup.pullModel(entry.name)
+986:        await appState.ollamaSetup.detectState()
+987:        if case .ready = appState.ollamaSetup.setupState {
+1004:    switch appState.ollamaSetup.warmupState {
+1015:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+1025:        appState.ollamaSetup.warmUpModel(appState.settings.llmModel)
+40:            whisperKitSetupContent
+47:        case .ready = appState.whisperKitSetup.setupState
+165:        Task { await appState.whisperKitSetup.detectState() }
+170:        Task { await appState.whisperKitSetup.detectState() }
+205:  private var whisperKitSetupContent: some View {
+206:    switch appState.whisperKitSetup.setupState {
+228:            appState.whisperKitSetup.downloadModel()
+257:            appState.whisperKitSetup.cancelDownload()
+284:          Task { await appState.whisperKitSetup.detectState() }
+301:      Task { await appState.whisperKitSetup.forceDetectState() }
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift | sed -n '90,155p' && nl -ba Sources/EnviousWispr/App/BenchmarkSuite.swift | sed -n '1,140p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+    90	          )
+    91	          .font(.stHelper)
+    92	          .foregroundStyle(.stTextTertiary)
+    93	        }
+    94	        BrandedRow(showDivider: false) {
+    95	          Button("Open Console.app") {
+    96	            NSWorkspace.shared.open(
+    97	              URL(fileURLWithPath: "/System/Applications/Utilities/Console.app"))
+    98	          }
+    99	        }
+   100	      }
+   101	
+   102	      // ── Performance ───────────────────────────────────────────────────
+   103	      BrandedSection(header: "Performance") {
+   104	        if appState.benchmark.isRunning {
+   105	          BrandedRow {
+   106	            HStack {
+   107	              ProgressView()
+   108	                .controlSize(.small)
+   109	              Text(appState.benchmark.progress)
+   110	                .font(.caption)
+   111	            }
+   112	          }
+   113	        } else {
+   114	          BrandedRow {
+   115	            HStack {
+   116	              Button("Run ASR Benchmark") {
+   117	                Task { await appState.benchmark.run(using: appState.asrManager) }
+   118	              }
+   119	              Button("Run Pipeline Benchmark") {
+   120	                Task { await appState.benchmark.runPipelineBenchmark(using: appState.asrManager) }
+   121	              }
+   122	            }
+   123	          }
+   124	        }
+   125	
+   126	        if !appState.benchmark.results.isEmpty {
+   127	          BrandedRow {
+   128	            ForEach(appState.benchmark.results) { result in
+   129	              HStack {
+   130	                Text(result.label)
+   131	                  .font(.caption)
+   132	                Spacer()
+   133	                Text(String(format: "%.2fs", result.processingTime))
+   134	                  .font(.caption)
+   135	                  .monospacedDigit()
+   136	                Text(String(format: "%.0fx RT", result.rtf))
+   137	                  .font(.caption)
+   138	                  .foregroundStyle(.secondary)
+   139	                  .monospacedDigit()
+   140	              }
+   141	            }
+   142	          }
+   143	        }
+   144	
+   145	        if let pipeline = appState.benchmark.pipelineResult {
+   146	          BrandedRow {
+   147	            VStack(alignment: .leading, spacing: 4) {
+   148	              Text("Pipeline Benchmark Results")
+   149	                .font(.caption).bold()
+   150	              HStack {
+   151	                Text("Batch ASR:")
+   152	                Spacer()
+   153	                Text(String(format: "%.3fs", pipeline.batchASRTime))
+   154	                  .monospacedDigit()
+   155	              }.font(.caption)
+     1	@preconcurrency import AVFoundation
+     2	import EnviousWisprASR
+     3	import EnviousWisprAudio
+     4	import EnviousWisprCore
+     5	import Foundation
+     6	
+     7	/// Measures ASR transcription performance across different audio durations.
+     8	@MainActor
+     9	@Observable
+    10	final class BenchmarkSuite {
+    11	  struct Result: Identifiable, Sendable {
+    12	    let id = UUID()
+    13	    let label: String
+    14	    let processingTime: TimeInterval
+    15	    /// Real-time factor: how many seconds of audio are processed per second.
+    16	    let rtf: Double
+    17	  }
+    18	
+    19	  /// Results from a full pipeline benchmark run.
+    20	  struct PipelineBenchmarkResult: Sendable {
+    21	    let batchASRTime: TimeInterval
+    22	    let streamingFinalizeTime: TimeInterval?
+    23	    let werDelta: Double?
+    24	    let audioDuration: TimeInterval
+    25	  }
+    26	
+    27	  private(set) var results: [Result] = []
+    28	  private(set) var pipelineResult: PipelineBenchmarkResult?
+    29	  private(set) var isRunning = false
+    30	  private(set) var progress: String = ""
+    31	
+    32	  /// Ensure model is loaded, returning false (and updating progress) if loading fails.
+    33	  private func ensureModelLoaded(using asrManager: any ASRManagerInterface) async -> Bool {
+    34	    guard !asrManager.isModelLoaded else { return true }
+    35	    progress = "Loading model..."
+    36	    do {
+    37	      try await asrManager.loadModel()
+    38	      return true
+    39	    } catch {
+    40	      progress = "Model load failed: \(error.localizedDescription)"
+    41	      return false
+    42	    }
+    43	  }
+    44	
+    45	  /// Run ASR benchmarks with the given ASR manager.
+    46	  func run(using asrManager: any ASRManagerInterface) async {
+    47	    guard !isRunning else { return }
+    48	    isRunning = true
+    49	    results = []
+    50	
+    51	    guard await ensureModelLoaded(using: asrManager) else {
+    52	      isRunning = false
+    53	      return
+    54	    }
+    55	
+    56	    let durations: [TimeInterval] = [5, 15, 30]
+    57	
+    58	    for duration in durations {
+    59	      progress = "Testing \(Int(duration))s audio..."
+    60	      let samples = generateTestAudio(duration: duration)
+    61	
+    62	      let start = CFAbsoluteTimeGetCurrent()
+    63	      _ = try? await asrManager.transcribe(audioSamples: samples, options: .default)
+    64	      let elapsed = CFAbsoluteTimeGetCurrent() - start
+    65	
+    66	      results.append(
+    67	        Result(
+    68	          label: "\(Int(duration))s",
+    69	          processingTime: elapsed,
+    70	          rtf: duration / elapsed
+    71	        ))
+    72	    }
+    73	
+    74	    progress = "Complete"
+    75	    isRunning = false
+    76	  }
+    77	
+    78	  /// Run pipeline benchmark: batch ASR, streaming ASR (if supported), and WER comparison.
+    79	  func runPipelineBenchmark(using asrManager: any ASRManagerInterface) async {
+    80	    guard !isRunning else { return }
+    81	    isRunning = true
+    82	    pipelineResult = nil
+    83	
+    84	    guard await ensureModelLoaded(using: asrManager) else {
+    85	      isRunning = false
+    86	      return
+    87	    }
+    88	
+    89	    // Load test audio — try jfk.wav from WhisperKit test resources, fall back to synthetic
+    90	    let testAudioDuration: TimeInterval
+    91	    let testSamples: [Float]
+    92	
+    93	    // Resolve jfk.wav relative to the bundle: .app is inside the project's build/ dir,
+    94	    // so go up two levels (Contents/MacOS → .app → build/) then ../Tests/Resources/
+    95	    let executableURL = Bundle.main.executableURL ?? URL(fileURLWithPath: "/")
+    96	    let projectRoot =
+    97	      executableURL
+    98	      .deletingLastPathComponent()  // MacOS/
+    99	      .deletingLastPathComponent()  // Contents/
+   100	      .deletingLastPathComponent()  // EnviousWispr.app/
+   101	      .deletingLastPathComponent()  // build/
+   102	    let jfkURL = projectRoot.appendingPathComponent("Tests/Resources/jfk.wav")
+   103	    if FileManager.default.fileExists(atPath: jfkURL.path) {
+   104	      progress = "Loading test audio..."
+   105	      do {
+   106	        testSamples = try loadAudioFile(url: jfkURL)
+   107	        testAudioDuration = Double(testSamples.count) / AudioConstants.sampleRate
+   108	      } catch {
+   109	        progress = "Failed to load test audio: \(error.localizedDescription)"
+   110	        isRunning = false
+   111	        return
+   112	      }
+   113	    } else {
+   114	      testAudioDuration = 15.0
+   115	      testSamples = generateTestAudio(duration: testAudioDuration)
+   116	    }
+   117	
+   118	    // Step 1: Batch ASR
+   119	    progress = "Running batch ASR..."
+   120	    let batchStart = CFAbsoluteTimeGetCurrent()
+   121	    let batchResult = try? await asrManager.transcribe(audioSamples: testSamples, options: .default)
+   122	    let batchTime = CFAbsoluteTimeGetCurrent() - batchStart
+   123	    let batchTranscript = batchResult?.text ?? ""
+   124	
+   125	    // Step 2: Streaming ASR (if supported)
+   126	    var streamingFinalizeTime: TimeInterval?
+   127	    var streamingTranscript: String?
+   128	    var werDelta: Double?
+   129	
+   130	    let supportsStreaming = await asrManager.activeBackendSupportsStreaming
+   131	    if supportsStreaming {
+   132	      progress = "Running streaming ASR..."
+   133	      do {
+   134	        try await asrManager.startStreaming(options: .default)
+   135	
+   136	        // Chunk the samples into AVAudioPCMBuffers and feed them
+   137	        let chunkSize = AudioConstants.captureBufferSize
+   138	        let format = AVAudioFormat(
+   139	          commonFormat: .pcmFormatFloat32,
+   140	          sampleRate: AudioConstants.sampleRate,
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/App/CaptureTelemetryState.swift | sed -n '1,180p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+nl: Sources/EnviousWispr/App/CaptureTelemetryState.swift: No such file or directory
+
+exec
+/bin/zsh -lc "nl -ba /Users/m4pro_sv/.codex/memories/MEMORY.md | sed -n '912,950p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+   912	## Task 1: Repo code-quality and Sentry issue audits, main remaining debt is AppState and pipeline orchestration
+   913	
+   914	### rollout_summary_files
+   915	
+   916	- rollout_summaries/2026-04-10T17-10-13-BUTu-enviouswispr_sentry_issues_deep_code_review.md (cwd=/Users/m4pro_sv/Desktop/EnviousWispr, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/10/rollout-2026-04-10T13-10-13-019d785f-6f0e-76f2-8442-c04ce2e36c38.jsonl, updated_at=2026-04-10T17:15:52+00:00, thread_id=019d785f-6f0e-76f2-8442-c04ce2e36c38, production issue review)
+   917	- rollout_summaries/2026-04-07T01-59-14-QgzF-enviouswispr_code_quality_re_audit_after_pipeline_refactor.md (cwd=/Users/m4pro_sv/Desktop/EnviousWispr, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/06/rollout-2026-04-06T21-59-14-019d65aa-5171-70c3-acc9-09bf0c312c13.jsonl, updated_at=2026-04-07T02:03:41+00:00, thread_id=019d65aa-5171-70c3-acc9-09bf0c312c13, follow-up audit)
+   918	- rollout_summaries/2026-04-06T19-54-41-B8vE-enviouswispr_code_quality_and_pipeline_dedup_audit.md (cwd=/Users/m4pro_sv/Desktop/EnviousWispr, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/06/rollout-2026-04-06T15-54-41-019d645c-9278-7c11-864a-37e584a36702.jsonl, updated_at=2026-04-07T01:19:23+00:00, thread_id=019d645c-9278-7c11-864a-37e584a36702, broader baseline audit)
+   919	- rollout_summaries/2026-04-10T21-19-53-pSbM-code_review_pr_237_238_whisperkit_llm_timeout_tail_fallback.md (cwd=/Users/m4pro_sv/Desktop/EnviousWispr, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/10/rollout-2026-04-10T17-19-53-019d7944-01ae-7390-aebf-36ddf455013a.jsonl, updated_at=2026-04-10T21:21:25+00:00, thread_id=019d7944-01ae-7390-aebf-36ddf455013a, targeted PR review)
+   920	
+   921	### keywords
+   922	
+   923	- AppState, PipelineSettingsSync, TranscriptionPipeline, WhisperKitPipeline, TranscriptFinalizer, TextProcessingRunner, PasteCascadeExecutor, VADMonitorLoop, Sentry, model_load_failed, negative VAD duration, transcribeWithStreamingRescue, v1.7.1, v1.8.0, v1.9.1
+   924	
+   925	## Task 2: Launch-video scene audit and selective port, only Scenes 3 and 5 required edits
+   926	
+   927	### rollout_summary_files
+   928	
+   929	- rollout_summaries/2026-04-19T07-42-01-Rv0E-launch_video_scene_audit_and_port_messy_dictation_endcard.md (cwd=/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr, rollout_path=/Users/m4pro_sv/.codex/sessions/2026/04/19/rollout-2026-04-19T03-42-01-019da4b0-76f7-7bc0-b877-c09dff4b190c.jsonl, updated_at=2026-04-19T07:47:19+00:00, thread_id=019da4b0-76f7-7bc0-b877-c09dff4b190c, implementation task)
+   930	
+   931	### keywords
+   932	
+   933	- Remotion, scene audit, reference JSX, shipped TSX, MessyDictation, EndCard, MacDictationIcon, useCurrentFrame, frame-based motion, npx tsc --noEmit, do not run render
+   934	
+   935	## User preferences
+   936	
+   937	- for broad audits, the user asked to be "BRUTAL but FAIR" and to preserve explicit architectural exceptions that "do NOT ding us on these" -> be candid, but do not penalize intentional tradeoffs they already scoped out [Task 1]
+   938	- across these audits the user repeatedly asked to check git history between versions instead of assuming a current defect is new, so version-scoped reviews should verify whether a bug is already fixed before labeling it current [Task 1]
+   939	- for the launch-video work, the user wanted file:line references, ordering by visual importance, conservative edits inside `src/scenes/`, and explicitly said not to run the final Remotion render [Task 2]
+   940	
+   941	## Reusable knowledge
+   942	
+   943	- Repo-level audits consistently found the package boundary cleaner than the behavior boundary: extracted helpers (`TranscriptFinalizer`, `TextProcessingRunner`, `PasteCascadeExecutor`, `VADMonitorLoop`) reduced duplication, but `AppState` and the two pipelines remain the main orchestration debt center. [Task 1]
+   944	- Current code already contains the later Parakeet streaming rescue path (`transcribeWithStreamingRescue()`), so older-version Sentry issues around empty streaming finalize should be classified as fixed-in-history rather than current defects. [Task 1]
+   945	- Negative VAD durations were traced to transport/validation risk in `AudioCaptureProxy.decodeVADSegments()`, not the in-process `SilenceDetector` segment generator. [Task 1]
+   946	- The launch-video comparison pattern that worked was conservative: audit reference JSX vs shipped TSX scene by scene, keep no-op scenes untouched, convert browser-only CSS motion into Remotion frame-based motion, and verify with `npx tsc --noEmit` instead of rendering when the user says not to render. [Task 2]
+   947	
+   948	## Failures and how to do differently
+   949	
+   950	- Symptom: an audit overstates regressions after a refactor. Cause: it ignores intentional exceptions or already-extracted helper ownership. Fix: compare against the user’s accepted tradeoffs and the before/after architecture, not an abstract ideal. [Task 1]
+
+exec
+/bin/zsh -lc "rg --files Sources | rg 'CaptureTelemetry|Telemetry'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWisprServices/CaptureTelemetryState.swift
+Sources/EnviousWisprServices/TelemetryService.swift
+
+exec
+/bin/zsh -lc "rg -n \"finalizationResult = try await transcriptFinalizer\\.finalize|FinalizationRequest|prepareBackendSilently|func transcribeWithStreamingRescue|func handle\\(event\" Sources/EnviousWisprPipeline/TranscriptionPipeline.swift Sources/EnviousWisprPipeline/WhisperKitPipeline.swift" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:923:        finalizationResult = try await transcriptFinalizer.finalize(
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:924:          FinalizationRequest(
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1288:  private func transcribeWithStreamingRescue(
+Sources/EnviousWisprPipeline/TranscriptionPipeline.swift:1355:  public func handle(event: PipelineEvent) async throws {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:354:  public func handle(event: PipelineEvent) async throws {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:386:  public func prepareBackendSilently() async {
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:970:        finalizationResult = try await transcriptFinalizer.finalize(
+Sources/EnviousWisprPipeline/WhisperKitPipeline.swift:971:          FinalizationRequest(
+
+exec
+/bin/zsh -lc "rg -n \"public protocol ASRManagerInterface|activeBackendType|loadModelSilently|switchBackend|startStreaming|finalizeStreaming|transcribe\\(\" Sources/EnviousWisprASR/ASRManagerInterface.swift" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+9:public protocol ASRManagerInterface: AnyObject {
+11:  var activeBackendType: ASRBackendType { get }
+24:  func loadModelSilently() async
+27:  func switchBackend(to type: ASRBackendType) async
+33:  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
+36:  func startStreaming(options: TranscriptionOptions) async throws
+38:  func finalizeStreaming() async throws -> ASRResult
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprServices/CaptureTelemetryState.swift | sed -n '1,180p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	import Foundation
+     2	
+     3	/// App-wide telemetry state for audio capture diagnostics. Owns dedupe state
+     4	/// for zombie-engine zero-peak events (#302) and the monotonic counter of
+     5	/// `AVAudioEngineConfigurationChange` notifications since launch (used as the
+     6	/// smoking-gun diagnostic for #294).
+     7	///
+     8	/// Shared across both pipelines so a Parakeet-to-WhisperKit switch does not
+     9	/// reset dedupe, and so `timeSinceLastSuccessfulRecordingMs` is an app-level
+    10	/// baseline rather than pipeline-local.
+    11	@MainActor
+    12	public final class CaptureTelemetryState {
+    13	  private var lastZombieEmittedAt: ContinuousClock.Instant?
+    14	  private var lastZombieRoute: String?
+    15	  private var lastSuccessfulRecordingAt: ContinuousClock.Instant?
+    16	  private(set) public var configurationChangeCount: Int = 0
+    17	
+    18	  public init() {}
+    19	
+    20	  /// Called at transcript save (not paste end) so clipboard-only users are
+    21	  /// covered. Resets zombie dedupe so a successful recording sandwiched
+    22	  /// between two zombie events still surfaces the second event.
+    23	  public func recordSuccessfulRecording() {
+    24	    lastSuccessfulRecordingAt = .now
+    25	    lastZombieEmittedAt = nil
+    26	    lastZombieRoute = nil
+    27	  }
+    28	
+    29	  /// Returns true if a zombie event on `route` should emit to Sentry now.
+    30	  /// False when a prior event fired less than `window` ago on the same route
+    31	  /// with no intervening successful recording.
+    32	  public func shouldEmitZombie(route: String, window: Duration) -> Bool {
+    33	    guard let last = lastZombieEmittedAt, lastZombieRoute == route else {
+    34	      return true
+    35	    }
+    36	    return .now - last >= window
+    37	  }
+    38	
+    39	  /// Marks that a zombie event was observed (regardless of whether it emitted
+    40	  /// to Sentry). The 30s window is relative to the most recent observation,
+    41	  /// not the most recent emission, so rapid retries stay suppressed.
+    42	  public func markZombieEmitted(route: String) {
+    43	    lastZombieEmittedAt = .now
+    44	    lastZombieRoute = route
+    45	  }
+    46	
+    47	  public func incrementConfigChange() {
+    48	    configurationChangeCount += 1
+    49	  }
+    50	
+    51	  /// Milliseconds since the last successful recording. Nil if the app session
+    52	  /// has never produced a successful recording yet.
+    53	  public func timeSinceLastSuccessfulRecordingMs() -> Int? {
+    54	    guard let last = lastSuccessfulRecordingAt else { return nil }
+    55	    let elapsed = ContinuousClock.now - last
+    56	    let (seconds, attoseconds) = elapsed.components
+    57	    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+    58	  }
+    59	}
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprASR/ASRManagerInterface.swift | sed -n '1,70p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	@preconcurrency import AVFoundation
+     2	import EnviousWisprCore
+     3	
+     4	/// Abstraction over ASR management — enables swapping between in-process and XPC implementations.
+     5	///
+     6	/// `ASRManager` (in-process) and `ASRManagerProxy` (XPC) both conform to this protocol.
+     7	/// Pipelines and AppState interact through this interface only.
+     8	@MainActor
+     9	public protocol ASRManagerInterface: AnyObject {
+    10	  // Observable state
+    11	  var activeBackendType: ASRBackendType { get }
+    12	  var isModelLoaded: Bool { get }
+    13	  var isStreaming: Bool { get }  // periphery:ignore - read via existential type (ASRManagerProxy)
+    14	
+    15	  // Download progress (0.0–1.0), phase description, and detail string.
+    16	  // Updated during loadModel() when model download is in progress.
+    17	  // periphery:ignore:all - read via existential type in OnboardingV2View progress polling
+    18	  var downloadProgress: Double { get }
+    19	  var downloadPhase: String { get }
+    20	  var downloadDetail: String { get }
+    21	
+    22	  // Model lifecycle
+    23	  func loadModel() async throws
+    24	  func loadModelSilently() async
+    25	  func unloadModel() async  // periphery:ignore - called via existential type (ASRManager idle timer)
+    26	  func setInitialBackendType(_ type: ASRBackendType)
+    27	  func switchBackend(to type: ASRBackendType) async
+    28	
+    29	  // Capability
+    30	  var activeBackendSupportsStreaming: Bool { get async }
+    31	
+    32	  // Batch transcription
+    33	  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
+    34	
+    35	  // Streaming transcription
+    36	  func startStreaming(options: TranscriptionOptions) async throws
+    37	  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws
+    38	  func finalizeStreaming() async throws -> ASRResult
+    39	  func cancelStreaming() async
+    40	
+    41	  // Pipeline lifecycle hooks
+    42	  func noteTranscriptionComplete(policy: ModelUnloadPolicy)
+    43	  func cancelIdleTimer()
+    44	
+    45	  // Crash notification — fires when XPC ASR service dies during an active session.
+    46	  // Wired by AppState to route to the active pipeline (same pattern as AudioCaptureProxy.onEngineInterrupted).
+    47	  var onServiceInterrupted: (() -> Void)? { get set }
+    48	}
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWisprPipeline/TranscriptionPipeline.swift | sed -n '1280,1330p' && nl -ba Sources/EnviousWisprPipeline/TranscriptionPipeline.swift | sed -n '1350,1385p' && nl -ba Sources/EnviousWisprPipeline/WhisperKitPipeline.swift | sed -n '960,1005p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+  1280	    )
+  1281	  }
+  1282	
+  1283	  // MARK: - Streaming Rescue
+  1284	
+  1285	  /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
+  1286	  /// and VAD detected speech. Heart-level rescue: captured samples are already available,
+  1287	  /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
+  1288	  private func transcribeWithStreamingRescue(
+  1289	    samples: [Float],
+  1290	    hasSpeechEvidence: Bool
+  1291	  ) async throws -> ASRResult {
+  1292	    // 1. Try streaming finalize (happy path)
+  1293	    do {
+  1294	      let result = try await asrManager.finalizeStreaming()
+  1295	      let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+  1296	      if !text.isEmpty {
+  1297	        return result
+  1298	      }
+  1299	      // Streaming returned empty -- check rescue eligibility below
+  1300	    } catch is CancellationError {
+  1301	      throw CancellationError()
+  1302	    } catch {
+  1303	      await AppLogger.shared.log(
+  1304	        "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
+  1305	        level: .info, category: "Pipeline"
+  1306	      )
+  1307	    }
+  1308	
+  1309	    // 2. No speech evidence means genuine silence, not a rescue candidate.
+  1310	    // Return an empty result so the caller handles it with the appropriate message.
+  1311	    guard hasSpeechEvidence else {
+  1312	      return ASRResult(
+  1313	        text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+  1314	    }
+  1315	
+  1316	    // 3. Batch rescue: speech was detected but streaming failed to decode it.
+  1317	    await AppLogger.shared.log(
+  1318	      "Streaming rescue: speech evidence found, retrying batch (\(samples.count) samples)",
+  1319	      level: .info, category: "Pipeline"
+  1320	    )
+  1321	
+  1322	    let result = try await asrManager.transcribe(
+  1323	      audioSamples: samples, options: transcriptionOptions)
+  1324	
+  1325	    await AppLogger.shared.log(
+  1326	      "Streaming rescue: batch produced \(result.text.count) chars",
+  1327	      level: .info, category: "Pipeline"
+  1328	    )
+  1329	
+  1330	    return result
+  1350	      }
+  1351	      return .error(message: msg)
+  1352	    }
+  1353	  }
+  1354	
+  1355	  public func handle(event: PipelineEvent) async throws {
+  1356	    switch event {
+  1357	    case .preWarm:
+  1358	      try await preWarmAudioInput()
+  1359	    case .toggleRecording(let config):
+  1360	      await toggleRecording(config: config)
+  1361	    case .requestStop:
+  1362	      await requestStop()
+  1363	    case .cancelRecording:
+  1364	      await cancelRecording()
+  1365	    case .reset:
+  1366	      reset()
+  1367	    }
+  1368	  }
+  1369	
+  1370	  /// Issue #289: dumb external-error sink. No transition side-effects, no
+  1371	  /// retry scheduling — callers own the decision to surface an error here.
+  1372	  public func setExternalError(_ message: String) {
+  1373	    currentTranscript = nil
+  1374	    state = .error(message)
+  1375	  }
+  1376	
+  1377	  /// Issue #289: see `DictationPipeline.clearPendingStallRecovery`.
+  1378	  public func clearPendingStallRecovery() {
+  1379	    pendingStallRecoveryToken = nil
+  1380	  }
+  1381	
+  1382	  /// Fan out frozen config values to substeps and derive decode options.
+  1383	  /// Called once at `startRecording` after `currentSessionConfig` is set.
+  1384	  /// `llmPolishStep` is written here rather than read via the config because
+  1385	  /// its internal caches key off provider/model identity, and the
+   960	          "WhisperKit ASR completed in \(String(format: "%.3f", asrEnd - asrStart))s "
+   961	            + "(\(asrText.count) chars, lang=\(asrLanguage ?? "?"), incremental=\(usedIncremental))",
+   962	          level: .info, category: "WhisperKitPipeline"
+   963	        )
+   964	      }
+   965	
+   966	      // Post-ASR finalization: text processing -> store -> paste
+   967	      let recordingDuration = Double(rawSamples.count) / 16000.0
+   968	      let finalizationResult: FinalizationResult
+   969	      do {
+   970	        finalizationResult = try await transcriptFinalizer.finalize(
+   971	          FinalizationRequest(
+   972	            asrText: asrText,
+   973	            language: asrLanguage,
+   974	            duration: recordingDuration,
+   975	            processingTime: asrEnd - asrStart,
+   976	            backendType: .whisperKit,
+   977	            targetApp: targetApp,
+   978	            targetElement: targetElement,
+   979	            autoCopyToClipboard: autoCopyToClipboard,
+   980	            autoPasteToActiveApp: autoPasteToActiveApp,
+   981	            restoreClipboardAfterPaste: restoreClipboardAfterPaste,
+   982	            steps: textProcessingSteps
+   983	          ))
+   984	      } catch is CancellationError {
+   985	        frozenSnapshot = nil
+   986	        return
+   987	      } catch let error as FinalizationError {
+   988	        switch error {
+   989	        case .emptyAfterProcessing:
+   990	          SentryBreadcrumb.captureError(
+   991	            HeartPathError.emptyAfterProcessing(
+   992	              route: audioCapture.currentAudioRoute,
+   993	              wasPolishEnabled: llmPolishStep.isEnabled
+   994	            ),
+   995	            category: .heartPathFinalization,
+   996	            stage: "processing",
+   997	            extra: [
+   998	              "capture.route": audioCapture.currentAudioRoute,
+   999	              "polish.enabled": llmPolishStep.isEnabled,
+  1000	              "backend": "whisperKit",
+  1001	              "capture_session_id": Int(audioCapture.currentCaptureSessionID),
+  1002	            ]
+  1003	          )
+  1004	          state = .error("No text after processing")
+  1005	          frozenSnapshot = nil
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift | sed -n '1,70p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+     1	import EnviousWisprASR
+     2	import EnviousWisprCore
+     3	import EnviousWisprLLM
+     4	import EnviousWisprServices
+     5	import IOKit.pwr_mgt
+     6	import SwiftUI
+     7	
+     8	// MARK: - ViewModel
+     9	
+    10	@MainActor
+    11	@Observable
+    12	final class OnboardingV2ViewModel {
+    13	  enum Screen { case welcome, settingUp, ready }
+    14	  enum SetupPhase { case checklist, permissions }
+    15	
+    16	  enum ChecklistItemStatus: Equatable {
+    17	    case pending, inProgress, completed
+    18	    case error(String)
+    19	
+    20	    var isInProgress: Bool {
+    21	      if case .inProgress = self { return true }
+    22	      return false
+    23	    }
+    24	  }
+    25	
+    26	  var currentScreen: Screen = .welcome
+    27	  var setupPhase: SetupPhase = .checklist
+    28	  var checklistStatuses: [ChecklistItemStatus] = [.pending, .pending, .pending]
+    29	
+    30	  var micGranted = false
+    31	  var accessibilityGranted = false
+    32	  var showSkipLink = false
+    33	
+    34	  var downloadError: String?
+    35	  /// Raw error details for support diagnostics (hidden behind "Copy error details" button).
+    36	  var rawErrorDetails: String?
+    37	  var retryCount = 0
+    38	
+    39	  /// ViewModel-owned progress state, polled from ASR manager.
+    40	  /// SwiftUI can't observe @Observable properties through protocol existentials
+    41	  /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
+    42	  var downloadProgress: Double = 0
+    43	  var downloadPhase: String = ""
+    44	  var downloadDetail: String = ""
+    45	  private var progressPollTimer: Timer?
+    46	
+    47	  /// Quirky installation message, cycled during the compilation phase.
+    48	  var installQuip: String = ""
+    49	  private var quipTimer: Timer?
+    50	  private var quipIndex: Int = 0
+    51	
+    52	  /// Fun status messages shown during model compilation (~20-30s wait).
+    53	  private static let installQuips = [
+    54	    "Tuning the neural ears...",
+    55	    "Teaching AI to listen politely...",
+    56	    "Loading all 50,000 words...",
+    57	    "Installing 'um' and 'uh' filters...",
+    58	    "Calibrating whisper detection...",
+    59	    "Warming up Apple Silicon...",
+    60	    "Polishing the speech engine...",
+    61	    "Training patience module...",
+    62	    "Preparing to ignore background noise...",
+    63	    "Sharpening neural networks...",
+    64	    "Convincing AI that you said 'duck'...",
+    65	    "Almost there... pinky promise",
+    66	  ]
+    67	
+    68	  // Sleep prevention — holds a power assertion during download to prevent macOS sleep.
+    69	  private var sleepAssertionID: IOPMAssertionID = 0
+    70	  private var isSleepPrevented = false
+
+exec
+/bin/zsh -lc "nl -ba Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift | sed -n '20,45p' && nl -ba Sources/EnviousWispr/Views/Settings/WordFixSettingsView.swift | sed -n '28,78p'" in /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr
+ succeeded in 0ms:
+    20	
+    21	      List(appState.transcriptCoordinator.filteredTranscripts, selection: $tc.selectedTranscriptID)
+    22	      { transcript in
+    23	        TranscriptRowView(transcript: transcript)
+    24	          .tag(transcript.id)
+    25	      }
+    26	      .opacity(isRecording ? 0.4 : 1.0)
+    27	      .animation(.easeInOut(duration: 0.3), value: isRecording)
+    28	      .overlay {
+    29	        if appState.transcriptCoordinator.transcripts.isEmpty {
+    30	          ContentUnavailableView(
+    31	            "No Transcripts Yet",
+    32	            systemImage: "doc.text",
+    33	            description: Text("Your transcription history will appear here.")
+    34	          )
+    35	        }
+    36	      }
+    37	
+    38	      if !appState.transcriptCoordinator.transcripts.isEmpty {
+    39	        Divider()
+    40	        Button(role: .destructive) {
+    41	          showDeleteAllConfirmation = true
+    42	        } label: {
+    43	          Label("Delete All", systemImage: "trash")
+    44	            .font(.caption)
+    45	        }
+    28	      }
+    29	
+    30	      // ── Section 2: Custom Word List ───────────────────────────────────
+    31	      BrandedSection(
+    32	        header: "Custom Word List (\(appState.customWordsCoordinator.customWords.count) words)"
+    33	      ) {
+    34	        BrandedRow {
+    35	          HStack {
+    36	            TextField("Add word (e.g. EnviousWispr)", text: $newWord)
+    37	              .textFieldStyle(.roundedBorder)
+    38	              .onSubmit { addWord() }
+    39	
+    40	            Button("Add") { addWord() }
+    41	              .disabled(newWord.trimmingCharacters(in: .whitespaces).isEmpty)
+    42	          }
+    43	        }
+    44	
+    45	        if !errorMessage.isEmpty {
+    46	          BrandedRow {
+    47	            Text(errorMessage)
+    48	              .font(.stHelper)
+    49	              .foregroundStyle(.stError)
+    50	          }
+    51	        }
+    52	        if let storeError = appState.customWordsCoordinator.customWordError {
+    53	          BrandedRow {
+    54	            Text(storeError)
+    55	              .font(.stHelper)
+    56	              .foregroundStyle(.stError)
+    57	          }
+    58	        }
+    59	
+    60	        if appState.customWordsCoordinator.customWords.isEmpty {
+    61	          BrandedRow(showDivider: false) {
+    62	            Text(
+    63	              "No custom words yet. Add proper nouns, product names, or technical terms the ASR frequently misrecognizes."
+    64	            )
+    65	            .font(.stHelper)
+    66	            .foregroundStyle(.stTextTertiary)
+    67	          }
+    68	        } else {
+    69	          BrandedRow(showDivider: false) {
+    70	            WrappingHStack(spacing: 8) {
+    71	              ForEach(
+    72	                appState.customWordsCoordinator.customWords.sorted {
+    73	                  $0.canonical.localizedCaseInsensitiveCompare($1.canonical) == .orderedAscending
+    74	                }
+    75	              ) { word in
+    76	                CustomWordChip(
+    77	                  word: word,
+    78	                  onTap: {
+
+codex
+**Q1**
+
+Phase F is a real but modest hardening step. It is not ceremonial, but the new SPM library target is overbuilt for the current payoff.
+
+The cohesion claim is **partial**. `OllamaSetupService` and `WhisperKitSetupService` are both Settings-facing setup limbs: both are `@MainActor @Observable` services with setup state and user-triggered setup actions (`OllamaSetupService.swift:84-91`, `WhisperKitSetupService.swift:30-38`). Grouping those under `setup` is coherent. The preload observer is narrower: it watches `whisperKitSetup.setupState`, checks `asrManager.activeBackendType`, then calls `whisperKitPipeline.prepareBackendSilently()` (`AppState.swift:649-654`). That belongs to the WhisperKit setup/pipeline boundary, not to Ollama. It is acceptable inside a thin `SetupCoordinator`, but only if the coordinator is explicitly “optional setup orchestration,” not a generic setup bucket.
+
+The decoupling claim is also **partial**. AppState stops owning two leaf services and one task (`AppState.swift:25-31`), but the proposed coordinator still depends on `ASRManagerInterface` and a closure into `WhisperKitPipeline` because the current observer needs both (`AppState.swift:649`, `AppState.swift:654`). That is not vanity: the injected `preloadAction` is a real unit-test seam, and `ASRManagerInterface` is already the app’s intended ASR abstraction (`ASRManagerInterface.swift:9-27`). But it is not a major coupling reduction. It mainly moves a small lifecycle bridge out of AppState.
+
+Observation risk is **low if `setup` stays concrete**. The repo already has multi-level observable paths such as `appState.transcriptCoordinator.transcripts` (`TranscriptHistoryView.swift:21-29`), `appState.customWordsCoordinator.customWords` (`WordFixSettingsView.swift:31-72`), and `appState.benchmark.results` (`DiagnosticsSettingsView.swift:104-145`). The real trap is typing `setup` as `any SetupCoordinating`; the codebase already documents that SwiftUI cannot observe `@Observable` properties through protocol existentials (`OnboardingV2View.swift:39-42`). So the revision is: AppState should expose `let setup: SetupCoordinator`, not an existential, and the protocol should be test-only/package-scoped if it exists.
+
+Heart path check: Phase F does not touch the heart path directly. Grep found no `appState.ollamaSetup` or `appState.whisperKitSetup` in `Sources/EnviousWisprPipeline`, `Sources/EnviousWisprASR`, or `Sources/EnviousWisprAudio`; the only non-view consumers are AppDelegate cleanup, AppState wiring, and `PipelineSettingsSync` setup detection. Recording start routes through `active.handle(event: .preWarm)` and `.toggleRecording(...)` (`AppState.swift:522-563`), streaming setup/finalize lives inside `TranscriptionPipeline` (`TranscriptionPipeline.swift:467-493`, `1288-1323`), and finalization goes through `TranscriptFinalizer` (`TranscriptionPipeline.swift:920-930`, `WhisperKitPipeline.swift:966-982`). `WhisperKitPipeline.prepareBackendSilently()` is a background preload helper and explicitly says user recording handles its own load path (`WhisperKitPipeline.swift:382-386`).
+
+The library-target choice is the weakest part. The stale D7 concern is real: `EnviousWisprTests` already depends on `"EnviousWispr"` (`Package.swift:125-135`; the plan’s “line 138” is drifted). The secondary rationale, “right shape day-one,” is not strong enough by itself. A new target forces `public` exposure for an app-shell coordinator and its init/properties, while the architecture rules say public is expensive and new coordinators must justify themselves (`architecture-rules.md:14`, `115-119`). Put `SetupCoordinator` in the executable target first. Extract to a library target later only when a second production module actually needs it.
+
+Phase E ceiling honesty: this is not a Phase E problem and not a sign Phase F is undersized. The current bible already revised the target to `<= 12` direct concrete deps (`issue-319...md:1373-1375`, `1407-1411`). The current AppState has 20 file-scope `let` declarations if you count interfaces, pipelines, and peers (`AppState.swift:18-124`), but that is a noisy metric. The meaningful count is direct concrete ownership. Phase F should not absorb more properties just to hit a counter.
+
+**Q2**
+
+The bigger-bang refactor is `TelemetryObservationCoordinator`, not `BenchmarkCoordinator`, but it is also riskier. Telemetry wiring in AppState owns shared audio/ASR callback routing and Sentry context (`AppState.swift:310-340`, `343-363`), and `CaptureTelemetryState` is explicitly shared across both pipelines (`CaptureTelemetryState.swift:3-12`). That is more central god-object signal than setup. It is also closer to heart-adjacent failure handling, so it is not the better Phase F substitute.
+
+`BenchmarkCoordinator` is smaller and safer, but lower value: it mostly moves diagnostics view calls around `appState.benchmark` (`DiagnosticsSettingsView.swift:104-145`). Phase F as scoped is the right low-risk next move, with the target-placement revision.
+
+**Q3**
+
+- `AppState.startWhisperKitPreloadObservation()` body at `639-668`: **TRUE**. Current body is exactly `AppState.swift:639-668`.
+- Consumer counts: **PARTIAL/FALSE**. `AIPolishSettingsView` has **29** `appState.ollamaSetup.` occurrences, not 31. `SpeechEngineSettingsView` has **8**. `AppDelegate.swift:417` has **1** cleanup call. The standalone plan’s total 44 is therefore inflated; external service-access migration is 38 sites.
+- `Package.swift:138` includes `"EnviousWispr"` in test deps: **PARTIAL**. Substance true, line false. `"EnviousWispr"` is at `Package.swift:134`; line 138 starts the next test target.
+- Proposed init captures everything the observer needs: **TRUE**. External needs are `asrManager.activeBackendType` (`AppState.swift:649`) and `whisperKitPipeline.prepareBackendSilently()` (`AppState.swift:654`). The coordinator also owns `whisperKitSetup` and the task handle.
+- Contract delta table: **PARTIAL**. Missing deltas: new target/import graph in `Package.swift`, `AppState` import of `EnviousWisprAppCore` if library target remains, public `SetupCoordinator.init`, public passthrough properties, and the widened public API caused by moving app-shell code into a library target.
+- LOC estimates: **TRUE enough**. Nothing is off by 2x. `SetupCoordinator` around 95 LOC, AppState net reduction, view rename no-net LOC, and a 75-line test are plausible against current file sizes.
+
+**PROCEED-WITH-REVISIONS**
+
+Do Phase F, but keep `SetupCoordinator` in the existing executable target, expose it concretely from AppState, and keep the protocol/package-public surface out of the first PR unless tests prove it is needed. In plain English: moving this setup wiring out of AppState is worthwhile because it removes a small but real responsibility from the central object without touching dictation. Creating a new module for it is the part that turns a useful cleanup into architecture ceremony. Start local, keep it thin, and only promote it to a shared library when the code earns that boundary.
+
+
+2026-04-30T13:19:23.627906Z ERROR codex_core::session: failed to record rollout items: thread 019dde88-178d-7d51-9b65-cbd2a0bd75a6 not found
+tokens used
+126,995

--- a/docs/audits/2026-04-30-phase-f-grounded-review.txt
+++ b/docs/audits/2026-04-30-phase-f-grounded-review.txt
@@ -1,0 +1,36 @@
+**Q1**
+
+Phase F is a real but modest hardening step. It is not ceremonial, but the new SPM library target is overbuilt for the current payoff.
+
+The cohesion claim is **partial**. `OllamaSetupService` and `WhisperKitSetupService` are both Settings-facing setup limbs: both are `@MainActor @Observable` services with setup state and user-triggered setup actions (`OllamaSetupService.swift:84-91`, `WhisperKitSetupService.swift:30-38`). Grouping those under `setup` is coherent. The preload observer is narrower: it watches `whisperKitSetup.setupState`, checks `asrManager.activeBackendType`, then calls `whisperKitPipeline.prepareBackendSilently()` (`AppState.swift:649-654`). That belongs to the WhisperKit setup/pipeline boundary, not to Ollama. It is acceptable inside a thin `SetupCoordinator`, but only if the coordinator is explicitly “optional setup orchestration,” not a generic setup bucket.
+
+The decoupling claim is also **partial**. AppState stops owning two leaf services and one task (`AppState.swift:25-31`), but the proposed coordinator still depends on `ASRManagerInterface` and a closure into `WhisperKitPipeline` because the current observer needs both (`AppState.swift:649`, `AppState.swift:654`). That is not vanity: the injected `preloadAction` is a real unit-test seam, and `ASRManagerInterface` is already the app’s intended ASR abstraction (`ASRManagerInterface.swift:9-27`). But it is not a major coupling reduction. It mainly moves a small lifecycle bridge out of AppState.
+
+Observation risk is **low if `setup` stays concrete**. The repo already has multi-level observable paths such as `appState.transcriptCoordinator.transcripts` (`TranscriptHistoryView.swift:21-29`), `appState.customWordsCoordinator.customWords` (`WordFixSettingsView.swift:31-72`), and `appState.benchmark.results` (`DiagnosticsSettingsView.swift:104-145`). The real trap is typing `setup` as `any SetupCoordinating`; the codebase already documents that SwiftUI cannot observe `@Observable` properties through protocol existentials (`OnboardingV2View.swift:39-42`). So the revision is: AppState should expose `let setup: SetupCoordinator`, not an existential, and the protocol should be test-only/package-scoped if it exists.
+
+Heart path check: Phase F does not touch the heart path directly. Grep found no `appState.ollamaSetup` or `appState.whisperKitSetup` in `Sources/EnviousWisprPipeline`, `Sources/EnviousWisprASR`, or `Sources/EnviousWisprAudio`; the only non-view consumers are AppDelegate cleanup, AppState wiring, and `PipelineSettingsSync` setup detection. Recording start routes through `active.handle(event: .preWarm)` and `.toggleRecording(...)` (`AppState.swift:522-563`), streaming setup/finalize lives inside `TranscriptionPipeline` (`TranscriptionPipeline.swift:467-493`, `1288-1323`), and finalization goes through `TranscriptFinalizer` (`TranscriptionPipeline.swift:920-930`, `WhisperKitPipeline.swift:966-982`). `WhisperKitPipeline.prepareBackendSilently()` is a background preload helper and explicitly says user recording handles its own load path (`WhisperKitPipeline.swift:382-386`).
+
+The library-target choice is the weakest part. The stale D7 concern is real: `EnviousWisprTests` already depends on `"EnviousWispr"` (`Package.swift:125-135`; the plan’s “line 138” is drifted). The secondary rationale, “right shape day-one,” is not strong enough by itself. A new target forces `public` exposure for an app-shell coordinator and its init/properties, while the architecture rules say public is expensive and new coordinators must justify themselves (`architecture-rules.md:14`, `115-119`). Put `SetupCoordinator` in the executable target first. Extract to a library target later only when a second production module actually needs it.
+
+Phase E ceiling honesty: this is not a Phase E problem and not a sign Phase F is undersized. The current bible already revised the target to `<= 12` direct concrete deps (`issue-319...md:1373-1375`, `1407-1411`). The current AppState has 20 file-scope `let` declarations if you count interfaces, pipelines, and peers (`AppState.swift:18-124`), but that is a noisy metric. The meaningful count is direct concrete ownership. Phase F should not absorb more properties just to hit a counter.
+
+**Q2**
+
+The bigger-bang refactor is `TelemetryObservationCoordinator`, not `BenchmarkCoordinator`, but it is also riskier. Telemetry wiring in AppState owns shared audio/ASR callback routing and Sentry context (`AppState.swift:310-340`, `343-363`), and `CaptureTelemetryState` is explicitly shared across both pipelines (`CaptureTelemetryState.swift:3-12`). That is more central god-object signal than setup. It is also closer to heart-adjacent failure handling, so it is not the better Phase F substitute.
+
+`BenchmarkCoordinator` is smaller and safer, but lower value: it mostly moves diagnostics view calls around `appState.benchmark` (`DiagnosticsSettingsView.swift:104-145`). Phase F as scoped is the right low-risk next move, with the target-placement revision.
+
+**Q3**
+
+- `AppState.startWhisperKitPreloadObservation()` body at `639-668`: **TRUE**. Current body is exactly `AppState.swift:639-668`.
+- Consumer counts: **PARTIAL/FALSE**. `AIPolishSettingsView` has **29** `appState.ollamaSetup.` occurrences, not 31. `SpeechEngineSettingsView` has **8**. `AppDelegate.swift:417` has **1** cleanup call. The standalone plan’s total 44 is therefore inflated; external service-access migration is 38 sites.
+- `Package.swift:138` includes `"EnviousWispr"` in test deps: **PARTIAL**. Substance true, line false. `"EnviousWispr"` is at `Package.swift:134`; line 138 starts the next test target.
+- Proposed init captures everything the observer needs: **TRUE**. External needs are `asrManager.activeBackendType` (`AppState.swift:649`) and `whisperKitPipeline.prepareBackendSilently()` (`AppState.swift:654`). The coordinator also owns `whisperKitSetup` and the task handle.
+- Contract delta table: **PARTIAL**. Missing deltas: new target/import graph in `Package.swift`, `AppState` import of `EnviousWisprAppCore` if library target remains, public `SetupCoordinator.init`, public passthrough properties, and the widened public API caused by moving app-shell code into a library target.
+- LOC estimates: **TRUE enough**. Nothing is off by 2x. `SetupCoordinator` around 95 LOC, AppState net reduction, view rename no-net LOC, and a 75-line test are plausible against current file sizes.
+
+**PROCEED-WITH-REVISIONS**
+
+Do Phase F, but keep `SetupCoordinator` in the existing executable target, expose it concretely from AppState, and keep the protocol/package-public surface out of the first PR unless tests prove it is needed. In plain English: moving this setup wiring out of AppState is worthwhile because it removes a small but real responsibility from the central object without touching dictation. Creating a new module for it is the part that turns a useful cleanup into architecture ceremony. Start local, keep it thin, and only promote it to a shared library when the code earns that boundary.
+
+

--- a/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
+++ b/docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md
@@ -620,7 +620,7 @@ Each refactor pattern carries its own test strategy.
 | 3 | **C** | TranscriptCoordinator owns history | 1 | MEDIUM | #428 | SHIPPED (PR #432, 2026-04-21) | +283/−39 actual |
 | 4 | **D** | CustomWordsPropagator replaces 5-way fanout | 1 | MEDIUM | to open | PLANNED §10 | ~180 |
 | 5 | **E** | Architecture regression tests | 1 | SMALL | to open | PLANNED §11 | ~65 |
-| **F** | SetupCoordinator extraction (NEW v1.3) | 1 | MEDIUM | to open | PLANNED §17 | ~+90 net |
+| **F** | SetupCoordinator extraction (NEW v1.3) | 1 | MEDIUM | #501 | IN-FLIGHT (F-Exec, Codex grounded review 2026-04-30) | ~+135 net |
 | 6 | **R2** | WhisperKitBackend adapter | 1 | MEDIUM | #360 | PLANNED §12 | ~120 |
 | 7 | **R3** | Transcript out of logs | 1 | SMALL | #361 | PLANNED §13 | ~40 |
 | 8 | **R4** | BT route log rotation | 1 | SMALL | #362 | PLANNED §15 | ~45 |

--- a/docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md
+++ b/docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md
@@ -1,0 +1,286 @@
+# Phase F — SetupCoordinator extraction (#501)
+
+Parent epic: #319 (Hardening & Refactors). Bible §17. Depends on: nothing (independent). Blocks: Phase E (#502 — ceiling calibration).
+
+## Preface — Lane + Live UAT declaration (PR #498 — MANDATORY)
+
+- **Declared lane:** code (mixed_pr: false)
+- **Phase 3 obligations:** logic tests + smoke + Live UAT (synthetic dictation through real speakers + Settings tab visual confirmation) + Codex code-diff
+- **Live UAT:** Y — manual-human required for the Settings UI portion (no synthetic AX path covers Settings tabs cycling through setup states); synthetic dictation covers the heart-path regression check
+
+## Preface — User Rubric
+
+User Rubric: N/A — Hardening & Refactors is internal-only (Bible §0.7). No user-visible surface change. Settings tabs must look and behave identically.
+
+## 0. TL;DR
+
+Bundle three setup-related concerns currently owned by AppState (`ollamaSetup`, `whisperKitSetup`, `whisperKitPreloadTask` plus the observation wiring) into a new `SetupCoordinator` class living **alongside AppState in the existing executable target** (`Sources/EnviousWispr/App/SetupCoordinator.swift` — no new SPM target). AppState owns one `setup` property instead of three, exposed concretely (`let setup: SetupCoordinator`, not `any SetupCoordinating`). View call sites change `appState.X` → `appState.setup.X` (38 mechanical rewrites across 3 files). Net: AppState concrete-property count drops from 19 → 17. Pre-loaded for Phase E ceiling calibration.
+
+**Revised 2026-04-30 post-grounded-review:** Codex (`docs/audits/2026-04-30-phase-f-grounded-review.txt`) returned PROCEED-WITH-REVISIONS, killing the new SPM library target. D7's primary rationale (test-target access) is stale — `Package.swift:134` already includes `"EnviousWispr"` as a dep of `EnviousWisprTests`. New target would force unnecessary `public` API exposure on app-shell code, contradicting `architecture-rules.md` "public is expensive." Phase F now ships F-Exec.
+
+## 1. Problem
+
+AppState owns 19 file-scope concrete properties. Three of them — `ollamaSetup` (Ollama for cloud-style polish), `whisperKitSetup` (WhisperKit model lifecycle), `whisperKitPreloadTask` (background observation that triggers a model preload when WhisperKit becomes ready) — form a single cohesive concern (initial setup of optional limbs) that does not need to live on the central state object. Phase A+C+D shaved AppState to its current shape; Phase F removes the next-cohesive-cluster. Without F, Phase E's regression-test ceilings cannot be calibrated honestly because the post-A+C+D state is not the architectural target.
+
+## 2. Goals & non-goals
+
+### 2.1 Goals
+
+- AppState's three setup properties consolidated into one new owner.
+- New `SetupCoordinator` lives in `Sources/EnviousWispr/App/SetupCoordinator.swift` (executable target). No new SPM target.
+- AppState exposes `let setup: SetupCoordinator` concretely (NOT `any SetupCoordinating`) — `OnboardingV2View.swift:39-42` documents that SwiftUI `@Observable` tracking does not work through protocol existentials.
+- All view consumers continue observing the same `OllamaSetupService` / `WhisperKitSetupService` instances (Option A passthrough — no semantic-API wrapper).
+- `PipelineSettingsSync.onNeedsPreloadObservation` callback rerouted to call SetupCoordinator instead of AppState.
+- Settings tabs (AI Polish, Speech Engine) render and respond identically to current behavior.
+- Heart path is unaffected (raw transcription does not depend on setup services).
+
+### 2.2 Non-goals
+
+- No semantic-API wrapping (Option B per Bible §17.3 substep 2). Property-passthrough only. If a future phase needs `setup.ollamaReady`-style accessors, that is a separate phase.
+- No `reset()` method on the protocol (per Bible §17.3.1; no caller exists).
+- No extraction of `BenchmarkCoordinator` or `TelemetryObservationCoordinator` (Bible §17.7 — post-epic).
+- No move of `OllamaSetupService` or `WhisperKitSetupService` themselves; they already live in `EnviousWisprLLM` and `EnviousWisprASR` respectively.
+
+## 3. Design
+
+### 3.1 No Package.swift changes
+
+`SetupCoordinator` lives in `Sources/EnviousWispr/App/SetupCoordinator.swift` alongside AppState. No new SPM target. `EnviousWisprTests` already depends on `"EnviousWispr"` (`Package.swift:134`), so unit tests can import SetupCoordinator directly. Future extraction to a library target stays an option if a second production module ever needs it.
+
+### 3.2 SetupCoordinator class
+
+```swift
+// Sources/EnviousWispr/App/SetupCoordinator.swift
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprLLM
+
+// Internal — no public API; lives in executable target alongside AppState.
+@MainActor
+@Observable
+final class SetupCoordinator {
+  let ollamaSetup = OllamaSetupService()
+  let whisperKitSetup = WhisperKitSetupService()
+
+  @ObservationIgnored
+  private var whisperKitPreloadTask: Task<Void, Never>?
+
+  private let asrManager: any ASRManagerInterface
+  private let preloadAction: @MainActor () async -> Void
+
+  init(
+    asrManager: any ASRManagerInterface,
+    preloadAction: @escaping @MainActor () async -> Void
+  ) {
+    self.asrManager = asrManager
+    self.preloadAction = preloadAction
+  }
+
+  func startPreloadObservation() {
+    whisperKitPreloadTask?.cancel()
+    whisperKitPreloadTask = Task { [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+        guard self.asrManager.activeBackendType == .whisperKit else { return }
+        let currentState = self.whisperKitSetup.setupState
+        if currentState == .ready {
+          await self.preloadAction()
+          return
+        }
+        await withCheckedContinuation { continuation in
+          withObservationTracking {
+            _ = self.whisperKitSetup.setupState
+          } onChange: {
+            continuation.resume()
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The body of `startPreloadObservation()` is a verbatim move of `AppState.startWhisperKitPreloadObservation()` (currently lines 639–668), with `self.asrManager` and `self.preloadAction` substituted for the AppState-bound references.
+
+### 3.3 AppState shape change
+
+```swift
+// Sources/EnviousWispr/App/AppState.swift — diff sketch
+
+// REMOVED (lines 25, 26, 31 today):
+// let ollamaSetup = OllamaSetupService()
+// let whisperKitSetup = WhisperKitSetupService()
+// private var whisperKitPreloadTask: Task<Void, Never>?
+
+// ADDED at file scope (in same region):
+let setup: SetupCoordinator
+
+// REMOVED (lines 637–668 today): startWhisperKitPreloadObservation() body
+// — entire method moves to SetupCoordinator.
+
+// CHANGED in init() after asrManager + whisperKitPipeline are constructed:
+self.setup = SetupCoordinator(
+  asrManager: asrManager,
+  preloadAction: { [weak whisperKitPipeline] in
+    await whisperKitPipeline?.prepareBackendSilently()
+  }
+)
+
+// CHANGED at line 375:
+settingsSync.onNeedsPreloadObservation = { [weak setup = self.setup] in
+  setup?.startPreloadObservation()
+}
+
+// CHANGED at line 619 (the "kick the tires" call right after init):
+Task { [weak self] in
+  await self?.setup.whisperKitSetup.detectState()
+  self?.setup.startPreloadObservation()
+}
+```
+
+`PipelineSettingsSync` keeps taking `whisperKitSetup: WhisperKitSetupService` directly. AppState passes `setup.whisperKitSetup` instead of the old top-level property at the construction site (line 217).
+
+### 3.4 D7 supersession
+
+D7 (decisions doc 2026-04-18) said "build SetupCoordinator in a library target from day one." Its primary rationale (test-target access) was stale — `Package.swift:134` already includes `"EnviousWispr"` in `EnviousWisprTests.dependencies`. Codex grounded review 2026-04-30 (`docs/audits/2026-04-30-phase-f-grounded-review.txt`) recommended PROCEED-WITH-REVISIONS specifically to drop the library target: a new SPM module forces unnecessary `public` API exposure on app-shell code, contradicting `architecture-rules.md` "public is expensive" rule. **D7 is superseded by Phase F's grounded review.** Update `issue-319-open-decisions-2026-04-18.md` D7 entry as part of this PR.
+
+### 3.5 Edge cases (per workflow-process §10)
+
+- **Interrupted:** SetupCoordinator deinit has `whisperKitPreloadTask?.cancel()` not explicitly written but the Task captures `[weak self]` so cancellation propagates when the coordinator is freed. AppState owns it for the app lifetime, so this is theoretical.
+- **Deleted:** N/A — `setup` is a `let` on AppState, no deletion path.
+- **Mutated:** Backend-switch settings change calls `onNeedsPreloadObservation` → `setup.startPreloadObservation()`, which cancels the prior task and restarts. Identical behavior to today.
+- **Concurrent:** Two backend switches in fast succession → both fire `startPreloadObservation()` → first task cancels, second proceeds. Identical to today.
+- **Nil:** `[weak setup = self.setup]` capture in the `onNeedsPreloadObservation` closure handles AppState death (theoretical) without keeping setup alive.
+- **Stale:** Views observe `setup.ollamaSetup` and `setup.whisperKitSetup` directly. SwiftUI's @Observable change tracking sees the underlying service's properties changing because the path `appState.setup.ollamaSetup.setupState` traverses two `@Observable` boundaries (AppState and SetupCoordinator both are @Observable, the leaf service is @Observable). Spot-check during Live UAT.
+
+## 4. **MANDATORY** Contract deltas
+
+| Symbol | Before | After | Visibility | Notes |
+|---|---|---|---|---|
+| `AppState.ollamaSetup` | `let ollamaSetup: OllamaSetupService` | removed | — | replaced by `appState.setup.ollamaSetup` |
+| `AppState.whisperKitSetup` | `let whisperKitSetup: WhisperKitSetupService` | removed | — | replaced by `appState.setup.whisperKitSetup` |
+| `AppState.whisperKitPreloadTask` | `private var Task<Void, Never>?` | removed | — | moves to `SetupCoordinator` |
+| `AppState.startWhisperKitPreloadObservation()` | `private func` | removed | — | body moves to `SetupCoordinator.startPreloadObservation()` |
+| `AppState.setup` | — | `let setup: SetupCoordinator` | internal | new owned property — concrete type, NOT existential (preserves @Observable tracking) |
+| `SetupCoordinator` | — | `final class @MainActor @Observable` | internal | new — lives in executable target |
+
+No protocol surface in v1. No `public` API. No `reset()`.
+
+## 5. **MANDATORY** E2E state & lifecycle audit
+
+State that lives in SetupCoordinator: the two service instances + the preload task handle. State that lives elsewhere and is read by SetupCoordinator: `asrManager.activeBackendType` (read-only via interface), `whisperKitPipeline.prepareBackendSilently()` (call-only via injected closure). No new persisted state. No new app-lifecycle hooks.
+
+App-quit cleanup: `appState.ollamaSetup.cleanup()` at `AppDelegate.swift:417` becomes `appState.setup.ollamaSetup.cleanup()`. No new cleanup needed for SetupCoordinator itself; the Task is owned and will be cancelled when the coordinator deinits at app termination.
+
+## 6. **MANDATORY** Downstream consumer matrix
+
+| Consumer | File | Sites | Migration |
+|---|---|---|---|
+| AI Polish Settings tab | `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` | 29 | `appState.ollamaSetup.X` → `appState.setup.ollamaSetup.X` |
+| Speech Engine Settings tab | `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift` | 8 | `appState.whisperKitSetup.X` → `appState.setup.whisperKitSetup.X` |
+| AppDelegate quit hook | `Sources/EnviousWispr/App/AppDelegate.swift:417` | 1 | `appState.ollamaSetup.cleanup()` → `appState.setup.ollamaSetup.cleanup()` |
+| PipelineSettingsSync init | `Sources/EnviousWispr/App/AppState.swift:217` | 1 | pass `setup.whisperKitSetup` instead of `whisperKitSetup` |
+| AppState.init internal | `Sources/EnviousWispr/App/AppState.swift:619, 620, 375` | 3 | route through `self.setup` |
+
+Total: **42 sites** (38 external + 4 internal). All mechanical rewrites. Verified by Codex grep 2026-04-30.
+
+## 7. **MANDATORY** Failure-mode × caller table
+
+| Failure | Caller | Behavior before | Behavior after | Heart-path impact |
+|---|---|---|---|---|
+| OllamaSetupService unreachable | AI Polish view | Status shows "not running", buttons reflect state | Identical (same instance, same observation path) | None — limb |
+| WhisperKitSetupService download fails | Speech Engine view | Status shows error, retry button enabled | Identical | None — limb |
+| Backend switch during preload | settingsSync | Old preload task cancels, new starts | Identical (cancellation logic moves verbatim) | None — limb |
+| App quit during pull | AppDelegate | `ollamaSetup.cleanup()` cancels active pull | Identical | None |
+
+No failure mode changes. Heart path (audio capture → ASR → paste) does not consult either setup service.
+
+## 8. **MANDATORY** Caller-visible signals audit
+
+Settings tabs subscribe to `@Observable` property changes via SwiftUI's tracking. The change `appState.ollamaSetup.setupState` → `appState.setup.ollamaSetup.setupState` lengthens the keypath but does not change the observation graph: SwiftUI walks `appState` (Observable) → `setup` (Observable, new) → `ollamaSetup` (Observable, same) → `setupState`. All three boundaries are tracked. Live UAT must confirm that state transitions still re-render the views without lag or stuck state.
+
+## 9. **MANDATORY** Fallback source-of-truth audit
+
+No fallbacks. If SetupCoordinator misbehaves, the user sees broken Settings tabs but heart-path dictation continues. Per heart/limbs doctrine, this is acceptable — Settings UI for limb configuration is itself a limb.
+
+## 10. File-by-file changes
+
+| File | Change | Est. LOC delta |
+|---|---|---|
+| `Sources/EnviousWispr/App/SetupCoordinator.swift` | NEW (executable target, internal API) | +85 |
+| `Sources/EnviousWispr/App/AppState.swift` | Remove 3 properties + 1 method; add 1 property; rewire 3 call sites | −40, +10 |
+| `Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift` | 29 mechanical renames | ±29 (no net LOC) |
+| `Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift` | 8 mechanical renames | ±8 (no net LOC) |
+| `Sources/EnviousWispr/App/AppDelegate.swift` | 1 mechanical rename | ±1 |
+| `Sources/EnviousWispr/App/PipelineSettingsSync.swift` | No change to sync itself; AppState passes `setup.whisperKitSetup` at construction site | 0 |
+| `Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift` | NEW — preload observation start/cancel/fire test with fake `ASRManagerInterface` + recording closure | +75 |
+| `docs/feature-requests/issue-319-open-decisions-2026-04-18.md` | Update D7 entry: superseded by Phase F grounded review | +5 |
+
+**Net: ~+135 lines.** No `Package.swift` change, no new SPM target.
+
+## 11. Testing
+
+### 11.1 Live UAT spec
+
+**Pre-build:** `scripts/swift-test.sh` green.
+
+**Build:** `/wispr-rebuild-and-relaunch`.
+
+**Synthetic dictation regression (Code-lane default):**
+- `Tests/UITests/wispr_eyes.py test_recording(audio=tts("Phase F regression check sample one"), sentence="Phase F regression check sample one", hold=2.5, expect="Phase F", timeout=15)`. Expected: clipboard contains the transcribed sentence within 15 seconds. Confirms heart path unaffected.
+
+**Settings UI manual-human (cannot be synthesized):**
+1. Open Settings → Speech Engine. Confirm WhisperKit setup state matches current backend (ready/downloading/etc.).
+2. Trigger a backend switch (toggle Speech Engine selection if WhisperKit is selectable). Confirm preload observation re-fires (look for `[AppState]`-or-`[SetupCoordinator]` log line about preload starting).
+3. Open Settings → AI Polish. Confirm Ollama status renders. Click "Detect" → state cycles through detect/ready/error as expected.
+4. Quit the app. Confirm log line for `ollamaSetup.cleanup()` fires once.
+
+Output: `live-uat.json` in run dir with `{tts_sentence, expected_token, observed_clipboard, exit_code, app_path, settings_uat_pass: true|false}`.
+
+### 11.2 Other test obligations
+
+Unit test in `Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift`:
+- Construct SetupCoordinator with a fake `ASRManagerInterface` whose `activeBackendType` is `.parakeet`. Call `startPreloadObservation()`. Assert the preload-action closure is NOT invoked (recording closure → counter stays 0).
+- Construct with fake whose `activeBackendType` is `.whisperKit` and inject a `WhisperKitSetupService` whose `setupState` returns `.ready` synchronously. Assert preload-action closure invoked exactly once.
+- Call `startPreloadObservation()` twice → first task cancelled, second proceeds. Verify via task-handle inspection or invocation count.
+
+Tier obligation per workflow-process §11: **MEDIUM** (no SPM target change after F-Exec pivot). Adds: wispr-eyes on affected Settings UI per Live UAT §11.1.
+
+## 12. Blast radius & rollback
+
+**Blast radius:**
+- 42 call sites (38 external + 4 internal) across 4 files plus 1 new file plus AppState shape change.
+- No SPM target change → no clean-build cost.
+- No persisted state, no settings migration.
+
+**Rollback:** `git revert` of the merge commit. Properties return to AppState. SetupCoordinator file deleted. Package.swift target removed. Views revert to old keypath. No data loss.
+
+## 13. Ship criteria
+
+- [ ] `swift build -c release` exits 0
+- [ ] `scripts/swift-test.sh` exits 0 (includes the new SetupCoordinatorTests)
+- [ ] `swift test` includes SetupCoordinatorTests in passing set
+- [ ] AppState concrete-property count drops to 17 (verified by grep: `grep -cE "^  let [a-z]" Sources/EnviousWispr/App/AppState.swift` → expected 17)
+- [ ] Zero remaining hits for `appState\.ollamaSetup\b` and `appState\.whisperKitSetup\b` in `Sources/`
+- [ ] Live UAT pass per §11.1
+- [ ] Codex code-diff clean (no findings, or all addressed)
+- [ ] Periphery scan clean (or new findings explicitly acknowledged)
+- [ ] Architecture closeout block in PR description (per architecture-rules.md)
+- [ ] PR description names the run dir per workflow-process §1 step 9
+
+## 14. Open questions
+
+All resolved by Codex grounded review 2026-04-30:
+
+1. ~~F-Lib vs F-Exec~~ → **F-Exec** (no new SPM target).
+2. ~~Target name~~ → N/A.
+3. ~~SetupCoordinator @Observable?~~ → **Yes**, concrete `let setup: SetupCoordinator` on AppState. Codebase has working multi-level @Observable paths (e.g., `appState.transcriptCoordinator.transcripts` at `TranscriptHistoryView.swift:21-29`); existential typing breaks tracking per `OnboardingV2View.swift:39-42`.
+
+**Council:** skipped per `feedback_empirical_over_council` — Codex grep-verified the only structural fork. PR body will note `council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining`.
+
+## 15. Related
+
+- Bible: `docs/feature-requests/issue-319-2026-04-18-q2-hardening-epic.md` §17
+- Decisions doc: `docs/feature-requests/issue-319-open-decisions-2026-04-18.md` D7
+- Phase E (#502) — depends on this for ceiling calibration
+- Architecture rules: `.claude/rules/architecture-rules.md` (anti-god-object, dependency direction)


### PR DESCRIPTION
## Summary

Move three setup-orchestration concerns off AppState into a new internal class `SetupCoordinator`: `ollamaSetup`, `whisperKitSetup`, and the WhisperKit preload-observation task plus its method body. AppState now owns one concrete property (`let setup: SetupCoordinator`) instead of three.

Net AppState concrete file-scope `let` count: 20 → 18.

Per Bible §17 (epic #319 Hardening & Refactors), depended on by Phase E (#502) for ceiling calibration.

## Process

- **Plan:** `docs/feature-requests/issue-501-2026-04-30-phase-f-setup-coordinator.md`
- **Grounded review:** `docs/audits/2026-04-30-phase-f-grounded-review.txt` — PROCEED-WITH-REVISIONS
  - Killed the new SPM library target (D7's primary rationale was stale: `Package.swift:134` already includes `EnviousWispr` in `EnviousWisprTests` deps)
  - Concrete `let setup: SetupCoordinator` on AppState (not existential — preserves @Observable tracking)
- **Code-diff review:** `docs/audits/2026-04-30-phase-f-code-diff-review.txt` — clean, no actionable regressions
- **council-skip:** codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining
- **Phase 3 run dir:** `.validation/runs/20260430T142205Z-5d732f7/` — all Code-lane obligations satisfied (`check-validation.sh` PASS w/ advisory WARN on detected_lanes count for the standard plan-file companion case)

## Test plan

- [x] `scripts/swift-test.sh` — 498 tests pass (incl. 2 new SetupCoordinatorTests)
- [x] `swift build -c release` — clean
- [x] `bundle-dev.sh` smoke — app launches, runs
- [x] Manual Live UAT (founder, in-office):
  - Parakeet dictation
  - Apple Intelligence polish
  - WhisperKit (Speech Engine tab + dictation)
  - Ollama (AI Polish tab)
  - PTT long-form free-speech dictation
- [x] Codex code-diff review clean
- [x] Heart-path log scan clean (`bt-route.log` shows healthy warm-engine reuse, no errors anywhere)
