### PR TITLE
test(arch): catch Swift 6 access-level imports + parenthesized attributes (#502)

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
@@ -92,7 +92,10 @@ private func countTopLevelLetCollaborators(in body: String) -> Int {
 }
 
 private let collaboratorLetPattern: String = {
-  let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*[[:space:]]+)*"#
+  // Attribute can have a parenthesized argument list (`@available(macOS 14, *)`,
+  // `@Injected(...)`); the optional `(\([^)]*\))?` matches that. Multiple
+  // attributes in series allowed via `*` repetition.
+  let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
   let access = #"(public|internal|private|fileprivate|package|open)?"#
   return "^[[:space:]]*\(attrs)\(access)[[:space:]]*let[[:space:]]+[A-Za-z_]"
 }()

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -46,6 +46,9 @@ modules_scanned=0
 # Match `import EnviousWispr...` with:
 #   - Optional Swift attributes (e.g. `@preconcurrency`, `@_implementationOnly`,
 #     `@_spi(Internal)` — parenthesized argument allowed)
+#   - Optional access-level on the import statement (Swift 6:
+#     `public import`, `package import`, `internal import`, `fileprivate import`,
+#     `private import`)
 #   - Optional leading whitespace
 #   - Optional import-kind tokens (`struct`, `class`, `enum`, `protocol`, `func`,
 #     `var`, `let`, `typealias`) for scoped imports like
@@ -53,8 +56,9 @@ modules_scanned=0
 # Requires start-of-line anchoring to avoid matching literal text inside
 # comments or strings.
 import_kinds='(typealias|struct|class|enum|protocol|let|var|func)'
+import_access='(public|package|internal|fileprivate|private)'
 import_attr='(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*'
-import_grep_pattern="^[[:space:]]*${import_attr}import[[:space:]]+(${import_kinds}[[:space:]]+)?EnviousWispr"
+import_grep_pattern="^[[:space:]]*${import_attr}(${import_access}[[:space:]]+)?import[[:space:]]+(${import_kinds}[[:space:]]+)?EnviousWispr"
 
 for module_dir in Sources/*/; do
   module=$(basename "$module_dir")


### PR DESCRIPTION
Followup to #504 / Phase E (#502). Two correctness fixes flagged by GitHub Codex full-file review after merge.

## Summary

1. **Script**: Swift 6 access-level imports (`internal import EnviousWisprPipeline`, `public import ...`, `package import ...`) were not matched by the dep-direction grep. Pattern extended to allow optional access-level token between attributes and `import`.

2. **Test**: AppState collaborator detector missed `let` declarations with parenthesized attributes (`@available(macOS 14, *) let svc = ...`, `@Injected(...) let svc = ...`). Attribute regex extended to allow optional `(\([^)]*\))?` argument list, mirroring the bash script's pattern.

Both pass negative-test verification:
- All 4 access-level / attribute-combo import variants caught when injected as backward edges into Core.
- `@available(...) let testCanary20` correctly counted (20 > 19, ceiling fires).

No runtime change. `swift test` 501 passing. Codex code-diff: clean.

`council-skip: codex-grounded-review unnecessary — these are correctness fixes to architecture-regression tests, no design ambiguity.`

## Test plan

- [x] swift test passes locally
- [x] `internal import EnviousWisprPipeline` injection caught
- [x] `public import EnviousWisprPipeline` injection caught
- [x] `package import EnviousWisprPipeline` injection caught
- [x] `@preconcurrency internal import struct EnviousWisprPipeline.Foo` injection caught
- [x] `@available(macOS 14, *) let testCanary20 = ...` triggers count ceiling
