### PR TITLE
ci: remove arch-lint job; move dep-direction to local pre-push (#502)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -147,16 +147,3 @@ jobs:
             -o /tmp/foundation_models_probe
 
           echo "==> FoundationModels compile probe PASSED"
-
-  arch-lint:
-    runs-on: [self-hosted, enviouswispr-release]
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-
-      - name: Architecture dep-direction
-        run: bash scripts/check-dependency-direction.sh


### PR DESCRIPTION
Council-driven safety-architecture tuning. PR removes the `arch-lint` CI job that Phase E (#502) added; the dep-direction check now fires locally pre-push. Architecture regression tests stay in `swift test`.

## What changed (in plain English)

Two days ago Phase E added a gate that fires at PR time if AppState grows past its ceiling or if module dependencies point the wrong way. The founder pointed out a real problem: with GitHub-hosted runners (~1 hour per PR), catching architectural mistakes after the work is done is the wrong altitude. By the time CI says "you grew AppState," the work is already done; redoing it is expensive.

Council (GPT + Gemini in parallel, with full context on our existing scaffolding and recent incidents) converged on:

1. **Pre-push, not pre-commit.** Pre-commit is too aggressive — Claude saves intermediate broken states while iterating. Pre-push catches drift before CI but after convergence.
2. **CI as backstop, not primary detector.** CI confirms; local hooks detect.
3. **Plan-template fields:** require *Metric Definition* and *Earliest Failure Point* for any architecture-affecting plan. Stops two reviewers from blessing the same number with different definitions (which happened with Phase F → Phase E) and stops gates from being placed at the wrong workflow stage (which happened with Phase E itself).
4. **Council preamble + Codex grounded-review template:** add a bounded one-line premise check ("up to 2 missing assumptions / ambiguous metrics / misplaced gates") before normal review.
5. **Council-skip exception narrowed:** workflow-gate / plan-template / validation-lane / hook / memory-rule changes MUST go through council even if user surface is N/A.

## What this PR contains (single file change)

`.github/workflows/pr-check.yml` — removes the 13-line `arch-lint` job. The dep-direction script keeps existing in `scripts/check-dependency-direction.sh` and is invoked by the local push-discipline hook on relevant changes.

The other four edits land in local-only files in the main tree (project convention: rules + templates + memory live outside git, the harness reads them on every session). They take effect immediately for the next session.

## Why this PR is small

The actual safety-arch tuning is mostly *local-config* and *prompt* changes. Only the CI workflow lives in git. By the time you read this, Codex grounded reviews, council prompts, and the plan template are all already updated in the main tree.

## Test plan

- [x] `bash scripts/check-dependency-direction.sh` runs sub-second locally; pre-push hook tested with intentional backward-edge injection (still detects).
- [x] Architecture regression tests still run via `swift test` (501 passing).
- [x] `actionlint .github/workflows/pr-check.yml` clean (only pre-existing self-hosted-label warnings).
- [x] Council ran (GPT + Gemini, parallel); both responses captured, both converged.

`council-skip: N/A — council ran, both providers agreed, recommendations applied. This PR implements the converged outcome.`
