### PR TITLE
refactor(pipeline): R5 — extract HeartPathTelemetryEmitter (#290)

### DIFF
--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -1,0 +1,34 @@
+import EnviousWisprAudio
+import Foundation
+
+/// Per-call context for `HeartPathTelemetryEmitter.noAudioCaptured(...)`.
+///
+/// The shape mirrors the parameters previously threaded into
+/// `TranscriptionPipeline.emitNoAudioCapturedEvent(wasStreaming:)` and
+/// `WhisperKitPipeline.emitNoAudioCapturedEvent()`.
+struct NoAudioContext: Sendable {
+  let sessionID: UInt64
+  let durationMs: Int
+  let wasStreaming: Bool
+  let route: String
+  let isActivelyCapturing: Bool
+  let captureSourceType: String
+  let inputDeviceUIDPreferred: String?
+  let inputDeviceUIDSystemDefault: String?
+}
+
+/// Per-call context for `HeartPathTelemetryEmitter.zombieZeroPeakIfNeeded(...)`.
+///
+/// Mirrors the parameters previously consumed by
+/// `emitZombieEngineEventIfNeeded(rawSamples:peakAudioLevel:)` in both
+/// pipelines.
+struct ZeroPeakContext: Sendable {
+  let sessionID: UInt64
+  let durationMs: Int
+  let route: String
+  let sampleCount: Int
+  let isActivelyCapturing: Bool
+  let captureSourceType: String
+  let inputDeviceUIDPreferred: String?
+  let inputDeviceUIDSystemDefault: String?
+}

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -1,0 +1,264 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Owns the SHARED heart-path infrastructure-failure telemetry that previously
+/// lived duplicated across `TranscriptionPipeline` and `WhisperKitPipeline`.
+///
+/// Five events:
+///   1. capture stall (watchdog-fired)
+///   2. XPC reply failure (proxy-side)
+///   3. capture session interruption (route-change / runtime error)
+///   4. no audio captured (rawSamples-empty terminal branch)
+///   5. zombie zero-peak (peak == 0 with non-empty samples — issue #302)
+///
+/// Engine-internal telemetry (Parakeet streaming, MLX kernels; WhisperKit
+/// language detection, batch failures, model load) is NOT moved here by
+/// design — those events stay in their owning pipeline. See `#290` plan.
+///
+/// Sentry payload shapes (category, tags, extras keys, breadcrumb messages)
+/// are reproduced exactly from the prior in-pipeline implementations so the
+/// triage Routine that polls Sentry every 4 hours continues filing GitHub
+/// issues with stable grouping. See `.claude/knowledge/sentry-triage-pipeline.md`.
+///
+/// The Sentry sink is injected as a closure callback rather than a protocol
+/// (per `feedback_no_actor_protocol_existential_hot_path.md`), keeping the
+/// emitter concrete and the test seam recording-closure-shaped.
+@MainActor
+final class HeartPathTelemetryEmitter {
+
+  // MARK: - Sinks (closure-based; default wires SentryBreadcrumb)
+
+  typealias CaptureErrorSink = @MainActor (
+    _ error: any Error,
+    _ category: SentryBreadcrumb.ErrorCategory,
+    _ stage: String,
+    _ extra: [String: Any]?
+  ) -> Void
+
+  typealias BreadcrumbSink = @MainActor (
+    _ stage: String,
+    _ message: String,
+    _ data: [String: Any]?
+  ) -> Void
+
+  // MARK: - Identity & dependencies
+
+  /// Backend that owns this emitter. Used to preserve the historical
+  /// asymmetry where WhisperKit's `captureSessionInterruption` extra carried
+  /// `"backend": "whisperKit"` while Parakeet's did not.
+  private let backend: ASRBackendType
+  private let captureTelemetry: CaptureTelemetryState
+  private let captureError: CaptureErrorSink
+  private let addBreadcrumb: BreadcrumbSink
+
+  // MARK: - Per-session dedup state
+
+  /// One Sentry event per wedge incident even though the stall watchdog and
+  /// the rawSamples-empty branch both observe the same session. Reset on
+  /// session-id change.
+  private var stallEventAlreadyCaptured: Bool = false
+  private var lastObservedCaptureSession: UInt64 = 0
+  /// Set when the proxy's reply-path swallowed an XPC failure. The
+  /// rawSamples-empty branch dedups against this so we emit
+  /// `xpc_service_error` once instead of also firing `no_audio_captured`
+  /// for the same incident.
+  private var xpcReplyFailedThisSession: Bool = false
+
+  init(
+    backend: ASRBackendType,
+    captureTelemetry: CaptureTelemetryState,
+    captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
+      SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
+    },
+    addBreadcrumb: @escaping BreadcrumbSink = { stage, message, data in
+      SentryBreadcrumb.add(stage: stage, message: message, level: .warning, data: data)
+    }
+  ) {
+    self.backend = backend
+    self.captureTelemetry = captureTelemetry
+    self.captureError = captureError
+    self.addBreadcrumb = addBreadcrumb
+  }
+
+  // MARK: - Events
+
+  /// Emit `audio_capture_stalled` once per session. Subsequent calls within
+  /// the same session are dropped silently (dedup).
+  /// Returns true if the event fired (caller may chain terminal-state work).
+  @discardableResult
+  func stallFired(
+    ctx: CaptureStallContext,
+    isActivelyCapturing: Bool
+  ) -> Bool {
+    resetIfNewSession(ctx.sessionID)
+    guard !stallEventAlreadyCaptured else { return false }
+    stallEventAlreadyCaptured = true
+
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.sourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: isActivelyCapturing,
+      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+      failureMode: "stall_window_elapsed",
+      stallContext: ctx
+    )
+    captureError(
+      HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
+      .audioCaptureStalled,
+      "recording",
+      extras
+    )
+    return true
+  }
+
+  /// Emit `xpc_service_error`. Marks the session so a subsequent rawSamples-empty
+  /// branch dedups to a breadcrumb instead of a duplicate captureError.
+  func xpcReplyFailed(ctx: XPCReplyFailureContext) {
+    resetIfNewSession(ctx.sessionID)
+    xpcReplyFailedThisSession = true
+    captureError(
+      HeartPathError.xpcReplyFailed(ctx: ctx),
+      .xpcServiceError,
+      "audio",
+      [
+        "xpc.reply_stage": ctx.replyStage,
+        "xpc.error_domain": ctx.errorDomain,
+        "xpc.error_code": ctx.errorCode,
+        "capture_session_id": Int(ctx.sessionID),
+      ]
+    )
+  }
+
+  /// Emit `audio_capture_failed` for a capture-session interruption. Backend
+  /// extra preserved exactly as it was per pipeline (WhisperKit included it,
+  /// Parakeet did not).
+  func captureSessionInterrupted(ctx: CaptureSessionInterruptionContext) {
+    var extra: [String: Any] = [
+      "capture_session.kind": ctx.kind.rawValue,
+      "capture_session.reason_code": ctx.reasonCode.map { $0 } ?? NSNull(),
+      "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
+      "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
+      "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
+      "capture_session.error_description": ctx.errorDescription ?? NSNull(),
+      "capture.is_actively_capturing": ctx.isActivelyCapturing,
+      "capture_session_id": Int(ctx.sessionID),
+    ]
+    // Historical asymmetry — only WhisperKit's interruption carried the
+    // backend extra. Preserve to keep Sentry grouping/triage stable.
+    if backend == .whisperKit {
+      extra["backend"] = backend.rawValue
+    }
+    captureError(
+      HeartPathError.captureSessionInterrupted(ctx: ctx),
+      .audioCaptureFailed,
+      "audio",
+      extra
+    )
+  }
+
+  /// Emit either a deduped breadcrumb (if a stall or XPC failure already
+  /// fired for this session) or a terminal `no_audio_captured` captureError.
+  /// Mirrors the prior in-pipeline `emitNoAudioCapturedEvent` call sites.
+  func noAudioCaptured(ctx: NoAudioContext) {
+    resetIfNewSession(ctx.sessionID)
+    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
+      let dedupedFrom =
+        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
+      addBreadcrumb(
+        "recording",
+        dedupedBreadcrumbMessage,
+        [
+          "deduped_from": dedupedFrom,
+          "capture_session_id": Int(ctx.sessionID),
+        ]
+      )
+      return
+    }
+    let err = HeartPathError.noAudioCaptured(
+      sessionID: ctx.sessionID,
+      durationMs: ctx.durationMs,
+      wasStreaming: ctx.wasStreaming,
+      route: ctx.route
+    )
+    captureError(
+      err,
+      .audioCaptureFailed,
+      "recording",
+      SentryAudioExtras.buildCaptureExtras(
+        route: ctx.route,
+        sourceType: ctx.captureSourceType,
+        sessionID: ctx.sessionID,
+        isActivelyCapturing: ctx.isActivelyCapturing,
+        inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+        inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+        failureMode: "no_audio_captured"
+      )
+    )
+  }
+
+  /// Emit `zombie_engine_zero_peak` when the VAD gate gets a full recording
+  /// of exactly-zero audio with non-empty samples (matches the zombie-engine
+  /// failure described in `gotchas.md`). Dedupes via shared
+  /// `CaptureTelemetryState`. Returns true iff an event fired.
+  ///
+  /// Invariant: `markZombieEmitted` is called UNCONDITIONALLY before the
+  /// `shouldEmit` guard so the 30s dedup window slides forward on every
+  /// observation, not just on emissions. Rapid retries from the same route
+  /// stay suppressed instead of slipping through after the first emit's
+  /// window expires. See `CaptureTelemetryState.markZombieEmitted` doc
+  /// comment.
+  @discardableResult
+  func zombieZeroPeak(ctx: ZeroPeakContext) -> Bool {
+    let shouldEmit = captureTelemetry.shouldEmitZombie(
+      route: ctx.route, window: .seconds(30))
+    captureTelemetry.markZombieEmitted(route: ctx.route)
+    guard shouldEmit else { return false }
+
+    let err = HeartPathError.zombieEngineZeroPeak(
+      sessionID: ctx.sessionID,
+      durationMs: ctx.durationMs,
+      route: ctx.route,
+      sampleCount: ctx.sampleCount
+    )
+    captureError(
+      err,
+      .audioCaptureFailed,
+      "recording",
+      SentryAudioExtras.buildCaptureExtras(
+        route: ctx.route,
+        sourceType: ctx.captureSourceType,
+        sessionID: ctx.sessionID,
+        isActivelyCapturing: ctx.isActivelyCapturing,
+        inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+        inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+        failureMode: "zombie_engine_zero_peak",
+        timeSinceLastSuccessfulRecordingMs:
+          captureTelemetry.timeSinceLastSuccessfulRecordingMs(),
+        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+      )
+    )
+    return true
+  }
+
+  // MARK: - Private
+
+  /// Per-backend breadcrumb message text. Preserves the historical asymmetry
+  /// where WhisperKit's deduped breadcrumb included the backend tag.
+  private var dedupedBreadcrumbMessage: String {
+    switch backend {
+    case .parakeet: return "No audio captured (deduped)"
+    case .whisperKit: return "No audio captured (WhisperKit, deduped)"
+    }
+  }
+
+  private func resetIfNewSession(_ sessionID: UInt64) {
+    guard sessionID != lastObservedCaptureSession else { return }
+    lastObservedCaptureSession = sessionID
+    stallEventAlreadyCaptured = false
+    xpcReplyFailedThisSession = false
+  }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -118,15 +118,11 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   /// Late completion after cancel is guarded by checking state == .loadingModel before proceeding.
   private var modelLoadTask: Task<Void, any Error>?
 
-  // Issue #285 — stall vs final no-audio dedup. One Sentry event per wedge
-  // incident even though the stall watchdog and the `rawSamples.isEmpty`
-  // branch both observe the same session. Reset on session-id change.
-  private var stallEventAlreadyCaptured: Bool = false
-  private var lastObservedCaptureSession: UInt64 = 0
-  /// Set when the proxy's reply-path swallowed an XPC failure. The
-  /// rawSamples-empty branch dedups against this so we emit `xpc_service_error`
-  /// instead of also firing `no_audio_captured` for the same incident.
-  private var xpcReplyFailedThisSession: Bool = false
+  // Issue #285 dedup state moved to `HeartPathTelemetryEmitter` (#290 R5).
+  // Pipeline now delegates the four shared infrastructure events + the
+  // zombie zero-peak event to `telemetry`; engine-internal telemetry
+  // (streaming, MLX, model-load, ASR-empty) stays in this file by design.
+  private let telemetry: HeartPathTelemetryEmitter
 
   /// Issue #289 stall-recovery ownership token. Set to the stalled session's
   /// ID when `handleCaptureStall` flips state to `.error`, cleared by any path
@@ -172,6 +168,10 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     self.keychainManager = keychainManager
     self.captureTelemetry = captureTelemetry
     self.transcriptFinalizer = transcriptFinalizer
+    self.telemetry = HeartPathTelemetryEmitter(
+      backend: .parakeet,
+      captureTelemetry: captureTelemetry
+    )
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: makes the Parakeet path non-inferred. The
     // planner will force the legacy English-centric path for Parakeet
@@ -198,63 +198,25 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
   }
 
   public func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
-    SentryBreadcrumb.captureError(
-      HeartPathError.captureSessionInterrupted(ctx: ctx),
-      category: .audioCaptureFailed,
-      stage: "audio",
-      extra: [
-        "capture_session.kind": ctx.kind.rawValue,
-        "capture_session.reason_code": ctx.reasonCode.map { $0 } ?? NSNull(),
-        "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
-        "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
-        "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
-        "capture_session.error_description": ctx.errorDescription ?? NSNull(),
-        "capture.is_actively_capturing": ctx.isActivelyCapturing,
-        "capture_session_id": Int(ctx.sessionID),
-      ]
-    )
+    telemetry.captureSessionInterrupted(ctx: ctx)
   }
 
   public func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
-    resetStallFlagIfNewSession(ctx.sessionID)
-    xpcReplyFailedThisSession = true
-    SentryBreadcrumb.captureError(
-      HeartPathError.xpcReplyFailed(ctx: ctx),
-      category: .xpcServiceError,
-      stage: "audio",
-      extra: [
-        "xpc.reply_stage": ctx.replyStage,
-        "xpc.error_domain": ctx.errorDomain,
-        "xpc.error_code": ctx.errorCode,
-        "capture_session_id": Int(ctx.sessionID),
-      ]
-    )
+    telemetry.xpcReplyFailed(ctx: ctx)
   }
 
   public func handleCaptureStall(_ ctx: CaptureStallContext) {
-    resetStallFlagIfNewSession(ctx.sessionID)
-    guard !stallEventAlreadyCaptured else { return }
-    stallEventAlreadyCaptured = true
-    let extras = SentryAudioExtras.buildCaptureExtras(
-      route: ctx.route,
-      sourceType: ctx.sourceType,
-      sessionID: ctx.sessionID,
-      isActivelyCapturing: audioCapture.isActivelyCapturing,
-      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
-      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
-      failureMode: "stall_window_elapsed",
-      stallContext: ctx
-    )
-    SentryBreadcrumb.captureError(
-      HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
-      category: .audioCaptureStalled,
-      stage: "recording",
-      extra: extras
+    let fired = telemetry.stallFired(
+      ctx: ctx,
+      isActivelyCapturing: audioCapture.isActivelyCapturing
     )
 
     // Issue #289: flip terminal state SYNCHRONOUSLY before any await so a
     // racing PTT key-up can't slip into `stopAndTranscribe` against a live
-    // `.recording` state. `stallEventAlreadyCaptured` already dedups re-entry.
+    // `.recording` state. The emitter's per-session dedup already
+    // suppressed the captureError on re-entry; we still must guard the
+    // state flip the same way.
+    guard fired else { return }
     guard state == .recording else { return }
     stopRequested = true
     isPreWarmed = false
@@ -296,57 +258,26 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     _ = await audioCapture.stopCapture()
   }
 
-  private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
-    guard sessionID != lastObservedCaptureSession else { return }
-    lastObservedCaptureSession = sessionID
-    stallEventAlreadyCaptured = false
-    xpcReplyFailedThisSession = false
-  }
-
-  /// Emit either a dedup breadcrumb (stall already fired for this session) or a
-  /// terminal `audioCaptureFailed` captureError. Called from the rawSamples-empty
-  /// branch after stopCapture.
+  /// Build a per-call NoAudioContext from the pipeline's view of the audio
+  /// capture, then delegate to the emitter. Mirrors the previous in-pipeline
+  /// `emitNoAudioCapturedEvent(wasStreaming:)`.
   private func emitNoAudioCapturedEvent(wasStreaming: Bool) {
     let sessionID = audioCapture.currentCaptureSessionID
-    resetStallFlagIfNewSession(sessionID)
     let durationMs: Int = {
       guard let start = recordingStartTime else { return 0 }
       return Int(Date().timeIntervalSince(start) * 1000)
     }()
-    let route = audioCapture.currentAudioRoute
-    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
-      let dedupedFrom =
-        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
-      SentryBreadcrumb.add(
-        stage: "recording",
-        message: "No audio captured (deduped)",
-        level: .warning,
-        data: [
-          "deduped_from": dedupedFrom,
-          "capture_session_id": Int(sessionID),
-        ]
-      )
-      return
-    }
-    let err = HeartPathError.noAudioCaptured(
-      sessionID: sessionID,
-      durationMs: durationMs,
-      wasStreaming: wasStreaming,
-      route: route
-    )
-    SentryBreadcrumb.captureError(
-      err,
-      category: .audioCaptureFailed,
-      stage: "recording",
-      extra: SentryAudioExtras.buildCaptureExtras(
-        route: route,
-        sourceType: audioCapture.captureSourceType,
+    telemetry.noAudioCaptured(
+      ctx: NoAudioContext(
         sessionID: sessionID,
+        durationMs: durationMs,
+        wasStreaming: wasStreaming,
+        route: audioCapture.currentAudioRoute,
         isActivelyCapturing: audioCapture.isActivelyCapturing,
+        captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
           ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-        failureMode: "no_audio_captured"
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
       )
     )
   }
@@ -1023,47 +954,24 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     }
   }
 
-  /// Issue #302: emit a Sentry event when the VAD gate gets a full recording's
-  /// worth of exactly-zero audio. That signature (`peak == 0.0` with non-empty
-  /// samples) matches the zombie-engine failure described in gotchas.md, not
-  /// genuine silence (which has a noise floor). Dedupes via captureTelemetry.
+  /// Issue #302: zombie-engine zero-peak emission. Pre-checks the trigger
+  /// shape (`peak == 0.0` with enough samples) here because the pipeline
+  /// owns the sample buffer; the emitter handles dedup + payload shape.
   private func emitZombieEngineEventIfNeeded(rawSamples: [Float], peakAudioLevel: Float) {
     guard peakAudioLevel == 0.0,
       rawSamples.count >= AudioConstants.minimumTranscriptionSamples
     else { return }
-
-    let route = audioCapture.currentAudioRoute
-    let sessionID = audioCapture.currentCaptureSessionID
-    let durationMs = rawSamples.count * 1000 / 16_000
-    let shouldEmit = captureTelemetry.shouldEmitZombie(
-      route: route, window: .seconds(30))
-    captureTelemetry.markZombieEmitted(route: route)
-
-    guard shouldEmit else { return }
-
-    let err = HeartPathError.zombieEngineZeroPeak(
-      sessionID: sessionID,
-      durationMs: durationMs,
-      route: route,
-      sampleCount: rawSamples.count
-    )
-    SentryBreadcrumb.captureError(
-      err,
-      category: .audioCaptureFailed,
-      stage: "recording",
-      extra: SentryAudioExtras.buildCaptureExtras(
-        route: route,
-        sourceType: audioCapture.captureSourceType,
-        sessionID: sessionID,
+    telemetry.zombieZeroPeak(
+      ctx: ZeroPeakContext(
+        sessionID: audioCapture.currentCaptureSessionID,
+        durationMs: rawSamples.count * 1000 / 16_000,
+        route: audioCapture.currentAudioRoute,
+        sampleCount: rawSamples.count,
         isActivelyCapturing: audioCapture.isActivelyCapturing,
+        captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
           ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-        failureMode: "zombie_engine_zero_peak",
-        timeSinceLastSuccessfulRecordingMs:
-          captureTelemetry
-          .timeSinceLastSuccessfulRecordingMs(),
-        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
       )
     )
   }

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -115,6 +115,12 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   /// counter (#294 smoking-gun diagnostic).
   private let captureTelemetry: CaptureTelemetryState
 
+  /// Issue #285 dedup state moved to `HeartPathTelemetryEmitter` (#290 R5).
+  /// Pipeline delegates the four shared infrastructure events + zombie zero-peak
+  /// to `telemetry`; engine-internal telemetry (model load, LID, batch failures)
+  /// stays in this file by design.
+  private let telemetry: HeartPathTelemetryEmitter
+
   // Text processing steps (own instances — not shared with Parakeet)
   public let wordCorrectionStep = WordCorrectionStep()
   public let fillerRemovalStep = FillerRemovalStep()
@@ -164,6 +170,10 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     self.keychainManager = keychainManager
     self.languageDetector = languageDetector
     self.captureTelemetry = captureTelemetry
+    self.telemetry = HeartPathTelemetryEmitter(
+      backend: .whisperKit,
+      captureTelemetry: captureTelemetry
+    )
     self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: prevents a future codepath that skips the
@@ -190,68 +200,24 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   }
 
   public func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
-    SentryBreadcrumb.captureError(
-      HeartPathError.captureSessionInterrupted(ctx: ctx),
-      category: .audioCaptureFailed,
-      stage: "audio",
-      extra: [
-        "capture_session.kind": ctx.kind.rawValue,
-        "capture_session.reason_code": ctx.reasonCode.map { $0 } ?? NSNull(),
-        "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
-        "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
-        "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
-        "capture_session.error_description": ctx.errorDescription ?? NSNull(),
-        "capture.is_actively_capturing": ctx.isActivelyCapturing,
-        "capture_session_id": Int(ctx.sessionID),
-        "backend": "whisperKit",
-      ]
-    )
+    telemetry.captureSessionInterrupted(ctx: ctx)
   }
 
-  // Issue #285 dedup — stall vs rawSamples-empty for a single session.
-  private var stallEventAlreadyCaptured: Bool = false
-  private var lastObservedCaptureSession: UInt64 = 0
-  private var xpcReplyFailedThisSession: Bool = false
-
   public func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
-    resetStallFlagIfNewSession(ctx.sessionID)
-    xpcReplyFailedThisSession = true
-    SentryBreadcrumb.captureError(
-      HeartPathError.xpcReplyFailed(ctx: ctx),
-      category: .xpcServiceError,
-      stage: "audio",
-      extra: [
-        "xpc.reply_stage": ctx.replyStage,
-        "xpc.error_domain": ctx.errorDomain,
-        "xpc.error_code": ctx.errorCode,
-        "capture_session_id": Int(ctx.sessionID),
-      ]
-    )
+    telemetry.xpcReplyFailed(ctx: ctx)
   }
 
   public func handleCaptureStall(_ ctx: CaptureStallContext) {
-    resetStallFlagIfNewSession(ctx.sessionID)
-    guard !stallEventAlreadyCaptured else { return }
-    stallEventAlreadyCaptured = true
-    let extras = SentryAudioExtras.buildCaptureExtras(
-      route: ctx.route,
-      sourceType: ctx.sourceType,
-      sessionID: ctx.sessionID,
-      isActivelyCapturing: audioCapture.isActivelyCapturing,
-      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
-      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
-      failureMode: "stall_window_elapsed",
-      stallContext: ctx
-    )
-    SentryBreadcrumb.captureError(
-      HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
-      category: .audioCaptureStalled,
-      stage: "recording",
-      extra: extras
+    let fired = telemetry.stallFired(
+      ctx: ctx,
+      isActivelyCapturing: audioCapture.isActivelyCapturing
     )
 
     // Issue #289: synchronous terminal-state flip before any await — see
     // TranscriptionPipeline.handleCaptureStall for the race-closure rationale.
+    // The emitter's per-session dedup already suppressed the captureError on
+    // re-entry; we still must guard the state flip the same way.
+    guard fired else { return }
     guard state == .recording else { return }
     isPreWarmed = false
     recordingStartTime = nil
@@ -280,49 +246,23 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     _ = await audioCapture.stopCapture()
   }
 
-  private func resetStallFlagIfNewSession(_ sessionID: UInt64) {
-    guard sessionID != lastObservedCaptureSession else { return }
-    lastObservedCaptureSession = sessionID
-    stallEventAlreadyCaptured = false
-    xpcReplyFailedThisSession = false
-  }
-
   private func emitNoAudioCapturedEvent() {
     let sessionID = audioCapture.currentCaptureSessionID
-    resetStallFlagIfNewSession(sessionID)
     let durationMs: Int = {
       guard let start = recordingStartTime else { return 0 }
       return Int(Date().timeIntervalSince(start) * 1000)
     }()
-    let route = audioCapture.currentAudioRoute
-    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
-      let dedupedFrom =
-        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
-      SentryBreadcrumb.add(
-        stage: "recording",
-        message: "No audio captured (WhisperKit, deduped)",
-        level: .warning,
-        data: [
-          "deduped_from": dedupedFrom,
-          "capture_session_id": Int(sessionID),
-        ]
-      )
-      return
-    }
-    SentryBreadcrumb.captureError(
-      HeartPathError.noAudioCaptured(
-        sessionID: sessionID, durationMs: durationMs, wasStreaming: false, route: route),
-      category: .audioCaptureFailed,
-      stage: "recording",
-      extra: SentryAudioExtras.buildCaptureExtras(
-        route: route,
-        sourceType: audioCapture.captureSourceType,
+    telemetry.noAudioCaptured(
+      ctx: NoAudioContext(
         sessionID: sessionID,
+        durationMs: durationMs,
+        wasStreaming: false,
+        route: audioCapture.currentAudioRoute,
         isActivelyCapturing: audioCapture.isActivelyCapturing,
+        captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
           ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-        failureMode: "no_audio_captured"
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
       )
     )
   }
@@ -1272,47 +1212,24 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
   // MARK: - Zombie engine telemetry (#302)
 
-  /// Emit a Sentry event when the VAD gate gets a full recording of exactly-zero
-  /// audio. That signature (`peak == 0.0` with non-empty samples) matches the
-  /// zombie-engine failure described in gotchas.md, not genuine silence (which
-  /// has a noise floor). Dedupes via captureTelemetry.
+  /// Issue #302: zombie-engine zero-peak emission. Pre-checks the trigger
+  /// shape (`peak == 0.0` with enough samples) here because the pipeline
+  /// owns the sample buffer; the emitter handles dedup + payload shape.
   private func emitZombieEngineEventIfNeeded(rawSamples: [Float], peakAudioLevel: Float) {
     guard peakAudioLevel == 0.0,
       rawSamples.count >= AudioConstants.minimumTranscriptionSamples
     else { return }
-
-    let route = audioCapture.currentAudioRoute
-    let sessionID = audioCapture.currentCaptureSessionID
-    let durationMs = rawSamples.count * 1000 / 16_000
-    let shouldEmit = captureTelemetry.shouldEmitZombie(
-      route: route, window: .seconds(30))
-    captureTelemetry.markZombieEmitted(route: route)
-
-    guard shouldEmit else { return }
-
-    let err = HeartPathError.zombieEngineZeroPeak(
-      sessionID: sessionID,
-      durationMs: durationMs,
-      route: route,
-      sampleCount: rawSamples.count
-    )
-    SentryBreadcrumb.captureError(
-      err,
-      category: .audioCaptureFailed,
-      stage: "recording",
-      extra: SentryAudioExtras.buildCaptureExtras(
-        route: route,
-        sourceType: audioCapture.captureSourceType,
-        sessionID: sessionID,
+    telemetry.zombieZeroPeak(
+      ctx: ZeroPeakContext(
+        sessionID: audioCapture.currentCaptureSessionID,
+        durationMs: rawSamples.count * 1000 / 16_000,
+        route: audioCapture.currentAudioRoute,
+        sampleCount: rawSamples.count,
         isActivelyCapturing: audioCapture.isActivelyCapturing,
+        captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
           ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-        failureMode: "zombie_engine_zero_peak",
-        timeSinceLastSuccessfulRecordingMs:
-          captureTelemetry
-          .timeSinceLastSuccessfulRecordingMs(),
-        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
       )
     )
   }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -1,0 +1,580 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Unit tests for `HeartPathTelemetryEmitter` (#290 R5).
+///
+/// Two responsibilities under test:
+/// 1. Per-session dedup contract for stall + XPC + no-audio interactions.
+/// 2. Sentry payload shape preservation. Categories, stages, and load-bearing
+///    extras keys must match the prior in-pipeline implementations exactly so
+///    the live triage Routine continues filing GitHub issues with stable
+///    grouping.
+///
+/// Tests use injected closure sinks (no real Sentry SDK calls); the recording
+/// closure captures `(error, category, stage, extra)` tuples for assertion.
+@MainActor
+@Suite("HeartPathTelemetryEmitter — dedup + payload preservation")
+struct HeartPathTelemetryEmitterTests {
+
+  // MARK: - Test recorder
+
+  final class Recorder {
+    struct CapturedError {
+      /// The actual error value passed through. Codex code-review feedback
+      /// (2026-04-30): without capturing this, tests cannot detect a wrong
+      /// `HeartPathError` case being emitted.
+      let error: any Error
+      let category: SentryBreadcrumb.ErrorCategory
+      let stage: String
+      let extra: [String: Any]
+    }
+    struct CapturedBreadcrumb {
+      let stage: String
+      let message: String
+      let data: [String: Any]
+    }
+    var errors: [CapturedError] = []
+    var breadcrumbs: [CapturedBreadcrumb] = []
+  }
+
+  private static func makeEmitter(
+    backend: ASRBackendType,
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState(),
+    recorder: Recorder
+  ) -> HeartPathTelemetryEmitter {
+    HeartPathTelemetryEmitter(
+      backend: backend,
+      captureTelemetry: captureTelemetry,
+      captureError: { error, category, stage, extra in
+        recorder.errors.append(
+          .init(error: error, category: category, stage: stage, extra: extra ?? [:])
+        )
+      },
+      addBreadcrumb: { stage, message, data in
+        recorder.breadcrumbs.append(
+          .init(stage: stage, message: message, data: data ?? [:])
+        )
+      }
+    )
+  }
+
+  /// Expected key-set for every captureError that flows through
+  /// `SentryAudioExtras.buildCaptureExtras` with no optional add-ons.
+  /// Tests assert the full key-set matches so a forgotten/added extras key
+  /// trips the suite immediately. Stall, no-audio, and zombie events all
+  /// share this baseline; stall adds the `capture.stall.*` keys; zombie
+  /// adds the `time_since_last_successful_recording_ms` /
+  /// `config_change_count_since_launch` keys.
+  private static let baselineCaptureExtraKeys: Set<String> = [
+    "capture.source_type",
+    "capture.route",
+    "capture.failure_mode",
+    "capture.is_actively_capturing",
+    "capture_session_id",
+    "capture.input_device_uid_preferred",
+    "capture.input_device_uid_system_default",
+    "capture.input_device_divergence",
+  ]
+
+  private static let stallExtraKeys: Set<String> =
+    baselineCaptureExtraKeys.union([
+      "capture.stall.armed_at_uptime_ns",
+      "capture.stall.fired_at_uptime_ns",
+      "capture.stall.window_ms",
+      "capture.engine_started_successfully",
+      "capture.tap_installed",
+      "capture.format_mismatch",
+    ])
+
+  private static let zombieExtraKeys: Set<String> =
+    baselineCaptureExtraKeys.union([
+      "capture.time_since_last_successful_recording_ms",
+      "capture.config_change_count_since_launch",
+    ])
+
+  private static let xpcExtraKeys: Set<String> = [
+    "xpc.reply_stage", "xpc.error_domain", "xpc.error_code", "capture_session_id",
+  ]
+
+  private static let interruptionBaseExtraKeys: Set<String> = [
+    "capture_session.kind",
+    "capture_session.reason_code",
+    "capture_session.reason_label",
+    "capture_session.error_domain",
+    "capture_session.error_code",
+    "capture_session.error_description",
+    "capture.is_actively_capturing",
+    "capture_session_id",
+  ]
+
+  private static func stallContext(sessionID: UInt64 = 42) -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: sessionID,
+      armedAtUptimeNs: 1_000,
+      firedAtUptimeNs: 2_000,
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+    )
+  }
+
+  private static func xpcContext(sessionID: UInt64 = 42) -> XPCReplyFailureContext {
+    XPCReplyFailureContext(
+      replyStage: "stopCapture",
+      errorDomain: "NSCocoaErrorDomain",
+      errorCode: 4099,
+      errorDescription: "interrupted",
+      sessionID: sessionID
+    )
+  }
+
+  private static func interruptionContext(
+    sessionID: UInt64 = 42
+  ) -> CaptureSessionInterruptionContext {
+    CaptureSessionInterruptionContext(
+      kind: .runtimeError,
+      reasonCode: 1,
+      reasonLabel: nil,
+      errorDomain: "AVFoundationErrorDomain",
+      errorCode: -11800,
+      errorDescription: "operation could not be completed",
+      sessionID: sessionID,
+      isActivelyCapturing: true
+    )
+  }
+
+  private static func noAudioContext(sessionID: UInt64 = 42) -> NoAudioContext {
+    NoAudioContext(
+      sessionID: sessionID,
+      durationMs: 1234,
+      wasStreaming: false,
+      route: "built_in_mic",
+      isActivelyCapturing: false,
+      captureSourceType: "av_audio_engine",
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+    )
+  }
+
+  private static func zeroPeakContext(sessionID: UInt64 = 99) -> ZeroPeakContext {
+    ZeroPeakContext(
+      sessionID: sessionID,
+      durationMs: 2000,
+      route: "bt_headset",
+      sampleCount: 32_000,
+      isActivelyCapturing: false,
+      captureSourceType: "av_capture_session",
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+    )
+  }
+
+  // MARK: - Stall dedup
+
+  @Test("stallFired emits once per session and returns true the first time")
+  func stallFiresOnce() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+    let ctx = Self.stallContext(sessionID: 7)
+
+    let firstFired = emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
+    let secondFired = emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
+
+    #expect(firstFired)
+    #expect(!secondFired)
+    #expect(recorder.errors.count == 1)
+    let captured = recorder.errors[0]
+    #expect(captured.category == .audioCaptureStalled)
+    #expect(captured.stage == "recording")
+    #expect(captured.extra["capture_session_id"] as? Int == 7)
+    #expect(captured.extra["capture.failure_mode"] as? String == "stall_window_elapsed")
+  }
+
+  @Test("stallFired re-arms after a session-id change")
+  func stallReArmsOnSessionChange() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .whisperKit, recorder: recorder)
+
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 1), isActivelyCapturing: true)
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 1), isActivelyCapturing: true)
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 2), isActivelyCapturing: true)
+
+    #expect(recorder.errors.count == 2)
+    let firstSession = recorder.errors[0].extra["capture_session_id"] as? Int
+    let secondSession = recorder.errors[1].extra["capture_session_id"] as? Int
+    #expect(firstSession == 1)
+    #expect(secondSession == 2)
+  }
+
+  // MARK: - XPC reply
+
+  @Test("xpcReplyFailed always emits and pins the payload shape")
+  func xpcEmitsExpectedExtras() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    emitter.xpcReplyFailed(ctx: Self.xpcContext(sessionID: 12))
+
+    #expect(recorder.errors.count == 1)
+    let captured = recorder.errors[0]
+    #expect(captured.category == .xpcServiceError)
+    #expect(captured.stage == "audio")
+    #expect(captured.extra["xpc.reply_stage"] as? String == "stopCapture")
+    #expect(captured.extra["xpc.error_domain"] as? String == "NSCocoaErrorDomain")
+    #expect(captured.extra["xpc.error_code"] as? Int == 4099)
+    #expect(captured.extra["capture_session_id"] as? Int == 12)
+  }
+
+  // MARK: - captureSessionInterrupted backend asymmetry
+
+  @Test("captureSessionInterrupted omits backend extra for Parakeet")
+  func interruptionParakeetOmitsBackend() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    emitter.captureSessionInterrupted(ctx: Self.interruptionContext())
+
+    #expect(recorder.errors.count == 1)
+    let captured = recorder.errors[0]
+    #expect(captured.category == .audioCaptureFailed)
+    #expect(captured.stage == "audio")
+    #expect(captured.extra["backend"] == nil)
+    #expect(captured.extra["capture_session.kind"] as? String == "runtimeError")
+  }
+
+  @Test("captureSessionInterrupted includes backend extra for WhisperKit")
+  func interruptionWhisperKitIncludesBackend() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .whisperKit, recorder: recorder)
+
+    emitter.captureSessionInterrupted(ctx: Self.interruptionContext())
+
+    #expect(recorder.errors.count == 1)
+    #expect(recorder.errors[0].extra["backend"] as? String == "whisperKit")
+  }
+
+  // MARK: - noAudioCaptured dedup paths
+
+  @Test("noAudioCaptured emits a captureError when no prior stall or XPC fired")
+  func noAudioFiresFreshSession() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 5))
+
+    #expect(recorder.errors.count == 1)
+    #expect(recorder.breadcrumbs.isEmpty)
+    let captured = recorder.errors[0]
+    #expect(captured.category == .audioCaptureFailed)
+    #expect(captured.stage == "recording")
+    #expect(captured.extra["capture.failure_mode"] as? String == "no_audio_captured")
+  }
+
+  @Test("noAudioCaptured dedups to a breadcrumb after a stall in the same session")
+  func noAudioDedupsAfterStall() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 9), isActivelyCapturing: true)
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 9))
+
+    // Stall captureError fired; noAudio dedup fired only as breadcrumb.
+    #expect(recorder.errors.count == 1)
+    #expect(recorder.errors[0].category == .audioCaptureStalled)
+    #expect(recorder.breadcrumbs.count == 1)
+    let crumb = recorder.breadcrumbs[0]
+    #expect(crumb.message == "No audio captured (deduped)")
+    #expect(crumb.data["deduped_from"] as? String == "audio_capture_stalled")
+    #expect(crumb.data["capture_session_id"] as? Int == 9)
+  }
+
+  @Test("noAudioCaptured dedup breadcrumb for WhisperKit carries WhisperKit-tagged message")
+  func noAudioDedupBreadcrumbWhisperKitTag() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .whisperKit, recorder: recorder)
+
+    emitter.xpcReplyFailed(ctx: Self.xpcContext(sessionID: 9))
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 9))
+
+    #expect(recorder.breadcrumbs.count == 1)
+    #expect(recorder.breadcrumbs[0].message == "No audio captured (WhisperKit, deduped)")
+    #expect(recorder.breadcrumbs[0].data["deduped_from"] as? String == "xpc_reply_failed")
+  }
+
+  @Test("noAudioCaptured re-arms after session-id change")
+  func noAudioReArmsOnSessionChange() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 1), isActivelyCapturing: true)
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 2))
+
+    // Different session — neither dedup flag applies.
+    #expect(recorder.errors.count == 2)  // stall (s=1), noAudio (s=2)
+    #expect(recorder.errors[1].category == .audioCaptureFailed)
+    #expect(recorder.errors[1].extra["capture.failure_mode"] as? String == "no_audio_captured")
+    #expect(recorder.breadcrumbs.isEmpty)
+  }
+
+  // MARK: - Zombie zero-peak
+
+  @Test("zombieZeroPeak fires when CaptureTelemetryState allows")
+  func zombieZeroPeakFires() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    let emitter = Self.makeEmitter(
+      backend: .parakeet,
+      captureTelemetry: captureTelemetry,
+      recorder: recorder
+    )
+
+    let fired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext())
+
+    #expect(fired)
+    #expect(recorder.errors.count == 1)
+    let captured = recorder.errors[0]
+    #expect(captured.category == .audioCaptureFailed)
+    #expect(captured.stage == "recording")
+    #expect(captured.extra["capture.failure_mode"] as? String == "zombie_engine_zero_peak")
+    #expect(captured.extra["capture_session_id"] as? Int == 99)
+  }
+
+  @Test("zombieZeroPeak suppresses repeat within the dedup window")
+  func zombieZeroPeakDedups() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    let emitter = Self.makeEmitter(
+      backend: .whisperKit,
+      captureTelemetry: captureTelemetry,
+      recorder: recorder
+    )
+
+    let firstFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext())
+    let secondFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext(sessionID: 100))
+
+    #expect(firstFired)
+    #expect(!secondFired)
+    #expect(recorder.errors.count == 1)
+  }
+
+  // MARK: - Codex code-review additions (2026-04-30)
+
+  /// Codex round-3 (2026-04-30) — replaces the round-2 theater test with a
+  /// time-based probe that distinguishes "old mark still active" from
+  /// "suppressed call refreshed the window". `CaptureTelemetryState`
+  /// exposes a caller-specified window on `shouldEmitZombie(route:window:)`,
+  /// so we can use a SHORT probe window after a sleep to test the
+  /// invariant without widening the production API:
+  ///
+  ///   1. Emit once — fires (returns true), marks at T₀.
+  ///   2. Sleep ~1.1s.
+  ///   3. Call `zombieZeroPeak` again — suppressed by the emitter's 30s
+  ///      dedup window (still well within 30s of T₀).
+  ///   4. Probe `shouldEmitZombie(route:, window: 1s)`.
+  ///
+  /// If the suppressed path correctly called `markZombieEmitted`: the
+  /// mark timestamp is fresh (just now < 1s ago), `shouldEmitZombie` with
+  /// a 1s window returns FALSE.
+  ///
+  /// If the suppressed path skipped `markZombieEmitted` (the regression
+  /// we are guarding against): the mark timestamp is from T₀ (>1.1s ago),
+  /// `shouldEmitZombie` with a 1s window returns TRUE — and the test
+  /// fails.
+  ///
+  /// ~1.1s real-time sleep is the cost of the honest probe; one test run.
+  @Test("zombieZeroPeak refreshes the dedup window on every observation, not just emits")
+  func zombieZeroPeakSuppressedRefreshesWindow() async throws {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    let emitter = Self.makeEmitter(
+      backend: .parakeet, captureTelemetry: captureTelemetry, recorder: recorder)
+
+    // T₀: first emit — fires, marks at T₀.
+    let firstFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext())
+    #expect(firstFired)
+
+    // Sleep just past the probe window.
+    try await Task.sleep(for: .milliseconds(1_100))
+
+    // Second emit on same route — suppressed by emitter's 30s dedup.
+    let secondFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext(sessionID: 100))
+    #expect(!secondFired)
+
+    // Probe with a 1s window. If the suppressed call advanced the mark
+    // (correct behavior), the route is still in-window and shouldEmit
+    // returns false. If it didn't advance (regression), the original
+    // T₀ mark is >1.1s old and shouldEmit returns true.
+    let shouldEmitNow = captureTelemetry.shouldEmitZombie(
+      route: "bt_headset", window: .seconds(1))
+    #expect(
+      !shouldEmitNow,
+      "suppressed zombieZeroPeak failed to refresh dedup window — `markZombieEmitted` may have been gated by `shouldEmit`"
+    )
+  }
+
+  /// Codex code-review gap #2: assert the actual `HeartPathError` case
+  /// emitted for each event so a regression that picks the wrong case
+  /// trips the suite. Recorder discards-the-error pattern was the gap.
+  @Test("each event emits the matching HeartPathError case")
+  func eachEventEmitsExpectedHeartPathErrorCase() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .whisperKit, recorder: recorder)
+
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 1), isActivelyCapturing: true)
+    emitter.xpcReplyFailed(ctx: Self.xpcContext(sessionID: 2))
+    emitter.captureSessionInterrupted(ctx: Self.interruptionContext(sessionID: 3))
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 4))
+    _ = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext(sessionID: 5))
+
+    #expect(recorder.errors.count == 5)
+
+    guard let stallErr = recorder.errors[0].error as? HeartPathError,
+      case .audioCaptureStalled(let stallSession, _) = stallErr
+    else {
+      Issue.record("expected .audioCaptureStalled, got \(recorder.errors[0].error)")
+      return
+    }
+    #expect(stallSession == 1)
+
+    guard let xpcErr = recorder.errors[1].error as? HeartPathError,
+      case .xpcReplyFailed(let xpcCtx) = xpcErr
+    else {
+      Issue.record("expected .xpcReplyFailed, got \(recorder.errors[1].error)")
+      return
+    }
+    #expect(xpcCtx.sessionID == 2)
+
+    guard let interruptionErr = recorder.errors[2].error as? HeartPathError,
+      case .captureSessionInterrupted(let intCtx) = interruptionErr
+    else {
+      Issue.record("expected .captureSessionInterrupted, got \(recorder.errors[2].error)")
+      return
+    }
+    #expect(intCtx.sessionID == 3)
+
+    guard let noAudioErr = recorder.errors[3].error as? HeartPathError,
+      case .noAudioCaptured(let naSession, let durationMs, let wasStreaming, let route) = noAudioErr
+    else {
+      Issue.record("expected .noAudioCaptured, got \(recorder.errors[3].error)")
+      return
+    }
+    #expect(naSession == 4)
+    #expect(durationMs == 1234)
+    #expect(!wasStreaming)
+    #expect(route == "built_in_mic")
+
+    guard let zombieErr = recorder.errors[4].error as? HeartPathError,
+      case .zombieEngineZeroPeak(let zSession, _, let zRoute, let sampleCount) = zombieErr
+    else {
+      Issue.record("expected .zombieEngineZeroPeak, got \(recorder.errors[4].error)")
+      return
+    }
+    #expect(zSession == 5)
+    #expect(zRoute == "bt_headset")
+    #expect(sampleCount == 32_000)
+  }
+
+  /// Codex code-review gap #1 (stall): assert the COMPLETE extras key-set
+  /// for the stall event, not just selected keys. A forgotten or added key
+  /// trips the suite.
+  @Test("stallFired extras key-set matches the stall payload contract exactly")
+  func stallFiredExtrasKeySetExact() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    _ = emitter.stallFired(ctx: Self.stallContext(sessionID: 7), isActivelyCapturing: true)
+
+    #expect(recorder.errors.count == 1)
+    let actualKeys = Set(recorder.errors[0].extra.keys)
+    #expect(
+      actualKeys == Self.stallExtraKeys,
+      "stall extras key-set drift: \(actualKeys.symmetricDifference(Self.stallExtraKeys))")
+  }
+
+  /// Codex code-review gap #1 (xpc): exact key-set for the XPC event.
+  @Test("xpcReplyFailed extras key-set matches the xpc payload contract exactly")
+  func xpcReplyFailedExtrasKeySetExact() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    emitter.xpcReplyFailed(ctx: Self.xpcContext(sessionID: 12))
+
+    #expect(recorder.errors.count == 1)
+    let actualKeys = Set(recorder.errors[0].extra.keys)
+    #expect(
+      actualKeys == Self.xpcExtraKeys,
+      "xpc extras key-set drift: \(actualKeys.symmetricDifference(Self.xpcExtraKeys))")
+  }
+
+  /// Codex code-review gap #1 (interruption + backend asymmetry): exact
+  /// key-set for both backends. Parakeet omits `backend`; WhisperKit adds
+  /// it. The full set is otherwise identical.
+  @Test("captureSessionInterrupted extras key-set is exact per backend")
+  func captureSessionInterruptedExtrasKeySetExact() {
+    let parakeetRec = Recorder()
+    let parakeet = Self.makeEmitter(backend: .parakeet, recorder: parakeetRec)
+    parakeet.captureSessionInterrupted(ctx: Self.interruptionContext())
+    let parakeetKeys = Set(parakeetRec.errors[0].extra.keys)
+    #expect(
+      parakeetKeys == Self.interruptionBaseExtraKeys,
+      "parakeet interruption key drift: \(parakeetKeys.symmetricDifference(Self.interruptionBaseExtraKeys))"
+    )
+
+    let whisperRec = Recorder()
+    let whisper = Self.makeEmitter(backend: .whisperKit, recorder: whisperRec)
+    whisper.captureSessionInterrupted(ctx: Self.interruptionContext())
+    let whisperKeys = Set(whisperRec.errors[0].extra.keys)
+    let expectedWhisperKeys = Self.interruptionBaseExtraKeys.union(["backend"])
+    #expect(
+      whisperKeys == expectedWhisperKeys,
+      "whisperKit interruption key drift: \(whisperKeys.symmetricDifference(expectedWhisperKeys))")
+  }
+
+  /// Codex code-review gap #1 (noAudio fresh): exact key-set when no prior
+  /// dedup hit.
+  @Test("noAudioCaptured extras key-set matches the no-audio payload contract exactly")
+  func noAudioCapturedExtrasKeySetExact() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 5))
+
+    #expect(recorder.errors.count == 1)
+    let actualKeys = Set(recorder.errors[0].extra.keys)
+    #expect(
+      actualKeys == Self.baselineCaptureExtraKeys,
+      "noAudio extras key-set drift: \(actualKeys.symmetricDifference(Self.baselineCaptureExtraKeys))"
+    )
+  }
+
+  /// Codex code-review gap #1 (zombie): exact key-set, including the two
+  /// zombie-only enrichment keys.
+  @Test("zombieZeroPeak extras key-set matches the zombie payload contract exactly")
+  func zombieZeroPeakExtrasKeySetExact() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    // Pre-seed a successful recording so the
+    // `time_since_last_successful_recording_ms` key is non-nil. In
+    // production at least one successful recording will have happened
+    // before the zombie code path can fire.
+    captureTelemetry.recordSuccessfulRecording()
+    let emitter = Self.makeEmitter(
+      backend: .parakeet, captureTelemetry: captureTelemetry, recorder: recorder)
+
+    _ = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext())
+
+    #expect(recorder.errors.count == 1)
+    let actualKeys = Set(recorder.errors[0].extra.keys)
+    #expect(
+      actualKeys == Self.zombieExtraKeys,
+      "zombie extras key-set drift: \(actualKeys.symmetricDifference(Self.zombieExtraKeys))")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -1,0 +1,376 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Pipeline-level tests for the `HeartPathTelemetryEmitter` wiring.
+///
+/// Codex round-1 (2026-04-30) flagged two gaps the emitter unit tests
+/// alone could not catch:
+///   3. Pipeline-level dedup + terminal-state flip: a future refactor that
+///      drops `guard fired else { return }` in `handleCaptureStall` would
+///      still pass emitter unit tests. We must observe both the Sentry
+///      dedup contract AND the `state` flip contract holding at the
+///      pipeline boundary.
+///   4. Backend wiring proof: each pipeline must construct its emitter
+///      with the correct `ASRBackendType`. The asymmetric `"backend"`
+///      extra on `captureSessionInterruption` is the cheapest observable
+///      witness.
+///
+/// Codex round-2 (2026-04-30) caught that an earlier version of the dedup
+/// test only fired Sentry events from `.idle` state, so the
+/// `guard state == .recording` path bailed both calls regardless of the
+/// emitter's return value. That made the terminal-state-flip claim
+/// theater. The fix lives in `parakeetPipelineStallFlipsStateOnceFromRecording`
+/// below, which uses `FixtureAudioCapture` + `startRecording(...)` to
+/// drive into `.recording` before calling `handleCaptureStall`.
+///
+/// We test `TranscriptionPipeline` (Parakeet) directly because its
+/// dependencies are easy to stub. The WhisperKit equivalent would require
+/// constructing a real `WhisperKitBackend` actor; the asymmetry it depends
+/// on is already proven by the unit tests in
+/// `HeartPathTelemetryEmitterTests` plus the literal `backend: .whisperKit`
+/// argument at the WhisperKit init site. Adding a full pipeline init test
+/// for WhisperKit would not catch a regression the unit tests miss.
+@MainActor
+@Suite("HeartPathTelemetryEmitter — pipeline wiring + dedup at pipeline level")
+struct HeartPathTelemetryWiringTests {
+
+  // MARK: - Spy bridge
+
+  /// Sendable-by-mutex captured-call list. The Sentry delegate runs on
+  /// whichever thread the SDK fires from, so the storage must be
+  /// thread-safe; the test reads on @MainActor after the synchronous
+  /// pipeline call returns.
+  private final class CaptureSpy: @unchecked Sendable {
+    struct Captured {
+      let category: SentryBreadcrumb.ErrorCategory
+      let stage: String
+      let extra: [String: Any]
+    }
+    private let lock = NSLock()
+    private var _calls: [Captured] = []
+
+    var calls: [Captured] {
+      lock.lock()
+      defer { lock.unlock() }
+      return _calls
+    }
+
+    func record(_ call: Captured) {
+      lock.lock()
+      defer { lock.unlock() }
+      _calls.append(call)
+    }
+  }
+
+  /// Install a spy on `SentryBreadcrumb.captureErrorDelegate` for the
+  /// duration of the test, then restore the prior delegate. The
+  /// delegate hook (`SentryBreadcrumb.swift:145`) fires synchronously
+  /// before the SDK dispatch, so spy.calls is observable immediately
+  /// after the pipeline method returns.
+  private static func withCaptureSpy(
+    _ body: (CaptureSpy) -> Void
+  ) {
+    let spy = CaptureSpy()
+    let prior = SentryBreadcrumb.captureErrorDelegate
+    SentryBreadcrumb.captureErrorDelegate = { _, category, stage, extra in
+      spy.record(.init(category: category, stage: stage, extra: extra ?? [:]))
+    }
+    defer { SentryBreadcrumb.captureErrorDelegate = prior }
+    body(spy)
+  }
+
+  // MARK: - Test doubles
+
+  private static func makeStubAudio() -> NoOpAudioCapture {
+    NoOpAudioCapture()
+  }
+
+  private static func makeASR() -> NoOpASRManager {
+    NoOpASRManager()
+  }
+
+  private static func makePipeline() -> TranscriptionPipeline {
+    TranscriptionPipeline(
+      audioCapture: makeStubAudio(),
+      asrManager: makeASR(),
+      transcriptStore: TranscriptStore()
+    )
+  }
+
+  private static func stallContext(sessionID: UInt64) -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: sessionID,
+      armedAtUptimeNs: 1_000,
+      firedAtUptimeNs: 2_000,
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil
+    )
+  }
+
+  private static func interruptionContext(
+    sessionID: UInt64
+  ) -> CaptureSessionInterruptionContext {
+    CaptureSessionInterruptionContext(
+      kind: .runtimeError,
+      reasonCode: 1,
+      reasonLabel: nil,
+      errorDomain: "AVFoundationErrorDomain",
+      errorCode: -11800,
+      errorDescription: nil,
+      sessionID: sessionID,
+      isActivelyCapturing: true
+    )
+  }
+
+  // MARK: - Tests
+
+  /// Codex gap #4 — Parakeet pipeline must construct its emitter with
+  /// `.parakeet`. The captureSessionInterruption extras are the cheapest
+  /// witness: Parakeet omits the `"backend"` key.
+  @Test("TranscriptionPipeline interruption extras omit backend key (Parakeet wiring)")
+  func parakeetPipelineWiringOmitsBackendExtra() {
+    let pipeline = Self.makePipeline()
+
+    Self.withCaptureSpy { spy in
+      pipeline.handleCaptureSessionInterruption(Self.interruptionContext(sessionID: 1))
+
+      #expect(spy.calls.count == 1)
+      let call = spy.calls[0]
+      #expect(call.category == .audioCaptureFailed)
+      #expect(call.stage == "audio")
+      #expect(call.extra["backend"] == nil)
+      #expect(call.extra["capture_session_id"] as? Int == 1)
+    }
+  }
+
+  /// Codex gap #3 (Sentry-emit half) — pipeline-level emit dedup. Two
+  /// consecutive `handleCaptureStall` calls on the same session must
+  /// produce ONE captureError. Proves the emitter the pipeline uses is
+  /// connected to the same dedup state. Does NOT verify the
+  /// terminal-state flip — that lives in the next test.
+  @Test("TranscriptionPipeline.handleCaptureStall dedups Sentry emits per session")
+  func parakeetPipelineStallDedupsSentryPerSession() {
+    let pipeline = Self.makePipeline()
+
+    Self.withCaptureSpy { spy in
+      pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
+      pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
+
+      #expect(spy.calls.count == 1)
+      #expect(spy.calls[0].category == .audioCaptureStalled)
+      #expect(spy.calls[0].extra["capture_session_id"] as? Int == 7)
+    }
+  }
+
+  /// Sanity companion to the dedup test: a different `sessionID` re-arms
+  /// the dedup, proving it is not a global one-shot.
+  @Test("TranscriptionPipeline.handleCaptureStall re-arms Sentry emits on session change")
+  func parakeetPipelineStallReArmsOnSession() {
+    let pipeline = Self.makePipeline()
+
+    Self.withCaptureSpy { spy in
+      pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))
+      pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))  // suppressed
+      pipeline.handleCaptureStall(Self.stallContext(sessionID: 2))  // fresh session
+
+      #expect(spy.calls.count == 2)
+      let sessions = spy.calls.compactMap { $0.extra["capture_session_id"] as? Int }
+      #expect(sessions == [1, 2])
+    }
+  }
+
+  /// Codex gap #3 — `guard fired else { return }` in
+  /// `TranscriptionPipeline.handleCaptureStall` must prevent a
+  /// session-deduped call from incorrectly flipping state to `.error`.
+  ///
+  /// Test shape (Codex round-3 suggestion):
+  ///   1. Pre-dedup the emitter's stall flag while the pipeline is `.idle`
+  ///      by calling `handleCaptureStall(sessionID: N)`. The `.idle` state
+  ///      gate bails before any state mutation, but the emitter's
+  ///      per-session dedup still flips internally (it runs FIRST).
+  ///   2. Drive into `.recording` via `startRecording(...)`.
+  ///   3. Call `handleCaptureStall(sessionID: N)` again — same session.
+  ///
+  /// With `guard fired else { return }` present (correct): emitter returns
+  /// false (already deduped), the guard short-circuits before the
+  /// `state == .recording` check, state stays `.recording`.
+  ///
+  /// Without that guard (regression): emitter returns false but control
+  /// reaches `guard state == .recording`, which passes, so state
+  /// incorrectly flips to `.error` and `pendingStallRecoveryToken` is
+  /// reset — breaking the #289 token-gated recovery contract.
+  ///
+  /// The first-stall-from-recording case (state → .error on first hit) is
+  /// covered implicitly: if the emitter's pre-dedup wiring breaks, the
+  /// second call would emit and the test fails for the opposite reason.
+  @Test("TranscriptionPipeline.handleCaptureStall guard fired prevents deduped state flip")
+  func parakeetPipelineStallGuardFiredPreventsDedupedFlip() async throws {
+    let fixture = try SyntheticAudioFixture.make(
+      fileName: "r5-stall-guard-fired.wav",
+      pattern: .toneBurst
+    )
+    let audioCapture = try FixtureAudioCapture(fixtureURL: fixture.url)
+    let asrManager = MockASRManager(
+      transcribeBehavior: .success(
+        ASRResult(
+          text: "",
+          language: "en",
+          duration: fixture.durationSeconds,
+          processingTime: 0.01,
+          backendType: .parakeet
+        )
+      )
+    )
+    let pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: TranscriptStore()
+    )
+
+    // Step 1: pre-dedup the emitter's stall flag while pipeline is .idle.
+    // `handleCaptureStall` calls telemetry.stallFired (which dedups
+    // per-session) BEFORE the state guard, so the emitter's internal
+    // flag gets set even though pipeline state stays .idle.
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 99))
+    #expect(pipeline.state == .idle)
+
+    // Step 2: drive into .recording.
+    let config = DictationSessionConfig.testDefault(
+      autoPasteToActiveApp: false,
+      vadSensitivity: 0.5,
+      languageMode: .auto,
+      llmProvider: .openAI,
+      llmModel: "gpt-test"
+    )
+    await pipeline.startRecording(config: config)
+
+    let reachedRecording = await pollUntil(timeout: .seconds(1)) {
+      pipeline.state == .recording
+    }
+    #expect(reachedRecording)
+
+    // Step 3: same-session stall, now from .recording. Emitter returns
+    // false (deduped). With `guard fired else { return }`: state stays
+    // .recording. Without it: state flips to .error.
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 99))
+
+    #expect(
+      pipeline.state == .recording,
+      "deduped stall must NOT flip state — `guard fired` regressed?")
+
+    await pipeline.cancelRecording()
+  }
+}
+
+@MainActor
+private func pollUntil(
+  timeout: Duration,
+  interval: Duration = .milliseconds(10),
+  condition: @escaping @MainActor () -> Bool
+) async -> Bool {
+  let deadline = ContinuousClock.now + timeout
+  while ContinuousClock.now < deadline {
+    if condition() {
+      return true
+    }
+    try? await Task.sleep(for: interval)
+  }
+  return condition()
+}
+
+// MARK: - Stubs (test-local)
+
+/// Minimal `AudioCaptureInterface` stub for pipeline-construction tests.
+/// All capture lifecycle methods are no-ops; only the small read-only
+/// surface the pipeline reads in `handleCaptureStall` /
+/// `handleCaptureSessionInterruption` matters.
+@MainActor
+private final class NoOpAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "built_in_mic"
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "av_audio_engine"
+  var noiseSuppressionEnabled: Bool = false
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func buildEngine(noiseSuppression: Bool) {}
+  func preWarm() async throws {}
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}
+
+/// Minimal `ASRManagerInterface` stub. Pipeline construction reads no ASR
+/// state in the telemetry callbacks under test; methods throw or return
+/// trivial values so any unintended invocation surfaces immediately.
+@MainActor
+private final class NoOpASRManager: ASRManagerInterface {
+  var activeBackendType: ASRBackendType = .parakeet
+  var isModelLoaded: Bool = false
+  var isStreaming: Bool = false
+  var downloadProgress: Double = 0
+  var downloadPhase: String = "idle"
+  var downloadDetail: String = ""
+  var onServiceInterrupted: (() -> Void)?
+
+  func loadModel() async throws {}
+  func loadModelSilently() async {}
+  func unloadModel() async {}
+  func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
+  func switchBackend(to type: ASRBackendType) async { activeBackendType = type }
+
+  var activeBackendSupportsStreaming: Bool { get async { false } }
+
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
+    throw NoOpError.unexpected
+  }
+  func startStreaming(options: TranscriptionOptions) async throws { throw NoOpError.unexpected }
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws { throw NoOpError.unexpected }
+  func finalizeStreaming() async throws -> ASRResult { throw NoOpError.unexpected }
+  func cancelStreaming() async {}
+  func noteTranscriptionComplete(policy: ModelUnloadPolicy) {}
+  func cancelIdleTimer() {}
+
+  enum NoOpError: Error { case unexpected }
+}


### PR DESCRIPTION
## Summary

R5 of #319 Q2 Hardening. Extracts five shared infrastructure-failure telemetry events (capture stall, XPC reply failure, capture session interruption, no-audio-captured, zombie zero-peak) out of duplicated code in TranscriptionPipeline and WhisperKitPipeline into a single `HeartPathTelemetryEmitter`. Pipelines become thin call-throughs. Engine-internal telemetry stays where it lives by design.

## Phase 0 strategic council

Before scoping, ran a council of GPT (gpt-5.4 medium) + Gemini (gemini-2.5-pro) + Codex (gpt-5.5 high reasoning, full code access) on the broader question: invest in a large telemetry refactor (observer pattern), or ship the small tidy-up? **All three voices converged on Path A+** — small tidy-up plus the zombie zero-peak event so the queued zombie-recovery feature slots cleanly. Path B (observer inversion) explicitly rejected as a state-model refactor wearing telemetry-refactor clothes; premature for our scale and would touch the heart path for purely internal benefit. Trigger to revisit Path B documented.

Vendor decision: keep Sentry. Keep PostHog. TelemetryDeck previously evaluated and rejected; saved as durable feedback to pre-empt future suggestion. Privacy line saved as durable rule: rich metadata in, transcript content out.

## What changed

Code (5 files):
- `Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift` (new, 264 lines)
- `Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift` (new, 34 lines)
- `Sources/EnviousWisprPipeline/TranscriptionPipeline.swift` (170 deletions, 74 additions)
- `Sources/EnviousWisprPipeline/WhisperKitPipeline.swift` (155 deletions, 55 additions)
- `Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift` (new, 18 tests)
- `Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift` (new, 4 pipeline-level tests)

Sentry payload shape preserved exactly. Per-backend asymmetries preserved exactly (WhisperKit-only `"backend"` extra on captureSessionInterruption; WhisperKit-tagged dedup breadcrumb message). Load-bearing for the live triage Routine that polls Sentry every 4 hours.

Sentry sink injected as a closure callback rather than a protocol field (matches Phase A standing pattern: avoid any-of-MainActor-protocol indirection on warm paths).

## Validation

- `swift build -c release` exit 0
- `scripts/swift-test.sh` 523/523 green (22 new tests in 2 new test files)
- 4 rounds of Codex code-review, final verdict PROCEED-AS-IS
- Mutation test: removing `guard fired else { return }` from TranscriptionPipeline.handleCaptureStall causes the new pipeline-level test to fail exactly where Codex predicted (state == .error instead of .recording). Confirms the test catches the regression it claims to.
- Privacy payload audit clean: zero forbidden field names (text/transcript/content/original/corrected/prompt/output) in emitter or context structs.
- Phase 3 validation: `scripts/validate-pr.sh` + `scripts/check-validation.sh` both PASS for run dir at `.validation/runs/2026-04-30T20-05-03Z-454af7b/` (Code lane, all 4 obligations satisfied: tests, smoke, live-uat, codex-review).
- Live UAT post-rebuild: TTS sentence "hello world this is a heart path test" → recorded → transcribed to "Hello world, this is a heartpath test." → clipboard updated. Pipeline 1.7s. Heart path intact end-to-end.

## Architecture closeout

- Module: `EnviousWisprPipeline` (no new module-boundary changes)
- Dependency direction: emitter depends on Services (Sentry) + Core (ASRBackendType). No upward imports.
- Heart-path doctrine preserved: emitter failure leaves the heart path intact.
- Engines' deliberate isolation rule preserved: engine-internal telemetry stays in each pipeline.
- AppState concrete-collaborator count: unchanged.

Refs: closes #290 (R5 — this PR). Parent #319 Q2 Hardening epic. Unblocks #312 (zombie audio recovery — slots cleanly into the new `zombieZeroPeak` method).

## Test plan

- [x] swift build -c release (passes)
- [x] swift-test.sh (523/523)
- [x] Mutation test on `guard fired else { return }` (test fails when guard removed)
- [x] Phase 3 validate-pr.sh + check-validation.sh (PASS, all 4 obligations)
- [x] Live UAT: TTS-driven end-to-end recording → transcript → paste (PASS, 1.7s pipeline)
- [x] Privacy field grep on emitter + contexts (zero hits)
