### PR TITLE
Drop tone-preset names from homepage benefit card

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -372,7 +372,7 @@ const jsonLdFaq = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#0099aa" stroke-width="2" stroke-linecap="round"><path d="M12 2L15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2z"/></svg>
           </div>
           <h3>Cleans Up Your Words</h3>
-          <p>Removes ums, fixes grammar, and polishes your text automatically. Choose from clean, formal, or casual styles, or write your own custom prompt.</p>
+          <p>Removes ums, fixes grammar, and polishes your text automatically. Or write a custom prompt to control exactly how it shapes your output.</p>
         </div>
         <div class="benefit-card reveal" style="--i:3">
           <div class="benefit-icon amber" aria-hidden="true">


### PR DESCRIPTION
## Summary

The "Cleans Up Your Words" benefit card on the homepage advertised three named polish styles: "Choose from clean, formal, or casual styles." Friendly and Professional preset modes are being retired; only Standard and Custom remain. The card no longer names retired presets.

Before:
> Removes ums, fixes grammar, and polishes your text automatically. Choose from clean, formal, or casual styles, or write your own custom prompt.

After:
> Removes ums, fixes grammar, and polishes your text automatically. Or write a custom prompt to control exactly how it shapes your output.

## Scope clarification

Polish itself stays. This change is scoped to the **named preset variations** that are being retired (Friendly + Professional). Standard polish and Custom prompts remain.

## Test plan
- [x] Build green (42 pages, 1.41s)
- [x] "clean, formal, or casual" no longer in built homepage
- [x] "write a custom prompt" present in built homepage

## Process
`council-skip: marketing-lane (founder-approved)` per `feedback_marketing_lane.md`. Single-line copy change.

## Related follow-ups (separate PRs)
- 8 blog posts still describe "four writing style presets (Standard, Formal, Friendly, and Custom)" — needs comprehensive rewrite. Filing separately.
- OG image regeneration (em-dash violation, unrelated to this preset retirement).
