### PR TITLE
fix(website): lazy-load Remark42 comments to clear blog-post console 401

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -753,7 +753,7 @@ const breadcrumbJsonLd = JSON.stringify({
 </script>
 
 <script is:inline>
-  // Remark42 comments - only load on production
+  // Remark42 comments - only load on production, only when reader scrolls near the comments section
   if (window.location.hostname === 'enviouswispr.com') {
     var remark_config = {
       host: 'https://comments.enviouswispr.com',
@@ -764,6 +764,21 @@ const breadcrumbJsonLd = JSON.stringify({
       page_title: document.title,
     };
 
-    !function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);
+    var loadRemark42 = function () {
+      !function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);
+    };
+
+    var mount = document.getElementById('remark42');
+    if (mount && 'IntersectionObserver' in window) {
+      var io = new IntersectionObserver(function (entries) {
+        if (entries.some(function (e) { return e.isIntersecting; })) {
+          io.disconnect();
+          loadRemark42();
+        }
+      }, { rootMargin: '400px 0px' });
+      io.observe(mount);
+    } else {
+      loadRemark42();
+    }
   }
 </script>


### PR DESCRIPTION
## Summary

- Defer Remark42 embed script load until the comments section is ~400px from the viewport
- Removes the anon-user 401 console error from above-the-fold pageviews on every blog post
- Helps LCP on long-form blog posts (currently 3.1-3.4s per unlighthouse audit)

## Context

First full-site Lighthouse crawl via [unlighthouse](https://unlighthouse.dev) on 2026-04-30 surfaced a -4 best-practices hit on every blog post. Console error source: `comments.enviouswispr.com/api/v1/user` returning 401 for anonymous visitors (Remark42's design — anon GET to `/user` is documented to return 401, not an actual error). Lazy-loading the widget eliminates the cost for the ~majority of blog readers who never scroll to comments.

`council-skip: zero-blast-radius (behavior-shim, single file, ~17 LOC, no new APIs)`

## Test plan

- [x] `astro build` clean
- [x] Rendered HTML on 9 blog posts contains the IntersectionObserver wrapper
- [x] Codex review on diff: no regressions
- [ ] Post-merge: re-run unlighthouse, confirm best-practices score 100 on blog posts and console-error count drops to 0
