### PR TITLE
refactor(asr): R2 — pipeline fully decoupled from WhisperKit (#360)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,10 @@ let package = Package(
         "EnviousWisprPostProcessing",
         "EnviousWisprServices",
         "EnviousWisprStorage",
-        "WhisperKit",
+        // R2 (#360): WhisperKit dependency dropped — Pipeline no longer
+        // references WhisperKit-typed values directly. The reach goes
+        // through `EnviousWisprASR`'s package-access seams
+        // (`makeIncrementalSession`, `observeLID`).
       ],
       path: "Sources/EnviousWisprPipeline"
     ),

--- a/Sources/EnviousWisprASR/LIDObservation.swift
+++ b/Sources/EnviousWisprASR/LIDObservation.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Sendable raw observation from a single WhisperKit `detectLangauge` window.
+///
+/// `WhisperKit.detectLangauge` returns a single-entry `langProbs` map of the form
+/// `{detectedLanguage: logProb}` — i.e. the argmax language for that window plus
+/// its log-softmax score. Per-window aggregation (vote counting + mean probability)
+/// happens in `LanguageDetector` against a batch of these.
+///
+/// This is the Sendable surface that crosses the `WhisperKitBackend` actor boundary.
+/// The non-Sendable `WhisperKit` reference itself never leaves the backend.
+package struct RawLIDObservation: Sendable, Equatable {
+  package let argmaxLang: String
+  package let logProb: Double
+
+  package init(argmaxLang: String, logProb: Double) {
+    self.argmaxLang = argmaxLang
+    self.logProb = logProb
+  }
+}
+
+/// Outcome of a backend-side LID observation pass. Distinguishes Bypass
+/// (`.unavailable`, `.noWindows`) from Failure (`.error`) and Success
+/// (`.observations`) so the classifier can map each to the matching abstain reason.
+///
+/// Cancellation is a separate Bypass: the user hotkey-cancelled mid-flight; the
+/// classifier should NOT touch session memory in this case (matches today's
+/// behavior in `LanguageDetector.detect` cancellation branch).
+package enum LIDObservationBatch: Sendable {
+  /// Backend not ready (WhisperKit handle is nil — model unloaded). Caller
+  /// abstains; pipeline passes nil language to `WhisperKit.transcribe`, letting
+  /// WhisperKit's internal LID run during transcribe.
+  case unavailable
+
+  /// User hotkey-cancelled during the LID window pass. Caller abstains
+  /// without touching session memory.
+  ///
+  /// Note: cancellation responsiveness is slightly faster than the previous
+  /// inline implementation. The old `LanguageDetector.runMultiWindowLID`
+  /// caught `CancellationError` thrown from inside `whisperKit.detectLangauge`
+  /// in the same try/catch as other errors and continued to the next window
+  /// (cancellation only took effect at the next pre-window
+  /// `Task.checkCancellation()`). This implementation surfaces inner
+  /// cancellation immediately. The downstream classifier behavior is
+  /// unchanged (clean abstain, no memory touch).
+  case cancelled
+
+  /// Voiced audio insufficient to construct any usable window. Caller
+  /// abstains with reason `too_short` (matches today's empty-result branch).
+  case noWindows
+
+  /// All attempted windows failed (WhisperKit threw on every one). Caller
+  /// abstains with reason `internal_error` and records the abstain in
+  /// session memory.
+  case error(reason: String)
+
+  /// One or more usable observations. Caller runs the multi-window
+  /// classifier (vote-count + mean-prob aggregation, then five-layer
+  /// classifier).
+  case observations([RawLIDObservation])
+}

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -1,6 +1,9 @@
 import EnviousWisprCore
 import Foundation
-@preconcurrency import WhisperKit
+
+// R2 (#360): no longer reaches `WhisperKit` directly. The non-Sendable
+// reference stays inside `WhisperKitBackend.observeLID`; this actor consumes
+// only the Sendable `LIDObservationBatch` shape.
 
 /// Passive UX fallback event emitted by `LanguageDetector`.
 ///
@@ -106,20 +109,26 @@ public actor LanguageDetector {
   /// - Parameters:
   ///   - samples: 16kHz mono Float32 voiced samples. May be the raw captured
   ///     buffer or a VAD-filtered subset; the detector itself just windows what
-  ///     it is given.
+  ///     it is given. Forwarded to `observerFn` for the per-window WhisperKit
+  ///     calls.
   ///   - voicedDuration: Total voiced duration, in seconds. Used by the speech
   ///     gate (Layer 1).
-  ///   - whisperKit: Loaded WhisperKit instance. Passed in per call so the
-  ///     detector does not own model lifecycle.
+  ///   - observerFn: Closure that runs the WhisperKit-side LID call and returns
+  ///     a `LIDObservationBatch`. R2 (#360) — moves the WhisperKit handle out
+  ///     of this actor. The closure is called only when actually needed (after
+  ///     the locked-mode bypass and Layer 1 speech gate). The closure must
+  ///     return a Sendable batch; the non-Sendable `WhisperKit` reference
+  ///     stays inside the backend's actor isolation.
   ///   - mode: Current `LanguageMode` (auto or locked). Captured here (not at
   ///     recording-start) so late user toggles are respected.
-  public func detect(
+  package func detect(
     samples: [Float],
     voicedDuration: TimeInterval,
-    whisperKit: WhisperKit?,
+    observerFn: @Sendable () async -> LIDObservationBatch,
     mode: LanguageMode
   ) async -> LanguageDetectionResult {
-    // Locked short-circuit. No model call required.
+    // Locked short-circuit. No model call required. observerFn is NOT invoked
+    // — pinned by `R2-CHAR-050` characterization test (added 2026-04-30).
     if case .locked(let code) = mode {
       let normalized = Self.normalizeLangCode(code)
       return LanguageDetectionResult(
@@ -149,27 +158,41 @@ public actor LanguageDetector {
       return .abstain(voicedDuration: voicedDuration)
     }
 
-    guard let kit = whisperKit else {
-      await log("LID abstain: whisperKit instance unavailable")
+    // Layer 2: multi-window detection. The backend runs the WhisperKit calls
+    // and returns a Sendable batch. We map each batch variant to the matching
+    // abstain reason — this preserves the per-failure-mode semantics from
+    // the previous inline implementation.
+    let batch = await observerFn()
+    let multi: MultiWindowLID
+    switch batch {
+    case .unavailable:
+      // Same as today's nil-handle abstain (with persistMemory side effect).
+      await log("LID abstain: backend reports model unavailable")
       memory.recordAbstain(now: now)
       persistMemory()
       return .abstain(voicedDuration: voicedDuration)
-    }
-
-    // Layer 2: multi-window detection with majority-vote aggregation.
-    let multi: MultiWindowLID
-    do {
-      multi = try await runMultiWindowLID(
-        samples: samples, voicedDuration: voicedDuration, whisperKit: kit)
-    } catch is CancellationError {
+    case .cancelled:
       // User hotkey-cancelled: abstain cleanly, do not touch session memory.
+      // The classifier-side observable behavior (clean abstain, no memory
+      // touch, no telemetry) matches the previous inline implementation.
+      // The backend-side cancellation path is slightly more responsive — see
+      // `LIDObservationBatch.cancelled` doc comment for the detail.
       await log("LID cancelled during detectLanguage windows")
       return .abstain(voicedDuration: voicedDuration)
-    } catch {
-      await log("LID failed, abstaining: \(error.localizedDescription)")
+    case .noWindows:
+      // No windows constructible from the provided samples. Treat as
+      // empty-result abstain (matches today's empty-windows guard).
       memory.recordAbstain(now: now)
       persistMemory()
       return .abstain(voicedDuration: voicedDuration)
+    case .error(let reason):
+      // All windows failed. Matches today's outer-catch abstain branch.
+      await log("LID failed, abstaining: \(reason)")
+      memory.recordAbstain(now: now)
+      persistMemory()
+      return .abstain(voicedDuration: voicedDuration)
+    case .observations(let observations):
+      multi = aggregateObservations(observations)
     }
 
     guard !multi.voteCounts.isEmpty else {
@@ -517,71 +540,29 @@ public actor LanguageDetector {
     let windowCount: Int
   }
 
-  private func runMultiWindowLID(
-    samples: [Float],
-    voicedDuration: TimeInterval,
-    whisperKit: WhisperKit
-  ) async throws -> MultiWindowLID {
-    let sampleRate = LanguageDetectorThresholds.sampleRate
-    let totalSamples = samples.count
-    // Dedupe (startIdx, endIdx) pairs so short clips don't get counted
-    // twice — the fixed windows and the full-window range can collapse to
-    // identical slices on <3s audio and double-count under majority vote.
-    var windows: [[Float]] = []
-    var seenRanges: Set<[Int]> = []
-
-    func appendIfNew(_ startIdx: Int, _ endIdx: Int) {
-      guard endIdx > startIdx else { return }
-      guard seenRanges.insert([startIdx, endIdx]).inserted else { return }
-      windows.append(Array(samples[startIdx..<endIdx]))
-    }
-
-    for w in LanguageDetectorThresholds.windows {
-      let startIdx = min(totalSamples, Int(w.start * Double(sampleRate)))
-      let endIdx = min(totalSamples, Int(w.end * Double(sampleRate)))
-      appendIfNew(startIdx, endIdx)
-    }
-    // Full voiced window capped at 12s (always tried so we always have >=1,
-    // but deduped against the fixed windows above for short clips).
-    let fullEnd = min(
-      totalSamples, Int(LanguageDetectorThresholds.fullWindowMaxSec * Double(sampleRate)))
-    appendIfNew(0, fullEnd)
-    guard !windows.isEmpty else {
-      return MultiWindowLID(voteCounts: [:], meanProbs: [:], windowCount: 0)
-    }
-
-    // Run up to 4 windows. The spec says "up to 4"; for short voicedDuration
-    // many of the fixed windows collapse to empty and are skipped above.
-    let capped = Array(windows.prefix(4))
-
-    // WhisperKit's `detectLangauge` returns a single-entry `langProbs` map
-    // `{detectedLanguage: logProb}` — it's the argmax + its log-softmax, not
-    // a distribution over all languages. Aggregation must be majority vote
-    // over per-window argmaxes, with per-window exp(logProb) as a
-    // within-window confidence signal.
+  /// Aggregate per-window observations into vote counts + mean probabilities.
+  ///
+  /// R2 (#360): This is the post-WhisperKit-call portion of the previous
+  /// `runMultiWindowLID`. Window construction + the `detectLangauge` call moved
+  /// to `WhisperKitBackend.observeLID`, which returns a `[RawLIDObservation]`
+  /// inside `LIDObservationBatch.observations`. This helper takes that array
+  /// and produces the `MultiWindowLID` shape the classifier consumes.
+  ///
+  /// Aggregation rule (preserved verbatim from the previous inline code):
+  /// - Each observation contributes one vote to its `argmaxLang`.
+  /// - Each observation's clamped `exp(logProb)` contributes to the per-language
+  ///   probability sum.
+  /// - The returned `meanProbs[lang]` is the average exp(logProb) across windows
+  ///   where that language won.
+  private func aggregateObservations(_ observations: [RawLIDObservation]) -> MultiWindowLID {
     var votes: [String: Int] = [:]
     var probSum: [String: Double] = [:]
-    var counted = 0
-    for (i, window) in capped.enumerated() {
-      try Task.checkCancellation()
-      // WhisperKit API is `detectLangauge(audioArray:)` (original typo
-      // preserved upstream — do not "fix" it).
-      let result: (language: String, langProbs: [String: Float])
-      do {
-        result = try await whisperKit.detectLangauge(audioArray: window)
-      } catch {
-        await log("LID window \(i) failed: \(error.localizedDescription)")
-        continue
-      }
-      let lang = result.language
-      // Safety: langProbs is single-entry; fall back to 0 log-prob if the
-      // detected language isn't represented (shouldn't happen per spec).
-      let lp = Double(result.langProbs[lang] ?? 0)
-      let p = min(max(exp(lp), 0), 1)
-      votes[lang, default: 0] += 1
-      probSum[lang, default: 0] += p
-      counted += 1
+    for obs in observations {
+      let p = min(max(exp(obs.logProb), 0), 1)
+      votes[obs.argmaxLang, default: 0] += 1
+      probSum[obs.argmaxLang, default: 0] += p
     }
+    let counted = observations.count
     guard counted > 0 else {
       return MultiWindowLID(voteCounts: [:], meanProbs: [:], windowCount: 0)
     }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -27,22 +27,12 @@ public actor WhisperKitBackend: ASRBackend {
 
   /// Exposes the configured model variant name (e.g. `openai_whisper-large-v3-v20240930_turbo`).
   /// Read-only; used by telemetry to tag per-transcription events with the model in use.
-  public var modelVariantName: String { modelVariant }
+  package var modelVariantName: String { modelVariant }
 
-  /// Transitional reach for LanguageDetector LID call from `WhisperKitPipeline`.
-  /// R2 (#360) commit 3 narrows this to package/private after the LID
-  /// migration in commit 2 lands.
-  public var whisperKitInstance: WhisperKit? { whisperKit }
-
-  /// Transitional surface — no current consumer. The incremental worker no
-  /// longer takes a tokenizer parameter (R2 #360 commit 1). Removed in
-  /// commit 3 alongside `whisperKitInstance` narrowing.
-  public var whisperKitTokenizer: (any WhisperTokenizer)? { whisperKit?.tokenizer }
-
-  public init() {}
+  package init() {}
 
   /// Single source of truth for the shipped default model variant.
-  public static func defaultModelVariant() -> String {
+  package static func defaultModelVariant() -> String {
     "openai_whisper-large-v3-v20240930_turbo"
   }
 
@@ -69,7 +59,7 @@ public actor WhisperKitBackend: ASRBackend {
   /// `WhisperKitSetupService.getLocalModelPath`, so a non-nil path here implies
   /// the artifacts are all present. Used by silent/background warmup paths
   /// that must never trigger a network download.
-  public func prepareIfCached() async throws -> Bool {
+  package func prepareIfCached() async throws -> Bool {
     guard !isReady else { return true }
     guard let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) else {
       return false  // Model not cached or cache incomplete — skip silently.

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -171,6 +171,80 @@ public actor WhisperKitBackend: ASRBackend {
     return WhisperKitIncrementalWorker(whisperKit: kit, decodingOptions: opts)
   }
 
+  // R2 (#360): vend Sendable LID observations so the non-Sendable WhisperKit
+  // handle never crosses an actor boundary. The window-loop logic is
+  // migrated verbatim from `LanguageDetector.runMultiWindowLID` (the previous
+  // owner). The classifier in `LanguageDetector` consumes the resulting
+  // `LIDObservationBatch` and runs the same five-layer decision logic.
+  //
+  // Window construction (start/end indices, fixed windows, full-window cap,
+  // dedup, prefix-4) MUST match the original to preserve characterization
+  // (per `Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift`).
+  package func observeLID(
+    samples: [Float],
+    maxWindows: Int
+  ) async -> LIDObservationBatch {
+    guard let kit = whisperKit else { return .unavailable }
+
+    let sampleRate = LanguageDetectorThresholds.sampleRate
+    let totalSamples = samples.count
+    var windows: [[Float]] = []
+    var seenRanges: Set<[Int]> = []
+
+    func appendIfNew(_ startIdx: Int, _ endIdx: Int) {
+      guard endIdx > startIdx else { return }
+      guard seenRanges.insert([startIdx, endIdx]).inserted else { return }
+      windows.append(Array(samples[startIdx..<endIdx]))
+    }
+
+    for w in LanguageDetectorThresholds.windows {
+      let startIdx = min(totalSamples, Int(w.start * Double(sampleRate)))
+      let endIdx = min(totalSamples, Int(w.end * Double(sampleRate)))
+      appendIfNew(startIdx, endIdx)
+    }
+    let fullEnd = min(
+      totalSamples, Int(LanguageDetectorThresholds.fullWindowMaxSec * Double(sampleRate)))
+    appendIfNew(0, fullEnd)
+    guard !windows.isEmpty else {
+      return .noWindows
+    }
+
+    let capped = Array(windows.prefix(maxWindows))
+
+    // WhisperKit's `detectLangauge` returns a single-entry `langProbs` map
+    // `{detectedLanguage: logProb}` — argmax + its log-softmax. Per-window
+    // collection here; aggregation (vote-count + mean prob) lives in the
+    // classifier.
+    var observations: [RawLIDObservation] = []
+    var lastError: String?
+    for (i, window) in capped.enumerated() {
+      if Task.isCancelled { return .cancelled }
+      let result: (language: String, langProbs: [String: Float])
+      do {
+        // WhisperKit API is `detectLangauge(audioArray:)` (original typo
+        // preserved upstream — do not "fix" it).
+        result = try await kit.detectLangauge(audioArray: window)
+      } catch is CancellationError {
+        return .cancelled
+      } catch {
+        lastError = error.localizedDescription
+        await AppLogger.shared.log(
+          "LID window \(i) failed: \(error.localizedDescription)",
+          level: .info, category: "WhisperKitBackend"
+        )
+        continue
+      }
+      let lang = result.language
+      let lp = Double(result.langProbs[lang] ?? 0)
+      observations.append(RawLIDObservation(argmaxLang: lang, logProb: lp))
+    }
+
+    if observations.isEmpty {
+      return .error(reason: lastError ?? "all_windows_failed")
+    }
+    return .observations(observations)
+  }
+
   // Called by WhisperKitPipeline in EnviousWisprPipeline. `package` access is
   // sufficient: both targets live in the same SPM package, so no `public`
   // exposure is needed.

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -29,10 +29,14 @@ public actor WhisperKitBackend: ASRBackend {
   /// Read-only; used by telemetry to tag per-transcription events with the model in use.
   public var modelVariantName: String { modelVariant }
 
-  /// Exposes the WhisperKit instance for background incremental transcription.
+  /// Transitional reach for LanguageDetector LID call from `WhisperKitPipeline`.
+  /// R2 (#360) commit 3 narrows this to package/private after the LID
+  /// migration in commit 2 lands.
   public var whisperKitInstance: WhisperKit? { whisperKit }
 
-  /// Exposes the tokenizer for prompt token encoding (used by incremental worker tail decode).
+  /// Transitional surface — no current consumer. The incremental worker no
+  /// longer takes a tokenizer parameter (R2 #360 commit 1). Removed in
+  /// commit 3 alongside `whisperKitInstance` narrowing.
   public var whisperKitTokenizer: (any WhisperTokenizer)? { whisperKit?.tokenizer }
 
   public init() {}
@@ -151,6 +155,21 @@ public actor WhisperKitBackend: ASRBackend {
   }
 
   // MARK: - Private
+
+  // R2 (#360): vend an opaque incremental session so Pipeline does not need
+  // the WhisperKit handle. Returns nil when the model is not loaded; caller
+  // must treat as "incremental unavailable" and fall back to batch transcribe
+  // (which itself will throw `ASRError.notReady` if the model is also nil —
+  // both paths gate on the same `whisperKit` reference). See
+  // `docs/feature-requests/issue-360-2026-04-30-r2-approach-c-plus-lid-split.md`
+  // §9 for the honest fallback semantics.
+  package func makeIncrementalSession(options: TranscriptionOptions)
+    async -> (any WhisperKitIncrementalSession)?
+  {
+    guard let kit = whisperKit else { return nil }
+    let opts = makeDecodeOptions(from: options, sampleCount: 0)
+    return WhisperKitIncrementalWorker(whisperKit: kit, decodingOptions: opts)
+  }
 
   // Called by WhisperKitPipeline in EnviousWisprPipeline. `package` access is
   // sufficient: both targets live in the same SPM package, so no `public`

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
@@ -1,0 +1,39 @@
+import EnviousWisprCore
+
+/// Opaque handle to a WhisperKit-backed incremental transcription session.
+///
+/// Owned and vended by `WhisperKitBackend` via `makeIncrementalSession(options:)`.
+/// Pipeline code drives the lifecycle (start → finalize or cancel) without
+/// holding any WhisperKit-specific type.
+///
+/// This is the seam the R2 refactor (#360) introduces to remove three
+/// cross-module reaches into `WhisperKitBackend`'s public surface:
+/// - `whisperKitInstance` (dropped, was used to construct the worker directly)
+/// - `whisperKitTokenizer` (dropped, was dead code in the worker)
+/// - direct `WhisperKitIncrementalWorker` type reference in Pipeline
+///
+/// All three are replaced by `any WhisperKitIncrementalSession`. The full
+/// boundary cleanup (Pipeline drops `import WhisperKit`, `Package.swift`
+/// drops the WhisperKit dependency from the `EnviousWisprPipeline` target,
+/// `WhisperKitBackend.whisperKitInstance`/`whisperKitTokenizer` go internal)
+/// lands after the LanguageDetector reach also migrates — see plan §3.5
+/// commit 3.
+package protocol WhisperKitIncrementalSession: Sendable {
+  /// Begin background incremental decoding cycles. The provider closure is
+  /// called periodically to fetch the growing audio buffer.
+  func start(
+    audioSamplesProvider: @Sendable @escaping () async -> (samples: [Float], count: Int)
+  ) async
+
+  /// Stop the incremental loop and produce the final result. `finalSamples`
+  /// is the post-VAD audio and `speechSegments` are the VAD speech ranges.
+  /// The session may apply tail-decode logic over the uncovered portion.
+  func finalize(
+    finalSamples: [Float],
+    speechSegments: [SpeechSegment]
+  ) async -> IncrementalResult
+
+  /// Cancel the incremental loop without producing a result. Used on PTT
+  /// cancel and on stop-recording-too-short paths.
+  func cancel() async
+}

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
@@ -6,18 +6,11 @@ import EnviousWisprCore
 /// Pipeline code drives the lifecycle (start → finalize or cancel) without
 /// holding any WhisperKit-specific type.
 ///
-/// This is the seam the R2 refactor (#360) introduces to remove three
-/// cross-module reaches into `WhisperKitBackend`'s public surface:
-/// - `whisperKitInstance` (dropped, was used to construct the worker directly)
-/// - `whisperKitTokenizer` (dropped, was dead code in the worker)
-/// - direct `WhisperKitIncrementalWorker` type reference in Pipeline
-///
-/// All three are replaced by `any WhisperKitIncrementalSession`. The full
-/// boundary cleanup (Pipeline drops `import WhisperKit`, `Package.swift`
-/// drops the WhisperKit dependency from the `EnviousWisprPipeline` target,
-/// `WhisperKitBackend.whisperKitInstance`/`whisperKitTokenizer` go internal)
-/// lands after the LanguageDetector reach also migrates — see plan §3.5
-/// commit 3.
+/// This is the seam introduced by the R2 refactor (#360) so that
+/// `WhisperKitPipeline` does not import the WhisperKit package and does not
+/// reach into ASR-internal types. The conformer (`WhisperKitIncrementalWorker`)
+/// is `package`-access; the protocol is `package`-access; both stay confined
+/// to `EnviousWisprASR`.
 package protocol WhisperKitIncrementalSession: Sendable {
   /// Begin background incremental decoding cycles. The provider closure is
   /// called periodically to fetch the growing audio buffer.

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -2,15 +2,15 @@ import EnviousWisprCore
 import Foundation
 @preconcurrency import WhisperKit
 
-public struct IncrementalResult: Sendable {
-  public let text: String?
-  public let samplesCovered: Int
-  public let decodeCount: Int
-  public let totalDecodeTimeMs: Int  // periphery:ignore - telemetry field, populated for diagnostics
-  public let accepted: Bool
-  public let mode: String
-  public let strategy: String
-  public let tailDecodeMs: Int
+package struct IncrementalResult: Sendable {
+  package let text: String?
+  package let samplesCovered: Int
+  package let decodeCount: Int
+  package let totalDecodeTimeMs: Int  // periphery:ignore - telemetry field, populated for diagnostics
+  package let accepted: Bool
+  package let mode: String
+  package let strategy: String
+  package let tailDecodeMs: Int
 }
 
 /// Periodically transcribes the growing audio buffer during recording.
@@ -20,7 +20,7 @@ public struct IncrementalResult: Sendable {
 /// - Short recordings (<30s): re-transcribe full buffer each cycle (highest quality)
 /// - Long recordings (>30s): use clipTimestamps to only decode new audio (efficient)
 /// - On finalize: async tail decode covers speech after the last worker result
-public actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
+package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   private let whisperKit: WhisperKit
   private let baseDecodingOptions: DecodingOptions
   private let cadence: Duration = .seconds(3)
@@ -36,12 +36,12 @@ public actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   private var running = false
   private var loopTask: Task<Void, Never>?
 
-  public init(whisperKit: WhisperKit, decodingOptions: DecodingOptions) {
+  package init(whisperKit: WhisperKit, decodingOptions: DecodingOptions) {
     self.whisperKit = whisperKit
     self.baseDecodingOptions = decodingOptions
   }
 
-  public func start(
+  package func start(
     audioSamplesProvider: @Sendable @escaping () async -> (samples: [Float], count: Int)
   ) {
     running = true
@@ -59,7 +59,7 @@ public actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   }
 
   // periphery:ignore:parameters speechSegments - kept for API compatibility; energy-based gate replaced VAD segment check
-  public func finalize(
+  package func finalize(
     finalSamples: [Float],
     speechSegments: [SpeechSegment]
   ) async -> IncrementalResult {
@@ -189,7 +189,7 @@ public actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
     }
   }
 
-  public func cancel() {
+  package func cancel() {
     running = false
     loopTask?.cancel()
     loopTask = nil

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -20,10 +20,9 @@ public struct IncrementalResult: Sendable {
 /// - Short recordings (<30s): re-transcribe full buffer each cycle (highest quality)
 /// - Long recordings (>30s): use clipTimestamps to only decode new audio (efficient)
 /// - On finalize: async tail decode covers speech after the last worker result
-public actor WhisperKitIncrementalWorker {
+public actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   private let whisperKit: WhisperKit
   private let baseDecodingOptions: DecodingOptions
-  private let tokenizer: (any WhisperTokenizer)?
   private let cadence: Duration = .seconds(3)
   private let longRecordingThreshold: Int = 16000 * 30
 
@@ -37,12 +36,9 @@ public actor WhisperKitIncrementalWorker {
   private var running = false
   private var loopTask: Task<Void, Never>?
 
-  public init(
-    whisperKit: WhisperKit, decodingOptions: DecodingOptions, tokenizer: (any WhisperTokenizer)?
-  ) {
+  public init(whisperKit: WhisperKit, decodingOptions: DecodingOptions) {
     self.whisperKit = whisperKit
     self.baseDecodingOptions = decodingOptions
-    self.tokenizer = tokenizer
   }
 
   public func start(

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -151,7 +151,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   private var vadMonitorTask: Task<Void, Never>?
   /// Frozen snapshot of recording state, built before teardown for post-recording error enrichment.
   private var frozenSnapshot: SentryBreadcrumb.RecordingSnapshot?
-  private var incrementalWorker: WhisperKitIncrementalWorker?
+  private var incrementalWorker: (any WhisperKitIncrementalSession)?
   private var modelUnloadTask: Task<Void, Never>?
 
   /// Issue #289 stall-recovery ownership token (see TranscriptionPipeline).
@@ -1119,15 +1119,12 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   // MARK: - Incremental Worker
 
   private func startIncrementalWorker() async {
-    guard let kit = await backend.whisperKitInstance else { return }
-    let opts = await backend.makeDecodeOptions(from: transcriptionOptions, sampleCount: 0)
-    // BRAIN: gotcha id=nonisolated-unsafe-tokenizer
-    // nonisolated(unsafe): WhisperTokenizer is not Sendable but is safe to transfer —
-    // the backend is the sole owner and we pass it to a single actor that holds it for its lifetime.
-    nonisolated(unsafe) let tokenizer = await backend.whisperKitTokenizer
-    let worker = WhisperKitIncrementalWorker(
-      whisperKit: kit, decodingOptions: opts, tokenizer: tokenizer)
-    self.incrementalWorker = worker
+    // R2 (#360): vended via opaque session protocol so Pipeline holds no
+    // WhisperKit-specific type. Returns nil iff backend's `whisperKit` is nil
+    // (model unloaded). Same gating as today's reach into `whisperKitInstance`.
+    guard let session = await backend.makeIncrementalSession(options: transcriptionOptions)
+    else { return }
+    self.incrementalWorker = session
 
     let isXPCMode = audioCapture is AudioCaptureProxy
     let capture = audioCapture
@@ -1142,7 +1139,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       // 5 min (max recording) = ~19MB. Bounded by TimingConstants.maxRecordingDuration.
       var nextIndex = 0
       var accumulated: [Float] = []
-      await worker.start(audioSamplesProvider: { @MainActor in
+      await session.start(audioSamplesProvider: { @MainActor in
         let (newSamples, totalCount) = await capture.getSamplesSnapshot(fromIndex: nextIndex)
         accumulated.append(contentsOf: newSamples)
         nextIndex = totalCount
@@ -1150,7 +1147,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       })
     } else {
       // In-process mode: read directly from MainActor-isolated capturedSamples.
-      await worker.start(audioSamplesProvider: { @MainActor in
+      await session.start(audioSamplesProvider: { @MainActor in
         let samples = capture.capturedSamples
         return (samples: samples, count: samples.count)
       })

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -6,7 +6,12 @@ import EnviousWisprLLM
 import EnviousWisprServices
 import EnviousWisprStorage
 import Foundation
-@preconcurrency import WhisperKit
+
+// R2 (#360): the pipeline holds no WhisperKit-typed values after the
+// Approach C session protocol + LID-button refactor, so it no longer
+// imports the vendor module directly. The dependency is also dropped from
+// the EnviousWisprPipeline target in `Package.swift`. All vendor reach now
+// goes through `EnviousWisprASR`'s package-access seams.
 
 /// Internal state machine for the WhisperKit highway — independent of PipelineState.
 public enum WhisperKitPipelineState: Equatable, Sendable {
@@ -675,13 +680,14 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     // Multilingual v1 (W2): detect language on voiced audio before transcribe.
     // Heart protection: detector never throws; if it abstains, pass nil to
     // TranscriptionOptions.language so WhisperKit's internal LID runs.
-    // languageMode is captured lazily so a user toggling Auto<->Locked
-    // mid-recording is respected.
+    // languageMode comes from the frozen DictationSessionConfig captured at
+    // startRecording (Phase B refactor, PR #424); mid-recording user toggles
+    // are NOT applied to the in-flight session by design.
     let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
-    // R2 (#360): closure-based observer. The non-Sendable `WhisperKit` handle
+    // R2 (#360): closure-based observer. The non-Sendable WhisperKit handle
     // stays inside the backend's actor isolation; only the Sendable
-    // `LIDObservationBatch` crosses to the LanguageDetector classifier.
-    // The previous `nonisolated(unsafe) let kitForLID` workaround is gone.
+    // LIDObservationBatch crosses to the LanguageDetector classifier.
+    // The previous unsafe-Sendable workaround is gone.
     // Snapshot `samples` into an immutable binding so the @Sendable observer
     // closure does not capture the surrounding `var samples` (would race).
     let observerSamples = samples
@@ -1125,8 +1131,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
   private func startIncrementalWorker() async {
     // R2 (#360): vended via opaque session protocol so Pipeline holds no
-    // WhisperKit-specific type. Returns nil iff backend's `whisperKit` is nil
-    // (model unloaded). Same gating as today's reach into `whisperKitInstance`.
+    // WhisperKit-specific type. Returns nil iff the backend's WhisperKit
+    // model is unloaded (same gating as the legacy reach this replaced).
     guard let session = await backend.makeIncrementalSession(options: transcriptionOptions)
     else { return }
     self.incrementalWorker = session

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -678,14 +678,19 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     // languageMode is captured lazily so a user toggling Auto<->Locked
     // mid-recording is respected.
     let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
-    // nonisolated(unsafe): WhisperKit is an actor/reference-typed handle that is
-    // not Sendable. Safe to pass to the detector actor because the backend owns
-    // it for its lifetime and the detector only calls read-only detectLanguage.
-    nonisolated(unsafe) let kitForLID = await backend.whisperKitInstance
+    // R2 (#360): closure-based observer. The non-Sendable `WhisperKit` handle
+    // stays inside the backend's actor isolation; only the Sendable
+    // `LIDObservationBatch` crosses to the LanguageDetector classifier.
+    // The previous `nonisolated(unsafe) let kitForLID` workaround is gone.
+    // Snapshot `samples` into an immutable binding so the @Sendable observer
+    // closure does not capture the surrounding `var samples` (would race).
+    let observerSamples = samples
     let lidResult = await languageDetector.detect(
       samples: samples,
       voicedDuration: voicedDurationSec,
-      whisperKit: kitForLID,
+      observerFn: { [backend] in
+        await backend.observeLID(samples: observerSamples, maxWindows: 4)
+      },
       mode: languageMode
     )
     lastLanguageDetection = lidResult


### PR DESCRIPTION
## Summary

PR 2 of 2 for the R2 refactor (#360, Bible §3.4 / §12). Closes the WhisperKit module-boundary debt that's been outstanding since Multilingual v1 shipped.

After this PR:
- `EnviousWisprPipeline` does not import the `WhisperKit` package and does not depend on it in `Package.swift`.
- The two `nonisolated(unsafe)` declarations in the heart-path stop sequence are gone.
- `WhisperKitBackend`'s public surface is reduced to the `ASRBackend` protocol requirements.

## Three commits

1. **`c9792d9`** — Approach C: opaque `WhisperKitIncrementalSession` protocol, `WhisperKitIncrementalWorker` conforms, `makeIncrementalSession` vends the session, dead `tokenizer` parameter deleted.
2. **`f5dbcca`** — LID button on backend: `observeLID(samples:maxWindows:)` returns Sendable `LIDObservationBatch` enum (`.unavailable`, `.cancelled`, `.noWindows`, `.error`, `.observations`), `LanguageDetector.detect` consumes a closure-based observer, the WhisperKit-handle window-loop migrates verbatim from `LanguageDetector.runMultiWindowLID` to `WhisperKitBackend.observeLID`.
3. **`42954f3`** — cleanup: drop public `whisperKitInstance`/`whisperKitTokenizer` properties, drop `import WhisperKit` from Pipeline, drop `"WhisperKit"` from `EnviousWisprPipeline` target in `Package.swift`, narrow `WhisperKitIncrementalWorker` + `IncrementalResult` + four reach-only `WhisperKitBackend` methods from `public` to `package`.

## What this lands

| Metric | Pre-R2 | Post-R2 |
|---|---|---|
| `import WhisperKit` in `WhisperKitPipeline.swift` | 1 | **0** |
| `nonisolated(unsafe)` in `WhisperKitPipeline.swift` | 2 | **0** |
| `whisperKitInstance` / `whisperKitTokenizer` / `WhisperKitIncrementalWorker` reaches in `Sources/EnviousWisprPipeline/` | 4 | **0** |
| `Package.swift` `EnviousWisprPipeline` target WhisperKit dep | yes | **dropped** |
| `WhisperKitBackend` reach-only public surface | 6 (whisperKitInstance + whisperKitTokenizer + 4 same-package helpers) | **0** (only ASRBackend protocol requirements remain public) |

## Process notes for reviewer

This PR went through the full plan/council/grounded-review/code-review gauntlet:

- **Plan v2** at `docs/feature-requests/issue-360-2026-04-30-r2-approach-c-plus-lid-split.md` — revised after three-reviewer feedback (GPT + Gemini + Codex grounded). Council critiques saved at `/tmp/r2-plan/{gpt,gemini}-critique.md`. Plan-stage Codex audit at `docs/audits/2026-04-30-r2-plus-lid-grounded-review.txt`.
- **Per-commit Codex code-diff review** — each of the 3 commits was Codex-reviewed and amended locally until clean before the next commit started.
- **Final cumulative Codex review** on the 3-commit diff to catch cross-commit issues.

PR 1 of 2 (#522 / squash 22b72ba) shipped the characterization safety net (17 tests pinning classifier decision branches + determinism harness) on 2026-04-30. **The R2 characterization tests are unchanged in this PR** — they continue to pass against the post-refactor classifier, which is the intent.

## Validation

- `swift build` exit 0
- `scripts/swift-test.sh` 540/540 green (full suite)
- All R2 ship criteria from plan §13 satisfied (verified by grep above)
- Manual cold-path baseline captured pre-R2 for post-merge comparison: decode p50 622ms / reload p50 0.60s on 5 raw dictations with `ModelUnloadPolicy=immediately` (`/tmp/r2-cold-baseline-pre-refactor.md`)

## Top 3 things to look at first

1. **Backend-side LID window migration** at `Sources/EnviousWisprASR/WhisperKitBackend.swift:166-235`. Verbatim port of the previous `LanguageDetector.runMultiWindowLID:520-592`. Easy to break inadvertently. The `LIDObservationBatch` enum cases + the `LanguageDetector.detect` switch-on-batch should preserve every pre-existing abstain reason.
2. **Locked-only incremental-worker behavior** at `WhisperKitPipeline.swift:471-482`. The session is created only in locked language mode (Auto skips incremental and goes straight to batch decode at finalize). Unchanged by R2; just confirming the protocol boundary didn't quietly disturb it.
3. **Package-access seams** Pipeline now relies on. `makeIncrementalSession`, `observeLID`, `WhisperKitIncrementalSession`, `LIDObservationBatch`, `RawLIDObservation`, `IncrementalResult`, `WhisperKitIncrementalWorker` — all `package`. Visible across the SPM package boundary, invisible outside. Confirm nothing accidentally leaks public.

## One intentional behavior change

The new code returns `LIDObservationBatch.cancelled` immediately on inner-await `CancellationError` from `WhisperKit.detectLangauge`. The previous inline implementation swallowed inner cancellation in the per-window try/catch and continued to the next window's pre-check. The new behavior is more responsive (faster cancel response, no wasted windows after cancel). The classifier-side observable behavior (clean abstain, no memory touch) is unchanged. Documented in `LIDObservationBatch.cancelled` doc comment.

## Issue / parent

- Issue: #360
- PR 1: #522 (merged 22b72ba)
- Parent epic: #319 Hardening & Refactors
- Plan: `docs/feature-requests/issue-360-2026-04-30-r2-approach-c-plus-lid-split.md` (v2)
