### PR TITLE
fix(website): remove scroll-reveal from homepage hero h1 + subtitle (LCP fix)

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -146,8 +146,8 @@ const jsonLdFaq = JSON.stringify({
         </svg>
       </div>
 
-      <h1 class="reveal" style="--i:1">Talk naturally. <br/>Paste perfectly.</h1>
-      <p class="hero-sub reveal" style="--i:2">The fastest way to turn your voice into polished text on Mac. Private by design: your voice never leaves your device.</p>
+      <h1>Talk naturally. <br/>Paste perfectly.</h1>
+      <p class="hero-sub">The fastest way to turn your voice into polished text on Mac. Private by design: your voice never leaves your device.</p>
 
       <div class="hero-ctas reveal" style="--i:3">
         <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary">


### PR DESCRIPTION
## Summary

- Drop `.reveal` class from `<h1>` and `<p class="hero-sub">` on the homepage
- Both elements are above the fold and were starting at `opacity: 0`, only animating in after JS loaded + IntersectionObserver fired + a 400ms CSS transition completed
- Side-effect bug fix: hero text is now visible to users with JavaScript disabled

## Context

unlighthouse 2026-04-30 audit found homepage LCP at **3.5s** — worst of any audited page. Lighthouse identified the hero subtitle (`<p class="hero-sub">`) as the LCP element. The `.reveal` pattern is correct UX for below-fold content (animates in as users scroll) but actively wrong for above-fold content where the user is already looking at it.

After the fix the LCP element renders as soon as CSS is parsed, with zero JS dependency.

Below-fold `.reveal` animations on `hero-ctas`, `hero-req`, `hero-trust`, all `section-head` blocks, etc. are unchanged.

`council-skip: zero-blast-radius (single file, 2 chars × 2 deletions, no new APIs, fully reversible)`

## Test plan

- [x] `astro build` clean
- [x] Rendered `dist/index.html` confirms no `class="reveal"` on the LCP `<h1>` and `<p class="hero-sub">`
- [x] Below-fold reveal animations confirmed intact (hero-ctas, etc.)
- [x] Codex review on diff: no regressions
- [ ] Post-deploy: re-run unlighthouse, confirm homepage LCP drops below 2.5s (CWV "Good" threshold)
- [ ] Post-deploy: visually check homepage in browser — hero text should be visible immediately

## Bonus side fix

Hero `<h1>` and subtitle were previously hidden from users with JavaScript disabled (only `prefers-reduced-motion` users got a fallback to visible). This change makes them render unconditionally.
