### PR TITLE
content(blog): retire Friendly + Formal preset references across 20 posts (#517)

### DIFF
--- a/website/src/content/blog/async-communication-better-when-you-speak.md
+++ b/website/src/content/blog/async-communication-better-when-you-speak.md
@@ -46,16 +46,17 @@ Fifteen seconds of speaking. The teammate gets the full context: what was wrong,
 
 ## Right tone, right tool
 
-Not every message should sound the same. A Slack reply to your team is casual. An email to a client is professional. A project brief in Notion needs structure and detail.
+Not every message should sound the same. A Slack reply to your team is casual. A client email is more structured. A project brief in Notion needs structure and detail.
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) that shape how your dictation gets processed:
+EnviousWispr's polish step handles this in two layers. The default polish removes filler words, fixes punctuation, and tightens structure without flattening your voice into corporate prose. It works well across most async writing, so the same workflow handles a Slack reply and a status update.
 
-- **Friendly.** Keeps it concise and conversational. Filler words get removed, punctuation gets cleaned up, but the casual register stays intact. The result reads like you typed it quickly and naturally, not like you dictated into enterprise software. Great for Slack.
-- **Formal.** Shifts to a more polished tone. Sentences get tightened, and the overall structure reads like a professional email rather than a transcribed conversation. Ideal for client-facing messages.
-- **Standard.** A balanced middle ground that preserves your full train of thought, organizes it with reasonable structure, and keeps technical terms or project-specific language intact. Works well for project docs and updates.
-- **Custom.** Write your own processing instructions for full control over how your dictation gets cleaned up.
+When you need a specific shape, the Custom prompt option lets you write your own polish instructions. A few that work well:
 
-Switching between presets takes a single click in the menu bar. You speak naturally every time. The preset handles the translation to the right register.
+- "Keep this casual and concise. Don't formalize." For Slack and team threads.
+- "Tighten sentence structure and produce a polished tone with proper paragraphs." For client-facing email.
+- "Preserve technical terms and project-specific language. Output as a structured paragraph." For project docs and updates.
+
+You change the Custom prompt as your task changes, and the polish step picks it up on your next dictation. You speak naturally every time.
 
 ## Privacy: your work conversations stay on-device
 

--- a/website/src/content/blog/dictate-emails-speed-of-thought.md
+++ b/website/src/content/blog/dictate-emails-speed-of-thought.md
@@ -24,17 +24,17 @@ But raw speed only matters if the output is usable. Nobody wants to send an emai
 
 EnviousWispr handles this differently. After transcription, your text runs through an LLM that strips filler words, fixes punctuation, tightens sentence structure, and adjusts tone. You speak your thoughts loosely. What lands in your email client reads like you sat down and wrote it carefully. The whole cycle (record, transcribe, clean up, paste) takes a second or two on Apple Silicon.
 
-## Writing Style Presets for Every Email Type
+## AI Polish for Every Email Type
 
-Not every email sounds the same. A response to a board member requires different language than a quick delegation to your direct report. EnviousWispr's four writing style presets (Standard, Formal, Friendly, and Custom) let you shape the output to match the context.
-
-### Formal correspondence
-
-Switch to the Formal preset for structured, professional prose. Dictate your key points conversationally, and the LLM will output polished paragraphs with proper salutations and clear paragraph breaks. Useful for investor updates, client responses, and cross-functional announcements.
+Not every email sounds the same. A response to a board member requires different language than a quick delegation to your direct report. EnviousWispr's polish step adapts to what you're writing, and Custom prompts let you lock in a specific shape when you need one.
 
 ### Quick replies
 
-The Standard preset works well for brevity. Speak a few sentences, get back a clean, direct response. No fluff, no preamble. This is ideal for the Slack-style "acknowledged, here's the next step" messages that pile up between meetings.
+The default polish works well for brevity. Speak a few sentences, get back a clean, direct response. No fluff, no preamble. This is ideal for the Slack-style "acknowledged, here's the next step" messages that pile up between meetings.
+
+### Structured correspondence
+
+For investor updates, client responses, and cross-functional announcements, dictate your key points conversationally and the polish step outputs paragraphs with proper punctuation and clear breaks. Want consistent salutations and a sign-off across every email? Save those expectations as a Custom prompt and the polish step applies them every time until you change it.
 
 ### Delegation emails
 
@@ -42,7 +42,7 @@ The LLM post-processing step naturally formats action-oriented dictation into st
 
 ### Custom prompts
 
-The Custom preset lets you write your own processing instructions. Want your email client output to always include a greeting and sign-off? Want bullet points for action items? Write the prompt once and every dictation follows your rules.
+The Custom prompt option lets you write your own processing instructions. Want your email output to always include a greeting and sign-off? Want bullet points for action items? Write the prompt once and every dictation follows your rules until you change it.
 
 ## Sensitive Data Stays on Your MacBook
 

--- a/website/src/content/blog/dictate-first-drafts-sound-like-you.md
+++ b/website/src/content/blog/dictate-first-drafts-sound-like-you.md
@@ -1,6 +1,6 @@
 ---
 title: "Dictate First Drafts That Sound Like You"
-description: "Most dictation tools strip your voice. Here's how to dictate first drafts that keep your writing style intact using presets and LLM post-processing."
+description: "Most dictation tools strip your voice. Here's how to dictate first drafts that keep your writing style intact using on-device polish and Custom prompts."
 pubDate: 2026-03-14
 updatedDate: 2026-04-04
 tags: ["writing", "dictation", "workflow", "writing-style"]
@@ -30,12 +30,10 @@ EnviousWispr splits the work into two stages: transcription and post-processing.
 
 Here's what makes the difference for writers:
 
-- **Writing style presets.** Four built-in modes that shape how the LLM cleans up your dictation. **Friendly** keeps your natural voice and conversational rhythm intact (contractions, sentence fragments, the way you actually talk). **Standard** gives you clean, balanced prose. **Formal** tightens everything up for professional or academic contexts. **Custom** lets you write your own processing instructions.
-- **LLM post-processing.** Your on-device LLM (Apple Intelligence, Ollama) or a cloud API (OpenAI, Gemini) handles the cleanup. It strips filler words, fixes punctuation, and reshapes the text according to whichever preset you've selected. The result sounds like you wrote it, not like a template.
+- **On-device polish that keeps your voice.** Your local LLM (Apple Intelligence, Ollama) or a cloud API (OpenAI, Gemini) cleans up the raw transcription: filler words go, punctuation gets fixed, structure tightens, but your contractions, sentence fragments, and rhythm stay intact. The default polish is tuned for natural-sounding output, not corporate sameness.
+- **Custom prompts for explicit control.** When you want to lock in a specific style, write a Custom prompt and the polish step uses it for every dictation until you change it. Examples: "use em dashes, not semicolons", "keep sentence fragments, they're intentional", "format as Markdown with H2 headings".
 
-Switching presets takes one click, so you can move between freewriting and polished output without changing how you speak. You're in control.
-
-> **Tip:** The Custom preset lets you write your own post-processing instructions: things like "use em dashes, not semicolons" or "format as Markdown with H2 headings." Full control over how your dictation gets shaped.
+You can change the Custom prompt as your task changes (drafting one minute, client-facing prose the next), and the polish step picks it up on your next dictation. You're in control.
 
 For a deeper look at how the transcription and post-processing pipeline connects, see the [How It Works](/how-it-works/) page.
 
@@ -49,17 +47,18 @@ Download the latest `.dmg` from the [GitHub releases page](https://github.com/sa
 
 No account. No API key. No subscription. It's free.
 
-### Step 2: Pick Your Writing Style Preset
+### Step 2: Set Up Polish (and a Custom Prompt If You Need One)
 
-The speech model downloads automatically on first launch. Once that's done (a few minutes), open EnviousWispr's settings and choose the writing style preset that matches what you're working on:
+The speech model downloads automatically on first launch. Once that's done (a few minutes), open EnviousWispr's settings. The default polish is tuned to keep your voice intact while cleaning up filler words and punctuation. For most writing, that's the right starting point.
 
-**Friendly.** For novelists, bloggers, and freewriters who want their natural voice preserved. Filler words go away, but contractions, casual phrasing, and your sentence rhythm stay intact.
+If you want to lock in a specific shape, write a Custom prompt. Pick whichever pattern matches what you're working on:
 
-**Standard.** The balanced middle ground. Clean, readable prose that works for newsletters, articles, and general drafting. Your voice comes through, just a bit more polished.
+- "Keep my natural voice, contractions, and sentence rhythm. Don't formalize." For novels, blog drafts, freewriting.
+- "Output clean, readable prose with light polish. Keep my voice." For newsletters and articles.
+- "Tighten sentence structure, remove casual phrasing, produce polished prose." For academic papers, client deliverables.
+- "Use em dashes instead of semicolons. Preserve sentence fragments when intentional." For specific style preferences.
 
-**Formal.** For academic papers, client deliverables, and professional correspondence. Tighter sentence structure, no casual phrasing, polished output.
-
-**Custom.** Write your own post-processing instructions for full control: things like "use em dashes, not semicolons" or "keep sentence fragments, they're intentional."
+The Custom prompt sticks until you change it.
 
 Post-processing can run on-device (Apple Intelligence, Ollama) or through cloud APIs (OpenAI, Gemini). Your raw dictation never leaves your device unless you explicitly configure an external API.
 
@@ -67,7 +66,7 @@ Post-processing can run on-device (Apple Intelligence, Ollama) or through cloud 
 
 Hold your hotkey. Start talking. Don't edit in your head; just speak. Release the hotkey when you're done with a thought. A second or two later on Apple Silicon, polished text lands in your writing app, styled the way you specified.
 
-That's it. No copying and pasting. No switching apps. The text pastes into the app that has focus, cleaned up according to your chosen writing style.
+That's it. No copying and pasting. No switching apps. The text pastes into the app that has focus, cleaned up according to your polish settings.
 
 ## What the Difference Actually Looks Like
 
@@ -89,15 +88,15 @@ You open Ulysses. You hold the hotkey. You talk for three minutes about whatever
 
 ### Blog Drafting in iA Writer
 
-You have an outline. You dictate each section, one hotkey press at a time. Your writing style preset cleans up each chunk into polished prose. Each dictation chunk lands in iA Writer ready to edit. By the time you've walked through your outline, you have a 1,200-word rough draft that took fifteen minutes instead of an hour.
+You have an outline. You dictate each section, one hotkey press at a time. The polish step cleans up each chunk into prose that still sounds like you. Each dictation chunk lands in iA Writer ready to edit. By the time you've walked through your outline, you have a 1,200-word rough draft that took fifteen minutes instead of an hour.
 
 ### Quick Slack Replies Between Writing Sessions
 
-You switch to Slack. You flip your preset to Friendly (casual tone, natural phrasing). You dictate a reply to your editor. It reads like a quick message, not like a paragraph from your manuscript. Back to writing. One click to switch presets, no friction.
+You switch to Slack. The default polish keeps things conversational without over-formalizing. You dictate a reply to your editor. It reads like a quick message, not like a paragraph from your manuscript. Back to writing.
 
 ### Capturing Ideas on a Walk
 
-You're away from your desk but your Mac Mini is running at home. You come back, sit down, double-press your hotkey to lock recording, and dump every idea you had on your walk. The post-processor cleans it up with your Friendly preset: natural, lightly polished, captured. You'll shape it later.
+You're away from your desk but your Mac Mini is running at home. You come back, sit down, double-press your hotkey to lock recording, and dump every idea you had on your walk. The post-processor cleans it up while keeping your natural phrasing: lightly polished, captured. You'll shape it later.
 
 ## Why Privacy Matters for Writers
 
@@ -111,8 +110,8 @@ For a detailed look at how on-device processing compares to cloud alternatives, 
 
 Most writers who've tried dictation and quit had one of three problems:
 
-1. **The output didn't sound like them.** Solved by writing style presets that match your tone, plus the Custom preset for full control over processing instructions.
-2. **Switching between contexts was tedious.** One-click preset switching makes it fast.
+1. **The output didn't sound like them.** Solved by an on-device polish step tuned to keep your voice, plus a Custom prompt for full control over processing instructions.
+2. **Switching between contexts was tedious.** Edit the Custom prompt as your task changes; the polish step picks it up on your next dictation.
 3. **Privacy concerns with cloud tools.** Solved by on-device processing that never phones home.
 
 The first few sessions feel awkward. You'll over-explain, stumble, repeat yourself. That's normal. The post-processor catches most of it, and within a week you'll find a rhythm. Dictation isn't a replacement for writing; it's a way to get your first draft out of your head faster so you can spend your energy on editing, which is where the real writing happens anyway.
@@ -122,7 +121,7 @@ The first few sessions feel awkward. You'll over-explain, stumble, repeat yourse
 EnviousWispr is free and yours to keep. No strings.
 
 1. [Download EnviousWispr free](/#download), or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases)
-2. Pick the writing style preset that matches your voice: Friendly, Standard, Formal, or Custom
+2. Leave polish on the default, or write a Custom prompt that matches your voice
 3. Dictate your next first draft
 
 ## Related Posts

--- a/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+++ b/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
@@ -31,9 +31,9 @@ But raw transcription isn't a script. It's a wall of text with filler words, fal
 
 ## Post-Processing: Your Script's Formatting Brain
 
-EnviousWispr's post-processing pipeline cleans up your speech after transcription: removing filler words, fixing punctuation, and producing polished text. You can choose between four writing style presets (Standard, Formal, Friendly, and Custom) to control the tone. For podcast scripting, the Friendly preset preserves your conversational voice while cleaning up the rough edges.
+EnviousWispr's post-processing pipeline cleans up your speech after transcription: removing filler words, fixing punctuation, and producing polished text. The default polish preserves your conversational voice while cleaning up the rough edges, which is what you want for podcast scripting.
 
-The Custom preset lets you write specific processing instructions, like "keep sentence fragments, add section breaks between topics, format with H2 headings." That level of control makes dictated scripts even more useful.
+When you need a specific shape (interview prep, solo script, show notes, cold open), the Custom prompt option lets you write processing instructions like "keep sentence fragments, add section breaks between topics, format with H2 headings." That level of control makes dictated scripts even more useful.
 
 The output has the structure you need: cleaned of "um" and "you know," but still sounding like you.
 
@@ -47,7 +47,7 @@ Here's what that looks like in practice, dictating a cold open for an episode ab
 
 That's a usable cold open. It sounds like you because it literally is you, just without the filler words and with proper punctuation. Read that back into the mic and it works immediately. The idea made it from your head to the page before it had a chance to evaporate.
 
-With the Custom preset, you can fine-tune output for different show formats: interview prep as numbered questions, solo scripts with paragraph breaks, show notes as bullet summaries, cold opens tightened to three punchy sentences.
+With a Custom prompt, you can fine-tune output for different show formats: interview prep as numbered questions, solo scripts with paragraph breaks, show notes as bullet summaries, cold opens tightened to three punchy sentences.
 
 Check [how EnviousWispr's pipeline works](/how-it-works/) for the full picture on how transcription and post-processing fit together.
 
@@ -83,7 +83,7 @@ This is the hardest habit to break. You'll say something awkward, and every inst
 
 ### Use Verbal Section Markers
 
-Say "new section" or "next topic" or "heading: [topic name]" as you dictate. The post-processing pipeline picks up on these verbal cues and uses them to add structure to your output. With the Custom preset, you have full control over how those markers get formatted.
+Say "new section" or "next topic" or "heading: [topic name]" as you dictate. The post-processing pipeline picks up on these verbal cues and uses them to add structure to your output. With a Custom prompt, you have full control over how those markers get formatted.
 
 ### Do a Read-Back Pass
 
@@ -94,7 +94,7 @@ After dictating, read the script out loud once. Not to edit the words, but to ed
 If you already have EnviousWispr installed, you can start dictating episode scripts right now:
 
 1. Open your writing app: whatever you use for scripts (Notion, Obsidian, Google Docs, a plain text editor)
-2. Choose the Friendly writing style preset to keep your conversational tone while cleaning up filler words
+2. Leave polish on the default; it keeps your conversational tone intact while cleaning up filler words
 3. Hold the hotkey and talk through your next episode's cold open
 4. Look at the output. Adjust the prompt. Try again
 

--- a/website/src/content/blog/dictation-for-developers-code-reviews.md
+++ b/website/src/content/blog/dictation-for-developers-code-reviews.md
@@ -22,25 +22,19 @@ So you write something minimal. "Fixed race condition in queue handler." Your re
 
 The fix isn't writing better descriptions through sheer discipline. The fix is making it easier to produce them without breaking your train of thought. If you can just talk through what you did, the same way you'd explain it to a colleague at your desk, the description writes itself.
 
-## Writing style presets: match the tone to the task
+## AI polish: clean output that matches your task
 
-Not all developer writing sounds the same. A commit message is terse. A PR description is structured. A Slack reply is conversational. EnviousWispr ships with four writing style presets (**Standard**, **Formal**, **Friendly**, and **Custom**) that control how the AI polish shapes your dictated text.
+Not all developer writing sounds the same. A commit message is terse. A PR description is structured. A Slack reply is conversational. EnviousWispr's AI polish step cleans up your dictated text by removing filler words, fixing punctuation, and tightening structure, so what you say comes out the way you'd want a colleague to read it.
 
-Here's how each one maps to developer tasks:
+For most developer writing (review comments, ticket updates, README sections, Slack threads), the default polish handles the cleanup without over-formalizing or stripping your voice. You speak naturally and the output reads naturally.
 
-### Formal
+For specialized formatting, EnviousWispr's Custom prompt option lets you write your own instructions for the polish step. A few examples that work well for developer workflows:
 
-Best for PR descriptions, documentation, and design docs. Full sentences, proper punctuation, structured prose. You talk through your reasoning and the post-processor organizes it into clean, readable text. Markdown headers, bullet points, and code references stay intact.
+- "Format as a markdown bullet list with code references in backticks." Useful for changelog entries or release notes.
+- "Write in past tense and group changes by subsystem." Useful for postmortem timelines.
+- "Output API documentation with parameter and return descriptions." Useful for public method docs.
 
-### Standard
-
-The default. Works well for most developer writing: review comments, ticket updates, README sections. It cleans up filler words and fixes punctuation without over-formalizing.
-
-### Friendly
-
-Best for Slack messages and casual communication. Keeps things informal, closer to how you'd actually talk. "Hey, the deploy is blocked on that config change, can you merge it when you get a chance" comes out natural, not stiff.
-
-You switch between presets with a click. Pick the tone that matches what you're writing, and the post-processor handles the rest. With the Custom preset, you can write your own system prompt for specialized formatting like API docs or structured changelogs.
+The Custom prompt sticks until you change it, so once you have a prompt that fits your team's style, you can leave it in place and dictate against it for as long as you need.
 
 ## Real workflow: dictating a PR description
 
@@ -80,7 +74,7 @@ This works especially well for longer review comments, the kind where you need t
 
 Technical documentation has the highest typing-to-thinking ratio of anything developers write. You know what the system does. You just need to get it into words. Dictation makes this almost trivial.
 
-For documentation, the Formal writing style preset works well. It produces structured prose with proper punctuation and clean paragraphs. You talk through the architecture the way you'd explain it to a new team member, and the output lands polished and ready to commit. Custom prompts let you go even further: tell the post-processor to format output as API documentation with parameter descriptions, or to use specific header structures.
+For documentation, the polish step produces structured prose with proper punctuation and clean paragraphs. You talk through the architecture the way you'd explain it to a new team member, and the output lands polished and ready to commit. Custom prompts let you go further: tell the post-processor to format output as API documentation with parameter descriptions, or to use specific header structures.
 
 This is particularly useful for the kind of documentation that always gets skipped: the "how does this subsystem actually work" docs that everyone wishes existed but nobody wants to sit down and type out. Speaking is lower friction than typing for this kind of knowledge dump, and the difference is enough to make it actually happen.
 
@@ -100,15 +94,15 @@ For developers working on proprietary codebases, under NDA, or at companies with
 
 To set up for developer use:
 
-1. **Open Settings** and choose your writing style preset. Formal works well for PR descriptions and docs, Friendly for Slack.
-2. **Pick your hotkey.** Choose something that doesn't collide with your IDE shortcuts.
-3. **Switch presets as needed.** When you move from writing a PR description to replying in Slack, switch from Formal to Friendly with a click.
+1. **Pick your hotkey.** Choose something that doesn't collide with your IDE shortcuts.
+2. **Leave polish on.** Default polish handles most developer writing (review comments, ticket updates, README sections) without over-formalizing.
+3. **Set a Custom prompt for the niches.** API docs, changelog entries, structured postmortems. The Custom prompt sticks until you change it.
 
-It's fast to switch, and you'll quickly develop a habit of matching the preset to the task. Hold the hotkey in GitHub with Formal selected, get a detailed PR description. Switch to Friendly for Slack, get a casual reply.
+Hold the hotkey in GitHub, talk through your PR description, and the polished text lands ready to paste. Move to Slack and the same workflow handles a quick reply.
 
 ## Related Posts
 
-- [Why I Switched from Typing to Dictating Git Commits](/blog/switched-typing-to-dictating-git-commits/). A practical look at dictating commit messages with writing style presets.
+- [Why I Switched from Typing to Dictating Git Commits](/blog/switched-typing-to-dictating-git-commits/). A practical look at dictating commit messages with on-device polish.
 - [Voice Coding on macOS Without Cloud APIs](/blog/voice-coding-macos-without-cloud/). The full case for on-device voice input in dev workflows.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). Setup walkthrough from download to first dictation.
 

--- a/website/src/content/blog/dictation-for-writers-skip-blank-page.md
+++ b/website/src/content/blog/dictation-for-writers-skip-blank-page.md
@@ -32,17 +32,15 @@ The shift is psychological as much as practical. When you dictate, you give your
 
 Most dictation tools were built for business users dictating emails and memos. Writers need something different. You need output that sounds like writing, not like a transcribed meeting. And you need it to land in your writing app, formatted the way you work.
 
-EnviousWispr handles this with writing style presets and LLM post-processing that matter specifically to writers.
+EnviousWispr handles this with on-device LLM post-processing tuned specifically for writers.
 
-### Writing Style Presets: Match Your Tone Instantly
+### Polish That Keeps Your Voice
 
-After EnviousWispr transcribes your speech, it runs the text through a local LLM for post-processing. You choose from four writing style presets (**Standard**, **Formal**, **Friendly**, and **Custom**) that shape how the AI polish cleans up your dictation. For first-draft prose, Friendly keeps your natural voice and conversational rhythm intact. Standard gives you clean, balanced output. Formal tightens everything up for professional contexts.
+After EnviousWispr transcribes your speech, it runs the text through a local LLM for post-processing. The default polish removes filler words, fixes punctuation, and tightens structure without flattening your phrasing into corporate prose. The result is a clean first draft that sounds like you, not like a robot or a memo.
 
-That processing can run fully on-device with Apple Intelligence or Ollama, without sending your words anywhere. The result is a clean first draft that sounds like you, not like a robot or a corporate memo.
+That processing can run fully on-device with Apple Intelligence or Ollama, without sending your words anywhere.
 
-Switching presets takes one click, so you can move between brainstorming (Friendly, loose and natural), blog drafting (Standard, clean but conversational), and client-facing work (Formal, polished) without friction.
-
-Custom prompts let you write your own post-processing instructions: "format as screenplay-style dialogue," "keep this as stream of consciousness with line breaks," or anything else you need. Set your custom system prompt in Settings under AI Polish.
+For writers who want explicit control over the output, the Custom prompt option lets you write your own post-processing instructions: "format as screenplay-style dialogue," "keep this as stream of consciousness with line breaks," "preserve em-dashes and parentheticals," or anything else you need. Set your custom system prompt in Settings under AI Polish, and the polish step uses it for every dictation until you change it.
 
 For a step-by-step look at how this works in a real writing session, see [Voice to Prose: A Realistic Writing Workflow](/blog/voice-to-prose-writing-workflow/).
 
@@ -109,7 +107,7 @@ You can read more about [how the pipeline works](/how-it-works/), from microphon
 
 ## Related Posts
 
-- [Dictate First Drafts That Sound Like You](/blog/dictate-first-drafts-sound-like-you/). How writing style presets preserve your voice during dictation.
+- [Dictate First Drafts That Sound Like You](/blog/dictate-first-drafts-sound-like-you/). How on-device polish preserves your voice during dictation.
 - [Voice to Prose: A Realistic Writing Workflow](/blog/voice-to-prose-writing-workflow/). A real before-and-after look at dictated prose.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
 
@@ -117,7 +115,7 @@ You can read more about [how the pipeline works](/how-it-works/), from microphon
 
 EnviousWispr is free. You don't need an account, a subscription, or an API key.
 
-[Download EnviousWispr free](/#download) or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases). Install it, grant microphone and accessibility permissions, and you're dictating within a few minutes. The speech model downloads automatically. Pick a writing style preset that matches your voice, and try dictating your next first draft instead of typing it.
+[Download EnviousWispr free](/#download) or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases). Install it, grant microphone and accessibility permissions, and you're dictating within a few minutes. The speech model downloads automatically. Try dictating your next first draft instead of typing it, and write a Custom prompt later if you want output shaped to your specific style.
 
 The blank page problem doesn't go away. But when you can speak your way past it, it stops being the thing that kills your morning.
 

--- a/website/src/content/blog/dictation-parents-type-one-handed.md
+++ b/website/src/content/blog/dictation-parents-type-one-handed.md
@@ -75,7 +75,7 @@ Standing in the kitchen, checking what's left in the fridge: "We need milk, eggs
 
 ### Work messages during nap time
 
-The baby just fell asleep on you on the couch, Mac Mini running quietly in the corner hooked up to the TV. You can't move without waking them, but you need to reply to a few Slack messages. Push-to-talk at a low volume, and EnviousWispr handles the rest. You can pick a writing style preset (Standard, Formal, Friendly, or Custom) to match the tone you need.
+The baby just fell asleep on you on the couch, Mac Mini running quietly in the corner hooked up to the TV. You can't move without waking them, but you need to reply to a few Slack messages. Push-to-talk at a low volume, and EnviousWispr handles the rest. The on-device polish step cleans up your dictation, and a Custom prompt lets you lock in a specific tone if you need one.
 
 ### Capturing ideas before they vanish
 

--- a/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
+++ b/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
@@ -66,16 +66,17 @@ The ten minutes after a video call are the highest-value window for follow-up me
 
 These are repetitive and formulaic, perfect for dictation. You know what you worked on. Just say it. The post-processing handles formatting.
 
-## Writing Style Presets: Match the Tone to the Task
+## AI Polish: Match the Tone to the Task
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) that control how the LLM post-processor shapes your output. You switch between them with a click, matching the tone to what you're writing:
+EnviousWispr's polish step cleans up your dictation by stripping filler words, fixing punctuation, and tightening structure without flattening your voice. The default is calibrated to handle most remote-work writing well, so the same workflow handles a Slack reply, a ticket comment, and a status update.
 
-- **Friendly for Slack.** Casual and concise. Strips filler words but doesn't over-formalize. The result reads like a quick typed message, not a business memo.
-- **Formal for email and docs.** Polished tone, proper grammar, structured paragraphs. Your spoken brain dump comes out as something you'd be happy to send to a client.
-- **Standard for everything else.** The default. Cleans up your speech without pushing it in either direction. Works well for ticket comments, status updates, and general-purpose writing.
-- **Custom for specific needs.** Write your own processing instructions to get exactly the output format you want.
+When you need a specific shape (a more structured client email, a formatted standup, a postmortem timeline), the Custom prompt option lets you write your own polish instructions and reuse them across dictations:
 
-Switching takes a single click, and you'll quickly build a habit of toggling before you dictate.
+- "Casual and concise. Strip filler but don't over-formalize." Useful for Slack and team threads.
+- "Polished tone, proper grammar, structured paragraphs." Useful for client-facing email and docs.
+- "Output as a bulleted list grouped by project." Useful for daily standups.
+
+The Custom prompt sticks until you change it, so once you've dialled in a shape that fits your team, you can leave it in place and dictate against it for as long as you need.
 
 ## The Ergonomic Case for Mixing Voice and Keyboard
 
@@ -106,7 +107,7 @@ EnviousWispr is [free](https://github.com/saurabhav88/EnviousWispr). Works out o
 
 Start small. Pick one high-volume context (Slack replies or email) and commit to dictating instead of typing for a full day. You'll feel awkward for the first hour. By the end of the day, you'll notice how much less your hands hurt.
 
-Then get comfortable switching between Friendly (for Slack) and Formal (for email) as you move between tasks. Once that toggle becomes second nature, dictation stops being something you're "trying" and starts being how you work.
+Once that habit clicks, dictation stops being something you're "trying" and starts being how you work.
 
 ## Related Posts
 

--- a/website/src/content/blog/essay-outline-by-talking-it-out.md
+++ b/website/src/content/blog/essay-outline-by-talking-it-out.md
@@ -23,15 +23,15 @@ Speaking changes the dynamic. You're not editing as you go; you're just thinking
 
 There's a practical speed advantage too. Most people speak at 130-150 words per minute but type at 40-60. For the brainstorming phase of an outline, where volume of ideas matters more than polish, voice wins by a wide margin.
 
-## The setup: pick a preset, start talking
+## The setup: a Custom prompt, then start talking
 
-Here's how EnviousWispr fits in. Instead of dictating raw text and then manually reorganizing it, the LLM post-processor cleans up your spoken thoughts into polished, structured prose. Choose the **Formal** writing style preset for academic work; it tightens sentence structure and produces clean, organized output from your rambling.
+Here's how EnviousWispr fits in. Instead of dictating raw text and then manually reorganizing it, the LLM post-processor cleans up your spoken thoughts into structured prose. For academic work, set a Custom prompt that tightens sentence structure and produces clean, organized output from your rambling.
 
 Hold the hotkey, talk through your argument, and release. EnviousWispr transcribes your speech locally, runs it through the LLM post-processor, and delivers cleaned-up text. The whole thing takes a few seconds on any M-series chip.
 
-The Formal preset gives you the most structured output, but even Standard produces clean prose that's easy to reorganize into an outline. The key insight is that speaking your argument out loud forces you to linearize it, and the structure emerges from how you naturally explain things.
+The default polish already produces clean prose that's easy to reorganize into an outline. The key insight is that speaking your argument out loud forces you to linearize it, and the structure emerges from how you naturally explain things.
 
-The Custom writing style preset takes this even further. You can write specific instructions like "organize my thoughts into an essay outline with a thesis and three supporting points, Roman numeral formatting." That turns a one-minute ramble directly into a formatted outline without any manual reorganizing.
+A Custom prompt takes this further. You can write specific instructions like "organize my thoughts into an essay outline with a thesis and three supporting points, Roman numeral formatting." That turns a one-minute ramble directly into a formatted outline without any manual reorganizing.
 
 ## Walking through a real example
 
@@ -39,7 +39,7 @@ Let's say you're writing a paper on why public libraries remain relevant in the 
 
 > "Okay so I think my main argument is that public libraries are still important even though everything is online now. First because they provide free internet access to people who can't afford it at home, which is a huge equity issue. Second, they're community spaces, like, people go there for job help, ESL classes, after-school programs, stuff that has nothing to do with books. And third, they curate information in a way that algorithms don't. Librarians help people find trustworthy sources instead of just whatever shows up first on Google."
 
-Not exactly polished academic writing. But that's the point: you're thinking, not editing. After EnviousWispr processes it with the Formal preset, the LLM cleans it into structured prose. With a quick reorganization, you get something like:
+Not exactly polished academic writing. But that's the point: you're thinking, not editing. After EnviousWispr processes it with an academic Custom prompt, the LLM cleans it into structured prose. With a quick reorganization, you get something like:
 
 ---
 
@@ -70,15 +70,13 @@ Once you've got the basic pattern down, there are a few ways to build on it.
 
 Your first spoken pass gives you the skeleton. But you can refine it the same way. Look at what you've got, notice a weak point, hold the hotkey again: "Actually, for section two I should focus more on the employment statistics. Libraries in low-income areas have higher job placement rates for people who use their career services." The post-processor cleans it up, and you drop it into your outline where it fits.
 
-### Match the preset to the context
+### Match the prompt to the assignment
 
-For essay work, the Formal preset gives you the tightest, most structured output. But if you're brainstorming early ideas, try Friendly; it keeps your natural phrasing intact, which can help you find your argument before you formalize it. Switch between presets with one click as your thinking evolves from rough brainstorm to polished draft.
+A Custom prompt lets you save specific instructions for different assignment types, like "organize as compare-and-contrast with point-by-point structure" or "structure as a five-paragraph essay with topic sentences." Build a small library of prompts for different essay formats and swap them in as your assignment changes.
 
-The Custom preset lets you save specific instructions for different assignment types, like "organize as compare-and-contrast with point-by-point structure" or "structure as a five-paragraph essay with topic sentences." Build a small library of prompts for different essay formats.
+### Brainstorm with the default, structure with a Custom prompt
 
-### Switch presets as you switch tasks
-
-If you're dictating rough notes one minute and drafting polished outline text the next, flip between Friendly and Formal with one click. Friendly for raw brainstorming, Formal for structured output. It takes a second and keeps each task's output matching its purpose.
+If you're dictating rough notes one minute and drafting polished outline text the next, the default polish handles the brainstorm well, keeping your natural phrasing intact so you can find your argument before you formalize it. When you're ready to structure the outline, swap in your academic Custom prompt and the next dictation comes back organized.
 
 ## Why this works for students specifically
 
@@ -94,7 +92,7 @@ A few things make this approach a good fit for the student workflow.
 
 ## Get started
 
-If you've got a paper due and the outline isn't cooperating, try talking it out. [Get EnviousWispr free](/#download), or download it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Set the writing style to Formal, and spend one minute speaking your argument out loud.
+If you've got a paper due and the outline isn't cooperating, try talking it out. [Get EnviousWispr free](/#download), or download it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Set a Custom prompt for academic structure, and spend one minute speaking your argument out loud.
 
 ## Related Posts
 

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -85,13 +85,13 @@ EnviousWispr works well with zero configuration, but if you want to tune it to y
 
 EnviousWispr downloads its speech recognition model automatically on first launch. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine is available for 100+ languages. The download takes a minute or two, and the model is cached locally from then on.
 
-### Writing style presets
+### AI polish
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) that control the tone of your post-processed output. Switch between them depending on the task: Formal for polished emails, Standard for general writing, Friendly for casual messages.
+EnviousWispr's polish step removes filler words, fixes punctuation, and tightens structure without flattening your voice. The default works well for most writing. When you need a specific shape (a more polished tone, a particular format, your personal style rules), a Custom prompt lets you write your own polish instructions and reuse them.
 
 ### Custom prompts
 
-Custom prompts let you tell the post-processor exactly how to handle your speech: "format as bullet points," "translate to Spanish," "write in my style: short sentences, no semicolons." Set your own system prompt in Settings under AI Polish.
+Custom prompts let you tell the post-processor exactly how to handle your speech: "format as bullet points," "translate to Spanish," "write in my style: short sentences, no semicolons." Set your own system prompt in Settings under AI Polish, and the polish step uses it for every dictation until you change it.
 
 ### Custom word dictionary
 

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -79,7 +79,7 @@ Apple's built-in dictation has improved significantly. On Apple Silicon Macs run
 Where it falls short:
 
 - **No post-processing.** What you say is what you get, filler words and all.
-- **Limited customization.** No writing style presets, no custom prompts, no way to adjust output formatting.
+- **Limited customization.** No custom prompts, no way to adjust output formatting.
 - **No hands-free mode.** You need to trigger it each time.
 - **No custom word dictionary.** No way to teach it your terminology.
 
@@ -147,9 +147,9 @@ EnviousWispr downloads its speech recognition model automatically on first launc
 
 If you want to avoid holding keys, just double-press your hotkey to lock recording. No settings change needed. Speak naturally, then press once to finish or triple-press to cancel.
 
-### Choose a Writing Style Preset
+### Tune the Polish Step
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) so you can match the tone of your output to the task at hand. Custom mode lets you write your own system prompt for full control over output formatting.
+EnviousWispr's polish step cleans up your dictation by default, removing filler words and fixing punctuation without flattening your voice. When you need a specific shape (a particular tone, format, or convention), a Custom prompt lets you write your own polish instructions and reuse them across dictations.
 
 ## A Tool That Works When You Need It
 

--- a/website/src/content/blog/meeting-notes-polished-summaries.md
+++ b/website/src/content/blog/meeting-notes-polished-summaries.md
@@ -26,9 +26,9 @@ But the real leverage comes from what happens next.
 
 ## From raw dictation to structured summary
 
-Out of the box, EnviousWispr cleans up filler words, fixes punctuation, and adjusts tone using one of four writing style presets (Standard, Formal, Friendly, and Custom). That alone transforms your dictation. But for meeting notes, the real unlock is structure.
+Out of the box, EnviousWispr cleans up filler words, fixes punctuation, and tightens structure. That alone transforms your dictation. But for meeting notes, the real unlock is structure.
 
-The Custom writing style preset lets you tell the post-processor exactly how to format your output. For meeting summaries, a prompt like this works well:
+A Custom prompt lets you tell the post-processor exactly how to format your output. For meeting summaries, a prompt like this works well:
 
 **"Format as a meeting summary. Include: attendees mentioned, key decisions, action items with owners and due dates, and open questions. Use bullet points. Keep it concise."**
 
@@ -69,7 +69,7 @@ For an exec who regularly discusses confidential business matters, this isn't a 
 
 Not every meeting summary goes to the same place. A quick standup recap might go straight into Slack. A board prep summary might go into Notion or a Google Doc. A one-on-one follow-up might become an email.
 
-You can switch between four writing style presets (Standard, Formal, Friendly, and Custom) to match the context. Toggling between presets takes a single click and gets you the right tone for each destination.
+For each destination, a Custom prompt tuned to that surface produces the right shape. Save a "board summary" prompt, a "Slack recap" prompt, an "email follow-up" prompt; swap them in as the destination changes and the polish step picks up the new instructions on your next dictation.
 
 ## Making it part of your routine
 
@@ -79,12 +79,12 @@ A few tips for getting started:
 
 - **Start with high-stakes meetings.** Board reviews, strategy sessions, client calls, wherever the cost of lost context is highest.
 - **Keep your dictation loose.** Don't try to speak in polished sentences. The LLM handles cleanup. Just get the facts out.
-- **Pick the right writing style preset.** Formal works well for board summaries, Standard for most internal recaps, Friendly for team Slack channels.
+- **Save a Custom prompt per destination.** Board summaries want structured prose; Slack recaps want bullet points; email follow-ups want a short paragraph plus action items. Build the prompts once and reuse them.
 - **Use hands-free mode for longer debriefs.** If you need to talk through a complex meeting for two or three minutes, double-press your hotkey to lock recording so you don't have to hold a key the entire time.
 
 ## Get started
 
-[Download EnviousWispr free](/#download), or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). It's free; install it and start dictating. No registration, no payment. The speech model downloads automatically on first launch. Pick a writing style preset that fits your workflow.
+[Download EnviousWispr free](/#download), or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). It's free; install it and start dictating. No registration, no payment. The speech model downloads automatically on first launch. Try the default polish first, and write a Custom prompt if you want output shaped to your specific workflow.
 
 ## Related Posts
 

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -93,7 +93,7 @@ For many people, especially those dictating work-related content on a Mac, on-de
 
 EnviousWispr is an on-device dictation app for macOS. It ships with two transcription backends: Parakeet for fast English dictation and WhisperKit for multi-language support. Both run natively via Core ML on Apple Silicon. Your audio is recorded, transcribed, and post-processed locally. Recordings never leave your Mac.
 
-Here's what the workflow looks like: hold a hotkey, speak, release. A second or two later, polished text lands on your clipboard or pastes directly into the app you're using. Post-processing (punctuation cleanup, filler word removal, tone adjustment) runs through your choice of AI provider: Apple Intelligence and Ollama for fully on-device, or OpenAI and Gemini if you prefer cloud. Four writing style presets (Standard, Formal, Friendly, Custom) let you shape the output for different contexts.
+Here's what the workflow looks like: hold a hotkey, speak, release. A second or two later, polished text lands on your clipboard or pastes directly into the app you're using. Post-processing (punctuation cleanup, filler word removal, tone adjustment) runs through your choice of AI provider: Apple Intelligence and Ollama for fully on-device, or OpenAI and Gemini if you prefer cloud. A Custom prompt lets you shape the output for different contexts; the polish step uses your prompt for every dictation until you change it.
 
 Here's what that looks like in practice:
 

--- a/website/src/content/blog/podcast-show-notes-to-blog-posts.md
+++ b/website/src/content/blog/podcast-show-notes-to-blog-posts.md
@@ -40,9 +40,9 @@ You can dictate show notes in the same conversational tone your audience already
 
 ## Post-Processing That Shapes Your Output
 
-This is where things get genuinely useful for podcast show notes blog posts. EnviousWispr's [post-processing pipeline](/how-it-works/) cleans up your dictation and formats it into polished text. You can choose between four writing style presets (Standard, Formal, Friendly, and Custom) to control the tone of your output. For show notes, the Standard or Friendly preset keeps things conversational and scannable. For a more polished blog version, the Formal preset produces structured prose.
+This is where things get genuinely useful for podcast show notes blog posts. EnviousWispr's [post-processing pipeline](/how-it-works/) cleans up your dictation and formats it into polished text. The default polish keeps things conversational and scannable, which is what you want for show notes. For a more structured blog version, a Custom prompt produces tighter prose with proper paragraphs.
 
-The Custom preset lets you write your own processing instructions, like telling the pipeline to format output as bullet-point show notes with a summary paragraph, or to expand dictation into a full 800-1200 word blog post with H2 headings. That makes it fast to repurpose podcast content into different written formats from the same dictation.
+A Custom prompt lets you write your own processing instructions: tell the pipeline to format output as bullet-point show notes with a summary paragraph, or to expand dictation into a full 800-1200 word blog post with H2 headings. Save one prompt per output format and swap them between dictations. That makes it fast to repurpose podcast content into different written formats from the same dictation.
 
 Here's what this looks like end to end, dictating a recap right after recording:
 
@@ -90,7 +90,7 @@ Here's what a podcast-to-blog workflow looks like end to end:
 2. **Dictate show notes** immediately after recording. Hold the hotkey, speak a 2-3 minute recap of the episode, release.
 3. **Post-processing cleans and formats** the output as structured show notes (summary, key topics, resources)
 4. **Paste into your podcast host.** The text is already on your clipboard or pasted directly into the focused app.
-5. **Dictate again for the blog version.** Speak the same recap, switch to a different writing style preset, and let the post-processing reformat it as a full blog post.
+5. **Dictate again for the blog version.** Speak the same recap, swap in your "blog post" Custom prompt, and let the post-processing reformat it as a full blog post.
 6. **Light editing pass.** Clean up any details the LLM missed, add your episode embed link, publish.
 
 Total time for both show notes and a blog post: 10-15 minutes instead of an hour-plus of typing. You stay in your natural spoken medium the entire time.
@@ -99,7 +99,7 @@ Total time for both show notes and a blog post: 10-15 minutes instead of an hour
 
 Podcasters produce enormous amounts of spoken content that rarely gets repurposed. The friction isn't creative; you already have the ideas and the words. The friction is the format conversion: turning spoken thoughts into written text.
 
-Dictation with on-device post-processing removes that friction. You speak your show notes and blog posts the same way you speak your episodes. Writing style presets handle the tone, and the Custom preset handles fine-grained formatting. Everything stays local on your Mac.
+Dictation with on-device post-processing removes that friction. You speak your show notes and blog posts the same way you speak your episodes. The default polish handles tone and cleanup; Custom prompts handle fine-grained formatting. Everything stays local on your Mac.
 
 ## Related Posts
 
@@ -107,6 +107,6 @@ Dictation with on-device post-processing removes that friction. You speak your s
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
 - [On-device vs. cloud dictation: what's private](/blog/on-device-vs-cloud-dictation-privacy/). Why on-device matters for pre-release and embargoed podcast content.
 
-[Download EnviousWispr free](https://enviouswispr.com/#download). No account, no subscription, no API key required. The speech model downloads automatically on first launch. Choose a writing style preset, and start turning episodes into written content the same day. The source is [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases) if you want to inspect it first.
+[Download EnviousWispr free](https://enviouswispr.com/#download). No account, no subscription, no API key required. The speech model downloads automatically on first launch. Try the default polish, or write a Custom prompt for show-note formatting, and start turning episodes into written content the same day. The source is [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases) if you want to inspect it first.
 
 *Comparing tools for episode-to-text workflows? See [vs MacWhisper](/compare/macwhisper/), [vs Otter.ai](/compare/otter-ai/), or [browse all comparisons](/compare/).*

--- a/website/src/content/blog/switched-typing-to-dictating-git-commits.md
+++ b/website/src/content/blog/switched-typing-to-dictating-git-commits.md
@@ -1,6 +1,6 @@
 ---
 title: "Dictating Git Commits on macOS: Better Messages, Less Typing"
-description: "Dictating git commits produces better messages than typing. Here's how writing style presets and LLM post-processing make voice commit messages practical."
+description: "Dictating git commits produces better messages than typing. Here's how on-device polish and Custom prompts make voice commit messages practical."
 pubDate: 2026-03-16
 updatedDate: 2026-04-04
 tags: ["developer", "git", "workflow", "dictation"]
@@ -35,19 +35,21 @@ The other factor is speed. Speaking is roughly three to four times faster than t
 Developers who make this switch consistently report the same thing: looking back through their git history, the typed era is full of one-liners while the dictated era has context, reasoning, and descriptions that actually help when revisiting the code six months later.
 
 
-## Choosing the right writing style for commits
+## Shaping the polish for commit messages
 
-The key to making developer dictation practical is matching the tone to the context. For Slack replies, Friendly mode works well: natural, conversational. For documentation, Formal produces full prose with proper paragraphs.
+The key to making developer dictation practical is matching the output to the context. Slack replies want casual phrasing. Documentation wants full prose with proper paragraphs.
 
-But for commit messages, something stripped down works best: terse, technical, no fluff.
+For commit messages, something stripped down works best: terse, technical, no fluff.
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom), and for terminal work, Standard hits the sweet spot. It cleans up filler words, fixes punctuation, and keeps output direct without over-formalizing. No "So basically what I did was..." making it into a commit message. The post-processor keeps things technical and to the point.
+EnviousWispr's default polish already keeps output direct and technical without over-formalizing. No "So basically what I did was..." making it into a commit message. For terminal work, that's usually enough.
+
+When you want exact formatting (conventional commits, specific scope tags, mandatory body structure), a Custom prompt locks it in. Write something like "output as a conventional commit with type, scope, and body" and the polish step uses it for every dictation until you change it.
 
 ## How the post-processor shapes commit messages
 
-This is where it gets good. EnviousWispr's LLM post-processing step cleans up your spoken words into properly structured text. The Standard preset strips filler, fixes punctuation, and keeps output direct, which already gets you most of the way to a good commit message.
+This is where it gets good. EnviousWispr's LLM post-processing step cleans up your spoken words into properly structured text. The default polish strips filler, fixes punctuation, and keeps output direct, which already gets you most of the way to a good commit message.
 
-With the Custom preset, you can go even further: define exact formatting rules like "output as a conventional commit with type, scope, and body." You tell the post-processor precisely how to structure your commits, changelogs, or any other output format.
+With a Custom prompt, you can go even further: define exact formatting rules like "output as a conventional commit with type, scope, and body." You tell the post-processor precisely how to structure your commits, changelogs, or any other output format.
 
 The results are surprisingly good. Hold the hotkey and say:
 
@@ -110,7 +112,7 @@ A few things worth knowing when using developer dictation daily.
 
 **You'll feel weird at first.** Talking to your Mac in an open office is awkward. Starting at home helps, and most teams wear headphones anyway. If self-consciousness is a concern, start with commit messages: they're short, private, and the improvement is immediately visible in your git log.
 
-**Switching presets becomes second nature.** You'll quickly build a habit of toggling between Standard for terminal work and Friendly for Slack before you dictate. It's a single click.
+**A Custom prompt for commits is worth setting once.** A "conventional commit" prompt produces consistent, well-structured messages across every dictation in your terminal. Set it once and forget it.
 
 **It helps with RSI.** After eight-plus hours of typing every day, being able to offload even a portion of that to voice makes a noticeable difference in wrist strain by end of day. If RSI is your primary motivation, there's a dedicated guide on [voice input for RSI](/blog/voice-input-rsi-keyboard-free-workflow/).
 
@@ -120,7 +122,7 @@ If you want to try dictating git commits, here's the minimal setup.
 
 1. [Download EnviousWispr free](/#download) or grab it directly from the [releases page](https://github.com/saurabhav88/EnviousWispr/releases) and grant it microphone and accessibility permissions on first launch
 2. The speech model downloads automatically on first launch. No model selection needed.
-3. Select the **Standard** writing style preset. It keeps output direct and technical, which works well for commit messages.
+3. Leave polish on the default for direct, technical output, or set a "conventional commit" Custom prompt for stricter formatting.
 4. Open your terminal, hold the hotkey, describe your change, release
 
 That's the whole workflow. Hold, speak, release. Your commit message lands formatted and ready to go. EnviousWispr is [free](https://github.com/saurabhav88/EnviousWispr): no account, no API key, no subscription.

--- a/website/src/content/blog/take-lecture-notes-by-speaking.md
+++ b/website/src/content/blog/take-lecture-notes-by-speaking.md
@@ -29,13 +29,13 @@ Switch to **hands-free mode** by double-pressing your hotkey. This locks recordi
 
 Hands-free mode detects natural pauses in your speech, so each thought gets processed as its own chunk. You'll see transcribed text appear as you go.
 
-## Step 3: Pick the right writing style preset
+## Step 3: Tune the polish step for lecture notes
 
 Raw transcription is useful, but the real power for students is in post-processing. EnviousWispr runs your transcribed text through an LLM that cleans it up, removing filler words like "um" and "uh," fixing punctuation, and producing polished output. Post-processing can run on-device (Apple Intelligence, Ollama) or via cloud providers (OpenAI, Gemini).
 
-The app ships with four writing style presets (Standard, Formal, Friendly, and Custom). For lecture notes, **Standard** works well: it cleans up your speech into clear, well-punctuated prose without making it overly stiff.
+The default polish works well for lecture notes: it cleans up your speech into clear, well-punctuated prose without making it overly stiff.
 
-With the Custom preset, you can tell the post-processor to format output as bullet points, bold key terms, or organize by topic. You can tailor post-processing per class: chronological formatting for history, emphasis on formulas for science. The built-in presets also turn your raw dictation into clean, readable notes without any manual formatting during the lecture.
+When you want more structure, a Custom prompt lets you tell the post-processor exactly how to shape the output: format as bullet points, bold key terms, organize by topic. You can tailor your prompt per class: chronological formatting for history, emphasis on formulas for science. Save one prompt per subject and swap them in as the lecture changes.
 
 ## Step 4: Position your microphone and speak naturally
 
@@ -89,7 +89,7 @@ If you're ready to try voice notes for students, the setup takes less than five 
 1. [Download EnviousWispr free](/#download) or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases)
 2. Grant microphone access on first launch (the speech model downloads automatically)
 3. Double-press your hotkey to activate hands-free mode
-5. Pick a writing style preset
+5. Leave polish on the default, or write a Custom prompt for your subject
 6. Start your next lecture
 
 ## Related Posts

--- a/website/src/content/blog/voice-coding-macos-without-cloud.md
+++ b/website/src/content/blog/voice-coding-macos-without-cloud.md
@@ -45,7 +45,7 @@ Getting started takes about five minutes:
 
 3. **Set your hotkey.** Pick a key combination that doesn't collide with your IDE shortcuts. Hold to record, release to transcribe; the cycle completes in a second or two.
 
-4. **Choose a writing style preset.** EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) that control how the LLM post-processor shapes your output. Use Formal for documentation and PR descriptions, Standard for general-purpose writing, and Friendly for Slack and casual messages. Switch between them with a click as you move between tasks. With the Custom preset, you can tell the post-processor exactly what you need: "Format as a markdown bullet list," "Write in past tense for a changelog entry," "Keep it under two sentences."
+4. **Tune the polish step.** EnviousWispr's polish removes filler words, fixes punctuation, and tightens structure without flattening your voice. The default works well across most developer writing (PRs, review comments, docs, Slack). For specialized formatting, a Custom prompt lets you tell the post-processor exactly what you need: "Format as a markdown bullet list," "Write in past tense for a changelog entry," "Keep it under two sentences." The Custom prompt sticks until you change it.
 
 ## Real examples: where voice dictation fits a dev workflow
 
@@ -53,7 +53,7 @@ Getting started takes about five minutes:
 
 Writing docs is one of the highest-friction tasks in software development. You know the architecture. You can explain it verbally in two minutes. But sitting down to type it out feels like a chore, so it doesn't get done. Dictation lets you capture that explanation while it's still sharp in your mind, before the details fade and the motivation disappears.
 
-With EnviousWispr, you can talk through the architecture the way you'd explain it to a new teammate, and the post-processor formats it as clean markdown. Switch to the Formal writing style preset and you get a solid first draft by speaking naturally: proper paragraphs, clean punctuation, structured prose.
+With EnviousWispr, you can talk through the architecture the way you'd explain it to a new teammate, and the post-processor formats it as clean markdown. Set a Custom prompt for documentation ("output as structured markdown with proper paragraphs and code references in backticks") and you get a solid first draft by speaking naturally: proper paragraphs, clean punctuation, structured prose.
 
 Here's what that looks like in practice:
 
@@ -83,7 +83,7 @@ The LLM post-processor smooths the phrasing and fixes any verbal artifacts. The 
 
 Instead of switching mental modes to write a structured bug report, just describe what happened: "When you click the export button with an empty dataset, the app throws an unhandled exception instead of showing the empty state. Expected behavior is the empty state view with a message saying no data to export. Repro steps: create a new project, don't add any data, click export."
 
-Use the Formal preset to keep the output structured and professional, and the result arrives clean and ready to paste into your issue tracker.
+A Custom prompt for bug reports ("output as steps to reproduce, expected behavior, actual behavior") keeps the output structured, and the result arrives clean and ready to paste into your issue tracker.
 
 ## Cloud vs. local: an honest comparison
 
@@ -100,7 +100,7 @@ It's worth being direct about the trade-offs.
 - **Data stays on your machine.** No audio leaves your Mac. Period. This isn't a policy; it's an architecture. There's no server to send to.
 - **No latency dependency.** Transcription speed depends on your hardware, not your internet connection. On Apple Silicon, the full pipeline runs in one to two seconds.
 - **No recurring cost.** No API usage fees, no subscription tiers, no per-minute billing. EnviousWispr is free.
-- **Customization.** Writing style presets, custom prompts, and choice of LLM provider: you control the pipeline. Cloud APIs give you an endpoint and a response format.
+- **Customization.** Custom polish prompts and choice of LLM provider: you control the pipeline. Cloud APIs give you an endpoint and a response format.
 - **Works offline.** Airplane, coffee shop with bad WiFi, or just a network outage. Local transcription doesn't care.
 
 We cover this comparison in much more depth in [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). For developers specifically, the privacy argument usually closes the discussion. If you're dictating anywhere near proprietary code, internal discussions, or sensitive project details, sending that audio to an external API is a risk most security-conscious teams won't accept.
@@ -113,7 +113,7 @@ If you want to understand the full transcription and post-processing pipeline be
 
 ## Related Posts
 
-- [Dictation for Developers: Code Reviews and PRs](/blog/dictation-for-developers-code-reviews/). How to use writing style presets for PR descriptions, review comments, and docs.
+- [Dictation for Developers: Code Reviews and PRs](/blog/dictation-for-developers-code-reviews/). How on-device polish handles PR descriptions, review comments, and docs.
 - [Why I Switched from Typing to Dictating Git Commits](/blog/switched-typing-to-dictating-git-commits/). A real before-and-after comparison of typed vs. dictated commit messages.
 - [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). A fair comparison of where your recordings go.
 

--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -48,13 +48,11 @@ Here's a real example, dictating a status update instead of typing one:
 
 That took about ten seconds to speak. Typing it, with RSI making every keystroke a negotiation, would have taken two or three painful minutes. Same information, zero keystrokes.
 
-## Writing Style Presets for Different Contexts
+## AI Polish for Different Contexts
 
-One concern people have about switching to voice input is that different contexts need different kinds of text. A Slack message should sound casual. A client email needs a professional tone.
+One concern people have about switching to voice input is that different contexts need different kinds of text. A Slack message should sound casual. A client email needs a more structured tone.
 
-EnviousWispr ships with four writing style presets (Standard, Formal, Friendly, and Custom) that control how the AI polish shapes your dictated text. Switch to Friendly for casual Slack messages, Formal for client emails, or use Custom to write your own system prompt with specific formatting rules. It takes one click to change.
-
-Toggling between presets is fast and keeps the rework cycle to a minimum.
+EnviousWispr's AI polish step cleans up your dictation by removing filler words, fixing punctuation, and tightening structure. The default polish handles most everyday writing well: Slack threads, internal notes, ticket comments. For contexts where you need a specific shape (more structured client emails, formatted lists, particular phrasing), the Custom prompt option lets you write your own polish instructions and reuse them across dictations.
 
 This matters for RSI because it reduces the need to go back to the keyboard and fix tone or formatting. When voice output is already close to what you need, you're not adding correction keystrokes on top.
 
@@ -100,7 +98,7 @@ If you're dealing with RSI, the last thing you need is a setup process that invo
 
 That's three steps from download to functional voice input. The speech model downloads automatically on first launch. Works out of the box with no account creation and no payment. EnviousWispr is free.
 
-If you want to fine-tune the experience later (switching between writing style presets, adding custom words, setting a custom prompt) that's all available in settings. But the default configuration produces clean, accurate text out of the box.
+If you want to fine-tune the experience later (adding custom words, setting a custom polish prompt) that's all available in settings. But the default configuration produces clean, accurate text out of the box.
 
 ## This Isn't Medical Advice, But It Is Practical Advice
 

--- a/website/src/content/blog/voice-to-prose-writing-workflow.md
+++ b/website/src/content/blog/voice-to-prose-writing-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: "Voice to Prose on macOS: A Realistic Writing Workflow"
-description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, writing style presets, and first-draft setup tips."
+description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, custom polish prompts, and first-draft setup tips."
 pubDate: 2026-03-24
 updatedDate: 2026-04-04
 tags: ["writing", "workflow", "dictation", "writing-style"]
@@ -17,31 +17,24 @@ Understanding what happens between your voice and the finished text helps you ge
 
 1. **Record.** Hold the hotkey, speak, release. The app captures raw audio from your microphone.
 2. **Transcribe.** Your speech is converted to text locally via Core ML, using on-device speech recognition. This is a literal transcription; every filler word, false start, and repeated phrase comes through.
-3. **Post-process.** An LLM cleans up the raw transcription. It strips filler words, fixes punctuation, corrects grammar, and reshapes the text according to your chosen writing style preset (Formal, Standard, or Friendly).
+3. **Post-process.** An LLM cleans up the raw transcription. It strips filler words, fixes punctuation, corrects grammar, and tightens structure. If you want output shaped a specific way (a particular tone, format, or convention), a Custom prompt lets you tell the polish step exactly how to handle your dictation.
 
 The third step is where the writing happens. Raw transcription is messy. Post-processing is what turns "so basically what I'm trying to say is that like the pipeline has three steps and each one does a different thing" into a coherent sentence. You can read more about the technical details on the [how EnviousWispr's transcription pipeline works](/how-it-works/) page.
 
 The whole cycle takes a second or two on Apple Silicon. Fast enough that you don't lose your train of thought waiting for output.
 
-## Choosing the right writing style preset
+## Shaping the output with a Custom prompt
 
-The default post-processing does a solid job: it removes filler words, fixes punctuation, and produces clean sentences. But writers need to match the output to their context. That's what EnviousWispr's four writing style presets are for.
+The default post-processing does a solid job: it removes filler words, fixes punctuation, and produces clean sentences without flattening your voice. For most writing (blog drafts, journal entries, articles, freewriting) the default is the right starting point. The output reads like you wrote it: conversational, direct, human.
 
-### Friendly: for blog drafts and freewriting
+When you need a specific shape, a Custom prompt is the lever. You write a single instruction once and the polish step applies it to every dictation until you change it. A few that work well for writers:
 
-This is the preset most writers will reach for first. It cleans up filler words and fixes punctuation, but keeps your natural voice, contractions, and sentence rhythm intact. The output reads like you wrote it: conversational, direct, human. Perfect for blog posts, journal entries, and first drafts of anything.
+- "Keep my natural voice and contractions intact. Don't formalize." Useful for blog drafts.
+- "Tighten sentence structure and remove casual phrasing." Useful for client deliverables and formal essays.
+- "Format as screenplay-style dialogue with character names in caps." Useful for fiction.
+- "Keep this as stream of consciousness with line breaks, do not punctuate aggressively." Useful for raw morning pages.
 
-### Standard: the balanced middle ground
-
-A bit more polished than Friendly, Standard smooths out rough edges while keeping your core voice. Good for newsletter drafts, articles, or anything where you want clean prose without sounding corporate.
-
-### Formal: for professional and academic work
-
-When you need tighter, more structured output (client deliverables, formal essays, professional correspondence), Formal tightens sentence structure, removes casual phrasing, and produces polished prose.
-
-The point is this: you dictate once, and the preset shapes how it reads. Switching between presets takes one click, so you can draft a blog post in Friendly mode, then switch to Formal for a client email, without changing how you speak.
-
-With the Custom preset, you can write your own post-processing instructions for even more control: things like "format as screenplay dialogue" or "keep this as raw stream of consciousness."
+You can change the Custom prompt as your task changes (drafting one minute, client correspondence the next), and the polish step picks up the new instructions on your next dictation.
 
 ## A realistic example: before and after
 
@@ -105,11 +98,11 @@ The best workflow uses both. Dictate the rough draft. Type the edits. That's the
 
 [Download EnviousWispr free](https://enviouswispr.com/#download), no account, no subscription required. It takes a couple of minutes to set up on any Apple Silicon Mac running macOS Sonoma or later. On first launch, grant microphone access and the speech model downloads automatically. No model selection needed. The source is also [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases).
 
-Then try this: open whatever you're working on, hold the hotkey, and talk through your next paragraph. See what comes back. Try switching between the Friendly, Standard, and Formal presets until the output matches how you write.
+Then try this: open whatever you're working on, hold the hotkey, and talk through your next paragraph. See what comes back. Adjust your Custom prompt until the output matches how you write.
 
 ## Related Posts
 
-- [Dictate First Drafts That Sound Like You](/blog/dictate-first-drafts-sound-like-you/). How writing style presets preserve your voice during dictation.
+- [Dictate First Drafts That Sound Like You](/blog/dictate-first-drafts-sound-like-you/). How on-device polish preserves your voice during dictation.
 - [Dictation for Writers: Skip the Blank Page](/blog/dictation-for-writers-skip-blank-page/). Why speaking bypasses writer's block.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). Full setup walkthrough from download to first dictation.
 

--- a/website/src/content/blog/welcome-to-enviouswispr.md
+++ b/website/src/content/blog/welcome-to-enviouswispr.md
@@ -32,8 +32,8 @@ Spoken in ten seconds. Polished, structured, ready to send. Your audio never lef
 A few things that make it worth using day-to-day:
 
 - **Hands-free mode.** Double-press your hotkey to lock recording for longer dictation sessions. Triple-press to cancel.
-- **Writing style presets.** Choose between Standard, Formal, Friendly, or Custom to control the tone of your output.
-- **Custom prompts.** Tell the post-processor to write in your style, translate on the fly, or format output as bullet points.
+- **AI polish that keeps your voice.** The default polish step removes filler words, fixes punctuation, and tightens structure without flattening your phrasing.
+- **Custom prompts.** Write your own polish instructions for any context: "format as bullet points," "translate to Spanish," "write in my style: short sentences, no semicolons." The polish step uses your prompt for every dictation until you change it.
 - **Custom word dictionary.** Add names, technical terms, and jargon so the app gets your words right every time.
 
 ## Getting started


### PR DESCRIPTION
## Summary

Friendly and Formal (Professional) writing-style presets are being retired from the app. Standard and Custom remain. Polish itself stays.

This PR reframes every blog post that marketed "four writing style presets" or named specific presets. Default polish + Custom prompt is now the control surface for tone and shape.

## Affected files (20)

20 blog posts in `website/src/content/blog/`. Heavier H2/H3 rewrites in `dictation-for-developers-code-reviews.md`, `voice-input-rsi-keyboard-free-workflow.md`, `dictate-emails-speed-of-thought.md`, `voice-to-prose-writing-workflow.md`, `dictate-first-drafts-sound-like-you.md`, `essay-outline-by-talking-it-out.md`, `meeting-notes-polished-summaries.md`, `take-lecture-notes-by-speaking.md`, `voice-coding-macos-without-cloud.md`, `switched-typing-to-dictating-git-commits.md`, `dictation-remote-workers-tired-of-typing.md`. Lighter mentions cleaned in the rest.

## Acceptance check

- `grep -E "(\bFriendly\b|\bFormal\b|four writing style preset|preset)"` in `website/src/content/blog/` returns zero matches
- Frontmatter `description` fields updated where they mentioned presets
- Affected anchors removed cleanly (no orphaned headings)
- Build passes: 42 pages, 1.59s

## Lane

Content lane (per `marketing-lane` rule): no council, no Codex, no plan file, no eval gate. `council-skip: marketing-lane`.

## Test plan

- [x] `npx astro build` passes locally (42 pages, 1.59s)
- [x] Final grep shows zero remaining preset references
- [ ] CI `build-check` green
- [ ] Auto-merge on green

Closes #517
