### PR TITLE
content(blog): add Healthcare workflow post + repoint homepage card (#520)

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -45,6 +45,7 @@
 - [Meeting notes and polished summaries](https://enviouswispr.com/blog/meeting-notes-polished-summaries/): Post-meeting workflow.
 - [Podcast show notes to blog posts](https://enviouswispr.com/blog/podcast-show-notes-to-blog-posts/): Repurposing workflow.
 - [Async communication is better when you speak](https://enviouswispr.com/blog/async-communication-better-when-you-speak/): Async-first communication.
+- [macOS dictation for healthcare: on-device charting](https://enviouswispr.com/blog/dictation-for-healthcare-on-device-charting/): On-device clinical documentation, no BAA needed for the dictation step.
 
 ## Behind the scenes
 

--- a/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
+++ b/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
@@ -1,0 +1,135 @@
+---
+title: "macOS Dictation for Healthcare: On-Device Charting Without the Cloud"
+description: "On-device voice dictation for clinicians. Patient notes, referrals, and discharge summaries on your Mac. No cloud uploads, no BAA gymnastics."
+pubDate: 2026-04-30
+tags: ["healthcare", "dictation", "privacy", "charting", "hipaa"]
+draft: false
+author: "Saurabh Vaish"
+---
+
+It's 4:47 PM. You have nine charts to close before you can leave. Each one needs a SOAP note, a few referral letters need to go out tomorrow, and the discharge summary for the patient who was released this morning is still in draft. You sit down at the EMR, your hands hurt from a day of clicks, and you start typing.
+
+This is the quiet tax of modern medicine. Documentation has crept past the appointment itself in time cost. Most clinicians spend more of their workday charting than seeing patients. The American Medical Association has tracked this; ratios of two hours of EMR time per hour of patient time are typical. By the time you finish notes, the family time you wanted is gone.
+
+Dictation should fix this. The catch is that most dictation tools route your patient's name, history, and clinical findings through someone else's servers. For anyone working under HIPAA, that's a real conversation with the vendor, the BAA, and the IT department before you can even start. And the price tags on legacy medical dictation tools are not small.
+
+That's the gap on-device dictation closes. Hold a hotkey, speak your note, release. A second or two later, polished text lands in whatever EMR field has focus. The audio never leaves your Mac. There's no upload to negotiate, no third party to add to a BAA, no cloud round-trip to wait on.
+
+## Why most dictation tools are awkward for clinicians
+
+The built-in macOS dictation works in a basic way, but it sends audio to Apple's servers for processing in many configurations. Cloud-based dictation tools route everything to a vendor data center. Even when those vendors offer healthcare-tier contracts, you're still adding another link to the audit chain and another entity that has access to your patient's voice.
+
+A few practical problems with cloud dictation in a clinical setting:
+
+- **The audio is the sensitive thing.** Your transcript might say "Mr. Smith, 64-year-old male presenting with chest pain." But the audio holds his exact name, your voice, and any background sounds the mic picked up: a colleague's hallway conversation, a phone ringing in the next exam room, ambient PHI you didn't intend to capture. A cloud service receives all of that.
+- **BAAs cover policy, not architecture.** A signed BAA means a vendor agrees to handle PHI under HIPAA rules. It doesn't change the fact that the audio left your device, was processed on someone else's hardware, and may be retained for an audit window you don't control.
+- **Your IT department has to bless every new vendor.** Even small dictation tools become a procurement project. By the time you've gotten approval, you've already typed the chart by hand.
+- **It costs.** Dragon Medical and similar enterprise dictation tools run hundreds of dollars per clinician per year. For a small practice or a solo provider, that adds up fast.
+
+## What on-device dictation gets you
+
+EnviousWispr runs the entire pipeline on your Mac. The audio is captured, transcribed via on-device speech recognition through Core ML on the Neural Engine, and cleaned up by an LLM that can also run on-device using Apple Intelligence or Ollama. Nothing leaves your machine unless you explicitly choose a cloud LLM provider for the polish step (and you can pick on-device polish to keep the whole pipeline local).
+
+This is architecture, not policy. A few things follow from it:
+
+- **No vendor sees the audio.** The recording is processed in memory and discarded. There's no server log, no retention window, no third-party audit chain to navigate.
+- **No BAA needed for the dictation step itself.** Your existing EMR vendor's BAA still covers the chart that ends up in their system. EnviousWispr just hands you polished text on the clipboard or pastes it into the focused field; it has no role in storing or transmitting patient data.
+- **No internet required.** Charting in a basement office with bad WiFi, a rural clinic with patchy coverage, or a hospital floor where corporate WiFi is locked down all work the same way. Local speech recognition does not care.
+- **The economics are different.** EnviousWispr is free. There's no per-seat license, no annual renewal, no usage-based billing.
+
+A note on terminology: HIPAA is a regulation about how covered entities handle protected health information across their full workflow. EnviousWispr removes the audio-data risk surface that most dictation tools introduce, which is a meaningful piece. The rest of your HIPAA workflow (storage, access controls, audit logs, what your EMR does with the chart after you save it) is still your responsibility, and your existing controls there don't change. We're not selling HIPAA compliance; we're selling on-device architecture that doesn't add new exposure.
+
+For a deeper look at how on-device processing differs from cloud alternatives in general, see [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/).
+
+## Real workflows: charting between patients
+
+Here's what this actually looks like inside a typical EMR session.
+
+### SOAP notes in any EMR text field
+
+You finish with a patient. You walk back to your workstation. The EMR is already open with the chart focused. You click into the assessment field, hold your hotkey, and say:
+
+> "Patient is a 58-year-old female presenting with two-week history of progressive shortness of breath on exertion. Denies chest pain, fever, or recent travel. Exam notable for bilateral lower extremity edema and a new S3 gallop. EKG shows new left bundle branch block. BNP elevated at 1,400. Likely new-onset heart failure with reduced ejection fraction; will start guideline-directed medical therapy and refer to cardiology for echo and further evaluation. Will follow up in two weeks."
+
+You release. A second or two later, the field has cleaned-up text: punctuated, structured, ready to save. The polish step removed your filler words, fixed any verbal artifacts, and produced a chart entry that reads like you took the time to type it. Twenty seconds of speaking replaced what would have been three or four minutes of typing.
+
+EnviousWispr writes into whatever field has focus. That means it works in Epic's Smart Phrases, Cerner Millennium documentation pages, AthenaClinicals chart sections, NextGen progress notes, eClinicalWorks visit notes, OpenEMR free-text fields, or any web-based EMR you can click into. There's no integration to install. The text lands in the field as if you had typed it.
+
+### Referral letters between rounds
+
+Referral letters are repetitive in shape and unique in content. You name the patient, summarize the relevant history, state the clinical question, and ask for the consultation. That's a paragraph or two of structured prose every time.
+
+Hold the hotkey and dictate the body. The polish step formats it as a clean letter. If you want consistent salutations, sign-offs, or your standard closing language, write a Custom prompt that sets those expectations once and the polish step applies them to every dictation until you change it. A prompt like "format as a referral letter with a Dear Dr. X greeting, three short paragraphs, and a sign-off matching my role" sticks until you change it.
+
+### Discharge summaries before you leave
+
+Discharge summaries are the longest documentation task most clinicians hit during a typical shift. They cover admission course, key findings, treatments, current status, and the post-discharge plan. Typing one out at the end of a long day is the worst kind of fatigue work.
+
+Dictate it section by section. Speak the admission course as you remember it. Speak the hospital course. Speak the discharge plan. The polish step structures each chunk and you reorder if needed. A 15-minute typing job becomes a five-minute speaking job.
+
+### Voice typing for the parts of the day that aren't clinical
+
+Charting is most of the writing, but it isn't all of it. Email replies to staff, message threads with referring physicians, drafts to the practice manager, end-of-day notes to yourself. All of it is faster spoken. Hold the hotkey, talk, release. Same workflow, different field.
+
+## Custom prompts: lock in your documentation style
+
+EnviousWispr's polish step has a default that handles general writing well. For clinical documentation, a Custom prompt is worth setting once. The polish step uses your prompt for every dictation until you change it.
+
+A few patterns that work well for clinicians:
+
+- **SOAP format.** "Output structured as Subjective, Objective, Assessment, Plan with each section as its own paragraph. Preserve clinical terms and dosing details exactly."
+- **Referral letters.** "Format as a referral letter with a brief patient summary, the clinical question, and a closing thanking the consultant. Three paragraphs maximum."
+- **Discharge summaries.** "Output organized by Admission Course, Hospital Course, and Discharge Plan. Use bullet points where appropriate for medication lists and follow-up instructions."
+- **Patient instructions.** "Translate clinical jargon to plain language at a 6th-grade reading level. Use second-person voice. Output as a numbered list of action items."
+
+You can swap prompts as your task changes (a chart note one minute, a patient handout the next), and the polish step picks up the new instructions on your next dictation.
+
+## Compared to enterprise medical dictation
+
+Dragon Medical and similar enterprise tools have been the default for clinical dictation for years. They work, and they're integrated into many hospital systems. The trade-offs are real: hundreds of dollars per clinician per year, IT integration overhead, and (in many configurations) cloud-routed audio that adds to your BAA chain.
+
+EnviousWispr is a different shape:
+
+- **Free.** No license, no renewal.
+- **On-device by default.** No BAA needed for the dictation step.
+- **Works across every app.** Not bound to a specific EMR integration.
+- **Faster to set up.** Download, grant microphone access, start dictating. The full setup is under five minutes.
+- **No medical-specific vocabulary tuning out of the box.** This is a real trade-off. Dragon Medical includes specialty-tuned models. EnviousWispr's default models handle common clinical terminology well but do not match a specialty-tuned model for very niche vocabulary. The Custom Words feature lets you add specific terms (drug names, uncommon procedures, your colleagues' names) so the speech model gets them right. For most general clinical workflows, this gap closes quickly. For very subspecialty work with unusual terminology, you may want to evaluate carefully.
+
+## Privacy reality check
+
+Architectural privacy is a meaningful piece of a HIPAA workflow, not the whole thing. EnviousWispr removes one specific risk surface (audio data leaving your Mac during dictation). It doesn't replace your existing controls.
+
+What still matters in your full clinical workflow:
+
+- The EMR you paste into still has its own data flow, retention policy, and BAA obligations.
+- Your screen lock, login security, and physical access to the workstation still apply.
+- Anyone walking past while you're dictating can hear what you say.
+- If you choose a cloud LLM provider for the polish step, the cleaned-up text (without the original audio) goes through that provider. Use on-device polish (Apple Intelligence or Ollama) to keep the whole pipeline local.
+
+What changes:
+
+- The audio never reaches a vendor. There's no recording stored anywhere outside your Mac's working memory.
+- No new BAA is required for the dictation step.
+
+If you want the full picture on the privacy architecture, the [on-device vs cloud privacy post](/blog/on-device-vs-cloud-dictation-privacy/) covers what each approach does with your data and what that implies.
+
+## Getting started
+
+EnviousWispr is free to download. The source is available on GitHub under BSL 1.1.
+
+1. [Download EnviousWispr](/#download), or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases).
+2. Drag it to Applications. On first launch, grant microphone and accessibility permissions.
+3. The speech model downloads automatically. This takes a minute or two and is cached locally from then on.
+4. Pick a hotkey that doesn't collide with your EMR shortcuts. Hold to record, release to transcribe.
+5. Open your EMR, click into a chart field, hold the hotkey, and speak your first note. The polish step cleans it up and the text lands in the field.
+
+If you want consistent SOAP structure or referral-letter formatting, write a Custom prompt for that workflow in Settings under AI Polish. The prompt sticks until you change it.
+
+## Related Posts
+
+- [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). The full architectural comparison for privacy-conscious clinicians.
+- [Meeting Notes and Polished Summaries](/blog/meeting-notes-polished-summaries/). The post-meeting workflow that translates well to clinical handoffs.
+- [Voice Input for RSI: Keyboard-Free Workflow](/blog/voice-input-rsi-keyboard-free-workflow/). For clinicians dealing with hand and wrist strain from documentation load.
+
+*Comparing dictation tools for clinical use? See [vs Dragon](/compare/dragon/), [vs WisprFlow](/compare/wisprflow/), or [browse all comparisons](/compare/).*

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -286,7 +286,7 @@ const jsonLdFaq = JSON.stringify({
           <span class="uc-cta">Read the workflow</span>
         </a>
 
-        <a href="/blog/macos-dictation-offline-private/" class="uc-card reveal" style="--i:8">
+        <a href="/blog/dictation-for-healthcare-on-device-charting/" class="uc-card reveal" style="--i:8">
           <span class="uc-badge"><span class="uc-badge-icon" aria-hidden="true">🩺</span>For Healthcare</span>
           <h3 class="uc-headline">Chart notes without the keyboard.</h3>
           <p class="uc-tasks">Patient notes, referral letters, discharge summaries. Nothing leaves your Mac.</p>


### PR DESCRIPTION
## Summary

The homepage 3×3 use-cases grid (#515) had 8 of 9 cards linking to a persona-specific blog post. The 9th, "For Healthcare", placeholder-linked to the privacy post. This PR fills the gap.

## Changes

- **New post:** `website/src/content/blog/dictation-for-healthcare-on-device-charting.md` (~1,900 words). Covers SOAP charting in any EMR field (Epic / Cerner / Athena / NextGen / OpenEMR), referral letters, discharge summaries, custom prompts for clinical formats, comparison to Dragon Medical, and a HIPAA reality check.
- **Homepage card:** `website/src/pages/index.astro` Healthcare card `href` updated from `/blog/macos-dictation-offline-private/` to the new slug.
- **`llms.txt`:** new entry under Use Cases.

## Compliance / brand checks

- No em-dashes / en-dashes (grep clean).
- BSL 1.1 source-available framing; no "open source" claim.
- HIPAA framed as architectural risk-surface reduction, not compliance certification. Explicitly says "we're not selling HIPAA compliance; we're selling on-device architecture that doesn't add new exposure."
- Custom prompts framing (no preset names, consistent with #517 sweep).
- Brand voice: relief-centered, plain-spoken.

## Build

43 pages (up from 42). 1.43s build time.

## Lane

Content lane (per `marketing-lane` rule): no council, no Codex, no plan file, no eval gate. `council-skip: marketing-lane`.

## Test plan

- [x] `npx astro build` passes locally
- [x] Healthcare post appears in `dist/blog/dictation-for-healthcare-on-device-charting/`
- [x] Homepage Healthcare card href points to new post
- [x] `llms.txt` lists the new post under Use Cases
- [ ] CI `build-check` green
- [ ] Auto-merge on green

Closes #520
