### PR TITLE
feat(website): blog post sidebar with TOC, share buttons, related (#512)

### DIFF
--- a/website/src/components/BlogShareRow.astro
+++ b/website/src/components/BlogShareRow.astro
@@ -1,0 +1,117 @@
+---
+// Always-visible share row that lives below the article body and above related-posts.
+// Stays accessible at all viewport widths and at browser zoom > 100% where the desktop
+// sidebar would disappear. Same set of share networks as BlogSidebar (Copy / X / LinkedIn / Email).
+//
+// Behavior is wired by the shared share-buttons script in BlogPost.astro — both this row and
+// the sidebar use `data-share="..."` and the same script handles them with a single delegate.
+---
+<section class="blog-share-row" aria-label="Share this post">
+  <span class="share-row-label">Share</span>
+  <div class="share-row-buttons" data-share-block="row">
+    <button type="button" class="share-row-btn share-row-btn-primary" data-share="copy" aria-label="Copy link">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      <span class="share-row-btn-label">Copy link</span>
+    </button>
+    <button type="button" class="share-row-btn" data-share="x" aria-label="Share on X">
+      <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      <span class="share-row-btn-label">X</span>
+    </button>
+    <button type="button" class="share-row-btn" data-share="linkedin" aria-label="Share on LinkedIn">
+      <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.95v5.66H9.36V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45z"/></svg>
+      <span class="share-row-btn-label">LinkedIn</span>
+    </button>
+    <button type="button" class="share-row-btn" data-share="email" aria-label="Share via email">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+      <span class="share-row-btn-label">Email</span>
+    </button>
+  </div>
+</section>
+
+<style>
+  .blog-share-row {
+    margin-top: 48px;
+    padding: 20px 24px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    background: var(--surface);
+  }
+
+  .share-row-label {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-3);
+  }
+
+  .share-row-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .share-row-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    min-height: 44px;
+    box-sizing: border-box;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: #fff;
+    color: var(--text-2);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+  }
+
+  .share-row-btn:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .share-row-btn-primary {
+    background: var(--text);
+    color: #fff;
+    border-color: var(--text);
+  }
+
+  .share-row-btn-primary:hover {
+    background: #2a2035;
+    border-color: #2a2035;
+    color: #fff;
+  }
+
+  .share-row-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .share-row-btn.share-btn-success {
+    background: rgba(110, 231, 183, 0.18);
+    color: #047857;
+    border-color: rgba(110, 231, 183, 0.5);
+  }
+
+  @media (max-width: 600px) {
+    .blog-share-row {
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 16px 20px;
+    }
+    .share-row-buttons {
+      width: 100%;
+    }
+    .share-row-btn {
+      flex: 1 1 calc(50% - 6px);
+      justify-content: center;
+    }
+  }
+</style>

--- a/website/src/components/BlogSidebar.astro
+++ b/website/src/components/BlogSidebar.astro
@@ -1,0 +1,289 @@
+---
+// Desktop-only sticky sidebar for blog posts.
+// - Auto-generated TOC from H2/H3 inside .blog-body, with IntersectionObserver scroll-spy.
+// - Sidebar share row (Copy / X / LinkedIn / Email) — duplicates BlogShareRow at bottom for desktop convenience.
+// - Hidden below 1080px viewport. Always-visible share lives in BlogShareRow at bottom of article.
+//
+// Accessibility:
+// - <nav aria-label="On this page"> for TOC.
+// - <button> elements for share actions (real interactive controls).
+// - aria-live="polite" status region updates on copy success.
+// - Skip-link is rendered by BlogPost.astro at the top of .blog-post-main, targeting #blog-toc.
+---
+<aside class="blog-post-sidebar" aria-label="Article side rail">
+  <nav class="toc" id="blog-toc" aria-label="On this page">
+    <p class="toc-label">On this page</p>
+    <ul id="toc-list" class="toc-list"></ul>
+  </nav>
+  <div class="sidebar-share-block">
+    <p class="sidebar-share-label">Share</p>
+    <div class="sidebar-share-buttons" data-share-block="sidebar">
+      <button type="button" class="sidebar-share-btn sidebar-share-btn-primary" data-share="copy" aria-label="Copy link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        <span class="sidebar-share-btn-label">Copy link</span>
+      </button>
+      <button type="button" class="sidebar-share-btn" data-share="x" aria-label="Share on X">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        <span class="sidebar-share-btn-label">X</span>
+      </button>
+      <button type="button" class="sidebar-share-btn" data-share="linkedin" aria-label="Share on LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13" aria-hidden="true"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.95v5.66H9.36V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45z"/></svg>
+        <span class="sidebar-share-btn-label">LinkedIn</span>
+      </button>
+      <button type="button" class="sidebar-share-btn" data-share="email" aria-label="Share via email">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="13" height="13" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        <span class="sidebar-share-btn-label">Email</span>
+      </button>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .blog-post-sidebar {
+    display: none;
+  }
+
+  @media (min-width: 1080px) {
+    .blog-post-sidebar {
+      display: block;
+      position: sticky;
+      top: 100px;
+      max-height: calc(100vh - 120px);
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+  }
+
+  /* TOC */
+  .toc {
+    margin-bottom: 32px;
+  }
+
+  .toc-label,
+  .sidebar-share-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-3);
+    margin: 0 0 12px 0;
+  }
+
+  .toc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border-left: 1px solid var(--border);
+  }
+
+  .toc-item {
+    margin: 0;
+  }
+
+  .toc-list a {
+    display: block;
+    padding: 8px 12px;
+    min-height: 36px;
+    box-sizing: border-box;
+    margin-left: -1px;
+    border-left: 2px solid transparent;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--text-3);
+    text-decoration: none;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .toc-list a:hover {
+    color: var(--text);
+  }
+
+  .toc-list a[aria-current="location"] {
+    color: var(--accent);
+    font-weight: 600;
+    border-left-color: var(--accent);
+  }
+
+  .toc-h3 a {
+    padding-left: 28px;
+    font-size: 12.5px;
+  }
+
+  /* Share block in sidebar */
+  .sidebar-share-block {
+    border-top: 1px solid var(--border);
+    padding-top: 24px;
+  }
+
+  .sidebar-share-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .sidebar-share-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    min-height: 40px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--text-2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+    text-align: left;
+  }
+
+  .sidebar-share-btn:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .sidebar-share-btn-primary {
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-color: rgba(124, 58, 237, 0.18);
+    font-weight: 600;
+  }
+
+  .sidebar-share-btn-primary:hover {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+
+  .sidebar-share-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .sidebar-share-btn.share-btn-success {
+    background: rgba(110, 231, 183, 0.15);
+    color: #047857;
+    border-color: rgba(110, 231, 183, 0.4);
+  }
+</style>
+
+<script>
+  (function () {
+    const tocList = document.getElementById('toc-list');
+    if (!tocList) return;
+
+    const headings = Array.from(
+      document.querySelectorAll<HTMLHeadingElement>('.blog-body h2, .blog-body h3'),
+    );
+    if (headings.length < 3) {
+      // Sidebar still shows share block — TOC is the only thing hidden.
+      // If sidebar should disappear entirely on TOC-less posts, that's a v1.1 decision.
+      const tocBlock = tocList.closest('.toc') as HTMLElement | null;
+      if (tocBlock) tocBlock.style.display = 'none';
+      return;
+    }
+
+    const usedIds = new Set<string>();
+    const items: Array<{ id: string; link: HTMLAnchorElement; heading: HTMLHeadingElement }> = [];
+
+    headings.forEach((h) => {
+      let id = h.id;
+      if (!id) {
+        const base = (h.textContent || '')
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, '')
+          .trim()
+          .replace(/\s+/g, '-')
+          .slice(0, 80) || 'section';
+        id = base;
+        let suffix = 2;
+        while (usedIds.has(id) || document.getElementById(id)) {
+          id = `${base}-${suffix}`;
+          suffix += 1;
+        }
+        h.id = id;
+      }
+      usedIds.add(id);
+
+      const li = document.createElement('li');
+      li.className = `toc-item toc-${h.tagName.toLowerCase()}`;
+      const a = document.createElement('a');
+      a.href = `#${id}`;
+      a.textContent = h.textContent || '';
+      a.dataset.tocTarget = id;
+      li.appendChild(a);
+      tocList.appendChild(li);
+      items.push({ id, link: a, heading: h });
+    });
+
+    if (!('IntersectionObserver' in window)) return;
+
+    const setActive = (id: string | null) => {
+      items.forEach((it) => {
+        if (it.id === id) {
+          it.link.setAttribute('aria-current', 'location');
+        } else {
+          it.link.removeAttribute('aria-current');
+        }
+      });
+      // Stash the active id so the share buttons can compose section-anchor URLs.
+      if (id) {
+        document.documentElement.dataset.tocActive = id;
+      } else {
+        delete document.documentElement.dataset.tocActive;
+      }
+    };
+
+    const intersecting = new Set<string>();
+
+    const recompute = () => {
+      // Prefer the topmost currently-intersecting heading.
+      const inZone = items.find((it) => intersecting.has(it.id));
+      if (inZone) {
+        setActive(inZone.id);
+        return;
+      }
+      // Otherwise pick the last heading that has scrolled above the active band — that's
+      // the section the reader is currently inside.
+      const ACTIVE_TOP = 100;
+      let lastPassed: typeof items[number] | null = null;
+      for (const it of items) {
+        if (it.heading.getBoundingClientRect().top < ACTIVE_TOP) lastPassed = it;
+      }
+      setActive(lastPassed ? lastPassed.id : null);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          const id = (e.target as HTMLElement).id;
+          if (e.isIntersecting) intersecting.add(id);
+          else intersecting.delete(id);
+        });
+        recompute();
+      },
+      {
+        rootMargin: '-100px 0px -70% 0px',
+        threshold: 0,
+      },
+    );
+
+    items.forEach((it) => observer.observe(it.heading));
+
+    // Recompute on scroll for the "passed but no longer intersecting" fallback.
+    let scrollTick = false;
+    window.addEventListener(
+      'scroll',
+      () => {
+        if (scrollTick) return;
+        scrollTick = true;
+        requestAnimationFrame(() => {
+          scrollTick = false;
+          recompute();
+        });
+      },
+      { passive: true },
+    );
+  })();
+</script>

--- a/website/src/components/BlogSidebar.astro
+++ b/website/src/components/BlogSidebar.astro
@@ -177,8 +177,9 @@
       document.querySelectorAll<HTMLHeadingElement>('.blog-body h2, .blog-body h3'),
     );
     if (headings.length < 3) {
-      // Sidebar still shows share block — TOC is the only thing hidden.
-      // If sidebar should disappear entirely on TOC-less posts, that's a v1.1 decision.
+      // Sidebar still shows share block. Mark <html> so the skip-link in BlogPost.astro
+      // hides itself (otherwise keyboard users tab to a dead target).
+      document.documentElement.classList.add('toc-hidden');
       const tocBlock = tocList.closest('.toc') as HTMLElement | null;
       if (tocBlock) tocBlock.style.display = 'none';
       return;
@@ -187,21 +188,26 @@
     const usedIds = new Set<string>();
     const items: Array<{ id: string; link: HTMLAnchorElement; heading: HTMLHeadingElement }> = [];
 
+    const slugify = (text: string): string =>
+      text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+        .slice(0, 80) || 'section';
+
     headings.forEach((h) => {
-      let id = h.id;
-      if (!id) {
-        const base = (h.textContent || '')
-          .toLowerCase()
-          .replace(/[^\w\s-]/g, '')
-          .trim()
-          .replace(/\s+/g, '-')
-          .slice(0, 80) || 'section';
-        id = base;
-        let suffix = 2;
-        while (usedIds.has(id) || document.getElementById(id)) {
-          id = `${base}-${suffix}`;
-          suffix += 1;
-        }
+      // Dedupe every heading ID — including ones rehype-slug may have already generated —
+      // because authored markdown can produce repeat headings ("Setup", "Why this matters")
+      // that the markdown processor will assign the same id, breaking TOC anchors.
+      const baseId = h.id || slugify(h.textContent || '');
+      let id = baseId;
+      let suffix = 2;
+      while (usedIds.has(id)) {
+        id = `${baseId}-${suffix}`;
+        suffix += 1;
+      }
+      if (h.id !== id) {
         h.id = id;
       }
       usedIds.add(id);

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import BlogSidebar from '../components/BlogSidebar.astro';
+import BlogShareRow from '../components/BlogShareRow.astro';
 
 interface RelatedPost {
   slug: string;
@@ -140,7 +142,10 @@ const breadcrumbJsonLd = JSON.stringify({
     {faqJsonLd && <script type="application/ld+json" set:html={faqJsonLd}></script>}
   </Fragment>
   <div class="blog-post-page">
-    <div class="blog-post-container">
+    <div class="blog-post-grid">
+      <div class="blog-post-main">
+
+      <a href="#blog-toc" class="skip-to-toc">Skip to On this page</a>
 
       <a href="/blog/" class="back-link">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
@@ -190,6 +195,10 @@ const breadcrumbJsonLd = JSON.stringify({
         </div>
       </section>
 
+      <BlogShareRow />
+
+      <div id="share-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
       <aside class="author-bio" aria-label="About the author">
         <div class="author-bio-inner">
           <div class="author-bio-text">
@@ -231,6 +240,10 @@ const breadcrumbJsonLd = JSON.stringify({
         </a>
       </nav>
 
+      </div><!-- /.blog-post-main -->
+
+      <BlogSidebar />
+
     </div>
   </div>
 </BaseLayout>
@@ -242,10 +255,62 @@ const breadcrumbJsonLd = JSON.stringify({
     z-index: 1;
   }
 
-  .blog-post-container {
+  .blog-post-grid {
     max-width: 720px;
     margin: 0 auto;
     padding: 0 32px;
+  }
+
+  .blog-post-main {
+    min-width: 0;
+  }
+
+  @media (min-width: 1080px) {
+    .blog-post-grid {
+      max-width: 1080px;
+      display: grid;
+      grid-template-columns: 720px 240px;
+      column-gap: 60px;
+      align-items: start;
+    }
+  }
+
+  /* Skip-link for keyboard users to reach the desktop TOC.
+     Visible only when focused; in DOM order it sits at the top of .blog-post-main,
+     before the back-link, so Tab from page chrome lands here first. */
+  .skip-to-toc {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+  .skip-to-toc:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    display: inline-block;
+    padding: 8px 14px;
+    margin-bottom: 16px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 6px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   /* Back link */
@@ -717,7 +782,7 @@ const breadcrumbJsonLd = JSON.stringify({
     .blog-post-page {
       padding: 100px 0 64px;
     }
-    .blog-post-container {
+    .blog-post-grid {
       padding: 0 20px;
     }
     .blog-title {
@@ -750,6 +815,94 @@ const breadcrumbJsonLd = JSON.stringify({
     });
     pre.appendChild(btn);
   });
+</script>
+
+<script>
+  // Share buttons — handles both BlogSidebar and BlogShareRow via event delegation.
+  // Telemetry fires AFTER success: clipboard write resolves, or window.open returns
+  // (popup blockers will swallow the open call but the click intent has already happened).
+  // For email (mailto:) we fire on click since the OS hands off and we can't observe.
+  (function () {
+    const slug = window.location.pathname.replace(/^\/blog\//, '').replace(/\/$/, '');
+    const title = document.title;
+
+    const fireTelemetry = (network: string) => {
+      const w = window as unknown as { posthog?: { capture?: (e: string, p: object) => void } };
+      if (typeof w.posthog !== 'undefined' && typeof w.posthog.capture === 'function') {
+        w.posthog.capture('share_clicked', { network, slug });
+      }
+    };
+
+    const status = document.getElementById('share-status');
+    const announce = (msg: string) => {
+      if (status) status.textContent = msg;
+    };
+
+    const composeUrl = () => {
+      // Prefer section-anchor when scroll-spy has marked an active heading.
+      const activeId = document.documentElement.dataset.tocActive;
+      const base = window.location.origin + window.location.pathname;
+      return activeId ? `${base}#${activeId}` : base;
+    };
+
+    const handleClick = async (btn: HTMLButtonElement) => {
+      const network = btn.getAttribute('data-share');
+      if (!network) return;
+      const url = composeUrl();
+
+      if (network === 'copy') {
+        try {
+          await navigator.clipboard.writeText(url);
+          fireTelemetry('copy');
+          announce('Link copied to clipboard');
+          flashSuccess(btn, 'Copied!');
+        } catch {
+          announce('Copy failed. Use your browser’s URL bar instead.');
+        }
+        return;
+      }
+
+      if (network === 'email') {
+        const subject = encodeURIComponent(title);
+        const body = encodeURIComponent(`${title}\n\n${url}`);
+        const href = `mailto:?subject=${subject}&body=${body}`;
+        fireTelemetry('email');
+        window.location.href = href;
+        return;
+      }
+
+      if (network === 'x') {
+        const intent = `https://x.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`;
+        fireTelemetry('x');
+        window.open(intent, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
+      if (network === 'linkedin') {
+        const intent = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+        fireTelemetry('linkedin');
+        window.open(intent, '_blank', 'noopener,noreferrer');
+        return;
+      }
+    };
+
+    const flashSuccess = (btn: HTMLButtonElement, label: string) => {
+      const labelEl = btn.querySelector<HTMLElement>('[class$="-btn-label"]');
+      const original = labelEl?.textContent;
+      if (labelEl) labelEl.textContent = label;
+      btn.classList.add('share-btn-success');
+      setTimeout(() => {
+        if (labelEl && typeof original === 'string') labelEl.textContent = original;
+        btn.classList.remove('share-btn-success');
+      }, 1800);
+    };
+
+    document.querySelectorAll<HTMLButtonElement>('[data-share]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        void handleClick(btn);
+      });
+    });
+  })();
 </script>
 
 <script is:inline>

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -276,29 +276,38 @@ const breadcrumbJsonLd = JSON.stringify({
   }
 
   /* Skip-link for keyboard users to reach the desktop TOC.
-     Visible only when focused; in DOM order it sits at the top of .blog-post-main,
-     before the back-link, so Tab from page chrome lands here first. */
+     Removed from focus order entirely below 1080px (where the sidebar is hidden) and on
+     TOC-less posts (where BlogSidebar's script adds .toc-hidden to the <html> element).
+     Otherwise visible only when focused. */
   .skip-to-toc {
-    position: absolute;
-    left: -9999px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
+    display: none;
   }
-  .skip-to-toc:focus {
-    position: static;
-    width: auto;
-    height: auto;
-    display: inline-block;
-    padding: 8px 14px;
-    margin-bottom: 16px;
-    background: var(--accent);
-    color: #fff;
-    font-size: 13px;
-    font-weight: 600;
-    text-decoration: none;
-    border-radius: 6px;
+  @media (min-width: 1080px) {
+    .skip-to-toc {
+      display: inline-block;
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+    .skip-to-toc:focus {
+      position: static;
+      width: auto;
+      height: auto;
+      padding: 8px 14px;
+      margin-bottom: 16px;
+      background: var(--accent);
+      color: #fff;
+      font-size: 13px;
+      font-weight: 600;
+      text-decoration: none;
+      border-radius: 6px;
+    }
+    :root.toc-hidden .skip-to-toc {
+      display: none;
+    }
   }
 
   .sr-only {


### PR DESCRIPTION
## Summary

Adds a sticky right-rail sidebar to blog posts on desktop (≥1080px) plus an always-visible share row below the article. Closes #512.

- **TOC** auto-generated from H2/H3, IntersectionObserver scroll-spy, collision-safe heading-ID dedup.
- **Share** in two surfaces: sidebar buttons (desktop sidebar) + inline share row (always visible). Four networks: Copy link (primary), X, LinkedIn, Email (mailto:). Section-anchor copy uses the active heading from scroll-spy.
- **Skip-link** to #blog-toc for keyboard users; only shown when sidebar is showing (no dead-target trap on mobile or TOC-less posts).
- **aria-live="polite"** status region announces "Link copied to clipboard" on success.
- **Telemetry** fires after success: PostHog `share_clicked` with `{ network, slug }`. No transcript content.

## Process

- Plan: `docs/feature-requests/issue-512-2026-04-30-blog-sidebar.md` (local-only, gitignored).
- Council: 4 personas (Marcus / Diana / Aaron / Frank) × 2 providers = 8 background subagents. Convergent feedback: dishonest tab order claim, telemetry on click vs success, missing email, zoom-collapse hides share, missing aria-live, larger click targets.
- Grounded review: codex `gpt-5.5` flagged 2 WARNINGs on the initial commit (dead skip-link target, pre-existing duplicate IDs not deduped); fixed in follow-up commit.
- Smoke validation: 10/10 Playwright assertions pass on a long blog post (sidebar visible at 1440px, hidden at 900px and 375px, TOC has 12 unique anchors, scroll-spy sets aria-current, copy returns URL with section anchor, skip-link removed from focus order at small widths).

## Test plan

- [ ] Open any long blog post on desktop (≥1080px). Verify sticky TOC on the right, sections highlight as you scroll.
- [ ] Click "Copy link" while inside a section: clipboard contains URL with `#section-id`.
- [ ] Verify visible "Copied!" label change; screen readers announce "Link copied to clipboard".
- [ ] Resize browser below 1080px. Sidebar disappears. Share row remains visible at the bottom of the article.
- [ ] Tab through the page on desktop — confirm skip-link works (jumps focus to TOC).
- [ ] Open PostHog Live View; click each share button; verify `share_clicked` events with `network` ∈ {copy, x, linkedin, email}.
