### PR TITLE
fix(website): blog sidebar TOC was rendering unstyled (Astro scope miss)

### DIFF
--- a/website/src/components/BlogSidebar.astro
+++ b/website/src/components/BlogSidebar.astro
@@ -69,6 +69,8 @@
     margin: 0 0 12px 0;
   }
 
+  /* TOC list items are created at runtime via document.createElement, so they don't
+     receive Astro's scoped class hashes. Use :global() so the styles match. */
   .toc-list {
     list-style: none;
     padding: 0;
@@ -76,37 +78,38 @@
     border-left: 1px solid var(--border);
   }
 
-  .toc-item {
+  .toc-list :global(li) {
     margin: 0;
+    padding: 0;
   }
 
-  .toc-list a {
+  .toc-list :global(a) {
     display: block;
-    padding: 8px 12px;
-    min-height: 36px;
-    box-sizing: border-box;
+    padding: 6px 14px;
     margin-left: -1px;
     border-left: 2px solid transparent;
-    font-size: 13px;
-    line-height: 1.45;
+    font-size: 12.5px;
+    line-height: 1.4;
     color: var(--text-3);
     text-decoration: none;
+    font-weight: 500;
     transition: color 0.15s ease, border-color 0.15s ease;
   }
 
-  .toc-list a:hover {
+  .toc-list :global(a:hover) {
     color: var(--text);
   }
 
-  .toc-list a[aria-current="location"] {
+  .toc-list :global(a[aria-current="location"]) {
     color: var(--accent);
     font-weight: 600;
     border-left-color: var(--accent);
   }
 
-  .toc-h3 a {
+  .toc-list :global(li.toc-h3 a) {
     padding-left: 28px;
-    font-size: 12.5px;
+    font-size: 12px;
+    color: var(--text-3);
   }
 
   /* Share block in sidebar */


### PR DESCRIPTION
## Summary

The TOC items in the blog sidebar shipped in #534 were rendering as raw blue underlined text, ignoring all the styling I wrote in BlogSidebar.astro. Cause: TOC `<li>` and `<a>` elements are created at runtime via `document.createElement`, so they don't receive Astro's scoped CSS class hashes. The component's scoped selectors (`.toc-list a {...}`) targeted the hashed attribute and missed every runtime-created descendant.

Fix: wrap descendant selectors in `:global()` — `.toc-list :global(a) {...}`, `.toc-list :global(li.toc-h3 a) {...}`. Tightened the visual design while in there.

## Verified

Playwright screenshot at 1440px on the healthcare blog post: muted gray TOC links, no underlines, 12.5px font with 6px vertical padding, H3s indented to 28px. Computed styles: color rgb(102,90,125), text-decoration none, font-weight 500.

## Test plan

- [ ] Open any blog post on desktop (≥1080px). TOC reads as a compact muted list, not a blue wall of text.
- [ ] H3 items (subsections) are indented and slightly smaller than H2 items.
- [ ] Hover a TOC link — color shifts to default text color, no underline appears.
- [ ] Scroll: active section gets purple text + left border, all without bringing back underlines.
