### PR TITLE
seo: AI crawler allows + Organization sameAs (closes #539)

### DIFF
--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,39 @@
+# Default: open to all crawlers, including search engines.
 User-agent: *
+Allow: /
+
+# Explicit AI crawler allows. We want to be cited by AI search.
+# (User-agent: * already permits these; explicit rules are an
+# affirmative signal that we welcome citation, not just access.)
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: CCBot
 Allow: /
 
 Sitemap: https://enviouswispr.com/sitemap-index.xml

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,9 @@ const jsonLdOrg = JSON.stringify({
   "logo": "https://enviouswispr.com/favicon.svg",
   "sameAs": [
     "https://x.com/EnviousLabs",
-    "https://github.com/saurabhav88/EnviousWispr"
+    "https://www.youtube.com/@EnviousLabs",
+    "https://www.linkedin.com/company/envious-labs/",
+    "https://github.com/Envious-Labs-LLC"
   ]
 });
 


### PR DESCRIPTION
## Summary

Two zero-blast-radius SEO improvements bundled. Both target AI search visibility per the textbook-load of all 23 claude-seo skills (2026-04-30 session).

- **robots.txt** — explicit Allow blocks for GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Bingbot, CCBot. The wildcard rule already permits these; explicit allows serve as an affirmative "we want to be cited" signal.
- **Organization JSON-LD sameAs** — added youtube.com/@EnviousLabs, linkedin.com/company/envious-labs/, github.com/Envious-Labs-LLC. Removed the personal-account github URL (kept under Person schema where it belongs). Closes #539.

Both changes target the same root insight: brand mentions correlate ~3x stronger than backlinks for AI citations (Ahrefs Dec 2025). YouTube specifically at 0.737. The sameAs array is how schema declares entity equivalence to Google's Knowledge Graph and downstream AI training corpora.

## Test plan

- [ ] CI build-check green
- [ ] Manual: load `https://enviouswispr.com/robots.txt` after deploy, verify explicit AI crawler stanzas present
- [ ] Manual: view-source on homepage, verify `Organization` JSON-LD sameAs has 4 entries
- [ ] Validator: paste homepage HTML into https://validator.schema.org — Organization block should validate

## Tier

`council-skip: zero-blast-radius` (single-value config / user-facing copy / 35+3 line additive change, no new symbols, single-commit revertible). Per workflow-process.md §1 narrow exception.

## Refs

- Closes #539 (Organization sameAs gap)
- Companion to #536 (compare-page uniqueness audit)
- Companion to #537 (indexation diagnostic)
- Companion to #538 (brand-mention strategy)
- knowledge/seo-operations.md `RULE: corrected-seo-2026`
