### PR TITLE
fix(audio): RotatingFileSink — loop write(2) to handle short writes + EINTR (#478)

### DIFF
--- a/Sources/EnviousWisprAudio/RotatingFileSink.swift
+++ b/Sources/EnviousWisprAudio/RotatingFileSink.swift
@@ -24,6 +24,9 @@ import os
 ///   safety automatically. The path/maxSize/maxFiles are immutable; the only
 ///   mutable state is the on-disk file itself, which is protected by the two
 ///   locks above.
+/// - Writes loop on short returns from `write(2)` and retry on `EINTR` so a
+///   partial syscall never truncates a log line and still proceeds into
+///   rotation. See `writeAllBytes(_:_:_:)`.
 ///
 /// ## Rotation policy
 ///
@@ -103,13 +106,15 @@ public final class RotatingFileSink: @unchecked Sendable {
     guard flock(lockFd, LOCK_EX) == 0 else { return }
     defer { _ = flock(lockFd, LOCK_UN) }
 
-    // 2. Active log: open separately and write.
+    // 2. Active log: open separately and write. `writeAllBytes` loops on
+    // short writes and retries on EINTR so that a partial `write(2)` cannot
+    // truncate the message and still proceed into rotation logic.
     let logFd = path.path.withCString { open($0, O_WRONLY | O_APPEND | O_CREAT, 0o644) }
     guard logFd >= 0 else { return }
 
-    _ = data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Int in
-      guard let base = buf.baseAddress else { return 0 }
-      return write(logFd, base, buf.count)
+    _ = data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Bool in
+      guard let base = buf.baseAddress else { return false }
+      return Self.writeAllBytes(logFd, base, buf.count)
     }
 
     var st = stat()
@@ -122,6 +127,56 @@ public final class RotatingFileSink: @unchecked Sendable {
     if oversize {
       rotate(path: path, maxFiles: maxFiles)
     }
+  }
+
+  /// Writes `count` bytes from `base` to `fd` using `write(2)`, looping on
+  /// short writes and retrying on `EINTR`. Returns `true` if all bytes were
+  /// committed, `false` on a hard error (`errno != EINTR`) or a zero-byte
+  /// return (which on a regular file would otherwise spin indefinitely).
+  ///
+  /// `write(2)` is allowed to write fewer bytes than requested, even on
+  /// regular files, and may return `-1` with `errno == EINTR` if the call is
+  /// interrupted by a signal. The previous single-call site discarded the
+  /// return value and silently truncated log lines under those conditions.
+  private static func writeAllBytes(
+    _ fd: Int32,
+    _ base: UnsafeRawPointer,
+    _ count: Int
+  ) -> Bool {
+    writeAllBytes(base, count) { ptr, n in
+      write(fd, ptr, n)
+    }
+  }
+
+  /// Test seam for `writeAllBytes(_:_:_:)`. The syscall is injected as a
+  /// closure so unit tests can deterministically simulate short writes,
+  /// `EINTR`, hard errors, and zero-byte returns. Production callers go
+  /// through the `(fd:base:count:)` overload above.
+  ///
+  /// Behaviour matches a standard POSIX retry loop:
+  /// - `n > 0`: advance the cursor and continue until the buffer is drained.
+  /// - `n < 0` and `errno == EINTR`: retry without advancing.
+  /// - `n < 0` and `errno != EINTR`: hard error — bail with `false`.
+  /// - `n == 0`: bail with `false` (defensive — a regular file should never
+  ///   short-return zero, but the loop must not spin if it does).
+  internal static func writeAllBytes(
+    _ base: UnsafeRawPointer,
+    _ count: Int,
+    using writeFn: (UnsafeRawPointer, Int) -> Int
+  ) -> Bool {
+    var remaining = count
+    var cursor = base
+    while remaining > 0 {
+      let n = writeFn(cursor, remaining)
+      if n > 0 {
+        cursor = cursor.advanced(by: n)
+        remaining -= n
+        continue
+      }
+      if n < 0 && errno == EINTR { continue }
+      return false
+    }
+    return true
   }
 
   /// Drops the oldest archive, shifts each `.i` → `.i+1`, and renames the

--- a/Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift
+++ b/Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -162,5 +163,128 @@ struct RotatingFileSinkTests {
       return s.contains(siblingMarker)
     }
     #expect(foundSomewhere)
+  }
+
+  // MARK: - writeAllBytes loop (Codex finding #478)
+
+  /// Issue #478: `write(2)` may return fewer bytes than requested, or fail
+  /// with `EINTR`, even on regular files. The previous append path discarded
+  /// the return value, silently truncating log lines and breaking the sink's
+  /// "no torn lines" invariant. These tests pin the retry loop's behaviour.
+
+  @Test("writeAllBytes succeeds when underlying write reports a full success")
+  func writeAllBytes_fullWriteSucceeds() throws {
+    let payload = Array("abcdefghij".utf8)
+    var calls = 0
+    let ok = payload.withUnsafeBufferPointer { buf -> Bool in
+      RotatingFileSink.writeAllBytes(
+        UnsafeRawPointer(buf.baseAddress!),
+        buf.count
+      ) { _, n in
+        calls += 1
+        return n
+      }
+    }
+    #expect(ok)
+    #expect(calls == 1)
+  }
+
+  @Test("writeAllBytes advances cursor across multiple short writes")
+  func writeAllBytes_shortWritesAdvanceCursor() throws {
+    let payload = Array(repeating: UInt8(0xAB), count: 256)
+    // Closure returns 100, 100, 56 — two short writes followed by the tail.
+    var schedule = [100, 100, 56]
+    var seen: [Int] = []
+    let ok = payload.withUnsafeBufferPointer { buf -> Bool in
+      let basePtr = UnsafeRawPointer(buf.baseAddress!)
+      return RotatingFileSink.writeAllBytes(basePtr, buf.count) { ptr, n in
+        let chunk = schedule.removeFirst()
+        // Each call should see a cursor advanced by the previous chunks.
+        let offset = ptr.distance(to: basePtr) * -1
+        seen.append(offset)
+        return min(chunk, n)
+      }
+    }
+    #expect(ok)
+    #expect(schedule.isEmpty)
+    #expect(seen == [0, 100, 200])
+  }
+
+  @Test("writeAllBytes retries on EINTR")
+  func writeAllBytes_retriesOnEINTR() throws {
+    let payload = Array("retry-payload".utf8)
+    var calls = 0
+    let ok = payload.withUnsafeBufferPointer { buf -> Bool in
+      RotatingFileSink.writeAllBytes(
+        UnsafeRawPointer(buf.baseAddress!),
+        buf.count
+      ) { _, n in
+        calls += 1
+        if calls == 1 {
+          errno = EINTR
+          return -1
+        }
+        return n
+      }
+    }
+    #expect(ok)
+    #expect(calls == 2)
+  }
+
+  @Test("writeAllBytes bails on a hard error (errno != EINTR)")
+  func writeAllBytes_failsOnHardError() throws {
+    let payload = Array("hard-error".utf8)
+    var calls = 0
+    let ok = payload.withUnsafeBufferPointer { buf -> Bool in
+      RotatingFileSink.writeAllBytes(
+        UnsafeRawPointer(buf.baseAddress!),
+        buf.count
+      ) { _, _ in
+        calls += 1
+        errno = EIO
+        return -1
+      }
+    }
+    #expect(!ok)
+    #expect(calls == 1)
+  }
+
+  @Test("writeAllBytes bails on a zero-byte return so it does not spin")
+  func writeAllBytes_failsOnZeroWrite() throws {
+    let payload = Array("zero-write".utf8)
+    var calls = 0
+    let ok = payload.withUnsafeBufferPointer { buf -> Bool in
+      RotatingFileSink.writeAllBytes(
+        UnsafeRawPointer(buf.baseAddress!),
+        buf.count
+      ) { _, _ in
+        calls += 1
+        return 0
+      }
+    }
+    #expect(!ok)
+    #expect(calls == 1)
+  }
+
+  // MARK: - Production-path integration (large buffer)
+
+  @Test("Large append lands intact through the production write loop")
+  func largeBufferAppendIsIntact() throws {
+    let dir = try Self.makeIsolatedDirectory("large-append")
+    defer { Self.cleanup(dir) }
+
+    let path = dir.appendingPathComponent("sink.log")
+    // Size cap large enough that no rotation fires; exercises the writeAll
+    // loop end-to-end through `RotatingFileSink.append`.
+    let sink = RotatingFileSink(path: path, maxSize: 8 * 1_024 * 1_024, maxFiles: 1)
+
+    // 256 KB single message — large enough that a real short write or
+    // signal interruption is plausible under load. We assert byte equality.
+    let body = String(repeating: "x", count: 256 * 1_024)
+    let payload = body + "\n"
+    sink.append(payload)
+
+    let read = try String(contentsOf: path, encoding: .utf8)
+    #expect(read == payload)
   }
 }

--- a/docs/feature-requests/issue-478-2026-04-30-rotatingfilesink-partial-write.md
+++ b/docs/feature-requests/issue-478-2026-04-30-rotatingfilesink-partial-write.md
@@ -1,0 +1,221 @@
+# Issue #478 — RotatingFileSink: handle short writes from `write(2)` — 2026-04-30
+
+GitHub issue: `#478`. Parent / epic: none (Codex follow-up to #476 Phase R4). Tier: SMALL. Status: DRAFT.
+
+## Preface — Lane + Live UAT declaration
+
+**Lane:** Code (`Sources/EnviousWisprAudio/RotatingFileSink.swift`, `Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift`).
+
+**Live UAT:** N — internal log-sink infrastructure with no app/UI surface. Correctness is unit-testable via the `writeAllBytes` testable seam. Smoke + logic tests cover the production path; no human-observable behavior changes for the user.
+
+## Preface — User Rubric
+
+User Rubric: N/A — internal log-infrastructure follow-up to Phase R4 (#319 Bible). No user-visible surface; users never read `bt-route.log`.
+
+## Preface — Council/Codex routing
+
+`council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining` (per `.claude/rules/workflow-process.md §1` "Codex grounded review settles the only fork" exception).
+
+Disqualifier check (all clear):
+- No workflow gate / template / lane / hook / memory rule change.
+- No numerical target with ambiguous measurement.
+- No fitness gate.
+- No CI workflow change.
+
+Codex already prescribed the exact fix in the issue body; this plan executes it.
+
+## 0. TL;DR
+
+`RotatingFileSink.atomicAppendWithRotation` issues a single `write(2)` and discards the return value. POSIX `write(2)` may legally return fewer bytes than requested (or `-1` with `errno == EINTR`) even on regular files under signal/IO-pressure. Today, that silently truncates a log line and proceeds into the size/rotation check, breaking the sink's "no torn lines" invariant. Fix: extract a `writeAllBytes` loop that retries on `EINTR` and advances on short writes until all bytes are committed or a hard error fires. Tests use a closure-injected variant to simulate short writes / EINTR / hard errors deterministically.
+
+## 1. Problem
+
+The current append path:
+
+```swift
+_ = data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Int in
+  guard let base = buf.baseAddress else { return 0 }
+  return write(logFd, base, buf.count)
+}
+```
+
+ignores the return value. Three failure modes:
+
+1. **Short write.** `write(2)` returns `n < buf.count` — tail of the message is silently dropped. Concurrent in-process tests claim "no torn lines"; a real short write breaks that.
+2. **EINTR.** `write(2)` returns `-1` with `errno == EINTR` — the entire write is silently lost.
+3. **Hard error.** `write(2)` returns `-1` with `errno != EINTR` — silently dropped, but at least the line vanishes cleanly.
+
+Cases 1 and 2 are the real defect — partial / no data lands but rotation still fires.
+
+## 2. Goals & non-goals
+
+**Goals.**
+- Preserve the "no torn lines" invariant under short writes and EINTR.
+- Keep the public API and call shape identical (single-line `sink.append(message)`).
+- Keep the lock model identical (in-process unfair lock + cross-process flock on stable companion).
+- Add a testable seam so the loop's correctness is verified deterministically, not by chance.
+
+**Non-goals.**
+- Surfacing write failures to callers. The sink is best-effort logging; silent degrade is the documented contract.
+- Changing rotation behavior on partial-write-followed-by-rotation. Already correct: the `fstat` size check sees only what landed, so a partially-written line never triggers premature rotation in a way that breaks today's semantics. Post-fix, full lines always land before the size check, so rotation logic is unchanged.
+- Surfacing failures to a metrics counter. Out of scope; reserve for a follow-up if real-world sinks start dropping.
+
+## 3. Design
+
+Extract a private static helper:
+
+```swift
+/// Writes `count` bytes from `base` to the file descriptor via `write(2)`,
+/// looping on short writes and retrying on EINTR. Returns true if all bytes
+/// were written; false on a hard error (errno != EINTR) or zero-byte write
+/// (which would otherwise spin forever on a regular file).
+private static func writeAllBytes(
+  _ fd: Int32,
+  _ base: UnsafeRawPointer,
+  _ count: Int
+) -> Bool {
+  writeAllBytes(base, count) { ptr, n in
+    write(fd, ptr, n)
+  }
+}
+
+/// Test seam — same loop logic, but the syscall is injected. EINTR signaled
+/// by returning `-1` and setting `errno = EINTR` BEFORE returning.
+internal static func writeAllBytes(
+  _ base: UnsafeRawPointer,
+  _ count: Int,
+  using writeFn: (UnsafeRawPointer, Int) -> Int
+) -> Bool {
+  var remaining = count
+  var cursor = base
+  while remaining > 0 {
+    let n = writeFn(cursor, remaining)
+    if n > 0 {
+      cursor = cursor.advanced(by: n)
+      remaining -= n
+      continue
+    }
+    if n < 0 && errno == EINTR { continue }
+    return false
+  }
+  return true
+}
+```
+
+Replace the existing `_ = data.withUnsafeBytes ...` block with:
+
+```swift
+_ = data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Bool in
+  guard let base = buf.baseAddress else { return false }
+  return Self.writeAllBytes(logFd, base, buf.count)
+}
+```
+
+The `_ =` discard is intentional: the sink is best-effort. We do not propagate failures.
+
+Errors (hard error or zero-write) cause the loop to bail. The active fd is still closed in the existing `defer`-equivalent line (note: today's code uses `close(logFd)` explicitly before rotation, not a defer; the fix preserves that ordering — close before rotate stays).
+
+## 3b. Ownership justification
+
+The helper lives as a `private static` inside `RotatingFileSink` because:
+- It is only called from `atomicAppendWithRotation`.
+- No other module needs a generic `writeAll` helper (POSIX wrappers are not part of the public Audio API surface).
+- A free function in `EnviousWisprCore` would be wrong — Core has no other POSIX-syscall code today and adding one tempts future drift.
+
+If a second caller emerges, promote to a module-level free function in `EnviousWisprAudio` or `EnviousWisprCore`. Until then, encapsulating it inside the only consumer keeps the surface area honest.
+
+## 3a. Metric Definition + Earliest Failure Point
+
+Not architecture-affecting — single-function fix inside an existing well-bounded class.
+
+## 4. Contract deltas
+
+- `RotatingFileSink.append(_:)` — public contract unchanged. Best-effort, silent on failure. The "no torn lines" invariant becomes load-bearing rather than aspirational.
+- New private symbol `writeAllBytes(_:_:_:)` (production overload) and `writeAllBytes(_:_:_:using:)` (test seam, `internal` access). Test seam is reachable from `EnviousWisprTests` via `@testable import EnviousWisprAudio`, matching the existing pattern.
+
+No public surface change. No call-site change other than the one inside `atomicAppendWithRotation`.
+
+## 5. E2E state & lifecycle audit
+
+- **Pre-fix:** lock held → write may short → fstat sees partial size → may or may not trigger rotation depending on accumulated truncation → rotate → close → unlock. Correctness hole: log line lost.
+- **Post-fix:** lock held → writeAllBytes loops until full or hard-error → fstat sees real post-write size → rotation fires deterministically → close → unlock.
+
+State transitions otherwise identical.
+
+## 6. Downstream consumer matrix
+
+Single caller: `Sources/EnviousWisprAudio/AudioCaptureManager.swift:533` (`btRouteSink`). No other production callers (verified via `grep -rn "RotatingFileSink" Sources/`). Test consumer: `Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift`. Both unaffected by the change — call shape preserved.
+
+## 7. Failure-mode × caller table
+
+| Caller | Failure mode | Today | Post-fix |
+|---|---|---|---|
+| `btRouteSink.append(line)` from `AudioCaptureManager` | full success | line written | line written |
+| same | short write (n < count) | line truncated, no error | line written via loop |
+| same | EINTR | line dropped silently | line written after retry |
+| same | hard error (EIO/ENOSPC) | line dropped silently | line dropped silently (best-effort contract preserved) |
+| same | zero-byte write (rare on regular files) | infinite loop possible if loop existed naively | loop bails to avoid spin |
+
+## 8. Caller-visible signals audit
+
+`append` returns `Void`. No signal change. Call sites in `AudioCaptureManager` (`btRouteSink.append("...\n")`) are unchanged.
+
+## 9. Fallback source-of-truth audit
+
+The fallback for "log line could not be written" is documented silent-drop. That stays. The fix removes a silent-drop case (short write); the remaining silent-drop case (hard error) is the only one that should still happen.
+
+## 10. File-by-file changes
+
+- `Sources/EnviousWisprAudio/RotatingFileSink.swift` — extract `writeAllBytes` (production + test-seam overloads), replace single-call write block with the loop helper, update doc comment in the `## Concurrency model` block to mention "writes loop on short / EINTR".
+- `Tests/EnviousWisprTests/Core/RotatingFileSinkTests.swift` — add a sub-suite for `writeAllBytes` with five tests (full, short, EINTR retry, hard error, zero-byte). Add one large-buffer integration test that drives `RotatingFileSink.append` with a ≥256 KB payload to exercise the production path.
+
+LOC budget: ~60 LOC source change, ~80 LOC test additions.
+
+## 11. Testing
+
+**Unit tests for `writeAllBytes` (test-seam variant):**
+
+1. `writeAllBytes_fullWriteSucceeds` — single call returns full count → returns true, all bytes consumed.
+2. `writeAllBytes_shortWritesAdvanceCursor` — closure returns 100, then 100, then 56 for a 256-byte buffer → returns true, cursor advanced correctly across calls.
+3. `writeAllBytes_retriesOnEINTR` — closure returns `-1` with `errno = EINTR` once, then full success → returns true.
+4. `writeAllBytes_failsOnHardError` — closure returns `-1` with `errno = EIO` → returns false, no further calls.
+5. `writeAllBytes_failsOnZeroWrite` — closure returns 0 → returns false (avoid infinite loop).
+
+**Integration test (production path):**
+
+6. `largeBufferAppendIsIntact` — append a 256 KB message, read file back, verify byte-for-byte equality. Even if no short write occurs in practice, this exercises the loop helper through the production overload.
+
+**Existing tests** must continue to pass:
+- `appendOrderPreserved`
+- `rotationCapsRetention`
+- `concurrentInProcessWritersAreAtomic`
+- (cross-process smoke test below line 131)
+
+Run: `scripts/swift-test.sh` exits 0; `swift build -c release` exits 0.
+
+No Live UAT — internal log infrastructure with no user surface (per Preface).
+
+## 12. Blast radius & rollback
+
+- One file, one helper, one call site change in production.
+- Single git revert restores prior behavior.
+- No data migration, no on-disk format change, no flag.
+
+## 13. Ship criteria
+
+1. `swift build -c release` exits 0.
+2. `scripts/swift-test.sh` exits 0 (existing + new tests).
+3. Codex code-diff review (`codex review --uncommitted`) reports clean.
+4. PR body declares `council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining`.
+5. CI `build-check` green.
+6. `gh issue close 478` after merge.
+
+## 14. Open questions
+
+None.
+
+## 15. Related
+
+- Issue #476 (PR that introduced RotatingFileSink — Phase R4 of #319 Bible).
+- Issue #362 (BT route log rotation — design context).
+- `.claude/rules/architecture-rules.md` Audio/ASR Danger Zones — RotatingFileSink callers must NOT be invoked under RT lock; unchanged by this fix.


### PR DESCRIPTION
## Summary

- Replaces the single unchecked `write(2)` in `atomicAppendWithRotation` with a `writeAllBytes` retry loop that handles short writes and `EINTR`. POSIX `write(2)` may legally short-return or fail with `EINTR` even on regular files; today's code silently truncates the log line and proceeds into rotation, breaking the sink's "no torn lines" invariant.
- Adds a closure-injected test seam (`writeAllBytes(_:_:_:using:)`) so the loop's correctness is verified deterministically: full success, multiple short writes, EINTR retry, hard error, and zero-byte return paths are all covered.
- Closes #478.

`council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining`

Plan: `docs/feature-requests/issue-478-2026-04-30-rotatingfilesink-partial-write.md`. Disqualifier check (workflow-process §1): no workflow gate / template / lane / hook / memory rule change; no ambiguous numerical target; no fitness gate; no CI workflow change.

## Test plan

- [x] `swift build -c release` exits 0
- [x] `scripts/swift-test.sh` exits 0 (546 tests, 55 suites)
- [x] `RotatingFileSinkTests` — 10/10 pass (5 new + 5 existing)
- [x] Codex code-diff review: clean — "no actionable regressions"
- [ ] CI `build-check` green
- [ ] Verify `gh issue close 478` post-merge

No Live UAT — internal log infrastructure, no app/UI surface.