### PR TITLE
docs(uat): point V2 fault-injection harness at wispr-rebuild-debug flow (#549)

### DIFF
--- a/Tests/RuntimeUAT/SCENARIOS.md
+++ b/Tests/RuntimeUAT/SCENARIOS.md
@@ -4,7 +4,7 @@ Standing menu of runtime fault scenarios for EnviousWispr (issue #291). On-deman
 
 ## Prerequisites
 
-1. App built in DEBUG mode and launched with `EW_FAULT_INJECTION=1` set in its environment. The `DebugFaultEndpoint` only starts under that env var.
+1. **Build and launch via `wispr-rebuild-debug`.** The skill compiles `-c debug` (so `#if DEBUG` seams are present) and launches `build/EnviousWispr Local.app` with `EW_FAULT_INJECTION=1` set via `open --env`. The `DebugFaultEndpoint` only starts when both gates are satisfied (DEBUG build + env var). Plain `scripts/bundle-dev.sh` produces a release build that does NOT contain the V2 endpoint — by design.
 2. `Tests/RuntimeUAT/` requirements (Accessibility permission, mic, OpenAI key for TTS) — see `README.md`.
 3. Per-launch token written by the app at `~/Library/Logs/EnviousWispr/fault-token-<pid>` (`0600` perms).
 

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -2,8 +2,11 @@
 V2 fault-injection harness for EnviousWispr (issue #291).
 
 Drives the DEBUG-only `DebugFaultEndpoint` in the running app via a localhost
-TCP listener. The app must be launched with `EW_FAULT_INJECTION=1` set in its
-environment so the endpoint starts; without it, the endpoint is inert.
+TCP listener. To run end-to-end: invoke the `wispr-rebuild-debug` skill, which
+compiles `-c debug` (so `#if DEBUG` seams are present) and launches the debug
+bundle with `EW_FAULT_INJECTION=1` set via `open --env`. Without both gates
+satisfied (DEBUG build AND env var), the endpoint is inert. The release path
+(`scripts/bundle-dev.sh`) does NOT contain the endpoint — by design.
 
 Wire protocol (per `Sources/EnviousWispr/App/Debug/DebugFaultEndpoint.swift`):
 
@@ -123,12 +126,14 @@ def _find_app_pid() -> int:
 
 def _read_token(pid: int) -> str:
     """Read the per-launch fault token. Raises if the file is missing — that
-    means the app was launched without `EW_FAULT_INJECTION=1`."""
+    means the app was not launched via `wispr-rebuild-debug` (or equivalent
+    debug-bundle path that sets `EW_FAULT_INJECTION=1`)."""
     path = TOKEN_DIR / f"fault-token-{pid}"
     if not path.exists():
         raise RuntimeError(
-            f"fault token not found at {path} — launch {APP_NAME} with "
-            "`EW_FAULT_INJECTION=1` in its environment so the DEBUG endpoint starts"
+            f"fault token not found at {path} — invoke the `wispr-rebuild-debug` "
+            "skill to build and launch the debug bundle with EW_FAULT_INJECTION=1 set. "
+            "The release path (`scripts/bundle-dev.sh`) does not contain the endpoint."
         )
     return path.read_text(encoding="utf-8").strip()
 


### PR DESCRIPTION
## Scope

**Docs/dev-tooling update only. No V2 runtime validation claimed.**

Two files changed, prose only:

- `Tests/RuntimeUAT/SCENARIOS.md` — Prerequisites prose now references the `wispr-rebuild-debug` skill flow instead of bare `EW_FAULT_INJECTION=1` env-var launch instructions that the canonical install path could not satisfy.
- `Tests/RuntimeUAT/faultInjection.py` — Module docstring + token-not-found error message rewritten to point at the skill flow.

## Why this PR exists

When the founder tried to run V2 fault-injection scenarios post-merge of #544, the canonical install path (`scripts/bundle-dev.sh` → `swift build -c release` → `open`) could not satisfy V2's two gates: `#if DEBUG` strips the symbols from release, and `open(1)` does not propagate `EW_FAULT_INJECTION=1` env vars. Issue #547 catalogued the gap.

The fix is a one-line change to the `wispr-rebuild-debug` skill: launch with `open --env "EW_FAULT_INJECTION=1" "$DEST"` instead of plain `open`. That skill lives in `.claude/skills/` (gitignored, local artifact) and is updated separately. This PR updates the runtime-UAT prose to reflect the new flow so future readers find the right entry point.

## What did NOT change

- No `Sources/` change.
- No harness logic change. The Python module parses, runs, and behaves identically — only docstring and one `RuntimeError()` message string changed.
- No `Package.swift`, no test surface, no CI config.

## Validation

Phase 3 validation skipped — Docs/dev-tooling lane PR. Skip-note recorded at `.validation/runs/2026-05-02T03-03-16Z-pre-commit/skip-note.txt` documenting the lane classification and the explicit non-claim of V2 end-to-end runtime validation.

The skill-side change that enables actual V2 runtime UAT will be exercised on the next normal `wispr-rebuild-debug` cycle from a worktree containing V2 source. That validation is independent of this PR.

## Push-discipline note

Push used the documented `SKIP_PUSH_CHECKS=1` escape hatch. Reason: the main tree's working branch has an unrelated unbuilt ship-path commit (a one-line doc-comment change in `HeartPathTelemetryEmitter.swift`) that the build-freshness hook flagged. Running `swift build` in the main tree or moving its branch state would have created more procedural risk than the scoped override for this docs-only PR. Audited to `.claude/push-audit.log` per the hook's documented contract.

## Closes

- Resolves #549 (V2 fault-injection runtime path).
- Resolves #547 (bundle/launch gap) by inheritance — the skill-side change makes the canonical debug path runnable without further infrastructure work.

## Out of scope (separate work)

- #548 (P0 workflow remediation: plan-template, council preamble, grounded-review template, push-hook hardening) — independent.
- Bible v1.29 changelog entry — parked on its own branch, ships separately.