### PR TITLE
security(logging): gate WordCorrector debug logs behind #if DEBUG (#563)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -50,17 +50,21 @@ public struct WordCorrector: Sendable {
         if alias.contains(" ") {
           if let existing = multiAliasMap[key], existing != word.canonical {
             collisionCount += 1
-            Self.logger.debug(
-              "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
-            )
+            #if DEBUG
+              Self.logger.debug(
+                "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
+              )
+            #endif
           }
           multiAliasMap[key] = word.canonical
         } else {
           if let existing = singleAliasMap[key], existing != word.canonical {
             collisionCount += 1
-            Self.logger.debug(
-              "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
-            )
+            #if DEBUG
+              Self.logger.debug(
+                "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
+              )
+            #endif
           }
           singleAliasMap[key] = word.canonical
         }
@@ -73,8 +77,10 @@ public struct WordCorrector: Sendable {
       if !key.contains(" ") {
         if let existing = singleAliasMap[key] {
           if existing != word.canonical {
-            Self.logger.debug(
-              "Canonical '\(word.canonical)' skipped: key '\(key)' already maps to '\(existing)'")
+            #if DEBUG
+              Self.logger.debug(
+                "Canonical '\(word.canonical)' skipped: key '\(key)' already maps to '\(existing)'")
+            #endif
           }
         } else {
           singleAliasMap[key] = word.canonical
@@ -147,9 +153,11 @@ public struct WordCorrector: Sendable {
             tokens.replaceSubrange(i..<(i + n), with: [firstPrefix + canonical + lastSuffix])
             replacements += 1
             matched = true
-            Self.logger.debug(
-              "WordCorrector: type=ngram-compound source='\(rawConcat)' target='\(canonical)' n=\(n)"
-            )
+            #if DEBUG
+              Self.logger.debug(
+                "WordCorrector: type=ngram-compound source='\(rawConcat)' target='\(canonical)' n=\(n)"
+              )
+            #endif
             break
           }
         }
@@ -178,8 +186,10 @@ public struct WordCorrector: Sendable {
             tokens.replaceSubrange(i..<(i + span), with: [firstPrefix + canonical + lastSuffix])
             replacements += 1
             matched = true
-            Self.logger.debug(
-              "WordCorrector: type=multi-word-exact source='\(rawPhrase)' target='\(canonical)'")
+            #if DEBUG
+              Self.logger.debug(
+                "WordCorrector: type=multi-word-exact source='\(rawPhrase)' target='\(canonical)'")
+            #endif
             break
           }
         }
@@ -220,9 +230,11 @@ public struct WordCorrector: Sendable {
                   i..<(i + span), with: [firstPrefix + bestCanonical + lastSuffix])
                 replacements += 1
                 matched = true
-                Self.logger.debug(
-                  "WordCorrector: type=multi-word-fuzzy source='\(rawPhrase)' target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3))"
-                )
+                #if DEBUG
+                  Self.logger.debug(
+                    "WordCorrector: type=multi-word-fuzzy source='\(rawPhrase)' target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3))"
+                  )
+                #endif
                 break
               }
             }
@@ -243,7 +255,9 @@ public struct WordCorrector: Sendable {
       // Pass 3: exact single-word alias (includes canonical self-entries)
       if let canonical = singleAliasMap[coreLower], core != canonical {
         replacements += 1
-        Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
+        #if DEBUG
+          Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
+        #endif
         return prefix + canonical + suffix
       }
 
@@ -283,9 +297,11 @@ public struct WordCorrector: Sendable {
         core != bestMatch
       {
         replacements += 1
-        Self.logger.debug(
-          "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
-        )
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
+          )
+        #endif
         return prefix + bestMatch + suffix
       }
 
@@ -314,9 +330,11 @@ public struct WordCorrector: Sendable {
         core != bestMatch
       {
         replacements += 1
-        Self.logger.debug(
-          "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
-        )
+        #if DEBUG
+          Self.logger.debug(
+            "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
+          )
+        #endif
         return prefix + bestMatch + suffix
       }
 


### PR DESCRIPTION
Closes #563.

## Summary
- WordCorrector declares its own `os.Logger` (line 29) and bypasses the AppLogger `#if DEBUG` gate that R3 (#475) installed for release builds.
- All 9 `Self.logger.debug(...)` call sites in this file interpolate user-defined custom-word data (alias keys, canonical words, raw transcript token fragments) — release builds were leaking that into the unified-log database under subsystem `com.enviouswispr` category `WordCorrector`.
- Each call site now wrapped in `#if DEBUG / #endif`. Debug behavior unchanged; release builds emit nothing for this subsystem/category.

## Scope rationale (council-skip: zero-blast-radius)
- 1 file, 9 sites, mechanical compile-time gate.
- No semantic change: control-flow side effects (`collisionCount`, `replacements`, `matched`, `break`, `return`) all remain outside the guards.
- No expression-context concerns (Codex confirmed).
- Mirrors the R3 / PR #475 pattern.
- Bucket: `logging-gate` (extension of zero-blast-radius pattern; same shape as R3).

## Why 9 sites instead of the 3 the audit named
V3 audit and Codex parallel review flagged the alias-collision sites at lines 53, 61, 76. Reading the full file surfaced 6 more sites with the exact same shape (transcript tokens / canonical words interpolated into `Self.logger.debug`). All 9 leak custom-word PII; gating only the 3 named would leave the same hole open in 6 paths.

## Audit reference
`docs/audits/2026-05-02-v3-entitlement-pii.md` — finding #1 in the "Findings I missed that Codex caught" section.

## Test plan
- [x] `swift build -c debug` clean
- [x] Codex review: ship verdict, no expression-context concerns, no other os.Logger bypasses in EnviousWisprPostProcessing
- [ ] CI build-check green
- [ ] Post-merge: verify release build emits nothing under `log show --predicate 'subsystem == "com.enviouswispr" AND category == "WordCorrector"'`
