### PR TITLE
security(llm): set store=false on OpenAI Chat Completions requests (#565)

### DIFF
--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -198,6 +198,7 @@ public struct LLMModelDiscovery: Sendable {
       "model": modelID,
       "messages": [["role": "user", "content": "Hi"]],
       "max_tokens": 5,
+      "store": false,
     ]
 
     guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -28,6 +28,7 @@ public struct OpenAIConnector: TranscriptPolisher {
       "messages": messages,
       "max_completion_tokens": config.maxTokens,
       "temperature": config.temperature,
+      "store": false,
     ]
     if let reasoningEffort = config.reasoningEffort {
       body["reasoning_effort"] = reasoningEffort


### PR DESCRIPTION
Closes #565.
Spawns #571 (Gemini parity, needs API verification).

## Summary
- Adds \`\"store\": false\` to OpenAI polish (\`OpenAIConnector.swift\`) and OpenAI probe (\`LLMModelDiscovery.swift\`).
- Prewarm path at \`LLMNetworkSession.swift:108-112\` already sets it. Now consistent across all three OpenAI POST sites.

## Honest framing — this is smaller than the issue described
The issue body framed \`store\` as the abuse-monitoring retention switch. Codex review of the diff verified that's incorrect: \`store\` actually controls output storage for distillation/evals, default false. The 30-day abuse-monitoring retention is a separate account-level policy with no per-request opt-out.

So this PR is closer to "make the existing default explicit" than "opt out of retention." Worth shipping anyway:
- Explicit intent visible in code (no ambiguity)
- Insurance against future API default changes
- Consistency with the prewarm path

I left this PR at the smaller scope and updated #565 to reflect the actual semantics.

## Scope rationale (council-skip: zero-blast-radius)
- 2 files, 2 lines added.
- Single-value config, no behavior change at the API today.
- Reversible via single-commit revert.
- Bucket: \`single-value-config\` per §1.

## Audit reference
\`docs/audits/2026-05-02-v3-entitlement-pii.md\` — finding #7 in the "Findings I missed that Codex caught" section.

## Test plan
- [x] \`swift build -c debug\` clean
- [x] Codex review: JSON-safe, completed scope (added probeOpenAI per Codex finding)
- [ ] CI build-check green
- [ ] Functional test: dictate with cloud OpenAI polish, observe 200 response (no API regression)
