### PR TITLE
security(storage): harden transcripts + custom-words file permissions (#561, #562)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -27,13 +27,40 @@ public final class CustomWordsManager {
       // Application Support is always available on macOS, but guard defensively.
       let fallback = FileManager.default.temporaryDirectory.appendingPathComponent(
         "EnviousWispr", isDirectory: true)
-      try? FileManager.default.createDirectory(at: fallback, withIntermediateDirectories: true)
+      Self.prepareAppSupportDirectory(at: fallback)
       fileURL = fallback.appendingPathComponent("custom-words.json")
+      Self.tightenFileIfPresent(at: fileURL)
       return
     }
     let appSupport = baseURL.appendingPathComponent("EnviousWispr", isDirectory: true)
-    try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+    Self.prepareAppSupportDirectory(at: appSupport)
     fileURL = appSupport.appendingPathComponent("custom-words.json")
+    Self.tightenFileIfPresent(at: fileURL)
+  }
+
+  /// Create the EnviousWispr Application Support directory at 0700 and drop a
+  /// `.metadata_never_index` Spotlight marker. Re-enforced on every init in
+  /// case a backup restore or user action loosened permissions. Soft-fails on
+  /// any filesystem operation. (V3 audit #561 / #562.)
+  private static func prepareAppSupportDirectory(at url: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+    try? fm.setAttributes(
+      [.posixPermissions: 0o700],
+      ofItemAtPath: url.path
+    )
+    let marker = url.appendingPathComponent(".metadata_never_index")
+    if !fm.fileExists(atPath: marker.path) {
+      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
+    }
+  }
+
+  /// Force `custom-words.json` to 0600 if it already exists. Migrates installs
+  /// that pre-date this hardening.
+  private static func tightenFileIfPresent(at url: URL) {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else { return }
+    try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
   }
 
   // MARK: - Built-in Defaults
@@ -275,11 +302,36 @@ public final class CustomWordsManager {
     return nil
   }
 
+  /// Persist the custom-words file at 0600.
+  ///
+  /// Writes to a temp file at 0600 first via `Foundation.open(... 0o600)`
+  /// then renames into place. Mirrors `KeychainManager.store` to avoid the
+  /// brief world-readable window that `Data.write(.atomic)` + post-write
+  /// chmod creates. (V3 audit #561.)
   private func saveFile(_ file: CustomWordsFile) throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(file)
-    try data.write(to: fileURL, options: .atomic)
+    let tmpURL = fileURL.deletingLastPathComponent().appendingPathComponent(
+      ".custom-words.json.tmp")
+    let fm = FileManager.default
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      guard fd >= 0 else {
+        throw CocoaError(.fileWriteUnknown)
+      }
+      let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try fh.write(contentsOf: data)
+      try fh.close()
+      if fm.fileExists(atPath: fileURL.path) {
+        _ = try fm.replaceItemAt(fileURL, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: fileURL)
+      }
+    } catch {
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
   }
 
   // MARK: - Runtime Merge

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -2,6 +2,14 @@ import EnviousWisprCore
 import Foundation
 
 /// Persists transcripts as JSON files in Application Support.
+///
+/// Privacy posture (V3 audit #561 / #562):
+/// - Directory created at 0700 (owner-only access). Re-enforced at every init
+///   in case a backup restore or user action loosened permissions.
+/// - Each file written at 0600 by setting POSIX permissions immediately after
+///   the atomic write succeeds.
+/// - `.metadata_never_index` marker dropped at directory creation so Spotlight
+///   does not index transcript text.
 @MainActor
 public final class TranscriptStore {
   private let directory: URL
@@ -9,11 +17,8 @@ public final class TranscriptStore {
   public init() {
     directory = AppConstants.appSupportURL
       .appendingPathComponent(AppConstants.transcriptsDir, isDirectory: true)
-
-    try? FileManager.default.createDirectory(
-      at: directory,
-      withIntermediateDirectories: true
-    )
+    Self.prepareDirectory(at: directory)
+    Self.scheduleMigration(in: directory)
   }
 
   // Tests only. Reached via `@testable import EnviousWisprStorage`.
@@ -25,18 +30,74 @@ public final class TranscriptStore {
   // periphery:ignore
   internal init(directory: URL) {
     self.directory = directory
-    try? FileManager.default.createDirectory(
-      at: directory,
-      withIntermediateDirectories: true
-    )
+    Self.prepareDirectory(at: directory)
+    Self.scheduleMigration(in: directory)
   }
 
-  /// Save a transcript to disk.
+  /// Save a transcript to disk at 0600.
+  ///
+  /// Writes to a temp file at 0600 first via `Foundation.open(... 0o600)`
+  /// then renames into place. Mirrors the pattern in `KeychainManager.store`
+  /// and avoids the brief world-readable window that `Data.write(.atomic)`
+  /// + post-write chmod creates.
   public func save(_ transcript: Transcript) throws {
     let filename = "\(transcript.id.uuidString).json"
     let url = directory.appendingPathComponent(filename)
     let data = try JSONEncoder().encode(transcript)
-    try data.write(to: url, options: .atomic)
+    let tmpURL = directory.appendingPathComponent(".\(transcript.id.uuidString).tmp")
+    let fm = FileManager.default
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      guard fd >= 0 else {
+        throw CocoaError(.fileWriteUnknown)
+      }
+      let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try fh.write(contentsOf: data)
+      try fh.close()
+      if fm.fileExists(atPath: url.path) {
+        _ = try fm.replaceItemAt(url, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: url)
+      }
+    } catch {
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
+  }
+
+  /// Create the directory at 0700, drop a `.metadata_never_index` Spotlight
+  /// marker, and re-enforce permissions on every call. Soft-fails on any
+  /// filesystem operation — better to lose a privacy guarantee than crash.
+  private static func prepareDirectory(at directory: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+    try? fm.setAttributes(
+      [.posixPermissions: 0o700],
+      ofItemAtPath: directory.path
+    )
+    let marker = directory.appendingPathComponent(".metadata_never_index")
+    if !fm.fileExists(atPath: marker.path) {
+      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
+    }
+  }
+
+  /// Walk existing files and force them to 0600. Migrates installs that
+  /// pre-date this hardening so a user with months of old transcripts is
+  /// not left with world-readable files until each is rewritten.
+  ///
+  /// Dispatched off the main actor so an install with thousands of
+  /// transcripts (founder's machine has 6,300+) does not stutter the UI
+  /// at app launch. Each setAttributes call is fast individually, but the
+  /// loop adds up.
+  private static func scheduleMigration(in directory: URL) {
+    Task.detached(priority: .utility) {
+      let fm = FileManager.default
+      guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else { return }
+      for entry in entries where entry.hasSuffix(".json") {
+        let path = directory.appendingPathComponent(entry).path
+        try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+      }
+    }
   }
 
   /// Load all transcripts, sorted by creation date (newest first).
@@ -84,13 +145,11 @@ public final class TranscriptStore {
   }
 
   /// Delete all transcripts from disk atomically.
-  /// Removes and recreates the directory to avoid partial-failure states.
+  /// Removes and recreates the directory with the same hardened permissions
+  /// + Spotlight marker established at init.
   public func deleteAll() throws {
     guard FileManager.default.fileExists(atPath: directory.path) else { return }
     try FileManager.default.removeItem(at: directory)
-    try FileManager.default.createDirectory(
-      at: directory,
-      withIntermediateDirectories: true
-    )
+    Self.prepareDirectory(at: directory)
   }
 }


### PR DESCRIPTION
Closes #561, closes #562.

## Summary
Two issues bundled because both touch the same persistence layer in `Application Support/EnviousWispr/`:

- **#561 chmod 0700/0600**: directory + JSON files were world-readable per macOS default. On a multi-user Mac, any other local user could read transcripts (which contain PII) and the custom-words list.
- **#562 Spotlight indexing**: `~/Library/Application Support/EnviousWispr/transcripts/` was indexed by macOS by default. User dictating "appointment with Dr. X about hypertension" then typing "hypertension" into Spotlight would surface the transcript JSON.

## Approach
Mirrors the established pattern in `Sources/EnviousWisprLLM/KeychainManager.swift:57-84`:
- Write to a temp file at `0600` via `Foundation.open(O_CREAT|O_WRONLY|O_TRUNC, 0o600)`
- Then `replaceItemAt` / `moveItem` for the atomic rename
- Avoids the brief world-readable window that `Data.write(.atomic)` + post-write `chmod` creates

Three hardening additions per file:
1. **Directory at 0700** with `.metadata_never_index` marker, re-enforced on every init (handles backup-restore loosened perms)
2. **Files at 0600** via secure-open
3. **Migration of existing files** to 0600 via `Task.detached(priority: .utility)` so the founder's 6,300-file install does not stutter app launch

## Codex grounded review iterations
First pass had three issues; this PR addresses all of them:
1. `Data.write(.atomic)` briefly exposed files at default `0644` before chmod tightened them — replaced with secure-open temp-file pattern
2. `deleteAll()` recreated the transcripts dir with default perms and no Spotlight marker — now uses the same `prepareDirectory()` helper
3. The migration loop ran on `@MainActor` and could stutter the UI on a 6,300-file install — moved to `Task.detached(.utility)`

## Lane
Code lane (Sources/EnviousWisprStorage/, Sources/EnviousWisprPostProcessing/). Mixed-PR rule does not trigger.

## Process rationale (council-skip)
Operational hardening with no design ambiguity. The implementation mirrors `KeychainManager.swift` directly. Codex grounded review settled implementation forks (atomic-write semantics, migration off main actor, deleteAll consistency). Tag: \`council-skip: codex-grounded-review-settled\`.

## Audit reference
\`docs/audits/2026-05-02-v3-entitlement-pii.md\` — findings #1 (chmod) and #8 (Spotlight). Both were also confirmed in the prior 2026-04-26 audit; ran for one cycle without a fix.

## Test plan
- [x] \`swift build -c debug\` clean
- [x] 11 existing TranscriptStore + CustomWordsPropagator tests pass with new secure-write path
- [x] Codex grounded review verdict: ship after iteration
- [ ] CI build-check green
- [ ] Post-merge runtime verify on founder's machine:
  - \`stat -f "%Sp" ~/Library/Application\\ Support/EnviousWispr/transcripts\` returns \`drwx------\`
  - \`stat -f "%Sp"\` on a transcript JSON returns \`-rw-------\`
  - \`stat -f "%Sp" ~/Library/Application\\ Support/EnviousWispr/custom-words.json\` returns \`-rw-------\`
  - \`.metadata_never_index\` files exist in both dirs
  - Dictate, wait 60s, \`mdfind -onlyin ~/Library/Application\\ Support/EnviousWispr "<token>"\` returns nothing
