### PR TITLE
security(observability): redact exceptions, context, and tags in Sentry beforeSend (#566)

### DIFF
--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -108,35 +108,60 @@ public enum ObservabilityBootstrap {
 
         // Redact extra context values
         if let extra = event.extra {
-          var redactedExtra: [String: Any] = [:]
-          for (key, value) in extra {
-            if let str = value as? String {
-              redactedExtra[key] = ObservabilityBootstrap.redactString(str)
-            } else {
-              redactedExtra[key] = value
-            }
-          }
-          event.extra = redactedExtra
+          event.extra = ObservabilityBootstrap.redactDict(extra)
         }
 
-        // Redact breadcrumb messages
+        // Redact breadcrumb messages and data
         if let crumbs = event.breadcrumbs {
           for crumb in crumbs {
             if let msg = crumb.message {
               crumb.message = ObservabilityBootstrap.redactString(msg)
             }
             if let data = crumb.data {
-              var redactedData: [String: Any] = [:]
-              for (key, value) in data {
-                if let str = value as? String {
-                  redactedData[key] = ObservabilityBootstrap.redactString(str)
-                } else {
-                  redactedData[key] = value
-                }
-              }
-              crumb.data = redactedData
+              crumb.data = ObservabilityBootstrap.redactDict(data)
             }
           }
+        }
+
+        // Redact exception value + mechanism data. Sentry's native crash
+        // handler captures the formatted exception message into
+        // `event.exceptions[].value`; without this pass, a future
+        // `fatalError("transcript=\(text)")` would leak. Verified during V3
+        // audit (#566): no current call sites interpolate transcript-typed
+        // values into fatal traps, but defense-in-depth — a regression
+        // would be invisible until users started crashing.
+        if let exceptions = event.exceptions {
+          for exception in exceptions {
+            if let value = exception.value {
+              exception.value = ObservabilityBootstrap.redactString(value)
+            }
+            if let mechData = exception.mechanism?.data {
+              exception.mechanism?.data = ObservabilityBootstrap.redactDict(mechData)
+            }
+          }
+        }
+
+        // Redact context dictionaries (arbitrary nested string values).
+        // Current contexts are diagnostic counts/statuses, but context is
+        // the natural place where future diagnostic strings would land —
+        // protect it now so a future change doesn't bypass redaction.
+        if let context = event.context {
+          var redactedContext: [String: [String: Any]] = [:]
+          for (key, inner) in context {
+            redactedContext[key] = ObservabilityBootstrap.redactDict(inner)
+          }
+          event.context = redactedContext
+        }
+
+        // Redact tag values. Current tags are low-cardinality strings
+        // (build_type, app_version), but cheap defense-in-depth against
+        // a future tag whose value bleeds transcript-shaped data.
+        if let tags = event.tags {
+          var redactedTags: [String: String] = [:]
+          for (key, value) in tags {
+            redactedTags[key] = ObservabilityBootstrap.redactString(value)
+          }
+          event.tags = redactedTags
         }
 
         return event
@@ -147,6 +172,22 @@ public enum ObservabilityBootstrap {
     SentrySDK.configureScope { scope in
       scope.setTag(value: environment == "development" ? "debug" : "release", key: "app.build_type")
     }
+  }
+
+  /// Redact every String value in a `[String: Any]` dictionary, leaving
+  /// non-string values untouched. Shared by Sentry beforeSend redaction
+  /// of `event.extra`, `breadcrumb.data`, `event.context`, and
+  /// `exception.mechanism.data`.
+  static func redactDict(_ input: [String: Any]) -> [String: Any] {
+    var output: [String: Any] = [:]
+    for (key, value) in input {
+      if let str = value as? String {
+        output[key] = redactString(str)
+      } else {
+        output[key] = value
+      }
+    }
+    return output
   }
 
   /// Redacts a string if it matches known PII patterns:


### PR DESCRIPTION
Closes #566.

## Summary
Sentry \`beforeSend\` redacted \`event.message\`, \`event.extra\`, \`breadcrumb.message\`, and \`breadcrumb.data\` but missed \`event.exceptions[].value\`, \`event.exceptions[].mechanism.data\`, \`event.context\`, and \`event.tags\`. This PR closes those gaps and DRYs the dict-walk logic.

## Context
Currently unexploited: zero \`fatalError\` / \`preconditionFailure\` / \`assertionFailure\` call sites in \`Sources/\` interpolate transcript-typed values (verified by grep). But:
- A future \`fatalError(\"transcript=\\(text)\")\` would leak the formatted exception message via Sentry's native crash handler.
- \`event.context\` is the natural place for future diagnostic strings (\`SentryBreadcrumb.swift:92-99,165-185\` already populate contexts) — protect it now.

## Changes
- **Exception redaction**: walk \`event.exceptions ?? []\`, redact each \`exception.value\` (optional String) and \`exception.mechanism?.data\` values.
- **Context redaction**: recursive redaction of \`event.context\` dict-of-dicts.
- **Tag redaction**: redact every \`event.tags\` value (defense-in-depth — current tags are low-cardinality \`build_type\` / \`app_version\`, but cheap insurance).
- **DRY**: extracted \`redactDict([String: Any]) -> [String: Any]\` helper, replaces 3 inlined dict-walks (extra, breadcrumb.data, exception.mechanism.data).

## Codex grounded review verdict
Ship with the context redaction. Verified:
- Sentry SDK 9.10.0 Exception is \`NSObject\` class — iterating \`event.exceptions\` and mutating propagates correctly (not value-type copies)
- \`Exception.value\` is \`String?\`, \`Mechanism.data\` is \`[String: Any]?\` — code uses \`if let\` correctly
- \`beforeSend\` order is independent across redaction sites
- \`user\`, \`fingerprint\`, \`transaction\` don't need redaction: no app call sites set them, \`sendDefaultPii=false\` already covers \`user\`

## Lane
Code lane (Sources/EnviousWisprServices/). 1 file.

## Process rationale (council-skip)
Sentry redaction extension. No design ambiguity. Same shape as existing redaction sites. Codex grounded review settled implementation forks (Exception class semantics, optional unwrapping, ordering). Tag: \`council-skip: codex-grounded-review-settled\`.

## Audit reference
\`docs/audits/2026-05-02-v3-entitlement-pii.md\` — finding #10.

## Test plan
- [x] \`swift build -c debug\` clean
- [x] Codex grounded review: ship with context redaction (added)
- [ ] CI build-check green
- [ ] Post-merge runtime verification: trigger a controlled \`fatalError(\"XYZZY-SECRET-...\")\` in a debug build with Sentry attached, confirm captured event has \`[REDACTED]\` in exception value (deferred to release-build smoke test)
