### PR TITLE
feat(telemetry): observe OS audio events from production for cross-user data (#574)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -1,13 +1,19 @@
 import AppKit
+import EnviousWisprASR
+import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
 @preconcurrency import Sparkle
 import SwiftUI
 
+// Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` were previously
+// DEBUG-only here for `DebugFaultEndpoint`. They are now needed in release
+// builds too because `AudioSystemEventReporter` (production telemetry)
+// references `AudioCaptureInterface` and `ASRManagerInterface` types from
+// those modules.
+
 #if DEBUG
-  import EnviousWisprASR
-  import EnviousWisprAudio
   import EnviousWisprPipeline
 #endif
 
@@ -46,6 +52,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `applicationWillTerminate`. Compiled out of release entirely.
     private var debugFaultEndpoint: DebugFaultEndpoint?
   #endif
+
+  /// Production telemetry observer for OS-level audio events (issue #574).
+  /// Sentry breadcrumb on every fire; PostHog event on fire-during-recording.
+  /// Constructed in `applicationDidFinishLaunching` after AppState is ready;
+  /// torn down in `applicationWillTerminate` for clean observer removal.
+  private var audioSystemEventReporter: AudioSystemEventReporter?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Hide dock icon on launch — we're a menu bar utility.
@@ -174,6 +186,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         debugFaultEndpoint = endpoint
       }
     #endif
+
+    // Production telemetry: OS-level audio events (issue #574). Always on in
+    // release; ships to all users so we get cross-user data on what real
+    // devices/routes/connections users actually hit.
+    audioSystemEventReporter = AudioSystemEventReporter(
+      audioCapture: appState.audioCapture,
+      asrManager: appState.asrManager,
+      pipelineStateProvider: { [weak appState = self.appState] in
+        appState?.pipelineState ?? .idle
+      }
+    )
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {
@@ -452,6 +475,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       debugFaultEndpoint?.stop()
       debugFaultEndpoint = nil
     #endif
+
+    // Issue #574: tear down audio-event observers cleanly.
+    audioSystemEventReporter = nil
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Sources/EnviousWispr/App/AudioSystemEventReporter.swift
+++ b/Sources/EnviousWispr/App/AudioSystemEventReporter.swift
@@ -1,0 +1,207 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// Production telemetry observer for OS-level audio events (issue #574).
+///
+/// Goal: get cross-user data on which audio events real production users
+/// actually trigger (BT pair, system input flip, USB plug, Continuity Camera
+/// mic arrival), so we can decide whether V2 Lane A synthetic scenarios are
+/// testing physically possible states. Without this data the decision is
+/// theoretical.
+///
+/// Approach: extend existing production telemetry rather than build a parallel
+/// DEBUG-only listener. Sentry breadcrumb on every fire (always),
+/// `audio.system_event_during_recording` PostHog event on fire-during-active-
+/// recording.
+///
+/// Owner: `AppDelegate` (matches `DebugFaultEndpoint` retain pattern). NOT on
+/// AppState — Bible epic #319 (Phase E #502, Phase F #503) actively shrinks
+/// AppState. Reporter holds plain collaborator references (no AppState back-
+/// reference) so it cannot accidentally mutate AppState state.
+///
+/// Process placement: host app. CoreAudio system-object property listeners
+/// fire in any process; `AVCaptureDevice.wasConnected/wasDisconnected`
+/// notifications post via NotificationCenter to any registered observer.
+/// Service-side observers are out of scope (audio service has no
+/// `ObservabilityBootstrap.initialize()` call) — `Audio engine interrupted`
+/// Sentry event from the recovery path covers engine-config events for now.
+///
+/// Concurrency: `@MainActor`. Observer callbacks fire on HAL/NotificationCenter
+/// queues; each block snapshots payload synchronously, then hops to MainActor
+/// via `Task { @MainActor }` before reading collaborator state and emitting
+/// telemetry. `SentrySDK.addBreadcrumb` takes a synchronized lock — keeping
+/// emission off HAL threads is load-bearing.
+@MainActor
+final class AudioSystemEventReporter {
+  private let audioCapture: any AudioCaptureInterface
+  private let asrManager: any ASRManagerInterface
+  private let pipelineStateProvider: @MainActor () -> PipelineState
+
+  /// CoreAudio property listener blocks. Stored as instance state so the same
+  /// reference can be passed to `AudioObjectRemovePropertyListenerBlock` in
+  /// deinit — required for clean removal (matches `AudioDeviceMonitor` pattern
+  /// in `Sources/EnviousWisprAudio/AudioDeviceManager.swift`).
+  ///
+  /// `nonisolated(unsafe)` because Swift 6 makes `@MainActor` class `deinit`
+  /// nonisolated; deinit must touch these storage slots to remove the
+  /// listeners. The blocks themselves are non-`Sendable` function types but
+  /// the actual access pattern is single-shot — set in init, read once in
+  /// deinit, never racing.
+  nonisolated(unsafe) private var defaultInputListener: AudioObjectPropertyListenerBlock?
+  nonisolated(unsafe) private var defaultOutputListener: AudioObjectPropertyListenerBlock?
+
+  /// NotificationCenter observer tokens. Same `nonisolated(unsafe)` rationale
+  /// as above.
+  nonisolated(unsafe) private var captureDeviceConnectedToken: (any NSObjectProtocol)?
+  nonisolated(unsafe) private var captureDeviceDisconnectedToken: (any NSObjectProtocol)?
+
+  init(
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    pipelineStateProvider: @escaping @MainActor () -> PipelineState
+  ) {
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.pipelineStateProvider = pipelineStateProvider
+    registerCoreAudioListeners()
+    registerCaptureDeviceObservers()
+  }
+
+  deinit {
+    // CoreAudio listener removal must use the same block reference passed to
+    // the registration call. Tokens are stored as instance state above.
+    if let block = defaultInputListener {
+      var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+      )
+      AudioObjectRemovePropertyListenerBlock(
+        AudioObjectID(kAudioObjectSystemObject), &addr, nil, block)
+    }
+    if let block = defaultOutputListener {
+      var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+      )
+      AudioObjectRemovePropertyListenerBlock(
+        AudioObjectID(kAudioObjectSystemObject), &addr, nil, block)
+    }
+    if let token = captureDeviceConnectedToken {
+      NotificationCenter.default.removeObserver(token)
+    }
+    if let token = captureDeviceDisconnectedToken {
+      NotificationCenter.default.removeObserver(token)
+    }
+  }
+
+  // MARK: - Observer registration
+
+  private func registerCoreAudioListeners() {
+    // Default input device change — fires when user pairs BT, plugs USB,
+    // toggles input in System Settings, etc.
+    let inputBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      // HAL callback thread. Hop to MainActor before reading state or emitting.
+      Task { @MainActor [weak self] in
+        self?.emit(event: "coreAudio.defaultInputDevice.changed", context: [:])
+      }
+    }
+    var inputAddr = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultInputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let inputStatus = AudioObjectAddPropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject), &inputAddr, nil, inputBlock)
+    if inputStatus == noErr {
+      defaultInputListener = inputBlock
+    } else {
+      Task {
+        await AppLogger.shared.log(
+          "[AudioSystemEventReporter] failed to register default-input listener: status=\(inputStatus)",
+          level: .info, category: "Audio"
+        )
+      }
+    }
+
+    let outputBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      Task { @MainActor [weak self] in
+        self?.emit(event: "coreAudio.defaultOutputDevice.changed", context: [:])
+      }
+    }
+    var outputAddr = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let outputStatus = AudioObjectAddPropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject), &outputAddr, nil, outputBlock)
+    if outputStatus == noErr {
+      defaultOutputListener = outputBlock
+    } else {
+      Task {
+        await AppLogger.shared.log(
+          "[AudioSystemEventReporter] failed to register default-output listener: status=\(outputStatus)",
+          level: .info, category: "Audio"
+        )
+      }
+    }
+  }
+
+  private func registerCaptureDeviceObservers() {
+    captureDeviceConnectedToken = NotificationCenter.default.addObserver(
+      forName: .AVCaptureDeviceWasConnected, object: nil, queue: nil
+    ) { [weak self] notification in
+      // NotificationCenter dispatch queue. Capture payload synchronously,
+      // then hop to MainActor.
+      let deviceTypeRaw =
+        (notification.object as? AVCaptureDevice)?.deviceType.rawValue ?? "unknown"
+      Task { @MainActor [weak self] in
+        self?.emit(
+          event: "captureDevice.connected",
+          context: ["device_type": deviceTypeRaw])
+      }
+    }
+    captureDeviceDisconnectedToken = NotificationCenter.default.addObserver(
+      forName: .AVCaptureDeviceWasDisconnected, object: nil, queue: nil
+    ) { [weak self] notification in
+      let deviceTypeRaw =
+        (notification.object as? AVCaptureDevice)?.deviceType.rawValue ?? "unknown"
+      Task { @MainActor [weak self] in
+        self?.emit(
+          event: "captureDevice.disconnected",
+          context: ["device_type": deviceTypeRaw])
+      }
+    }
+  }
+
+  // MARK: - Emission
+
+  private func emit(event: String, context: [String: String]) {
+    // Snapshot collaborators on MainActor.
+    let route = audioCapture.currentAudioRoute  // built_in_mic / capture_session_bt / unknown
+    let backend = asrManager.activeBackendType.rawValue  // parakeet / whisperKit
+    let recordingActive = pipelineStateProvider() == .recording
+
+    var data: [String: Any] = [
+      "transport": route,
+      "backend": backend,
+    ]
+    for (key, value) in context {
+      data[key] = value
+    }
+
+    SentryBreadcrumb.add(stage: "audio.device", message: event, data: data)
+
+    if recordingActive {
+      TelemetryService.shared.audioSystemEventDuringRecording(
+        event: event, backend: backend, transport: route)
+    }
+  }
+}

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -154,6 +154,27 @@ public final class TelemetryService {
       ])
   }
 
+  // MARK: - Audio System Events (issue #574)
+
+  /// Fired when an OS-level audio event (default-device change, capture-device
+  /// connect/disconnect) is observed during an active recording. Lets us
+  /// correlate route changes with active heart-path activity in PostHog so
+  /// future V2 Lane A scenarios are designed against actual user behavior.
+  ///
+  /// Idle-time events fire only as Sentry breadcrumbs (no PostHog event) so
+  /// we do not flood the dashboard with background route churn.
+  public func audioSystemEventDuringRecording(
+    event: String, backend: String, transport: String
+  ) {
+    PostHogSDK.shared.capture(
+      "audio.system_event_during_recording",
+      properties: [
+        "event": event,
+        "backend": backend,
+        "transport": transport,
+      ])
+  }
+
   // MARK: - Permissions
 
   public func permissionStatus(permission: String, status: String, context: String) {


### PR DESCRIPTION
## Summary

Closes #574. Adds `AudioSystemEventReporter` (host-side, retained by `AppDelegate`) that observes four OS-level audio events and emits production telemetry:

- `kAudioHardwarePropertyDefaultInputDevice` change
- `kAudioHardwarePropertyDefaultOutputDevice` change
- `AVCaptureDevice.wasConnectedNotification`
- `AVCaptureDevice.wasDisconnectedNotification`

On every fire: Sentry breadcrumb at `category: pipeline.audio.device`. When `AppState.pipelineState == .recording`, also fires a new PostHog event `audio.system_event_during_recording` so we can compute "of N production recordings, M had a route change mid-flight."

## Why this and not a DEBUG-only profiler

Original scope (issue body + the discarded plan) was a DEBUG-only listener with 30-day local analysis. That ships nowhere and produces N=1 founder data. Production telemetry surface (`SentryBreadcrumb` + `TelemetryService`) already exists and is initialized only in the host app (`EnviousWisprApp.swift:15` → `ObservabilityBootstrap.initialize()`). Adding observers there reuses existing infrastructure; the audio service XPC process has no `ObservabilityBootstrap` and would emit nothing.

Drift trail preserved at `docs/feature-requests/issue-574-2026-05-02-audio-trigger-profiler-DISCARDED.md`. Plan: `docs/feature-requests/issue-574-2026-05-02-production-audio-telemetry.md`.

## Why AppDelegate, not AppState

Bible epic #319 (Phase E #502, Phase F #503) actively shrinks AppState. Adding a process-scoped OS-event observer to AppState contradicts that direction even when under the ≤19 ceiling. AppDelegate is the established home for app-process-lifetime infrastructure (`debugFaultEndpoint` already lives there). Reporter holds plain collaborator references at init — `audioCapture`, `asrManager`, `pipelineStateProvider` closure — not a back-reference to AppState. AppState collaborator count unchanged.

## Privacy

Breadcrumb data uses transport labels (`built_in_mic`, `capture_session_bt`, `unknown`) and `AVCaptureDevice.DeviceType` raw values only. No `localizedName`, no UID, no device IDs. Apple documents `localizedName` as "for display in the user interface," which is enough to treat it as user-identifying surface for remote telemetry.

## Concurrency

Observer callbacks fire on HAL/NotificationCenter queues; each block snapshots payload synchronously then hops to MainActor via `Task { @MainActor }` before reading collaborator state and emitting telemetry. `SentrySDK.addBreadcrumb` takes a synchronized lock — keeping emission off HAL threads is load-bearing. Listener-block storage uses `nonisolated(unsafe)` so deinit can remove observers cleanly (matches `AudioDeviceMonitor` pattern at `AudioDeviceManager.swift:230`).

Codex code-diff review: APPROVE, no blocking issues across Swift 6 concurrency, heart-path safety, privacy, lifecycle + module edges.

## Test plan

- [x] `swift build -c debug` exit 0
- [x] `swift build -c release --arch arm64` exit 0
- [x] `scripts/swift-test.sh` — 551 tests pass
- [x] `scripts/check-dependency-direction.sh` — clean across 11 modules
- [x] Codex code-diff review: APPROVE
- [ ] Live UAT (post-merge, founder machine): pair Bose QC headphones, dictate, verify Sentry breadcrumb on next captured error AND PostHog `audio.system_event_during_recording` event appears in dashboard within an hour
- [ ] 7 days post-deploy: query Sentry / PostHog with `environment=production` and confirm cross-user data lands
