### PR TITLE
ops(tok-routine): assign default P-tier on Codex-finding issue creation

### DIFF
--- a/workers/sentry-triage/routine-prompt-tok-codex.md
+++ b/workers/sentry-triage/routine-prompt-tok-codex.md
@@ -350,7 +350,12 @@ AND the finding is CONCRETE and you can confidently explain why it is valid.
 Actions:
 1. Create a new issue via `mcp__github__issue_write`:
    - Title: `Codex finding: <one-line summary> (from #{pr_number})`
-   - Labels: `codex-review`, `auto-triaged` (these are the ONLY labels on a brand-new issue, so additive vs replace doesn't matter here — but on every subsequent label edit on this issue, use the additive rule from the ATTACH path).
+   - Labels: `codex-review`, `auto-triaged`, AND a default P-tier (see severity rule below). These are the ONLY labels on a brand-new issue, so additive vs replace doesn't matter here — but on every subsequent label edit on this issue, use the additive rule from the ATTACH path.
+   - Severity rule (deterministic; choose ONE P-tier label):
+     - `P2-medium` — finding touches heart-path code (`Sources/EnviousWisprPipeline/`, `Sources/EnviousWisprAudio/`, `Sources/EnviousWisprASR/`, paste cascade), CI / signing / release pipeline, security, or test integrity (test that doesn't actually validate the claimed behavior).
+     - `P3-low` — frontend / website visual bug, observability/telemetry gap, workflow-prompt refinement, or any code-level finding outside heart-path.
+     - `P4-backlog` — pure documentation / changelog / stale-reference / dead-link cleanup. No code or workflow impact.
+   - When uncertain between two tiers, pick the lower-impact tier. The founder can escalate; auto-routine should never inflate severity.
    - Body (template below — pick marker variant by finding type)
 2. Sub-issue link to Epic: Hardening & Refactors (#319):
    ```


### PR DESCRIPTION
## Summary

- TOK was creating new Codex-finding issues with only `codex-review` + `auto-triaged`, no P-tier — surfaced today when an audit found 18 of 69 open issues missing severity (7 from TOK).
- Add a deterministic severity rule mirroring TIK's pattern: P2 (heart-path / CI / security / test integrity), P3 (frontend / observability / workflow), P4 (docs / changelog / stale-ref).
- When uncertain, picks the lower tier — founder escalates, routine never inflates.

`council-skip: zero-blast-radius (LLM prompts — Routine reference copy, no runtime effect on the EnviousWispr app)`. Same exception as #590, which shipped this file.

The 18 unlabeled open issues were already labeled by hand in this session (#392 P1, #578/498/406/393/384 P2, #593/545/532/429/401/294 P3, #592/580/546/533/510/284 P4).

## Test plan
- [x] Diff is +6/-1, single file under `workers/sentry-triage/`
- [x] No `Sources/`, `Tests/`, `Package.swift`, or website changes — Phase 3 lanes N/A
- [x] Source-of-truth is the live Routine config in claude.ai; the next TOK redeploy will pick this up. Reference prompt in repo now matches intended behavior.
