### PR TITLE
feat(paste): 'Auto-paste needs Accessibility' educational toast (#500)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -229,6 +229,13 @@ final class AppState {
     )
     settingsSync.applyInitialSettings(settings)
 
+    recordingOverlay.setGrantHandler { [weak self] in
+      _ = self?.permissions.requestAccessibilityAccess()
+    }
+    recordingOverlay.setAccessibilityWarningDismissedProvider { [weak self] in
+      self?.permissions.accessibilityWarningDismissed ?? false
+    }
+
     // Wire dictation activity provider (after all stored properties initialized)
     polishService.setDictationActivity(self)
 
@@ -848,7 +855,15 @@ final class AppState {
         }
       }
     }()
-    let autoPaste = activePipelineIdle && permissions.hasAccessibilityPermission
+    // #500: drop the legacy `permissions.hasAccessibilityPermission` gate so the
+    // paste cascade always runs. The cascade already handles AX-not-trusted
+    // gracefully at PasteCascadeExecutor.swift:106-118 (forces `.nonText`,
+    // skips all tiers, falls through to clipboard) AND emits the
+    // `.clipboardOnlyAccessibilityDenied` outcome which routes to the
+    // educational `.accessibilityToast` overlay. The legacy gate bypassed
+    // the cascade entirely (TranscriptFinalizer:143 direct copyToClipboard),
+    // depriving AX-denied users of both the diagnostic and the toast.
+    let autoPaste = activePipelineIdle
     let resolvedModel: String = {
       switch settings.llmProvider {
       case .appleIntelligence: return "apple-intelligence"

--- a/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWispr/App/RecordingOverlayPanel.swift
@@ -46,7 +46,19 @@ final class RecordingOverlayPanel {
   /// Tracks lock state for flicker guard comparison.
   private var isRecordingLocked: Bool = false
 
+  private var accessibilityToastShownThisSession: Bool = false
+  private var grantHandler: (() -> Void)?
+  private var accessibilityWarningDismissedProvider: () -> Bool = { false }
+
   // MARK: - Intent-driven API
+
+  func setGrantHandler(_ handler: @escaping () -> Void) {
+    grantHandler = handler
+  }
+
+  func setAccessibilityWarningDismissedProvider(_ provider: @escaping () -> Bool) {
+    accessibilityWarningDismissedProvider = provider
+  }
 
   /// Unified entry point: render the overlay for the given intent.
   /// Guards against identical intents to prevent flicker.
@@ -97,6 +109,20 @@ final class RecordingOverlayPanel {
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showClipboardFallback()
+    case .accessibilityToast:
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: "Accessibility permission needed for auto-paste",
+          .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
+        ])
+      if accessibilityToastShownThisSession || accessibilityWarningDismissedProvider() {
+        showClipboardFallback()
+      } else {
+        accessibilityToastShownThisSession = true
+        showAccessibilityToast()
+      }
     case .warning(let message):
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
@@ -225,6 +251,35 @@ final class RecordingOverlayPanel {
     DispatchQueue.main.async(execute: work)
   }
 
+  /// Show a transient Accessibility permission notice that auto-dismisses after 6s.
+  func showAccessibilityToast() {
+    guard panel == nil else {
+      transitionToAccessibilityToast()
+      scheduleAutoDismiss(seconds: 6.0)
+      return
+    }
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.showPanel(
+        content: AccessibilityToastView(onGrant: { [weak self] in
+          self?.grantHandler?()
+          self?.hide()
+        }).frame(width: 300, height: 56),
+        width: 300,
+        height: 56
+      )
+      self.scheduleAutoDismiss(seconds: 6.0)
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
+  }
+
   /// Auto-dismiss timer for transient notices (clipboard fallback, errors).
   private var autoDismissTask: Task<Void, Never>?
 
@@ -307,6 +362,39 @@ final class RecordingOverlayPanel {
     guard panel == nil else { return }
 
     showPanel(content: PolishingOverlayView(label: label).frame(width: 185, height: 44), width: 185)
+  }
+
+  /// Transition an existing panel to the Accessibility permission notice.
+  private func transitionToAccessibilityToast() {
+    guard let existingPanel = panel else { return }
+    let y = existingPanel.frame.origin.y
+
+    panel = nil
+    autoDismissTask?.cancel()
+    autoDismissTask = nil
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    CATransaction.flush()
+    existingPanel.close()
+
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.showPanel(
+        content: AccessibilityToastView(onGrant: { [weak self] in
+          self?.grantHandler?()
+          self?.hide()
+        }).frame(width: 300, height: 56),
+        width: 300,
+        height: 56,
+        y: y
+      )
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
   }
 
   /// Transition an existing panel from recording to polishing mode.
@@ -855,5 +943,35 @@ struct NotificationOverlayView: View {
     .background(
       style.usesDistressLips
         ? AnyView(DistressCapsuleBackground()) : AnyView(OverlayCapsuleBackground()))
+  }
+}
+
+// MARK: - AccessibilityToastView
+
+struct AccessibilityToastView: View {
+  let onGrant: () -> Void
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: "lock.shield.fill")
+        .foregroundStyle(.orange)
+        .font(.system(size: 16))
+      Text("Auto-paste needs Accessibility")
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(.white)
+      Spacer(minLength: 8)
+      Button(action: onGrant) {
+        Text("Grant")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.white)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 4)
+          .background(Capsule().fill(Color.orange.opacity(0.85)))
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .background(OverlayCapsuleBackground())
   }
 }

--- a/Sources/EnviousWisprPipeline/DictationPipeline.swift
+++ b/Sources/EnviousWisprPipeline/DictationPipeline.swift
@@ -26,6 +26,10 @@ public enum OverlayIntent: Equatable, Sendable {
   /// Transient notice shown when paste fell back to clipboard-only (Tier 3).
   /// Auto-dismissed by the overlay panel after a short delay.
   case clipboardFallback
+  /// Educational notice shown once-per-session when paste cascade falls back
+  /// to clipboard because Accessibility permission is denied. Includes an
+  /// inline Grant button. Auto-dismissed after about 6 seconds.
+  case accessibilityToast
   /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
   /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
   case warning(message: String)

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -22,6 +22,7 @@ internal enum PasteDeliveryOutcome: Equatable, Sendable {
     focus: PasteFocusClassification,
     targetBundleID: String?
   )
+  case clipboardOnlyAccessibilityDenied(targetBundleID: String?)
   case cgEventCreationFailed(accessibilityTrusted: Bool)
 }
 
@@ -30,6 +31,13 @@ internal struct PasteDeliveryResult {
   let tier: PasteTier
   let durationMs: Int
   let outcome: PasteDeliveryOutcome
+
+  var pasteTierLabel: String {
+    if case .clipboardOnlyAccessibilityDenied = outcome {
+      return "clipboard_only_ax_denied"
+    }
+    return tier.rawValue
+  }
 }
 
 /// Three-way classification of the focused AX element at paste time.
@@ -243,6 +251,9 @@ internal final class PasteCascadeExecutor {
       outcome = .delivered(tier: tier, durationMs: durationMs)
     } else if let accessibilityTrusted = cgEventFailureAccessibilityTrusted {
       outcome = .cgEventCreationFailed(accessibilityTrusted: accessibilityTrusted)
+    } else if !axTrusted {
+      outcome = .clipboardOnlyAccessibilityDenied(
+        targetBundleID: request.targetApp?.bundleIdentifier)
     } else {
       outcome = .clipboardOnly(
         tiersAttempted: tiersAttempted,
@@ -296,6 +307,13 @@ internal final class PasteCascadeExecutor {
           "paste.cgevent_failed": true,
           "paste.tier_failures": tierFailures,
         ]
+      )
+    case .clipboardOnlyAccessibilityDenied(let targetBundleID):
+      SentryBreadcrumb.add(
+        stage: "paste",
+        message: "paste.outcome=clipboard_only_ax_denied",
+        level: .info,
+        data: ["target_bundle_id": targetBundleID ?? "unknown"]
       )
     }
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -66,7 +66,9 @@ public final class PipelineStateChangeHandler {
     let plan = PipelineStateChangePlanner.plan(
       to: newState,
       pipelineOverlayIntent: pipelineOverlayIntent,
-      isClipboardFallback: currentTranscript?.metrics?.pasteTier == "clipboard_only",
+      isClipboardFallback: currentTranscript?.metrics?.pasteTier?.hasPrefix("clipboard_only")
+        ?? false,
+      isAccessibilityToast: currentTranscript?.metrics?.pasteTier == "clipboard_only_ax_denied",
       lastPolishError: lastPolishError,
       hasCurrentTranscript: currentTranscript != nil
     )

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -66,8 +66,8 @@ public final class PipelineStateChangeHandler {
     let plan = PipelineStateChangePlanner.plan(
       to: newState,
       pipelineOverlayIntent: pipelineOverlayIntent,
-      isClipboardFallback: currentTranscript?.metrics?.pasteTier?.hasPrefix("clipboard_only")
-        ?? false,
+      isClipboardFallback: currentTranscript?.metrics?.pasteTier == "clipboard_only"
+        || currentTranscript?.metrics?.pasteTier == "clipboard_only_ax_denied",
       isAccessibilityToast: currentTranscript?.metrics?.pasteTier == "clipboard_only_ax_denied",
       lastPolishError: lastPolishError,
       hasCurrentTranscript: currentTranscript != nil

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -66,6 +66,7 @@ enum PipelineStateChangePlanner {
     to newState: any PipelineStateProtocol,
     pipelineOverlayIntent: OverlayIntent,
     isClipboardFallback: Bool,
+    isAccessibilityToast: Bool,
     lastPolishError: String?,
     hasCurrentTranscript: Bool
   ) -> PipelineStateChangePlan {
@@ -77,7 +78,9 @@ enum PipelineStateChangePlanner {
     let resolvedOverlayIntent: OverlayIntent
     switch newState.activity {
     case .complete:
-      if isClipboardFallback {
+      if isAccessibilityToast {
+        resolvedOverlayIntent = .accessibilityToast
+      } else if isClipboardFallback {
         resolvedOverlayIntent = .clipboardFallback
       } else if lastPolishError != nil {
         resolvedOverlayIntent = pipelineOverlayIntent

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -923,7 +923,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       transcript.metrics = ExecutionMetrics(
         asrLatencySeconds: asrEnd - asrStart,
         llmLatencySeconds: polishDuration,
-        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+        pasteTier: finalizationResult.pasteResult?.pasteTierLabel,
         pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
         targetApp: pasteTargetApp,
         coldStart: false,
@@ -937,7 +937,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
           "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
           "asr_s": String(format: "%.3f", asrEnd - asrStart),
           "polish_s": String(format: "%.3f", polishDuration),
-          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+          "paste_tier": finalizationResult.pasteResult?.pasteTierLabel ?? "none",
           "backend": asrManager.activeBackendType.rawValue,
         ])
       captureTelemetry.recordSuccessfulRecording()

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -987,7 +987,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       transcript.metrics = ExecutionMetrics(
         asrLatencySeconds: asrEnd - asrStart,
         llmLatencySeconds: polishDuration,
-        pasteTier: finalizationResult.pasteResult?.tier.rawValue,
+        pasteTier: finalizationResult.pasteResult?.pasteTierLabel,
         pasteLatencyMs: finalizationResult.pasteResult?.durationMs,
         targetApp: pasteTargetApp,
         coldStart: false,
@@ -1001,7 +1001,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           "e2e_s": String(format: "%.3f", pipelineEnd - pipelineStart),
           "asr_s": String(format: "%.3f", asrEnd - asrStart),
           "polish_s": String(format: "%.3f", polishDuration),
-          "paste_tier": finalizationResult.pasteResult?.tier.rawValue ?? "none",
+          "paste_tier": finalizationResult.pasteResult?.pasteTierLabel ?? "none",
         ])
       captureTelemetry.recordSuccessfulRecording()
       frozenSnapshot = nil

--- a/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@MainActor
+@Suite("PasteDeliveryResult pasteTierLabel")
+struct PasteDeliveryResultLabelTests {
+
+  @Test("AX-denied clipboard outcome uses sentinel paste tier label")
+  func axDeniedClipboardOutcomeUsesSentinelLabel() {
+    let result = PasteDeliveryResult(
+      tier: .clipboardOnly,
+      durationMs: 4,
+      outcome: .clipboardOnlyAccessibilityDenied(targetBundleID: "com.example.target")
+    )
+
+    #expect(result.pasteTierLabel == "clipboard_only_ax_denied")
+  }
+
+  @Test("non-AX-denied outcomes use raw tier value")
+  func nonAXDeniedOutcomesUseRawTierValue() {
+    let results: [PasteDeliveryResult] = [
+      PasteDeliveryResult(
+        tier: .axDirect,
+        durationMs: 1,
+        outcome: .delivered(tier: .axDirect, durationMs: 1)
+      ),
+      PasteDeliveryResult(
+        tier: .cgEvent,
+        durationMs: 2,
+        outcome: .delivered(tier: .cgEvent, durationMs: 2)
+      ),
+      PasteDeliveryResult(
+        tier: .appleScript,
+        durationMs: 3,
+        outcome: .delivered(tier: .appleScript, durationMs: 3)
+      ),
+      PasteDeliveryResult(
+        tier: .clipboardOnly,
+        durationMs: 4,
+        outcome: .delivered(tier: .clipboardOnly, durationMs: 4)
+      ),
+      PasteDeliveryResult(
+        tier: .clipboardOnly,
+        durationMs: 5,
+        outcome: .clipboardOnly(
+          tiersAttempted: [],
+          focus: .missing,
+          targetBundleID: nil
+        )
+      ),
+      PasteDeliveryResult(
+        tier: .clipboardOnly,
+        durationMs: 6,
+        outcome: .cgEventCreationFailed(accessibilityTrusted: false)
+      ),
+    ]
+
+    for result in results {
+      #expect(result.pasteTierLabel == result.tier.rawValue)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -136,6 +136,26 @@ struct PipelineStateChangeHandlerTests {
     #expect(calls.completedCalls.count == 1)
   }
 
+  @Test("complete + AX-denied paste tier routes to accessibilityToast overlay")
+  func completeAccessibilityDeniedRoutesToToast() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "clipboard_only_ax_denied")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: transcript
+    )
+
+    #expect(spy.calls == [OverlaySpy.Call(intent: .accessibilityToast)])
+    #expect(calls.scheduleWarningCount == 0)
+    #expect(calls.appendedCalls.count == 1)
+    #expect(calls.completedCalls.count == 1)
+  }
+
   // MARK: - Transcript-conditional guards
 
   @Test("complete without current transcript: neither append nor telemetry fires (Phase C)")

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -33,6 +33,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: Self.hiddenIntent,
       isClipboardFallback: true,
+      isAccessibilityToast: false,
       lastPolishError: "polish failed for some reason",
       hasCurrentTranscript: true
     )
@@ -44,12 +45,69 @@ struct PipelineStateChangePlannerTests {
     #expect(!plan.effects.contains(.cancelPendingWarning))
   }
 
+  @Test("complete + accessibility toast + clipboard fallback -> accessibilityToast wins")
+  func completeAccessibilityToastWinsOverClipboardFallback() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: true,
+      isAccessibilityToast: true,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.accessibilityToast)))
+    #expect(!plan.effects.contains(.showOverlay(.clipboardFallback)))
+  }
+
+  @Test("complete + clipboard fallback without accessibility toast -> clipboardFallback")
+  func completeClipboardFallbackWithoutAccessibilityToast() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: true,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.clipboardFallback)))
+    #expect(!plan.effects.contains(.showOverlay(.accessibilityToast)))
+  }
+
+  @Test("complete + accessibility toast without clipboard fallback -> accessibilityToast")
+  func completeAccessibilityToastStandalone() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: true,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.accessibilityToast)))
+    #expect(!plan.effects.contains(.showOverlay(.clipboardFallback)))
+  }
+
+  @Test("non-complete + accessibility toast input does not emit accessibilityToast")
+  func nonCompleteAccessibilityToastInputDoesNotEmitToast() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.recording,
+      pipelineOverlayIntent: Self.recordingIntent,
+      isClipboardFallback: true,
+      isAccessibilityToast: true,
+      lastPolishError: nil,
+      hasCurrentTranscript: true
+    )
+    #expect(!plan.effects.contains(.showOverlay(.accessibilityToast)))
+    #expect(plan.effects.contains(.showOverlay(Self.recordingIntent)))
+  }
+
   @Test("complete + polish failed (not clipboard) -> overlay + schedulePolishFailedWarning")
   func completePolishFailedSchedulesWarning() {
     let plan = PipelineStateChangePlanner.plan(
       to: PipelineState.complete,
       pipelineOverlayIntent: Self.hiddenIntent,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: "openai 429 rate-limited",
       hasCurrentTranscript: true
     )
@@ -66,6 +124,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: Self.hiddenIntent,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: true
     )
@@ -88,6 +147,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: Self.hiddenIntent,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -107,6 +167,7 @@ struct PipelineStateChangePlannerTests {
         to: state,
         pipelineOverlayIntent: Self.recordingIntent,
         isClipboardFallback: false,
+        isAccessibilityToast: false,
         lastPolishError: nil,
         hasCurrentTranscript: false
       )
@@ -130,6 +191,7 @@ struct PipelineStateChangePlannerTests {
       to: WhisperKitPipelineState.ready,
       pipelineOverlayIntent: Self.hiddenIntent,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -155,6 +217,7 @@ struct PipelineStateChangePlannerTests {
         to: state,
         pipelineOverlayIntent: intent,
         isClipboardFallback: false,
+        isAccessibilityToast: false,
         lastPolishError: nil,
         hasCurrentTranscript: false
       )
@@ -173,6 +236,7 @@ struct PipelineStateChangePlannerTests {
       to: WhisperKitPipelineState.startingUp,
       pipelineOverlayIntent: .processing(label: "Starting..."),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -180,6 +244,7 @@ struct PipelineStateChangePlannerTests {
       to: WhisperKitPipelineState.loadingModel,
       pipelineOverlayIntent: .processing(label: "Loading model..."),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -195,6 +260,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.error("mic_disconnected"),
       pipelineOverlayIntent: .error(message: "mic_disconnected"),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -212,6 +278,7 @@ struct PipelineStateChangePlannerTests {
       to: WhisperKitPipelineState.error("whisperkit_load_failed"),
       pipelineOverlayIntent: .error(message: "whisperkit_load_failed"),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -226,6 +293,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: true
     )
@@ -245,6 +313,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: "fail",
       hasCurrentTranscript: true
     )
@@ -263,6 +332,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       isClipboardFallback: true,
+      isAccessibilityToast: false,
       lastPolishError: "fail",
       hasCurrentTranscript: true
     )
@@ -280,6 +350,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.recording,
       pipelineOverlayIntent: .recording(audioLevel: 0),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )
@@ -296,6 +367,7 @@ struct PipelineStateChangePlannerTests {
       to: PipelineState.error("bad"),
       pipelineOverlayIntent: .error(message: "bad"),
       isClipboardFallback: false,
+      isAccessibilityToast: false,
       lastPolishError: nil,
       hasCurrentTranscript: false
     )


### PR DESCRIPTION
## Summary

When the paste cascade falls back to clipboard because Accessibility permission is denied, surface a one-time-per-session educational toast in the existing top-center notch overlay family. Subsequent paste fallbacks within the same session degrade to the existing short "Copied. Press ⌘V to paste" pill. Heart path untouched.

Closes #500. Folded-in from #440 (same Sentry fingerprint).

## Why

Sentry showed 4 production users on v1.9.4 with `paste_failed (clipboard_only, tiersAttempted=[])` events. PostHog cross-check 2026-05-02: all 4 users had `permission.status: accessibility, status=denied` events at app launch. They were dictating successfully and seeing "Copied. Press ⌘V" every time with no signal connecting the friction to the missing permission. Onboarding research already showed users decline AX out of trust caution.

Original framing was a P1 paste cascade defect; data work flipped it to a UX enhancement (relabeled `enhancement` `P2-medium` 2026-05-02).

## What changed

**`PasteCascadeExecutor`** — new `PasteDeliveryOutcome.clipboardOnlyAccessibilityDenied(targetBundleID:)` returned when AX is untrusted at cascade entry AND no tier was attempted. New `pasteTierLabel` computed property maps it to sentinel string `"clipboard_only_ax_denied"`. Sentry `paste_failed` `captureError` is suppressed for this case (breadcrumb only) since it's intentional fallback, not a defect.

**`OverlayIntent.accessibilityToast`** — new public case in `DictationPipeline.swift`.

**Pipelines** (`TranscriptionPipeline`, `WhisperKitPipeline`) — write `pasteTierLabel` into `ExecutionMetrics.pasteTier` and the PostHog `paste.completed` payload.

**`PipelineStateChangeHandler` + `Planner`** — handler computes `isAccessibilityToast` from the metrics sentinel, passes to planner. Planner emits `.accessibilityToast` for `.complete` activity when true, taking precedence over generic clipboard fallback. `isClipboardFallback` widened to explicitly accept both `"clipboard_only"` and `"clipboard_only_ax_denied"` (per Codex review revision in commit 2).

**`RecordingOverlayPanel`** — new `AccessibilityToastView` (300×56 capsule, amber `lock.shield.fill` icon, inline orange "Grant" pill), `showAccessibilityToast()` and `transitionToAccessibilityToast()` mirroring existing patterns, session-scoped `accessibilityToastShownThisSession` flag, `setGrantHandler(_:)` and `setAccessibilityWarningDismissedProvider(_:)` closure injection.

**`AppState`** — wires Grant action (calls existing `permissions.requestAccessibilityAccess()`) and dismissal-state provider. **Drops the legacy `permissions.hasAccessibilityPermission` gate from `autoPaste` calculation** (line 858) so the cascade always runs. The cascade itself already handles AX-not-trusted gracefully at `PasteCascadeExecutor.swift:106-118`; the upstream gate was redundant defense and was bypassing our new educational layer entirely (caught by Live UAT).

## Process

| Step | Result |
|---|---|
| Plan written by Claude | `docs/feature-requests/issue-500-2026-05-02-ax-permission-paste-toast.md` (gitignored) |
| Codex grounded review on plan | YES_WITH_REVISIONS — caught the metrics→handler→planner emission path Claude initially got wrong |
| Plan revised | Approach updated to the actual code architecture |
| Council | Skipped per `council-skip: codex-grounded-review settled the only fork; founder visually approved final UX direction across two iterations of mockup feedback` |
| Code written by Codex | One-shot from the revised plan in a worktree, no commits |
| Adversarial review by Claude | Found 2 minor non-blocking flags (PostHog tier-string contract change, session-flag set-before-render-confirmed) |
| Build + tests | `swift build -c release` clean; 557→558 tests pass after Codex revision |
| Live UAT (founder) | First dictation: toast renders correctly top-center with Grant button. Second dictation: short pill (session-rate-limit working). Grant click: opens System Settings → Accessibility. Cmd+V always pastes the dictated text. |
| Codex code-diff review | PROCEED-WITH-REVISIONS — flagged hasPrefix overreach + handler test gap |
| Revisions applied | Commit 2 in this PR |

## Operational notes

- **PostHog dashboards** filtering on `tier == "clipboard_only"` will need to either add `"clipboard_only_ax_denied"` to their filter set or switch to a `hasPrefix` match. New label is more informative — segments AX-denied users explicitly.
- **No impact on AX-granted users.** The cascade-gate removal is byte-identical for them (the gate only mattered for AX-denied users).
- **Sentry signal quieted** for the AX-denied case: `paste_failed` captureError no longer fires for this known-and-handled state, only a breadcrumb. Reduces false-positive noise.

## Tests

- `PasteDeliveryResultLabelTests` (new) — sentinel mapping for the new outcome.
- `PipelineStateChangePlannerTests` — extended with 4 cases covering toast precedence, standalone toast, fallback-only, and non-complete-state suppression. All 16 existing call sites propagated with the new `isAccessibilityToast: false` arg.
- `PipelineStateChangeHandlerTests` — extended with `completeAccessibilityDeniedRoutesToToast` end-to-end routing test.
- Full suite: 558/558 passing locally.

## Test plan

- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` 558/558 pass
- [x] Codex grounded review on plan: PROCEED with revisions absorbed
- [x] Codex code-diff review: PROCEED-WITH-REVISIONS, all revisions in commit 2
- [x] Live UAT founder validated (4/4 items)
- [ ] CI build-check green (pending)
