### PR TITLE
deps(whisperkit): migrate to argmax-oss-swift 1.0.0 (#597)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "bc09741bd25d8e28f06eb353cceb9109b7d9a4f047380e4393a595d52b34ceea",
+  "originHash" : "fb2a129a0ee4f439432cccbf7881b1ebad9ed9c757c0b8f16543a8d52af6d6b6",
   "pins" : [
+    {
+      "identity" : "argmax-oss-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/argmax-oss-swift",
+      "state" : {
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
+      }
+    },
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
@@ -53,69 +62,6 @@
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
-        "version" : "2.3.2"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
-      }
-    },
-    {
-      "identity" : "whisperkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argmaxinc/WhisperKit.git",
-      "state" : {
-        "revision" : "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef",
-        "version" : "0.18.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .library(name: "EnviousWisprLLM", targets: ["EnviousWisprLLM"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.12.0"),
+    .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
     .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
@@ -59,7 +59,7 @@ let package = Package(
       dependencies: [
         "EnviousWisprCore",
         "EnviousWisprAudio",
-        "WhisperKit",
+        .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
       ],
       path: "Sources/EnviousWisprASR"
@@ -101,7 +101,7 @@ let package = Package(
         "EnviousWisprCore",
         "EnviousWisprASR",
         "EnviousWisprAudio",
-        "WhisperKit",
+        .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
       ],
       path: "Sources/EnviousWisprASRService",
@@ -118,7 +118,7 @@ let package = Package(
         "EnviousWisprASR",
         "EnviousWisprLLM",
         "EnviousWisprPipeline",
-        "WhisperKit",
+        .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
         "Sparkle",
       ],

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -3,12 +3,11 @@ import Foundation
 @preconcurrency import WhisperKit
 
 /// Hardcoded compute options optimized for Apple Silicon dictation.
-/// Audio encoder + text decoder → Neural Engine, mel spectrogram → GPU, prefill → CPU only.
+/// Audio encoder + text decoder → Neural Engine, mel spectrogram → GPU.
 private let dictationComputeOptions = ModelComputeOptions(
   melCompute: .cpuAndGPU,
   audioEncoderCompute: .cpuAndNeuralEngine,
-  textDecoderCompute: .cpuAndNeuralEngine,
-  prefillCompute: .cpuOnly
+  textDecoderCompute: .cpuAndNeuralEngine
 )
 
 /// WhisperKit ASR backend — broad language support with hardcoded dictation-optimized quality.
@@ -257,7 +256,6 @@ public actor WhisperKitBackend: ASRBackend {
     opts.skipSpecialTokens = true
     opts.suppressBlank = true
     opts.usePrefillPrompt = true
-    opts.usePrefillCache = true
 
     // Use VAD chunking for long recordings to prevent hallucinated repetitions
     let thirtySeconds = 16000 * 30  // 480_000 samples


### PR DESCRIPTION
Closes #597.

## Summary

- Swap package dependency from `argmaxinc/WhisperKit` v0.18.0 to its renamed successor `argmaxinc/argmax-oss-swift` v1.0.0 (released 2026-05-01).
- Remove two settings retired in 1.0.0: `prefillCompute:` parameter on `ModelComputeOptions` and `opts.usePrefillCache = true` in `makeDecodeOptions`. Both removed alongside the `TextDecoderContextPrefill` model.
- Three target dependency references switched from the bare `"WhisperKit"` shorthand to `.product(name: "WhisperKit", package: "argmax-oss-swift")` — the new package name no longer matches the product name, so SwiftPM requires the explicit form.

Module name `WhisperKit` is preserved by the renamed package, so the three `@preconcurrency import WhisperKit` sites in `Sources/EnviousWisprASR/` compile unchanged. Hugging Face cache path is unchanged; existing model bytes survive the upgrade and users do not re-download.

## Why now

Precursor to #452. Re-downloading the model gives identical bytes (no upstream model fix), and no newer date-stamped model variant exists. The fix for #452 (the "Thank you" hallucination) is decoder-option tuning. We want to be on the current package before tuning.

## Test plan

Live UAT on a release build, `argmax-oss-swift v1.0.0` resolved cleanly:

- [x] Test A — short WhisperKit recording: "Testing 1, 2, 3 on WhisperKit." in 2.5s
- [x] Test C — 41s WhisperKit clip exercising the `.vad` chunking branch: full passage transcribed in 4.3s
- [x] Test E — model file mtimes/sizes/checksums identical pre- and post-launch (no re-download)
- [x] Test D — Parakeet regression check: clean transcript on retry (first attempt was a transient mic-routing hiccup, unrelated to this change)
- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` — 558/558 tests pass

## Process

- Plan: `docs/feature-requests/issue-597-2026-05-03-whisperkit-1-0-0-migration.md` (gitignored — local design artifact)
- Codex grounded review: `docs/audits/2026-05-03-whisperkit-1-0-0-migration-grounded-review.txt` (gitignored). Verdict: YES_WITH_REVISIONS. The two flagged corrections (missed `usePrefillCache` removal, explicit `.product()` form) were applied before commit.
- council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining

## Out of scope (filed as #598)

Standalone bench/eval packages under `scripts/multilingual-eval/runner/` and `scripts/multilingual-eval/bench/` still pin old `argmaxinc/WhisperKit.git` and use the removed APIs. They're not part of the shipped app, so they cannot block this PR. Tracked separately at #598 (P3) — to be migrated before next multilingual eval cycle.
