### PR TITLE
fix(whisperkit): enable detectLanguage when language nil (#560)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -244,6 +244,15 @@ public actor WhisperKitBackend: ASRBackend {
 
     // Shared options (from TranscriptionOptions)
     opts.language = options.language
+    // When the caller cannot specify a language, ask WhisperKit to detect it.
+    // WhisperKit's library default is `detectLanguage = !usePrefillPrompt`; with
+    // prefill on (we keep it on for performance on the known-language path) the
+    // default resolves to false, and nil-language silently English-prefills via
+    // `Constants.defaultLanguageCode` (TextDecoder.swift:183). Opt into detect
+    // explicitly only when language is nil. This mirrors WhisperKit's own
+    // auto-detect gate (TranscribeTask.swift:341 checks `language == nil`).
+    // BRAIN: gotcha id=detect-language-when-nil
+    opts.detectLanguage = (options.language == nil)
     opts.wordTimestamps = options.enableTimestamps
 
     // Hardcoded dictation-optimized defaults

--- a/Tests/EnviousWisprASRTests/WhisperKitBackendDecodeOptionsTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitBackendDecodeOptionsTests.swift
@@ -1,0 +1,49 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprASR
+
+@Suite("WhisperKitBackend decode options")
+struct WhisperKitBackendDecodeOptionsTests {
+
+  @Test("detectLanguage true when language nil for auto-mode LID-abstain path")
+  func test_detectLanguage_true_when_language_nil_for_auto_mode_LID_abstain_path() async {
+    let sut = WhisperKitBackend()
+    let options = TranscriptionOptions(language: nil)
+
+    let decodeOptions = await sut.makeDecodeOptions(from: options, sampleCount: 0)
+
+    #expect(decodeOptions.detectLanguage == true)
+  }
+
+  @Test(
+    "detectLanguage false when language locked to explicit code",
+    arguments: ["es", "en", "ja", "de"])
+  func test_detectLanguage_false_when_language_locked_to_explicit_code(_ language: String) async {
+    let sut = WhisperKitBackend()
+    let options = TranscriptionOptions(language: language)
+
+    let decodeOptions = await sut.makeDecodeOptions(from: options, sampleCount: 0)
+
+    #expect(decodeOptions.detectLanguage == false)
+  }
+
+  // Documents WhisperKit's own contract: only `nil` triggers auto-detect.
+  // Empty / whitespace strings are non-nil so detectLanguage stays false; the
+  // string is then forwarded to WhisperKit which (per TextDecoder.swift:183-184)
+  // builds "<||>", fails the tokenizer lookup, and falls back to the english
+  // token. Safe but does not auto-detect. We do NOT defensively normalize
+  // empty to nil, because that would diverge from WhisperKit's own gate at
+  // TranscribeTask.swift:341 which uses `options.language == nil` exactly.
+  @Test(
+    "detectLanguage false when language is empty or whitespace (matches WhisperKit's nil-only auto-detect contract)",
+    arguments: ["", " ", "   "])
+  func test_detectLanguage_false_when_language_empty_or_whitespace(_ language: String) async {
+    let sut = WhisperKitBackend()
+    let options = TranscriptionOptions(language: language)
+
+    let decodeOptions = await sut.makeDecodeOptions(from: options, sampleCount: 0)
+
+    #expect(decodeOptions.detectLanguage == false)
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #560 (Part B). Production user (env=production, v1.9.4, M2 MBA) hit `asr_empty_result` twice on 2026-04-30 when sub-1s clips caused our `LanguageDetector` to abstain and WhisperKit silently decoded the non-English utterance as English-default to empty.
- Root cause: `WhisperKitBackend.makeDecodeOptions` never set `DecodingOptions.detectLanguage`, which defaults to `!usePrefillPrompt` = false when prefill is on. Verified against `.../v1.0.0/Sources/WhisperKit/Core/Configurations.swift:226` and Argmax's own test suite at `UnitTests.swift:1444-1450` which asserts every `(usePrefillPrompt, detectLanguage)` combination.
- Fix: 1 conditional line + 7 lines of comment in `WhisperKitBackend.swift`. Mirrors WhisperKit's own gate at `TranscribeTask.swift:341` (`options.language == nil`). Known-language path keeps prefill optimization; auto-mode LID-abstain path gains real auto-detect.
- **Out of scope (deferred):** Part A observability split (existing breadcrumbs already let us hand-correlate); Parakeet empty-result sub-cases (different root cause); `LLMPolishStep` language fallback when WhisperKit-detected ≠ our-LID-abstained (filed as follow-up in plan §15).

## Validation

- New test file `WhisperKitBackendDecodeOptionsTests.swift` with 3 `@Test` functions covering 8 cases:
  - `language=nil` → `detectLanguage=true` (the fix)
  - `language=es|en|ja|de` (4 parameterized) → `detectLanguage=false` (Aaron's locked-mode regression check)
  - `language=""|" "|"   "` (3 parameterized) → `detectLanguage=false` (documents WhisperKit's nil-only auto-detect contract; we deliberately do NOT defensively normalize empty to nil because that would diverge from `TranscribeTask.swift:341`)
- Mutation check passed locally: temporarily inverting the production line correctly fails the nil-language test, proving the test exercises the contract (not a tautology).
- `swift build --build-tests` exit 0; `scripts/swift-test.sh --filter WhisperKitBackendDecodeOptionsTests` 8 cases passed in 1ms; `swift build -c release` exit 0.
- Live UAT (25 short clips × 5 languages, latency budget ≤100ms median regression) deferred to post-merge: see follow-up issue for the joint Thank-You + #560 UAT pass.

## Council + grounded review

- 4 personas × GPT + Gemini = 8 background subagents (Frank, Meera, Diana, Aaron). 8 of 8 said ship; concerns flagged were latency (now measured per UAT spec), English-no-regression (added explicit sub-1s English test cases), and locked-mode regression (now a named test parameterized over 4 codes).
- Codex grounded review round 1: `docs/audits/2026-05-03-codex-issue-560-plan-grounded-review.md` — PROCEED-WITH-REVISIONS (12 findings).
- Codex grounded review round 2: `docs/audits/2026-05-03-codex-issue-560-plan-grounded-review-round2.md` — verified all revisions landed.
- Code written by Codex in worktree `wt-560-whisperkit-detect-language`; adversarial code review done by main session (separation preserved). Mutation check + reading WhisperKit source (TextDecoder.swift:183 + TranscribeTask.swift:341) grounded all claims.

## Plan + knowledge

- Plan: `docs/feature-requests/issue-560-2026-05-03-whisperkit-detect-language.md`
- Knowledge: `.claude/knowledge/whisperkit-research.md` § Language Detection (8 new FACT/RULE entries; sibling section to Thank-You session's Hallucination Prevention)

## Test plan

- [x] `swift build --build-tests` exit 0
- [x] `swift build -c release` exit 0
- [x] All 8 new test cases pass
- [x] Mutation check confirms tests exercise the contract
- [ ] Post-merge: full multilingual UAT (25 short clips × 5 languages) on the rebuilt + relaunched app, jointly with the Thank-You #452 fix
- [ ] Post-merge: monitor Sentry ENVIOUSWISPR-P fingerprint for absence of new events on next user sessions
