### PR TITLE
fix(whisperkit): suppress 'Thank you' hallucination via clipTimestamps (#452)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -183,6 +183,8 @@ public final class ASRManagerProxy: ASRManagerInterface {
   {
     let data = audioSamples.withUnsafeBytes { Data($0) }
     let language = options.language ?? ""
+    let speechSegmentsData =
+      options.speechSegments.isEmpty ? nil : try JSONEncoder().encode(options.speechSegments)
 
     let (resultData, error): (Data?, NSError?) = try await withCheckedThrowingContinuation {
       (cont: CheckedContinuation<(Data?, NSError?), any Error>) in
@@ -190,7 +192,8 @@ public final class ASRManagerProxy: ASRManagerInterface {
       serviceProxy { proxy in
         proxy.transcribeSamples(
           data, sampleCount: audioSamples.count,
-          language: language, enableTimestamps: options.enableTimestamps
+          language: language, enableTimestamps: options.enableTimestamps,
+          speechSegmentsData: speechSegmentsData
         ) { resultData, nsError in
           guard_.resume(returning: (resultData, nsError))
         }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -257,14 +257,27 @@ public actor WhisperKitBackend: ASRBackend {
     opts.suppressBlank = true
     opts.usePrefillPrompt = true
 
-    // Use VAD chunking for long recordings to prevent hallucinated repetitions
-    let thirtySeconds = 16000 * 30  // 480_000 samples
+    // VAD-driven clip seek: feed only voiced ranges to the decoder.
+    // Each pair is (startSec, endSec) in WhisperKit's expected sample-rate space.
+    if !options.speechSegments.isEmpty {
+      let sampleRate = Float(WhisperKit.sampleRate)
+      var clipTimestamps: [Float] = []
+      clipTimestamps.reserveCapacity(options.speechSegments.count * 2)
+      for segment in options.speechSegments {
+        clipTimestamps.append(Float(segment.startSample) / sampleRate)
+        clipTimestamps.append(Float(segment.endSample) / sampleRate)
+      }
+      opts.clipTimestamps = clipTimestamps
+    }
+
+    // Use VAD chunking for long recordings to prevent hallucinated repetitions.
+    let thirtySeconds = Int(WhisperKit.sampleRate) * 30
     // BRAIN: gotcha id=vad-chunking-30s
     opts.chunkingStrategy = sampleCount > thirtySeconds ? .vad : ChunkingStrategy.none
 
-    // Disable windowClipTime (default 1.0s) which skips the last 1s of audio.
-    // We pad audio with silence instead, which provides the look-ahead context
-    // the decoder needs without sacrificing real content.
+    // Keep current behavior for this PR: WhisperKit's default 1.0 subtracts time
+    // from the end of every seek clip, which can clip legitimate trailing speech
+    // when clipTimestamps come from raw VAD segment ends.
     // BRAIN: gotcha id=window-clip-time-zero
     opts.windowClipTime = 0
 

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -114,6 +114,7 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
   func transcribeSamples(
     _ data: Data, sampleCount: Int, language: String, enableTimestamps: Bool,
+    speechSegmentsData: Data?,
     reply: @escaping (Data?, NSError?) -> Void
   ) {
     nonisolated(unsafe) let safeReply = reply
@@ -139,9 +140,17 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
           return Array(raw.bindMemory(to: Float.self))
         }
 
-        var options = TranscriptionOptions()
-        options.language = language.isEmpty ? nil : language
-        options.enableTimestamps = enableTimestamps
+        let speechSegments =
+          if let speechSegmentsData {
+            try JSONDecoder().decode([SpeechSegment].self, from: speechSegmentsData)
+          } else {
+            [SpeechSegment]()
+          }
+        let options = TranscriptionOptions(
+          language: language.isEmpty ? nil : language,
+          enableTimestamps: enableTimestamps,
+          speechSegments: speechSegments
+        )
 
         // Route to the active backend
         let result: EnviousWisprCore.ASRResult

--- a/Sources/EnviousWisprCore/ASRResult.swift
+++ b/Sources/EnviousWisprCore/ASRResult.swift
@@ -37,11 +37,17 @@ public struct ASRResult: Sendable, Codable {
 public struct TranscriptionOptions: Sendable, Codable {
   public var language: String?
   public var enableTimestamps: Bool = true
+  public var speechSegments: [SpeechSegment] = []
 
   public static let `default` = TranscriptionOptions()
 
-  public init(language: String? = nil, enableTimestamps: Bool = true) {
+  public init(
+    language: String? = nil,
+    enableTimestamps: Bool = true,
+    speechSegments: [SpeechSegment] = []
+  ) {
     self.language = language
     self.enableTimestamps = enableTimestamps
+    self.speechSegments = speechSegments
   }
 }

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -36,9 +36,11 @@ import Foundation
   ///   - sampleCount: Number of Float32 samples in data.
   ///   - language: ISO 639-1 language code, or empty string for auto-detect.
   ///   - enableTimestamps: Whether to generate word-level timestamps.
+  ///   - speechSegmentsData: JSON-encoded [SpeechSegment], or nil when no VAD segments exist.
   ///   - reply: (Codable-encoded ASRResult as Data, or nil) + (NSError or nil).
   func transcribeSamples(
     _ data: Data, sampleCount: Int, language: String, enableTimestamps: Bool,
+    speechSegmentsData: Data?,
     reply: @escaping (Data?, NSError?) -> Void)
 
   // MARK: - Streaming Transcription (Parakeet)

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -35,7 +35,7 @@ public enum AppConstants {
 // MARK: - Speech Segment
 
 /// A contiguous range of audio samples identified as speech by VAD.
-public struct SpeechSegment: Sendable {
+public struct SpeechSegment: Sendable, Codable {
   public let startSample: Int
   public let endSample: Int
   public init(startSample: Int, endSample: Int) {

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -35,6 +35,50 @@ public enum WhisperKitPipelineState: Equatable, Sendable {
   }
 }
 
+internal enum WhisperKitPipelineSpeechRouting {
+  static func hasSpeechEvidence(vadSegments: [SpeechSegment]?) -> Bool {
+    vadSegments.map { !$0.isEmpty } ?? true
+  }
+
+  static func paddedASRSamples(
+    rawSamples: [Float],
+    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
+  ) -> [Float] {
+    padIfShort(rawSamples, minimumSamples: minimumSamples)
+  }
+
+  static func paddedLIDSamples(
+    filteredSamples: [Float],
+    rawSamples: [Float],
+    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
+  ) -> [Float] {
+    var samples = filteredSamples
+    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
+      samples = rawSamples
+    }
+    return padIfShort(samples, minimumSamples: minimumSamples)
+  }
+
+  static func transcriptionOptions(
+    from base: TranscriptionOptions,
+    speechSegments: [SpeechSegment]
+  ) -> TranscriptionOptions {
+    TranscriptionOptions(
+      language: base.language,
+      enableTimestamps: base.enableTimestamps,
+      speechSegments: speechSegments
+    )
+  }
+
+  private static func padIfShort(
+    _ samples: [Float],
+    minimumSamples: Int
+  ) -> [Float] {
+    guard samples.count > 0 && samples.count < minimumSamples else { return samples }
+    return samples + [Float](repeating: 0, count: minimumSamples - samples.count)
+  }
+}
+
 // MARK: - PipelineStateProtocol conformance
 
 extension WhisperKitPipelineState: PipelineStateProtocol {
@@ -588,8 +632,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       return
     }
 
-    // Post-capture VAD filtering — remove silence segments
-    var samples: [Float]
+    // Post-capture VAD routing: ASR gets raw audio + segment metadata; LID keeps
+    // the current voiced-only filtered buffer.
+    let speechSegments: [SpeechSegment]
+    var lidSamples: [Float]
+    var asrSamples = rawSamples
     var hasSpeechEvidence = false
     var vadSegmentCount = 0
     var vadSpeechDurationMs = 0
@@ -597,44 +644,47 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     if isXPCMode {
       // XPC mode: VAD segments returned atomically with samples from stopCapture() (#226).
       let segments = captureResult.vadSegments
-      hasSpeechEvidence = !segments.isEmpty
+      speechSegments = segments
+      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(vadSegments: segments)
       vadSegmentCount = segments.count
       vadSpeechDurationMs =
         segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
       if !segments.isEmpty {
-        samples = SampleFilter.filter(from: rawSamples, segments: segments)
+        lidSamples = SampleFilter.filter(from: rawSamples, segments: segments)
         let pct = String(
-          format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
+          format: "%.1f", Double(lidSamples.count) / Double(max(rawSamples.count, 1)) * 100)
         Task {
           await AppLogger.shared.log(
-            "WhisperKit VAD (XPC) filtered to \(samples.count) samples (\(pct)% voiced)",
+            "WhisperKit VAD (XPC): \(vadSegmentCount) speech segments, totalVoicedMs=\(vadSpeechDurationMs), asrSamples=raw(\(rawSamples.count)), lidSamples=\(lidSamples.count) (\(pct)% voiced)",
             level: .info, category: "WhisperKitPipeline"
           )
         }
       } else {
-        samples = rawSamples
+        lidSamples = rawSamples
       }
     } else if let detector = silenceDetector {
       await detector.finalizeSegments(totalSampleCount: rawSamples.count)
       let segments = await detector.speechSegments
-      hasSpeechEvidence = !segments.isEmpty
+      speechSegments = segments
+      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(vadSegments: segments)
       vadSegmentCount = segments.count
       vadSpeechDurationMs =
         segments.reduce(0) { $0 + ($1.endSample - $1.startSample) } * 1000 / 16000
-      samples = await detector.filterSamples(from: rawSamples)
+      lidSamples = await detector.filterSamples(from: rawSamples)
       let pct = String(
-        format: "%.1f", Double(samples.count) / Double(max(rawSamples.count, 1)) * 100)
+        format: "%.1f", Double(lidSamples.count) / Double(max(rawSamples.count, 1)) * 100)
       Task {
         await AppLogger.shared.log(
-          "WhisperKit VAD filtered to \(samples.count) samples (\(pct)% voiced)",
+          "WhisperKit VAD: \(vadSegmentCount) speech segments, totalVoicedMs=\(vadSpeechDurationMs), asrSamples=raw(\(rawSamples.count)), lidSamples=\(lidSamples.count) (\(pct)% voiced)",
           level: .info, category: "WhisperKitPipeline"
         )
       }
     } else {
-      samples = rawSamples
+      speechSegments = []
+      lidSamples = rawSamples
       // No VAD detector available -- default to true so empty ASR results
       // still fire Sentry errors (fail toward visibility).
-      hasSpeechEvidence = true
+      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(vadSegments: nil)
     }
     let peakAudioLevel = rawSamples.reduce(Float(0)) { max($0, abs($1)) }
 
@@ -666,16 +716,20 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       return
     }
 
-    // Fallback: if VAD was too aggressive, use raw
     let minimumSamples = AudioConstants.minimumTranscriptionSamples
-    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
-      samples = rawSamples
-    }
-
-    // Pad short recordings
-    if samples.count > 0 && samples.count < minimumSamples {
-      samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
-    }
+    asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
+      rawSamples: rawSamples,
+      minimumSamples: minimumSamples
+    )
+    lidSamples = WhisperKitPipelineSpeechRouting.paddedLIDSamples(
+      filteredSamples: lidSamples,
+      rawSamples: rawSamples,
+      minimumSamples: minimumSamples
+    )
+    transcriptionOptions = WhisperKitPipelineSpeechRouting.transcriptionOptions(
+      from: transcriptionOptions,
+      speechSegments: speechSegments
+    )
 
     // Multilingual v1 (W2): detect language on voiced audio before transcribe.
     // Heart protection: detector never throws; if it abstains, pass nil to
@@ -688,11 +742,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     // stays inside the backend's actor isolation; only the Sendable
     // LIDObservationBatch crosses to the LanguageDetector classifier.
     // The previous unsafe-Sendable workaround is gone.
-    // Snapshot `samples` into an immutable binding so the @Sendable observer
-    // closure does not capture the surrounding `var samples` (would race).
-    let observerSamples = samples
+    // Snapshot `lidSamples` into an immutable binding so the @Sendable observer
+    // closure does not capture the surrounding `var lidSamples` (would race).
+    let observerSamples = lidSamples
     let lidResult = await languageDetector.detect(
-      samples: samples,
+      samples: lidSamples,
       voicedDuration: voicedDurationSec,
       observerFn: { [backend] in
         await backend.observeLID(samples: observerSamples, maxWindows: 4)
@@ -810,7 +864,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
           let batchStart = CFAbsoluteTimeGetCurrent()
           let batchResult = try await backend.transcribe(
-            audioSamples: samples, options: transcriptionOptions)
+            audioSamples: asrSamples, options: transcriptionOptions)
           let batchMs = Int((CFAbsoluteTimeGetCurrent() - batchStart) * 1000)
           asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
           asrLanguage = batchResult.language
@@ -825,7 +879,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         }
       } else {
         let batchResult = try await backend.transcribe(
-          audioSamples: samples, options: transcriptionOptions)
+          audioSamples: asrSamples, options: transcriptionOptions)
         asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
         asrLanguage = batchResult.language
       }

--- a/Tests/EnviousWisprASRTests/WhisperKitBackendClipTimestampsTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitBackendClipTimestampsTests.swift
@@ -1,0 +1,115 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+@preconcurrency import WhisperKit
+
+@testable import EnviousWisprASR
+
+@Suite("WhisperKitBackend clipTimestamps")
+struct WhisperKitBackendClipTimestampsTests {
+  @Test("clipTimestamps empty when no speech segments")
+  func clipTimestamps_emptyWhenNoSpeechSegments() async {
+    let backend = WhisperKitBackend()
+    let opts = await backend.makeDecodeOptions(
+      from: TranscriptionOptions(speechSegments: []),
+      sampleCount: 16_000
+    )
+
+    #expect(opts.clipTimestamps.isEmpty)
+  }
+
+  @Test("clipTimestamps pairs converted to seconds")
+  func clipTimestamps_pairsConvertedToSeconds() async {
+    let backend = WhisperKitBackend()
+    let sampleRate = Float(WhisperKit.sampleRate)
+    let segments = [
+      SpeechSegment(
+        startSample: Int(WhisperKit.sampleRate), endSample: Int(WhisperKit.sampleRate) * 2),
+      SpeechSegment(
+        startSample: Int(WhisperKit.sampleRate) * 3, endSample: Int(WhisperKit.sampleRate) * 4),
+    ]
+
+    let opts = await backend.makeDecodeOptions(
+      from: TranscriptionOptions(speechSegments: segments),
+      sampleCount: Int(WhisperKit.sampleRate) * 5
+    )
+
+    #expect(
+      opts.clipTimestamps == [
+        Float(segments[0].startSample) / sampleRate,
+        Float(segments[0].endSample) / sampleRate,
+        Float(segments[1].startSample) / sampleRate,
+        Float(segments[1].endSample) / sampleRate,
+      ])
+  }
+
+  @Test("windowClipTime is still zero")
+  func windowClipTime_isStillZero() async {
+    let backend = WhisperKitBackend()
+    let opts = await backend.makeDecodeOptions(
+      from: TranscriptionOptions(
+        speechSegments: [SpeechSegment(startSample: 0, endSample: Int(WhisperKit.sampleRate))]
+      ),
+      sampleCount: Int(WhisperKit.sampleRate)
+    )
+
+    #expect(opts.windowClipTime == 0)
+  }
+
+  @Test("chunking strategy unchanged for 30s boundary")
+  func chunkingStrategyUnchangedFor30sBoundary() async {
+    let backend = WhisperKitBackend()
+    let thirtySeconds = Int(WhisperKit.sampleRate) * 30
+
+    let atBoundary = await backend.makeDecodeOptions(
+      from: .default,
+      sampleCount: thirtySeconds
+    )
+    let aboveBoundary = await backend.makeDecodeOptions(
+      from: .default,
+      sampleCount: thirtySeconds + 1
+    )
+
+    // Disambiguate: `.none` alone resolves to Optional<ChunkingStrategy>.none (nil),
+    // not ChunkingStrategy.none. The actual value is .some(ChunkingStrategy.none).
+    #expect(atBoundary.chunkingStrategy == ChunkingStrategy.none)
+    #expect(aboveBoundary.chunkingStrategy == ChunkingStrategy.vad)
+  }
+
+  @Test("zero-width speech segment produces clip pair")
+  func clipTimestamps_zeroWidthSegmentDoesNotCrash() async {
+    let backend = WhisperKitBackend()
+    let segment = SpeechSegment(
+      startSample: Int(WhisperKit.sampleRate),
+      endSample: Int(WhisperKit.sampleRate)
+    )
+
+    let opts = await backend.makeDecodeOptions(
+      from: TranscriptionOptions(speechSegments: [segment]),
+      sampleCount: Int(WhisperKit.sampleRate) * 2
+    )
+
+    #expect(opts.clipTimestamps == [1.0, 1.0])
+  }
+
+  @Test("empty speechSegments produces same options as default")
+  func emptySpeechSegments_producesSameOptionsAsToday() async {
+    let backend = WhisperKitBackend()
+    let defaultOptions = await backend.makeDecodeOptions(
+      from: .default,
+      sampleCount: 16_000
+    )
+    let explicitEmptyOptions = await backend.makeDecodeOptions(
+      from: TranscriptionOptions(speechSegments: []),
+      sampleCount: 16_000
+    )
+
+    #expect(defaultOptions.clipTimestamps == explicitEmptyOptions.clipTimestamps)
+    #expect(defaultOptions.windowClipTime == explicitEmptyOptions.windowClipTime)
+    #expect(defaultOptions.chunkingStrategy == explicitEmptyOptions.chunkingStrategy)
+    #expect(defaultOptions.language == explicitEmptyOptions.language)
+    #expect(defaultOptions.wordTimestamps == explicitEmptyOptions.wordTimestamps)
+    #expect(defaultOptions.suppressBlank == explicitEmptyOptions.suppressBlank)
+    #expect(defaultOptions.usePrefillPrompt == explicitEmptyOptions.usePrefillPrompt)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitPipelineSpeechSegmentsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitPipelineSpeechSegmentsTests.swift
@@ -1,0 +1,58 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@Suite("WhisperKitPipeline speech-segment routing")
+struct WhisperKitPipelineSpeechSegmentsTests {
+  @Test("pipeline passes speech segments to backend options")
+  func pipelinePassesSpeechSegmentsToBackend() {
+    let segments = [
+      SpeechSegment(startSample: 1_000, endSample: 8_000),
+      SpeechSegment(startSample: 12_000, endSample: 18_000),
+    ]
+    let base = TranscriptionOptions(language: "en", enableTimestamps: false)
+
+    let options = WhisperKitPipelineSpeechRouting.transcriptionOptions(
+      from: base,
+      speechSegments: segments
+    )
+
+    #expect(options.language == "en")
+    #expect(options.enableTimestamps == false)
+    #expect(options.speechSegments.map(\.startSample) == [1_000, 12_000])
+    #expect(options.speechSegments.map(\.endSample) == [8_000, 18_000])
+  }
+
+  @Test("VAD gate still fires on zero segments")
+  func vadGateStillFires_onZeroSegments() {
+    #expect(WhisperKitPipelineSpeechRouting.hasSpeechEvidence(vadSegments: []) == false)
+    #expect(WhisperKitPipelineSpeechRouting.hasSpeechEvidence(vadSegments: nil) == true)
+  }
+
+  @Test("LID samples unchanged when ASR samples are raw")
+  func lidSamplesUnchanged_whenAsrSamplesAreRaw() {
+    // Pick a voiced range comfortably above minimumTranscriptionSamples
+    // so paddedLIDSamples does NOT fall back to raw substitution
+    // (which is its documented behavior when filtered audio is too short to drive LID).
+    let rawSamples = Array(repeating: Float(0.25), count: 60_000)
+    let voicedStart = 8_000
+    let voicedEnd = voicedStart + AudioConstants.minimumTranscriptionSamples + 4_000  // > minimum
+    let speechSegments = [SpeechSegment(startSample: voicedStart, endSample: voicedEnd)]
+    let expectedLIDSamples = SampleFilter.filter(from: rawSamples, segments: speechSegments)
+
+    let asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
+      rawSamples: rawSamples,
+      minimumSamples: AudioConstants.minimumTranscriptionSamples
+    )
+    let lidSamples = WhisperKitPipelineSpeechRouting.paddedLIDSamples(
+      filteredSamples: expectedLIDSamples,
+      rawSamples: rawSamples,
+      minimumSamples: AudioConstants.minimumTranscriptionSamples
+    )
+
+    #expect(asrSamples.count == rawSamples.count)
+    #expect(lidSamples == expectedLIDSamples)
+    #expect(lidSamples.count < asrSamples.count)
+  }
+}


### PR DESCRIPTION
Closes #452.

## Summary

Wires WhisperKit's `DecodingOptions.clipTimestamps` to our existing upstream Silero VAD output. Decoder now seeks only over voiced ranges; silent gaps are not transcribed and cannot hallucinate. This is the Argmax-blessed recipe documented at the Mintlify VAD docs page, not a community threshold-tightening workaround.

## Why now

Field evidence on founder's machine: 43 of 541 WhisperKit transcripts hallucinate `"Thank you"` / `"Thanks for watching"` / `"Subtitles by Amara"`. Median trailing-case duration 13.5s (NOT just short clips). Re-downloading the model gave identical bytes; no newer variant exists; argmax-oss-swift v1.0.0 (just shipped via PR #599) is packaging-only. The fix has to come from how we use WhisperKit.

## What changes

- `SpeechSegment` gains `Codable` conformance.
- `TranscriptionOptions` gains `speechSegments: [SpeechSegment] = []`.
- XPC layer carries segments via explicit JSON-encoded `Data?` parameter on `transcribeSamples` (XPC protocol decomposes `TranscriptionOptions` into primitives; auto-Codable does not cross the boundary on its own).
- `WhisperKitBackend.makeDecodeOptions` builds `clipTimestamps` `[Float]` of (start_sec, end_sec) pairs using `WhisperKit.sampleRate`. `windowClipTime` stays at 0.
- `WhisperKitPipeline` splits the audio buffer: ASR receives raw audio + segments; LID keeps voiced-only filtered (must not change LID input).
- Helper enum `WhisperKitPipelineSpeechRouting` factors the routing logic for testability.

## What does NOT change

- Upstream Silero VAD gate (zero segments → skip ASR) is unchanged.
- Parakeet path (it ignores the new field).
- WhisperKit incremental/streaming worker (out of scope; no clipTimestamps integration).
- `padAudioWithSilence` in `WhisperKitBackend.transcribe` (unchanged trailing pad).

## Test plan

- [x] `swift build -c release` clean (79.28s)
- [x] `scripts/swift-test.sh` — 567/567 tests pass (558 existing + 6 new ASR + 3 new pipeline)
- [ ] Bundle release app; Live UAT per plan §11.1:
  - Test A — 5 representative trailing-Thank-you cases from history (suppression target ≥ 4/5)
  - Test B — silent clip → empty transcript
  - Test C — legitimate "thank you" preservation (must not regress)
  - Test D — 30s+ clip exercising VAD chunking branch
  - Test E — Parakeet path regression check
  - Test F — heart-path latency within 110% of baseline (`scripts/heart-path-bench.sh --cold`)

## Process audit trail

- Plan: `docs/feature-requests/issue-452-2026-05-03-whisperkit-clip-timestamps.md`
- Codex grounded review on plan: `docs/audits/2026-05-03-issue-452-clip-timestamps-grounded-review.txt` (YES_WITH_REVISIONS; all 6 findings applied before implementation)
- Implementation: Codex via codex-companion `task` runtime
- Adversarial review on diff: Claude main thread (caught 2 test bugs Codex didn't catch)

## Out of scope

- Phrase blacklist / regex post-filter — rejected (false-positives on legitimate "thank you")
- Decoder threshold tightening (`noSpeechThreshold` etc.) — Argmax's own example app uses defaults; not validated as a fix
- Standalone bench/eval packages under `scripts/multilingual-eval/` — tracked at #598
