### PR TITLE
chore(content): update WhisperKit links to argmax-oss-swift repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Both models run entirely on-device using CoreML. First launch downloads and comp
 
 ## Features
 
-- **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/WhisperKit) (OpenAI Whisper)
+- **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/argmax-oss-swift) (OpenAI Whisper)
 - **Voice Activity Detection** via Silero VAD for hands-free stop
 - **LLM polish** with OpenAI GPT or Google Gemini (bring your own API key)
 - **Custom vocabulary** for names, brands, and technical terms the ASR might miss

--- a/website/src/content/blog/voice-coding-macos-without-cloud.md
+++ b/website/src/content/blog/voice-coding-macos-without-cloud.md
@@ -27,7 +27,7 @@ Apple's built-in dictation improved significantly with on-device processing in m
 
 ## How on-device transcription actually works
 
-EnviousWispr runs transcription locally using two backends: Parakeet, a streaming English model optimized for fast dictation, and [WhisperKit](https://github.com/argmaxinc/WhisperKit), which runs Apple's Whisper speech recognition model for multi-language support. Both compile to run via Core ML, which means they execute directly on your Mac's Neural Engine, the dedicated machine learning hardware built into every Apple Silicon chip.
+EnviousWispr runs transcription locally using two backends: Parakeet, a streaming English model optimized for fast dictation, and [WhisperKit](https://github.com/argmaxinc/argmax-oss-swift), which runs Apple's Whisper speech recognition model for multi-language support. Both compile to run via Core ML, which means they execute directly on your Mac's Neural Engine, the dedicated machine learning hardware built into every Apple Silicon chip.
 
 Here's what that means in practice: your audio goes from your microphone to a local model running on your hardware. No network request. No API call. No server. The transcription pipeline runs entirely within your Mac's process space, and the audio buffer is discarded after processing.
 

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -434,7 +434,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Audio processing</td>
-            <td><span class="table-highlight">On-device</span> (<a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a>)</td>
+            <td><span class="table-highlight">On-device</span> (<a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a>)</td>
             <td>On-device (Apple Silicon); cloud fallback on Intel</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -467,7 +467,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
             <td>Proprietary Nuance engine (decades of refinement)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -429,7 +429,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
             <td>Google Cloud Speech API</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -489,7 +489,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
             <td>OpenAI Whisper models (various sizes)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -488,7 +488,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
             <td>Cloud speech API</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -494,7 +494,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
             <td>Proprietary cloud ASR</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -416,7 +416,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><span class="table-highlight"><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></span> (dual engines, on-device)</td>
+            <td><span class="table-highlight"><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></span> (dual engines, on-device)</td>
             <td>Whisper (on-device, multiple model sizes)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -437,7 +437,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a></td>
             <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">whisper.cpp</a></td>
           </tr>
           <tr>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -400,7 +400,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engine</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (Apple Silicon optimized)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (Apple Silicon optimized)</td>
             <td><a href="https://github.com/ggerganov/whisper.cpp" style="color: var(--accent); text-decoration: underline;">whisper.cpp</a> (C/C++ port of OpenAI Whisper)</td>
           </tr>
           <tr>
@@ -468,7 +468,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>
         <div class="advantage-title">Apple Silicon optimized</div>
-        <p class="advantage-desc">EnviousWispr uses <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a>, both purpose-built for the Neural Engine on Apple Silicon. whisper.cpp targets broad hardware compatibility, not peak Mac performance. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
+        <p class="advantage-desc">EnviousWispr uses <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a>, both purpose-built for the Neural Engine on Apple Silicon. whisper.cpp targets broad hardware compatibility, not peak Mac performance. See <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">how the pipeline works</a>.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔄</div>
@@ -667,7 +667,7 @@ const breadcrumbJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr use whisper.cpp internally?</div>
-        <p class="faq-a">No. EnviousWispr uses <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation optimized for Core ML and the Neural Engine) and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model). Both are optimized for Apple Silicon rather than broad hardware compatibility.</p>
+        <p class="faq-a">No. EnviousWispr uses <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation optimized for Core ML and the Neural Engine) and <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model). Both are optimized for Apple Silicon rather than broad hardware compatibility.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr faster than whisper.cpp?</div>
@@ -695,7 +695,7 @@ const breadcrumbJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr use whisper.cpp under the hood?</div>
-        <p class="faq-a">No. EnviousWispr uses two different engines: <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model) and <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation). WhisperKit runs Whisper models via Core ML and the Neural Engine, which is a different implementation path than whisper.cpp's C/C++ approach. Both are valid ways to run on-device speech recognition, optimized for different goals.</p>
+        <p class="faq-a">No. EnviousWispr uses two different engines: <a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> (NVIDIA's CTC-based model) and <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (a Swift-native Whisper implementation). WhisperKit runs Whisper models via Core ML and the Neural Engine, which is a different implementation path than whisper.cpp's C/C++ approach. Both are valid ways to run on-device speech recognition, optimized for different goals.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use whisper.cpp and EnviousWispr together?</div>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -375,7 +375,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
             <td>Cloud speech API</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -443,7 +443,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Speech engines</td>
-            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/WhisperKit" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
+            <td><a href="https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2" style="color: var(--accent); text-decoration: underline;">Parakeet TDT</a> + <a href="https://github.com/argmaxinc/argmax-oss-swift" style="color: var(--accent); text-decoration: underline;">WhisperKit</a> (on-device)</td>
             <td>Cloud speech API</td>
           </tr>
           <tr>


### PR DESCRIPTION
## Summary

- Argmax renamed/re-released the WhisperKit Swift package as `argmax-oss-swift` (1.0.0) on 2026-05-01. The old `argmaxinc/WhisperKit` repo still 301s to the new one but is unmaintained.
- Updated 13 customer-facing files (README + website blog + 11 comparison pages) to link directly at the live repo. No redirect hop, no reader landing on a dead-looking page.
- No code, no dependencies, no SwiftPM changes. Pure URL refresh.

## Lane

Content. README + `website/src/content/` + `website/src/pages/compare/`. No code-lane files touched.

## Origin

Codex scan ran on 2026-05-04 to validate that #598 captures all stale links. It confirmed only the two standalone eval packages still pin the old URL as a real dependency, but flagged 13 prose links that should point at the live repo for visitor-facing accuracy. This PR fixes the prose; #598 stays open for the eval-tool dependency migration whenever multilingual eval next runs.

## Test plan

- [x] `git diff` shows 16 line changes across 13 files, all the same URL swap.
- [x] New URL `https://github.com/argmaxinc/argmax-oss-swift` returns 200.
- [x] No source code, no Package.swift, no workflow changes.
