### PR TITLE
fix(blog): drop redundant H3 TOC color override (#545)

### DIFF
--- a/website/src/components/BlogSidebar.astro
+++ b/website/src/components/BlogSidebar.astro
@@ -109,7 +109,6 @@
   .toc-list :global(li.toc-h3 a) {
     padding-left: 28px;
     font-size: 12px;
-    color: var(--text-3);
   }
 
   /* Share block in sidebar */


### PR DESCRIPTION
## Summary

The .toc-list :global(li.toc-h3 a) rule re-declared color: var(--text-3), which has higher CSS specificity than the hover and aria-current=location rules above it. H3 TOC links stayed muted gray on hover AND during scroll-spy active state, eliminating visual feedback.

## Fix

Drop the redundant color declaration. Base .toc-list :global(a) already sets the muted color, so H3 links inherit it; hover and aria-current rules now win as intended.

Codex grounded review: PROCEED — no other toc-h3 color override in website/src.

## Test plan

- [x] Codex review: PROCEED
- [ ] Visual smoke after merge: hover blog TOC H3 link shows --text color; scroll into H3 section shows --accent + bold

council-skip: zero-blast-radius (website/src/ user-facing copy/style)

Closes #545
