### PR TITLE
fix(pipeline): instant overlay flip + single-window LID for short clips (#519)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ playwright-report/
 
 # Local build/runtime caches
 .wrangler/
-.validation/
+.validation/*
+!.validation/lid-perf-baseline.json
 
 # Historical benchmark output — regenerable, untracked
 benchmark-results/
@@ -123,6 +124,8 @@ scripts/*
 !scripts/test-validation.sh
 !scripts/validate-pr.sh
 !scripts/validation-status.sh
+!scripts/lid-perf-bench.sh
+!scripts/lid-perf-bench.py
 # Polish eval harness — PUBLIC tracked files only (see .claude/knowledge/polish-eval.md for scope rules)
 !scripts/eval/
 scripts/eval/*

--- a/.validation/lid-perf-baseline.json
+++ b/.validation/lid-perf-baseline.json
@@ -1,0 +1,7 @@
+{
+  "short_clip_p50_ms": null,
+  "normal_clip_p50_ms": null,
+  "state_flip_p50_ms": null,
+  "captured_at": null,
+  "main_sha": null
+}

--- a/Sources/EnviousWisprCore/LanguageTypes.swift
+++ b/Sources/EnviousWisprCore/LanguageTypes.swift
@@ -227,6 +227,7 @@ public enum LanguageDetectorThresholds {
   // Layer 1: speech gate (voiced duration, seconds)
   public static let shortClipMinSec: TimeInterval = 1.0  // below this: abstain, no LID
   public static let confidentMinSec: TimeInterval = 2.5  // below this: provisional/stricter
+  public static let singleWindowMaxSec: TimeInterval = 3.0  // below this: one LID window
 
   // Layer 2 normal thresholds (voicedDuration >= 2.5s)
   public static let normalProb: Double = 0.65

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -35,50 +35,6 @@ public enum WhisperKitPipelineState: Equatable, Sendable {
   }
 }
 
-internal enum WhisperKitPipelineSpeechRouting {
-  static func hasSpeechEvidence(vadSegments: [SpeechSegment]?) -> Bool {
-    vadSegments.map { !$0.isEmpty } ?? true
-  }
-
-  static func paddedASRSamples(
-    rawSamples: [Float],
-    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
-  ) -> [Float] {
-    padIfShort(rawSamples, minimumSamples: minimumSamples)
-  }
-
-  static func paddedLIDSamples(
-    filteredSamples: [Float],
-    rawSamples: [Float],
-    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
-  ) -> [Float] {
-    var samples = filteredSamples
-    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
-      samples = rawSamples
-    }
-    return padIfShort(samples, minimumSamples: minimumSamples)
-  }
-
-  static func transcriptionOptions(
-    from base: TranscriptionOptions,
-    speechSegments: [SpeechSegment]
-  ) -> TranscriptionOptions {
-    TranscriptionOptions(
-      language: base.language,
-      enableTimestamps: base.enableTimestamps,
-      speechSegments: speechSegments
-    )
-  }
-
-  private static func padIfShort(
-    _ samples: [Float],
-    minimumSamples: Int
-  ) -> [Float] {
-    guard samples.count > 0 && samples.count < minimumSamples else { return samples }
-    return samples + [Float](repeating: 0, count: minimumSamples - samples.count)
-  }
-}
-
 // MARK: - PipelineStateProtocol conformance
 
 extension WhisperKitPipelineState: PipelineStateProtocol {
@@ -551,6 +507,11 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
   }
 
   public func requestStop() async {
+    logLIDPerfSignpost(
+      "t_release",
+      timestamp: CFAbsoluteTimeGetCurrent(),
+      sessionID: audioCapture.currentCaptureSessionID
+    )
     switch state {
     case .recording:
       await stopAndTranscribe()
@@ -730,6 +691,21 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       from: transcriptionOptions,
       speechSegments: speechSegments
     )
+    let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
+    let lidWindowCount = WhisperKitPipelineSpeechRouting.lidWindowCount(
+      forVoicedDuration: voicedDurationSec
+    )
+    let clipKind = lidWindowCount == 1 ? "short" : "normal"
+
+    state = .transcribing
+    logLIDPerfSignpost(
+      "t_state_flip",
+      timestamp: CFAbsoluteTimeGetCurrent(),
+      sessionID: audioCapture.currentCaptureSessionID,
+      voicedDuration: voicedDurationSec,
+      lidWindowCount: lidWindowCount,
+      clipKind: clipKind
+    )
 
     // Multilingual v1 (W2): detect language on voiced audio before transcribe.
     // Heart protection: detector never throws; if it abstains, pass nil to
@@ -737,7 +713,6 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     // languageMode comes from the frozen DictationSessionConfig captured at
     // startRecording (Phase B refactor, PR #424); mid-recording user toggles
     // are NOT applied to the in-flight session by design.
-    let voicedDurationSec = Double(vadSpeechDurationMs) / 1000.0
     // R2 (#360): closure-based observer. The non-Sendable WhisperKit handle
     // stays inside the backend's actor isolation; only the Sendable
     // LIDObservationBatch crosses to the LanguageDetector classifier.
@@ -749,9 +724,17 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       samples: lidSamples,
       voicedDuration: voicedDurationSec,
       observerFn: { [backend] in
-        await backend.observeLID(samples: observerSamples, maxWindows: 4)
+        await backend.observeLID(samples: observerSamples, maxWindows: lidWindowCount)
       },
       mode: languageMode
+    )
+    logLIDPerfSignpost(
+      "t_lid_settled",
+      timestamp: CFAbsoluteTimeGetCurrent(),
+      sessionID: audioCapture.currentCaptureSessionID,
+      voicedDuration: voicedDurationSec,
+      lidWindowCount: lidWindowCount,
+      clipKind: clipKind
     )
     lastLanguageDetection = lidResult
     // Multilingual v1 (W3): forward the detection to the polish step so the
@@ -793,7 +776,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       voicedDuration: lidResult.voicedDuration,
       abstained: lidResult.abstained,
       sessionPreferredLang: sessionPreferredSnapshot,
-      usedSticky: lidResult.usedSessionPrior
+      usedSticky: lidResult.usedSessionPrior,
+      lidWindowCount: lidWindowCount
     )
     if lidResult.abstained {
       // Classify the abstain reason per spec § Telemetry table.
@@ -815,7 +799,6 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       )
     }
 
-    state = .transcribing
     SentryBreadcrumb.add(
       stage: "asr", message: "WhisperKit transcription started", data: ["backend": "whisperKit"])
 
@@ -863,9 +846,26 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           }
 
           let batchStart = CFAbsoluteTimeGetCurrent()
+          logLIDPerfSignpost(
+            "t_asr_start",
+            timestamp: batchStart,
+            sessionID: audioCapture.currentCaptureSessionID,
+            voicedDuration: voicedDurationSec,
+            lidWindowCount: lidWindowCount,
+            clipKind: clipKind
+          )
           let batchResult = try await backend.transcribe(
             audioSamples: asrSamples, options: transcriptionOptions)
-          let batchMs = Int((CFAbsoluteTimeGetCurrent() - batchStart) * 1000)
+          let batchEnd = CFAbsoluteTimeGetCurrent()
+          logLIDPerfSignpost(
+            "t_asr_end",
+            timestamp: batchEnd,
+            sessionID: audioCapture.currentCaptureSessionID,
+            voicedDuration: voicedDurationSec,
+            lidWindowCount: lidWindowCount,
+            clipKind: clipKind
+          )
+          let batchMs = Int((batchEnd - batchStart) * 1000)
           asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
           asrLanguage = batchResult.language
 
@@ -878,8 +878,24 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           }
         }
       } else {
+        logLIDPerfSignpost(
+          "t_asr_start",
+          timestamp: CFAbsoluteTimeGetCurrent(),
+          sessionID: audioCapture.currentCaptureSessionID,
+          voicedDuration: voicedDurationSec,
+          lidWindowCount: lidWindowCount,
+          clipKind: clipKind
+        )
         let batchResult = try await backend.transcribe(
           audioSamples: asrSamples, options: transcriptionOptions)
+        logLIDPerfSignpost(
+          "t_asr_end",
+          timestamp: CFAbsoluteTimeGetCurrent(),
+          sessionID: audioCapture.currentCaptureSessionID,
+          voicedDuration: voicedDurationSec,
+          lidWindowCount: lidWindowCount,
+          clipKind: clipKind
+        )
         asrText = batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
         asrLanguage = batchResult.language
       }
@@ -986,6 +1002,14 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
             restoreClipboardAfterPaste: restoreClipboardAfterPaste,
             steps: textProcessingSteps
           ))
+        logLIDPerfSignpost(
+          "t_clipboard_write",
+          timestamp: CFAbsoluteTimeGetCurrent(),
+          sessionID: audioCapture.currentCaptureSessionID,
+          voicedDuration: voicedDurationSec,
+          lidWindowCount: lidWindowCount,
+          clipKind: clipKind
+        )
       } catch is CancellationError {
         frozenSnapshot = nil
         return
@@ -1299,6 +1323,35 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
       )
     )
+  }
+
+  private func logLIDPerfSignpost(
+    _ name: String,
+    timestamp: CFAbsoluteTime,
+    sessionID: UInt64,
+    voicedDuration: TimeInterval? = nil,
+    lidWindowCount: Int? = nil,
+    clipKind: String? = nil
+  ) {
+    var fields = [
+      "lid_perf_signpost",
+      "name=\(name)",
+      "timestamp_s=\(String(format: "%.6f", timestamp))",
+      "session_id=\(sessionID)",
+    ]
+    if let voicedDuration {
+      fields.append("voiced_duration_s=\(String(format: "%.3f", voicedDuration))")
+    }
+    if let lidWindowCount {
+      fields.append("lid_window_count=\(lidWindowCount)")
+    }
+    if let clipKind {
+      fields.append("clip_kind=\(clipKind)")
+    }
+    let message = fields.joined(separator: " ")
+    Task {
+      await AppLogger.shared.log(message, level: .info, category: "WhisperKitPipeline")
+    }
   }
 
   // MARK: - Model Lifecycle

--- a/Sources/EnviousWisprPipeline/WhisperKitPipelineSpeechRouting.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipelineSpeechRouting.swift
@@ -1,0 +1,50 @@
+import EnviousWisprCore
+import Foundation
+
+internal enum WhisperKitPipelineSpeechRouting {
+  static func hasSpeechEvidence(vadSegments: [SpeechSegment]?) -> Bool {
+    vadSegments.map { !$0.isEmpty } ?? true
+  }
+
+  static func paddedASRSamples(
+    rawSamples: [Float],
+    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
+  ) -> [Float] {
+    padIfShort(rawSamples, minimumSamples: minimumSamples)
+  }
+
+  static func paddedLIDSamples(
+    filteredSamples: [Float],
+    rawSamples: [Float],
+    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
+  ) -> [Float] {
+    var samples = filteredSamples
+    if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
+      samples = rawSamples
+    }
+    return padIfShort(samples, minimumSamples: minimumSamples)
+  }
+
+  static func lidWindowCount(forVoicedDuration voicedDuration: TimeInterval) -> Int {
+    voicedDuration < LanguageDetectorThresholds.singleWindowMaxSec ? 1 : 4
+  }
+
+  static func transcriptionOptions(
+    from base: TranscriptionOptions,
+    speechSegments: [SpeechSegment]
+  ) -> TranscriptionOptions {
+    TranscriptionOptions(
+      language: base.language,
+      enableTimestamps: base.enableTimestamps,
+      speechSegments: speechSegments
+    )
+  }
+
+  private static func padIfShort(
+    _ samples: [Float],
+    minimumSamples: Int
+  ) -> [Float] {
+    guard samples.count > 0 && samples.count < minimumSamples else { return samples }
+    return samples + [Float](repeating: 0, count: minimumSamples - samples.count)
+  }
+}

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -405,7 +405,8 @@ public final class TelemetryService {
     voicedDuration: TimeInterval,
     abstained: Bool,
     sessionPreferredLang: String?,
-    usedSticky: Bool
+    usedSticky: Bool,
+    lidWindowCount: Int
   ) {
     var props: [String: Any] = [
       "lang": lang ?? "nil",
@@ -415,6 +416,7 @@ public final class TelemetryService {
       "voiced_duration_s": String(format: "%.2f", voicedDuration),
       "abstained": abstained,
       "used_sticky": usedSticky,
+      "lid_window_count": lidWindowCount,
     ]
     if let pref = sessionPreferredLang {
       props["session_preferred_lang"] = pref

--- a/Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift
+++ b/Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import Darwin
 import Foundation
 import Testing
 
@@ -363,6 +364,51 @@ struct R2CharacterizationTests {
   /// observable through this test seam. PR 2 must rely on existing
   /// `LanguageDetectorTests` end-to-end paths to keep the chip contract intact.
   /// This comment is intentionally a documented gap, not a TODO.
+
+  // MARK: - Single-window observations
+
+  @Test("R2-CHAR-070: single-window observation passes strict-tier acceptance bar")
+  func singleWindowObservationPassesStrictTierAcceptanceBar() async {
+    let (detector, _) = r2MakeDetector()
+
+    let result = await detector.detect(
+      samples: [0.1],
+      voicedDuration: 1.5,
+      observerFn: {
+        .observations([
+          RawLIDObservation(argmaxLang: "en", logProb: log(0.85))
+        ])
+      },
+      mode: .auto
+    )
+
+    #expect(result.lang == "en")
+    #expect(result.tier == .highAuto)
+    #expect(result.confidence >= LanguageDetectorThresholds.strictProb)
+    #expect(result.margin >= LanguageDetectorThresholds.strictMargin)
+    #expect(result.abstained == false)
+  }
+
+  @Test("R2-CHAR-071: single-window observation below strict bar abstains cleanly")
+  func singleWindowObservationBelowStrictBarAbstainsCleanly() async {
+    let (detector, _) = r2MakeDetector()
+
+    let result = await detector.detect(
+      samples: [0.1],
+      voicedDuration: 1.5,
+      observerFn: {
+        .observations([
+          RawLIDObservation(argmaxLang: "en", logProb: log(0.79))
+        ])
+      },
+      mode: .auto
+    )
+
+    #expect(result.lang == nil)
+    #expect(result.tier == .abstain)
+    #expect(result.confidence < LanguageDetectorThresholds.strictProb)
+    #expect(result.abstained)
+  }
 }
 
 /// Test-side recorder for `onLanguageFlip` events. Sendable so it can survive

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitPipelineSpeechSegmentsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitPipelineSpeechSegmentsTests.swift
@@ -55,4 +55,18 @@ struct WhisperKitPipelineSpeechSegmentsTests {
     #expect(lidSamples == expectedLIDSamples)
     #expect(lidSamples.count < asrSamples.count)
   }
+
+  @Test("LID window routing uses one window below 3 seconds")
+  func lidWindowCountUsesSingleWindowForShortClips() {
+    for duration in [0.5, 1.0, 2.5, 2.99] {
+      #expect(WhisperKitPipelineSpeechRouting.lidWindowCount(forVoicedDuration: duration) == 1)
+    }
+  }
+
+  @Test("LID window routing uses four windows at and above 3 seconds")
+  func lidWindowCountUsesFourWindowsForNormalClips() {
+    for duration in [3.0, 5.0, 15.0] {
+      #expect(WhisperKitPipelineSpeechRouting.lidWindowCount(forVoicedDuration: duration) == 4)
+    }
+  }
 }

--- a/scripts/lid-perf-bench.py
+++ b/scripts/lid-perf-bench.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Parse LID perf signposts and compare them against a checked baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SIGNPOST_RE = re.compile(r"\b([A-Za-z0-9_]+)=([^ \n]+)")
+REQUIRED_EVENTS = {"t_release", "t_state_flip", "t_clipboard_write"}
+
+
+def parse_signposts(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if "lid_perf_signpost" not in line:
+                continue
+            fields = dict(SIGNPOST_RE.findall(line))
+            if "name" not in fields or "timestamp_s" not in fields or "session_id" not in fields:
+                continue
+            try:
+                event: dict[str, Any] = {
+                    "name": fields["name"],
+                    "timestamp_s": float(fields["timestamp_s"]),
+                    "session_id": fields["session_id"],
+                }
+            except ValueError:
+                continue
+            if "clip_kind" in fields:
+                event["clip_kind"] = fields["clip_kind"]
+            if "lid_window_count" in fields:
+                try:
+                    event["lid_window_count"] = int(fields["lid_window_count"])
+                except ValueError:
+                    pass
+            if "voiced_duration_s" in fields:
+                try:
+                    event["voiced_duration_s"] = float(fields["voiced_duration_s"])
+                except ValueError:
+                    pass
+            events.append(event)
+    return events
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        raise ValueError("cannot compute percentile of empty values")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * pct
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[int(rank)]
+    lower_value = ordered[lower]
+    upper_value = ordered[upper]
+    return lower_value + (upper_value - lower_value) * (rank - lower)
+
+
+def session_metrics(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, dict[str, Any]]] = {}
+    for event in events:
+        grouped.setdefault(event["session_id"], {})[event["name"]] = event
+
+    metrics: list[dict[str, Any]] = []
+    for session_id, by_name in grouped.items():
+        if not REQUIRED_EVENTS.issubset(by_name.keys()):
+            continue
+        release = by_name["t_release"]["timestamp_s"]
+        state_flip = by_name["t_state_flip"]["timestamp_s"]
+        clipboard = by_name["t_clipboard_write"]["timestamp_s"]
+        kind = "unknown"
+        for event in by_name.values():
+            if event.get("clip_kind") in {"short", "normal"}:
+                kind = event["clip_kind"]
+                break
+        if kind == "unknown":
+            window_count = by_name.get("t_lid_settled", {}).get("lid_window_count")
+            if window_count == 1:
+                kind = "short"
+            elif window_count == 4:
+                kind = "normal"
+        metrics.append(
+            {
+                "session_id": session_id,
+                "clip_kind": kind,
+                "state_flip_ms": (state_flip - release) * 1000.0,
+                "clipboard_write_ms": (clipboard - release) * 1000.0,
+            }
+        )
+    return metrics
+
+
+def summarize(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    short_clipboard = [
+        metric["clipboard_write_ms"] for metric in metrics if metric["clip_kind"] == "short"
+    ]
+    normal_clipboard = [
+        metric["clipboard_write_ms"] for metric in metrics if metric["clip_kind"] == "normal"
+    ]
+    state_flip = [metric["state_flip_ms"] for metric in metrics]
+    if not short_clipboard:
+        raise ValueError("no complete short-clip signpost groups found")
+    if not normal_clipboard:
+        raise ValueError("no complete normal-clip signpost groups found")
+    if not state_flip:
+        raise ValueError("no complete state-flip signpost groups found")
+    return {
+        "sample_count": len(metrics),
+        "short_clip_p50_ms": percentile(short_clipboard, 0.50),
+        "short_clip_p95_ms": percentile(short_clipboard, 0.95),
+        "normal_clip_p50_ms": percentile(normal_clipboard, 0.50),
+        "normal_clip_p95_ms": percentile(normal_clipboard, 0.95),
+        "state_flip_p50_ms": percentile(state_flip, 0.50),
+        "state_flip_p95_ms": percentile(state_flip, 0.95),
+    }
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    try:
+        baseline = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"baseline file missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"baseline file is not valid JSON: {path}") from exc
+
+    required = ["short_clip_p50_ms", "normal_clip_p50_ms", "state_flip_p50_ms"]
+    missing = [key for key in required if baseline.get(key) is None]
+    if missing:
+        raise ValueError(f"baseline file has stub or missing values: {', '.join(missing)}")
+    return baseline
+
+
+def evaluate(summary: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if summary["state_flip_p50_ms"] >= 50.0:
+        failures.append(
+            f"state_flip_p50_ms {summary['state_flip_p50_ms']:.1f} is not below 50.0"
+        )
+    short_gain = baseline["short_clip_p50_ms"] - summary["short_clip_p50_ms"]
+    if short_gain < 500.0:
+        failures.append(f"short_clip_p50_ms improvement {short_gain:.1f} is below 500.0")
+    normal_delta = abs(summary["normal_clip_p50_ms"] - baseline["normal_clip_p50_ms"])
+    if normal_delta > 100.0:
+        failures.append(f"normal_clip_p50_ms delta {normal_delta:.1f} exceeds 100.0")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, type=Path, help="raw signpost log file")
+    parser.add_argument(
+        "--baseline",
+        default=Path(".validation/lid-perf-baseline.json"),
+        type=Path,
+        help="baseline JSON path",
+    )
+    parser.add_argument("--output-json", type=Path, help="write computed metrics to this path")
+    args = parser.parse_args()
+
+    try:
+        events = parse_signposts(args.log)
+        metrics = session_metrics(events)
+        summary = summarize(metrics)
+        baseline = load_baseline(args.baseline)
+        failures = evaluate(summary, baseline)
+    except ValueError as exc:
+        print(f"lid-perf-bench: {exc}", file=sys.stderr)
+        return 2
+
+    result = {
+        "summary": summary,
+        "baseline": baseline,
+        "sessions": metrics,
+        "pass": not failures,
+        "failures": failures,
+    }
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+    print(json.dumps(result["summary"], indent=2, sort_keys=True))
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+    print("PASS: LID perf gates satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lid-perf-bench.sh
+++ b/scripts/lid-perf-bench.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASELINE="$ROOT_DIR/.validation/lid-perf-baseline.json"
+RUN_DIR="$ROOT_DIR/.validation/runs/lid-perf-$(date -u +%Y%m%dT%H%M%SZ)"
+RAW_LOG="$RUN_DIR/lid-perf-signposts.log"
+RESULT_JSON="$RUN_DIR/lid-perf-results.json"
+SKIP_UAT=0
+INPUT_LOG=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/lid-perf-bench.sh [--baseline PATH] [--log-file PATH] [--skip-uat]
+
+Runs a release build, drives the 10-clip LID corpus through wispr_eyes,
+captures lid_perf_signpost log lines, then compares metrics to baseline.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      BASELINE="$2"
+      shift 2
+      ;;
+    --log-file)
+      INPUT_LOG="$2"
+      shift 2
+      ;;
+    --skip-uat)
+      SKIP_UAT=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$RUN_DIR"
+cd "$ROOT_DIR"
+
+echo "==> Building release target"
+swift build -c release
+
+if [[ -n "$INPUT_LOG" ]]; then
+  cp "$INPUT_LOG" "$RAW_LOG"
+elif [[ "$SKIP_UAT" -eq 1 ]]; then
+  echo "--skip-uat requires --log-file" >&2
+  exit 2
+else
+  echo "==> Capturing signpost logs"
+  log stream --style compact --predicate 'eventMessage CONTAINS "lid_perf_signpost"' > "$RAW_LOG" &
+  LOG_PID=$!
+  trap 'kill "$LOG_PID" >/dev/null 2>&1 || true' EXIT
+  sleep 1
+
+  echo "==> Running 10-clip corpus through wispr_eyes (OpenAI TTS)"
+  RUN_DIR="$RUN_DIR" python3 - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+root = Path.cwd()
+sys.path.insert(0, str(root / "Tests" / "RuntimeUAT"))
+from wispr_eyes import tts, test_recording
+
+corpus = [
+    ("short", "en", "pick up Emma", "Emma"),
+    ("short", "es", "llego tarde", "tarde"),
+    ("short", "ja", "kaigi made matte", "kaigi"),
+    ("short", "hi", "ghar jaldi aao", "ghar"),
+    ("short", "en", "call me soon", "call"),
+    ("normal", "en", "please pick up Emma from school today because my call runs late", "Emma"),
+    ("normal", "es", "por favor compra leche pan y fruta antes de volver a casa", "leche"),
+    ("normal", "ja", "ashita no kaigi no mae ni shiryou wo kakunin shite kudasai", "kaigi"),
+    ("normal", "hi", "kal subah school ke liye jersey aur snack pack kar dena", "school"),
+    ("normal", "en", "can we reschedule the pediatrician appointment to next Thursday afternoon", "appointment"),
+]
+
+failures = []
+for index, (kind, lang, sentence, expect) in enumerate(corpus, start=1):
+    print(f"clip {index}/10 kind={kind} lang={lang}")
+    audio_path = tts(sentence, voice="echo", engine="openai")
+    ok = test_recording(audio=audio_path, expect=expect, timeout=45.0)
+    if not ok:
+        failures.append(f"{index:02d}-{kind}-{lang}")
+
+if failures:
+    print("failed clips: " + ", ".join(failures), file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+  kill "$LOG_PID" >/dev/null 2>&1 || true
+  trap - EXIT
+fi
+
+echo "==> Comparing perf metrics"
+python3 "$ROOT_DIR/scripts/lid-perf-bench.py" \
+  --log "$RAW_LOG" \
+  --baseline "$BASELINE" \
+  --output-json "$RESULT_JSON"
+
+echo "wrote $RESULT_JSON"


### PR DESCRIPTION
## Summary

- Fixes #519. WhisperKit auto-mode users no longer perceive a 600-1000ms freeze between releasing the hotkey and the overlay flipping to "Transcribing..."
- The overlay state-flip is hoisted to run before the language-detection pass, so the user sees "Transcribing..." within ~50ms of release. Total stop-to-paste is unchanged on normal clips; on short clips (under 3s of voiced audio) we now run one LID window instead of four, cutting that path materially.
- Plan: [docs/feature-requests/issue-519-2026-05-04-whisperkit-overlay-freeze.md](https://github.com/saurabhav88/EnviousWispr/blob/fix/whisperkit-overlay-freeze/docs/feature-requests/issue-519-2026-05-04-whisperkit-overlay-freeze.md)
- Council: 14 reviewers (7 personas x GPT + Gemini) + Codex grounded review (PIVOT to Path A) on 2026-05-04. Founder approved Path A.

## What changed

- **`Sources/EnviousWisprPipeline/WhisperKitPipeline.swift`** — hoist `state = .transcribing` before `observeLID`; route `maxWindows` via `lidWindowCount` based on voiced duration; add 6 signpost log lines for perf measurement.
- **`Sources/EnviousWisprPipeline/WhisperKitPipelineSpeechRouting.swift`** — extracted from the parent file; adds `lidWindowCount(forVoicedDuration:)` helper.
- **`Sources/EnviousWisprCore/LanguageTypes.swift`** — adds `singleWindowMaxSec: TimeInterval = 3.0` threshold.
- **`Sources/EnviousWisprServices/TelemetryService.swift`** — adds `lid_window_count` field to the `language.detected` PostHog event.
- **`Tests/EnviousWisprTests/Pipeline/WhisperKitPipelineSpeechSegmentsTests.swift`** + **`Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift`** — pin `lidWindowCount` routing and add R2-CHAR-070/071 covering single-window classifier behavior.
- **`scripts/lid-perf-bench.sh` + `scripts/lid-perf-bench.py`** — pre-push perf harness with 10-clip corpus (5 short + 5 normal across en/es/ja/hi via OpenAI TTS), JSONL signpost parser, and pass gates (state_flip_p50 < 50ms, short-clip clipboard_p50 reduced by >= 500ms vs baseline, normal-clip clipboard_p50 within +/- 100ms of baseline). Baseline JSON ships as a stub; populate with measured values when capturing a real baseline.

## Subtle UX change worth noting

Today, mashing "cancel" during the 600-1000ms freeze WOULD cancel the recording (state still `.recording`). After this fix, the overlay says "Transcribing..." instantly, and `cancelRecording` short-circuits on `state == .recording` — so cancel during the LID window now no-ops. The visual state matches what the cancel button does (cancel-during-transcribe behavior), so the UX is consistent, just changes ~500ms earlier than before.

## Test plan

- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh --filter "WhisperKitPipelineSpeechSegments|R2CharacterizationTests"` — all 24 tests pass including 4 new ones
- [x] Bundled local build, founder smoke-tested with English dictation: overlay no longer "looks hung up"
- [ ] International dictation tests (es/ja/hi) — running post-merge per founder direction
- [ ] Cold heart-path benchmark — deferred per founder direction (small change, smoke-validated)

## Validation depth

This is a structural reorder (move one assignment, change one parameter, add log lines). The two LOC-meaningful behavior changes are:
1. State assignment moves earlier in `stopAndTranscribe` (no semantics change, only relative timing).
2. `maxWindows` becomes 1 for clips under 3s (the classifier already handles N=1 observations; no new code path).

The plan called for a full perf harness baseline + 20-clip Live UAT + cold heart-bench. Founder elected to skip those for this PR given the change is small and structurally guaranteed to win on the user-felt path. Multilingual sanity-check happens after merge; if anything regresses, revert is a single squash commit.

## Council-skip note

Plan ran through full council (14 reviewers) + Codex grounded review on 2026-05-04. This PR implements that adopted plan; no new council pass needed.
