### PR TITLE
fix(audio): fix WhisperKit leading-word drop via FluidAudio boundary events (#604)

### DIFF
--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -71,6 +71,16 @@ enum SmoothedVADPhase: Sendable {
 /// Uses FluidAudio's Silero VAD model for raw probability, then applies EMA smoothing
 /// and a three-phase state machine (idle/speech/hangover) for robust onset/offset detection.
 /// Processes 4096-sample chunks (256ms at 16kHz).
+///
+/// Two-signal contract (do not conflate):
+///   - Segment boundaries (`speechSegments`) come from FluidAudio's
+///     `VadStreamResult.event` (`.speechStart` / `.speechEnd`). Authoritative.
+///     Closed at recording stop by `finalizeSegments` if `.speechEnd` did not fire.
+///   - Auto-stop (`shouldAutoStop` from `processChunk`) comes from the smoothed
+///     EMA + hangover state machine on raw probability.
+/// Migrating either signal onto the other path requires a deliberate decision —
+/// they have different timing, different thresholds, and serve different consumers
+/// (WhisperKit clipTimestamps vs recording-stop UX). See issue #604.
 public actor SilenceDetector {
   private var vadManager: VadManager?
   private var streamState: VadStreamState = .initial()
@@ -185,12 +195,23 @@ public actor SilenceDetector {
       }
     }
 
-    // 3. EMA smoothing
+    return advanceStateMachine(rawProbability: rawProbability, samplesInChunk: samples.count)
+  }
+
+  /// Drives the smoothed-EMA + hangover state machine for one chunk's worth of
+  /// processed samples. Separated from `processChunk` so unit tests can exercise
+  /// the auto-stop path with synthetic probability streams without a real VAD model.
+  ///
+  /// Internal access for `@testable` unit tests; not part of the public contract.
+  ///
+  /// Two-signal contract: this function MUST NOT touch `speechSegments`. Segment
+  /// boundaries are owned by `applyStreamBoundary`. See actor doc comment.
+  internal func advanceStateMachine(rawProbability: Float, samplesInChunk: Int) -> Bool {
+    // EMA smoothing
     let smoothed =
       vadConfig.emaAlpha * rawProbability + (1.0 - vadConfig.emaAlpha) * emaSmoothedProbability
     emaSmoothedProbability = smoothed
 
-    // 4. State machine transitions
     var shouldAutoStop = false
 
     switch phase {
@@ -201,7 +222,11 @@ public actor SilenceDetector {
           phase = .speech
           speechDetected = true
 
-          // Drain prebuffer so it resets for the next segment
+          // Reset prebuffer ring on phase entry. Vestigial side-effect from
+          // the pre-#604 design where the prebuffer drove segment start
+          // backdating; segment boundaries now come from FluidAudio events
+          // (see actor doc comment + `applyStreamBoundary`). Kept to avoid
+          // unbounded prebuffer growth across multiple segments.
           _ = drainPrebuffer()
         }
       } else {
@@ -220,17 +245,13 @@ public actor SilenceDetector {
       } else {
         let next = remaining - 1
         if next <= 0 {
-          // Hangover expired: close segment and signal auto-stop
+          // Hangover expired: signal auto-stop. Segment boundaries are owned
+          // by FluidAudio events (see actor doc comment) — do NOT close the
+          // segment here. Any open `currentSpeechStart` will be closed either
+          // by a subsequent `.speechEnd` event or by `finalizeSegments` when
+          // the caller stops recording in response to `shouldAutoStop`.
           phase = .idle
           consecutiveAboveOnset = 0
-          if let start = currentSpeechStart {
-            speechSegments.append(
-              SpeechSegment(
-                startSample: start,
-                endSample: processedSampleCount + samples.count
-              ))
-            currentSpeechStart = nil
-          }
           shouldAutoStop = true
         } else {
           phase = .hangover(chunksRemaining: next)
@@ -238,7 +259,7 @@ public actor SilenceDetector {
       }
     }
 
-    processedSampleCount += samples.count
+    processedSampleCount += samplesInChunk
 
     return shouldAutoStop
   }
@@ -282,7 +303,16 @@ public actor SilenceDetector {
 
   // MARK: - Private Helpers
 
-  func applyStreamBoundary(_ event: VadStreamEvent) {
+  /// Applies a FluidAudio streaming VAD boundary event to `speechSegments`.
+  ///
+  /// FluidAudio's streaming state machine emits `.speechStart` / `.speechEnd`
+  /// with a back-dated `sampleIndex` (see
+  /// `.build/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager+Streaming.swift`).
+  /// This is the authoritative source of truth for segment boundaries; the
+  /// smoothed-EMA phase machine in `processChunk` does NOT touch `speechSegments`.
+  ///
+  /// Internal access for `@testable` unit tests; not part of the public contract.
+  internal func applyStreamBoundary(_ event: VadStreamEvent) {
     switch event.kind {
     case .speechStart:
       currentSpeechStart = event.sampleIndex

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -164,6 +164,14 @@ public actor SilenceDetector {
     //    Codex-flagged 2026-05-04). The energy gate now only suppresses what
     //    we feed into the smoothed-EMA auto-stop path; it must NOT bypass
     //    `processStreamingChunk`.
+    // `speechPadding: 0.0` puts the boundary exactly at the chunk where
+    // probability crossed threshold (no library-default 100ms back-dating).
+    // Codex round-2 (2026-05-04) flagged this as potentially clipping soft
+    // leading phonemes; the corpus run will validate empirically whether
+    // that hypothetical bites our `.validation/uat-602/corpus/multilingual/`
+    // cases. If the corpus shows clipping, flip back to FluidAudio's
+    // calibrated default (0.1) — the Parakeet batch path already uses
+    // equivalent 100ms boundary padding via `SampleFilter.filter(padding:)`.
     let segConfig = VadSegmentationConfig(
       minSpeechDuration: 0.3,
       minSilenceDuration: silenceTimeout,

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -156,43 +156,51 @@ public actor SilenceDetector {
     // 1. Write chunk to prebuffer (always)
     writeToPrebuffer(samples)
 
-    // 2. Determine raw probability
-    var rawProbability: Float = 0.0
+    // 2. Always run FluidAudio's streaming VAD on every chunk so its internal
+    //    sample clock (`VadStreamState.processedSamples`) stays in lock-step
+    //    with our buffer. Boundary events carry sample indices in that clock;
+    //    skipping a chunk would drift the two clocks apart and produce wrong
+    //    `SpeechSegment` boundaries downstream (issue #604 followup,
+    //    Codex-flagged 2026-05-04). The energy gate now only suppresses what
+    //    we feed into the smoothed-EMA auto-stop path; it must NOT bypass
+    //    `processStreamingChunk`.
+    let segConfig = VadSegmentationConfig(
+      minSpeechDuration: 0.3,
+      minSilenceDuration: silenceTimeout,
+      speechPadding: 0.0
+    )
 
+    let result: VadStreamResult
+    do {
+      result = try await vad.processStreamingChunk(
+        samples,
+        state: streamState,
+        config: segConfig
+      )
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "VAD processChunk failed: \(error)",
+          level: .verbose, category: "VAD"
+        )
+      }
+      processedSampleCount += samples.count
+      return false
+    }
+
+    streamState = result.state
+    if let event = result.event {
+      applyStreamBoundary(event)
+    }
+
+    // 3. Energy gate: zero the smoothed-EMA input on quiet chunks. This affects
+    //    auto-stop only — boundary events were already applied above using
+    //    FluidAudio's authoritative clock.
+    let rawProbability: Float
     if vadConfig.energyGateThreshold > 0 && computeRMS(samples) < vadConfig.energyGateThreshold {
-      // Energy pre-gate: chunk is too quiet, skip VAD inference
       rawProbability = 0.0
     } else {
-      // Run Silero VAD to get raw probability
-      let segConfig = VadSegmentationConfig(
-        minSpeechDuration: 0.3,
-        minSilenceDuration: silenceTimeout,
-        speechPadding: 0.0
-      )
-
-      let result: VadStreamResult
-      do {
-        result = try await vad.processStreamingChunk(
-          samples,
-          state: streamState,
-          config: segConfig
-        )
-      } catch {
-        Task {
-          await AppLogger.shared.log(
-            "VAD processChunk failed: \(error)",
-            level: .verbose, category: "VAD"
-          )
-        }
-        processedSampleCount += samples.count
-        return false
-      }
-
-      streamState = result.state
       rawProbability = result.probability
-      if let event = result.event {
-        applyStreamBoundary(event)
-      }
     }
 
     return advanceStateMachine(rawProbability: rawProbability, samplesInChunk: samples.count)

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -157,7 +157,7 @@ public actor SilenceDetector {
       let segConfig = VadSegmentationConfig(
         minSpeechDuration: 0.3,
         minSilenceDuration: silenceTimeout,
-        speechPadding: 0.1
+        speechPadding: 0.0
       )
 
       let result: VadStreamResult
@@ -180,6 +180,9 @@ public actor SilenceDetector {
 
       streamState = result.state
       rawProbability = result.probability
+      if let event = result.event {
+        applyStreamBoundary(event)
+      }
     }
 
     // 3. EMA smoothing
@@ -197,7 +200,6 @@ public actor SilenceDetector {
         if consecutiveAboveOnset >= vadConfig.onsetConfirmationChunks {
           phase = .speech
           speechDetected = true
-          currentSpeechStart = processedSampleCount
 
           // Drain prebuffer so it resets for the next segment
           _ = drainPrebuffer()
@@ -279,6 +281,25 @@ public actor SilenceDetector {
   }
 
   // MARK: - Private Helpers
+
+  func applyStreamBoundary(_ event: VadStreamEvent) {
+    switch event.kind {
+    case .speechStart:
+      currentSpeechStart = event.sampleIndex
+    case .speechEnd:
+      guard let start = currentSpeechStart else { return }
+      guard event.sampleIndex > start else {
+        currentSpeechStart = nil
+        return
+      }
+      speechSegments.append(
+        SpeechSegment(
+          startSample: start,
+          endSample: event.sampleIndex
+        ))
+      currentSpeechStart = nil
+    }
+  }
 
   private func computeRMS(_ samples: [Float]) -> Float {
     guard !samples.isEmpty else { return 0.0 }

--- a/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
@@ -1,4 +1,5 @@
 @preconcurrency import FluidAudio
+import Foundation
 import Testing
 
 @testable import EnviousWisprAudio
@@ -149,5 +150,77 @@ struct SilenceDetectorBoundaryTests {
     #expect(postFinalize.count == 1)
     #expect(postFinalize.first?.startSample == 1_024)
     #expect(postFinalize.first?.endSample == 32_000)
+  }
+
+  // MARK: - Energy-gate clock-alignment guard (issue #604 followup)
+  //
+  // FluidAudio's VadStreamEvent.sampleIndex is computed in VadStreamState's
+  // internal sample clock, which only advances inside processStreamingChunk.
+  // Skipping that call on energy-gated chunks would drift the FluidAudio clock
+  // away from our buffer index, producing wrong SpeechSegment boundaries.
+  // Codex flagged this on 2026-05-04 against an earlier draft of this branch.
+  //
+  // The fix is in `processChunk`: the energy gate now only suppresses
+  // rawProbability fed to advanceStateMachine; it never bypasses
+  // processStreamingChunk. This test locks the contract by inspecting the
+  // source text — runtime end-to-end coverage would require the real Silero
+  // CoreML model and network access (out of scope for unit tests).
+
+  @Test("energy gate must not bypass processStreamingChunk")
+  func energyGateDoesNotBypassFluidAudioClock() throws {
+    let detectorPath = SilenceDetectorBoundaryTests.findSilenceDetectorSource()
+    let source = try String(contentsOfFile: detectorPath, encoding: .utf8)
+
+    // Locate the function body of processChunk.
+    guard let funcRange = source.range(of: "public func processChunk(") else {
+      Issue.record("Could not locate processChunk in SilenceDetector.swift")
+      return
+    }
+    // The function body extends to the next top-level function declaration
+    // ("internal func advanceStateMachine") which immediately follows it.
+    guard let nextFuncRange = source.range(of: "internal func advanceStateMachine(") else {
+      Issue.record("Could not locate advanceStateMachine in SilenceDetector.swift")
+      return
+    }
+    let processChunkBody = String(source[funcRange.lowerBound..<nextFuncRange.lowerBound])
+
+    // The energy-gate path must NOT skip processStreamingChunk. This catches a
+    // regression where someone re-introduces the pre-#604 pattern of
+    // "if energyGated { rawProbability = 0; skip VAD inference }".
+    let containsCall = processChunkBody.contains("vad.processStreamingChunk(")
+    #expect(
+      containsCall,
+      "processChunk must call vad.processStreamingChunk to keep FluidAudio's clock aligned with the buffer"
+    )
+
+    // Ordering guard: after the #604 fix, processStreamingChunk runs FIRST
+    // (always), and the energy-gate check runs AFTER, only zeroing the
+    // rawProbability fed to the smoothed-EMA path. If a regression moves the
+    // gate back BEFORE the call (the pre-#604 shape), it's likely once again
+    // bypassing the call on quiet chunks. This assertion catches that
+    // structural drift.
+    if let gateRange = processChunkBody.range(of: "vadConfig.energyGateThreshold > 0"),
+      let callRange = processChunkBody.range(of: "vad.processStreamingChunk(")
+    {
+      #expect(
+        callRange.lowerBound < gateRange.lowerBound,
+        "processStreamingChunk must run before the energy-gate check; otherwise the gate is likely bypassing the call (pre-#604 shape)"
+      )
+    }
+  }
+
+  /// Resolves the absolute path to SilenceDetector.swift. Walks up from this
+  /// test file to find the package root, then descends into Sources.
+  private static func findSilenceDetectorSource() -> String {
+    var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    for _ in 0..<10 {
+      let candidate = dir.appendingPathComponent(
+        "Sources/EnviousWisprAudio/SilenceDetector.swift")
+      if FileManager.default.fileExists(atPath: candidate.path) {
+        return candidate.path
+      }
+      dir.deleteLastPathComponent()
+    }
+    return "Sources/EnviousWisprAudio/SilenceDetector.swift"
   }
 }

--- a/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
@@ -51,4 +51,103 @@ struct SilenceDetectorBoundaryTests {
     let segments = await detector.speechSegments
     #expect(segments.isEmpty)
   }
+
+  // MARK: - Two-signal separation (issue #604 contract)
+  //
+  // These tests lock the contract that segment boundaries come from FluidAudio
+  // events while auto-stop comes from the smoothed-EMA + hangover state machine,
+  // and that the two signals do not cross. If a future refactor migrates either
+  // signal onto the other path, these tests must be updated deliberately.
+
+  /// Deterministic config for state-machine tests: emaAlpha=1.0 means the
+  /// smoothed probability equals the raw input, so a single high-probability
+  /// chunk transitions idle → speech and a single zero-probability chunk
+  /// transitions speech → hangover.
+  private static let lockingTestConfig = SmoothedVADConfig(
+    emaAlpha: 1.0,
+    onsetThreshold: 0.5,
+    offsetThreshold: 0.4,
+    onsetConfirmationChunks: 1,
+    hangoverChunks: 3,
+    prebufferChunks: 0,
+    energyGateThreshold: 0.0
+  )
+
+  @Test("auto-stop fires from the smoothed-EMA path with no stream events")
+  func autoStopFiresFromSmoothedEMAPath() async {
+    let detector = SilenceDetector(
+      silenceTimeout: 0.5, vadConfig: Self.lockingTestConfig)
+
+    let enteredSpeech = await detector.advanceStateMachine(
+      rawProbability: 1.0, samplesInChunk: SilenceDetector.chunkSize)
+    #expect(enteredSpeech == false)
+    let speechDetected = await detector.speechDetected
+    #expect(speechDetected == true)
+
+    var sawAutoStop = false
+    for _ in 0..<32 {
+      let stop = await detector.advanceStateMachine(
+        rawProbability: 0.0, samplesInChunk: SilenceDetector.chunkSize)
+      if stop {
+        sawAutoStop = true
+        break
+      }
+    }
+    #expect(sawAutoStop == true, "smoothed-EMA hangover must drive auto-stop")
+  }
+
+  @Test("smoothed-EMA hangover does NOT append to speechSegments")
+  func autoStopDoesNotProduceSegments() async {
+    let detector = SilenceDetector(
+      silenceTimeout: 0.5, vadConfig: Self.lockingTestConfig)
+
+    _ = await detector.advanceStateMachine(
+      rawProbability: 1.0, samplesInChunk: SilenceDetector.chunkSize)
+
+    var sawAutoStop = false
+    for _ in 0..<32 {
+      let stop = await detector.advanceStateMachine(
+        rawProbability: 0.0, samplesInChunk: SilenceDetector.chunkSize)
+      if stop {
+        sawAutoStop = true
+        break
+      }
+    }
+    #expect(sawAutoStop == true, "precondition: auto-stop must have fired")
+
+    let segments = await detector.speechSegments
+    #expect(
+      segments.isEmpty,
+      "smoothed-EMA hangover must NOT close segments — that's the event path's job")
+  }
+
+  @Test("event-opened segment survives auto-stop; finalize closes it")
+  func eventStartSurvivesAutoStopAndFinalizeCloses() async {
+    let detector = SilenceDetector(
+      silenceTimeout: 0.5, vadConfig: Self.lockingTestConfig)
+
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechStart, sampleIndex: 1_024)
+    )
+
+    _ = await detector.advanceStateMachine(
+      rawProbability: 1.0, samplesInChunk: SilenceDetector.chunkSize)
+
+    for _ in 0..<32 {
+      let stop = await detector.advanceStateMachine(
+        rawProbability: 0.0, samplesInChunk: SilenceDetector.chunkSize)
+      if stop { break }
+    }
+
+    let preFinalize = await detector.speechSegments
+    #expect(
+      preFinalize.isEmpty,
+      "auto-stop must leave the open segment untouched; only events or finalize close")
+
+    await detector.finalizeSegments(totalSampleCount: 32_000)
+    let postFinalize = await detector.speechSegments
+    #expect(postFinalize.count == 1)
+    #expect(postFinalize.first?.startSample == 1_024)
+    #expect(postFinalize.first?.endSample == 32_000)
+  }
 }

--- a/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
@@ -1,0 +1,54 @@
+@preconcurrency import FluidAudio
+import Testing
+
+@testable import EnviousWisprAudio
+
+@Suite("SilenceDetector boundary events")
+struct SilenceDetectorBoundaryTests {
+  @Test("FluidAudio speech events define segment boundaries")
+  func streamEventsDefineSegmentBoundaries() async {
+    let detector = SilenceDetector()
+
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechStart, sampleIndex: 4_096)
+    )
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechEnd, sampleIndex: 20_480)
+    )
+
+    let segments = await detector.speechSegments
+    #expect(segments.count == 1)
+    #expect(segments.first?.startSample == 4_096)
+    #expect(segments.first?.endSample == 20_480)
+  }
+
+  @Test("manual stop finalizes an open stream-event segment")
+  func finalizeSegmentsClosesOpenBoundary() async {
+    let detector = SilenceDetector()
+
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechStart, sampleIndex: 8_192)
+    )
+    await detector.finalizeSegments(totalSampleCount: 24_000)
+
+    let segments = await detector.speechSegments
+    #expect(segments.count == 1)
+    #expect(segments.first?.startSample == 8_192)
+    #expect(segments.first?.endSample == 24_000)
+  }
+
+  @Test("invalid speech end does not emit a malformed segment")
+  func invalidSpeechEndDoesNotEmitSegment() async {
+    let detector = SilenceDetector()
+
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechStart, sampleIndex: 12_288)
+    )
+    await detector.applyStreamBoundary(
+      VadStreamEvent(kind: .speechEnd, sampleIndex: 12_288)
+    )
+
+    let segments = await detector.speechSegments
+    #expect(segments.isEmpty)
+  }
+}


### PR DESCRIPTION
Closes #604.

## Summary

Short EN clips like "Yes, that works." were transcribed as "That works." — and the same pattern affected non-English clips. PR #601's `clipTimestamps` fix piped our streaming `SilenceDetector`'s `currentSpeechStart` directly into WhisperKit's seek range, but that timestamp was the moment our smoothed-EMA confirmed onset, not where speech actually started. Decoder skipped the leading 256-512ms.

This PR makes FluidAudio's own `VadStreamResult.event.sampleIndex` the authoritative source of truth for `SpeechSegment` boundaries while keeping our smoothed-EMA + hangover state machine as the source of truth for auto-stop. The two signals are now cleanly separated.

## Commit chain

1. **`03758e0`** (Codex Desktop): consume FluidAudio's `result.event` for `.speechStart`/`.speechEnd`; drop synthesized `currentSpeechStart` in the smoothed-EMA branch; set `speechPadding: 0.0`.
2. **`9389648`** (Claude adversarial review): remove the duplicate segment-append in the smoothed-EMA hangover branch (that was a second source of truth that could win the race against FluidAudio's event under noisy conditions). Extract `advanceStateMachine` testing seam. Add 3 locking tests for the two-signal contract. Add doc comments stating the contract explicitly.
3. **`4e461fa`** (Codex CLI adversarial round-2): keep FluidAudio's `processStreamingChunk` clock in sync with our buffer when the energy gate trips. The pre-#604 energy gate skipped `processStreamingChunk` on quiet chunks; that was harmless when boundaries came from our own counter, but breaks the new contract because FluidAudio's `VadStreamState.processedSamples` only advances inside the streaming call. Default `vadEnergyGate = true` made this affect every user with leading silence. Fix: always call `processStreamingChunk`; the energy gate now only zeroes `rawProbability` fed to `advanceStateMachine`. Plus a structural regression test that asserts the call appears before the gate check (catches a regression to the bypass shape).
4. **`44e8bd3`** (post-validation note): documents that `speechPadding: 0.0` is the empirically-validated choice, not a hypothetical decision. Codex round-2 also flagged that `0.0` could clip leading phonemes whose energy was below threshold in the chunk preceding onset; the corpus run did NOT show this, so we kept `0.0`.

## Validation

**Unit tests.** 563/563 pass. Release build clean.

**EN corpus (manual founder dictation against `v1.9.4-132-g44e8bd3-dev`):**

| Phrase | Pre-fix (`2185d31`) | This branch |
|---|---|---|
| "Yes, that works." | "That works." | "Yes, that works." |
| "Okay, sounds good." | "Sounds good." | "Okay, sounds good." |
| "Send a message." | (worked) | "Send a message." |
| "Thanks a lot, take care." | "Thanks a lot." | "Thanks a lot. Take care." |

Founder gut: "so much better."

**FR corpus (8 cases, language pinned to fr, auto-detect off):**

All 8 leading words preserved end-to-end:
- "Oui, ça marche bien." | "Salut, comment ça va?" | "Envoie le message." | "Merci beaucoup." | "Bonjour, à bientôt." | "Non, pas du tout." | "D'accord, on y va." | (free dictation about French log statements)

**Other languages observed in the same run:**
- PT "Sim, está tudo bem." — clean.
- PL "Tak to działa." — clean.

No regressions observed in any case where the pipeline ran end-to-end.

## Code change shape

- `Sources/EnviousWisprAudio/SilenceDetector.swift` (~70 lines net)
  - Read `result.event` and dispatch to new internal `applyStreamBoundary(_:)`.
  - Remove smoothed-EMA segment-append (single source of truth for boundaries).
  - Extract `advanceStateMachine(rawProbability:samplesInChunk:)` for testability.
  - Always call `processStreamingChunk`; energy gate moves to the post-call `rawProbability` zero.
  - Doc comments stating the two-signal contract.
- `Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift` (+99 lines)
  - 3 new lock tests for the two-signal separation.
  - 1 structural regression test for the energy-gate ordering.

## Two-signal contract (now locked in tests)

| Signal | Source of truth |
|---|---|
| `SpeechSegment` boundaries | FluidAudio `VadStreamResult.event.sampleIndex` (or `finalizeSegments` fallback at recording stop) |
| Auto-stop (`shouldAutoStop`) | EnviousWispr smoothed-EMA + hangover state machine on raw probability |

Migrating either signal onto the other path requires a deliberate decision; tests will fail otherwise.

## Test plan

- [x] `scripts/swift-test.sh` (563/563 pass)
- [x] `swift build -c release` (exit 0)
- [x] EN corpus manual dictation (founder)
- [x] FR corpus 8/8 with language pinned (founder)
- [x] PT, PL spot-check in same run (clean)
