### PR TITLE
fix(polish): restore AFM custom vocab + ASR enrichment lost in #614 + cleanup

### DIFF
--- a/.github/workflows/polish-eval-smoke.yml
+++ b/.github/workflows/polish-eval-smoke.yml
@@ -49,7 +49,6 @@ jobs:
               - 'Sources/EnviousWisprPostProcessing/CustomWordsManager.swift'
               - 'Sources/EnviousWisprCore/PolishMode.swift'
               - 'Sources/EnviousWisprCore/PolishPlan.swift'
-              - 'Sources/EnviousWisprCore/PolishStyleConfig.swift'
               - 'Sources/EnviousWisprCore/PromptEnvelope.swift'
               - 'Sources/EnviousWisprCore/PromptBuildInput.swift'
               - 'scripts/eval/**'

--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -569,18 +569,34 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
         return langClause + modePrompt
       }()
 
-      // Issue #614, 2026-05-04: post-rip-out, every caller passes
-      // `PolishInstructions.default`. The dual-mode router's `basePrompt`
-      // (with optional language clause) is the only system prompt AFM
-      // ever sees. The `instructions` parameter is kept on the signature
-      // for protocol-shape parity with other connectors but goes unread
-      // here. Aligning all three connector signatures to drop the param
-      // is a separate refactor backlog item (#591).
-      _ = instructions
+      // Issue #616, 2026-05-04: extract the suffix that
+      // `LLMPolishStep.appleIntelligenceInstructions` appended on top of
+      // `PolishInstructions.default.systemPrompt` (the speech-to-text-awareness
+      // clause and, when non-empty, the user's Custom Words block) and
+      // concatenate it onto `basePrompt`. Production callers always pass a
+      // default-prefixed prompt (verified `SettingsManager.activePolishInstructions`
+      // hardcoded to `.default`). The defensive `else` branch is forward-safety
+      // for a future non-default caller; `assertionFailure` in debug catches
+      // such a caller at test time so the silent-empty-suffix path is loud.
+      // Aligning all three connector signatures to drop the `instructions`
+      // param entirely is a separate refactor backlog item (#591).
+      let defaultPrompt = PolishInstructions.default.systemPrompt
+      let suffix: String
+      if instructions.systemPrompt.hasPrefix(defaultPrompt) {
+        suffix = String(instructions.systemPrompt.dropFirst(defaultPrompt.count))
+      } else {
+        assertionFailure(
+          "AppleIntelligenceConnector: instructions.systemPrompt does not have the expected default prefix; "
+            + "suffix passthrough disabled. Update this connector if a new caller is intentionally passing "
+            + "non-default instructions."
+        )
+        suffix = ""
+      }
+      let systemPrompt = basePrompt + suffix
 
       return LanguageModelSession(
         model: model,
-        instructions: basePrompt
+        instructions: systemPrompt
       )
     }
   #endif

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -485,13 +485,3 @@ public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
     }
   }
 }
-
-// MARK: - String helpers
-
-extension String {
-  /// Returns nil if the string is empty or whitespace-only.
-  var nilIfEmpty: String? {
-    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : self
-  }
-}

--- a/Tests/RuntimeUAT/SCENARIOS.md
+++ b/Tests/RuntimeUAT/SCENARIOS.md
@@ -86,7 +86,7 @@ Start recording, dispatch `force_proxy_buffer_drop(1000)` so the next 1000 buffe
 ### A6_settings_storm (Lane A — settings)
 Backends: both. Budget: 30s. Mechanism: settings.
 
-During an active recording, navigate to AI Polish settings. Toggle `wordCorrectionEnabled`, `fillerRemovalEnabled`, `writingStylePreset`, `customSystemPrompt`, and `useExtendedThinking`. Recording continues; toggles apply via `PipelineSettingsSync` live-sync.
+During an active recording, navigate to AI Polish settings. Toggle `wordCorrectionEnabled` and `fillerRemovalEnabled`. Recording continues; toggles apply via `PipelineSettingsSync` live-sync.
 
 **Do NOT toggle:** `noiseSuppression` (cancels active Parakeet recording per `PipelineSettingsSync.swift:175-185`); frozen-at-start fields (`autoCopyToClipboard`, `restoreClipboardAfterPaste`, `vadAutoStop`, `vadSilenceTimeout`, `vadSensitivity`, `vadEnergyGate`, `languageMode`, `useStreamingASR`).
 

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -826,7 +826,7 @@ def _read_setting(key: str) -> Optional[str]:
         runtime_budget_seconds=30.0,
         founder_required=False,
         negative_control="Remove wordCorrectionEnabled live-sync from PipelineSettingsSync; setting takes no effect mid-record",
-        description="Toggle wordCorrectionEnabled / fillerRemovalEnabled / useExtendedThinking during active recording",
+        description="Toggle wordCorrectionEnabled / fillerRemovalEnabled during active recording",
     )
 )
 def A6_settings_storm(**_) -> dict:


### PR DESCRIPTION
## Summary

Fixes the AFM polish regression caught by post-launch Codex grounded review on #615 (`236c156`): the rip-out collapsed a three-branch sentinel in `AppleIntelligenceConnector.makeSession` whose `hasPrefix(default)` branch was the only one that fired in production. That branch did suffix-passthrough for two unrelated payloads, both silently dropped after collapse:

- **ASR enrichment clause** (`"This is speech-to-text output. Remove false starts..."`) — targets eval failures #17 (false starts) and #19 (formality downgrade).
- **User's Custom Words** via `CustomVocabularyFormatter.render` — every AFM user with custom words got their terms dropped before reaching the on-device model.

Restored with a one-branch prefix-strip + assertion: if `instructions.systemPrompt` has the `PolishInstructions.default` prefix (the only shape any production caller passes today, per Codex grep through `SettingsManager.activePolishInstructions:336` → `AppState:887` → both pipelines:1304/1385 → `PipelineSettingsSync:202` → `LLMPolishStep:205`), strip the default and concatenate the suffix onto `basePrompt`. Otherwise fall back to `basePrompt` only with `assertionFailure` in debug so a future broken caller is caught at test time.

Five commits, one logical PR:

1. `b7eb3d9` chore(polish): remove orphaned `String.nilIfEmpty` (post-#614 dead code Periphery flagged)
2. `a9ae58b` fix(polish): restore AFM custom vocab + ASR enrichment (the actual regression fix)
3. `6ceb018` chore(ci): drop deleted `PolishStyleConfig.swift` from `polish-eval-smoke` watcher (allowlist line pointing at a file deleted in #614)
4. `0a70192` docs(uat): align `SCENARIOS.md` A6 prose with `faultInjection.py` reality (drop `writingStylePreset`, `customSystemPrompt`, `useExtendedThinking` from prose toggle list — implementation only flips `wordCorrectionEnabled` + `fillerRemovalEnabled`)
5. `1a4f06e` docs(uat): drop `useExtendedThinking` from A6 `ScenarioMeta.description` too (Codex code-diff catch — same lie in the python metadata string)

Closes #616.

## Plan, audits, council

- Plan: `docs/feature-requests/issue-616-2026-05-04-afm-custom-vocab-restoration.md`
- Plan-time grounded review: `docs/audits/2026-05-04-issue-616-grounded-review.txt` — verdict `PROCEED-WITH-REVISIONS`. Three revisions applied (assertionFailure on defensive else, SCENARIOS narrowed to two real toggles, UAT spec accounts for `AppLogger` actor + debug-gate constraints).
- Code-diff review: `docs/audits/2026-05-04-issue-616-code-review.txt` — verdict `APPROVE-WITH-REVISIONS`. One revision applied (commit 5: `faultInjection.py:829` description string).
- `council-skip: regression-only restoration of pre-#614 behavior, no new design surface, Codex grounded review settles all technical claims`

## Test plan

- [x] `swift build -c release` exit 0 (build clean, only pre-existing OnboardingV2View concurrency warnings unrelated to this PR)
- [x] `scripts/swift-test.sh` — 556 tests passed
- [x] **Live UAT (founder-run)** — temporary diagnostic confirmed `hadPrefix=true hasASR=true hasVocab=true instr.count=2779 base.count=2223 sys.count=4343 custom.count=26` on dictation through dev bundle. Suffix-passthrough fires; 26 of 32 custom-vocab lines reach `LanguageModelSession` (rest trimmed by formatter's pre-existing 2000-char cap). Diagnostic stripped before commit; not in the diff.
- [x] Codex code-diff review applied
- [ ] CI `build-check` green
- [ ] `polish-eval-smoke` advisory result reviewed (advisory only; not blocking per `validation-discipline.md §10`)
- [ ] Post-merge: confirm running app from main rebuild still polishes correctly on Apple Intelligence (founder will dictate one sentence after merge as smoke check)

## Open follow-ups (not in this PR)

- **AFM dual-mode router telemetry never reaches PostHog.** `router_mode` and `router_basis` are defined on `TelemetryService.llmPolishCompleted` as optional fields but the production AFM call path never passes them. Issue #616 §6 raises this as a separate item; defer to follow-up under epic #318.
- **No `had_custom_vocab_in_prompt` telemetry.** Adding this would let us empirically confirm the suffix-passthrough behavior in production going forward instead of relying on local diagnostic files. Defer to follow-up under epic #318.
- **Drop the `instructions` parameter from connector signatures (#591).** Post-launch audit flagged this as cleanup; out of scope here.
- **AFM custom-vocab effectiveness question.** Live UAT showed AFM preserves named entities that came through Whisper correctly (Saurabh, Malavika, ChatGPT, Claude Code, VS Code, macOS, Qualtrics — 7/7) but did NOT correct the misheard "Pavarthi" → "Parvati" despite Parvati being in the vocab list. This is consistent with both pre-#614 and post-#616 behavior — i.e., AFM's small on-device model has weaker custom-vocab-following than cloud models. Pre-existing quality question, not a regression caused by this PR.
