### PR TITLE
feat(settings): AI Polish model picker rework + per-provider explainer (#617)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -3,6 +3,42 @@ import EnviousWisprCore
 import EnviousWisprLLM
 import SwiftUI
 
+// MARK: - Model Recommendation Classifier (#617)
+
+/// Token-based classifier deciding whether a discovered model should land in the
+/// "Recommended for cleanup" group of the AI Polish picker. Pure function, no
+/// view dependencies. **Lives at file scope (not private to `AIPolishSettingsView`)
+/// solely so that `AIPolishClassifierTests` in `Tests/EnviousWisprTests/Settings/`
+/// can reach it via `@testable import EnviousWispr`.** Has no other consumers
+/// inside the app module; do not adopt it elsewhere without revisiting placement.
+///
+/// A model is recommended when its lowercased id (split on `-./_/`) contains a
+/// positive token (mini, nano, flash) AND no disqualifier token. Disqualifiers
+/// rule out specialized variants that would polish poorly (code, audio, image,
+/// realtime, search, transcribe, native/live audio variants, music gen).
+///
+/// Live validation against OpenAI + Gemini APIs (2026-05-04):
+/// `docs/audits/2026-05-04-issue-617-classifier-validation.txt`.
+enum AIPolishModelClassifier {
+  static let positives: Set<String> = ["mini", "nano", "flash"]
+  static let disqualifiers: Set<String> = [
+    "realtime", "audio", "native", "live",
+    "tts", "image", "search", "transcribe", "banana", "codex",
+  ]
+
+  /// Returns true if the model id is a Mini/Nano/Flash variant suitable for
+  /// transcript cleanup.
+  static func isRecommendedForCleanup(_ id: String) -> Bool {
+    let tokens = Set(
+      id.lowercased()
+        .split(whereSeparator: { "-._/".contains($0) })
+        .map(String.init)
+    )
+    return !tokens.isDisjoint(with: positives)
+      && tokens.isDisjoint(with: disqualifiers)
+  }
+}
+
 /// LLM provider configuration, API keys, Ollama wizard, and prompt editing.
 struct AIPolishSettingsView: View {
   @Environment(AppState.self) private var appState
@@ -99,7 +135,7 @@ struct AIPolishSettingsView: View {
       // ── Section 3: Model ──────────────────────────────────────
       if showModelSection {
         BrandedSection(header: "Model") {
-          BrandedRow {
+          BrandedRow(showDivider: false) {
             HStack {
               Picker("Model", selection: $state.settings.llmModel) {
                 if appState.llmDiscovery.discoveredModels.isEmpty
@@ -115,16 +151,7 @@ struct AIPolishSettingsView: View {
                   .tag(appState.settings.llmModel)
                 }
 
-                ForEach(appState.llmDiscovery.discoveredModels) { model in
-                  HStack {
-                    Text(model.displayName)
-                    if !model.isAvailable {
-                      Image(systemName: "lock.fill")
-                        .font(.caption2)
-                    }
-                  }
-                  .tag(model.id)
-                }
+                modelPickerSections
               }
 
               if appState.settings.llmProvider == .ollama {
@@ -146,27 +173,17 @@ struct AIPolishSettingsView: View {
               }
             }
           }
-
-          if let selectedModel = appState.llmDiscovery.discoveredModels.first(where: {
-            $0.id == appState.settings.llmModel
-          }),
-            !selectedModel.isAvailable
-          {
-            BrandedRow {
-              Text("This model requires a paid API plan.")
-                .font(.stHelper)
-                .foregroundStyle(.stWarning)
-            }
-          }
-
-          // Model recommendation cards (cloud providers only)
-          if appState.settings.llmProvider != .ollama {
-            BrandedRow(showDivider: false) {
-              modelRecommendationCards
-            }
-          }
         } footer: {
           FrozenPerRecordingFootnote()
+        }
+      }
+
+      // ── Section 3.5: Why use <Provider> (cloud only) ─────────
+      if isCloudProvider {
+        BrandedSection(header: cloudProviderExplainerHeader) {
+          BrandedRow(showDivider: false) {
+            cloudProviderExplainer
+          }
         }
       }
 
@@ -367,116 +384,118 @@ struct AIPolishSettingsView: View {
     }
   }
 
-  // MARK: - Model Recommendation Cards
+  // MARK: - Model Picker Sections (#617)
 
+  /// Three labeled groups of discovered models. Empty groups are suppressed.
+  /// Locked rows are disabled so a user can't pick something the API will reject.
   @ViewBuilder
-  private var modelRecommendationCards: some View {
-    let cards = modelCards(for: appState.settings.llmProvider)
-    if !cards.isEmpty {
-      VStack(spacing: 0) {
-        ForEach(cards.indices, id: \.self) { index in
-          let card = cards[index]
-          HStack(spacing: 10) {
-            ZStack {
-              RoundedRectangle(cornerRadius: 7)
-                .fill(card.iconBg)
-                .frame(width: 28, height: 28)
-              Text(card.icon)
-                .font(.system(size: 13))
-            }
+  private var modelPickerSections: some View {
+    let discovered = appState.llmDiscovery.discoveredModels
+    let recommended = discovered.filter {
+      $0.isAvailable && AIPolishModelClassifier.isRecommendedForCleanup($0.id)
+    }
+    let other = discovered.filter {
+      $0.isAvailable && !AIPolishModelClassifier.isRecommendedForCleanup($0.id)
+    }
+    let locked = discovered.filter { !$0.isAvailable }
 
-            VStack(alignment: .leading, spacing: 1) {
-              Text(card.name)
-                .font(.caption)
-                .fontWeight(.medium)
-              Text(card.desc)
-                .font(.caption2)
-                .foregroundStyle(Color.stTextTertiary)
-            }
-
-            Spacer()
-
-            Text(card.badge)
-              .font(.caption2)
-              .fontWeight(.semibold)
-              .padding(.horizontal, 7)
-              .padding(.vertical, 2)
-              .background(
-                Capsule().fill(card.badgeBg)
-              )
-              .overlay(
-                Capsule().strokeBorder(card.badgeBorder, lineWidth: 1)
-              )
-              .foregroundStyle(card.badgeFg)
-          }
-          .padding(.vertical, 6)
-
-          if index < cards.count - 1 {
-            Divider()
-          }
+    if !recommended.isEmpty {
+      Section("Recommended for cleanup") {
+        ForEach(recommended) { model in
+          Text(model.displayName).tag(model.id)
         }
       }
-
-      Text(
-        "Transcript cleanup is straightforward — smaller models handle it well at a fraction of the cost."
-      )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextTertiary)
-      .fixedSize(horizontal: false, vertical: true)
+    }
+    if !other.isEmpty {
+      Section("Other available models") {
+        ForEach(other) { model in
+          Text(model.displayName).tag(model.id)
+        }
+      }
+    }
+    if !locked.isEmpty {
+      Section("Not available with your API key") {
+        ForEach(locked) { model in
+          HStack {
+            Image(systemName: "lock.fill").font(.caption2)
+            Text(model.displayName)
+          }
+          .tag(model.id)
+          .selectionDisabled(true)
+        }
+      }
     }
   }
 
-  private struct ModelCardInfo {
-    let name: String
-    let desc: String
-    let badge: String
-    let icon: String
-    let iconBg: Color
-    let badgeBg: Color
-    let badgeBorder: Color
-    let badgeFg: Color
+  // MARK: - Cloud Provider Explainer (#617)
+
+  private var cloudProviderExplainerHeader: String {
+    appState.settings.llmProvider == .openAI ? "Why use OpenAI" : "Why use Gemini"
   }
 
-  private func modelCards(for provider: LLMProvider) -> [ModelCardInfo] {
-    switch provider {
-    case .openAI:
-      return [
-        ModelCardInfo(
-          name: "GPT-4o Mini", desc: "Fast · Affordable · Great quality", badge: "Best value",
-          icon: "⚡", iconBg: Color.stSuccess.opacity(0.10), badgeBg: Color.stSuccess.opacity(0.12),
-          badgeBorder: Color.stSuccess.opacity(0.22), badgeFg: Color(hex: "007a4d")),
-        ModelCardInfo(
-          name: "GPT-4.1 Mini", desc: "Fast · Affordable · Newer", badge: "Also great", icon: "✦",
-          iconBg: Color.cyan.opacity(0.10), badgeBg: Color.cyan.opacity(0.12),
-          badgeBorder: Color.cyan.opacity(0.22), badgeFg: Color(hex: "006f7a")),
-        ModelCardInfo(
-          name: "GPT-4o / 4.1", desc: "Slower · Higher cost", badge: "Premium", icon: "◈",
-          iconBg: Color.primary.opacity(0.05), badgeBg: Color.primary.opacity(0.05),
-          badgeBorder: Color.primary.opacity(0.09), badgeFg: Color.secondary),
-        ModelCardInfo(
-          name: "GPT-3.5 Turbo", desc: "Cheapest · Lower quality", badge: "Budget", icon: "◇",
-          iconBg: Color.primary.opacity(0.05), badgeBg: Color.primary.opacity(0.05),
-          badgeBorder: Color.primary.opacity(0.09), badgeFg: Color.secondary),
-      ]
-    case .gemini:
-      return [
-        ModelCardInfo(
-          name: "Gemini 2.0 Flash", desc: "Fast · Affordable · Great quality", badge: "Best value",
-          icon: "⚡", iconBg: Color.stSuccess.opacity(0.10), badgeBg: Color.stSuccess.opacity(0.12),
-          badgeBorder: Color.stSuccess.opacity(0.22), badgeFg: Color(hex: "007a4d")),
-        ModelCardInfo(
-          name: "Gemini 1.5 Flash", desc: "Fast · Stable · Proven", badge: "Also great", icon: "✦",
-          iconBg: Color.cyan.opacity(0.10), badgeBg: Color.cyan.opacity(0.12),
-          badgeBorder: Color.cyan.opacity(0.22), badgeFg: Color(hex: "006f7a")),
-        ModelCardInfo(
-          name: "Gemini 2.0 Pro", desc: "Slower · Higher cost", badge: "Premium", icon: "◈",
-          iconBg: Color.primary.opacity(0.05), badgeBg: Color.primary.opacity(0.05),
-          badgeBorder: Color.primary.opacity(0.09), badgeFg: Color.secondary),
-      ]
-    case .ollama:
-      return []  // Ollama uses the dynamic Manage Models list instead
-    default:
-      return []
+  @ViewBuilder
+  private var cloudProviderExplainer: some View {
+    if appState.settings.llmProvider == .openAI {
+      VStack(alignment: .leading, spacing: 10) {
+        Text(
+          "Apple Intelligence cleans up short dictation well. OpenAI is a step up for longer recordings, lists, and code. You bring your own API key, you only pay OpenAI for what you use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to OpenAI under your API account."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Text(
+          "Picking the right model. OpenAI sells several sizes inside each generation. For dictation cleanup, look for Mini in the name. Those are tuned for fast, light tasks and run roughly 3 to 10 times cheaper than the flagships. Nano is even smaller and faster. The unsuffixed flagships (GPT-5, GPT-4.1) and anything labeled Pro are overkill for this job."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Text(
+          "Locked models? Those aren't blocked by EnviousWispr. Your OpenAI API key doesn't currently have access to them. OpenAI gates some models behind spend tier or organization verification."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Link(
+          "How OpenAI model availability works by usage tier",
+          destination: URL(
+            string:
+              "https://help.openai.com/en/articles/10362446-api-model-availability-by-usage-tier-and-verification-status"
+          )!
+        )
+        .font(.stHelper)
+      }
+    } else if appState.settings.llmProvider == .gemini {
+      VStack(alignment: .leading, spacing: 10) {
+        Text(
+          "Apple Intelligence cleans up short dictation well. Gemini is a step up for longer recordings, lists, and code. You bring your own API key, the free tier is generous for personal use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to Google under your Gemini API account."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Text(
+          "Picking the right model. Gemini sells two sizes inside each generation. For dictation cleanup, look for Flash in the name. Those are tuned for fast, light tasks. Pro models are overkill: slightly smarter on hard reasoning, slower and pricier on a job that doesn't need it."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Text(
+          "Locked models? Those aren't blocked by EnviousWispr. Your Gemini API key doesn't currently have access to them. Some Gemini models are gated by region, billing tier, or preview status."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Link(
+          "Gemini API rate limits by tier",
+          destination: URL(string: "https://ai.google.dev/gemini-api/docs/rate-limits")!
+        )
+        .font(.stHelper)
+      }
     }
   }
 

--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -14,6 +14,7 @@ public struct LLMModelDiscovery: Sendable {
   private static let excludePatterns = [
     "tts", "image", "robotics", "computer-use", "deep-research",
     "gemma", "exp-", "embedding", "aqa", "vision", "nano-banana",
+    "lyria",
   ]
 
   /// Suffixes that indicate versioned duplicates (keep only the base model).

--- a/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+
+/// Issue #617 — locks the contract of `AIPolishModelClassifier.isRecommendedForCleanup`.
+///
+/// Cases drawn from live OpenAI + Gemini API validation
+/// (`docs/audits/2026-05-04-issue-617-classifier-validation.txt`) plus the
+/// adversarial set Codex grounded review demanded for matcher-broadening
+/// tests (`.claude/rules/workflow-process.md §9`).
+@Suite("AIPolishModelClassifier — recommended-for-cleanup classifier")
+struct AIPolishClassifierTests {
+
+  // MARK: - Positives (must return true)
+
+  @Test("OpenAI Mini variants are recommended")
+  func openAIMiniIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-4.1-mini"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5-mini"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5-mini-2025-08-07"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("o4-mini"))
+  }
+
+  @Test("OpenAI Nano variants are recommended")
+  func openAINanoIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-4.1-nano"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5-nano"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5-nano-2025-08-07"))
+  }
+
+  @Test("Gemini Flash variants are recommended")
+  func geminiFlashIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.0-flash"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash-lite"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-1.5-flash-8b"))
+  }
+
+  @Test("Mixed-case ids normalize")
+  func mixedCaseNormalizes() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("GPT-4o-Mini"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("Gemini-2.5-Flash"))
+  }
+
+  // MARK: - Negatives — flagships (no positive token)
+
+  @Test("Flagship models without size suffix are not recommended")
+  func flagshipsAreNotRecommended() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5-pro"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4.1"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-pro"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("chatgpt-4o-latest"))
+  }
+
+  // MARK: - Negatives — disqualifier tokens (Codex adversarial set)
+
+  @Test("Realtime / audio / live / native disqualifiers block recommendation")
+  func audioLikeDisqualifiers() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini-realtime-preview"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini-audio-preview"))
+    #expect(
+      !AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash-native-audio-preview"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash-live"))
+  }
+
+  @Test("Image / TTS / banana disqualifiers block recommendation")
+  func mediaDisqualifiers() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-image-1-mini"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash-image"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-2.5-flash-preview-tts"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("nano-banana"))
+  }
+
+  @Test("Codex disqualifier blocks code-tuned mini variants")
+  func codexDisqualifier() {
+    // Surfaced 2026-05-04 by live validation against Saurabh's OpenAI key —
+    // gpt-5.1-codex-mini is the actual case this disqualifier was added for.
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.1-codex-mini"))
+  }
+
+  @Test("Search / transcribe disqualifiers block recommendation")
+  func searchTranscribeDisqualifiers() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini-search-preview"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini-transcribe"))
+  }
+
+  // MARK: - Negatives — token boundary (substring false-positive guards)
+
+  @Test("Token-boundary substrings do not match positive tokens")
+  func tokenBoundaryGuards() {
+    // `minimax` contains "mini" as substring but tokenized it's a single token.
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("minimax-text"))
+    // `flashlight` contains "flash" as substring.
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("flashlight-v1"))
+  }
+
+  // MARK: - Negatives — degenerate input
+
+  @Test("Empty string is not recommended")
+  func emptyString() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup(""))
+  }
+}


### PR DESCRIPTION
Closes #617. Folds the prior #618.

## Summary

- Sunsets four stale hardcoded model recommendation cards (Best value / Also great / Premium / Budget) and the generic "Transcript cleanup is straightforward..." describer line under the picker.
- Replaces them with a per-provider explainer block (OpenAI / Gemini) below the Model section. Three short paragraphs: pitch over Apple Intelligence, naming guide ("look for Mini / Flash"), and a one-line note explaining locked-model semantics, plus a help link to the provider's tier docs.
- Restructures the model dropdown into three labeled `Section` groups: "Recommended for cleanup", "Other available models", "Not available with your API key". Empty groups are suppressed; locked rows use `.selectionDisabled(true)` so they cannot be picked.
- Recommendation classifier is token-based (`AIPolishModelClassifier.isRecommendedForCleanup`): positive tokens `mini`/`nano`/`flash` AND no disqualifier in `{realtime, audio, native, live, tts, image, search, transcribe, banana, codex}`. Validated against live OpenAI + Gemini API responses 2026-05-04.
- Adds `lyria` to `LLMModelDiscovery.excludePatterns` so Google's music-gen models drop out of the discovered list (folded in from #618).
- Removes the per-row "This model requires a paid API plan" warning. The new group label communicates the same thing more accurately.

## Test plan
- [x] All 567 existing tests pass (`scripts/swift-test.sh`)
- [x] 11 new classifier tests pass (`scripts/swift-test.sh --filter AIPolishClassifier`)
- [x] Release build clean (`swift build -c release`)
- [x] Live UAT verified by founder (panel renders correctly across OpenAI / Gemini / Apple Intelligence / Ollama; locked rows unselectable; explainer copy renders)
- [x] Codex grounded review on plan (verdict YES_WITH_REVISIONS, 6 revisions folded; `docs/audits/2026-05-04-issue-617-grounded-review.txt`)
- [x] Codex code-diff review (verdict APPROVE_WITH_NITS; nit 1 `selectionDisabled` swap applied; nit 2 docstring tightened; nit 3 benign drift; `docs/audits/2026-05-04-issue-617-code-diff-review.txt`)
- [ ] CI green

## Plan
`docs/feature-requests/issue-617-2026-05-04-ai-polish-explainer-naming-guide.md` (local artifact; `docs/` is gitignored per project convention)

## Note
Parallel session is patching custom-vocab on Apple Intelligence (`AppleIntelligenceConnector.swift` + prompt builders). Zero file overlap with this PR; safe to merge in either order.
