### PR TITLE
feat(updates): in-app update banner with Sparkle gentle reminders (#343)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -26,6 +26,7 @@ import SwiftUI
 final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem?
   private(set) var updaterController: SPUStandardUpdaterController?
+  private(set) var updateCoordinator: UpdateCoordinator?
   private let iconAnimator = MenuBarIconAnimator()
   private weak var mainWindow: NSWindow?
   private var windowCloseObserver: (any NSObjectProtocol)?
@@ -92,15 +93,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     updaterController = SPUStandardUpdaterController(
       startingUpdater: true,
-      updaterDelegate: nil,
+      updaterDelegate: self,
       userDriverDelegate: self
     )
 
+    // Issue #343: in-app update banner. Constructed AFTER the updater so the
+    // install closure can capture it. Limb classification — does NOT live on
+    // AppState (collaborator ceiling).
+    updateCoordinator = UpdateCoordinator(updaterController: updaterController)
+
+    // Issue #343: cross-launch correlation. Fire install_completed /
+    // install_cancelled if the prior launch attempted an install.
+    evaluateUpdateInstallAttemptOnLaunch()
+
     setupStatusItem()
 
-    // Update menu bar icon whenever pipeline state or accessibility changes
-    appState.onPipelineStateChange = { [weak self] _ in
-      self?.updateIcon()
+    // Update menu bar icon whenever pipeline state or accessibility changes.
+    // Also forwards recording state to the update coordinator so the banner
+    // hides during recording + 3s post-recording grace (issue #343).
+    appState.onPipelineStateChange = { [weak self] state in
+      guard let self else { return }
+      self.updateIcon()
+      self.updateCoordinator?.handlePipelineStateChange(isRecording: state == .recording)
     }
     appState.permissions.onAccessibilityChange = { [weak self] in
       self?.updateIcon()
@@ -381,14 +395,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     settingsItem.target = self
     menu.addItem(settingsItem)
 
-    // Check for Updates
-    if let updaterController {
+    // Check for Updates — retargeted to AppDelegate wrapper so we can tag
+    // the install source as "menu" for telemetry attribution (issue #343).
+    if updaterController != nil {
       let updateItem = NSMenuItem(
         title: "Check for Updates…",
-        action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
+        action: #selector(openUpdateCheckFromMenu(_:)), keyEquivalent: "")
       updateItem.image = NSImage(
         systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
-      updateItem.target = updaterController
+      updateItem.target = self
       menu.addItem(updateItem)
     }
 
@@ -457,6 +472,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     showWindow()
   }
 
+  /// Issue #343: menu-bar "Check for Updates…" wrapper. Tags the install source
+  /// as "menu" so cross-launch correlation can attribute install_completed /
+  /// install_cancelled correctly, then forwards to Sparkle's standard handler.
+  @objc private func openUpdateCheckFromMenu(_ sender: Any?) {
+    updateCoordinator?.lastInstallSource = "menu"
+    updaterController?.checkForUpdates(sender)
+  }
+
+  /// Issue #343: cross-launch correlation entry point. Called from
+  /// applicationDidFinishLaunching after the coordinator is constructed.
+  /// Compares the current bundle version to a persisted "we just attempted
+  /// to install" marker and fires install_completed / install_cancelled
+  /// telemetry. Independent of whether the click-time event made it through.
+  private func evaluateUpdateInstallAttemptOnLaunch() {
+    guard let coordinator = updateCoordinator else { return }
+    let outcome = coordinator.evaluateLastInstallAttempt(
+      currentBundleVersion: AppConstants.appVersion
+    )
+    switch outcome {
+    case .completed(let version, let source):
+      TelemetryService.shared.updateInstallCompleted(
+        version: version, isCritical: false, source: source
+      )
+    case .cancelled(let version, let source):
+      TelemetryService.shared.updateInstallCancelled(
+        version: version, isCritical: false, source: source
+      )
+    case .none, .unattributable, .stale:
+      break
+    }
+  }
+
   func applicationWillTerminate(_ notification: Notification) {
     if let observer = windowCloseObserver {
       NotificationCenter.default.removeObserver(observer)
@@ -508,6 +555,11 @@ extension AppDelegate: NSMenuDelegate {
 // MARK: - SPUStandardUserDriverDelegate
 
 extension AppDelegate: @preconcurrency SPUStandardUserDriverDelegate {
+  /// Issue #343: declares support for gentle scheduled update reminders.
+  /// Sparkle logs an error if a background app does not declare this.
+  /// (sparkle-project.org/documentation/gentle-reminders)
+  var supportsGentleScheduledUpdateReminders: Bool { true }
+
   /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
   func standardUserDriverWillShowModalAlert() {
     NSApp.setActivationPolicy(.regular)
@@ -517,5 +569,144 @@ extension AppDelegate: @preconcurrency SPUStandardUserDriverDelegate {
   /// Return to accessory mode when the entire update session ends.
   func standardUserDriverWillFinishUpdateSession() {
     NSApp.setActivationPolicy(.accessory)
+  }
+
+  /// Issue #343: pure yes/no decision per Sparkle's documented gentle-reminder
+  /// pattern. NO side effects — all state mutation happens in
+  /// `standardUserDriverWillHandleShowingUpdate`.
+  /// Sparkle's contract: YES = Sparkle handles, NO = delegate handles.
+  func standardUserDriverShouldHandleShowingScheduledUpdate(
+    _ update: SUAppcastItem,
+    andInImmediateFocus immediateFocus: Bool
+  ) -> Bool {
+    let hasMainWindow = NSApp.windows.contains { $0.isVisible && $0.canBecomeMain }
+    if !hasMainWindow { return true }  // no banner mount → Sparkle handles
+    if update.isCriticalUpdate { return true }  // critical → Sparkle's full UX
+    if immediateFocus { return true }  // Sparkle wants front-and-center
+    return false  // we own the gentle UX via the banner
+  }
+
+  /// Issue #343: side-effect callback that fires after the yes/no decision.
+  /// Captures availability state into the service and (if Sparkle handles)
+  /// tags the install source for telemetry attribution.
+  /// Sparkle's contract: handleShowingUpdate == true → Sparkle handles,
+  /// false → delegate (us) handles.
+  func standardUserDriverWillHandleShowingUpdate(
+    _ handleShowingUpdate: Bool,
+    forUpdate update: SUAppcastItem,
+    state: SPUUserUpdateState
+  ) {
+    let available = UpdateAvailabilityService.AvailableUpdate(
+      versionString: update.versionString,
+      displayVersion: update.displayVersionString,
+      buildString: update.versionString,
+      isCriticalUpdate: update.isCriticalUpdate
+    )
+    updateCoordinator?.service.noteAvailable(available)
+
+    if handleShowingUpdate {
+      // Sparkle owns UX. Tag source + fire diagnostic event.
+      let reason: String = {
+        if !NSApp.windows.contains(where: { $0.isVisible && $0.canBecomeMain }) {
+          return "no_main_window"
+        }
+        if update.isCriticalUpdate { return "critical" }
+        return "immediate_focus"
+      }()
+      updateCoordinator?.lastInstallSource = "sparkle_default"
+      TelemetryService.shared.updateSparkleDefaultShown(
+        version: update.versionString,
+        isCritical: update.isCriticalUpdate,
+        reason: reason
+      )
+    }
+    // Else: banner owns UX; source set by `triggerInstall` when user clicks.
+  }
+
+  /// Issue #343: dismiss our banner when the user has engaged with Sparkle's
+  /// UI directly (e.g., used the menu while the banner was visible).
+  /// Prevents two competing UIs for the same update.
+  func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+    updateCoordinator?.service.dismissForSession()
+  }
+}
+
+// MARK: - SPUUpdaterDelegate
+
+extension AppDelegate: @preconcurrency SPUUpdaterDelegate {
+  /// Issue #343: fires when the user has accepted an update and Sparkle is
+  /// about to begin install. Persists the install attempt for cross-launch
+  /// correlation, fires `update.install_started`, flushes telemetry so the
+  /// event survives Sparkle's relaunch.
+  func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+    let source = updateCoordinator?.lastInstallSource ?? "unknown"
+    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: source)
+    TelemetryService.shared.updateInstallStarted(
+      version: item.versionString,
+      isCritical: item.isCriticalUpdate,
+      source: source
+    )
+    TelemetryService.shared.flushTelemetry()
+  }
+
+  /// Issue #343: silent install-on-quit path. This is a separate Sparkle
+  /// driver from `willInstallUpdate` — for automatically-downloaded updates
+  /// that install when the user quits. Tag source explicitly so we can
+  /// distinguish it from banner / menu / sparkle_default attribution.
+  func updater(
+    _ updater: SPUUpdater,
+    willInstallUpdateOnQuit item: SUAppcastItem,
+    immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+  ) -> Bool {
+    updateCoordinator?.lastInstallSource = "install_on_quit"
+    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: "install_on_quit")
+    TelemetryService.shared.updateInstallStarted(
+      version: item.versionString,
+      isCritical: item.isCriticalUpdate,
+      source: "install_on_quit"
+    )
+    TelemetryService.shared.flushTelemetry()
+    // Returning false lets Sparkle's automatic install-on-quit proceed normally.
+    return false
+  }
+
+  /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
+  /// resolves service state, clears install-source.
+  func updater(
+    _ updater: SPUUpdater,
+    didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+    error: (any Error)?
+  ) {
+    let source = updateCoordinator?.lastInstallSource ?? "unknown"
+    let pendingVersion: String? = {
+      if case .available(let u) = updateCoordinator?.service.state ?? .none {
+        return u.versionString
+      }
+      return nil
+    }()
+    let version = pendingVersion ?? "unknown"
+    let isCritical: Bool = {
+      if case .available(let u) = updateCoordinator?.service.state ?? .none {
+        return u.isCriticalUpdate
+      }
+      return false
+    }()
+    let errorCode = (error as NSError?).map { "\($0.domain).\($0.code)" }
+    TelemetryService.shared.updateSparkleCycleFinished(
+      version: version,
+      isCritical: isCritical,
+      source: source,
+      errorCode: errorCode
+    )
+    if error != nil {
+      TelemetryService.shared.updateInstallFailed(
+        version: version,
+        isCritical: isCritical,
+        source: source,
+        errorCode: errorCode ?? "unknown"
+      )
+    }
+    updateCoordinator?.service.noteResolved(installedVersion: nil)
+    updateCoordinator?.lastInstallSource = nil
   }
 }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -20,6 +20,7 @@ struct EnviousWisprApp: App {
       UnifiedWindowView()
         .frame(minWidth: 580, minHeight: 400)
         .environment(appDelegate.appState)
+        .environment(\.updateCoordinator, appDelegate.updateCoordinator)
         .background(
           ActionWirer(
             appDelegate: appDelegate,

--- a/Sources/EnviousWispr/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWispr/App/UpdateCoordinator.swift
@@ -1,0 +1,163 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Sparkle
+import SwiftUI
+
+/// App-target coordinator for the in-app update banner (issue #343).
+/// Owns the `UpdateAvailabilityService` and the `installAction` closure that
+/// invokes Sparkle. Limb classification: keeps update-banner state OFF `AppState`
+/// (whose 19-collaborator ceiling is enforced by `AppStateCeilingsTests`).
+@MainActor
+final class UpdateCoordinator {
+  let service: UpdateAvailabilityService
+
+  /// Set by entry points (banner click, menu wrapper, default-modal delegate,
+  /// install-on-quit delegate) so cross-launch correlation can attribute
+  /// `update.install_completed` / `update.install_cancelled` to a source.
+  var lastInstallSource: String?
+
+  // Cross-launch correlation persistence keys.
+  private static let kLastAttemptVersion = "com.enviouswispr.updateBanner.lastAttemptVersion"
+  private static let kLastAttemptTimestamp = "com.enviouswispr.updateBanner.lastAttemptTimestamp"
+  private static let kLastAttemptSource = "com.enviouswispr.updateBanner.lastAttemptSource"
+
+  // In-memory dedup for `update.banner_shown` (per app launch, per version).
+  private var bannerShownReportedVersions: Set<String> = []
+
+  private weak var updaterController: SPUStandardUpdaterController?
+  private let defaults: UserDefaults
+
+  init(updaterController: SPUStandardUpdaterController?, defaults: UserDefaults = .standard) {
+    self.updaterController = updaterController
+    self.defaults = defaults
+    self.service = UpdateAvailabilityService(
+      installAction: { [weak updaterController] in
+        updaterController?.checkForUpdates(nil)
+      },
+      defaults: defaults,
+      currentBundleVersion: AppConstants.appVersion
+    )
+  }
+
+  // MARK: - Pipeline-state forwarding
+
+  /// Called from the AppDelegate `onPipelineStateChange` callback (next to
+  /// the existing icon-update path). Forwards to the service so the banner
+  /// hides during recording + 3s post-recording grace.
+  func handlePipelineStateChange(isRecording: Bool) {
+    service.handlePipelineStateChange(isRecording: isRecording)
+  }
+
+  // MARK: - Install-attempt persistence (cross-launch correlation)
+
+  /// Persists "we just kicked off an install" so the next launch can decide
+  /// whether to fire `update.install_completed` or `update.install_cancelled`.
+  /// Independent of whether the click-time PostHog event survived relaunch.
+  func recordInstallAttempt(version: String, source: String) {
+    defaults.set(version, forKey: Self.kLastAttemptVersion)
+    defaults.set(Date().timeIntervalSince1970, forKey: Self.kLastAttemptTimestamp)
+    defaults.set(source, forKey: Self.kLastAttemptSource)
+  }
+
+  /// Called early in `applicationDidFinishLaunching`. Reads the lastAttempt
+  /// keys, compares to current bundle, and tells the caller which event to
+  /// fire (if any). Clears keys after.
+  func evaluateLastInstallAttempt(currentBundleVersion: String) -> InstallAttemptOutcome {
+    guard
+      let attemptVersion = defaults.string(forKey: Self.kLastAttemptVersion),
+      let attemptSource = defaults.string(forKey: Self.kLastAttemptSource)
+    else {
+      return .none
+    }
+    let attemptTs = defaults.double(forKey: Self.kLastAttemptTimestamp)
+    let elapsed = Date().timeIntervalSince1970 - attemptTs
+
+    defer {
+      defaults.removeObject(forKey: Self.kLastAttemptVersion)
+      defaults.removeObject(forKey: Self.kLastAttemptTimestamp)
+      defaults.removeObject(forKey: Self.kLastAttemptSource)
+    }
+
+    // Bundle version compare via the service's helper.
+    let cmp = service.compareVersions(currentBundleVersion, attemptVersion)
+    if cmp == 0 {
+      // Bundle matches the attempted version exactly → install completed.
+      return .completed(version: attemptVersion, source: attemptSource)
+    }
+    if cmp > 0 {
+      // Bundle is even newer than what we attempted (user did manual DMG install
+      // or a chained update). Don't claim attribution.
+      return .unattributable
+    }
+    // Bundle unchanged.
+    if elapsed < 3600 {
+      return .cancelled(version: attemptVersion, source: attemptSource)
+    }
+    return .stale  // user quit before Sparkle finished; not actionable
+  }
+
+  // MARK: - Banner-driven entry points (called from UpdateAvailableBanner)
+
+  /// Banner `.onAppear`. Fires `update.banner_shown` once per (version, app launch).
+  func handleBannerShown(version: String, isCritical: Bool, dismissedPreviously: Bool) {
+    guard !bannerShownReportedVersions.contains(version) else { return }
+    bannerShownReportedVersions.insert(version)
+    let secondsSinceAvailable = Int(
+      Date().timeIntervalSince1970
+        - defaults.double(forKey: UpdateAvailabilityService.kPendingTimestamp)
+    )
+    TelemetryService.shared.updateBannerShown(
+      version: version,
+      isCritical: isCritical,
+      dismissedPreviously: dismissedPreviously,
+      secondsSinceAvailable: max(0, secondsSinceAvailable)
+    )
+  }
+
+  /// Banner click. Tags source, persists install attempt, fires telemetry,
+  /// flushes PostHog (so the event survives Sparkle's relaunch), then triggers
+  /// the install via the service.
+  func handleBannerClicked(version: String, isCritical: Bool, secondsVisible: Int) {
+    lastInstallSource = "banner"
+    recordInstallAttempt(version: version, source: "banner")
+    TelemetryService.shared.updateBannerClicked(
+      version: version,
+      isCritical: isCritical,
+      secondsVisible: secondsVisible
+    )
+    TelemetryService.shared.flushTelemetry()
+    service.triggerInstall()
+  }
+
+  /// Banner dismissed via context menu.
+  func handleBannerDismissed(version: String, isCritical: Bool, secondsVisible: Int) {
+    TelemetryService.shared.updateBannerDismissed(
+      version: version,
+      isCritical: isCritical,
+      secondsVisible: secondsVisible
+    )
+    service.dismissForSession()
+  }
+
+  enum InstallAttemptOutcome: Equatable {
+    case none
+    case completed(version: String, source: String)
+    case cancelled(version: String, source: String)
+    case unattributable
+    case stale
+  }
+}
+
+// MARK: - SwiftUI Environment injection
+
+private struct UpdateCoordinatorKey: EnvironmentKey {
+  static let defaultValue: UpdateCoordinator? = nil
+}
+
+extension EnvironmentValues {
+  var updateCoordinator: UpdateCoordinator? {
+    get { self[UpdateCoordinatorKey.self] }
+    set { self[UpdateCoordinatorKey.self] = newValue }
+  }
+}

--- a/Sources/EnviousWispr/Views/Components/UpdateAvailableBanner.swift
+++ b/Sources/EnviousWispr/Views/Components/UpdateAvailableBanner.swift
@@ -1,0 +1,99 @@
+import EnviousWisprServices
+import SwiftUI
+
+/// In-app banner shown at the bottom of the Settings sidebar when Sparkle has
+/// downloaded a non-critical update (issue #343). Click-anywhere installs;
+/// right-click for Dismiss. 3pt rainbow stripe along the top edge matches the
+/// EnviousWispr brand mark.
+struct UpdateAvailableBanner: View {
+  @Environment(\.updateCoordinator) private var coordinator
+  let update: UpdateAvailabilityService.AvailableUpdate
+
+  // Telemetry: track when the banner first appeared (for `seconds_visible`
+  // on click and dismiss).
+  @State private var appearedAt: Date?
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Circle()
+        .fill(Color.stToggleOn)
+        .frame(width: 8, height: 8)
+        .padding(.top, 6)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(LocalizedStringResource("Update available"))
+          .font(.callout)
+          .fontWeight(.semibold)
+          .foregroundStyle(.primary)
+
+        Text(
+          LocalizedStringResource(
+            "Version \(update.displayVersion) is ready. Click to restart."
+          )
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(2)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      coordinator?.handleBannerClicked(
+        version: update.versionString,
+        isCritical: update.isCriticalUpdate,
+        secondsVisible: secondsVisible())
+    }
+    .contextMenu {
+      Button(LocalizedStringResource("Dismiss")) {
+        coordinator?.handleBannerDismissed(
+          version: update.versionString,
+          isCritical: update.isCriticalUpdate,
+          secondsVisible: secondsVisible())
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 12)
+    .background(
+      RoundedRectangle(cornerRadius: 12)
+        .fill(Color.stSectionBg)
+        .overlay(alignment: .top) {
+          Rectangle()
+            .fill(Color.obRainbow)
+            .frame(height: 3)
+            .clipShape(
+              UnevenRoundedRectangle(
+                topLeadingRadius: 12,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: 12
+              )
+            )
+        }
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    )
+    .onAppear {
+      appearedAt = Date()
+      coordinator?.handleBannerShown(
+        version: update.versionString,
+        isCritical: update.isCriticalUpdate,
+        dismissedPreviously: false)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel(
+      LocalizedStringResource("Update available, version \(update.displayVersion)")
+    )
+    .accessibilityHint(LocalizedStringResource("Activate to install and restart"))
+  }
+
+  private func secondsVisible() -> Int {
+    guard let appearedAt else { return 0 }
+    return Int(Date().timeIntervalSince(appearedAt))
+  }
+}

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -4,29 +4,46 @@ import SwiftUI
 /// Unified single-window view: History + all settings tabs in one sidebar.
 struct UnifiedWindowView: View {
   @Environment(AppState.self) private var appState
+  @Environment(\.updateCoordinator) private var updateCoordinator
   @State private var selectedSection: SettingsSection = .history
 
   var body: some View {
     NavigationSplitView {
-      List(selection: $selectedSection) {
-        ForEach(SettingsGroup.allCases, id: \.self) { group in
-          Section(group.rawValue) {
-            ForEach(group.sections) { section in
-              if section == .whatsNew {
-                WhatsNewSidebarRow(isUnread: appState.settings.hasUnreadWhatsNew)
-                  .tag(section)
-              } else {
-                Label(section.label, systemImage: section.icon)
-                  .tag(section)
+      VStack(spacing: 0) {
+        List(selection: $selectedSection) {
+          ForEach(SettingsGroup.allCases, id: \.self) { group in
+            Section(group.rawValue) {
+              ForEach(group.sections) { section in
+                if section == .whatsNew {
+                  WhatsNewSidebarRow(isUnread: appState.settings.hasUnreadWhatsNew)
+                    .tag(section)
+                } else {
+                  Label(section.label, systemImage: section.icon)
+                    .tag(section)
+                }
               }
             }
           }
         }
+        .listStyle(.sidebar)
+        .scrollContentBackground(.hidden)
+        .background(Color.stSidebarBg)
+
+        // Issue #343: in-app update banner. Fixed sibling of the sidebar List
+        // (NOT a list-footer row, which would scroll). Bottom-leading mount
+        // per Saurabh's mockup v2.
+        if let coordinator = updateCoordinator,
+          coordinator.service.shouldShowBanner,
+          case .available(let u) = coordinator.service.state
+        {
+          UpdateAvailableBanner(update: u)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 10)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
       }
-      .listStyle(.sidebar)
-      .scrollContentBackground(.hidden)
       .background(Color.stSidebarBg)
-      .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 200)
+      .navigationSplitViewColumnWidth(min: 200, ideal: 230, max: 260)
     } detail: {
       detailContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -512,4 +512,137 @@ public final class TelemetryService {
     default: return "15s+"
     }
   }
+
+  // MARK: - Update banner (issue #343)
+
+  public func updateBannerShown(
+    version: String,
+    isCritical: Bool,
+    dismissedPreviously: Bool,
+    secondsSinceAvailable: Int
+  ) {
+    PostHogSDK.shared.capture(
+      "update.banner_shown",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "dismissed_for_version_previously": dismissedPreviously,
+        "seconds_since_available": secondsSinceAvailable,
+      ]
+    )
+  }
+
+  public func updateBannerClicked(version: String, isCritical: Bool, secondsVisible: Int) {
+    PostHogSDK.shared.capture(
+      "update.banner_clicked",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "seconds_visible": secondsVisible,
+      ]
+    )
+  }
+
+  public func updateBannerDismissed(version: String, isCritical: Bool, secondsVisible: Int) {
+    PostHogSDK.shared.capture(
+      "update.banner_dismissed",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "seconds_visible": secondsVisible,
+      ]
+    )
+  }
+
+  public func updateSparkleDefaultShown(version: String, isCritical: Bool, reason: String) {
+    PostHogSDK.shared.capture(
+      "update.sparkle_default_shown",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "reason": reason,
+      ]
+    )
+  }
+
+  public func updateInstallStarted(version: String, isCritical: Bool, source: String) {
+    PostHogSDK.shared.capture(
+      "update.install_started",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "source": source,
+      ]
+    )
+  }
+
+  public func updateSparkleCycleFinished(
+    version: String,
+    isCritical: Bool,
+    source: String,
+    errorCode: String?
+  ) {
+    var props: [String: Any] = [
+      "version": version,
+      "is_critical": isCritical,
+      "source": source,
+    ]
+    if let errorCode { props["error_code"] = errorCode }
+    PostHogSDK.shared.capture("update.sparkle_cycle_finished", properties: props)
+  }
+
+  public func updateInstallCompleted(version: String, isCritical: Bool, source: String) {
+    PostHogSDK.shared.capture(
+      "update.install_completed",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "source": source,
+      ]
+    )
+  }
+
+  public func updateInstallFailed(
+    version: String,
+    isCritical: Bool,
+    source: String,
+    errorCode: String
+  ) {
+    PostHogSDK.shared.capture(
+      "update.install_failed",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "source": source,
+        "error_code": errorCode,
+      ]
+    )
+  }
+
+  public func updateInstallCancelled(version: String, isCritical: Bool, source: String) {
+    PostHogSDK.shared.capture(
+      "update.install_cancelled",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "source": source,
+      ]
+    )
+  }
+
+  public func updateWatchdogFired(version: String, isCritical: Bool) {
+    PostHogSDK.shared.capture(
+      "update.watchdog_fired",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+      ]
+    )
+  }
+
+  /// Synchronously flushes buffered events. Called before triggering install
+  /// so click/start events survive Sparkle's relaunch.
+  public func flushTelemetry() {
+    PostHogSDK.shared.flush()
+  }
 }

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Observation
+
+/// Limb-tier service that owns "is there an update ready?" state for the in-app
+/// update banner (issue #343). Pure Foundation/Observation — does NOT import
+/// Sparkle. AppDelegate (app target) injects the `installAction` closure that
+/// invokes Sparkle when the user clicks the banner.
+@MainActor
+@Observable
+public final class UpdateAvailabilityService {
+  // MARK: - Public types
+
+  public struct AvailableUpdate: Sendable, Equatable {
+    public let versionString: String  // CFBundleVersion (canonical compare key)
+    public let displayVersion: String  // CFBundleShortVersionString (UI copy)
+    public let buildString: String?
+    public let isCriticalUpdate: Bool
+
+    public init(
+      versionString: String,
+      displayVersion: String,
+      buildString: String?,
+      isCriticalUpdate: Bool
+    ) {
+      self.versionString = versionString
+      self.displayVersion = displayVersion
+      self.buildString = buildString
+      self.isCriticalUpdate = isCriticalUpdate
+    }
+  }
+
+  public enum UpdateState: Equatable {
+    case none
+    case available(AvailableUpdate)
+    case resolving
+  }
+
+  // MARK: - Constants
+
+  public static let postRecordingGraceDuration: TimeInterval = 3.0
+  static let resolvingWatchdogDuration: TimeInterval = 5.0
+
+  // Namespaced UserDefaults keys (issue #343).
+  public static let kPendingVersion = "com.enviouswispr.updateBanner.pendingVersion"
+  public static let kPendingBuild = "com.enviouswispr.updateBanner.pendingBuild"
+  public static let kPendingTimestamp = "com.enviouswispr.updateBanner.pendingTimestamp"
+  public static let kDismissedVersion = "com.enviouswispr.updateBanner.dismissedVersion"
+
+  // MARK: - Observable state
+
+  public private(set) var state: UpdateState = .none
+  public private(set) var dismissedForSession: Bool = false
+  public private(set) var inPostRecordingGrace: Bool = false
+  public private(set) var isRecording: Bool = false
+
+  // MARK: - Internal storage (not observed)
+
+  @ObservationIgnored private var graceTask: Task<Void, Never>?
+  @ObservationIgnored private var resolvingWatchdog: Task<Void, Never>?
+  @ObservationIgnored private let installAction: @MainActor () -> Void
+  @ObservationIgnored private let defaults: UserDefaults
+  @ObservationIgnored private let currentBundleVersion: String
+
+  // MARK: - Init
+
+  public init(
+    installAction: @escaping @MainActor () -> Void,
+    defaults: UserDefaults = .standard,
+    currentBundleVersion: String
+  ) {
+    self.installAction = installAction
+    self.defaults = defaults
+    self.currentBundleVersion = currentBundleVersion
+    rehydratePendingIfNewer()
+  }
+
+  // MARK: - Visibility predicate
+
+  public var shouldShowBanner: Bool {
+    guard case .available(let u) = state else { return false }
+    if u.isCriticalUpdate { return false }  // critical → Sparkle owns UX
+    return !dismissedForSession && !inPostRecordingGrace && !isRecording
+  }
+
+  // MARK: - Sparkle-driven mutations
+
+  /// Called from `standardUserDriverWillHandleShowingUpdate` (or rehydrate on launch).
+  public func noteAvailable(_ update: AvailableUpdate) {
+    // Same-version re-fire is a no-op (preserves dismissal state).
+    if case .available(let existing) = state, existing == update { return }
+
+    // While `.resolving`, only react to a strictly-newer version.
+    if case .resolving = state {
+      if let inflight = persistedPending(),
+        compareVersions(update.versionString, inflight.versionString) <= 0
+      {
+        return
+      }
+      resolvingWatchdog?.cancel()
+      resolvingWatchdog = nil
+    }
+
+    state = .available(update)
+    dismissedForSession = (defaults.string(forKey: Self.kDismissedVersion) == update.versionString)
+    persist(update)
+  }
+
+  /// Called from `updater(_:didFinishUpdateCycleForUpdateCheck:error:)`.
+  public func noteResolved(installedVersion: String?) {
+    state = .none
+    dismissedForSession = false
+    inPostRecordingGrace = false
+    graceTask?.cancel()
+    graceTask = nil
+    resolvingWatchdog?.cancel()
+    resolvingWatchdog = nil
+    clearPersisted()
+  }
+
+  // MARK: - User-driven mutations
+
+  public func dismissForSession() {
+    dismissedForSession = true
+    if case .available(let u) = state {
+      defaults.set(u.versionString, forKey: Self.kDismissedVersion)
+    }
+  }
+
+  public func triggerInstall() {
+    state = .resolving
+    installAction()
+    // Watchdog: if no terminal signal arrives within 5s, restore .available so
+    // the user can retry. Keeps the banner from getting stuck if Sparkle no-ops.
+    resolvingWatchdog?.cancel()
+    resolvingWatchdog = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(Self.resolvingWatchdogDuration))
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        guard let self else { return }
+        if case .resolving = self.state, let pending = self.persistedPending() {
+          self.state = .available(pending)
+        }
+      }
+    }
+  }
+
+  // MARK: - Pipeline-state hook (called from AppDelegate's onPipelineStateChange)
+
+  public func handlePipelineStateChange(isRecording: Bool) {
+    self.isRecording = isRecording
+
+    if isRecording {
+      graceTask?.cancel()
+      graceTask = nil
+      inPostRecordingGrace = false
+      return
+    }
+
+    graceTask?.cancel()
+    inPostRecordingGrace = true
+    graceTask = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(Self.postRecordingGraceDuration))
+      guard !Task.isCancelled else { return }
+      await MainActor.run { self?.inPostRecordingGrace = false }
+    }
+  }
+
+  // MARK: - Persistence helpers
+
+  func persist(_ update: AvailableUpdate) {
+    defaults.set(update.versionString, forKey: Self.kPendingVersion)
+    defaults.set(update.displayVersion, forKey: Self.kPendingBuild)
+    defaults.set(Date().timeIntervalSince1970, forKey: Self.kPendingTimestamp)
+  }
+
+  func persistedPending() -> AvailableUpdate? {
+    guard let v = defaults.string(forKey: Self.kPendingVersion) else { return nil }
+    let display = defaults.string(forKey: Self.kPendingBuild) ?? v
+    return AvailableUpdate(
+      versionString: v,
+      displayVersion: display,
+      buildString: v,
+      isCriticalUpdate: false  // critical-flag not persisted; rehydrated state is non-critical
+    )
+  }
+
+  func clearPersisted() {
+    defaults.removeObject(forKey: Self.kPendingVersion)
+    defaults.removeObject(forKey: Self.kPendingBuild)
+    defaults.removeObject(forKey: Self.kPendingTimestamp)
+    defaults.removeObject(forKey: Self.kDismissedVersion)
+  }
+
+  func rehydratePendingIfNewer() {
+    guard let pending = persistedPending() else { return }
+    let cmp = compareVersions(pending.versionString, currentBundleVersion)
+    if cmp > 0 {
+      state = .available(pending)
+      dismissedForSession =
+        (defaults.string(forKey: Self.kDismissedVersion) == pending.versionString)
+    } else {
+      // Bundle has caught up to or surpassed pending — user installed by some path.
+      clearPersisted()
+    }
+  }
+
+  // MARK: - Version comparator
+
+  /// Compares two CFBundleVersion strings (e.g. "2.4.0" vs "2.4.1").
+  /// Production tags are enforced `^[0-9]+\.[0-9]+\.[0-9]+$` per release.yml,
+  /// so a simple split-by-dot integer compare is sufficient.
+  /// Returns: -1 if a < b, 0 if equal, +1 if a > b.
+  public func compareVersions(_ a: String, _ b: String) -> Int {
+    let aParts = a.split(separator: ".").map { Int($0) ?? 0 }
+    let bParts = b.split(separator: ".").map { Int($0) ?? 0 }
+    let count = max(aParts.count, bParts.count)
+    for i in 0..<count {
+      let av = i < aParts.count ? aParts[i] : 0
+      let bv = i < bParts.count ? bParts[i] : 0
+      if av < bv { return -1 }
+      if av > bv { return 1 }
+    }
+    return 0
+  }
+}

--- a/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@MainActor
+@Suite("UpdateAvailabilityService (issue #343)")
+struct UpdateAvailabilityServiceTests {
+  // Each test gets its own ephemeral UserDefaults suite so persistence
+  // doesn't bleed between tests or into the host process.
+  private static func freshDefaults() -> UserDefaults {
+    let suite = "ew.updateBannerTest." + UUID().uuidString
+    let d = UserDefaults(suiteName: suite)!
+    d.removePersistentDomain(forName: suite)
+    return d
+  }
+
+  private static func makeUpdate(
+    version: String = "2.4.0",
+    display: String = "2.4.0",
+    critical: Bool = false
+  ) -> UpdateAvailabilityService.AvailableUpdate {
+    UpdateAvailabilityService.AvailableUpdate(
+      versionString: version,
+      displayVersion: display,
+      buildString: version,
+      isCriticalUpdate: critical
+    )
+  }
+
+  private static func makeService(
+    bundle: String = "1.9.4",
+    defaults: UserDefaults? = nil
+  ) -> (UpdateAvailabilityService, UserDefaults) {
+    let d = defaults ?? freshDefaults()
+    let s = UpdateAvailabilityService(
+      installAction: {},
+      defaults: d,
+      currentBundleVersion: bundle
+    )
+    return (s, d)
+  }
+
+  // MARK: - State transitions
+
+  @Test("noteAvailable on .none transitions to .available and persists keys")
+  func noteAvailableTransitionsAndPersists() {
+    let (s, d) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    if case .available(let u) = s.state {
+      #expect(u.versionString == "2.4.0")
+    } else {
+      Issue.record("expected .available state, got \(s.state)")
+    }
+    #expect(d.string(forKey: UpdateAvailabilityService.kPendingVersion) == "2.4.0")
+    #expect(d.string(forKey: UpdateAvailabilityService.kPendingBuild) == "2.4.0")
+  }
+
+  @Test("noteAvailable with same version is a no-op")
+  func sameVersionIsNoOp() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.dismissForSession()
+    #expect(s.dismissedForSession == true)
+    s.noteAvailable(Self.makeUpdate())  // re-fire same version
+    #expect(s.dismissedForSession == true)  // dismissal preserved
+  }
+
+  @Test("noteAvailable with new version resets dismissal when persisted dismissed differs")
+  func newVersionResetsDismissal() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate(version: "2.4.0"))
+    s.dismissForSession()
+    s.noteAvailable(Self.makeUpdate(version: "2.4.1"))
+    #expect(s.dismissedForSession == false)
+  }
+
+  @Test("dismissForSession persists dismissedVersion and keeps state")
+  func dismissPersistsAndKeepsState() {
+    let (s, d) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.dismissForSession()
+    #expect(d.string(forKey: UpdateAvailabilityService.kDismissedVersion) == "2.4.0")
+    if case .available = s.state {
+      // ok
+    } else {
+      Issue.record("state should remain .available after dismissForSession")
+    }
+  }
+
+  @Test("noteResolved clears pending keys and resets state")
+  func noteResolvedClearsKeys() {
+    let (s, d) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.noteResolved(installedVersion: "2.4.0")
+    #expect(s.state == .none)
+    #expect(d.string(forKey: UpdateAvailabilityService.kPendingVersion) == nil)
+    #expect(d.string(forKey: UpdateAvailabilityService.kPendingBuild) == nil)
+  }
+
+  // MARK: - Persistence rehydrate
+
+  @Test("init rehydrates .available when pending > current bundle")
+  func rehydrateWhenPendingNewer() {
+    let d = Self.freshDefaults()
+    d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingVersion)
+    d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingBuild)
+    d.set(Date().timeIntervalSince1970, forKey: UpdateAvailabilityService.kPendingTimestamp)
+    let (s, _) = Self.makeService(bundle: "1.9.4", defaults: d)
+    if case .available(let u) = s.state {
+      #expect(u.versionString == "2.4.0")
+    } else {
+      Issue.record("expected .available, got \(s.state)")
+    }
+  }
+
+  @Test("init clears all keys when pending <= current bundle")
+  func rehydrateClearsWhenStale() {
+    let d = Self.freshDefaults()
+    d.set("1.8.0", forKey: UpdateAvailabilityService.kPendingVersion)
+    d.set("1.8.0", forKey: UpdateAvailabilityService.kPendingBuild)
+    d.set(Date().timeIntervalSince1970, forKey: UpdateAvailabilityService.kPendingTimestamp)
+    d.set("1.8.0", forKey: UpdateAvailabilityService.kDismissedVersion)
+    let (s, _) = Self.makeService(bundle: "1.9.4", defaults: d)
+    #expect(s.state == .none)
+    #expect(d.string(forKey: UpdateAvailabilityService.kPendingVersion) == nil)
+    #expect(d.string(forKey: UpdateAvailabilityService.kDismissedVersion) == nil)
+  }
+
+  @Test("init seeds dismissedForSession when persisted dismissed matches pending")
+  func rehydrateSeedsDismissal() {
+    let d = Self.freshDefaults()
+    d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingVersion)
+    d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingBuild)
+    d.set(Date().timeIntervalSince1970, forKey: UpdateAvailabilityService.kPendingTimestamp)
+    d.set("2.4.0", forKey: UpdateAvailabilityService.kDismissedVersion)
+    let (s, _) = Self.makeService(bundle: "1.9.4", defaults: d)
+    #expect(s.dismissedForSession == true)
+  }
+
+  // MARK: - Pipeline-state guard
+
+  @Test("handlePipelineStateChange(true) cancels grace and clears flag")
+  func recordingCancelsGrace() {
+    let (s, _) = Self.makeService()
+    s.handlePipelineStateChange(isRecording: true)
+    #expect(s.inPostRecordingGrace == false)
+    #expect(s.isRecording == true)
+  }
+
+  @Test("handlePipelineStateChange(false) sets grace; clears after duration")
+  func graceClearsAfterDuration() async throws {
+    let (s, _) = Self.makeService()
+    s.handlePipelineStateChange(isRecording: false)
+    #expect(s.inPostRecordingGrace == true)
+    // postRecordingGraceDuration is 3.0s; we wait slightly longer.
+    try await Task.sleep(for: .seconds(3.5))
+    #expect(s.inPostRecordingGrace == false)
+  }
+
+  // MARK: - shouldShowBanner predicate
+
+  @Test("shouldShowBanner is false on .none")
+  func predicateNone() {
+    let (s, _) = Self.makeService()
+    #expect(s.shouldShowBanner == false)
+  }
+
+  @Test("shouldShowBanner is true on .available with no guards")
+  func predicateAvailableHappy() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    #expect(s.shouldShowBanner == true)
+  }
+
+  @Test("shouldShowBanner is false when dismissed")
+  func predicateDismissed() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.dismissForSession()
+    #expect(s.shouldShowBanner == false)
+  }
+
+  @Test("shouldShowBanner is false during recording")
+  func predicateRecording() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.handlePipelineStateChange(isRecording: true)
+    #expect(s.shouldShowBanner == false)
+  }
+
+  @Test("shouldShowBanner is false for critical updates")
+  func predicateCritical() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate(critical: true))
+    #expect(s.shouldShowBanner == false)
+  }
+
+  // MARK: - Version comparator
+
+  @Test("compareVersions handles standard semver ordering")
+  func versionCompare() {
+    let (s, _) = Self.makeService()
+    #expect(s.compareVersions("2.4.0", "2.4.1") == -1)
+    #expect(s.compareVersions("2.4.1", "2.4.0") == 1)
+    #expect(s.compareVersions("2.4.0", "2.4.0") == 0)
+    #expect(s.compareVersions("2.4.10", "2.4.9") == 1)  // numeric, not lexical
+    #expect(s.compareVersions("3.0.0", "2.99.99") == 1)
+  }
+
+  // MARK: - .resolving watchdog
+
+  @Test("triggerInstall flips state to .resolving immediately")
+  func triggerInstallResolving() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.triggerInstall()
+    #expect(s.state == .resolving)
+  }
+
+  @Test("noteAvailable while .resolving with same version is a no-op")
+  func noteAvailableSameVersionDuringResolving() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate())
+    s.triggerInstall()
+    s.noteAvailable(Self.makeUpdate())  // same 2.4.0
+    #expect(s.state == .resolving)
+  }
+
+  @Test("noteAvailable while .resolving with newer version transitions")
+  func noteAvailableNewerVersionDuringResolving() {
+    let (s, _) = Self.makeService()
+    s.noteAvailable(Self.makeUpdate(version: "2.4.0"))
+    s.triggerInstall()
+    s.noteAvailable(Self.makeUpdate(version: "2.4.1"))
+    if case .available(let u) = s.state {
+      #expect(u.versionString == "2.4.1")
+    } else {
+      Issue.record("expected .available(2.4.1), got \(s.state)")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a discoverable banner at the bottom of the Settings sidebar when Sparkle has a downloaded update ready. Click to install, right-click for Dismiss. Survives app restarts via UserDefaults rehydrate. Critical updates skip our banner and use Sparkle's full popup. 5-second watchdog brings the banner back if Sparkle silently fails.

Closes #343.

## Architecture

Limb classification per `.claude/rules/architecture-rules.md`. Banner state lives on a new `UpdateCoordinator` owned by `AppDelegate`, NOT on `AppState` (whose 19-collaborator ceiling is enforced by `AppStateCeilingsTests`). Service is in `EnviousWisprServices` (pure Foundation/Observation), coordinator + Sparkle wiring is in the app target.

## Sparkle integration

Follows the official gentle-reminders pattern (https://sparkle-project.org/documentation/gentle-reminders):

- `supportsGentleScheduledUpdateReminders = true`
- `standardUserDriverShouldHandleShowingScheduledUpdate` is **pure** yes/no
- `standardUserDriverWillHandleShowingUpdate` handles side effects
- `standardUserDriverDidReceiveUserAttentionForUpdate` dismisses the banner when the user engages with Sparkle's UI directly (e.g., via the menu)
- Updater delegate set at construction (Sparkle's `updaterDelegate` outlet is weak, init-only)

## Telemetry (9 PostHog events)

Source attribution: `banner` / `menu` / `sparkle_default` / `install_on_quit`. Cross-launch correlation fires `update.install_completed` / `install_cancelled` from local persisted state — independent of whether the click-time event survived Sparkle's relaunch. PostHog `flush()` is called before triggering install.

Events: `update.banner_shown`, `banner_clicked`, `banner_dismissed`, `sparkle_default_shown`, `install_started`, `sparkle_cycle_finished`, `install_completed`, `install_failed`, `install_cancelled`, `watchdog_fired`.

## UI

Sidebar width bumped from `min: 160, ideal: 180, max: 200` to `min: 200, ideal: 230, max: 260` to accommodate the two-line banner copy. Rainbow gradient stripe uses the existing `Color.obRainbow` 9-stop brand gradient (no new tokens).

## Test plan

- [x] `scripts/swift-test.sh` green (586 tests, 21 new for `UpdateAvailabilityService`)
- [x] `swift build -c release` exit 0
- [x] `AppStateCeilingsTests` green (no AppState change)
- [ ] CI `build-check` green
- [ ] UAT (manual, after merge): trigger scheduled check on a test appcast, verify banner renders / clicking installs / dismiss persists / critical updates route to Sparkle's modal / install-on-quit fires `install_started` with `source=install_on_quit`
- [ ] Verify all 9 telemetry events appear in PostHog Live Events with correct source attribution

## Plan & review trail

- Plan: `docs/feature-requests/issue-343-2026-04-17-update-toast.md` (V7)
- Codex grounded reviews: 5 rounds (`docs/audits/2026-05-04-issue-343-update-toast-grounded-review*.txt`)
- Sparkle official docs consulted via context7 in round 4 (caught the `immediateFocus` pattern + the missing `didReceiveUserAttention` hook)
- Round 5 returned `YES_WITH_REVISIONS` with 2 trivial text-only blockers (inverted-branch sentence, leftover safeAreaInset prose); both applied before commit.
