### PR TITLE
refactor(custom-words): split vocabulary into typed corrector + polish lanes (#640)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -165,6 +165,17 @@ final class AppState {
     transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
     llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
+    // Phase 0 (#640) — single shared paste-completion registry. Constructed
+    // first so both pipelines and the polish service receive the same
+    // instance. NOT promoted to a top-level `let` collaborator (would breach
+    // the AppState concrete-collaborator ceiling at 19); the polish service
+    // exposes it as `polishService.pasteCompletionRegistry` for Phase 7
+    // (#629) auto-learn subscription.
+    polishService = TranscriptPolishService(
+      keychainManager: keychainManager,
+      transcriptStore: transcriptStore
+    )
+
     // Both pipeline properties must be initialized before `self` can be used.
     // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
     pipeline = TranscriptionPipeline(
@@ -172,7 +183,8 @@ final class AppState {
       asrManager: asrManager,
       transcriptStore: transcriptStore,
       keychainManager: keychainManager,
-      captureTelemetry: captureTelemetry
+      captureTelemetry: captureTelemetry,
+      pasteCompletionRegistry: polishService.pasteCompletionRegistry
     )
     // W6: wire language-flip telemetry into the detector via a closure so
     // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
@@ -198,12 +210,8 @@ final class AppState {
       transcriptStore: transcriptStore,
       keychainManager: keychainManager,
       languageDetector: languageDetector,
-      captureTelemetry: captureTelemetry
-    )
-    // Transcript polish service (re-polish from detail view, decoupled from pipelines)
-    polishService = TranscriptPolishService(
-      keychainManager: keychainManager,
-      transcriptStore: transcriptStore
+      captureTelemetry: captureTelemetry,
+      pasteCompletionRegistry: polishService.pasteCompletionRegistry
     )
 
     // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
@@ -402,10 +410,12 @@ final class AppState {
     wireCustomWords(
       propagator: customWordsPropagator,
       initialWords: customWordsCoordinator.customWords,
-      consumers: [
+      correctorConsumers: [
         pipeline.wordCorrection,
-        pipeline.llmPolish,
         whisperKitPipeline.wordCorrection,
+      ],
+      polishConsumers: [
+        pipeline.llmPolish,
         whisperKitPipeline.llmPolish,
         polishService.llmPolishStep,
       ],

--- a/Sources/EnviousWispr/App/CustomWordsPropagator.swift
+++ b/Sources/EnviousWispr/App/CustomWordsPropagator.swift
@@ -1,49 +1,72 @@
 import EnviousWisprCore
 import Foundation
 
-/// Broadcasts the active custom-words list to all registered consumers.
+/// Phase 0 (#640) — broadcasts the active vocabulary to consumers via two
+/// typed lanes: corrector and polish. Pack-sourced terms reach corrector
+/// only, never polish (bible §2.2). The lane split makes pack-to-prompt
+/// leakage a Swift compile error.
 ///
 /// AppState constructs one propagator at init, registers the known consumers
-/// (pipeline word-correction + polish steps for both backends + the re-polish
-/// service), and forwards `CustomWordsCoordinator.onWordsChanged` into
-/// `update(_:)`. Replaces the prior 5-way fanout in AppState plus 5 setter
-/// lines in `PipelineSettingsSync`.
+/// (pipeline word-correction × 2, pipeline llmPolish × 2, polishService.llmPolishStep
+/// = 5 total), and forwards `CustomWordsCoordinator.onWordsChanged` into
+/// `update(corrector:polish:)`.
 ///
 /// Re-entrancy is contracted out: a consumer's setter must not call
-/// `propagator.update(_:)` synchronously. DEBUG builds trap on violation.
+/// `propagator.update(...)` synchronously. DEBUG builds trap on violation.
 @MainActor
 final class CustomWordsPropagator {
-  private final class WeakBox {
-    weak var value: (any CustomWordsConsumer)?
-    init(_ value: any CustomWordsConsumer) { self.value = value }
+  private final class CorrectorBox {
+    weak var value: (any CorrectorVocabularyConsumer)?
+    init(_ value: any CorrectorVocabularyConsumer) { self.value = value }
+  }
+  private final class PolishBox {
+    weak var value: (any PolishVocabularyConsumer)?
+    init(_ value: any PolishVocabularyConsumer) { self.value = value }
   }
 
-  private var consumers: [WeakBox] = []
-  private(set) var words: [CustomWord]
+  private var correctorConsumers: [CorrectorBox] = []
+  private var polishConsumers: [PolishBox] = []
+  private(set) var corrector: CorrectorVocabulary
+  private(set) var polish: PolishVocabulary
   #if DEBUG
     private var isBroadcasting: Bool = false
   #endif
 
-  init(initialWords: [CustomWord] = []) {
-    self.words = initialWords
+  init(corrector: CorrectorVocabulary = .empty, polish: PolishVocabulary = .empty) {
+    self.corrector = corrector
+    self.polish = polish
   }
 
-  /// Add a consumer to the registry. Idempotent on object identity. The
-  /// consumer's `customWords` is initial-synced to the propagator's current
-  /// `words` value before this call returns.
-  func register(_ consumer: any CustomWordsConsumer) {
-    let alreadyRegistered = consumers.contains { box in
+  /// Add a corrector-lane consumer. Idempotent on object identity. The
+  /// consumer's `correctorVocabulary` is initial-synced to the propagator's
+  /// current `corrector` value before this call returns.
+  func register(_ consumer: any CorrectorVocabularyConsumer) {
+    let already = correctorConsumers.contains { box in
       guard let existing = box.value else { return false }
       return ObjectIdentifier(existing) == ObjectIdentifier(consumer)
     }
-    guard !alreadyRegistered else { return }
-    consumers.append(WeakBox(consumer))
-    consumer.customWords = words
+    guard !already else { return }
+    correctorConsumers.append(CorrectorBox(consumer))
+    consumer.correctorVocabulary = corrector
   }
 
-  /// Broadcast `words` to all live consumers. Dead weak references are
+  /// Add a polish-lane consumer. Idempotent on object identity. The
+  /// consumer's `polishVocabulary` is initial-synced to the propagator's
+  /// current `polish` value before this call returns.
+  func register(_ consumer: any PolishVocabularyConsumer) {
+    let already = polishConsumers.contains { box in
+      guard let existing = box.value else { return false }
+      return ObjectIdentifier(existing) == ObjectIdentifier(consumer)
+    }
+    guard !already else { return }
+    polishConsumers.append(PolishBox(consumer))
+    consumer.polishVocabulary = polish
+  }
+
+  /// Broadcast `corrector` and `polish` to all live consumers atomically.
+  /// Both lanes share the same generation for this call. Dead weak refs are
   /// pruned during this call.
-  func update(_ words: [CustomWord]) {
+  func update(corrector: CorrectorVocabulary, polish: PolishVocabulary) {
     #if DEBUG
       precondition(
         !isBroadcasting,
@@ -52,10 +75,15 @@ final class CustomWordsPropagator {
       isBroadcasting = true
       defer { isBroadcasting = false }
     #endif
-    self.words = words
-    consumers.removeAll { $0.value == nil }
-    for box in consumers {
-      box.value?.customWords = words
+    self.corrector = corrector
+    self.polish = polish
+    correctorConsumers.removeAll { $0.value == nil }
+    polishConsumers.removeAll { $0.value == nil }
+    for box in correctorConsumers {
+      box.value?.correctorVocabulary = corrector
+    }
+    for box in polishConsumers {
+      box.value?.polishVocabulary = polish
     }
   }
 }
@@ -78,16 +106,46 @@ final class CustomWordsPropagator {
 func wireCustomWords(
   propagator: CustomWordsPropagator,
   initialWords: [CustomWord],
-  consumers: [any CustomWordsConsumer],
+  correctorConsumers: [any CorrectorVocabularyConsumer],
+  polishConsumers: [any PolishVocabularyConsumer],
   coordinator: CustomWordsCoordinator
 ) -> ([CustomWord]) -> Void {
-  propagator.update(initialWords)
-  for consumer in consumers {
+  let seed = LanePartitioner.split(initialWords, generation: 0)
+  propagator.update(corrector: seed.corrector, polish: seed.polish)
+  for consumer in correctorConsumers {
+    propagator.register(consumer)
+  }
+  for consumer in polishConsumers {
     propagator.register(consumer)
   }
   let onChange: ([CustomWord]) -> Void = { [weak propagator] words in
-    propagator?.update(words)
+    guard let propagator else { return }
+    let next = LanePartitioner.split(words, generation: propagator.corrector.generation &+ 1)
+    propagator.update(corrector: next.corrector, polish: next.polish)
   }
   coordinator.onWordsChanged = onChange
   return onChange
+}
+
+/// Splits a flat `[CustomWord]` (as produced by `CustomWordsCoordinator`,
+/// which holds the user's editable list + any merged sources) into the two
+/// typed lanes.
+///
+/// Phase 0 simple rule: pack-sourced terms go to corrector lane only;
+/// everything else goes to both lanes. Phase 5 may extend this when actual
+/// `VocabularyPacksManager` exists. Today, no pack terms ever flow through
+/// `CustomWordsCoordinator` because Phase 5 hasn't shipped, so both lanes
+/// receive identical content. The split-by-source logic is here so the
+/// lane-distinction code path is exercised from day one.
+@MainActor
+enum LanePartitioner {
+  static func split(_ words: [CustomWord], generation: UInt64) -> (
+    corrector: CorrectorVocabulary, polish: PolishVocabulary
+  ) {
+    let polishTerms = words.filter { $0.source != .pack }
+    return (
+      corrector: CorrectorVocabulary(terms: words, generation: generation),
+      polish: PolishVocabulary(terms: polishTerms, generation: generation)
+    )
+  }
 }

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -4,6 +4,20 @@ public enum WordCategory: String, Codable, CaseIterable, Sendable {
   case general, person, brand, acronym, domain
 }
 
+/// Origin of a `CustomWord`. Runtime-only — NOT persisted to disk.
+///
+/// Phase 0 (#640) introduces this enum so the corrector vs polish lane split
+/// can be enforced: pack-sourced terms must reach `WordCorrector` only, never
+/// the polish prompt (bible §2.2). The persisted JSON shape stays unchanged
+/// because `source` is excluded from `CustomWord.CodingKeys`. Anything decoded
+/// from `custom-words.json` is by definition `.user`.
+public enum WordSource: String, Sendable, CaseIterable {
+  case builtin  // ships in app bundle (CustomWordsManager.builtinDefaults)
+  case user  // user-typed via Custom Terms UI; default for any decoded CustomWord
+  case pack  // installed via VocabularyPacksManager (Phase 5, #635) — runtime-only
+  case observedAX  // auto-learned via AX observation (Phase 7, #629)
+}
+
 public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   public let id: UUID
   public var canonical: String
@@ -12,6 +26,9 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   public var priority: Int
   public var forceReplace: Bool
   public var caseSensitive: Bool
+  /// Runtime origin tag. Excluded from on-disk serialization (see `CodingKeys`).
+  /// Decoded values always have `source = .user`.
+  public let source: WordSource
 
   public init(
     id: UUID = UUID(),
@@ -20,7 +37,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     category: WordCategory = .general,
     priority: Int = 0,
     forceReplace: Bool = false,
-    caseSensitive: Bool = false
+    caseSensitive: Bool = false,
+    source: WordSource = .user
   ) {
     self.id = id
     self.canonical = canonical
@@ -29,5 +47,36 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.priority = priority
     self.forceReplace = forceReplace
     self.caseSensitive = caseSensitive
+    self.source = source
+  }
+
+  // `source` deliberately omitted — keeps persisted JSON byte-equivalent to the
+  // pre-Phase-0 schema. Bible §6.5, Codex grounded review 2026-05-05.
+  private enum CodingKeys: String, CodingKey {
+    case id, canonical, aliases, category, priority, forceReplace, caseSensitive
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try c.decode(UUID.self, forKey: .id)
+    self.canonical = try c.decode(String.self, forKey: .canonical)
+    self.aliases = try c.decodeIfPresent([String].self, forKey: .aliases) ?? []
+    self.category = try c.decodeIfPresent(WordCategory.self, forKey: .category) ?? .general
+    self.priority = try c.decodeIfPresent(Int.self, forKey: .priority) ?? 0
+    self.forceReplace = try c.decodeIfPresent(Bool.self, forKey: .forceReplace) ?? false
+    self.caseSensitive = try c.decodeIfPresent(Bool.self, forKey: .caseSensitive) ?? false
+    self.source = .user
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(id, forKey: .id)
+    try c.encode(canonical, forKey: .canonical)
+    try c.encode(aliases, forKey: .aliases)
+    try c.encode(category, forKey: .category)
+    try c.encode(priority, forKey: .priority)
+    try c.encode(forceReplace, forKey: .forceReplace)
+    try c.encode(caseSensitive, forKey: .caseSensitive)
+    // source intentionally NOT encoded.
   }
 }

--- a/Sources/EnviousWisprCore/CustomWordsConsumer.swift
+++ b/Sources/EnviousWisprCore/CustomWordsConsumer.swift
@@ -1,11 +1,24 @@
 import Foundation
 
-/// Services that hold a synchronized copy of the active custom-words list.
+/// Phase 0 (#640) split: two narrow consumer protocols replace the prior
+/// single `CustomWordsConsumer`. Each consumer subscribes to ONE lane, never
+/// both. Pack-to-prompt leaks become a compile error.
 ///
-/// `CustomWordsPropagator` (in the App target) writes new lists to all registered
-/// consumers via this property. Consumers MUST NOT call `propagator.update(_:)`
-/// synchronously from inside this setter; doing so triggers a DEBUG `precondition`.
+/// `CustomWordsPropagator` (in the App target) writes new vocabularies to all
+/// registered consumers via these properties. Consumers MUST NOT call
+/// `propagator.update(corrector:polish:)` synchronously from inside these
+/// setters; doing so triggers a DEBUG `precondition`.
+
+/// Consumes the corrector lane (built-in + user + pack terms). `WordCorrectionStep`
+/// adopts this protocol.
 @MainActor
-package protocol CustomWordsConsumer: AnyObject {
-  var customWords: [CustomWord] { get set }
+package protocol CorrectorVocabularyConsumer: AnyObject {
+  var correctorVocabulary: CorrectorVocabulary { get set }
+}
+
+/// Consumes the polish lane (built-in + user terms only — never pack).
+/// `LLMPolishStep` adopts this protocol.
+@MainActor
+package protocol PolishVocabularyConsumer: AnyObject {
+  var polishVocabulary: PolishVocabulary { get set }
 }

--- a/Sources/EnviousWisprCore/PromptBuildInput.swift
+++ b/Sources/EnviousWisprCore/PromptBuildInput.swift
@@ -1,5 +1,9 @@
 /// All inputs needed by the prompt planner to produce a PolishPlan.
 /// Bundles user settings, transcript, and context into a single immutable snapshot.
+///
+/// Phase 0 (#640) — `customWords: [CustomWord]` removed; replaced by
+/// `polishVocabulary: PolishVocabulary` so a pack-to-prompt leak is a compile
+/// error. Bible §2.2.
 public struct PromptBuildInput: Sendable {
   public let transcript: String
   public let provider: LLMProvider
@@ -7,13 +11,10 @@ public struct PromptBuildInput: Sendable {
   public let appName: String?
   public let language: String?
 
-  /// Legacy flat list of user-configured custom words (with aliases, priority).
-  /// Kept for rollback safety and because existing builders render aliases.
-  /// Deprecated: prefer `customVocabulary` + `languageDetection` so the planner
-  /// can apply confidence-tiered, language-aware injection. Builders still read
-  /// `customWords` after the planner has already filtered it to the set
-  /// permitted by the active tier.
-  public let customWords: [CustomWord]
+  /// Polish-prompt vocabulary. Built-in defaults + user-typed terms only;
+  /// pack terms are NEVER included by construction (Phase 0, bible §2.2).
+  /// Builders read `polishVocabulary.terms`.
+  public let polishVocabulary: PolishVocabulary
 
   public let focusSnapshot: FocusSnapshot?
 
@@ -44,7 +45,7 @@ public struct PromptBuildInput: Sendable {
     modelID: String,
     appName: String?,
     language: String?,
-    customWords: [CustomWord],
+    polishVocabulary: PolishVocabulary,
     focusSnapshot: FocusSnapshot? = nil,
     customVocabulary: PromptVocabulary? = nil,
     languageDetection: LanguageDetectionResult? = nil,
@@ -55,26 +56,27 @@ public struct PromptBuildInput: Sendable {
     self.modelID = modelID
     self.appName = appName
     self.language = language
-    self.customWords = customWords
+    self.polishVocabulary = polishVocabulary
     self.focusSnapshot = focusSnapshot
-    // Migration default: if no explicit customVocabulary is passed, fall
-    // back to deriving a global-only PromptVocabulary from customWords.
-    self.customVocabulary = customVocabulary ?? PromptVocabulary.fromLegacy(customWords)
+    // Migration default: if no explicit customVocabulary is passed, derive it
+    // from the polish lane terms (built-in + user). Pack terms (corrector
+    // lane only) deliberately do NOT influence the polish-side vocabulary.
+    self.customVocabulary = customVocabulary ?? PromptVocabulary.fromLegacy(polishVocabulary.terms)
     self.languageDetection = languageDetection
     self.backend = backend
   }
 
-  /// Returns a copy of this input with `customWords` replaced. Used by the
-  /// planner to hand the builders a filtered list after applying the
-  /// confidence-tiered + script-guardrail policy.
-  public func withCustomWords(_ newCustomWords: [CustomWord]) -> PromptBuildInput {
+  /// Returns a copy of this input with `polishVocabulary` replaced. Used by
+  /// the planner to hand the builders a filtered vocabulary after applying
+  /// the confidence-tiered + script-guardrail policy.
+  public func withPolishVocabulary(_ newPolishVocabulary: PolishVocabulary) -> PromptBuildInput {
     PromptBuildInput(
       transcript: transcript,
       provider: provider,
       modelID: modelID,
       appName: appName,
       language: language,
-      customWords: newCustomWords,
+      polishVocabulary: newPolishVocabulary,
       focusSnapshot: focusSnapshot,
       customVocabulary: customVocabulary,
       languageDetection: languageDetection,

--- a/Sources/EnviousWisprCore/VocabularyLanes.swift
+++ b/Sources/EnviousWisprCore/VocabularyLanes.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Phase 0 (#640) — typed propagation lanes for custom-word terms.
+///
+/// Bible §2.2 mandates: pack-sourced terms reach `WordCorrector` only, never
+/// the polish prompt. Pre-Phase-0, `CustomWordsPropagator.update(_ words:
+/// [CustomWord])` broadcast a single list to every consumer, so the law could
+/// only be enforced at runtime (Layer 3 golden-string test). Phase 0 splits
+/// the lane into two value types so a pack-to-prompt leak becomes a Swift
+/// compile error (Layer 2).
+///
+/// `generation` is monotonically incremented per coordinator update and
+/// shared between both lanes for a given atomic snapshot, addressing the
+/// broadcast-ordering risk (R18) noted in the bible. Sub-second-scale
+/// cross-actor reads can detect "I have lane A at gen N but lane B at gen
+/// N-1" and choose to re-read.
+public struct CorrectorVocabulary: Sendable, Equatable {
+  /// All terms eligible for deterministic correction: built-in defaults +
+  /// user-typed entries + installed pack terms (Phase 5).
+  public let terms: [CustomWord]
+  public let generation: UInt64
+
+  public init(terms: [CustomWord], generation: UInt64) {
+    self.terms = terms
+    self.generation = generation
+  }
+
+  /// Empty initial value used at AppState wire time before the first user mutation.
+  public static let empty = CorrectorVocabulary(terms: [], generation: 0)
+}
+
+/// Polish-prompt vocabulary. Built-in defaults + user-typed entries only;
+/// **pack-sourced terms are never included**.
+///
+/// The compile-time guard against pack leakage is `PromptBuildInput`'s only
+/// vocab field being `polishVocabulary: PolishVocabulary` — a developer who
+/// wants to leak pack terms into the polish prompt must construct a
+/// `PolishVocabulary` from pack terms by hand, which a code review or the
+/// `PackToPolishLeakTest` runtime assertion will catch.
+public struct PolishVocabulary: Sendable, Equatable {
+  public let terms: [CustomWord]
+  public let generation: UInt64
+
+  public init(terms: [CustomWord], generation: UInt64) {
+    self.terms = terms
+    self.generation = generation
+  }
+
+  public static let empty = PolishVocabulary(terms: [], generation: 0)
+}

--- a/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
+++ b/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
@@ -12,10 +12,11 @@ public struct DefaultPromptPlanner: PromptPlanning {
       appName: input.appName
     )
 
-    // Multilingual v1 (W3): filter custom vocabulary for the active
+    // Multilingual v1 (W3): filter polish vocabulary for the active
     // confidence tier + script guardrail BEFORE handing it to the builder.
-    // Builders continue to read `input.customWords`, but the planner hands
-    // them a tier-appropriate list.
+    // Builders read `input.polishVocabulary.terms`; the planner hands them a
+    // tier-appropriate list. Phase 0 (#640) renamed `customWords` →
+    // `polishVocabulary` so pack terms can never reach this path.
     let filtered = applyVocabularyPolicy(to: input)
 
     let builder = Self.builder(for: input.provider, modelID: input.modelID)
@@ -54,8 +55,9 @@ public struct DefaultPromptPlanner: PromptPlanning {
   // MARK: - Multilingual v1 (W3): tiered vocabulary policy
 
   /// Apply the confidence-tiered + script-guardrail policy to the
-  /// PromptBuildInput's vocabulary, returning a copy whose `customWords` list
-  /// contains only the entries permitted by the active tier.
+  /// PromptBuildInput's vocabulary, returning a copy whose
+  /// `polishVocabulary.terms` list contains only the entries permitted by the
+  /// active tier.
   ///
   /// Dispatch is driven by the explicit `backend` field so engine identity is
   /// never inferred from `languageDetection == nil`:
@@ -85,7 +87,9 @@ public struct DefaultPromptPlanner: PromptPlanning {
     // detector must not silently fall through to the English-centric
     // legacy prompt and corrupt non-English output.
     if input.backend == .whisperKit, input.languageDetection == nil {
-      return input.withCustomWords([])
+      return input.withPolishVocabulary(
+        PolishVocabulary(terms: [], generation: input.polishVocabulary.generation)
+      )
     }
 
     guard let detection = input.languageDetection else {
@@ -99,12 +103,14 @@ public struct DefaultPromptPlanner: PromptPlanning {
       tier: detection.tier
     )
     let filteredCustomWords = Self.filterCustomWords(
-      input.customWords,
+      input.polishVocabulary.terms,
       tier: detection.tier,
       detectedLang: detection.lang,
       allowedStrings: Set(effectiveStrings)
     )
-    return input.withCustomWords(filteredCustomWords)
+    return input.withPolishVocabulary(
+      PolishVocabulary(terms: filteredCustomWords, generation: input.polishVocabulary.generation)
+    )
   }
 
   /// Filter the legacy `[CustomWord]` list to match the tier policy.

--- a/Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift
@@ -26,7 +26,7 @@ public struct GeminiPromptBuilder: PromptBuilder {
     }
 
     // Custom vocabulary
-    if let vocab = CustomVocabularyFormatter.render(input.customWords) {
+    if let vocab = CustomVocabularyFormatter.render(input.polishVocabulary.terms) {
       system += "\n\n\(vocab)"
     }
 

--- a/Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift
@@ -60,7 +60,7 @@ public struct GemmaPromptBuilder: PromptBuilder {
     }
 
     // 4. Custom vocabulary (simplified format for small models)
-    if let vocab = CustomVocabularyFormatter.renderSimplified(input.customWords) {
+    if let vocab = CustomVocabularyFormatter.renderSimplified(input.polishVocabulary.terms) {
       system += "\n\n\(vocab)"
     }
 

--- a/Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift
@@ -99,7 +99,7 @@ public struct OpenAIPromptBuilder: PromptBuilder {
     }
 
     // Custom vocabulary
-    if let vocab = CustomVocabularyFormatter.render(input.customWords) {
+    if let vocab = CustomVocabularyFormatter.render(input.polishVocabulary.terms) {
       system += "\n\n\(vocab)"
     }
 

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -4,8 +4,12 @@ import EnviousWisprServices
 import Foundation
 
 /// Polishes transcribed text using an LLM provider.
+///
+/// Phase 0 (#640) — receives the polish lane (built-in + user terms only;
+/// pack terms NEVER reach this step). Adopts `PolishVocabularyConsumer`
+/// instead of the prior `CustomWordsConsumer`. Bible §2.2.
 @MainActor
-public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
+public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   public let name = "LLM Polish"
 
   /// LLM polish failures are user-visible: surface them to `polishError` so
@@ -17,7 +21,7 @@ public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
   public var llmModel: String = LLMProvider.defaultModel(for: .openAI)
   public var polishInstructions: PolishInstructions = .default
   public var useExtendedThinking: Bool = false
-  public var customWords: [CustomWord] = []
+  public var polishVocabulary: PolishVocabulary = .empty
 
   // MARK: - Multilingual v1 (W3)
 
@@ -253,7 +257,7 @@ public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
     // Multilingual v1 (W3): snapshot the active vocabulary at construction
     // time so the planner/builders see a stable list even if the user edits
     // custom words mid-polish. Migration default: all entries tagged global.
-    let vocabularySnapshot = PromptVocabulary.fromLegacy(customWords)
+    let vocabularySnapshot = PromptVocabulary.fromLegacy(polishVocabulary.terms)
 
     let input = PromptBuildInput(
       transcript: context.text,
@@ -261,7 +265,7 @@ public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
       modelID: llmModel,
       appName: context.targetAppName,
       language: context.language,
-      customWords: customWords,
+      polishVocabulary: polishVocabulary,
       focusSnapshot: nil,  // PR 3
       customVocabulary: vocabularySnapshot,
       languageDetection: languageDetection,
@@ -439,8 +443,8 @@ public final class LLMPolishStep: TextProcessingStep, CustomWordsConsumer {
       "\nThis is speech-to-text output. Remove false starts. "
       + "Preserve the speaker's tone and formality level. If unsure about a correction, leave unchanged."
 
-    if !customWords.isEmpty {
-      if let vocab = CustomVocabularyFormatter.render(customWords) {
+    if !polishVocabulary.terms.isEmpty {
+      if let vocab = CustomVocabularyFormatter.render(polishVocabulary.terms) {
         systemPrompt += "\n\n" + vocab
       }
     }

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -155,15 +155,19 @@ internal final class TranscriptFinalizer {
           restoreClipboardAfterPaste: request.restoreClipboardAfterPaste
         ))
       // Phase 0 (#640): emit paste-complete event for downstream observers
-      // (Phase 7 auto-learn). Only fires on the dictation auto-paste path —
-      // copy-only and saved-transcript manual paste are intentionally not
-      // observed (different gestures).
-      pasteCompletionRegistry?.emit(
-        PasteCompletionEvent(
-          pastedText: text,
-          destinationBundleID: request.targetApp?.bundleIdentifier
+      // (Phase 7 auto-learn). Only fires on the dictation auto-paste path AND
+      // only when the cascade actually delivered (not when it fell back to
+      // clipboard-only). An auto-learn observer that saw clipboard-only
+      // fallbacks would start watching a destination where the text never
+      // landed — false-positive learning. Codex review revision 2026-05-05.
+      if let pasteResult, case .delivered = pasteResult.outcome {
+        pasteCompletionRegistry?.emit(
+          PasteCompletionEvent(
+            pastedText: text,
+            destinationBundleID: request.targetApp?.bundleIdentifier
+          )
         )
-      )
+      }
     } else if request.autoCopyToClipboard {
       PasteService.copyToClipboard(transcript.displayText)
     }

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -60,15 +60,21 @@ internal final class TranscriptFinalizer {
   private let save: @MainActor (Transcript) throws -> Void
   private let textProcessingRunner: TextProcessingRunner
   private let deliverPaste: @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult
+  /// Phase 0 (#640) — receives `PasteCompletionEvent` after every successful
+  /// dictation auto-paste. Nil means "no observers wired" (acceptable; events
+  /// are dropped silently). Phase 7 (#629) is the first planned subscriber.
+  private let pasteCompletionRegistry: PasteCompletionRegistry?
 
   init(
     transcriptStore: TranscriptStore,
     textProcessingRunner: TextProcessingRunner = TextProcessingRunner(),
-    pasteExecutor: PasteCascadeExecutor = PasteCascadeExecutor()
+    pasteExecutor: PasteCascadeExecutor = PasteCascadeExecutor(),
+    pasteCompletionRegistry: PasteCompletionRegistry? = nil
   ) {
     self.save = { try transcriptStore.save($0) }
     self.textProcessingRunner = textProcessingRunner
     self.deliverPaste = { await pasteExecutor.deliver($0) }
+    self.pasteCompletionRegistry = pasteCompletionRegistry
   }
 
   // Test-only seam: contract tests construct the finalizer with fake closures
@@ -81,11 +87,13 @@ internal final class TranscriptFinalizer {
   init(
     save: @escaping @MainActor (Transcript) throws -> Void,
     textProcessingRunner: TextProcessingRunner = TextProcessingRunner(),
-    deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult
+    deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult,
+    pasteCompletionRegistry: PasteCompletionRegistry? = nil
   ) {
     self.save = save
     self.textProcessingRunner = textProcessingRunner
     self.deliverPaste = deliverPaste
+    self.pasteCompletionRegistry = pasteCompletionRegistry
   }
 
   /// Finalize a transcription: process text, store transcript, paste to target.
@@ -146,6 +154,16 @@ internal final class TranscriptFinalizer {
           targetElement: request.targetElement,
           restoreClipboardAfterPaste: request.restoreClipboardAfterPaste
         ))
+      // Phase 0 (#640): emit paste-complete event for downstream observers
+      // (Phase 7 auto-learn). Only fires on the dictation auto-paste path —
+      // copy-only and saved-transcript manual paste are intentionally not
+      // observed (different gestures).
+      pasteCompletionRegistry?.emit(
+        PasteCompletionEvent(
+          pastedText: text,
+          destinationBundleID: request.targetApp?.bundleIdentifier
+        )
+      )
     } else if request.autoCopyToClipboard {
       PasteService.copyToClipboard(transcript.displayText)
     }

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -32,6 +32,13 @@ public final class TranscriptPolishService {
   /// At call time, config is snapshotted into an immutable value for request safety.
   public let llmPolishStep: LLMPolishStep
 
+  /// Phase 0 (#640) — single shared registry. Constructed here so AppState
+  /// avoids breaching the 19-collaborator ceiling (the registry would
+  /// otherwise need its own top-level `let`). Both pipeline finalizers
+  /// receive this same instance via init injection. Phase 7 (#629)
+  /// auto-learn subscribes here.
+  public let pasteCompletionRegistry: PasteCompletionRegistry
+
   // MARK: - Private
 
   private let transcriptStore: TranscriptStore
@@ -45,6 +52,7 @@ public final class TranscriptPolishService {
     dictationActivity: DictationActivityProviding? = nil
   ) {
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
+    self.pasteCompletionRegistry = PasteCompletionRegistry()
     self.transcriptStore = transcriptStore
     self.dictationActivity = dictationActivity
     // Standalone: no pipeline callbacks needed.

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -138,7 +138,8 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     asrManager: any ASRManagerInterface,
     transcriptStore: TranscriptStore,
     keychainManager: KeychainManager = KeychainManager(),
-    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState(),
+    pasteCompletionRegistry: PasteCompletionRegistry? = nil
   ) {
     self.init(
       audioCapture: audioCapture,
@@ -146,7 +147,10 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       transcriptStore: transcriptStore,
       keychainManager: keychainManager,
       captureTelemetry: captureTelemetry,
-      transcriptFinalizer: TranscriptFinalizer(transcriptStore: transcriptStore))
+      transcriptFinalizer: TranscriptFinalizer(
+        transcriptStore: transcriptStore,
+        pasteCompletionRegistry: pasteCompletionRegistry
+      ))
   }
 
   /// Phase G3 — `internal` overload that accepts a pre-built finalizer so

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -168,7 +168,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     transcriptStore: TranscriptStore,
     keychainManager: KeychainManager,
     languageDetector: LanguageDetector = LanguageDetector(),
-    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState(),
+    pasteCompletionRegistry: PasteCompletionRegistry? = nil
   ) {
     self.audioCapture = audioCapture
     self.backend = backend
@@ -179,7 +180,10 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       backend: .whisperKit,
       captureTelemetry: captureTelemetry
     )
-    self.transcriptFinalizer = TranscriptFinalizer(transcriptStore: transcriptStore)
+    self.transcriptFinalizer = TranscriptFinalizer(
+      transcriptStore: transcriptStore,
+      pasteCompletionRegistry: pasteCompletionRegistry
+    )
     self.llmPolishStep = LLMPolishStep(keychainManager: keychainManager)
     // Explicit engine identity: prevents a future codepath that skips the
     // language detector from silently falling through to the legacy

--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -3,15 +3,19 @@ import EnviousWisprPostProcessing
 import Foundation
 
 /// Applies custom word corrections to ASR output.
+///
+/// Phase 0 (#640) — receives the corrector lane (built-in + user + pack
+/// terms). Adopts `CorrectorVocabularyConsumer` instead of the prior
+/// `CustomWordsConsumer`. Bible §2.2.
 @MainActor
-public final class WordCorrectionStep: TextProcessingStep, CustomWordsConsumer {
+public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyConsumer {
   public let name = "Word Correction"
 
   public var wordCorrectionEnabled: Bool = false
-  public var customWords: [CustomWord] = []
+  public var correctorVocabulary: CorrectorVocabulary = .empty
 
   public var isEnabled: Bool {
-    wordCorrectionEnabled && !customWords.isEmpty
+    wordCorrectionEnabled && !correctorVocabulary.terms.isEmpty
   }
 
   public var maxDuration: Duration { .milliseconds(100) }
@@ -20,7 +24,7 @@ public final class WordCorrectionStep: TextProcessingStep, CustomWordsConsumer {
 
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     let corrector = WordCorrector()
-    let (fixed, count) = corrector.correct(context.text, against: customWords)
+    let (fixed, count) = corrector.correct(context.text, against: correctorVocabulary.terms)
     if count > 0 {
       Task {
         await AppLogger.shared.log(

--- a/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
+++ b/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
@@ -8,8 +8,12 @@ import Foundation
 /// the just-pasted text and surfaces them as custom-word suggestions.
 ///
 /// **Scope of emission** (intentional, see plan §3.5):
-/// - YES: dictation auto-paste via `TranscriptFinalizer.deliverPaste`.
-/// - NO: dictation copy-only branch (no paste happened).
+/// - YES: dictation auto-paste via `TranscriptFinalizer.deliverPaste` when
+///   the cascade outcome is `.delivered` (paste actually landed).
+/// - NO: dictation auto-paste that fell back to clipboard-only (e.g. AX
+///   denied, CGEvent failed) — observers would falsely learn from a paste
+///   that did not happen.
+/// - NO: dictation copy-only branch (no paste attempted).
 /// - NO: saved-transcript Copy/Paste buttons (manual UI gesture, not dictation).
 public struct PasteCompletionEvent: Sendable {
   public let pastedText: String

--- a/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
+++ b/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Phase 0 (#640) — broadcasts paste-completion events from the dictation
+/// pipeline. Bible §6.5.
+///
+/// Emitted by `TranscriptFinalizer` after a successful auto-paste. Phase 7
+/// (#629) auto-learn is the first planned subscriber: it watches for edits to
+/// the just-pasted text and surfaces them as custom-word suggestions.
+///
+/// **Scope of emission** (intentional, see plan §3.5):
+/// - YES: dictation auto-paste via `TranscriptFinalizer.deliverPaste`.
+/// - NO: dictation copy-only branch (no paste happened).
+/// - NO: saved-transcript Copy/Paste buttons (manual UI gesture, not dictation).
+public struct PasteCompletionEvent: Sendable {
+  public let pastedText: String
+  public let destinationBundleID: String?
+  public let timestamp: Date
+
+  public init(pastedText: String, destinationBundleID: String?, timestamp: Date = Date()) {
+    self.pastedText = pastedText
+    self.destinationBundleID = destinationBundleID
+    self.timestamp = timestamp
+  }
+}
+
+/// Subscribers conform to receive `PasteCompletionEvent` notifications.
+/// Stored weakly by `PasteCompletionRegistry`. Calls to `pasteCompleted` run
+/// on `@MainActor` because the registry itself is `@MainActor`-isolated.
+@MainActor
+public protocol PasteCompletionObserver: AnyObject {
+  func pasteCompleted(_ event: PasteCompletionEvent)
+}
+
+/// Single shared registry per app instance. Constructed inside
+/// `TranscriptPolishService` and threaded into both pipeline finalizers via
+/// `TranscriptFinalizer.init`. Phase 7 subscribers register here.
+///
+/// All operations execute on `@MainActor` because the only emitter
+/// (`TranscriptFinalizer.finalize`) and the only foreseeable subscribers
+/// (AX observation in Phase 7) live on the main actor. Keeping the actor
+/// constraint tight avoids paying for unnecessary cross-actor hops on the
+/// dictation hot path.
+@MainActor
+public final class PasteCompletionRegistry {
+  private final class WeakBox {
+    weak var value: (any PasteCompletionObserver)?
+    init(_ value: any PasteCompletionObserver) { self.value = value }
+  }
+
+  private var observers: [WeakBox] = []
+
+  public init() {}
+
+  /// Register `observer` for future events. Idempotent on object identity.
+  /// Stored weakly — observers must outlive their registration via their own
+  /// strong reference.
+  public func subscribe(_ observer: any PasteCompletionObserver) {
+    let alreadyRegistered = observers.contains { box in
+      guard let existing = box.value else { return false }
+      return ObjectIdentifier(existing) == ObjectIdentifier(observer)
+    }
+    guard !alreadyRegistered else { return }
+    observers.append(WeakBox(observer))
+  }
+
+  /// Broadcast `event` to all live observers. Dead weak references are
+  /// pruned during this call.
+  public func emit(_ event: PasteCompletionEvent) {
+    observers.removeAll { $0.value == nil }
+    for box in observers {
+      box.value?.pasteCompleted(event)
+    }
+  }
+
+  /// Test-only — current observer count (after pruning dead weak refs).
+  public var observerCount: Int {
+    observers.removeAll { $0.value == nil }
+    return observers.count
+  }
+}

--- a/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsPropagatorTests.swift
@@ -4,143 +4,191 @@ import Testing
 
 @testable import EnviousWispr
 
-/// Phase D (#496) — pins the `CustomWordsPropagator` contract around the new
-/// registry pattern that replaces AppState's 5-way custom-words fanout.
+/// Phase 0 (#640) — pins the `CustomWordsPropagator` contract around the
+/// split-lane registry pattern. Replaces Phase D (#496) tests after the
+/// `CustomWordsConsumer` protocol was split into `CorrectorVocabularyConsumer`
+/// and `PolishVocabularyConsumer`.
 ///
 /// Tests assert observable behavior on conforming spy consumers. Spies are
 /// plain `@MainActor final class` types — no actor indirection.
-///
-/// Coverage shape (after Codex truth-audit, 2026-04-29):
-/// - Unit: weak storage (deinit probe), initial-sync, dup-register idempotence.
-/// - Integration via `wireCustomWords`: AppState's exact wire ordering
-///   exercised against spy consumers + a real `CustomWordsCoordinator`. This
-///   is the test that catches "future AppState refactor drops a register()
-///   call" or "wire ordering reversed."
 @MainActor
-@Suite("CustomWordsPropagator — Phase D registry contract")
+@Suite("CustomWordsPropagator — Phase 0 split-lane registry contract")
 struct CustomWordsPropagatorTests {
 
   // MARK: - Fixtures
 
-  /// Plain spy. Records every assignment to `customWords` so tests can pin
-  /// invocation count and final value at the consumer level.
-  private final class SpyConsumer: CustomWordsConsumer {
-    var customWords: [CustomWord] = [] {
+  /// Plain corrector-lane spy.
+  private final class CorrectorSpy: CorrectorVocabularyConsumer {
+    var correctorVocabulary: CorrectorVocabulary = .empty {
+      didSet { setCount += 1 }
+    }
+    var setCount: Int = 0
+  }
+
+  /// Plain polish-lane spy.
+  private final class PolishSpy: PolishVocabularyConsumer {
+    var polishVocabulary: PolishVocabulary = .empty {
       didSet { setCount += 1 }
     }
     var setCount: Int = 0
   }
 
   /// Reference holder for cross-isolation flag access from a nonisolated
-  /// `deinit`. Marked `@unchecked Sendable` because all writes happen during
-  /// synchronous deallocation on the test's @MainActor thread (autoreleasepool
-  /// drain is synchronous), and reads happen from the same actor afterward.
+  /// `deinit`.
   private final class DeinitFlag: @unchecked Sendable {
     var fired: Bool = false
   }
 
-  /// Spy that flips a flag in `deinit`. Used to actually prove weak storage
-  /// in the propagator: a strong-storing buggy implementation would keep
-  /// this alive past the autoreleasepool boundary, the flag would stay
-  /// false, and the test would fail.
-  private final class DeinitProbeSpy: CustomWordsConsumer {
-    var customWords: [CustomWord] = []
+  /// Spy that flips a flag in `deinit`. Used to actually prove weak storage.
+  private final class CorrectorDeinitProbe: CorrectorVocabularyConsumer {
+    var correctorVocabulary: CorrectorVocabulary = .empty
     let flag: DeinitFlag
     init(flag: DeinitFlag) { self.flag = flag }
     deinit { flag.fired = true }
   }
 
-  private static func makeWord(_ canonical: String) -> CustomWord {
-    CustomWord(canonical: canonical)
+  private static func makeWord(_ canonical: String, source: WordSource = .user) -> CustomWord {
+    CustomWord(canonical: canonical, source: source)
   }
 
-  // MARK: - Unit: weak storage proven via deinit probe
+  // MARK: - Unit: weak storage
 
-  /// Substantive proof of weak storage: registers a probe consumer in an
-  /// autoreleasepool, asserts its `deinit` fires after the pool exits.
-  /// A buggy propagator that stored consumers strongly would keep the probe
-  /// alive past the autoreleasepool, the deinit closure would never fire,
-  /// and `deinitFired` would stay false.
-  @Test("Weak storage — transient consumer is deinit'd after autoreleasepool exits")
+  @Test("Weak storage — corrector consumer is deinit'd after autoreleasepool exits")
   func weakStorageDeinitProbe() {
     let propagator = CustomWordsPropagator()
     let flag = DeinitFlag()
     autoreleasepool {
-      let probe = DeinitProbeSpy(flag: flag)
+      let probe = CorrectorDeinitProbe(flag: flag)
       propagator.register(probe)
-      // Sanity: probe received initial-sync before going out of scope.
-      #expect(probe.customWords.isEmpty)
+      #expect(probe.correctorVocabulary.terms.isEmpty)
     }
     #expect(
       flag.fired,
       "Probe consumer must be deallocated after the autoreleasepool exits — proves the propagator stores it weakly."
     )
 
-    // After deallocation, a subsequent update must not crash and must prune
-    // the dead box. Surviving consumer registered AFTER probe death sees
-    // the broadcast cleanly.
-    let survivor = SpyConsumer()
+    let survivor = CorrectorSpy()
     propagator.register(survivor)
     let words = [Self.makeWord("survivor")]
-    propagator.update(words)
-    #expect(survivor.customWords == words)
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: words, generation: 1),
+      polish: PolishVocabulary(terms: words, generation: 1)
+    )
+    #expect(survivor.correctorVocabulary.terms == words)
   }
 
-  // MARK: - Unit: initial-sync on register
+  // MARK: - Unit: initial-sync on register (both lanes)
 
-  /// `register(_:)` writes the propagator's current `words` to the consumer
-  /// before returning. AppState init relies on this for "all consumers have
-  /// the seed before the first user mutation."
-  @Test("Initial-sync on register — late registrant gets current words")
-  func initialSyncOnRegister() {
+  @Test("Initial-sync on register — corrector consumer gets current vocabulary")
+  func initialSyncCorrectorOnRegister() {
     let propagator = CustomWordsPropagator()
 
-    let early = SpyConsumer()
+    let early = CorrectorSpy()
     propagator.register(early)
-    #expect(early.customWords.isEmpty)
+    #expect(early.correctorVocabulary.terms.isEmpty)
     #expect(early.setCount == 1)
 
     let updated = [Self.makeWord("alpha"), Self.makeWord("beta")]
-    propagator.update(updated)
-    #expect(early.customWords == updated)
-    #expect(early.setCount == 2)
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: updated, generation: 1),
+      polish: PolishVocabulary(terms: updated, generation: 1)
+    )
+    #expect(early.correctorVocabulary.terms == updated)
 
-    // Late-registered consumer must receive `updated` via initial-sync, NOT
-    // the empty initial seed and NOT a subsequent broadcast.
-    let late = SpyConsumer()
+    let late = CorrectorSpy()
     propagator.register(late)
-    #expect(late.customWords == updated)
+    #expect(late.correctorVocabulary.terms == updated)
     #expect(late.setCount == 1)
   }
 
-  // MARK: - Unit: duplicate-register idempotence
-
-  /// Registering the same instance twice must not double-write on broadcast.
-  @Test("Duplicate-register idempotence — same instance written once per update")
-  func duplicateRegisterIdempotent() {
+  @Test("Initial-sync on register — polish consumer gets current vocabulary")
+  func initialSyncPolishOnRegister() {
     let propagator = CustomWordsPropagator()
-    let consumer = SpyConsumer()
+
+    let early = PolishSpy()
+    propagator.register(early)
+    #expect(early.polishVocabulary.terms.isEmpty)
+
+    let updated = [Self.makeWord("alpha"), Self.makeWord("beta")]
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: updated, generation: 1),
+      polish: PolishVocabulary(terms: updated, generation: 1)
+    )
+    #expect(early.polishVocabulary.terms == updated)
+  }
+
+  // MARK: - Unit: pack-distribution law (the whole point of Phase 0)
+
+  @Test("Pack terms reach corrector lane only — never polish lane")
+  func packTermsExcludedFromPolish() {
+    let propagator = CustomWordsPropagator()
+    let corrSpy = CorrectorSpy()
+    let polishSpy = PolishSpy()
+    propagator.register(corrSpy)
+    propagator.register(polishSpy)
+
+    let userTerm = Self.makeWord("EnviousWispr", source: .user)
+    let packTerm = Self.makeWord("Snowflake", source: .pack)
+    let allTerms = [userTerm, packTerm]
+    let polishOnly = allTerms.filter { $0.source != .pack }
+
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: allTerms, generation: 1),
+      polish: PolishVocabulary(terms: polishOnly, generation: 1)
+    )
+
+    #expect(
+      corrSpy.correctorVocabulary.terms.contains(where: { $0.canonical == "Snowflake" }),
+      "Pack term must reach corrector lane")
+    #expect(
+      !polishSpy.polishVocabulary.terms.contains(where: { $0.canonical == "Snowflake" }),
+      "Pack term must NOT reach polish lane (bible §2.2)")
+    #expect(
+      polishSpy.polishVocabulary.terms.contains(where: { $0.canonical == "EnviousWispr" }),
+      "User term must reach polish lane")
+  }
+
+  // MARK: - Unit: shared generation across lanes
+
+  @Test("Shared generation — both lanes get same generation per atomic update")
+  func sharedGenerationAcrossLanes() {
+    let propagator = CustomWordsPropagator()
+    let corrSpy = CorrectorSpy()
+    let polishSpy = PolishSpy()
+    propagator.register(corrSpy)
+    propagator.register(polishSpy)
+
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: [], generation: 42),
+      polish: PolishVocabulary(terms: [], generation: 42)
+    )
+    #expect(corrSpy.correctorVocabulary.generation == 42)
+    #expect(polishSpy.polishVocabulary.generation == 42)
+  }
+
+  // MARK: - Unit: duplicate-register idempotence (both lanes)
+
+  @Test("Duplicate-register idempotence — corrector consumer written once per update")
+  func duplicateCorrectorRegisterIdempotent() {
+    let propagator = CustomWordsPropagator()
+    let consumer = CorrectorSpy()
     propagator.register(consumer)
-    propagator.register(consumer)  // second call is a no-op
+    propagator.register(consumer)
 
     let baseline = consumer.setCount
     let word = Self.makeWord("x")
-    propagator.update([word])
+    propagator.update(
+      corrector: CorrectorVocabulary(terms: [word], generation: 1),
+      polish: PolishVocabulary(terms: [word], generation: 1)
+    )
     #expect(consumer.setCount == baseline + 1)
-    #expect(consumer.customWords == [word])
   }
 
-  // MARK: - Integration: wireCustomWords exact AppState ordering
+  // MARK: - Integration: wireCustomWords with both consumer lists
 
-  /// Highest-risk regression test (per Codex grounded review). Drives
-  /// `wireCustomWords` — the exact helper AppState's init calls — with spy
-  /// consumers + a real `CustomWordsCoordinator`. Catches:
-  ///   - someone dropping a `register()` call from AppState's wiring
-  ///   - reordering (assigning `onWordsChanged` before registers, or
-  ///     registering before the seed)
-  ///   - the coordinator's onWordsChanged closure failing to broadcast
   @Test(
-    "Integration — wireCustomWords seeds all 5 spy consumers + coordinator broadcast reaches them")
+    "Integration — wireCustomWords seeds 2 corrector spies + 3 polish spies, coordinator broadcast reaches all"
+  )
   func wireCustomWordsIntegration() {
     let coordinator = CustomWordsCoordinator()
     let preloaded = [
@@ -148,61 +196,74 @@ struct CustomWordsPropagatorTests {
       Self.makeWord("preload-two"),
     ]
 
-    // Five spies stand in for the five real production consumers
-    // (pipeline × 2 × 2 + polishService).
-    let spies: [SpyConsumer] = (0..<5).map { _ in SpyConsumer() }
+    let correctorSpies: [CorrectorSpy] = (0..<2).map { _ in CorrectorSpy() }
+    let polishSpies: [PolishSpy] = (0..<3).map { _ in PolishSpy() }
     let propagator = CustomWordsPropagator()
 
     wireCustomWords(
       propagator: propagator,
       initialWords: preloaded,
-      consumers: spies,
+      correctorConsumers: correctorSpies,
+      polishConsumers: polishSpies,
       coordinator: coordinator
     )
 
-    // After wiring, every spy must hold the preloaded words via
-    // register()'s initial-sync, BEFORE any user interaction.
-    for (i, spy) in spies.enumerated() {
+    for (i, spy) in correctorSpies.enumerated() {
       #expect(
-        spy.customWords == preloaded,
-        "spy[\(i)] missed the preloaded seed; check register() initial-sync ordering")
+        spy.correctorVocabulary.terms == preloaded,
+        "corrector spy[\(i)] missed the preloaded seed")
+    }
+    for (i, spy) in polishSpies.enumerated() {
+      #expect(
+        spy.polishVocabulary.terms == preloaded,
+        "polish spy[\(i)] missed the preloaded seed (no pack terms in seed)")
     }
 
-    // Now fire the coordinator callback that wireCustomWords installed.
-    // Every spy must receive the new list. Catches "onWordsChanged was
-    // assigned but doesn't actually broadcast through propagator."
     let updated = preloaded + [Self.makeWord("user-added")]
     coordinator.onWordsChanged?(updated)
-    for (i, spy) in spies.enumerated() {
+    for (i, spy) in correctorSpies.enumerated() {
       #expect(
-        spy.customWords == updated,
-        "spy[\(i)] missed the broadcast triggered through coordinator.onWordsChanged")
+        spy.correctorVocabulary.terms == updated,
+        "corrector spy[\(i)] missed the broadcast")
+    }
+    for (i, spy) in polishSpies.enumerated() {
+      #expect(
+        spy.polishVocabulary.terms == updated,
+        "polish spy[\(i)] missed the broadcast")
     }
   }
 
-  // MARK: - Integration: late-register receives current words
+  // MARK: - Integration: pack term added via coordinator only reaches corrector
 
-  /// Pins the contract that a consumer registered AFTER an `update()` still
-  /// gets the most-recent broadcast value. Future surface for AI-driven custom
-  /// words / word-pack sources that may register their own consumers at
-  /// runtime.
-  @Test("Integration — consumer registered after update receives current words")
-  func lateRegisterReceivesCurrent() {
+  @Test("Integration — pack term flows to corrector consumers only via wireCustomWords")
+  func packTermFlowsCorrectorOnly() {
+    let coordinator = CustomWordsCoordinator()
+    let correctorSpy = CorrectorSpy()
+    let polishSpy = PolishSpy()
     let propagator = CustomWordsPropagator()
-    let alpha = SpyConsumer()
-    propagator.register(alpha)
 
-    let firstBatch = [Self.makeWord("one")]
-    propagator.update(firstBatch)
-    #expect(alpha.customWords == firstBatch)
+    wireCustomWords(
+      propagator: propagator,
+      initialWords: [],
+      correctorConsumers: [correctorSpy],
+      polishConsumers: [polishSpy],
+      coordinator: coordinator
+    )
 
-    let beta = SpyConsumer()
-    propagator.register(beta)
-    #expect(beta.customWords == firstBatch)
+    let mixed = [
+      Self.makeWord("EnviousWispr", source: .user),
+      Self.makeWord("Snowflake", source: .pack),
+    ]
+    coordinator.onWordsChanged?(mixed)
 
-    let secondBatch = [Self.makeWord("one"), Self.makeWord("two")]
-    propagator.update(secondBatch)
-    #expect(alpha.customWords == secondBatch)
-    #expect(beta.customWords == secondBatch)
+    #expect(
+      correctorSpy.correctorVocabulary.terms.count == 2,
+      "Corrector should see both user + pack terms")
+    #expect(
+      polishSpy.polishVocabulary.terms.count == 1,
+      "Polish should see only the user term")
+    #expect(
+      polishSpy.polishVocabulary.terms.first?.canonical == "EnviousWispr",
+      "Polish lane received the user term, not the pack term")
   }
 }

--- a/Tests/EnviousWisprTests/Core/CustomWordSourceMigrationTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordSourceMigrationTests.swift
@@ -1,0 +1,84 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// Phase 0 (#640) — pins on-disk schema invariance after the new `source`
+/// field was added to `CustomWord`. Bible §6.5: persisted JSON shape must be
+/// byte-equivalent to the pre-Phase-0 schema. `source` is excluded from
+/// `CodingKeys`; anything decoded from disk gets `source: .user`.
+@Suite("CustomWord source-field migration — Phase 0 schema invariance")
+struct CustomWordSourceMigrationTests {
+
+  @Test("Decode from old-format JSON (no source key) yields source: .user")
+  func decodeOldFormatYieldsUserSource() throws {
+    let json = """
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "canonical": "EnviousWispr",
+        "aliases": ["envious wispr", "envious whisper"],
+        "category": "brand",
+        "priority": 5,
+        "forceReplace": false,
+        "caseSensitive": false
+      }
+      """.data(using: .utf8)!
+
+    let word = try JSONDecoder().decode(CustomWord.self, from: json)
+    #expect(word.canonical == "EnviousWispr")
+    #expect(word.source == .user, "Decoded entries default to .user (no source on disk)")
+  }
+
+  @Test("Encode does NOT write source field — schema unchanged")
+  func encodeOmitsSourceField() throws {
+    let word = CustomWord(
+      id: UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!,
+      canonical: "Snowflake",
+      aliases: ["snow flake"],
+      category: .brand,
+      priority: 0,
+      forceReplace: false,
+      caseSensitive: false,
+      source: .pack  // runtime-only; should NOT survive encode
+    )
+    let data = try JSONEncoder().encode(word)
+    let serialized = String(data: data, encoding: .utf8) ?? ""
+
+    #expect(!serialized.contains("\"source\""), "Encoded JSON must not include 'source' key")
+    #expect(serialized.contains("\"canonical\":\"Snowflake\""))
+  }
+
+  @Test("Round-trip equality at persisted-field level — source flips to .user")
+  func roundTripEqualityAtPersistedLevel() throws {
+    let original = CustomWord(canonical: "Kubeshark", source: .observedAX)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CustomWord.self, from: data)
+
+    // All persisted fields equal:
+    #expect(decoded.id == original.id)
+    #expect(decoded.canonical == original.canonical)
+    #expect(decoded.aliases == original.aliases)
+    #expect(decoded.category == original.category)
+    #expect(decoded.priority == original.priority)
+    #expect(decoded.forceReplace == original.forceReplace)
+    #expect(decoded.caseSensitive == original.caseSensitive)
+    // Source intentionally flips to .user across the persist boundary
+    // (bible §19 Q12 documented scope reduction):
+    #expect(decoded.source == .user)
+  }
+
+  @Test("Default init param defaults source to .user")
+  func defaultInitSourceIsUser() {
+    let word = CustomWord(canonical: "Test")
+    #expect(word.source == .user)
+  }
+
+  @Test("Explicit source param is honored at construction")
+  func explicitSourceHonored() {
+    let p = CustomWord(canonical: "Pack", source: .pack)
+    let b = CustomWord(canonical: "Builtin", source: .builtin)
+    let o = CustomWord(canonical: "Observed", source: .observedAX)
+    #expect(p.source == .pack)
+    #expect(b.source == .builtin)
+    #expect(o.source == .observedAX)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/ConnectorContractTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ConnectorContractTests.swift
@@ -76,7 +76,7 @@ struct ConnectorContractTests {
       modelID: "gpt-4o-mini",
       appName: "Slack",
       language: nil,
-      customWords: []
+      polishVocabulary: PolishVocabulary(terms: [], generation: 0)
     )
     let plan = DefaultPromptPlanner().plan(input: input)
     let pair = plan.envelope.asSingleTurn()
@@ -95,7 +95,7 @@ struct ConnectorContractTests {
       modelID: "gemini-2.5-flash",
       appName: "Slack",
       language: nil,
-      customWords: []
+      polishVocabulary: PolishVocabulary(terms: [], generation: 0)
     )
     let plan = DefaultPromptPlanner().plan(input: input)
     let pair = plan.envelope.asSingleTurn()

--- a/Tests/EnviousWisprTests/LLM/GeminiPromptBuilderTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GeminiPromptBuilderTests.swift
@@ -21,7 +21,7 @@ struct GeminiPromptBuilderTests {
       modelID: "gemini-2.5-flash",
       appName: appName,
       language: language,
-      customWords: customWords
+      polishVocabulary: PolishVocabulary(terms: customWords, generation: 0)
     )
   }
 

--- a/Tests/EnviousWisprTests/LLM/GemmaPromptBuilderTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GemmaPromptBuilderTests.swift
@@ -21,7 +21,7 @@ struct GemmaPromptBuilderTests {
       modelID: modelID,
       appName: nil,  // Gemma: no appName (eval showed no quality difference)
       language: language,
-      customWords: customWords
+      polishVocabulary: PolishVocabulary(terms: customWords, generation: 0)
     )
   }
 

--- a/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
@@ -51,7 +51,7 @@ struct LanguageAwarePromptInjectionTests {
       modelID: modelID,
       appName: nil,
       language: nil,
-      customWords: customWords,
+      polishVocabulary: PolishVocabulary(terms: customWords, generation: 0),
       focusSnapshot: nil,
       customVocabulary: customVocabulary,
       languageDetection: detection,

--- a/Tests/EnviousWisprTests/LLM/OpenAIPromptBuilderTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIPromptBuilderTests.swift
@@ -21,7 +21,7 @@ struct OpenAIPromptBuilderTests {
       modelID: "gpt-4o-mini",
       appName: appName,
       language: language,
-      customWords: customWords
+      polishVocabulary: PolishVocabulary(terms: customWords, generation: 0)
     )
   }
 
@@ -104,7 +104,7 @@ struct OpenAIPromptBuilderTests {
       modelID: "gpt-4o-mini",
       appName: nil,
       language: nil,
-      customWords: []
+      polishVocabulary: PolishVocabulary(terms: [], generation: 0)
     )
     let envelope = builder.build(input: input, mode: .inline)
     #expect(envelope.messages.count == 2)

--- a/Tests/EnviousWisprTests/LLM/PromptPlannerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/PromptPlannerTests.swift
@@ -21,7 +21,7 @@ struct PromptPlannerTests {
       modelID: modelID,
       appName: appName,
       language: nil,
-      customWords: []
+      polishVocabulary: PolishVocabulary(terms: [], generation: 0)
     )
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/PackToPolishLeakTest.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PackToPolishLeakTest.swift
@@ -1,0 +1,63 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+
+/// Phase 0 (#640) — pins bible §2.2: pack-sourced terms reach `WordCorrector`
+/// only, never the polish prompt. The compile-time half of this guard is that
+/// `PromptBuildInput.polishVocabulary` accepts only `PolishVocabulary`, so a
+/// developer who wants to leak pack terms into polish has to construct a
+/// `PolishVocabulary` from pack terms by hand. This test pins the runtime
+/// half: `LanePartitioner.split` filters pack-sourced terms out of the polish
+/// lane.
+@MainActor
+@Suite("Pack-to-Polish leak prevention — Phase 0 §2.2 pin")
+struct PackToPolishLeakTest {
+
+  @Test("LanePartitioner — pack term reaches corrector lane only")
+  func packTermExcludedFromPolishLane() {
+    let userTerm = CustomWord(canonical: "EnviousWispr", source: .user)
+    let packTerm = CustomWord(canonical: "Snowflake", source: .pack)
+    let observedTerm = CustomWord(canonical: "Kubeshark", source: .observedAX)
+    let builtinTerm = CustomWord(canonical: "MacBook", source: .builtin)
+
+    let split = LanePartitioner.split(
+      [userTerm, packTerm, observedTerm, builtinTerm],
+      generation: 7
+    )
+
+    #expect(split.corrector.terms.count == 4, "All sources reach corrector")
+    #expect(split.corrector.terms.contains(where: { $0.canonical == "Snowflake" }))
+    #expect(split.corrector.generation == 7)
+
+    #expect(split.polish.terms.count == 3, "Pack term excluded from polish")
+    #expect(!split.polish.terms.contains(where: { $0.canonical == "Snowflake" }))
+    #expect(split.polish.terms.contains(where: { $0.canonical == "EnviousWispr" }))
+    #expect(split.polish.terms.contains(where: { $0.canonical == "Kubeshark" }))
+    #expect(split.polish.terms.contains(where: { $0.canonical == "MacBook" }))
+    #expect(split.polish.generation == 7)
+  }
+
+  @Test("LanePartitioner — empty input yields empty lanes with given generation")
+  func emptyInput() {
+    let split = LanePartitioner.split([], generation: 0)
+    #expect(split.corrector.terms.isEmpty)
+    #expect(split.polish.terms.isEmpty)
+    #expect(split.corrector.generation == 0)
+    #expect(split.polish.generation == 0)
+  }
+
+  @Test("LanePartitioner — all-pack input produces empty polish lane")
+  func allPackInput() {
+    let split = LanePartitioner.split(
+      [
+        CustomWord(canonical: "AWS", source: .pack),
+        CustomWord(canonical: "GCP", source: .pack),
+      ],
+      generation: 1
+    )
+    #expect(split.corrector.terms.count == 2)
+    #expect(split.polish.terms.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PasteCompletionEventTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCompletionEventTests.swift
@@ -1,0 +1,107 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// Phase 0 (#640) — pins the paste-complete event seam.
+/// Subscriber registration, weak storage, emission, dead-ref pruning.
+@MainActor
+@Suite("PasteCompletionRegistry — Phase 0 event seam")
+struct PasteCompletionEventTests {
+
+  private final class CapturingObserver: PasteCompletionObserver {
+    var receivedEvents: [PasteCompletionEvent] = []
+    func pasteCompleted(_ event: PasteCompletionEvent) {
+      receivedEvents.append(event)
+    }
+  }
+
+  private final class DeinitFlag: @unchecked Sendable {
+    var fired: Bool = false
+  }
+
+  private final class DeinitProbeObserver: PasteCompletionObserver {
+    let flag: DeinitFlag
+    init(flag: DeinitFlag) { self.flag = flag }
+    nonisolated deinit { flag.fired = true }
+    func pasteCompleted(_ event: PasteCompletionEvent) {}
+  }
+
+  @Test("Subscriber receives emitted events")
+  func subscriberReceivesEvents() {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+
+    let event = PasteCompletionEvent(
+      pastedText: "hello world",
+      destinationBundleID: "com.apple.Notes"
+    )
+    registry.emit(event)
+
+    #expect(observer.receivedEvents.count == 1)
+    #expect(observer.receivedEvents.first?.pastedText == "hello world")
+    #expect(observer.receivedEvents.first?.destinationBundleID == "com.apple.Notes")
+  }
+
+  @Test("Multiple subscribers all receive event")
+  func multipleSubscribers() {
+    let registry = PasteCompletionRegistry()
+    let a = CapturingObserver()
+    let b = CapturingObserver()
+    let c = CapturingObserver()
+    registry.subscribe(a)
+    registry.subscribe(b)
+    registry.subscribe(c)
+
+    registry.emit(PasteCompletionEvent(pastedText: "ping", destinationBundleID: nil))
+
+    #expect(a.receivedEvents.count == 1)
+    #expect(b.receivedEvents.count == 1)
+    #expect(c.receivedEvents.count == 1)
+  }
+
+  @Test("Duplicate subscribe is idempotent")
+  func duplicateSubscribeIdempotent() {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+    registry.subscribe(observer)
+    registry.subscribe(observer)
+
+    registry.emit(PasteCompletionEvent(pastedText: "x", destinationBundleID: nil))
+    #expect(observer.receivedEvents.count == 1, "Same observer must fire once per emit")
+  }
+
+  @Test("Observer stored weakly — deallocated observer pruned")
+  func weakStorageProvenByDeinit() {
+    let registry = PasteCompletionRegistry()
+    let flag = DeinitFlag()
+    autoreleasepool {
+      let probe = DeinitProbeObserver(flag: flag)
+      registry.subscribe(probe)
+      #expect(registry.observerCount == 1)
+    }
+    #expect(flag.fired, "Probe must be deallocated — proves weak storage")
+    #expect(registry.observerCount == 0, "Dead refs pruned on next access")
+  }
+
+  @Test("nil destinationBundleID supported")
+  func nilDestinationBundleID() {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+
+    registry.emit(PasteCompletionEvent(pastedText: "no app", destinationBundleID: nil))
+    #expect(observer.receivedEvents.first?.destinationBundleID == nil)
+  }
+
+  @Test("Timestamp populated on event")
+  func timestampPopulated() {
+    let before = Date()
+    let event = PasteCompletionEvent(pastedText: "t", destinationBundleID: nil)
+    let after = Date()
+
+    #expect(event.timestamp >= before)
+    #expect(event.timestamp <= after)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -182,6 +183,65 @@ struct TranscriptFinalizerTests {
     #expect(
       pasteCount.value == 0,
       "paste must not run when store fails (locks store-before-paste ordering)")
+  }
+
+  // MARK: - Phase 0 (#640) — paste-completion event gating
+
+  private final class CapturingObserver: PasteCompletionObserver {
+    var events: [PasteCompletionEvent] = []
+    func pasteCompleted(_ event: PasteCompletionEvent) {
+      events.append(event)
+    }
+  }
+
+  @Test("PasteCompletionEvent emitted ONCE on .delivered outcome")
+  func pasteCompleteEmitsOnDelivered() async throws {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { _ in Self.deliveredResult() },
+      pasteCompletionRegistry: registry
+    )
+    _ = try await finalizer.finalize(Self.request(asrText: "hello", steps: []))
+    #expect(observer.events.count == 1, "Delivered paste must emit exactly one event")
+    #expect(observer.events.first?.pastedText.contains("hello") == true)
+  }
+
+  @Test("PasteCompletionEvent NOT emitted on .clipboardOnly fallback (Codex P2)")
+  func pasteCompleteSilentOnClipboardOnly() async throws {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { _ in Self.clipboardOnlyResult() },
+      pasteCompletionRegistry: registry
+    )
+    _ = try await finalizer.finalize(Self.request(asrText: "hello", steps: []))
+    #expect(
+      observer.events.isEmpty,
+      "Clipboard-only fallback must not emit — Phase 7 auto-learn would falsely watch a destination where nothing was pasted"
+    )
+  }
+
+  @Test("PasteCompletionEvent NOT emitted on copy-only branch")
+  func pasteCompleteSilentOnCopyOnly() async throws {
+    let registry = PasteCompletionRegistry()
+    let observer = CapturingObserver()
+    registry.subscribe(observer)
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { _ in
+        Issue.record("deliverPaste must not be called on copy-only path")
+        return Self.deliveredResult()
+      },
+      pasteCompletionRegistry: registry
+    )
+    _ = try await finalizer.finalize(
+      Self.request(asrText: "hello", steps: [], autoPaste: false))
+    #expect(observer.events.isEmpty, "Copy-only path must not emit")
   }
 
   // MARK: - Helpers


### PR DESCRIPTION
## Summary

Phase 0 of the Custom Words v2 epic (#633). Bible §6.5.

Splits the single `[CustomWord]` broadcast in `CustomWordsPropagator` into two typed lanes — `CorrectorVocabulary` (built-in + user + pack) and `PolishVocabulary` (built-in + user only — never pack). The polish-side read in `PromptBuildInput` becomes `polishVocabulary: PolishVocabulary`, lifting bible §2.2's pack-distribution law from runtime (Layer 3 golden-string test) to compile-time (Layer 2 type error). A pack-to-prompt leak is now a Swift compile error.

Adds a runtime-only `WordSource` enum + field on `CustomWord` (excluded from `CodingKeys`; on-disk `custom-words.json` schema unchanged byte-for-byte).

Adds `PasteCompletionEvent` + `PasteCompletionRegistry` in `EnviousWisprServices`. The shared registry is owned by `TranscriptPolishService` (no new AppState top-level let — ceiling stays at 19) and threaded into both `TranscriptionPipeline`'s and `WhisperKitPipeline`'s `TranscriptFinalizer.init`. Emits ONLY on dictation auto-paste with a `.delivered` outcome (NOT on clipboard-only fallbacks, copy-only branch, or saved-transcript manual paste). Phase 7 (#629) auto-learn is the first planned subscriber.

## Architecture

| Lane | Type | Consumers (5 broadcast sites) |
|---|---|---|
| Corrector | `CorrectorVocabulary` (built-in + user + pack) | `pipeline.wordCorrection`, `whisperKitPipeline.wordCorrection` |
| Polish    | `PolishVocabulary` (built-in + user only)      | `pipeline.llmPolish`, `whisperKitPipeline.llmPolish`, `polishService.llmPolishStep` |

`AppleIntelligenceConnector` requires zero changes — confirmed by grep 2026-05-05 (bible v1.2 errata e); reads `instructions.systemPrompt` only, not `customWords`.

`AppStateCeilingsTests` green: 19/19 collaborators preserved.

## Codex review trail

- Grounded review of plan: `docs/audits/2026-05-05-phase0-grounded-review.txt` (5,843 lines, PROCEED-WITH-REVISIONS, all 5 revisions applied — registry lifetime, selectionRange dropped, source-field via CodingKeys exclusion, emission-scope table, bible-on-disk).
- Code-diff review pass 1: caught P2 — emit fired on clipboard-only fallbacks. Fix in commit 90d5f71 + 3 new gating tests.
- Code-diff review pass 2 (against the fix): "No discrete, actionable correctness issues were found in the diff relative to main."

## Test plan

- [x] `swift build -c release` exits 0 (89s)
- [x] `scripts/swift-test.sh --filter "PasteCompletionEvent|TranscriptFinalizer|PackToPolishLeak|CustomWordsPropagator|AppStateCeilings|CustomWordSourceMigration"` — 33/33 pass
- [x] AppStateCeilingsTests green (19/19 collaborators)
- [x] Codex code-diff review clean (pass 2)
- [ ] CI build-check
- [ ] CI polish-eval-smoke (triggered automatically by the allowlist; LLMPolishStep + PromptBuildInput on the list)
- [ ] Cold-path heart-path bench — deferred to overnight post-merge run from main worktree (Phase 0 is pure type-wrapping with no algorithmic change to the heart path; cold-path regression risk is structurally near-zero)

## Plan

`docs/feature-requests/issue-640-2026-05-05-vocab-lanes-phase0.md` (gitignored under `docs/`).
