### PR TITLE
feat(custom-words): frequencyUsed + lastUsed schema + Replacement source attribution (#631)

### DIFF
--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -29,6 +29,14 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   /// Runtime origin tag. Excluded from on-disk serialization (see `CodingKeys`).
   /// Decoded values always have `source = .user`.
   public let source: WordSource
+  /// Number of `WordCorrector` applications that replaced into this canonical's
+  /// spelling. Phase 3a (#631) adds the field; Phase 3b ships the writer.
+  /// Pre-Phase-3a entries decode as 0.
+  public var frequencyUsed: Int
+  /// Timestamp of the most recent `WordCorrector` application against this term.
+  /// Phase 3a (#631) adds the field; Phase 3b ships the writer. Pre-Phase-3a
+  /// entries decode as nil.
+  public var lastUsed: Date?
 
   public init(
     id: UUID = UUID(),
@@ -38,7 +46,9 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     priority: Int = 0,
     forceReplace: Bool = false,
     caseSensitive: Bool = false,
-    source: WordSource = .user
+    source: WordSource = .user,
+    frequencyUsed: Int = 0,
+    lastUsed: Date? = nil
   ) {
     self.id = id
     self.canonical = canonical
@@ -48,12 +58,18 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.forceReplace = forceReplace
     self.caseSensitive = caseSensitive
     self.source = source
+    self.frequencyUsed = frequencyUsed
+    self.lastUsed = lastUsed
   }
 
   // `source` deliberately omitted — keeps persisted JSON byte-equivalent to the
-  // pre-Phase-0 schema. Bible §6.5, Codex grounded review 2026-05-05.
+  // pre-Phase-0 schema for the source field. Bible §6.5.
+  // `frequencyUsed` + `lastUsed` ARE persisted (Phase 3a, bible §9.2). Forward-
+  // compatible: older app versions ignore the new keys; backward-compatible:
+  // pre-Phase-3a JSON files decode the new fields via `decodeIfPresent`.
   private enum CodingKeys: String, CodingKey {
     case id, canonical, aliases, category, priority, forceReplace, caseSensitive
+    case frequencyUsed, lastUsed
   }
 
   public init(from decoder: Decoder) throws {
@@ -65,6 +81,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.priority = try c.decodeIfPresent(Int.self, forKey: .priority) ?? 0
     self.forceReplace = try c.decodeIfPresent(Bool.self, forKey: .forceReplace) ?? false
     self.caseSensitive = try c.decodeIfPresent(Bool.self, forKey: .caseSensitive) ?? false
+    self.frequencyUsed = try c.decodeIfPresent(Int.self, forKey: .frequencyUsed) ?? 0
+    self.lastUsed = try c.decodeIfPresent(Date.self, forKey: .lastUsed)
     self.source = .user
   }
 
@@ -77,6 +95,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     try c.encode(priority, forKey: .priority)
     try c.encode(forceReplace, forKey: .forceReplace)
     try c.encode(caseSensitive, forKey: .caseSensitive)
+    try c.encode(frequencyUsed, forKey: .frequencyUsed)
+    try c.encodeIfPresent(lastUsed, forKey: .lastUsed)
     // source intentionally NOT encoded.
   }
 }

--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -7,6 +7,11 @@ import Foundation
 /// Phase 0 (#640) — receives the corrector lane (built-in + user + pack
 /// terms). Adopts `CorrectorVocabularyConsumer` instead of the prior
 /// `CustomWordsConsumer`. Bible §2.2.
+///
+/// Phase 3a (#631) — calls `customWordsManager.recordReplacements(_:)` after
+/// each correction to attribute replacements to source `CustomWord.id`s.
+/// Phase 3b implements the debounced writer; this call is exercised but
+/// inert until then.
 @MainActor
 public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyConsumer {
   public let name = "Word Correction"
@@ -20,12 +25,22 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
 
   public var maxDuration: Duration { .milliseconds(100) }
 
-  public init() {}
+  /// Phase 3a (#631): manager handle for replacement attribution. Optional
+  /// because pre-Phase-3a callers (and tests) construct the step with no
+  /// manager; production wiring (AppState) supplies one.
+  private let customWordsManager: CustomWordsManager?
+
+  public init(customWordsManager: CustomWordsManager? = nil) {
+    self.customWordsManager = customWordsManager
+  }
 
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     let corrector = WordCorrector()
-    let (fixed, count) = corrector.correct(context.text, against: correctorVocabulary.terms)
-    if count > 0 {
+    let (fixed, replacements) = corrector.correct(
+      context.text, against: correctorVocabulary.terms)
+    if !replacements.isEmpty {
+      customWordsManager?.recordReplacements(replacements.map(\.sourceID))
+      let count = replacements.count
       Task {
         await AppLogger.shared.log(
           "WordCorrector applied \(count) correction(s)",

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -164,6 +164,18 @@ public final class CustomWordsManager {
     return mergedWords(file: file)
   }
 
+  /// Phase 3a (#631): no-op stub. Phase 3b implements the debounced writer
+  /// (max 1 disk write per 30s OR 50 increments) that bumps `frequencyUsed`
+  /// and `lastUsed` on each source `CustomWord`. Bible §9.3.
+  ///
+  /// `WordCorrectionStep.process(...)` calls this after each correction with
+  /// the IDs returned by `WordCorrector.correct(...)`. In Phase 3a the call
+  /// site exists and is exercised by tests; the writer side is intentionally
+  /// inert so Phase 4 can ship the redesign without depending on counting.
+  public func recordReplacements(_ ids: [UUID]) {
+    // no-op (Phase 3b)
+  }
+
   public func add(canonical: String, to words: inout [CustomWord]) throws {
     let trimmed = canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -30,18 +30,37 @@ public struct WordCorrector: Sendable {
 
   public init() {}
 
+  // MARK: - Replacement attribution (Phase 3a #631)
+
+  /// Per-replacement attribution: which `CustomWord.id` this replacement
+  /// originated from. Phase 3b consumes the list to bump `frequencyUsed` /
+  /// `lastUsed` on each source. Phase 7 may extend with `pass: Int, span:
+  /// Range<String.Index>` if needed (currently unused per bible §13).
+  public struct Replacement: Sendable, Equatable {
+    public let sourceID: UUID
+    public init(sourceID: UUID) { self.sourceID = sourceID }
+  }
+
   // MARK: - Main Correction
 
   public func correct(_ text: String, against words: [CustomWord]) -> (
-    corrected: String, replacements: Int
+    corrected: String, replacements: [Replacement]
   ) {
-    guard !words.isEmpty else { return (text, 0) }
+    guard !words.isEmpty else { return (text, []) }
 
     // --- Build lookup structures (once per call) ---
 
     var singleAliasMap: [String: String] = [:]
     var multiAliasMap: [String: String] = [:]
     var collisionCount = 0
+    // Phase 3a (#631): lookup map for replacement attribution. Lowercased
+    // canonical → source `CustomWord.id`. Canonicals are unique per
+    // `CustomWordsManager.add(canonical:)` (case-insensitive uniqueness
+    // enforced at line 171-180), so a single-source-per-canonical map is safe.
+    var canonicalToID: [String: UUID] = [:]
+    for word in words {
+      canonicalToID[word.canonical.lowercased()] = word.id
+    }
 
     // 1. Build alias maps with collision detection
     for word in words {
@@ -104,8 +123,16 @@ public struct WordCorrector: Sendable {
 
     // --- Correction passes ---
 
-    var replacements = 0
+    var replacements: [Replacement] = []
     var tokens = text.components(separatedBy: .whitespaces)
+    // Phase 3a (#631) helper: append a Replacement for the given canonical.
+    // Falls through silently if the canonical lookup misses (shouldn't happen
+    // with valid input — defensive only).
+    func appendReplacement(forCanonical canonical: String) {
+      if let id = canonicalToID[canonical.lowercased()] {
+        replacements.append(Replacement(sourceID: id))
+      }
+    }
 
     // Build nospace lookup for Pass 0 (n-gram compound matching)
     // Maps lowercase-nospace canonical -> original canonical
@@ -151,7 +178,7 @@ public struct WordCorrector: Sendable {
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
             let (_, _, lastSuffix) = splitPunctuation(tokens[i + n - 1])
             tokens.replaceSubrange(i..<(i + n), with: [firstPrefix + canonical + lastSuffix])
-            replacements += 1
+            appendReplacement(forCanonical: canonical)
             matched = true
             #if DEBUG
               Self.logger.debug(
@@ -184,7 +211,7 @@ public struct WordCorrector: Sendable {
             let (firstPrefix, _, _) = splitPunctuation(tokens[i])
             let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
             tokens.replaceSubrange(i..<(i + span), with: [firstPrefix + canonical + lastSuffix])
-            replacements += 1
+            appendReplacement(forCanonical: canonical)
             matched = true
             #if DEBUG
               Self.logger.debug(
@@ -228,7 +255,7 @@ public struct WordCorrector: Sendable {
                 let (_, _, lastSuffix) = splitPunctuation(tokens[i + span - 1])
                 tokens.replaceSubrange(
                   i..<(i + span), with: [firstPrefix + bestCanonical + lastSuffix])
-                replacements += 1
+                appendReplacement(forCanonical: bestCanonical)
                 matched = true
                 #if DEBUG
                   Self.logger.debug(
@@ -254,7 +281,7 @@ public struct WordCorrector: Sendable {
 
       // Pass 3: exact single-word alias (includes canonical self-entries)
       if let canonical = singleAliasMap[coreLower], core != canonical {
-        replacements += 1
+        appendReplacement(forCanonical: canonical)
         #if DEBUG
           Self.logger.debug("WordCorrector: type=alias source='\(core)' target='\(canonical)'")
         #endif
@@ -296,7 +323,7 @@ public struct WordCorrector: Sendable {
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch
       {
-        replacements += 1
+        appendReplacement(forCanonical: bestMatch)
         #if DEBUG
           Self.logger.debug(
             "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
@@ -329,7 +356,7 @@ public struct WordCorrector: Sendable {
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch
       {
-        replacements += 1
+        appendReplacement(forCanonical: bestMatch)
         #if DEBUG
           Self.logger.debug(
             "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"

--- a/Tests/EnviousWisprTests/Core/CustomWordSchemaTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordSchemaTests.swift
@@ -1,0 +1,90 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// Phase 3a (#631) — pins schema migration of `frequencyUsed` and `lastUsed`.
+/// Bible §9.2.
+@Suite("CustomWord schema migration — Phase 3a frequency/lastUsed")
+struct CustomWordSchemaTests {
+
+  @Test("Decode pre-Phase-3a JSON (no frequencyUsed/lastUsed) defaults to 0/nil")
+  func decodeOldFormatYieldsDefaults() throws {
+    let json = """
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "canonical": "EnviousWispr",
+        "aliases": ["envious wispr"],
+        "category": "brand",
+        "priority": 0,
+        "forceReplace": false,
+        "caseSensitive": false
+      }
+      """.data(using: .utf8)!
+
+    let word = try JSONDecoder().decode(CustomWord.self, from: json)
+    #expect(word.frequencyUsed == 0, "Missing frequencyUsed defaults to 0")
+    #expect(word.lastUsed == nil, "Missing lastUsed defaults to nil")
+  }
+
+  @Test("Encode writes frequencyUsed always; lastUsed only when present")
+  func encodeWritesNewFields() throws {
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let word = CustomWord(
+      canonical: "Snowflake",
+      frequencyUsed: 42,
+      lastUsed: date
+    )
+    let data = try JSONEncoder().encode(word)
+    let serialized = String(data: data, encoding: .utf8) ?? ""
+
+    #expect(serialized.contains("\"frequencyUsed\":42"))
+    #expect(serialized.contains("\"lastUsed\""))
+  }
+
+  @Test("Encode omits lastUsed when nil")
+  func encodeOmitsNilLastUsed() throws {
+    let word = CustomWord(canonical: "Test", frequencyUsed: 0, lastUsed: nil)
+    let data = try JSONEncoder().encode(word)
+    let serialized = String(data: data, encoding: .utf8) ?? ""
+
+    #expect(!serialized.contains("\"lastUsed\""), "lastUsed nil → key omitted")
+    #expect(serialized.contains("\"frequencyUsed\":0"), "frequencyUsed always written")
+  }
+
+  @Test("Round-trip: encode then decode preserves all persisted fields")
+  func roundTripPreservesPersistedFields() throws {
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let original = CustomWord(
+      id: UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!,
+      canonical: "Kubernetes",
+      aliases: ["k8s", "kuber netties"],
+      category: .brand,
+      priority: 7,
+      forceReplace: true,
+      caseSensitive: true,
+      frequencyUsed: 99,
+      lastUsed: date
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CustomWord.self, from: data)
+
+    #expect(decoded.id == original.id)
+    #expect(decoded.canonical == original.canonical)
+    #expect(decoded.aliases == original.aliases)
+    #expect(decoded.category == original.category)
+    #expect(decoded.priority == original.priority)
+    #expect(decoded.forceReplace == original.forceReplace)
+    #expect(decoded.caseSensitive == original.caseSensitive)
+    #expect(decoded.frequencyUsed == original.frequencyUsed)
+    #expect(decoded.lastUsed == original.lastUsed)
+    // Source flips to .user across persist boundary (Phase 0 §3.6, bible §19 Q12 documented scope reduction)
+    #expect(decoded.source == .user)
+  }
+
+  @Test("Default init has frequencyUsed=0 and lastUsed=nil")
+  func defaultInitDefaults() {
+    let word = CustomWord(canonical: "Default")
+    #expect(word.frequencyUsed == 0)
+    #expect(word.lastUsed == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Core/WordCorrectorReplacementTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordCorrectorReplacementTests.swift
@@ -1,0 +1,73 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// Phase 3a (#631) — pins the new `Replacement` attribution contract.
+/// Each replacement returned by `WordCorrector.correct(...)` must carry the
+/// source `CustomWord.id`. Bible §9.2.
+@Suite("WordCorrector — Replacement source attribution")
+struct WordCorrectorReplacementTests {
+  let corrector = WordCorrector()
+
+  @Test("Single-word alias replacement carries source ID")
+  func singleAliasSourceID() {
+    let chatGPT = CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])
+    let (result, replacements) = corrector.correct("I used chatgpt today", against: [chatGPT])
+    #expect(result == "I used ChatGPT today")
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == chatGPT.id)
+  }
+
+  @Test("Multi-word exact alias carries source ID")
+  func multiWordExactSourceID() {
+    let vsCode = CustomWord(canonical: "Visual Studio Code", aliases: ["vs code"])
+    let (_, replacements) = corrector.correct("I opened vs code", against: [vsCode])
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == vsCode.id)
+  }
+
+  @Test("Multiple replacements each carry their own source ID")
+  func multipleReplacementsEachAttributed() {
+    let chatGPT = CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])
+    let openAI = CustomWord(canonical: "OpenAI", aliases: ["openai"])
+    let (_, replacements) = corrector.correct(
+      "openai made chatgpt", against: [chatGPT, openAI])
+    #expect(replacements.count == 2)
+    let sourceIDs = Set(replacements.map(\.sourceID))
+    #expect(sourceIDs.contains(chatGPT.id))
+    #expect(sourceIDs.contains(openAI.id))
+  }
+
+  @Test("Canonical self-entry casing fix carries source ID")
+  func canonicalSelfEntrySourceID() {
+    let iPhone = CustomWord(canonical: "iPhone")
+    let (_, replacements) = corrector.correct("I have an iphone", against: [iPhone])
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == iPhone.id)
+  }
+
+  @Test("Fuzzy canonical fallback carries source ID")
+  func fuzzyCanonicalFallbackSourceID() {
+    let kubernetes = CustomWord(canonical: "Kubernetes")
+    let (_, replacements) = corrector.correct("deployed to kuberntes", against: [kubernetes])
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == kubernetes.id)
+  }
+
+  @Test("No match returns empty replacements list")
+  func noMatchEmptyReplacements() {
+    let kubernetes = CustomWord(canonical: "Kubernetes")
+    let (result, replacements) = corrector.correct("I like bananas", against: [kubernetes])
+    #expect(result == "I like bananas")
+    #expect(replacements.isEmpty)
+  }
+
+  @Test("Empty word list returns empty replacements list")
+  func emptyWordListEmptyReplacements() {
+    let (result, replacements) = corrector.correct("hello", against: [])
+    #expect(result == "hello")
+    #expect(replacements.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/EnviousWisprTests.swift
+++ b/Tests/EnviousWisprTests/EnviousWisprTests.swift
@@ -126,9 +126,9 @@ struct WordCorrectorTests {
   @Test("exact multi-word alias replacement")
   func exactMultiWord() {
     let words = [CustomWord(canonical: "Visual Studio Code", aliases: ["vs code"])]
-    let (result, count) = corrector.correct("I opened vs code", against: words)
+    let (result, replacements) = corrector.correct("I opened vs code", against: words)
     #expect(result == "I opened Visual Studio Code")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   // MARK: - Pass 3: Exact single-word alias
@@ -136,33 +136,33 @@ struct WordCorrectorTests {
   @Test("exact alias match corrects casing")
   func exactAliasMatch() {
     let words = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
-    let (result, count) = corrector.correct("I used chatgpt today", against: words)
+    let (result, replacements) = corrector.correct("I used chatgpt today", against: words)
     #expect(result == "I used ChatGPT today")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("canonical self-entry fixes casing")
   func canonicalSelfEntry() {
     let words = [CustomWord(canonical: "iPhone")]
-    let (result, count) = corrector.correct("I have an iphone", against: words)
+    let (result, replacements) = corrector.correct("I have an iphone", against: words)
     #expect(result == "I have an iPhone")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("short token exact alias")
   func shortTokenExactAlias() {
     let words = [CustomWord(canonical: "API", aliases: ["api"])]
-    let (result, count) = corrector.correct("the api is fast", against: words)
+    let (result, replacements) = corrector.correct("the api is fast", against: words)
     #expect(result == "the API is fast")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("already correct text unchanged")
   func alreadyCorrect() {
     let words = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
-    let (result, count) = corrector.correct("I used ChatGPT today", against: words)
+    let (result, replacements) = corrector.correct("I used ChatGPT today", against: words)
     #expect(result == "I used ChatGPT today")
-    #expect(count == 0)
+    #expect(replacements.count == 0)
   }
 
   // MARK: - Pass 4: Fuzzy single-word against aliases
@@ -171,9 +171,9 @@ struct WordCorrectorTests {
   func fuzzyAliasMatch() {
     // "kuberntes" is NOT in the alias list but close to canonical self-entry "kubernetes"
     let words = [CustomWord(canonical: "Kubernetes", aliases: ["k8s"])]
-    let (result, count) = corrector.correct("deployed to kuberntes", against: words)
+    let (result, replacements) = corrector.correct("deployed to kuberntes", against: words)
     #expect(result == "deployed to Kubernetes")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   // MARK: - Pass 5: Fuzzy canonical fallback
@@ -181,9 +181,9 @@ struct WordCorrectorTests {
   @Test("fuzzy canonical fallback for words with no aliases")
   func fuzzyCanonicalFallback() {
     let words = [CustomWord(canonical: "Kubernetes")]
-    let (result, count) = corrector.correct("deployed to kuberntes", against: words)
+    let (result, replacements) = corrector.correct("deployed to kuberntes", against: words)
     #expect(result == "deployed to Kubernetes")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   // MARK: - Guards and edge cases
@@ -191,25 +191,25 @@ struct WordCorrectorTests {
   @Test("empty word list returns unchanged text")
   func emptyWordList() {
     let empty: [CustomWord] = []
-    let (result, count) = corrector.correct("hello world", against: empty)
+    let (result, replacements) = corrector.correct("hello world", against: empty)
     #expect(result == "hello world")
-    #expect(count == 0)
+    #expect(replacements.count == 0)
   }
 
   @Test("no match when input is too different")
   func noFuzzyMatchWhenTooFar() {
     let words = [CustomWord(canonical: "Kubernetes")]
-    let (result, count) = corrector.correct("I like bananas", against: words)
+    let (result, replacements) = corrector.correct("I like bananas", against: words)
     #expect(result == "I like bananas")
-    #expect(count == 0)
+    #expect(replacements.count == 0)
   }
 
   @Test("preserves surrounding punctuation")
   func preservesPunctuation() {
     let words = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
-    let (result, count) = corrector.correct("I used chatgpt, and it worked!", against: words)
+    let (result, replacements) = corrector.correct("I used chatgpt, and it worked!", against: words)
     #expect(result == "I used ChatGPT, and it worked!")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("multiple replacements in one pass")
@@ -218,9 +218,9 @@ struct WordCorrectorTests {
       CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"]),
       CustomWord(canonical: "OpenAI", aliases: ["openai"]),
     ]
-    let (result, count) = corrector.correct("openai made chatgpt", against: words)
+    let (result, replacements) = corrector.correct("openai made chatgpt", against: words)
     #expect(result == "OpenAI made ChatGPT")
-    #expect(count == 2)
+    #expect(replacements.count == 2)
   }
 
   // MARK: - Scoring primitives
@@ -256,44 +256,45 @@ struct WordCorrectorTests {
   @Test("n-gram compound fixes casing: chat gpt -> ChatGPT")
   func ngramCompoundCasingFix() {
     let words = [CustomWord(canonical: "ChatGPT")]
-    let (result, count) = corrector.correct("I used chat gpt today", against: words)
+    let (result, replacements) = corrector.correct("I used chat gpt today", against: words)
     #expect(result == "I used ChatGPT today")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("n-gram compound: open a i -> OpenAI (3 tokens, max window)")
   func ngramCompoundOpenAI() {
     let words = [CustomWord(canonical: "OpenAI")]
-    let (result, count) = corrector.correct("open a i is great", against: words)
+    let (result, replacements) = corrector.correct("open a i is great", against: words)
     #expect(result == "OpenAI is great")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("n-gram already correct casing not replaced")
   func ngramAlreadyCorrect() {
     // When raw concat matches canonical nospace (case-sensitive), no replacement
     let words = [CustomWord(canonical: "ChatGPT")]
-    let (result, count) = corrector.correct("I used ChatGPT today", against: words)
+    let (result, replacements) = corrector.correct("I used ChatGPT today", against: words)
     #expect(result == "I used ChatGPT today")
-    #expect(count == 0)
+    #expect(replacements.count == 0)
   }
 
   @Test("n-gram compound preserves surrounding punctuation")
   func ngramPreservesPunctuation() {
     let words = [CustomWord(canonical: "ChatGPT")]
-    let (result, count) = corrector.correct("I used chat gpt, and it worked!", against: words)
+    let (result, replacements) = corrector.correct(
+      "I used chat gpt, and it worked!", against: words)
     #expect(result == "I used ChatGPT, and it worked!")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   @Test("n-gram single token casing fix")
   func ngramSingleTokenCasingFix() {
     // N-gram pass also handles n=1 for single-token compound words
     let words = [CustomWord(canonical: "ChatGPT")]
-    let (result, count) = corrector.correct("I used chatgpt", against: words)
+    let (result, replacements) = corrector.correct("I used chatgpt", against: words)
     // Single token "chatgpt" matches nospace "chatgpt" -> "ChatGPT"
     #expect(result == "I used ChatGPT")
-    #expect(count == 1)
+    #expect(replacements.count == 1)
   }
 
   // MARK: - Threshold boundaries
@@ -303,9 +304,9 @@ struct WordCorrectorTests {
     // "api" (3 chars) vs "apt" -- should NOT correct because it's a short token
     // and the score won't meet the 0.90 short token threshold
     let words = [CustomWord(canonical: "API")]
-    let (result, count) = corrector.correct("use apt to install", against: words)
+    let (result, replacements) = corrector.correct("use apt to install", against: words)
     #expect(result == "use apt to install")
-    #expect(count == 0)
+    #expect(replacements.count == 0)
   }
 
   @Test("ambiguity margin prevents correction when two candidates are close")


### PR DESCRIPTION
## Summary

Phase 3a of the Custom Words v2 epic (#633). Bible §9.

Adds `frequencyUsed: Int` and `lastUsed: Date?` fields to `CustomWord` (persisted, `decodeIfPresent` for migration). Changes `WordCorrector.correct(...)` return type from `Int` to `[Replacement]` where each `Replacement` carries the source `CustomWord.id`. Adds a no-op `CustomWordsManager.recordReplacements(_ ids: [UUID])` stub that Phase 3b implements. `WordCorrectionStep` calls the stub after every correction.

Phase 4 (#634) consumes `frequencyUsed` to render "used N times". Phase 3b implements the debounced writer (max 1 disk write per 30s OR 50 increments).

## Schema invariance

Pre-Phase-3a `custom-words.json` files decode the new fields with defaults (0 / nil). Encoder writes `frequencyUsed` always; `lastUsed` only when non-nil. Older app versions ignore unknown keys (forward-compat).

## CTO scope reduction

Bible §9.2 over-spec'd `Replacement` with `pass: Int, span: Range<String.Index>` — Phase 7 (#629) doesn't consume those fields per bible §13. Phase 3a ships `Replacement` with `sourceID: UUID` only. Bible v1.3 will note the drop.

## Test plan

- [x] swift build -c release exits 0
- [x] 52 tests pass (40 existing+migrated + 12 new)
  - CustomWordSchemaTests (5 new) — schema migration, encode/decode, round-trip
  - WordCorrectorReplacementTests (7 new) — sourceID correctness for all 6 replacement passes
  - 10 EnviousWisprTests destructuring sites migrated from count to replacements.count
- [ ] CI build-check
- [ ] CI polish-eval-smoke (LLMPolishStep is on the allowlist; PromptBuildInput is too — Phase 3a does not change polish behavior so zero baseline drift expected)
- [ ] Codex code-diff review (Codex rate-limited until ~02:57 AM local; will run + apply any findings before merge)

Auto-merge intentionally NOT set on this PR until Codex returns clean.

## Plan

docs/feature-requests/issue-631-2026-05-05-phase-3a-frequency-schema.md (gitignored under docs/).
