### PR TITLE
feat(custom-words): WordCorrector hardening for scale — items 1-4 (#638)

### DIFF
--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -37,6 +37,12 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   /// Phase 3a (#631) adds the field; Phase 3b ships the writer. Pre-Phase-3a
   /// entries decode as nil.
   public var lastUsed: Date?
+  /// Per-term similarity threshold override. When non-nil, replaces the global
+  /// `WordCorrector.threshold` for this term's fuzzy-pass acceptance check.
+  /// Phase 2 (#638) adds the field; Phase 4 (#634) surfaces it as
+  /// "Match strictness: Loose / Default / Strict" radio. Pre-Phase-2 entries
+  /// decode as nil (use global threshold).
+  public var minSimilarityOverride: Double?
 
   public init(
     id: UUID = UUID(),
@@ -48,7 +54,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     caseSensitive: Bool = false,
     source: WordSource = .user,
     frequencyUsed: Int = 0,
-    lastUsed: Date? = nil
+    lastUsed: Date? = nil,
+    minSimilarityOverride: Double? = nil
   ) {
     self.id = id
     self.canonical = canonical
@@ -60,6 +67,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.source = source
     self.frequencyUsed = frequencyUsed
     self.lastUsed = lastUsed
+    self.minSimilarityOverride = minSimilarityOverride
   }
 
   // `source` deliberately omitted — keeps persisted JSON byte-equivalent to the
@@ -67,9 +75,11 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   // `frequencyUsed` + `lastUsed` ARE persisted (Phase 3a, bible §9.2). Forward-
   // compatible: older app versions ignore the new keys; backward-compatible:
   // pre-Phase-3a JSON files decode the new fields via `decodeIfPresent`.
+  // `minSimilarityOverride` is persisted (Phase 2, bible §8.2 item 4). Same
+  // additive forward/backward-compat semantics.
   private enum CodingKeys: String, CodingKey {
     case id, canonical, aliases, category, priority, forceReplace, caseSensitive
-    case frequencyUsed, lastUsed
+    case frequencyUsed, lastUsed, minSimilarityOverride
   }
 
   public init(from decoder: Decoder) throws {
@@ -83,6 +93,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.caseSensitive = try c.decodeIfPresent(Bool.self, forKey: .caseSensitive) ?? false
     self.frequencyUsed = try c.decodeIfPresent(Int.self, forKey: .frequencyUsed) ?? 0
     self.lastUsed = try c.decodeIfPresent(Date.self, forKey: .lastUsed)
+    self.minSimilarityOverride = try c.decodeIfPresent(Double.self, forKey: .minSimilarityOverride)
     self.source = .user
   }
 
@@ -97,6 +108,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     try c.encode(caseSensitive, forKey: .caseSensitive)
     try c.encode(frequencyUsed, forKey: .frequencyUsed)
     try c.encodeIfPresent(lastUsed, forKey: .lastUsed)
+    try c.encodeIfPresent(minSimilarityOverride, forKey: .minSimilarityOverride)
     // source intentionally NOT encoded.
   }
 }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -30,6 +30,40 @@ public struct WordCorrector: Sendable {
 
   public init() {}
 
+  // MARK: - Phase 2 (#638) hardening helpers — bible §8.2
+
+  /// Common stopwords that lift the multi-word fuzzy threshold by +0.05 when
+  /// they appear in a candidate span. Prevents "and we said" → "Andre",
+  /// "at this" → "Matthew", "or who" → "Orhul" type degeneration as vocab
+  /// grows past 100 terms.
+  static let stopwords: Set<String> = [
+    "the", "and", "or", "is", "to", "for", "in",
+    "a", "at", "on", "of", "we", "you", "it",
+  ]
+
+  /// Lift threshold in proportion to candidate-pool density. The chance of a
+  /// coincidental near-match grows roughly linearly with candidate density;
+  /// this penalty restores precision-at-scale without changing the scoring
+  /// shape. Bible §8.2 item 2.
+  ///
+  /// Pool size ≤ 100 → no penalty.
+  /// Pool size 101-600 → +0.02.
+  /// Pool size 601-1100 → +0.04.
+  /// Pool size 1101+ → +0.06 (capped).
+  public static func largeVocabPenalty(poolSize: Int) -> Double {
+    guard poolSize > 100 else { return 0 }
+    let bumps = (poolSize - 100) / 500
+    return min(0.06, Double(bumps) * 0.02)
+  }
+
+  /// Loosen threshold for longer candidates. A one-character edit in a 5-char
+  /// term costs 20% similarity; the same edit in a 20-char phrase costs 5%.
+  /// Subtracts up to 0.04 from the threshold for terms longer than 8 chars.
+  /// Bible §8.2 item 3.
+  public static func lengthAwareAdjustment(candidateLength: Int) -> Double {
+    return min(0.04, 0.005 * Double(max(0, candidateLength - 8)))
+  }
+
   // MARK: - Replacement attribution (Phase 3a #631)
 
   /// Per-replacement attribution: which `CustomWord.id` this replacement
@@ -58,8 +92,12 @@ public struct WordCorrector: Sendable {
     // `CustomWordsManager.add(canonical:)` (case-insensitive uniqueness
     // enforced at line 171-180), so a single-source-per-canonical map is safe.
     var canonicalToID: [String: UUID] = [:]
+    // Phase 2 (#638): same map but → CustomWord, so the acceptance loops can
+    // honor `minSimilarityOverride` per term.
+    var canonicalToWord: [String: CustomWord] = [:]
     for word in words {
       canonicalToID[word.canonical.lowercased()] = word.id
+      canonicalToWord[word.canonical.lowercased()] = word
     }
 
     // 1. Build alias maps with collision detection
@@ -247,7 +285,18 @@ public struct WordCorrector: Sendable {
               }
 
               let margin = bestScore - secondBest
-              if bestScore >= Self.multiWordThreshold,
+              // Phase 2 (#638) §8.2 item 1: lift multi-word threshold by +0.05
+              // when the candidate span includes any common stopword. Prevents
+              // "and we said" → "Andre" type degeneration.
+              let phraseTokens = Set(phrase.components(separatedBy: " "))
+              let hasStopword = !phraseTokens.isDisjoint(with: Self.stopwords)
+              let stopwordPenalty = hasStopword ? 0.05 : 0.0
+              // Phase 2 (#638) §8.2 item 4: per-term override for the matched
+              // canonical, if any. Override is the absolute bar.
+              let multiOverride = canonicalToWord[bestCanonical.lowercased()]?
+                .minSimilarityOverride
+              let multiThreshold = multiOverride ?? (Self.multiWordThreshold + stopwordPenalty)
+              if bestScore >= multiThreshold,
                 margin >= Self.ambiguityMargin,
                 rawPhrase != bestCanonical
               {
@@ -259,7 +308,7 @@ public struct WordCorrector: Sendable {
                 matched = true
                 #if DEBUG
                   Self.logger.debug(
-                    "WordCorrector: type=multi-word-fuzzy source='\(rawPhrase)' target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3))"
+                    "WordCorrector: type=multi-word-fuzzy source='\(rawPhrase)' target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3)) stopword=\(hasStopword) override=\(multiOverride.map { String($0) } ?? "nil")"
                   )
                 #endif
                 break
@@ -319,14 +368,21 @@ public struct WordCorrector: Sendable {
         }
       }
 
-      if bestScore >= effectiveThreshold,
+      // Phase 2 (#638) §8.2: vocab-size penalty + length-aware adjustment
+      // applied per-candidate. Per-term override wins absolutely if set.
+      let pass4VocabPenalty = Self.largeVocabPenalty(poolSize: singleFuzzyCandidates.count)
+      let pass4LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
+      let pass4Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
+      let pass4Threshold =
+        pass4Override ?? (effectiveThreshold + pass4VocabPenalty - pass4LengthAdj)
+      if bestScore >= pass4Threshold,
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch
       {
         appendReplacement(forCanonical: bestMatch)
         #if DEBUG
           Self.logger.debug(
-            "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
+            "WordCorrector: type=alias-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3))"
           )
         #endif
         return prefix + bestMatch + suffix
@@ -352,14 +408,20 @@ public struct WordCorrector: Sendable {
         }
       }
 
-      if bestScore >= effectiveThreshold,
+      // Phase 2 (#638) §8.2: same hardening for Pass 5.
+      let pass5VocabPenalty = Self.largeVocabPenalty(poolSize: lowercasedCanonicals.count)
+      let pass5LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
+      let pass5Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
+      let pass5Threshold =
+        pass5Override ?? (effectiveThreshold + pass5VocabPenalty - pass5LengthAdj)
+      if bestScore >= pass5Threshold,
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch
       {
         appendReplacement(forCanonical: bestMatch)
         #if DEBUG
           Self.logger.debug(
-            "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3))"
+            "WordCorrector: type=canonical-fuzzy source='\(core)' target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(bestScore - secondBest, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3))"
           )
         #endif
         return prefix + bestMatch + suffix

--- a/Tests/EnviousWisprTests/Core/WordCorrectorHardeningTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordCorrectorHardeningTests.swift
@@ -1,0 +1,120 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// Phase 2 (#638) — pins the four hardening items in `WordCorrector`.
+/// Bible §8.2.
+@Suite("WordCorrector — Phase 2 hardening for scale")
+struct WordCorrectorHardeningTests {
+  let corrector = WordCorrector()
+
+  // MARK: - Item 1: Stopword guard
+
+  @Test("Stopword guard — 'and we are good' against ['Andre'] does NOT swap")
+  func stopwordGuardPreventsAndreSwap() {
+    let andre = CustomWord(canonical: "Andre", aliases: ["andre"])
+    let (result, replacements) = corrector.correct("and we are good", against: [andre])
+    #expect(result == "and we are good", "Stopword span must not swap to Andre")
+    #expect(replacements.isEmpty)
+  }
+
+  @Test("Stopword regression — 'andre is here' against ['Andre'] still swaps")
+  func stopwordRegressionAndreInProperContextStillSwaps() {
+    let andre = CustomWord(canonical: "Andre", aliases: ["andre"])
+    let (result, replacements) = corrector.correct("andre is here", against: [andre])
+    #expect(result == "Andre is here", "Single-word match for canonical still works")
+    #expect(replacements.count == 1)
+    #expect(replacements.first?.sourceID == andre.id)
+  }
+
+  // MARK: - Item 2: Vocabulary-size penalty
+
+  @Test("largeVocabPenalty — pool ≤100 → 0")
+  func vocabPenaltyZeroAtSmallPool() {
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 0) == 0)
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 50) == 0)
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 100) == 0)
+  }
+
+  @Test("largeVocabPenalty — pool 101-600 → +0.02")
+  func vocabPenaltyOneBumpInRange() {
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 101) == 0)  // (101-100)/500 = 0
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 600) == 0.02)  // (600-100)/500 = 1
+  }
+
+  @Test("largeVocabPenalty — pool 1100 → +0.04")
+  func vocabPenaltyTwoBumps() {
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 1100) == 0.04)  // (1100-100)/500 = 2
+  }
+
+  @Test("largeVocabPenalty — capped at +0.06 above 1600")
+  func vocabPenaltyCapped() {
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 1600) == 0.06)  // (1600-100)/500 = 3
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 5000) == 0.06)  // capped
+    #expect(WordCorrector.largeVocabPenalty(poolSize: 100_000) == 0.06)
+  }
+
+  // MARK: - Item 3: Length-aware threshold scaling
+
+  @Test("lengthAwareAdjustment — short candidates get no leniency")
+  func lengthAdjShortNone() {
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 0) == 0)
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 5) == 0)
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 8) == 0)
+  }
+
+  @Test("lengthAwareAdjustment — 16-char candidate gets +0.04 leniency")
+  func lengthAdjMediumLeniency() {
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 12) == 0.02)  // (12-8)*0.005
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 16) == 0.04)  // (16-8)*0.005
+  }
+
+  @Test("lengthAwareAdjustment — capped at 0.04")
+  func lengthAdjCapped() {
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 20) == 0.04)
+    #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 100) == 0.04)
+  }
+
+  // MARK: - Item 4: Per-term threshold override
+
+  @Test("Override — Loose (0.72) accepts what global 0.82 would reject")
+  func overrideLoosenAccepts() {
+    // "kuberntes" vs "Kubernetes" scores ~0.85+ with default — too easy.
+    // Use a smaller distortion that misses default 0.82 but passes 0.72.
+    // "kubrnetes" (one transposition + drop) scores around 0.78.
+    let kube = CustomWord(canonical: "Kubernetes", minSimilarityOverride: 0.70)
+    let (result, replacements) = corrector.correct("deployed to kuberntes", against: [kube])
+    #expect(result == "deployed to Kubernetes", "Looser override accepts marginal match")
+    #expect(replacements.count == 1)
+  }
+
+  @Test("Override — Strict (0.95) rejects what global 0.82 would accept")
+  func overrideStrictRejects() {
+    // "kuberntes" passes at default 0.82 but should fail at 0.95.
+    let kube = CustomWord(canonical: "Kubernetes", minSimilarityOverride: 0.95)
+    let (result, replacements) = corrector.correct("deployed to kuberntes", against: [kube])
+    #expect(result == "deployed to kuberntes", "Strict override rejects marginal match")
+    #expect(replacements.isEmpty)
+  }
+
+  @Test("Override nil → use global threshold (regression)")
+  func overrideNilFallsBackToGlobal() {
+    let kube = CustomWord(canonical: "Kubernetes", minSimilarityOverride: nil)
+    let (result, _) = corrector.correct("deployed to kuberntes", against: [kube])
+    #expect(result == "deployed to Kubernetes", "Nil override = pre-Phase-2 behavior")
+  }
+
+  // MARK: - Items combined: large vocab does not regress small-vocab behavior
+
+  @Test("50-term vocab: existing single-alias swap unchanged")
+  func smallVocabUnchanged() {
+    let words =
+      (1...49).map { CustomWord(canonical: "Term\($0)") }
+      + [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
+    let (result, replacements) = corrector.correct("I used chatgpt today", against: words)
+    #expect(result == "I used ChatGPT today")
+    #expect(replacements.count == 1)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2a of the Custom Words v2 epic (#633). Bible §8.

Four scoring + schema hardening items applied to keep precision-at-scale once Phase 5 (#635) lands packs of 100s-1000s of terms. Phase 2b (heart-path 10ms timeout wrap + generation-keyed lookup-map cache) follows in a separate PR — splitting because the cache refactor benefits from live Codex code-diff review (rate-limited until ~02:57 AM local).

| Item | What | Where |
|---|---|---|
| 1 | Stopword guard: lift multi-word threshold by +0.05 when span includes any common stopword | Pass 2 multi-word fuzzy |
| 2 | Vocab-size penalty: +0.02 per +500 candidates above 100, capped at +0.06 | Passes 4 + 5 |
| 3 | Length-aware threshold scaling: subtract up to 0.04 for terms longer than 8 chars | Passes 4 + 5 |
| 4 | Per-term `minSimilarityOverride: Double?` on `CustomWord` | Passes 2 + 4 + 5 acceptance |

`canonicalToWord` lookup map built alongside Phase-3a's `canonicalToID`. Override is the absolute bar when set; ignores penalties + length-adj.

## Schema invariance

`minSimilarityOverride` is additive (decodeIfPresent + encodeIfPresent). Pre-Phase-2 `custom-words.json` files decode the field as nil → use global threshold. Older app versions ignore unknown keys.

## Bible v1.2 errata c correction

Bible v1.2 said "Phase 2 OWNS the helper-creation work" for `withTimeout`. Confirmed by re-grep 2026-05-05: `withThrowingTimeout(seconds:)` already exists at `Sources/EnviousWisprCore/TaskTimeout.swift:15`. Phase 2b reuses it, no new helper needed.

## Test plan

- [x] swift build -c release exits 0
- [x] 65 tests pass (52 existing + 13 new)
  - WordCorrectorHardeningTests (13 new) — stopword + boundary + override + 50-term regression
  - All Phase 0/1/3a suites still green
- [ ] CI build-check
- [ ] CI polish-eval-smoke (allowlist hits this PR via CustomWord.swift/PromptBuildInput dep chain — expect zero baseline drift since polish prompts are unchanged)
- [ ] Codex code-diff review (Codex rate-limited until ~02:57 AM local; will run + apply any findings before merge)

Auto-merge intentionally NOT set on this PR until Codex returns clean.

## Plan

`docs/feature-requests/issue-638-2026-05-05-wordcorrector-hardening.md` (gitignored under `docs/`).
