### PR TITLE
perf(custom-words): WordCorrector lookup-map cache + heart-path 10ms timeout (#638 Phase 2b)

### DIFF
--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -1,5 +1,6 @@
 import EnviousWisprCore
 import EnviousWisprPostProcessing
+import EnviousWisprServices
 import Foundation
 
 /// Applies custom word corrections to ASR output.
@@ -12,17 +13,35 @@ import Foundation
 /// each correction to attribute replacements to source `CustomWord.id`s.
 /// Phase 3b implements the debounced writer; this call is exercised but
 /// inert until then.
+///
+/// Phase 2b (#638) — heart-path 10ms hard cap on `WordCorrector.correct(...)`
+/// invocation (bible §2.2.1) + generation-keyed cache of the lookup maps so
+/// they are rebuilt only when the vocabulary generation changes (bible §17
+/// R19). The correction runs OFF MainActor inside the timeout closure so
+/// the timer task can preempt; on timeout we return the raw text and emit a
+/// Sentry breadcrumb (no escalation).
 @MainActor
 public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyConsumer {
   public let name = "Word Correction"
 
   public var wordCorrectionEnabled: Bool = false
-  public var correctorVocabulary: CorrectorVocabulary = .empty
+  public var correctorVocabulary: CorrectorVocabulary = .empty {
+    didSet {
+      // Phase 2b (#638): invalidate the lookup-map cache when the vocabulary
+      // generation changes. Same generation → reuse cached lookups.
+      if oldValue.generation != correctorVocabulary.generation {
+        cachedLookups = nil
+      }
+    }
+  }
 
   public var isEnabled: Bool {
     wordCorrectionEnabled && !correctorVocabulary.terms.isEmpty
   }
 
+  /// Outer runner cap (unchanged). Phase 2b adds a tighter inner 10ms cap
+  /// that fires before this would, protecting the heart path from runaway
+  /// matcher cost on pathological vocab + transcript combinations.
   public var maxDuration: Duration { .milliseconds(100) }
 
   /// Phase 3a (#631): manager handle for replacement attribution. Optional
@@ -30,14 +49,44 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
   /// manager; production wiring (AppState) supplies one.
   private let customWordsManager: CustomWordsManager?
 
+  /// Phase 2b (#638): cached lookup maps keyed by `CorrectorVocabulary.generation`.
+  /// `WordCorrector.buildLookups(...)` is the only producer; `correct(_:using:)`
+  /// is the only consumer. Cache invalidates in the `correctorVocabulary`
+  /// setter when generation changes.
+  private struct CachedLookups {
+    let generation: UInt64
+    let lookups: WordCorrector.Lookups
+  }
+  private var cachedLookups: CachedLookups?
+
   public init(customWordsManager: CustomWordsManager? = nil) {
     self.customWordsManager = customWordsManager
   }
 
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
-    let corrector = WordCorrector()
-    let (fixed, replacements) = corrector.correct(
-      context.text, against: correctorVocabulary.terms)
+    let snapshot = correctorVocabulary
+    let lookups = ensureLookups(for: snapshot)
+
+    let inputText = context.text
+    let result: (corrected: String, replacements: [WordCorrector.Replacement])
+    do {
+      // Phase 2b (#638) bible §2.2.1: hard 10ms cap. WordCorrector.correct is
+      // pure CPU work; we run it OFF MainActor inside the timeout closure so
+      // the timer Task can preempt. On timeout, raw text passes through.
+      result = try await withThrowingTimeout(seconds: 0.010) {
+        let corrector = WordCorrector()
+        return corrector.correct(inputText, using: lookups)
+      }
+    } catch is TimeoutError {
+      SentryBreadcrumb.add(
+        stage: "wordcorrector",
+        message: "WordCorrector timeout (10ms cap exceeded)",
+        data: ["vocab_size": String(snapshot.terms.count)]
+      )
+      return context  // raw text passes through; heart path unaffected
+    }
+
+    let (fixed, replacements) = result
     if !replacements.isEmpty {
       customWordsManager?.recordReplacements(replacements.map(\.sourceID))
       let count = replacements.count
@@ -52,4 +101,23 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
     ctx.text = fixed
     return ctx
   }
+
+  /// Returns the cached lookups for `vocab` if the cache is fresh, otherwise
+  /// rebuilds and stores them. Test seam: `lookupCacheHits` /
+  /// `lookupCacheBuilds` expose effectiveness for the cache test.
+  private func ensureLookups(for vocab: CorrectorVocabulary) -> WordCorrector.Lookups {
+    if let cache = cachedLookups, cache.generation == vocab.generation {
+      lookupCacheHits += 1
+      return cache.lookups
+    }
+    let lookups = WordCorrector.buildLookups(words: vocab.terms)
+    cachedLookups = CachedLookups(generation: vocab.generation, lookups: lookups)
+    lookupCacheBuilds += 1
+    return lookups
+  }
+
+  /// Phase 2b (#638) test-only: counts cache hits across `process(...)` calls.
+  package internal(set) var lookupCacheHits: Int = 0
+  /// Phase 2b (#638) test-only: counts cache builds across `process(...)` calls.
+  package internal(set) var lookupCacheBuilds: Int = 0
 }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -64,43 +64,49 @@ public struct WordCorrector: Sendable {
     return min(0.04, 0.005 * Double(max(0, candidateLength - 8)))
   }
 
-  // MARK: - Replacement attribution (Phase 3a #631)
+  // MARK: - Phase 2b (#638) lookup-map cache
 
-  /// Per-replacement attribution: which `CustomWord.id` this replacement
-  /// originated from. Phase 3b consumes the list to bump `frequencyUsed` /
-  /// `lastUsed` on each source. Phase 7 may extend with `pass: Int, span:
-  /// Range<String.Index>` if needed (currently unused per bible §13).
-  public struct Replacement: Sendable, Equatable {
-    public let sourceID: UUID
-    public init(sourceID: UUID) { self.sourceID = sourceID }
+  /// Pre-built lookup structures for one `WordCorrector.correct(...)` call.
+  /// Phase 2b (#638) extracts what was previously rebuilt on every call so
+  /// `WordCorrectionStep` can cache it across calls of the same vocabulary
+  /// generation. Bible §17 R19 (matcher rebuild risk).
+  ///
+  /// Sendable so callers can hop the value across actors (e.g. running
+  /// `correct(...)` off MainActor inside the heart-path 10ms timeout).
+  public struct Lookups: Sendable {
+    public struct SurfaceCanonical: Sendable {
+      public let surface: String
+      public let canonical: String
+    }
+    public struct AliasCanonical: Sendable {
+      public let alias: String
+      public let canonical: String
+    }
+    public let singleAliasMap: [String: String]
+    public let multiAliasMap: [String: String]
+    public let nospaceCanonicalMap: [String: String]
+    public let canonicalToID: [String: UUID]
+    public let canonicalToWord: [String: CustomWord]
+    public let canonicals: [String]
+    public let lowercasedCanonicals: [String]
+    public let singleFuzzyCandidates: [SurfaceCanonical]
+    public let multiAliasByCount: [Int: [AliasCanonical]]
   }
 
-  // MARK: - Main Correction
-
-  public func correct(_ text: String, against words: [CustomWord]) -> (
-    corrected: String, replacements: [Replacement]
-  ) {
-    guard !words.isEmpty else { return (text, []) }
-
-    // --- Build lookup structures (once per call) ---
-
+  /// Build the lookup structures for a given vocabulary. Pure function.
+  /// `WordCorrectionStep` calls this once per generation change and reuses
+  /// the result across many `correct(...)` calls.
+  public static func buildLookups(words: [CustomWord]) -> Lookups {
     var singleAliasMap: [String: String] = [:]
     var multiAliasMap: [String: String] = [:]
     var collisionCount = 0
-    // Phase 3a (#631): lookup map for replacement attribution. Lowercased
-    // canonical → source `CustomWord.id`. Canonicals are unique per
-    // `CustomWordsManager.add(canonical:)` (case-insensitive uniqueness
-    // enforced at line 171-180), so a single-source-per-canonical map is safe.
     var canonicalToID: [String: UUID] = [:]
-    // Phase 2 (#638): same map but → CustomWord, so the acceptance loops can
-    // honor `minSimilarityOverride` per term.
     var canonicalToWord: [String: CustomWord] = [:]
     for word in words {
       canonicalToID[word.canonical.lowercased()] = word.id
       canonicalToWord[word.canonical.lowercased()] = word
     }
 
-    // 1. Build alias maps with collision detection
     for word in words {
       for alias in word.aliases {
         let key = alias.lowercased()
@@ -128,7 +134,6 @@ public struct WordCorrector: Sendable {
       }
     }
 
-    // 2. Add canonical self-entries (explicit aliases win)
     for word in words {
       let key = word.canonical.lowercased()
       if !key.contains(" ") {
@@ -145,21 +150,81 @@ public struct WordCorrector: Sendable {
       }
     }
 
-    // 3. Pre-index for fuzzy passes
     let canonicals = words.map(\.canonical)
     let lowercasedCanonicals = canonicals.map { $0.lowercased() }
-
-    // Single-word fuzzy candidates: all entries in singleAliasMap
-    let singleFuzzyCandidates = singleAliasMap.map { (surface: $0.key, canonical: $0.value) }
-
-    // Multi-word fuzzy candidates indexed by token count
-    var multiAliasByCount: [Int: [(alias: String, canonical: String)]] = [:]
+    let singleFuzzyCandidates = singleAliasMap.map {
+      Lookups.SurfaceCanonical(surface: $0.key, canonical: $0.value)
+    }
+    var multiAliasByCount: [Int: [Lookups.AliasCanonical]] = [:]
     for (alias, canonical) in multiAliasMap {
       let count = alias.components(separatedBy: " ").count
-      multiAliasByCount[count, default: []].append((alias, canonical))
+      multiAliasByCount[count, default: []].append(
+        Lookups.AliasCanonical(alias: alias, canonical: canonical))
     }
 
-    // --- Correction passes ---
+    var nospaceCanonicalMap: [String: String] = [:]
+    for word in words {
+      let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
+      nospaceCanonicalMap[nospace] = word.canonical
+      for alias in word.aliases {
+        let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
+        if nospaceCanonicalMap[aliasNospace] == nil {
+          nospaceCanonicalMap[aliasNospace] = word.canonical
+        }
+      }
+    }
+
+    return Lookups(
+      singleAliasMap: singleAliasMap,
+      multiAliasMap: multiAliasMap,
+      nospaceCanonicalMap: nospaceCanonicalMap,
+      canonicalToID: canonicalToID,
+      canonicalToWord: canonicalToWord,
+      canonicals: canonicals,
+      lowercasedCanonicals: lowercasedCanonicals,
+      singleFuzzyCandidates: singleFuzzyCandidates,
+      multiAliasByCount: multiAliasByCount
+    )
+  }
+
+  // MARK: - Replacement attribution (Phase 3a #631)
+
+  /// Per-replacement attribution: which `CustomWord.id` this replacement
+  /// originated from. Phase 3b consumes the list to bump `frequencyUsed` /
+  /// `lastUsed` on each source. Phase 7 may extend with `pass: Int, span:
+  /// Range<String.Index>` if needed (currently unused per bible §13).
+  public struct Replacement: Sendable, Equatable {
+    public let sourceID: UUID
+    public init(sourceID: UUID) { self.sourceID = sourceID }
+  }
+
+  // MARK: - Main Correction
+
+  /// Convenience overload — builds lookups inline. Use this when you only
+  /// call `correct` once per vocabulary (legacy callers, tests).
+  public func correct(_ text: String, against words: [CustomWord]) -> (
+    corrected: String, replacements: [Replacement]
+  ) {
+    guard !words.isEmpty else { return (text, []) }
+    let lookups = Self.buildLookups(words: words)
+    return correct(text, using: lookups)
+  }
+
+  /// Phase 2b (#638) primary entry point. Accepts pre-built lookups so
+  /// `WordCorrectionStep` can cache the build cost across calls of the same
+  /// vocabulary generation. Pure function — safe to call off any actor.
+  public func correct(_ text: String, using lookups: Lookups) -> (
+    corrected: String, replacements: [Replacement]
+  ) {
+    let singleAliasMap = lookups.singleAliasMap
+    let multiAliasMap = lookups.multiAliasMap
+    let nospaceCanonicalMap = lookups.nospaceCanonicalMap
+    let canonicalToID = lookups.canonicalToID
+    let canonicalToWord = lookups.canonicalToWord
+    let canonicals = lookups.canonicals
+    let lowercasedCanonicals = lookups.lowercasedCanonicals
+    let singleFuzzyCandidates = lookups.singleFuzzyCandidates
+    let multiAliasByCount = lookups.multiAliasByCount
 
     var replacements: [Replacement] = []
     var tokens = text.components(separatedBy: .whitespaces)
@@ -169,22 +234,6 @@ public struct WordCorrector: Sendable {
     func appendReplacement(forCanonical canonical: String) {
       if let id = canonicalToID[canonical.lowercased()] {
         replacements.append(Replacement(sourceID: id))
-      }
-    }
-
-    // Build nospace lookup for Pass 0 (n-gram compound matching)
-    // Maps lowercase-nospace canonical -> original canonical
-    // e.g., "chatgpt" -> "ChatGPT", "openai" -> "OpenAI", "vscode" -> "VS Code"
-    var nospaceCanonicalMap: [String: String] = [:]
-    for word in words {
-      let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
-      nospaceCanonicalMap[nospace] = word.canonical
-      // Also index aliases without spaces
-      for alias in word.aliases {
-        let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
-        if nospaceCanonicalMap[aliasNospace] == nil {
-          nospaceCanonicalMap[aliasNospace] = word.canonical
-        }
       }
     }
 
@@ -272,7 +321,9 @@ public struct WordCorrector: Sendable {
               var bestCanonical = ""
               var bestAlias = ""
 
-              for (alias, canonical) in candidates {
+              for entry in candidates {
+                let alias = entry.alias
+                let canonical = entry.canonical
                 let s = score(phrase, against: alias)
                 if s > bestScore {
                   if bestCanonical != canonical { secondBest = bestScore }
@@ -352,7 +403,9 @@ public struct WordCorrector: Sendable {
       var secondBest = 0.0
       var bestMatch = ""
 
-      for (surface, canonical) in singleFuzzyCandidates {
+      for entry in singleFuzzyCandidates {
+        let surface = entry.surface
+        let canonical = entry.canonical
         // Length-ratio pruning: skip if lengths differ too much for threshold
         let surfLen = surface.count
         let lenRatio = Double(min(coreLen, surfLen)) / Double(max(coreLen, surfLen))

--- a/Tests/EnviousWisprTests/Pipeline/WordCorrectionStepCacheTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WordCorrectionStepCacheTests.swift
@@ -1,0 +1,100 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Phase 2b (#638) — pins the lookup-map cache + heart-path 10ms timeout
+/// contracts on `WordCorrectionStep`. Bible §8.2 items 5-6, §17 R19, §2.2.1.
+@MainActor
+@Suite("WordCorrectionStep — Phase 2b cache + timeout")
+struct WordCorrectionStepCacheTests {
+
+  private static func makeContext(text: String) -> TextProcessingContext {
+    TextProcessingContext(text: text, language: "en")
+  }
+
+  // MARK: - Cache effectiveness
+
+  @Test("Cache: 10 calls with same generation → 1 build + 9 hits")
+  func cacheHitsAcrossSameGeneration() async throws {
+    let step = WordCorrectionStep()
+    step.wordCorrectionEnabled = true
+    let words = [
+      CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"]),
+      CustomWord(canonical: "OpenAI", aliases: ["openai"]),
+    ]
+    step.correctorVocabulary = CorrectorVocabulary(terms: words, generation: 1)
+
+    for _ in 0..<10 {
+      _ = try await step.process(Self.makeContext(text: "I used chatgpt today"))
+    }
+    #expect(step.lookupCacheBuilds == 1, "Only the first call should build")
+    #expect(step.lookupCacheHits == 9, "Subsequent 9 calls should hit cache")
+  }
+
+  @Test("Cache invalidation: generation bump triggers rebuild")
+  func cacheInvalidatesOnGenerationBump() async throws {
+    let step = WordCorrectionStep()
+    step.wordCorrectionEnabled = true
+    let words = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
+    step.correctorVocabulary = CorrectorVocabulary(terms: words, generation: 1)
+    _ = try await step.process(Self.makeContext(text: "chatgpt"))
+    _ = try await step.process(Self.makeContext(text: "chatgpt"))
+    #expect(step.lookupCacheBuilds == 1)
+    #expect(step.lookupCacheHits == 1)
+
+    step.correctorVocabulary = CorrectorVocabulary(terms: words, generation: 2)
+    _ = try await step.process(Self.makeContext(text: "chatgpt"))
+    #expect(step.lookupCacheBuilds == 2, "Generation bump must rebuild")
+    #expect(step.lookupCacheHits == 1, "No new hit (just rebuilt)")
+
+    _ = try await step.process(Self.makeContext(text: "chatgpt"))
+    #expect(step.lookupCacheBuilds == 2)
+    #expect(step.lookupCacheHits == 2, "Subsequent call hits the new cache")
+  }
+
+  @Test("Cache: same generation reused even when terms swapped (intentional)")
+  func cacheKeyedByGenerationOnly() async throws {
+    let step = WordCorrectionStep()
+    step.wordCorrectionEnabled = true
+    let chatGPT = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
+    step.correctorVocabulary = CorrectorVocabulary(terms: chatGPT, generation: 5)
+    _ = try await step.process(Self.makeContext(text: "anything"))
+    #expect(step.lookupCacheBuilds == 1)
+
+    // Swap terms but keep generation — propagator contract says this would
+    // never happen in production (generation bumps on every coordinator
+    // update), but pin the contract.
+    let openAI = [CustomWord(canonical: "OpenAI", aliases: ["openai"])]
+    step.correctorVocabulary = CorrectorVocabulary(terms: openAI, generation: 5)
+    _ = try await step.process(Self.makeContext(text: "anything"))
+    #expect(step.lookupCacheBuilds == 1, "No rebuild because generation unchanged")
+    #expect(step.lookupCacheHits == 1, "1 build + 1 hit = 2 calls total")
+  }
+
+  // MARK: - Heart-path correctness through the new path
+
+  @Test("Correction works through cache: chatgpt → ChatGPT")
+  func correctionStillWorks() async throws {
+    let step = WordCorrectionStep()
+    step.wordCorrectionEnabled = true
+    let words = [CustomWord(canonical: "ChatGPT", aliases: ["chatgpt"])]
+    step.correctorVocabulary = CorrectorVocabulary(terms: words, generation: 1)
+
+    let result = try await step.process(Self.makeContext(text: "I used chatgpt today"))
+    #expect(result.text == "I used ChatGPT today")
+  }
+
+  @Test("Empty vocabulary: no-op + no build")
+  func emptyVocabularyNoOp() async throws {
+    let step = WordCorrectionStep()
+    step.wordCorrectionEnabled = true
+    step.correctorVocabulary = .empty
+
+    let result = try await step.process(Self.makeContext(text: "hello world"))
+    #expect(result.text == "hello world")
+    // empty terms still builds an empty Lookups (cheap), so 1 build expected
+    #expect(step.lookupCacheBuilds == 1)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2b of the Custom Words v2 epic (#633). Bible §8.2 items 5-6, §17 R19, §2.2.1.

Two operational items that complete Phase 2's hardening: (5) heart-path 10ms hard timeout on `WordCorrectionStep.process(...)` and (6) generation-keyed cache of the lookup maps so they are rebuilt only when the vocabulary generation changes.

## Changes

**WordCorrector refactor:**
- New `public struct Lookups: Sendable` containing all lookup maps (singleAliasMap, multiAliasMap, nospaceCanonicalMap, canonicalToID, canonicalToWord, canonicals, lowercasedCanonicals, singleFuzzyCandidates, multiAliasByCount).
- Tuple types replaced with Sendable structs (SurfaceCanonical, AliasCanonical) so the value crosses actor boundaries cleanly.
- `public static func buildLookups(words:) -> Lookups`
- `public func correct(_ text: String, using lookups: Lookups)` — primary entry point. Pure function, safe off any actor.
- Convenience `correct(_:against:)` builds inline + delegates. Legacy callers and existing tests unchanged.

**WordCorrectionStep:**
- Caches `(generation, lookups)` pair. Setter `didSet` invalidates on generation change.
- 10ms timeout via existing `withThrowingTimeout(seconds: 0.010)`. Correction runs OFF MainActor inside the closure (WordCorrector is Sendable: struct, pure CPU work).
- TimeoutError → Sentry breadcrumb `wordcorrector.timeout` + raw context passthrough. Heart path unaffected.

## Bible v1.2 errata c correction

Errata c assumed Phase 2 had to write a `withTimeout` helper. Confirmed by re-grep: `withThrowingTimeout(seconds:)` already exists at `Sources/EnviousWisprCore/TaskTimeout.swift:15`. Phase 2b reuses it.

## Test plan

- [x] `swift build -c release` exits 0
- [x] 70 tests pass (65 prior + 5 new cache tests)
  - WordCorrectionStepCacheTests (5 new):
    - 10 calls with same generation → 1 build + 9 hits
    - generation bump invalidates
    - same-gen terms-swap reuses (contract pin)
    - correction still works through cache (chatgpt → ChatGPT)
    - empty vocab no-op
  - All Phase 0/1/3a/2a + base WordCorrector + CustomWord suites stay green
- [ ] CI build-check
- [ ] CI polish-eval-smoke (allowlist hits via dep chain — expect zero baseline drift since polish prompts are unchanged)
- [ ] Codex code-diff review (Codex rate-limited until ~02:57 AM; will run + apply any findings before merge)

Auto-merge intentionally NOT set on this PR until Codex returns clean.

## Plan

`docs/feature-requests/issue-638-2026-05-05-phase-2b-timeout-cache.md` (gitignored under `docs/`).
