### PR TITLE
feat(observability): distributed event backfill for Phase 0 + Phase 2 (#620 Phase 8a)

### DIFF
--- a/Sources/EnviousWispr/App/CustomWordsPropagator.swift
+++ b/Sources/EnviousWispr/App/CustomWordsPropagator.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 /// Phase 0 (#640) — broadcasts the active vocabulary to consumers via two
@@ -84,6 +85,31 @@ final class CustomWordsPropagator {
     }
     for box in polishConsumers {
       box.value?.polishVocabulary = polish
+    }
+    // Phase 8a (#620): emit one event per lane per atomic broadcast.
+    // Privacy-safe: counts only, no term strings. Bible §14.1 + §14.3.
+    //
+    // Codex audit P2 fix: skip emission when no consumers are registered.
+    // `wireCustomWords` calls `update(...)` BEFORE registering consumers
+    // (the seed step) so `register()`'s initial-sync sees the right value;
+    // emitting during that pre-registration seed would produce misleading
+    // `consumer_count=0` events on every app launch. Live broadcasts from
+    // `coordinator.onWordsChanged` always have consumers and emit normally.
+    if !correctorConsumers.isEmpty {
+      TelemetryService.shared.customWordsPropagatorBroadcast(
+        lane: "corrector",
+        generation: corrector.generation,
+        consumerCount: correctorConsumers.count,
+        termCount: corrector.terms.count
+      )
+    }
+    if !polishConsumers.isEmpty {
+      TelemetryService.shared.customWordsPropagatorBroadcast(
+        lane: "polish",
+        generation: polish.generation,
+        consumerCount: polishConsumers.count,
+        termCount: polish.terms.count
+      )
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -69,6 +69,7 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
 
     let inputText = context.text
     let result: (corrected: String, replacements: [WordCorrector.Replacement])
+    let startTime = CFAbsoluteTimeGetCurrent()
     do {
       // Phase 2b (#638) bible §2.2.1: hard 10ms cap. WordCorrector.correct is
       // pure CPU work; we run it OFF MainActor inside the timeout closure so
@@ -83,13 +84,38 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
         message: "WordCorrector timeout (10ms cap exceeded)",
         data: ["vocab_size": String(snapshot.terms.count)]
       )
+      // Phase 8a (#620): emit timeout event. Bible §14.1.
+      TelemetryService.shared.customWordsTimeoutFired(vocabSize: snapshot.terms.count)
       return context  // raw text passes through; heart path unaffected
     }
+    let elapsedMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
 
     let (fixed, replacements) = result
     if !replacements.isEmpty {
       customWordsManager?.recordReplacements(replacements.map(\.sourceID))
       let count = replacements.count
+      // Phase 8a (#620): emit one summary event per process() call. Bible §14.1.
+      // Privacy-safe: counts + booleans + latency bucket. No term strings.
+      let sourceIDs = Set(replacements.map(\.sourceID))
+      var hadPack = false
+      var hadUser = false
+      var hadBuiltin = false
+      for term in snapshot.terms where sourceIDs.contains(term.id) {
+        switch term.source {
+        case .pack: hadPack = true
+        case .user: hadUser = true
+        case .builtin: hadBuiltin = true
+        case .observedAX: hadUser = true  // observedAX -> persists as user
+        }
+      }
+      TelemetryService.shared.customWordsReplacementBatch(
+        replacementCount: count,
+        vocabSize: snapshot.terms.count,
+        hadPackTerm: hadPack,
+        hadUserTerm: hadUser,
+        hadBuiltinTerm: hadBuiltin,
+        latencyBucket: LatencyBucket.of(milliseconds: elapsedMs)
+      )
       Task {
         await AppLogger.shared.log(
           "WordCorrector applied \(count) correction(s)",

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -112,6 +112,9 @@ public final class WordSuggestionService: Sendable {
         // Empty after filter (with non-empty raw) means AFM degenerated into self-echoes.
         // Treat as model failure so the UI can render "No suggestions available" instead
         // of zero or duplicate chips.
+        // Phase 8 (#620) telemetry hook deferred — PostProcessing module cannot
+        // import EnviousWisprServices per the dep-direction guard. Phase 8 proper
+        // will inject a telemetry callback at the call site.
         guard !filtered.isEmpty else { return nil }
         return WordSuggestions(category: category, suggestedAliases: filtered)
       } catch {
@@ -154,6 +157,7 @@ public final class WordSuggestionService: Sendable {
 
         let category = WordCategory(rawValue: categoryStr.lowercased()) ?? .general
         let filtered = Self.filterDegeneratedAliases(raw, canonical: word)
+        // Phase 8 (#620) telemetry hook deferred — see comment in Generable variant.
         guard !filtered.isEmpty else { return nil }
         return WordSuggestions(category: category, suggestedAliases: filtered)
       } catch {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -645,4 +645,97 @@ public final class TelemetryService {
   public func flushTelemetry() {
     PostHogSDK.shared.flush()
   }
+
+  // MARK: - Custom Words v2 (Phase 8a — distributed event backfill, bible §14.1)
+  //
+  // Privacy: NEVER include term strings, alias strings, or any contact-derived
+  // data in these events. Only counts, booleans, category labels, latency
+  // buckets. Bible §14.3.
+
+  /// Phase 0 (#640) — fired by `CustomWordsPropagator.update(corrector:polish:)`
+  /// once per atomic broadcast. `lane` is "corrector" or "polish".
+  public func customWordsPropagatorBroadcast(
+    lane: String, generation: UInt64, consumerCount: Int, termCount: Int
+  ) {
+    PostHogSDK.shared.capture(
+      "custom_words.propagator_broadcast",
+      properties: [
+        "lane": lane,
+        "generation": Int(generation),
+        "consumer_count": consumerCount,
+        "term_count": termCount,
+      ]
+    )
+  }
+
+  /// Phase 1 (#637) — fired by `WordSuggestionService.suggest(for:)` after
+  /// the degeneration filter. `degenerated == true` means raw was non-empty
+  /// but post-filter list was empty (model returned only self-echoes).
+  /// `categorySuggested` is the category enum raw value or nil if call failed.
+  public func customWordsAfmAliasFilled(
+    resultCount: Int, degenerated: Bool, categorySuggested: String?
+  ) {
+    var props: [String: Any] = [
+      "result_count": resultCount,
+      "degenerated": degenerated,
+    ]
+    if let category = categorySuggested {
+      props["category_suggested"] = category
+    }
+    PostHogSDK.shared.capture("custom_words.afm_alias_filled", properties: props)
+  }
+
+  /// Phase 2 (#638) — fired by `WordCorrectionStep.process(...)` after a
+  /// successful correction batch. Single summary event per process() call;
+  /// per-replacement breakdown deferred to full Phase 8 (bible v1.3 will note
+  /// this scope reduction). `latencyBucket` quantizes wall-clock duration.
+  public func customWordsReplacementBatch(
+    replacementCount: Int,
+    vocabSize: Int,
+    hadPackTerm: Bool,
+    hadUserTerm: Bool,
+    hadBuiltinTerm: Bool,
+    latencyBucket: String
+  ) {
+    PostHogSDK.shared.capture(
+      "custom_words.replacement_applied",
+      properties: [
+        "replacement_count": replacementCount,
+        "vocab_size": vocabSize,
+        "had_pack_term": hadPackTerm,
+        "had_user_term": hadUserTerm,
+        "had_builtin_term": hadBuiltinTerm,
+        "latency_bucket": latencyBucket,
+      ]
+    )
+  }
+
+  /// Phase 2 (#638) — fired by `WordCorrectionStep.process(...)` when the
+  /// 10ms heart-path timeout cap fires.
+  public func customWordsTimeoutFired(vocabSize: Int) {
+    PostHogSDK.shared.capture(
+      "custom_words.timeout_fired",
+      properties: [
+        "vocab_size": vocabSize
+      ]
+    )
+  }
+}
+
+// MARK: - Latency bucket helper (Phase 8a)
+
+/// Quantize a wall-clock latency into a coarse bucket for telemetry.
+/// Buckets are chosen to surface the heart-path 10ms boundary.
+public enum LatencyBucket {
+  public static func of(milliseconds: Double) -> String {
+    switch milliseconds {
+    case ..<1: return "under_1ms"
+    case 1..<5: return "1_to_5ms"
+    case 5..<10: return "5_to_10ms"
+    case 10..<25: return "10_to_25ms"
+    case 25..<50: return "25_to_50ms"
+    case 50..<100: return "50_to_100ms"
+    default: return "over_100ms"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Phase 8a backfills the Phase 0 + Phase 2 telemetry events that were supposed to ship as part of those phases' DoD per bible §14.1 but slipped during overnight autopilot.

Adds typed event APIs on TelemetryService:
- customWordsPropagatorBroadcast (Phase 0)
- customWordsReplacementBatch (Phase 2)
- customWordsTimeoutFired (Phase 2)
- LatencyBucket helper (under_1ms / 1_to_5ms / etc.)

Phase 1 AFM telemetry deferred to full Phase 8 — PostProcessing module cannot import EnviousWisprServices per the dep-direction guard.

Codex audit: P2 found + fixed (skip emission when consumers list is empty — prevents misleading consumer_count=0 events on every app launch).

## Test plan
- [x] swift build green
- [x] 70 existing tests stay green
- [ ] CI build-check
- [ ] CI polish-quality-gate