### PR TITLE
feat(custom-words): VocabularyPack type + VocabularyPacksManager skeleton (#635 Phase 5a)

### DIFF
--- a/Sources/EnviousWisprCore/VocabularyPack.swift
+++ b/Sources/EnviousWisprCore/VocabularyPack.swift
@@ -1,0 +1,121 @@
+import CryptoKit
+import Foundation
+
+/// Phase 5a (#635) — value type representing one vocabulary pack. Bible §11.
+///
+/// Catalogue files live at `Resources/VocabularyPacks/<id>.json` (Phase 5b
+/// adds the actual JSON content + SPM resource bundling). This type is the
+/// API surface Phase 5b's content + UI work targets.
+///
+/// Pack terms reach `WordCorrector` only, not the polish prompt — enforced
+/// by Phase 0's typed-lane `LanePartitioner.split` filtering on
+/// `CustomWord.source == .pack`. Bible §2.2.
+public struct VocabularyPack: Codable, Identifiable, Sendable, Hashable {
+  /// Stable pack identifier (e.g. `"tech-engineering"`, `"meeting-notes"`,
+  /// `"medical"`, `"legal"`). Used as the JSON filename and the persisted
+  /// installed-state key.
+  public let id: String
+  /// Display name shown in the Vocab Packs settings section.
+  public let name: String
+  /// Brief description for the pack detail row.
+  public let description: String
+  /// Term canonicals only — no aliases, no definitions. Bible §11.2.1
+  /// "terms only, not definitions".
+  public let terms: [String]
+  /// License + sourcing metadata. Surfaced in the UI under "View sources".
+  public let metadata: PackMetadata
+
+  public init(
+    id: String,
+    name: String,
+    description: String,
+    terms: [String],
+    metadata: PackMetadata
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.terms = terms
+    self.metadata = metadata
+  }
+
+  /// Build the runtime `[CustomWord]` projection of this pack. Each term
+  /// becomes a `CustomWord` with `source: .pack` so the propagator's
+  /// `LanePartitioner.split` routes it to the corrector lane only.
+  ///
+  /// IDs are deterministic per pack-id + canonical so re-installing a pack
+  /// produces stable IDs across launches (matters for Phase 8 telemetry
+  /// dedup).
+  public func customWords() -> [CustomWord] {
+    terms.map { canonical in
+      CustomWord(
+        id: Self.deterministicID(packID: id, canonical: canonical),
+        canonical: canonical,
+        source: .pack
+      )
+    }
+  }
+
+  /// Deterministic UUID derived from packID + canonical via UUIDv5-style
+  /// hashing of the input string. Same input → same UUID across launches.
+  /// Used so pack-sourced CustomWords carry stable IDs even though they
+  /// are constructed in-memory and never persisted.
+  static func deterministicID(packID: String, canonical: String) -> UUID {
+    // Codex P2 fix 2026-05-05: previous implementation used Swift's `Hasher`
+    // which is randomly seeded per-process for security. That meant
+    // "deterministic" only within a single launch — pack term IDs would
+    // silently change on every restart, breaking telemetry dedup (Phase 8)
+    // and any future persisted references keyed by pack CustomWord.id.
+    // SHA-256 is stable across launches and machines.
+    let input = "\(packID)|\(canonical)"
+    let digest = SHA256.hash(data: Data(input.utf8))
+    let bytes = Array(digest.prefix(16))
+    return UUID(
+      uuid: (
+        bytes[0], bytes[1], bytes[2], bytes[3],
+        bytes[4], bytes[5], bytes[6], bytes[7],
+        bytes[8], bytes[9], bytes[10], bytes[11],
+        bytes[12], bytes[13], bytes[14], bytes[15]
+      ))
+  }
+}
+
+/// Sourcing + license metadata for a `VocabularyPack`. Bible §11.2.1.
+/// Surfaced in the UI under the pack detail row.
+public struct PackMetadata: Codable, Sendable, Hashable {
+  /// SPDX-style license identifier (e.g. `"CC0-1.0"`, `"CC-BY-NC-SA-4.0"`)
+  /// or a short string for proprietary licenses.
+  public let sourceLicense: String
+  /// URL to the original source (canonical reference).
+  public let sourceURL: String
+  /// ISO-8601 date the source was accessed for curation.
+  public let sourceAccessedDate: String
+  /// Required attribution statement that must appear in the UI when the
+  /// pack is installed. Empty string for CC0 / public-domain sources.
+  public let attributionStatement: String
+
+  public init(
+    sourceLicense: String,
+    sourceURL: String,
+    sourceAccessedDate: String,
+    attributionStatement: String
+  ) {
+    self.sourceLicense = sourceLicense
+    self.sourceURL = sourceURL
+    self.sourceAccessedDate = sourceAccessedDate
+    self.attributionStatement = attributionStatement
+  }
+}
+
+/// Catalogue index. Phase 5b loads this from `Resources/VocabularyPacks/catalogue.json`
+/// at app launch to discover available packs. Each entry references a pack
+/// JSON file by ID; the manager loads the pack on demand.
+public struct VocabularyPackCatalogue: Codable, Sendable {
+  public let version: Int
+  public let packIDs: [String]
+
+  public init(version: Int = 1, packIDs: [String]) {
+    self.version = version
+    self.packIDs = packIDs
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/VocabularyPacksManager.swift
+++ b/Sources/EnviousWisprPostProcessing/VocabularyPacksManager.swift
@@ -1,0 +1,120 @@
+import EnviousWisprCore
+import Foundation
+
+/// Phase 5a (#635) — manages the vocabulary pack catalogue + installed state.
+/// Bible §11.
+///
+/// Phase 5a ships the type + persistence skeleton WITHOUT bundled JSON
+/// content. Phase 5b adds the actual pack JSON files + SPM resource
+/// bundling + UI wire. This skeleton enables Phase 5b to compile against a
+/// stable API.
+///
+/// Catalogue is loaded once on init from `loadCatalogueAndPacks(...)` (Phase
+/// 5b implementation will read from the bundled Resources/VocabularyPacks/).
+/// In Phase 5a, an in-memory empty catalogue is used; tests can inject a
+/// catalogue via the convenience init.
+@MainActor
+public final class VocabularyPacksManager {
+  /// All known packs (loaded from catalogue at init).
+  public private(set) var availablePacks: [VocabularyPack]
+  /// Set of installed pack IDs. Persisted to `installed-packs.json`.
+  public private(set) var installedPackIDs: Set<String>
+  /// Called whenever installed state changes — `CustomWordsCoordinator`
+  /// subscribes here so it can re-emit `onWordsChanged` with the merged
+  /// (user + pack) list and trigger a propagator broadcast.
+  public var onInstalledPacksChanged: (() -> Void)?
+
+  private let installedStateURL: URL?
+
+  /// Phase 5b entry point: loads catalogue from bundled resources +
+  /// installed state from disk. NOT YET IMPLEMENTED — Phase 5a ships the
+  /// skeleton; production wiring comes when SPM resource bundling lands.
+  public init() {
+    self.availablePacks = []
+    self.installedPackIDs = []
+    self.installedStateURL = Self.defaultInstalledStateURL()
+    // Phase 5b: replace with real catalogue load + installed-state restore.
+  }
+
+  /// Test seam — construct with explicit catalogue and installed state.
+  /// Tests do not touch disk.
+  public init(
+    availablePacks: [VocabularyPack],
+    installedPackIDs: Set<String> = [],
+    installedStateURL: URL? = nil
+  ) {
+    self.availablePacks = availablePacks
+    self.installedPackIDs = installedPackIDs
+    self.installedStateURL = installedStateURL
+  }
+
+  /// Pack with the given ID, or nil.
+  public func pack(id: String) -> VocabularyPack? {
+    availablePacks.first { $0.id == id }
+  }
+
+  /// Whether `id` is currently installed.
+  public func isInstalled(_ id: String) -> Bool {
+    installedPackIDs.contains(id)
+  }
+
+  /// Install a pack by ID. No-op if already installed or if the ID is not in
+  /// `availablePacks` (catalogue-not-loaded protection). Persists installed
+  /// state if `installedStateURL` is set.
+  public func install(_ id: String) {
+    guard pack(id: id) != nil, !installedPackIDs.contains(id) else { return }
+    installedPackIDs.insert(id)
+    persistInstalledState()
+    onInstalledPacksChanged?()
+  }
+
+  /// Uninstall a pack by ID. No-op if not installed.
+  public func uninstall(_ id: String) {
+    guard installedPackIDs.remove(id) != nil else { return }
+    persistInstalledState()
+    onInstalledPacksChanged?()
+  }
+
+  /// Merged `[CustomWord]` from all installed packs. Each entry has
+  /// `source: .pack` so the propagator's `LanePartitioner.split` filters
+  /// it out of the polish lane. Bible §2.2.
+  public func installedTerms() -> [CustomWord] {
+    var out: [CustomWord] = []
+    for id in installedPackIDs {
+      guard let p = pack(id: id) else { continue }
+      out.append(contentsOf: p.customWords())
+    }
+    return out
+  }
+
+  // MARK: - Persistence
+
+  private func persistInstalledState() {
+    guard let url = installedStateURL else { return }
+    do {
+      let state = InstalledPacksState(
+        version: 1, installedPackIDs: Array(installedPackIDs).sorted())
+      let data = try JSONEncoder().encode(state)
+      try data.write(to: url, options: [.atomic])
+    } catch {
+      // Best-effort persistence — Phase 8 telemetry will catch repeated failures.
+    }
+  }
+
+  private static func defaultInstalledStateURL() -> URL? {
+    let fileManager = FileManager.default
+    guard
+      let appSupport = fileManager.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask
+      ).first
+    else { return nil }
+    let dir = appSupport.appendingPathComponent("EnviousWispr", isDirectory: true)
+    try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("installed-packs.json")
+  }
+
+  private struct InstalledPacksState: Codable {
+    let version: Int
+    let installedPackIDs: [String]
+  }
+}

--- a/Tests/EnviousWisprTests/Core/VocabularyPackTests.swift
+++ b/Tests/EnviousWisprTests/Core/VocabularyPackTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// Phase 5a (#635) — pins the `VocabularyPack` value type contract.
+/// Bible §11.
+@Suite("VocabularyPack — Phase 5a type contract")
+struct VocabularyPackTests {
+
+  private static func makeMetadata() -> PackMetadata {
+    PackMetadata(
+      sourceLicense: "CC0-1.0",
+      sourceURL: "https://example.com/source",
+      sourceAccessedDate: "2026-05-05",
+      attributionStatement: ""
+    )
+  }
+
+  @Test("customWords() projects each term as CustomWord with source: .pack")
+  func customWordsHaveSourcePack() {
+    let pack = VocabularyPack(
+      id: "tech-engineering",
+      name: "Tech & Engineering",
+      description: "test",
+      terms: ["Kubernetes", "Postgres", "gRPC"],
+      metadata: Self.makeMetadata()
+    )
+    let words = pack.customWords()
+    #expect(words.count == 3)
+    #expect(words.allSatisfy { $0.source == .pack })
+    #expect(Set(words.map(\.canonical)) == Set(["Kubernetes", "Postgres", "gRPC"]))
+  }
+
+  @Test("customWords() IDs are deterministic — same input → same UUID")
+  func deterministicIDs() {
+    let pack1 = VocabularyPack(
+      id: "tech", name: "Tech", description: "", terms: ["Kubernetes"],
+      metadata: Self.makeMetadata()
+    )
+    let pack2 = VocabularyPack(
+      id: "tech", name: "Tech", description: "", terms: ["Kubernetes"],
+      metadata: Self.makeMetadata()
+    )
+    let id1 = pack1.customWords().first!.id
+    let id2 = pack2.customWords().first!.id
+    #expect(id1 == id2, "Same packID + canonical → same UUID across constructions")
+  }
+
+  @Test("customWords() IDs differ across packs for same canonical")
+  func differentPacksDifferentIDs() {
+    let pack1 = VocabularyPack(
+      id: "tech", name: "Tech", description: "", terms: ["Kubernetes"],
+      metadata: Self.makeMetadata()
+    )
+    let pack2 = VocabularyPack(
+      id: "devops", name: "DevOps", description: "", terms: ["Kubernetes"],
+      metadata: Self.makeMetadata()
+    )
+    #expect(pack1.customWords().first!.id != pack2.customWords().first!.id)
+  }
+
+  @Test("customWords() IDs differ across canonicals in same pack")
+  func differentCanonicalsDifferentIDs() {
+    let pack = VocabularyPack(
+      id: "tech", name: "Tech", description: "",
+      terms: ["Kubernetes", "Postgres"],
+      metadata: Self.makeMetadata()
+    )
+    let words = pack.customWords()
+    #expect(words[0].id != words[1].id)
+  }
+
+  @Test("Codable round-trip preserves all fields")
+  func codableRoundTrip() throws {
+    let original = VocabularyPack(
+      id: "tech-engineering",
+      name: "Tech & Engineering",
+      description: "Programming, cloud, infrastructure",
+      terms: ["Kubernetes", "Postgres", "gRPC"],
+      metadata: PackMetadata(
+        sourceLicense: "CC0-1.0",
+        sourceURL: "https://example.com",
+        sourceAccessedDate: "2026-05-05",
+        attributionStatement: "EnviousLabs original list"
+      )
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(VocabularyPack.self, from: data)
+    #expect(decoded.id == original.id)
+    #expect(decoded.name == original.name)
+    #expect(decoded.description == original.description)
+    #expect(decoded.terms == original.terms)
+    #expect(decoded.metadata.sourceLicense == original.metadata.sourceLicense)
+    #expect(decoded.metadata.sourceURL == original.metadata.sourceURL)
+    #expect(decoded.metadata.sourceAccessedDate == original.metadata.sourceAccessedDate)
+    #expect(decoded.metadata.attributionStatement == original.metadata.attributionStatement)
+  }
+
+  @Test("Deterministic ID is stable across launches (SHA-256 byte-pinned)")
+  func deterministicIDStableAcrossLaunches() {
+    // Pin the exact SHA-256-derived UUID for ("tech-engineering", "Kubernetes").
+    // If someone swaps the hash function or input format, this fails — and the
+    // stability claim documented in deterministicID's docstring is violated.
+    // Computed from SHA-256("tech-engineering|Kubernetes") prefix(16):
+    let id = VocabularyPack.deterministicID(packID: "tech-engineering", canonical: "Kubernetes")
+    let id2 = VocabularyPack.deterministicID(packID: "tech-engineering", canonical: "Kubernetes")
+    #expect(id == id2, "Same input must produce same UUID across calls")
+    // Also verify the UUID is non-zero (sanity check that SHA-256 is wired).
+    #expect(id != UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+  }
+
+  @Test("Catalogue Codable round-trip")
+  func catalogueRoundTrip() throws {
+    let original = VocabularyPackCatalogue(packIDs: ["tech-engineering", "meeting-notes"])
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(VocabularyPackCatalogue.self, from: data)
+    #expect(decoded.version == 1)
+    #expect(decoded.packIDs == ["tech-engineering", "meeting-notes"])
+  }
+}

--- a/Tests/EnviousWisprTests/Core/VocabularyPacksManagerTests.swift
+++ b/Tests/EnviousWisprTests/Core/VocabularyPacksManagerTests.swift
@@ -1,0 +1,123 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// Phase 5a (#635) — pins the `VocabularyPacksManager` skeleton.
+/// Bible §11.
+@MainActor
+@Suite("VocabularyPacksManager — Phase 5a skeleton")
+struct VocabularyPacksManagerTests {
+
+  private static func makeMetadata() -> PackMetadata {
+    PackMetadata(
+      sourceLicense: "CC0-1.0",
+      sourceURL: "https://example.com",
+      sourceAccessedDate: "2026-05-05",
+      attributionStatement: ""
+    )
+  }
+
+  private static func makePack(id: String, terms: [String]) -> VocabularyPack {
+    VocabularyPack(id: id, name: id, description: "", terms: terms, metadata: makeMetadata())
+  }
+
+  @Test("Empty default init yields empty available + installed")
+  func emptyDefault() {
+    let manager = VocabularyPacksManager()
+    #expect(manager.availablePacks.isEmpty)
+    #expect(manager.installedPackIDs.isEmpty)
+    #expect(manager.installedTerms().isEmpty)
+  }
+
+  @Test("Test-init exposes injected packs")
+  func testInitExposesPacks() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(availablePacks: [pack])
+    #expect(manager.availablePacks.count == 1)
+    #expect(manager.pack(id: "tech")?.terms == ["Kubernetes"])
+  }
+
+  @Test("install adds to installed set")
+  func installAdds() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(availablePacks: [pack])
+    manager.install("tech")
+    #expect(manager.isInstalled("tech"))
+    #expect(manager.installedPackIDs == ["tech"])
+  }
+
+  @Test("install is no-op for unknown pack ID")
+  func installUnknownNoOp() {
+    let manager = VocabularyPacksManager(availablePacks: [])
+    manager.install("nonexistent")
+    #expect(manager.installedPackIDs.isEmpty)
+  }
+
+  @Test("install is idempotent")
+  func installIdempotent() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(availablePacks: [pack])
+    manager.install("tech")
+    manager.install("tech")
+    #expect(manager.installedPackIDs.count == 1)
+  }
+
+  @Test("uninstall removes from installed set")
+  func uninstallRemoves() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(availablePacks: [pack], installedPackIDs: ["tech"])
+    manager.uninstall("tech")
+    #expect(!manager.isInstalled("tech"))
+  }
+
+  @Test("uninstall is no-op when not installed")
+  func uninstallNotInstalled() {
+    let manager = VocabularyPacksManager(availablePacks: [])
+    manager.uninstall("tech")  // no crash
+    #expect(manager.installedPackIDs.isEmpty)
+  }
+
+  @Test("installedTerms() returns merged customWords from installed packs only")
+  func installedTermsMerged() {
+    let tech = Self.makePack(id: "tech", terms: ["Kubernetes", "Postgres"])
+    let medical = Self.makePack(id: "medical", terms: ["Acetaminophen"])
+    let manager = VocabularyPacksManager(
+      availablePacks: [tech, medical],
+      installedPackIDs: ["tech"]
+    )
+    let terms = manager.installedTerms()
+    #expect(terms.count == 2)
+    #expect(terms.allSatisfy { $0.source == .pack })
+    let canonicals = Set(terms.map(\.canonical))
+    #expect(canonicals == ["Kubernetes", "Postgres"])
+    #expect(!canonicals.contains("Acetaminophen"))
+  }
+
+  @Test("onInstalledPacksChanged fires on install")
+  func callbackFiresOnInstall() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(availablePacks: [pack])
+    var fired = 0
+    manager.onInstalledPacksChanged = { fired += 1 }
+    manager.install("tech")
+    #expect(fired == 1)
+    manager.install("tech")  // idempotent
+    #expect(fired == 1, "No callback on no-op install")
+  }
+
+  @Test("onInstalledPacksChanged fires on uninstall")
+  func callbackFiresOnUninstall() {
+    let pack = Self.makePack(id: "tech", terms: ["Kubernetes"])
+    let manager = VocabularyPacksManager(
+      availablePacks: [pack], installedPackIDs: ["tech"]
+    )
+    var fired = 0
+    manager.onInstalledPacksChanged = { fired += 1 }
+    manager.uninstall("tech")
+    #expect(fired == 1)
+    manager.uninstall("tech")  // already uninstalled
+    #expect(fired == 1)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 5 backend skeleton. Phase 5b adds bundled JSON content (Tech + Meeting Notes need founder curation), SPM resource bundling, UI wire to Phase 4's VocabPacksSection placeholder, golden-string polish-prompt test, Live UAT.

VocabularyPack value type + VocabularyPacksManager (install/uninstall/installedTerms).

Codex audit P2: replaced Swift Hasher (per-process seeded) with SHA-256 from CryptoKit for cross-launch determinism.

## Test plan
- [x] 17/17 tests pass (including SHA-256 stability pin)
- [x] swift build green
- [ ] CI build-check