### PR TITLE
diag(custom-words): visibility into corrector + AFM polish vocab path

### DIFF
--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -443,9 +443,31 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       "\nThis is speech-to-text output. Remove false starts. "
       + "Preserve the speaker's tone and formality level. If unsure about a correction, leave unchanged."
 
+    let termsCount = polishVocabulary.terms.count
+    Task {
+      await AppLogger.shared.log(
+        "AFM polish vocab inject: termsCount=\(termsCount)",
+        level: .info, category: "LLM"
+      )
+    }
     if !polishVocabulary.terms.isEmpty {
       if let vocab = CustomVocabularyFormatter.render(polishVocabulary.terms) {
+        let renderedChars = vocab.count
+        let preview = String(vocab.prefix(180))
+        Task {
+          await AppLogger.shared.log(
+            "AFM polish vocab rendered: chars=\(renderedChars) preview=\"\(preview)\"",
+            level: .info, category: "LLM"
+          )
+        }
         systemPrompt += "\n\n" + vocab
+      } else {
+        Task {
+          await AppLogger.shared.log(
+            "AFM polish vocab render returned nil despite termsCount=\(termsCount)",
+            level: .info, category: "LLM"
+          )
+        }
       }
     }
 

--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -68,6 +68,15 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
     let lookups = ensureLookups(for: snapshot)
 
     let inputText = context.text
+    let vocabCount = snapshot.terms.count
+    let generation = snapshot.generation
+    let inputChars = inputText.count
+    Task {
+      await AppLogger.shared.log(
+        "WordCorrection enter: vocab_count=\(vocabCount) generation=\(generation) input_chars=\(inputChars)",
+        level: .info, category: "Pipeline"
+      )
+    }
     let result: (corrected: String, replacements: [WordCorrector.Replacement])
     let startTime = CFAbsoluteTimeGetCurrent()
     do {

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -363,6 +363,20 @@ public struct WordCorrector: Sendable {
                   )
                 #endif
                 break
+              } else if bestScore > 0 {
+                #if DEBUG
+                  let reason: String
+                  if bestScore < multiThreshold {
+                    reason = "below_threshold"
+                  } else if margin < Self.ambiguityMargin {
+                    reason = "below_margin"
+                  } else {
+                    reason = "same_as_input"
+                  }
+                  Self.logger.debug(
+                    "WordCorrector: REJECT pass=multi-word-fuzzy source='\(rawPhrase)' best_target='\(bestCanonical)' alias='\(bestAlias)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(margin, format: .fixed(precision: 3)) threshold=\(multiThreshold, format: .fixed(precision: 3)) stopword=\(hasStopword) reason=\(reason)"
+                  )
+                #endif
               }
             }
           }
@@ -439,6 +453,21 @@ public struct WordCorrector: Sendable {
           )
         #endif
         return prefix + bestMatch + suffix
+      } else if bestScore > 0 {
+        #if DEBUG
+          let pass4Margin = bestScore - secondBest
+          let reason: String
+          if bestScore < pass4Threshold {
+            reason = "below_threshold"
+          } else if pass4Margin < Self.ambiguityMargin {
+            reason = "below_margin"
+          } else {
+            reason = "same_as_input"
+          }
+          Self.logger.debug(
+            "WordCorrector: REJECT pass=alias-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass4Margin, format: .fixed(precision: 3)) threshold=\(pass4Threshold, format: .fixed(precision: 3)) reason=\(reason)"
+          )
+        #endif
       }
 
       // Pass 5: fuzzy single-word against canonicals as fallback
@@ -478,6 +507,21 @@ public struct WordCorrector: Sendable {
           )
         #endif
         return prefix + bestMatch + suffix
+      } else if bestScore > 0 {
+        #if DEBUG
+          let pass5Margin = bestScore - secondBest
+          let reason: String
+          if bestScore < pass5Threshold {
+            reason = "below_threshold"
+          } else if pass5Margin < Self.ambiguityMargin {
+            reason = "below_margin"
+          } else {
+            reason = "same_as_input"
+          }
+          Self.logger.debug(
+            "WordCorrector: REJECT pass=canonical-fuzzy source='\(core)' best_target='\(bestMatch)' score=\(bestScore, format: .fixed(precision: 3)) margin=\(pass5Margin, format: .fixed(precision: 3)) threshold=\(pass5Threshold, format: .fixed(precision: 3)) reason=\(reason)"
+          )
+        #endif
       }
 
       return token


### PR DESCRIPTION
## Summary

- Three release-safe debug-only log additions for Custom Words debugging visibility.
- Confirms whether AFM polish receives custom vocabulary, what the corrector sees at step entry, and which candidates the corrector's fuzzy passes rejected and why.
- Codified from the 2026-05-05 PM debugging session that diagnosed #657 (cold-cache 10ms timeout firing before any pass executes).

## Test plan

- [x] `swift build -c debug` green
- [x] `swift build -c release` green
- [x] Validated end-to-end on real dictation 2026-05-05: app.log captures the new lines, OSLog reject lines visible via `log show --predicate 'subsystem == "com.enviouswispr" AND category == "WordCorrector"'`
- [x] Codex grounded review: PROCEED-AS-PLANNED on the diff
- [ ] CI build-check passes

## Validation evidence

The diagnostic instrumentation paid for itself the same day it was written: it produced the evidence that confirmed #657's cold-cache timeout failure mode AT 33-term scale (not just the 1,121-term packs originally measured). Comments on #657 and #653 document the findings.

## Refs

- #657 — root-cause issue this instrumentation surfaces (heart-path timeout). Recommended fix: Option A (remove cap entirely).
- #653 — Phase 5b validation, same root cause.
- #656 — Plan A diagnostic instrumentation source. Plan B (full flight recorder) remains correctly deferred to P4.
- #633 — Custom Words v2 epic.

## Notes for reviewer

- AppLogger calls no-op in release per `AppLogger.swift:88-90`. Production behavior unchanged.
- OSLog reject lines wrapped in `#if DEBUG`, same channel as existing accept lines.
- No new types, no new fields, no public API changes.
- All variables referenced in new lines verified in scope at their emission sites.
