### PR TITLE
[codex] fix audio format failure source telemetry

### DIFF
--- a/Sources/EnviousWispr/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWispr/App/BenchmarkSuite.swift
@@ -218,26 +218,27 @@ final class BenchmarkSuite {
 
     guard let sourceBuffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: frameCount)
     else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "BenchmarkSuite.loadAudioFile.source_buffer")
     }
     try file.read(into: sourceBuffer)
 
     // Resample if needed
     if sourceFormat.sampleRate == AudioConstants.sampleRate && sourceFormat.channelCount == 1 {
       guard let channelData = sourceBuffer.floatChannelData else {
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(
+          source: "BenchmarkSuite.loadAudioFile.source_channel_data")
       }
       return Array(UnsafeBufferPointer(start: channelData[0], count: Int(sourceBuffer.frameLength)))
     }
 
     guard let converter = AVAudioConverter(from: sourceFormat, to: format) else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "BenchmarkSuite.loadAudioFile.converter")
     }
 
     let ratio = AudioConstants.sampleRate / sourceFormat.sampleRate
     let outputFrames = AVAudioFrameCount(Double(frameCount) * ratio)
     guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: outputFrames) else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "BenchmarkSuite.loadAudioFile.output_buffer")
     }
 
     var error: NSError?
@@ -255,7 +256,8 @@ final class BenchmarkSuite {
     }
 
     guard error == nil, let channelData = outputBuffer.floatChannelData else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(
+        source: "BenchmarkSuite.loadAudioFile.output_channel_data")
     }
 
     return Array(UnsafeBufferPointer(start: channelData[0], count: Int(outputBuffer.frameLength)))

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -315,7 +315,8 @@ final class AVAudioEngineSource: AudioInputSource {
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     guard let fwd = forwarder else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(
+        source: "AVAudioEngineSource.startCapture.missing_forwarder")
     }
 
     // Reset stoppedFlag in case a config change happened during pre-roll
@@ -642,22 +643,24 @@ final class AVAudioEngineSource: AudioInputSource {
           interleaved: false
         )
       else {
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(source: "AVAudioEngineSource.recover.target_format")
       }
 
       guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(source: "AVAudioEngineSource.recover.converter")
       }
       self.converter = audioConverter
 
       guard let stoppedFlag = tapStoppedFlag else {
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(
+          source: "AVAudioEngineSource.recover.missing_stop_token")
       }
       stoppedFlag.reset()
       btCrashLogger.info("Recovery: stop token reset for new tap")
 
       guard let fwd = forwarder else {
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(
+          source: "AVAudioEngineSource.recover.missing_forwarder")
       }
 
       // Validate format before reinstalling tap.
@@ -666,7 +669,8 @@ final class AVAudioEngineSource: AudioInputSource {
         btCrashLogger.error(
           "Recovery: invalid input format \(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch — emergency teardown"
         )
-        throw AudioError.formatCreationFailed
+        throw AudioError.formatCreationFailed(
+          source: "AVAudioEngineSource.recover.invalid_input_format")
       }
 
       // Safety: remove tap again before reinstalling.

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -95,7 +95,7 @@ final class AVCaptureSessionSource: AudioInputSource {
 
     let input = try AVCaptureDeviceInput(device: mic)
     guard captureSession.canAddInput(input) else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "AVCaptureSessionSource.prepare.can_add_input")
     }
     captureSession.addInput(input)
 
@@ -113,7 +113,7 @@ final class AVCaptureSessionSource: AudioInputSource {
     ]
 
     guard captureSession.canAddOutput(output) else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "AVCaptureSessionSource.prepare.can_add_output")
     }
     captureSession.addOutput(output)
 
@@ -148,7 +148,7 @@ final class AVCaptureSessionSource: AudioInputSource {
     }
 
     guard started else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(source: "AVCaptureSessionSource.prepare.start_running")
     }
 
     AudioCaptureManager.btRouteLog(
@@ -160,7 +160,8 @@ final class AVCaptureSessionSource: AudioInputSource {
       throw AudioError.alreadyCapturing
     }
     guard let fwd = forwarder else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(
+        source: "AVCaptureSessionSource.startCapture.missing_forwarder")
     }
 
     let stream = AsyncStream<AVAudioPCMBuffer> { continuation in

--- a/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
+++ b/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
@@ -26,7 +26,7 @@ enum AudioBufferProcessor {
 
 /// Errors that can occur during audio operations.
 public enum AudioError: LocalizedError, Sendable {
-  case formatCreationFailed
+  case formatCreationFailed(source: String = "unknown")
   case alreadyCapturing
   case noBuiltInMicrophoneFound
 
@@ -35,6 +35,15 @@ public enum AudioError: LocalizedError, Sendable {
     case .formatCreationFailed: return "Failed to create audio format."
     case .alreadyCapturing: return "Audio capture is already active."
     case .noBuiltInMicrophoneFound: return "No built-in microphone found."
+    }
+  }
+
+  public var diagnosticSource: String? {
+    switch self {
+    case .formatCreationFailed(let source):
+      return source
+    case .alreadyCapturing, .noBuiltInMicrophoneFound:
+      return nil
     }
   }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -156,7 +156,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
     guard let source = activeSource else {
-      throw AudioError.formatCreationFailed
+      throw AudioError.formatCreationFailed(
+        source: "AudioCaptureManager.beginCapturePhase.no_active_source")
     }
 
     // Pre-allocate sample buffer

--- a/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
+++ b/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
@@ -1,0 +1,31 @@
+import EnviousWisprAudio
+import EnviousWisprServices
+
+@MainActor
+enum AudioCaptureFailureExtras {
+  static func build(
+    error: Error,
+    audioCapture: any AudioCaptureInterface,
+    failureMode: String,
+    backend: String? = nil
+  ) -> [String: Any] {
+    var extras = SentryAudioExtras.buildCaptureExtras(
+      route: audioCapture.currentAudioRoute,
+      sourceType: audioCapture.captureSourceType,
+      sessionID: audioCapture.currentCaptureSessionID,
+      isActivelyCapturing: audioCapture.isActivelyCapturing,
+      inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+        ? nil : audioCapture.preferredInputDeviceIDOverride,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: failureMode
+    )
+
+    if let source = (error as? AudioError)?.diagnosticSource {
+      extras["capture.error_source"] = source
+    }
+    if let backend {
+      extras["backend"] = backend
+    }
+    return extras
+  }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -514,14 +514,9 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
         error,
         category: .audioCaptureFailed,
         stage: "recording",
-        extra: SentryAudioExtras.buildCaptureExtras(
-          route: audioCapture.currentAudioRoute,
-          sourceType: audioCapture.captureSourceType,
-          sessionID: audioCapture.currentCaptureSessionID,
-          isActivelyCapturing: audioCapture.isActivelyCapturing,
-          inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
-            ? nil : audioCapture.preferredInputDeviceIDOverride,
-          inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        extra: AudioCaptureFailureExtras.build(
+          error: error,
+          audioCapture: audioCapture,
           failureMode: "thrown_start"
         )
       )

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -493,17 +493,12 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         )
       }
     } catch {
-      var extras = SentryAudioExtras.buildCaptureExtras(
-        route: audioCapture.currentAudioRoute,
-        sourceType: audioCapture.captureSourceType,
-        sessionID: audioCapture.currentCaptureSessionID,
-        isActivelyCapturing: audioCapture.isActivelyCapturing,
-        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
-          ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-        failureMode: "thrown_start"
+      let extras = AudioCaptureFailureExtras.build(
+        error: error,
+        audioCapture: audioCapture,
+        failureMode: "thrown_start",
+        backend: "whisperKit"
       )
-      extras["backend"] = "whisperKit"
       SentryBreadcrumb.captureError(
         error, category: .audioCaptureFailed, stage: "recording", extra: extras)
       state = .error("Recording failed: \(error.localizedDescription)")

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -1,0 +1,100 @@
+@preconcurrency import AVFoundation
+import Testing
+
+@testable import EnviousWisprAudio
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+@Suite("AudioCaptureFailureExtras")
+@MainActor
+struct AudioCaptureFailureExtrasTests {
+  @Test("format creation failures include the originating audio source")
+  func formatCreationFailureAddsSource() {
+    let capture = ExtrasAudioCapture()
+    capture.currentCaptureSessionID = 42
+    capture.preferredInputDeviceIDOverride = "preferred-mic"
+
+    let extras = AudioCaptureFailureExtras.build(
+      error: AudioError.formatCreationFailed(
+        source: "AVAudioEngineSource.startCapture.missing_forwarder"),
+      audioCapture: capture,
+      failureMode: "thrown_start"
+    )
+
+    #expect(
+      extras["capture.error_source"] as? String
+        == "AVAudioEngineSource.startCapture.missing_forwarder")
+    #expect(extras["capture.source_type"] as? String == "av_audio_engine")
+    #expect(extras["capture.failure_mode"] as? String == "thrown_start")
+    #expect(extras["capture_session_id"] as? Int == 42)
+    #expect(extras["capture.input_device_uid_preferred"] as? String == "preferred-mic")
+  }
+
+  @Test("non-audio errors omit the audio source and keep backend tag")
+  func nonAudioErrorOmitsSource() {
+    let extras = AudioCaptureFailureExtras.build(
+      error: GenericStartError.failed,
+      audioCapture: ExtrasAudioCapture(),
+      failureMode: "thrown_start",
+      backend: "whisperKit"
+    )
+
+    #expect(extras["capture.error_source"] == nil)
+    #expect(extras["backend"] as? String == "whisperKit")
+  }
+
+  @Test("audio error keeps user-facing message stable")
+  func audioErrorMessageStable() {
+    let error = AudioError.formatCreationFailed(source: "unit.test")
+    #expect(error.localizedDescription == "Failed to create audio format.")
+    #expect(error.diagnosticSource == "unit.test")
+  }
+}
+
+private enum GenericStartError: Error {
+  case failed
+}
+
+@MainActor
+private final class ExtrasAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "built_in_mic"
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "av_audio_engine"
+  var noiseSuppressionEnabled: Bool = false
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func buildEngine(noiseSuppression: Bool) {}
+  func preWarm() async throws {}
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}


### PR DESCRIPTION
## Summary

Closes #595.

Adds source-site detail to `AudioError.formatCreationFailed` so future `audio_capture_failed` Sentry events can show where the format failure originated instead of only pointing at the pipeline catch block.

## What changed

- Keeps the user-facing error text stable: `Failed to create audio format.`
- Adds low-cardinality `capture.error_source` extras for Parakeet and WhisperKit recording-start failures.
- Tags each current `formatCreationFailed` throw site in the audio stack and benchmark loader.
- Adds focused tests for the new extras helper and message stability.

## Validation

- `swift build -c release`
- `scripts/swift-test.sh --no-run`
- `scripts/swift-test.sh --filter AudioCaptureFailureExtrasTests`

## Notes

This is observability only. It does not change recording control flow or recovery behavior.
