### PR TITLE
test(llm): restore planner prompt coverage

### DIFF
--- a/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
@@ -404,4 +404,30 @@ struct LanguageAwarePromptInjectionTests {
   }
 
   // MARK: - Parakeet byte-identical characterization
+
+  @Test("Parakeet prompt output is byte-identical to legacy nil-backend output")
+  func parakeetByteIdenticalToLegacy() {
+    let words = [CustomWord(canonical: "EnviousWispr", aliases: ["Envious Whisper"])]
+    let legacyInput = input(
+      customWords: words,
+      detection: nil,
+      backend: nil
+    )
+    let parakeetInput = input(
+      customWords: words,
+      detection: nil,
+      backend: .parakeet
+    )
+
+    let legacyPlan = DefaultPromptPlanner().plan(input: legacyInput)
+    let parakeetPlan = DefaultPromptPlanner().plan(input: parakeetInput)
+
+    #expect(
+      legacyPlan.envelope.messages.map(\.role.rawValue)
+        == parakeetPlan.envelope.messages.map(\.role.rawValue),
+      "Explicit Parakeet must match legacy nil-backend prompt roles exactly")
+    #expect(
+      legacyPlan.envelope.messages.map(\.content) == parakeetPlan.envelope.messages.map(\.content),
+      "Explicit Parakeet must match legacy nil-backend prompt text byte-for-byte")
+  }
 }

--- a/Tests/EnviousWisprTests/LLM/PromptPlannerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/PromptPlannerTests.swift
@@ -120,4 +120,24 @@ struct PromptPlannerTests {
     let user = plan.envelope.messages[1].content
     #expect(user.contains("<transcript>"))
   }
+
+  @Test("Ollama Gemma plan uses few-shot prompt style")
+  func ollamaGemmaPlanStyle() {
+    let plan = planner.plan(input: makeInput(provider: .ollama, modelID: "gemma3:4b"))
+    let system = plan.envelope.messages[0].content
+    let user = plan.envelope.messages[1].content
+    #expect(system.contains("Example"))
+    #expect(system.contains("Now clean up this text:"))
+    #expect(!user.contains("<transcript>"))
+  }
+
+  @Test("Ollama non-Gemma plan uses OpenAI prose prompt style")
+  func ollamaNonGemmaPlanStyle() {
+    let plan = planner.plan(input: makeInput(provider: .ollama, modelID: "llama3.2"))
+    let system = plan.envelope.messages[0].content
+    let user = plan.envelope.messages[1].content
+    #expect(system.contains("Clean up this dictated transcript"))
+    #expect(!system.contains("Now clean up this text:"))
+    #expect(user.contains("<transcript>"))
+  }
 }


### PR DESCRIPTION
## Summary
- Restores end-to-end Ollama planner prompt-style assertions for Gemma and non-Gemma models.
- Restores Parakeet explicit-backend vs legacy nil-backend prompt payload equivalence coverage.

## Scope
- Test-only change.
- No product code changes.
- No custom-words work.

## Validation
- git diff --check
- scripts/swift-test.sh --filter PromptPlannerTests
- scripts/swift-test.sh --filter LanguageAwarePromptInjectionTests
- swift build -c release --arch arm64
- scripts/swift-test.sh --no-run
- scripts/swift-test.sh
- codex review --uncommitted (clean; raw swift test attempted by reviewer failed for known local wrapper/tooling reason)

Refs #626
Refs #627