### PR TITLE
fix(custom-words): remove silent-discard of long-input corrections (#657)

### DIFF
--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -1,5 +1,7 @@
 import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprPostProcessing
+import EnviousWisprServices
 import Foundation
 
 /// Result of running the text processing chain.
@@ -90,7 +92,8 @@ internal final class TextProcessingRunner {
         throw CancellationError()
       } catch {
         let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
-        let reason = error is TimeoutError ? "timed out" : "failed: \(error.localizedDescription)"
+        let isTimeout = error is TimeoutError
+        let reason = isTimeout ? "timed out" : "failed: \(error.localizedDescription)"
         // Apple Intelligence language-gate skips (unsupported input
         // language, output-language drift) are expected no-ops, not
         // polish failures. Log and continue with raw text; do not
@@ -110,11 +113,29 @@ internal final class TextProcessingRunner {
         if step.errorSurfacePolicy == .surface && !isLanguageGateSkip {
           polishError = error.localizedDescription
         }
-        Task {
-          await logger.log(
-            "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping",
-            level: .info, category: "TextProcessing"
+        // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
+        // exceeds its 3s `maxDuration`. The step's result was discarded; raw
+        // text passes through. The runner is the right owner because this is
+        // where the actual discard happens.
+        let logCapMessage: String
+        if isTimeout, stepName == "Word Correction",
+          let wcStep = step as? WordCorrectionStep
+        {
+          let capMs = budgetSeconds * 1000
+          let inputChars = input.text.count
+          TelemetryService.shared.customWordsTimeoutFired(
+            vocabSize: wcStep.correctorVocabulary.terms.count,
+            elapsedMs: stepMs,
+            inputChars: inputChars
           )
+          logCapMessage =
+            "\(stepName) timed out at \(String(format: "%.0f", capMs))ms cap after \(String(format: "%.1f", stepMs))ms — skipping"
+        } else {
+          logCapMessage =
+            "\(stepName) \(reason) after \(String(format: "%.1f", stepMs))ms — skipping"
+        }
+        Task {
+          await logger.log(logCapMessage, level: .info, category: "TextProcessing")
         }
         // Heart & Limbs: limb failed, continue with input text
       }

--- a/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
+++ b/Sources/EnviousWisprPipeline/WordCorrectionStep.swift
@@ -14,12 +14,15 @@ import Foundation
 /// Phase 3b implements the debounced writer; this call is exercised but
 /// inert until then.
 ///
-/// Phase 2b (#638) — heart-path 10ms hard cap on `WordCorrector.correct(...)`
-/// invocation (bible §2.2.1) + generation-keyed cache of the lookup maps so
-/// they are rebuilt only when the vocabulary generation changes (bible §17
-/// R19). The correction runs OFF MainActor inside the timeout closure so
-/// the timer task can preempt; on timeout we return the raw text and emit a
-/// Sentry breadcrumb (no escalation).
+/// Phase 2b (#638) — generation-keyed cache of the lookup maps so they are
+/// rebuilt only when the vocabulary generation changes (bible §17 R19).
+///
+/// #657 (2026-05-05) — heart-path inner 10ms cap removed: it was firing during
+/// cold-cache lookup-map builds and on long-input scoring, causing silent
+/// discard of the corrector result via the runner's outer timeout. The single
+/// remaining bound is the runner-level `maxDuration` cap below (3 seconds).
+/// Cap-trip telemetry now lives in `TextProcessingRunner` where the actual
+/// discard happens.
 @MainActor
 public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyConsumer {
   public let name = "Word Correction"
@@ -39,10 +42,14 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
     wordCorrectionEnabled && !correctorVocabulary.terms.isEmpty
   }
 
-  /// Outer runner cap (unchanged). Phase 2b adds a tighter inner 10ms cap
-  /// that fires before this would, protecting the heart path from runaway
-  /// matcher cost on pathological vocab + transcript combinations.
-  public var maxDuration: Duration { .milliseconds(100) }
+  /// Runner-level safety net. #657 (2026-05-05) raised this from 100ms to 3
+  /// seconds after empirical evidence showed the previous cap silently
+  /// discarded corrector output on paragraph-length input. The cap is now a
+  /// true runaway-protection ceiling, not a steady-state budget. When it
+  /// fires, `TextProcessingRunner` emits `custom_words.timeout_fired` with
+  /// vocabSize / elapsedMs / inputChars so we have feedback signal in
+  /// production.
+  public var maxDuration: Duration { .seconds(3) }
 
   /// Phase 3a (#631): manager handle for replacement attribution. Optional
   /// because pre-Phase-3a callers (and tests) construct the step with no
@@ -77,25 +84,16 @@ public final class WordCorrectionStep: TextProcessingStep, CorrectorVocabularyCo
         level: .info, category: "Pipeline"
       )
     }
-    let result: (corrected: String, replacements: [WordCorrector.Replacement])
     let startTime = CFAbsoluteTimeGetCurrent()
-    do {
-      // Phase 2b (#638) bible §2.2.1: hard 10ms cap. WordCorrector.correct is
-      // pure CPU work; we run it OFF MainActor inside the timeout closure so
-      // the timer Task can preempt. On timeout, raw text passes through.
-      result = try await withThrowingTimeout(seconds: 0.010) {
-        let corrector = WordCorrector()
-        return corrector.correct(inputText, using: lookups)
-      }
-    } catch is TimeoutError {
-      SentryBreadcrumb.add(
-        stage: "wordcorrector",
-        message: "WordCorrector timeout (10ms cap exceeded)",
-        data: ["vocab_size": String(snapshot.terms.count)]
-      )
-      // Phase 8a (#620): emit timeout event. Bible §14.1.
-      TelemetryService.shared.customWordsTimeoutFired(vocabSize: snapshot.terms.count)
-      return context  // raw text passes through; heart path unaffected
+    // #657: corrector runs OFF MainActor (the WordCorrector matcher is pure
+    // CPU; running it inline on @MainActor would stall the UI on long input).
+    // The only meaningful cap is the runner's outer 3s `maxDuration`; this
+    // 5-second inner wrapper exists solely to preserve the Phase 2b
+    // off-actor execution pattern. When the runner trips its 3s cap, child
+    // task cancellation propagates here too. Cap-trip telemetry now lives in
+    // `TextProcessingRunner` where the actual discard happens.
+    let result = try await withThrowingTimeout(seconds: 5.0) {
+      WordCorrector().correct(inputText, using: lookups)
     }
     let elapsedMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -710,13 +710,21 @@ public final class TelemetryService {
     )
   }
 
-  /// Phase 2 (#638) — fired by `WordCorrectionStep.process(...)` when the
-  /// 10ms heart-path timeout cap fires.
-  public func customWordsTimeoutFired(vocabSize: Int) {
+  /// #657 (2026-05-05) — fired by `TextProcessingRunner` when the
+  /// `WordCorrectionStep` exceeds its 3-second `maxDuration` cap and the
+  /// corrector result is discarded. Properties expanded from the prior
+  /// vocab-only shape so dashboards can slice cap-trips by input size.
+  public func customWordsTimeoutFired(
+    vocabSize: Int,
+    elapsedMs: Double,
+    inputChars: Int
+  ) {
     PostHogSDK.shared.capture(
       "custom_words.timeout_fired",
       properties: [
-        "vocab_size": vocabSize
+        "vocab_size": vocabSize,
+        "elapsed_ms": elapsedMs,
+        "input_chars": inputChars,
       ]
     )
   }

--- a/Tests/EnviousWisprTests/Pipeline/WordCorrectionStepCacheTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WordCorrectionStepCacheTests.swift
@@ -4,8 +4,12 @@ import Testing
 
 @testable import EnviousWisprPipeline
 
-/// Phase 2b (#638) — pins the lookup-map cache + heart-path 10ms timeout
-/// contracts on `WordCorrectionStep`. Bible §8.2 items 5-6, §17 R19, §2.2.1.
+/// Phase 2b (#638) — pins the lookup-map cache contract on
+/// `WordCorrectionStep`. Bible §8.2 items 5-6, §17 R19.
+///
+/// #657 (2026-05-05) — the inner 10ms timeout was removed; the only remaining
+/// bound is the runner-level 3-second `maxDuration` safety net. Cap-trip
+/// telemetry is owned by `TextProcessingRunner`, not this step.
 @MainActor
 @Suite("WordCorrectionStep — Phase 2b cache + timeout")
 struct WordCorrectionStepCacheTests {
@@ -96,5 +100,13 @@ struct WordCorrectionStepCacheTests {
     #expect(result.text == "hello world")
     // empty terms still builds an empty Lookups (cheap), so 1 build expected
     #expect(step.lookupCacheBuilds == 1)
+  }
+
+  // MARK: - #657 cap value pin
+
+  @Test("Outer cap is 3 seconds (#657)")
+  func outerCapIsThreeSeconds() {
+    let step = WordCorrectionStep()
+    #expect(step.maxDuration == .seconds(3))
   }
 }


### PR DESCRIPTION
## Summary

Fixes #657. Side-effect resolves the same root cause behind #653 (Phase 5b pack-corrector "did not fire" — full 1100-term validation deferred to Phase 5b shipping). Bible §23.2 row 2b unblocked.

Two timeouts were silently discarding the corrector's result on long input:

- **Inner 10ms** `withThrowingTimeout` inside `WordCorrectionStep.process(...)` was firing during cold-cache lookup-map builds at 33-term vocabularies (documented in #657 cold-cache addendum).
- **Outer 100ms** `WordCorrectionStep.maxDuration` was enforced by `TextProcessingRunner` via its own `withThrowingTimeout`. On long-input scoring the runner caught the trip silently and forwarded raw ASR to AFM polish.

## Empirical evidence (2026-05-05)

One-minute technical TTS harness with 33-term vocab, 1005-1007 char input:

| Run | Inner cap | Outer cap | Visible corrector fixes | Vocab hits |
|---|---|---|---|---|
| Pre-fix (control) | 10ms | 100ms | 1 (Malavica via AFM polish) | 13/18 |
| Diagnostic A | removed | raised to 60s | ~15 (Envious Whisper → EnviousWispr, clawed code → Claude Code, chat GPT codecs → ChatGPT Codex, etc.) | 15/18 |
| **This PR (Test 1)** | 5s no-op | 3s | ~15 visible fixes incl. all multi-word aliases | **18/18** |
| **This PR (Test 2)** | 5s no-op | 3s | ~15 visible fixes | 15/18 (3 alias-gap misses, not corrector-discard) |

Both PR runs showed the corrector emitting real OUT text materially different from RAW ASR — the timeout-discard mechanism is dead.

## Changes

- Raise the inner `withThrowingTimeout` from 10ms to 5 seconds. **Off-actor execution preserved** (the matcher is pure CPU; running it inline on `@MainActor` would stall the UI on long input — caught by Codex code-diff review). The 5s value is a belt-and-suspenders backstop only; the runner's 3s cap will trip first on any real runaway.
- Drop the inner cap's catch path. On the rare case the inner 5s fires before the outer 3s, the error propagates to the runner's catch and is handled there with consistent telemetry.
- Raise outer `maxDuration` from 100ms to 3 seconds (true runaway safety net).
- Move `customWordsTimeoutFired` telemetry from `WordCorrectionStep` to `TextProcessingRunner` where the actual discard happens. Extend the event with `elapsed_ms` and `input_chars` properties on the existing `custom_words.timeout_fired` PostHog event.
- AppLogger message in the runner's catch path now names the cap explicitly: `Word Correction timed out at 3000ms cap after Xms — skipping`.
- Drop the Phase 2 Sentry breadcrumb at `wordcorrector` stage (only emitted from the deleted inner-cap catch; no other code consumers).
- Pin the new cap value in `WordCorrectionStepCacheTests`.

## Telemetry-aggregation side effect

Per plan §5: corrector wall-time rolls into `polishDurationSeconds` via `TranscriptFinalizer`, which feeds `llm.polish_completed.latency_seconds`. Bounded by 3s per cap-trip event, sliceable via the new `custom_words.timeout_fired` count.

## Plan + reviews

- **Plan:** `docs/feature-requests/issue-657-2026-05-05-corrector-timeout-fix.md`
- **Council:** skipped per founder direction. Audit tag: `council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining`
- **Codex grounded review (plan):** PROCEED-WITH-REVISIONS — five revisions folded in (cachedLookups claim corrected; "50ms slow-mock" test replaced with property assertion; telemetry-aggregation side effect documented; signature source-break note; Phase 5b 1100-term scaling caveat in §11.2)
- **Codex code-diff review (round 1):** P1 caught — removing the inner wrapper had moved the matcher onto MainActor. Fixed via 5s no-op wrapper preserving off-actor execution.
- **Codex code-diff review (round 2):** clean ("no actionable correctness issues in the diff")

## Test plan

- [x] `swift build -c debug` clean
- [x] `swift build --build-tests` clean
- [x] `scripts/swift-test.sh` 673/673 pass (incl. existing TextProcessingRunner timeout tests + new `outerCapIsThreeSeconds` cap-pin)
- [x] Live UAT Test 1 — paragraph dictation: 18/18 vocab hits, 15+ visible multi-word corrector fixes
- [x] Live UAT Test 2 — paragraph dictation re-run: 15/18 (3 alias-gap misses, corrector itself working)
- [ ] Phase 5b 1100-term stress — deferred to Phase 5b shipping (not a blocker for the 33-term scenarios this PR targets)
