### PR TITLE
Fix pack term ASR near-miss correction

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -17,6 +17,10 @@ import os
 /// stricter threshold for short tokens (<= 4 chars).
 public struct WordCorrector: Sendable {
   public static let threshold: Double = 0.82
+  /// Curated packs are an explicit install signal. Keep short-token safety,
+  /// ambiguity margin, and per-term overrides, but do not let large pack size
+  /// erase known ASR-near-miss corrections like "Viper" -> "Vyper".
+  public static let packSourceThreshold: Double = 0.70
   public static let multiWordThreshold: Double = 0.85
   public static let shortTokenThreshold: Double = 0.90
   public static let ambiguityMargin: Double = 0.05
@@ -62,6 +66,23 @@ public struct WordCorrector: Sendable {
   /// Bible §8.2 item 3.
   public static func lengthAwareAdjustment(candidateLength: Int) -> Double {
     return min(0.04, 0.005 * Double(max(0, candidateLength - 8)))
+  }
+
+  private static func fuzzyThreshold(
+    for word: CustomWord?,
+    baseThreshold: Double,
+    vocabPenalty: Double,
+    lengthAdjustment: Double
+  ) -> Double {
+    if let override = word?.minSimilarityOverride {
+      return override
+    }
+
+    let defaultThreshold = baseThreshold + vocabPenalty - lengthAdjustment
+    if word?.source == .pack, baseThreshold == Self.threshold {
+      return min(defaultThreshold, Self.packSourceThreshold)
+    }
+    return defaultThreshold
   }
 
   // MARK: - Phase 2b (#638) lookup-map cache
@@ -439,9 +460,13 @@ public struct WordCorrector: Sendable {
       // applied per-candidate. Per-term override wins absolutely if set.
       let pass4VocabPenalty = Self.largeVocabPenalty(poolSize: singleFuzzyCandidates.count)
       let pass4LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
-      let pass4Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
-      let pass4Threshold =
-        pass4Override ?? (effectiveThreshold + pass4VocabPenalty - pass4LengthAdj)
+      let pass4Word = canonicalToWord[bestMatch.lowercased()]
+      let pass4Threshold = Self.fuzzyThreshold(
+        for: pass4Word,
+        baseThreshold: effectiveThreshold,
+        vocabPenalty: pass4VocabPenalty,
+        lengthAdjustment: pass4LengthAdj
+      )
       if bestScore >= pass4Threshold,
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch
@@ -493,9 +518,13 @@ public struct WordCorrector: Sendable {
       // Phase 2 (#638) §8.2: same hardening for Pass 5.
       let pass5VocabPenalty = Self.largeVocabPenalty(poolSize: lowercasedCanonicals.count)
       let pass5LengthAdj = Self.lengthAwareAdjustment(candidateLength: bestMatch.count)
-      let pass5Override = canonicalToWord[bestMatch.lowercased()]?.minSimilarityOverride
-      let pass5Threshold =
-        pass5Override ?? (effectiveThreshold + pass5VocabPenalty - pass5LengthAdj)
+      let pass5Word = canonicalToWord[bestMatch.lowercased()]
+      let pass5Threshold = Self.fuzzyThreshold(
+        for: pass5Word,
+        baseThreshold: effectiveThreshold,
+        vocabPenalty: pass5VocabPenalty,
+        lengthAdjustment: pass5LengthAdj
+      )
       if bestScore >= pass5Threshold,
         bestScore - secondBest >= Self.ambiguityMargin,
         core != bestMatch

--- a/Tests/EnviousWisprTests/Core/WordCorrectorHardeningTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordCorrectorHardeningTests.swift
@@ -77,6 +77,11 @@ struct WordCorrectorHardeningTests {
     #expect(WordCorrector.lengthAwareAdjustment(candidateLength: 100) == 0.04)
   }
 
+  @Test("packSourceThreshold — pack terms use the curated-pack fuzzy bar")
+  func packSourceThresholdValue() {
+    #expect(WordCorrector.packSourceThreshold == 0.70)
+  }
+
   // MARK: - Item 4: Per-term threshold override
 
   @Test("Override — Loose (0.72) accepts what global 0.82 would reject")
@@ -116,5 +121,40 @@ struct WordCorrectorHardeningTests {
     let (result, replacements) = corrector.correct("I used chatgpt today", against: words)
     #expect(result == "I used ChatGPT today")
     #expect(replacements.count == 1)
+  }
+
+  @Test("Pack source — large vocab still corrects ASR-mangled pack terms")
+  func packSourceLargeVocabStillCorrectsASRMangledPackTerms() {
+    let filler = (1...1_120).map { CustomWord(canonical: "SyntheticPackTerm\($0)", source: .pack) }
+    let vyper = CustomWord(canonical: "Vyper", source: .pack)
+    let kustomize = CustomWord(canonical: "Kustomize", source: .pack)
+    let tendis = CustomWord(canonical: "Tendis", source: .pack)
+    let helidon = CustomWord(canonical: "Helidon", source: .pack)
+    let yugabyte = CustomWord(canonical: "YugabyteDB", source: .pack)
+
+    let (result, replacements) = corrector.correct(
+      "Viper customize Tendas Helodon UgabyteDB",
+      against: filler + [vyper, kustomize, tendis, helidon, yugabyte]
+    )
+
+    #expect(result == "Vyper Kustomize Tendis Helidon YugabyteDB")
+    #expect(replacements.count == 5)
+    #expect(Set(replacements.map(\.sourceID)) == Set([
+      vyper.id, kustomize.id, tendis.id, helidon.id, yugabyte.id,
+    ]))
+  }
+
+  @Test("Pack source — unrelated real words remain unchanged")
+  func packSourceUnrelatedRealWordsRemainUnchanged() {
+    let filler = (1...1_120).map { CustomWord(canonical: "SyntheticPackTerm\($0)", source: .pack) }
+    let kustomize = CustomWord(canonical: "Kustomize", source: .pack)
+
+    let (result, replacements) = corrector.correct(
+      "the customer is happy",
+      against: filler + [kustomize]
+    )
+
+    #expect(result == "the customer is happy")
+    #expect(replacements.isEmpty)
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #658.
- Adds a pack-source fuzzy threshold so curated vocabulary packs can correct known ASR near-misses even with large pack vocabularies.
- Keeps short-token safety, ambiguity margin, and per-term similarity overrides intact.
- Adds regression coverage for Vyper, Kustomize, Tendis, Helidon, and YugabyteDB plus an unrelated-real-word guard case.

## Validation
- `scripts/swift-test.sh --filter packSourceLargeVocabStillCorrectsHighSimilarityMiss` failed before the fix.
- `scripts/swift-test.sh --filter WordCorrectorHardeningTests` passed.
- `scripts/swift-test.sh --filter WordCorrector` passed after rebase: 46 tests.
- `swift build -c release` passed before rebase with existing warnings only.
- `git diff --check` passed.
- `codex review --uncommitted -c model="gpt-5.2"` completed with no correctness findings.

## Notes
- The original issue described a real-English-word guard, but current `main` did not have a separate dictionary guard. The observed failure came from the large-vocab threshold/score behavior blocking pack ASR near-misses.