### PR TITLE
Fix flaky async test waits

### DIFF
--- a/Sources/EnviousWispr/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWispr/App/TranscriptCoordinator.swift
@@ -48,6 +48,10 @@ final class TranscriptCoordinator {
     }
   }
 
+  func waitForLoadForTesting() async {
+    await loadTask?.value
+  }
+
   /// Append a just-completed transcript to the in-memory cache.
   ///
   /// Precondition: the transcript has already been persisted by

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -165,6 +165,10 @@ public final class UpdateAvailabilityService {
     }
   }
 
+  func waitForPostRecordingGraceForTesting() async {
+    await graceTask?.value
+  }
+
   // MARK: - Persistence helpers
 
   func persist(_ update: AvailableUpdate) {

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
@@ -99,8 +99,7 @@ struct TranscriptCoordinatorTests {
     let coordinator = TranscriptCoordinator(store: store)
 
     coordinator.load()
-    // load() runs on a Task; wait for it.
-    try await Task.sleep(nanoseconds: 200_000_000)
+    await coordinator.waitForLoadForTesting()
 
     #expect(coordinator.transcripts.count == 3)
     let loadedIDs = Set(coordinator.transcripts.map(\.id))
@@ -123,7 +122,7 @@ struct TranscriptCoordinatorTests {
     let newRow = Self.makeTranscript(text: "appended")
     coordinator.append(newRow)
     coordinator.load()
-    try await Task.sleep(nanoseconds: 200_000_000)
+    await coordinator.waitForLoadForTesting()
 
     let ids = coordinator.transcripts.map(\.id)
     #expect(ids.count == 2)
@@ -151,7 +150,7 @@ struct TranscriptCoordinatorTests {
     coordinator.append(r2)
     coordinator.append(r3)
     coordinator.load()
-    try await Task.sleep(nanoseconds: 200_000_000)
+    await coordinator.waitForLoadForTesting()
 
     // Pre-merge in-memory order was [r3, r2, r1] (each append inserts at 0).
     // After merge: in-memory rows first (order preserved), then disk row.
@@ -170,7 +169,7 @@ struct TranscriptCoordinatorTests {
     let store = TranscriptStore(directory: dir)
     let coordinator = TranscriptCoordinator(store: store)
     coordinator.load()
-    try await Task.sleep(nanoseconds: 200_000_000)
+    await coordinator.waitForLoadForTesting()
 
     coordinator.delete(row)
     #expect(coordinator.transcripts.isEmpty)

--- a/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
@@ -153,8 +153,7 @@ struct UpdateAvailabilityServiceTests {
     let (s, _) = Self.makeService()
     s.handlePipelineStateChange(isRecording: false)
     #expect(s.inPostRecordingGrace == true)
-    // postRecordingGraceDuration is 3.0s; we wait slightly longer.
-    try await Task.sleep(for: .seconds(3.5))
+    await s.waitForPostRecordingGraceForTesting()
     #expect(s.inPostRecordingGrace == false)
   }
 


### PR DESCRIPTION
## Summary
- replace fixed sleeps in TranscriptCoordinator tests with an explicit wait for the active load task
- replace the post-recording grace timing guess with a wait for the actual grace task
- keep the changes scoped to test synchronization; no production behavior changes

Fixes #672

## Validation
- scripts/swift-test.sh --filter TranscriptCoordinator
- scripts/swift-test.sh --filter UpdateAvailabilityService
- scripts/swift-test.sh -c release --filter TranscriptCoordinator
- scripts/swift-test.sh -c release --filter UpdateAvailabilityService
- 5x repeat loop of both flaky-area filters
- swift build -c release
- git diff --check
- npx -y @openai/codex@latest review --uncommitted -c model="gpt-5.5" -c model_reasoning_effort="high" — no actionable findings

## Notes
- The installed Homebrew Codex CLI is 0.122.0 and rejects gpt-5.5. I used the transient latest CLI through npx, which reported 0.128.0 and accepted gpt-5.5 high.