### PR TITLE
content(blog): cross-link equity pass for under-connected posts (#678 follow-up)

### DIFF
--- a/website/src/content/blog/dictate-emails-speed-of-thought.md
+++ b/website/src/content/blog/dictate-emails-speed-of-thought.md
@@ -10,7 +10,7 @@ author: "Saurabh Vaish"
 
 The average executive types around 40 words per minute. They speak 130 to 150. That's roughly 3-4x throughput on the single activity that dominates their day: writing emails. That's a rough estimate, not a measured fact, but the gap is real and it compounds across dozens of messages a day.
 
-Between meetings, most leaders face a growing backlog of follow-up messages: updates, decisions, delegation, context for people who weren't in the room. The decisions happen fast. Writing them down doesn't. And dictating into a cloud tool that routes every word through someone else's servers isn't an option when you're handling sensitive strategy, personnel decisions, or M&A discussions.
+Between meetings, most leaders face a growing backlog of follow-up messages: updates, decisions, delegation, context for people who weren't in the room. The decisions happen fast. Writing them down doesn't. The same volume problem is true at the individual contributor level, where [remote workers tired of typing](/blog/dictation-remote-workers-tired-of-typing/) burn through Slack threads, ticket comments, and async updates all day. And dictating into a cloud tool that routes every word through someone else's servers isn't an option when you're handling sensitive strategy, personnel decisions, or M&A discussions.
 
 There's a faster, more private way.
 
@@ -93,6 +93,7 @@ The speech model downloads automatically on first launch. After that initial set
 
 - [Meeting Notes to Polished Summaries in Seconds](/blog/meeting-notes-polished-summaries/). Turn post-meeting chaos into structured summaries with action items.
 - [Async Communication Is Better When You Speak It](/blog/async-communication-better-when-you-speak/). Why dictating Slack messages and async updates beats typing them.
+- [Dictation for Remote Workers Tired of Typing](/blog/dictation-remote-workers-tired-of-typing/). The same speed gain across Slack, tickets, docs, and async standups.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
 
 Set your hotkey. Open your email client. Hold, speak, release. Your first dictated email will be done before you finish reading this sentence.

--- a/website/src/content/blog/dictate-first-drafts-sound-like-you.md
+++ b/website/src/content/blog/dictate-first-drafts-sound-like-you.md
@@ -128,6 +128,7 @@ EnviousWispr is free and yours to keep. No strings.
 
 - [Dictation for Writers: Skip the Blank Page](/blog/dictation-for-writers-skip-blank-page/). How speaking your first draft bypasses writer's block entirely.
 - [Voice to Prose: A Realistic Writing Workflow](/blog/voice-to-prose-writing-workflow/). A practical guide to building a full voice-to-prose session.
+- [Dictate Meeting Notes to Polished Summaries on Mac](/blog/meeting-notes-polished-summaries/). Apply the same dictate-then-polish loop to post-meeting recaps and exec briefings.
 - [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). A fair comparison of where your recordings go.
 
 Your words, your style, your Mac. Nothing leaves the building.

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -161,6 +161,8 @@ For people who rely on voice input as their primary way of writing, those aren't
 
 - [Voice Input for RSI: A Keyboard-Free Workflow](/blog/voice-input-rsi-keyboard-free-workflow/). A practical guide for people whose hands need a break from typing.
 - [On-Device vs Cloud Dictation: What Stays Private](/blog/on-device-vs-cloud-dictation-privacy/). A detailed comparison of where your recordings go with different tools.
+- [Dictate Meeting Notes to Polished Summaries on Mac](/blog/meeting-notes-polished-summaries/). Why on-device matters for board updates, M&A discussions, and personnel reviews.
+- [Dictation for Remote Workers Tired of Typing](/blog/dictation-remote-workers-tired-of-typing/). On-device speech-to-text fits naturally into Slack, email, and ticket workflows.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
 
 If you want to try it, [download EnviousWispr free](/#download) and start dictating, or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Skip the sign-up form. There isn't one. Just the app and your voice, with no audio leaving your Mac.

--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -116,6 +116,7 @@ EnviousWispr gives you a way to listen to that signal without losing your abilit
 
 - [macOS Dictation That Works Offline and Stays Private](/blog/macos-dictation-offline-private/). How EnviousWispr compares to other macOS dictation options for accessibility.
 - [Dictation for Remote Workers Tired of Typing](/blog/dictation-remote-workers-tired-of-typing/). The ergonomic case for mixing voice and keyboard input.
+- [Dictating Git Commits on macOS: Better Messages, Less Typing](/blog/switched-typing-to-dictating-git-commits/). For developers offloading the prose part of coding work to voice.
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). Minimal-typing setup guide from download to first dictation.
 
 Your hands will thank you.


### PR DESCRIPTION
## Summary

Follow-up to PR #683. After the question-format H2 + answer-block work, three of the five updated posts were under-connected on inbound internal links (meeting-notes, remote-workers, git-commits had 2-3 inbound vs the writers/RSI posts at 5). This pass restores parity.

| Post | Inbound before | Inbound after |
|---|---|---|
| meeting-notes-polished-summaries | 3 | 5 |
| dictation-remote-workers-tired-of-typing | 2 | 4 |
| switched-typing-to-dictating-git-commits | 2 | 3 |

Source posts edited:

- \`dictate-emails-speed-of-thought\` — adds inline body link to remote-workers in the email-volume paragraph + a 4th Related Posts entry. The remote-worker volume angle naturally mirrors the exec-volume angle the post already covers.
- \`macos-dictation-offline-private\` — adds Related Posts entries for both meeting-notes (privacy + sensitive meetings) and remote-workers (privacy + day-long Slack/email). This is the privacy-pillar post, so it makes sense as a hub.
- \`dictate-first-drafts-sound-like-you\` — adds Related Posts entry for meeting-notes (same dictate-then-polish loop, applied to recaps).
- \`voice-input-rsi-keyboard-free-workflow\` — adds Related Posts entry for git-commits (developers with RSI offloading the prose-of-code work to voice).

## Validation

- \`npm run build\` passed in \`website/\`: 43 pages.
- No em-dashes / en-dashes introduced (grep clean).
- Only one new body inline link total. The rest are Related Posts additions, capped at 5 entries per post.

## Test plan

- [x] Build passes locally
- [ ] CI \`build-check\` green
- [ ] After merge: ping IndexNow on the 4 source posts so re-crawls pick up the new outbound links
