### PR TITLE
[codex] Clarify LID benchmark needs debug bundle

### DIFF
--- a/scripts/lid-perf-bench.sh
+++ b/scripts/lid-perf-bench.sh
@@ -69,6 +69,7 @@ enable_app_file_logging() {
     echo "lid-perf-bench needs the current debug dev app so AppLogger writes app.log." >&2
     echo "Found version '${APP_VERSION:-unknown}' at $DEV_APP_PATH." >&2
     echo "Expected version '$EXPECTED_VERSION'." >&2
+    echo "Note: scripts/bundle-dev.sh creates a release-style '-dev' bundle; this benchmark needs a debug '-debug' bundle." >&2
     echo "Build and launch the debug dev app first, then rerun this script." >&2
     exit 2
   fi


### PR DESCRIPTION
## Summary
- Keep the LID benchmark preflight strict about requiring a `-debug` bundle.
- Add a clearer error note explaining that `scripts/bundle-dev.sh` creates a release-style `-dev` bundle, which is not enough for this benchmark.

## Why
The original auto-triaged finding suggested accepting `-dev`, but a proper Codex review caught that this would weaken the gate. This benchmark depends on debug-only app logging, so `-debug` is intentional.

## Validation
- `bash -n scripts/lid-perf-bench.sh`
- `git diff --check`
- `codex review --base origin/main -c model="gpt-5.5" -c model_reasoning_effort="high"`

Refs #681
