### PR TITLE
[codex] Keep custom-word sheet open on save failure

### DIFF
--- a/Sources/EnviousWispr/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWispr/App/CustomWordsCoordinator.swift
@@ -19,33 +19,55 @@ final class CustomWordsCoordinator {
     customWords = manager.load() ?? []
   }
 
-  func add(_ word: String) {
+  @discardableResult
+  func add(_ word: String) -> String? {
     do {
       try manager.add(canonical: word, to: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
+      return nil
     } catch {
       customWordError = error.localizedDescription
+      return customWordError
     }
   }
 
-  func remove(id: UUID) {
+  @discardableResult
+  func add(_ word: CustomWord) -> String? {
+    do {
+      try manager.add(word: word, to: &customWords)
+      onWordsChanged?(customWords)
+      customWordError = nil
+      return nil
+    } catch {
+      customWordError = error.localizedDescription
+      return customWordError
+    }
+  }
+
+  @discardableResult
+  func remove(id: UUID) -> String? {
     do {
       try manager.remove(id: id, from: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
+      return nil
     } catch {
       customWordError = error.localizedDescription
+      return customWordError
     }
   }
 
-  func update(_ word: CustomWord) {
+  @discardableResult
+  func update(_ word: CustomWord) -> String? {
     do {
       try manager.update(word: word, in: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
+      return nil
     } catch {
       customWordError = error.localizedDescription
+      return customWordError
     }
   }
 }

--- a/Sources/EnviousWispr/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWispr/Views/Settings/CustomWordEditSheet.swift
@@ -19,14 +19,15 @@ struct CustomWordEditSheet: View {
   @State private var suggestionsApplied = false
   @State private var noSuggestionsAvailable = false
   @State private var showingDeleteConfirmation = false
+  @State private var saveError: String?
   let wordSuggestionService: WordSuggestionService?
-  let onSave: (CustomWord) -> Void
+  let onSave: (CustomWord) -> String?
   let onDelete: (() -> Void)?
   @Environment(\.dismiss) private var dismiss
 
   init(
     word: CustomWord, wordSuggestionService: WordSuggestionService? = nil,
-    onSave: @escaping (CustomWord) -> Void,
+    onSave: @escaping (CustomWord) -> String?,
     onDelete: (() -> Void)? = nil
   ) {
     _word = State(initialValue: word)
@@ -126,6 +127,13 @@ struct CustomWordEditSheet: View {
       Toggle("Force replace (always apply, skip scoring)", isOn: $word.forceReplace)
         .toggleStyle(BrandedToggleStyle())
 
+      if let saveError {
+        Label(saveError, systemImage: "exclamationmark.triangle.fill")
+          .font(.stHelper)
+          .foregroundStyle(.red)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
       Spacer()
 
       // Actions
@@ -141,8 +149,12 @@ struct CustomWordEditSheet: View {
         Button("Cancel") { dismiss() }
           .keyboardShortcut(.cancelAction)
         Button("Save") {
-          onSave(word)
-          dismiss()
+          if let error = onSave(word) {
+            saveError = error
+          } else {
+            saveError = nil
+            dismiss()
+          }
         }
         .keyboardShortcut(.defaultAction)
         .disabled(word.canonical.trimmingCharacters(in: .whitespaces).isEmpty)

--- a/Sources/EnviousWispr/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/YourWordsView.swift
@@ -66,27 +66,13 @@ struct YourWordsView: View {
         wordSuggestionService: appState.customWordsCoordinator.suggestionService
       ) { newWord in
         let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)
-        guard !trimmedCanonical.isEmpty else { return }
-        // Skip enrichment in two cases:
-        //  1. `add()` was a no-op because the canonical already exists as a user
-        //     word — `existingIDs` catches that.
-        //  2. `add()` restored a previously-deleted built-in (e.g. "GitHub")
-        //     whose curated aliases must not be overwritten by sheet defaults.
-        //     Detected by the restored entry already carrying aliases.
-        let existingIDs = Set(appState.customWordsCoordinator.customWords.map(\.id))
-        appState.customWordsCoordinator.add(trimmedCanonical)
-        if let added = appState.customWordsCoordinator.customWords.first(where: {
-          $0.canonical.caseInsensitiveCompare(trimmedCanonical) == .orderedSame
-            && !existingIDs.contains($0.id)
-            && $0.aliases.isEmpty
-        }) {
-          var enriched = added
-          enriched.aliases = newWord.aliases
-          enriched.category = newWord.category
-          enriched.forceReplace = newWord.forceReplace
-          enriched.minSimilarityOverride = newWord.minSimilarityOverride
-          appState.customWordsCoordinator.update(enriched)
+        guard !trimmedCanonical.isEmpty else { return nil }
+        var wordToSave = newWord
+        wordToSave.canonical = trimmedCanonical
+        if let error = appState.customWordsCoordinator.add(wordToSave) {
+          return error
         }
+        return nil
       }
     }
   }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -262,7 +262,11 @@ public final class CustomWordsManager {
   }
 
   public func add(canonical: String, to words: inout [CustomWord]) throws {
-    let trimmed = canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+    try add(word: CustomWord(canonical: canonical), to: &words)
+  }
+
+  public func add(word: CustomWord, to words: inout [CustomWord]) throws {
+    let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     guard
       !words.contains(where: {
@@ -282,7 +286,12 @@ public final class CustomWordsManager {
       return
     }
 
-    file.words.append(CustomWord(canonical: trimmed))
+    var sanitized = word
+    sanitized.canonical = trimmed
+    sanitized.aliases = sanitized.aliases
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    file.words.append(sanitized)
     try saveFile(file)
     words = mergedWords(file: file)
   }

--- a/Tests/EnviousWisprTests/Core/CustomWordsManagerDiskRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordsManagerDiskRoundTripTests.swift
@@ -129,6 +129,34 @@ struct CustomWordsManagerDiskRoundTripTests {
     #expect(after.first?.frequencyUsed == 1)
   }
 
+  @Test("add persists aliases and matching policy in one write")
+  func addPersistsFullCustomWord() throws {
+    let path = Self.tempFileURL()
+    defer { Self.cleanup(path) }
+
+    let manager = CustomWordsManager(fileURL: path)
+    var words: [CustomWord] = []
+    let word = CustomWord(
+      canonical: "  GitLab  ",
+      aliases: [" git lab ", ""],
+      category: .brand,
+      forceReplace: true,
+      minSimilarityOverride: 0.92
+    )
+
+    try manager.add(word: word, to: &words)
+
+    let after = try Self.readWords(at: path)
+    #expect(after.count == 1)
+    #expect(after.first?.canonical == "GitLab")
+    #expect(after.first?.aliases == ["git lab"])
+    #expect(after.first?.category == .brand)
+    #expect(after.first?.forceReplace == true)
+    #expect(after.first?.minSimilarityOverride == 0.92)
+    let runtimeAdded = words.first { $0.canonical == "GitLab" }
+    #expect(runtimeAdded?.aliases == ["git lab"])
+  }
+
   @Test("Multiple flushes accumulate frequencyUsed across writes")
   func multipleFlushesAccumulate() throws {
     let path = Self.tempFileURL()


### PR DESCRIPTION
## Summary
- Keep the custom-word edit sheet open when local save fails, and show the existing save error in the sheet.
- Save a newly added word, aliases, category, force-replace setting, and strictness in one write instead of a two-step add-then-update path.
- Add disk round-trip coverage for the one-write custom-word add path.

## Why
The normal add-word flow should almost never fail, but if local storage is broken the old sheet could close while the word was not saved. This keeps the failure visible without adding a bigger UI redesign.

## Validation
- `git diff --check`
- `swift build -c release`
- `scripts/swift-test.sh --no-run`
- `scripts/swift-test.sh --filter CustomWordsManagerDiskRoundTripTests`
- Raw `swift build --build-tests` was tried first and hit the known local Testing.framework issue; the repo wrapper passed.
- `codex review --base origin/main -c model="gpt-5.5" -c model_reasoning_effort="high"` found no confirmed regression. Its own focused Swift test attempt hit local sandbox/cache/toolchain restrictions, so the review verdict is code-review-only on that extra test attempt.

Fixes #692
