### PR TITLE
[codex] Fix input device divergence telemetry

### DIFF
--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -31,13 +31,18 @@ public enum SentryAudioExtras {
       "capture.is_actively_capturing": isActivelyCapturing,
       "capture_session_id": Int(sessionID),
     ]
-    extras["capture.input_device_uid_preferred"] =
-      (inputDeviceUIDPreferred?.isEmpty == false) ? inputDeviceUIDPreferred! : NSNull()
-    extras["capture.input_device_uid_system_default"] =
-      (inputDeviceUIDSystemDefault?.isEmpty == false)
-      ? inputDeviceUIDSystemDefault! : NSNull()
-    extras["capture.input_device_divergence"] =
-      inputDeviceUIDPreferred != inputDeviceUIDSystemDefault
+    let normalizedPreferredUID = normalizeDeviceUID(inputDeviceUIDPreferred)
+    let normalizedSystemDefaultUID = normalizeDeviceUID(inputDeviceUIDSystemDefault)
+    let preferredInputSet = normalizedPreferredUID != nil
+    let inputDeviceDivergence =
+      normalizedPreferredUID != nil
+      && normalizedSystemDefaultUID != nil
+      && normalizedPreferredUID != normalizedSystemDefaultUID
+
+    extras["capture.input_device_uid_preferred"] = normalizedPreferredUID ?? NSNull()
+    extras["capture.input_device_uid_system_default"] = normalizedSystemDefaultUID ?? NSNull()
+    extras["capture.preferred_input_set"] = preferredInputSet
+    extras["capture.input_device_divergence"] = inputDeviceDivergence
 
     if let ctx = stallContext {
       extras["capture.stall.armed_at_uptime_ns"] = Int(ctx.armedAtUptimeNs)
@@ -62,5 +67,10 @@ public enum SentryAudioExtras {
     }
 
     return extras
+  }
+
+  private static func normalizeDeviceUID(_ uid: String?) -> String? {
+    guard let uid, !uid.isEmpty else { return nil }
+    return uid
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -77,6 +77,7 @@ struct HeartPathTelemetryEmitterTests {
     "capture_session_id",
     "capture.input_device_uid_preferred",
     "capture.input_device_uid_system_default",
+    "capture.preferred_input_set",
     "capture.input_device_divergence",
   ]
 

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -24,6 +24,7 @@ struct SentryAudioExtrasTests {
     #expect(extras["capture.failure_mode"] as? String == "stalled")
     #expect(extras["capture.is_actively_capturing"] as? Bool == true)
     #expect(extras["capture_session_id"] as? Int == 3)
+    #expect(extras["capture.preferred_input_set"] as? Bool == true)
     #expect(extras["capture.input_device_divergence"] as? Bool == false)
   }
 
@@ -38,7 +39,58 @@ struct SentryAudioExtrasTests {
       inputDeviceUIDSystemDefault: "AirPodsPro",
       failureMode: "no_audio_captured"
     )
+    #expect(extras["capture.preferred_input_set"] as? Bool == true)
     #expect(extras["capture.input_device_divergence"] as? Bool == true)
+  }
+
+  @Test("divergence false when no preferred input is set")
+  func noPreferredInputIsNotDivergence() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "xpc_proxy",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice",
+      failureMode: "zombie_engine_zero_peak"
+    )
+    #expect(extras["capture.preferred_input_set"] as? Bool == false)
+    #expect(extras["capture.input_device_uid_preferred"] is NSNull)
+    #expect(extras["capture.input_device_uid_system_default"] as? String == "BuiltInMicrophoneDevice")
+    #expect(extras["capture.input_device_divergence"] as? Bool == false)
+  }
+
+  @Test("divergence false when both input UIDs are unknown")
+  func bothUnknownInputUIDsAreNotDivergence() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "xpc_proxy",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "zombie_engine_zero_peak"
+    )
+    #expect(extras["capture.preferred_input_set"] as? Bool == false)
+    #expect(extras["capture.input_device_uid_preferred"] is NSNull)
+    #expect(extras["capture.input_device_uid_system_default"] is NSNull)
+    #expect(extras["capture.input_device_divergence"] as? Bool == false)
+  }
+
+  @Test("empty preferred input behaves like no preferred input")
+  func emptyPreferredInputUIDIsNotSet() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic",
+      sourceType: "xpc_proxy",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: "",
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice",
+      failureMode: "zombie_engine_zero_peak"
+    )
+    #expect(extras["capture.preferred_input_set"] as? Bool == false)
+    #expect(extras["capture.input_device_uid_preferred"] is NSNull)
+    #expect(extras["capture.input_device_divergence"] as? Bool == false)
   }
 
   @Test("stall context adds stall-specific keys + window ms math")
@@ -67,6 +119,7 @@ struct SentryAudioExtrasTests {
       polishModelSwapMs: 4500
     )
     #expect(extras["capture.stall.window_ms"] as? Int == 800)
+    #expect(extras["capture.preferred_input_set"] as? Bool == false)
     #expect(extras["capture.format_mismatch"] as? Bool == true)
     #expect(extras["capture.tap_installed"] as? Bool == true)
     #expect(extras["polish.recent_model_swap_ms"] as? Int == 4500)


### PR DESCRIPTION
## Summary
- Normalize preferred and system default input device UIDs before comparing them.
- Emit `capture.preferred_input_set` and only mark divergence when both devices are known and different.
- Add regression coverage for nil and empty preferred-device cases.

## Validation
- `scripts/swift-test.sh` passed: 723 tests in 83 suites.
- `swift build -c release` passed.
- Debug rebuild passed.
- Synthetic Runtime UAT passed with `test_recording(sentence="quick note this is an audio telemetry safety test", expect="telemetry")`.

Closes #706