### PR TITLE
[codex] Add ASR empty-result diagnostics

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -1,0 +1,96 @@
+import EnviousWisprCore
+import Foundation
+
+internal struct ASREmptyResultDiagnostics {
+  var backend: String
+  var mode: String?
+  var hasSpeechEvidence: Bool
+  var rawSampleCount: Int
+  var vadSegmentCount: Int
+  var vadSpeechDurationMs: Int
+  var peakAudioLevel: Float
+
+  var vadFilteredSampleCount: Int?
+  var finalSampleCount: Int?
+  var samplesPaddedToMinimum: Bool?
+  var usedRawFallbackAfterVAD: Bool?
+
+  var streamingResultChars: Int?
+  var streamingFinalizeFailed: Bool?
+  var streamingFinalizeErrorType: String?
+  var streamingBuffersDispatched: Int?
+  var streamingBuffersFed: Int?
+
+  var batchRescueAttempted: Bool?
+  var batchRescueResultChars: Int?
+
+  var incrementalAccepted: Bool?
+  var incrementalResultChars: Int?
+  var incrementalDecodeCount: Int?
+  var incrementalSamplesCovered: Int?
+  var incrementalStrategy: String?
+  var incrementalMode: String?
+  var incrementalTailDecodeMs: Int?
+
+  var speechSegments: [SpeechSegment] = []
+
+  func sentryExtra() -> [String: Any] {
+    var extra: [String: Any] = [
+      "backend": backend,
+      "has_speech_evidence": hasSpeechEvidence,
+      "raw_sample_count": rawSampleCount,
+      "vad_segment_count": vadSegmentCount,
+      "vad_speech_duration_ms": vadSpeechDurationMs,
+      "peak_audio_level": peakAudioLevel,
+      "asr.speech_segment_count": vadSegmentCount,
+    ]
+
+    if let mode {
+      extra["mode"] = mode
+    }
+    put(vadFilteredSampleCount, key: "asr.vad_filtered_sample_count", into: &extra)
+    put(finalSampleCount, key: "asr.final_sample_count", into: &extra)
+    put(samplesPaddedToMinimum, key: "asr.samples_padded_to_minimum", into: &extra)
+    put(usedRawFallbackAfterVAD, key: "asr.used_raw_fallback_after_vad", into: &extra)
+
+    put(streamingResultChars, key: "asr.streaming_result_chars", into: &extra)
+    put(streamingFinalizeFailed, key: "asr.streaming_finalize_failed", into: &extra)
+    put(streamingFinalizeErrorType, key: "asr.streaming_finalize_error_type", into: &extra)
+    put(streamingBuffersDispatched, key: "asr.streaming_buffers_dispatched", into: &extra)
+    put(streamingBuffersFed, key: "asr.streaming_buffers_fed", into: &extra)
+
+    put(batchRescueAttempted, key: "asr.batch_rescue_attempted", into: &extra)
+    put(batchRescueResultChars, key: "asr.batch_rescue_result_chars", into: &extra)
+
+    put(incrementalAccepted, key: "asr.incremental_accepted", into: &extra)
+    put(incrementalResultChars, key: "asr.incremental_result_chars", into: &extra)
+    put(incrementalDecodeCount, key: "asr.incremental_decode_count", into: &extra)
+    put(incrementalSamplesCovered, key: "asr.incremental_samples_covered", into: &extra)
+    put(incrementalStrategy, key: "asr.incremental_strategy", into: &extra)
+    put(incrementalMode, key: "asr.incremental_mode", into: &extra)
+    put(incrementalTailDecodeMs, key: "asr.incremental_tail_decode_ms", into: &extra)
+
+    addSpeechSegmentBounds(to: &extra)
+    return extra
+  }
+
+  private func addSpeechSegmentBounds(to extra: inout [String: Any]) {
+    guard let first = speechSegments.first else { return }
+    extra["asr.speech_segment_first_start_ms"] = samplesToMs(first.startSample)
+    extra["asr.speech_segment_first_end_ms"] = samplesToMs(first.endSample)
+
+    if let last = speechSegments.last, speechSegments.count > 1 {
+      extra["asr.speech_segment_last_start_ms"] = samplesToMs(last.startSample)
+      extra["asr.speech_segment_last_end_ms"] = samplesToMs(last.endSample)
+    }
+  }
+
+  private func samplesToMs(_ samples: Int) -> Int {
+    Int(Double(samples) * 1000 / AudioConstants.sampleRate)
+  }
+
+  private func put<T>(_ value: T?, key: String, into extra: inout [String: Any]) {
+    guard let value else { return }
+    extra[key] = value
+  }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptionPipeline.swift
@@ -724,12 +724,14 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     var hasSpeechEvidence = false
     var vadSegmentCount = 0
     var vadSpeechDurationMs = 0
+    var speechSegmentsForDiagnostics: [SpeechSegment] = []
     let isXPCMode = audioCapture is AudioCaptureProxy
     if isXPCMode {
       // XPC mode: VAD segments are returned atomically with samples from stopCapture().
       // This eliminates the call-order bug where separate getVADSegments() read
       // capturedSamples.count as 0 after stopCapture() cleared the buffer (#226).
       let segments = captureResult.vadSegments
+      speechSegmentsForDiagnostics = segments
       hasSpeechEvidence = !segments.isEmpty
       vadSegmentCount = segments.count
       vadSpeechDurationMs =
@@ -742,6 +744,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     } else if let detector = silenceDetector {
       await detector.finalizeSegments(totalSampleCount: rawSamples.count)
       let segments = await detector.speechSegments
+      speechSegmentsForDiagnostics = segments
       hasSpeechEvidence = !segments.isEmpty
       vadSegmentCount = segments.count
       vadSpeechDurationMs =
@@ -796,13 +799,18 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     // ASR backends require >= 1 second of audio.
     // If VAD filtering was too aggressive, fall back to raw samples.
     let minimumSamples = AudioConstants.minimumTranscriptionSamples
+    let vadFilteredSampleCount = samples.count
+    var usedRawFallbackAfterVAD = false
+    var samplesPaddedToMinimum = false
     if samples.count < minimumSamples && rawSamples.count >= minimumSamples {
       samples = rawSamples
+      usedRawFallbackAfterVAD = true
     }
 
     // Pad short recordings with silence so single-word inputs ("hey", "hi") work.
     if samples.count > 0 && samples.count < minimumSamples {
       samples.append(contentsOf: [Float](repeating: 0, count: minimumSamples - samples.count))
+      samplesPaddedToMinimum = true
     }
 
     state = .transcribing
@@ -822,14 +830,38 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
       // Streaming mode includes batch rescue: if finalize fails or returns empty
       // despite VAD speech evidence, retry with batch decode using captured samples.
       let result: ASRResult
+      var asrEmptyDiagnostics = ASREmptyResultDiagnostics(
+        backend: asrManager.activeBackendType.rawValue,
+        mode: wasStreaming ? "streaming" : "batch",
+        hasSpeechEvidence: hasSpeechEvidence,
+        rawSampleCount: rawSamples.count,
+        vadSegmentCount: vadSegmentCount,
+        vadSpeechDurationMs: vadSpeechDurationMs,
+        peakAudioLevel: peakAudioLevel,
+        vadFilteredSampleCount: vadFilteredSampleCount,
+        finalSampleCount: samples.count,
+        samplesPaddedToMinimum: samplesPaddedToMinimum,
+        usedRawFallbackAfterVAD: usedRawFallbackAfterVAD,
+        speechSegments: speechSegmentsForDiagnostics
+      )
       if wasStreaming {
-        result = try await transcribeWithStreamingRescue(
+        let rescue = try await transcribeWithStreamingRescue(
           samples: samples,
           hasSpeechEvidence: hasSpeechEvidence
         )
+        result = rescue.result
+        asrEmptyDiagnostics.streamingResultChars = rescue.diagnostics.streamingResultChars
+        asrEmptyDiagnostics.streamingFinalizeFailed = rescue.diagnostics.streamingFinalizeFailed
+        asrEmptyDiagnostics.streamingFinalizeErrorType =
+          rescue.diagnostics.streamingFinalizeErrorType
+        asrEmptyDiagnostics.batchRescueAttempted = rescue.diagnostics.batchRescueAttempted
+        asrEmptyDiagnostics.batchRescueResultChars = rescue.diagnostics.batchRescueResultChars
+        asrEmptyDiagnostics.streamingBuffersDispatched = streamingBuffersDispatched
+        asrEmptyDiagnostics.streamingBuffersFed = streamingBuffersFed
       } else {
         result = try await asrManager.transcribe(
           audioSamples: samples, options: transcriptionOptions)
+        asrEmptyDiagnostics.batchRescueAttempted = false
       }
 
       let asrEnd = CFAbsoluteTimeGetCurrent()
@@ -845,15 +877,7 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
                 NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"
               ]),
             category: .asrEmptyResult, stage: "asr",
-            extra: [
-              "backend": asrManager.activeBackendType.rawValue,
-              "mode": wasStreaming ? "streaming" : "batch",
-              "has_speech_evidence": true,
-              "raw_sample_count": rawSamples.count,
-              "vad_segment_count": vadSegmentCount,
-              "vad_speech_duration_ms": vadSpeechDurationMs,
-              "peak_audio_level": peakAudioLevel,
-            ],
+            extra: asrEmptyDiagnostics.sentryExtra(),
             snapshot: frozenSnapshot
           )
           state = .error("Couldn't catch that -- try again")
@@ -1248,24 +1272,43 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
 
   // MARK: - Streaming Rescue
 
+  private struct StreamingRescueDiagnostics {
+    var streamingResultChars: Int?
+    var streamingFinalizeFailed = false
+    var streamingFinalizeErrorType: String?
+    var batchRescueAttempted = false
+    var batchRescueResultChars: Int?
+  }
+
+  private struct StreamingRescueResult {
+    var result: ASRResult
+    var diagnostics: StreamingRescueDiagnostics
+  }
+
   /// Attempt streaming finalize, fall back to batch if streaming fails or returns empty
   /// and VAD detected speech. Heart-level rescue: captured samples are already available,
   /// and batch uses a separate AsrManager from streaming's SlidingWindowAsrManager.
   private func transcribeWithStreamingRescue(
     samples: [Float],
     hasSpeechEvidence: Bool
-  ) async throws -> ASRResult {
+  ) async throws -> StreamingRescueResult {
+    var diagnostics = StreamingRescueDiagnostics()
+
     // 1. Try streaming finalize (happy path)
     do {
       let result = try await asrManager.finalizeStreaming()
       let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      diagnostics.streamingResultChars = text.count
       if !text.isEmpty {
-        return result
+        diagnostics.batchRescueAttempted = false
+        return StreamingRescueResult(result: result, diagnostics: diagnostics)
       }
       // Streaming returned empty -- check rescue eligibility below
     } catch is CancellationError {
       throw CancellationError()
     } catch {
+      diagnostics.streamingFinalizeFailed = true
+      diagnostics.streamingFinalizeErrorType = String(reflecting: type(of: error))
       await AppLogger.shared.log(
         "Streaming finalize failed: \(error.localizedDescription), checking rescue eligibility",
         level: .info, category: "Pipeline"
@@ -1275,11 +1318,14 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
     // 2. No speech evidence means genuine silence, not a rescue candidate.
     // Return an empty result so the caller handles it with the appropriate message.
     guard hasSpeechEvidence else {
-      return ASRResult(
+      diagnostics.batchRescueAttempted = false
+      let result = ASRResult(
         text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+      return StreamingRescueResult(result: result, diagnostics: diagnostics)
     }
 
     // 3. Batch rescue: speech was detected but streaming failed to decode it.
+    diagnostics.batchRescueAttempted = true
     await AppLogger.shared.log(
       "Streaming rescue: speech evidence found, retrying batch (\(samples.count) samples)",
       level: .info, category: "Pipeline"
@@ -1287,13 +1333,15 @@ public final class TranscriptionPipeline: DictationPipeline, HeartPathTelemetryT
 
     let result = try await asrManager.transcribe(
       audioSamples: samples, options: transcriptionOptions)
+    diagnostics.batchRescueResultChars =
+      result.text.trimmingCharacters(in: .whitespacesAndNewlines).count
 
     await AppLogger.shared.log(
       "Streaming rescue: batch produced \(result.text.count) chars",
       level: .info, category: "Pipeline"
     )
 
-    return result
+    return StreamingRescueResult(result: result, diagnostics: diagnostics)
   }
 
   // MARK: - DictationPipeline Conformance

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -703,6 +703,7 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     }
 
     let minimumSamples = AudioConstants.minimumTranscriptionSamples
+    let vadFilteredSampleCount = lidSamples.count
     asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
       rawSamples: rawSamples,
       minimumSamples: minimumSamples
@@ -721,6 +722,20 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       forVoicedDuration: voicedDurationSec
     )
     let clipKind = lidWindowCount == 1 ? "short" : "normal"
+    var asrEmptyDiagnostics = ASREmptyResultDiagnostics(
+      backend: "whisperKit",
+      hasSpeechEvidence: hasSpeechEvidence,
+      rawSampleCount: rawSamples.count,
+      vadSegmentCount: vadSegmentCount,
+      vadSpeechDurationMs: vadSpeechDurationMs,
+      peakAudioLevel: peakAudioLevel,
+      vadFilteredSampleCount: vadFilteredSampleCount,
+      finalSampleCount: asrSamples.count,
+      samplesPaddedToMinimum: rawSamples.count > 0 && rawSamples.count < minimumSamples,
+      usedRawFallbackAfterVAD: false,
+      batchRescueAttempted: false,
+      speechSegments: speechSegments
+    )
 
     state = .transcribing
     logLIDPerfSignpost(
@@ -839,6 +854,14 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         let segments = await silenceDetector?.speechSegments ?? []
         let result = await worker.finalize(finalSamples: rawSamples, speechSegments: segments)
         incrementalWorker = nil
+        asrEmptyDiagnostics.incrementalAccepted = result.accepted
+        asrEmptyDiagnostics.incrementalResultChars =
+          result.text?.trimmingCharacters(in: .whitespacesAndNewlines).count
+        asrEmptyDiagnostics.incrementalDecodeCount = result.decodeCount
+        asrEmptyDiagnostics.incrementalSamplesCovered = result.samplesCovered
+        asrEmptyDiagnostics.incrementalStrategy = result.strategy
+        asrEmptyDiagnostics.incrementalMode = result.mode
+        asrEmptyDiagnostics.incrementalTailDecodeMs = result.tailDecodeMs
 
         let coveragePct =
           rawSamples.count > 0
@@ -882,6 +905,9 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           let batchResult = try await backend.transcribe(
             audioSamples: asrSamples, options: transcriptionOptions)
           let batchEnd = CFAbsoluteTimeGetCurrent()
+          asrEmptyDiagnostics.batchRescueAttempted = true
+          asrEmptyDiagnostics.batchRescueResultChars =
+            batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines).count
           logLIDPerfSignpost(
             "t_asr_end",
             timestamp: batchEnd,
@@ -913,6 +939,9 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
         )
         let batchResult = try await backend.transcribe(
           audioSamples: asrSamples, options: transcriptionOptions)
+        asrEmptyDiagnostics.batchRescueAttempted = false
+        asrEmptyDiagnostics.batchRescueResultChars =
+          batchResult.text.trimmingCharacters(in: .whitespacesAndNewlines).count
         logLIDPerfSignpost(
           "t_asr_end",
           timestamp: CFAbsoluteTimeGetCurrent(),
@@ -955,17 +984,13 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
               userInfo: [
                 NSLocalizedDescriptionKey:
                   "WhisperKit ASR returned empty text despite speech evidence"
-              ]),
+            ]),
             category: .asrEmptyResult, stage: "asr",
-            extra: [
-              "backend": "whisperKit",
-              "incremental": usedIncremental,
-              "has_speech_evidence": true,
-              "raw_sample_count": rawSamples.count,
-              "vad_segment_count": vadSegmentCount,
-              "vad_speech_duration_ms": vadSpeechDurationMs,
-              "peak_audio_level": peakAudioLevel,
-            ],
+            extra: {
+              var extra = asrEmptyDiagnostics.sentryExtra()
+              extra["incremental"] = usedIncremental
+              return extra
+            }(),
             snapshot: frozenSnapshot
           )
           state = .error("Couldn't catch that -- try again")

--- a/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
@@ -96,6 +96,83 @@ struct ASREmptyResultDiagnosticsTests {
     assertNoContentLikeKeys(extra)
   }
 
+  @Test("batch diagnostics omit streaming fields")
+  func batchDiagnosticsOmitStreamingFields() {
+    let diagnostics = ASREmptyResultDiagnostics(
+      backend: "parakeet",
+      mode: "batch",
+      hasSpeechEvidence: true,
+      rawSampleCount: 24_000,
+      vadSegmentCount: 1,
+      vadSpeechDurationMs: 900,
+      peakAudioLevel: 0.25,
+      vadFilteredSampleCount: 18_000,
+      finalSampleCount: 24_000,
+      samplesPaddedToMinimum: false,
+      usedRawFallbackAfterVAD: false,
+      batchRescueAttempted: false,
+      speechSegments: [SpeechSegment(startSample: 4_000, endSample: 12_000)]
+    )
+
+    let extra = diagnostics.sentryExtra()
+
+    #expect(extra["backend"] as? String == "parakeet")
+    #expect(extra["mode"] as? String == "batch")
+    #expect(extra["asr.batch_rescue_attempted"] as? Bool == false)
+    #expect(extra["asr.streaming_result_chars"] == nil)
+    #expect(extra["asr.streaming_finalize_failed"] == nil)
+    #expect(extra["asr.streaming_finalize_error_type"] == nil)
+    #expect(extra["asr.streaming_buffers_dispatched"] == nil)
+    #expect(extra["asr.streaming_buffers_fed"] == nil)
+    assertNoContentLikeKeys(extra)
+  }
+
+  @Test("zero speech segments do not emit segment bounds")
+  func zeroSpeechSegmentsDoNotEmitBounds() {
+    let diagnostics = ASREmptyResultDiagnostics(
+      backend: "parakeet",
+      mode: "batch",
+      hasSpeechEvidence: true,
+      rawSampleCount: 16_000,
+      vadSegmentCount: 0,
+      vadSpeechDurationMs: 0,
+      peakAudioLevel: 0.2,
+      speechSegments: []
+    )
+
+    let extra = diagnostics.sentryExtra()
+
+    #expect(extra["asr.speech_segment_count"] as? Int == 0)
+    #expect(extra["asr.speech_segment_first_start_ms"] == nil)
+    #expect(extra["asr.speech_segment_first_end_ms"] == nil)
+    #expect(extra["asr.speech_segment_last_start_ms"] == nil)
+    #expect(extra["asr.speech_segment_last_end_ms"] == nil)
+    assertNoContentLikeKeys(extra)
+  }
+
+  @Test("single speech segment emits first bounds only")
+  func singleSpeechSegmentEmitsFirstBoundsOnly() {
+    let diagnostics = ASREmptyResultDiagnostics(
+      backend: "parakeet",
+      mode: "streaming",
+      hasSpeechEvidence: true,
+      rawSampleCount: 16_000,
+      vadSegmentCount: 1,
+      vadSpeechDurationMs: 500,
+      peakAudioLevel: 0.2,
+      speechSegments: [SpeechSegment(startSample: 2_000, endSample: 10_000)]
+    )
+
+    let extra = diagnostics.sentryExtra()
+
+    #expect(extra["asr.speech_segment_count"] as? Int == 1)
+    #expect(extra["asr.speech_segment_first_start_ms"] as? Int == 125)
+    #expect(extra["asr.speech_segment_first_end_ms"] as? Int == 625)
+    #expect(extra["asr.speech_segment_last_start_ms"] == nil)
+    #expect(extra["asr.speech_segment_last_end_ms"] == nil)
+    assertNoContentLikeKeys(extra)
+  }
+
   private func assertNoContentLikeKeys(_ extra: [String: Any]) {
     for key in extra.keys {
       let lower = key.lowercased()
@@ -107,4 +184,3 @@ struct ASREmptyResultDiagnosticsTests {
     }
   }
 }
-

--- a/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
@@ -1,0 +1,110 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@Suite("ASR empty result diagnostics")
+struct ASREmptyResultDiagnosticsTests {
+
+  @Test("Parakeet diagnostics include streaming and rescue fields without content")
+  func parakeetDiagnosticsShape() {
+    let diagnostics = ASREmptyResultDiagnostics(
+      backend: "parakeet",
+      mode: "streaming",
+      hasSpeechEvidence: true,
+      rawSampleCount: 19_200,
+      vadSegmentCount: 1,
+      vadSpeechDurationMs: 688,
+      peakAudioLevel: 0.416,
+      vadFilteredSampleCount: 11_008,
+      finalSampleCount: 19_200,
+      samplesPaddedToMinimum: false,
+      usedRawFallbackAfterVAD: true,
+      streamingResultChars: 0,
+      streamingFinalizeFailed: false,
+      streamingBuffersDispatched: 3,
+      streamingBuffersFed: 3,
+      batchRescueAttempted: true,
+      batchRescueResultChars: 0,
+      speechSegments: [SpeechSegment(startSample: 1_000, endSample: 12_000)]
+    )
+
+    let extra = diagnostics.sentryExtra()
+
+    #expect(extra["backend"] as? String == "parakeet")
+    #expect(extra["mode"] as? String == "streaming")
+    #expect(extra["has_speech_evidence"] as? Bool == true)
+    #expect(extra["asr.streaming_result_chars"] as? Int == 0)
+    #expect(extra["asr.streaming_finalize_failed"] as? Bool == false)
+    #expect(extra["asr.streaming_buffers_dispatched"] as? Int == 3)
+    #expect(extra["asr.streaming_buffers_fed"] as? Int == 3)
+    #expect(extra["asr.batch_rescue_attempted"] as? Bool == true)
+    #expect(extra["asr.batch_rescue_result_chars"] as? Int == 0)
+    #expect(extra["asr.vad_filtered_sample_count"] as? Int == 11_008)
+    #expect(extra["asr.final_sample_count"] as? Int == 19_200)
+    #expect(extra["asr.used_raw_fallback_after_vad"] as? Bool == true)
+    #expect(extra["asr.samples_padded_to_minimum"] as? Bool == false)
+    #expect(extra["asr.speech_segment_first_start_ms"] as? Int == 62)
+    #expect(extra["asr.speech_segment_first_end_ms"] as? Int == 750)
+    assertNoContentLikeKeys(extra)
+  }
+
+  @Test("WhisperKit diagnostics keep comparable base fields and worker subset")
+  func whisperKitDiagnosticsShape() {
+    let diagnostics = ASREmptyResultDiagnostics(
+      backend: "whisperKit",
+      hasSpeechEvidence: true,
+      rawSampleCount: 32_000,
+      vadSegmentCount: 2,
+      vadSpeechDurationMs: 1_500,
+      peakAudioLevel: 0.3,
+      vadFilteredSampleCount: 24_000,
+      finalSampleCount: 32_000,
+      samplesPaddedToMinimum: false,
+      usedRawFallbackAfterVAD: false,
+      batchRescueAttempted: true,
+      batchRescueResultChars: 0,
+      incrementalAccepted: false,
+      incrementalResultChars: 0,
+      incrementalDecodeCount: 2,
+      incrementalSamplesCovered: 12_000,
+      incrementalStrategy: "tail_empty_fallback",
+      incrementalMode: "full",
+      incrementalTailDecodeMs: 54,
+      speechSegments: [
+        SpeechSegment(startSample: 0, endSample: 8_000),
+        SpeechSegment(startSample: 16_000, endSample: 32_000),
+      ]
+    )
+
+    let extra = diagnostics.sentryExtra()
+
+    #expect(extra["backend"] as? String == "whisperKit")
+    #expect(extra["mode"] == nil)
+    #expect(extra["asr.batch_rescue_attempted"] as? Bool == true)
+    #expect(extra["asr.batch_rescue_result_chars"] as? Int == 0)
+    #expect(extra["asr.incremental_accepted"] as? Bool == false)
+    #expect(extra["asr.incremental_result_chars"] as? Int == 0)
+    #expect(extra["asr.incremental_decode_count"] as? Int == 2)
+    #expect(extra["asr.incremental_strategy"] as? String == "tail_empty_fallback")
+    #expect(extra["asr.speech_segment_count"] as? Int == 2)
+    #expect(extra["asr.speech_segment_first_start_ms"] as? Int == 0)
+    #expect(extra["asr.speech_segment_first_end_ms"] as? Int == 500)
+    #expect(extra["asr.speech_segment_last_start_ms"] as? Int == 1000)
+    #expect(extra["asr.speech_segment_last_end_ms"] as? Int == 2000)
+    assertNoContentLikeKeys(extra)
+  }
+
+  private func assertNoContentLikeKeys(_ extra: [String: Any]) {
+    for key in extra.keys {
+      let lower = key.lowercased()
+      #expect(!lower.contains("text"))
+      #expect(!lower.contains("transcript"))
+      #expect(!lower.contains("content"))
+      #expect(!lower.contains("prompt"))
+      #expect(!lower.contains("output"))
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add a shared ASR empty-result diagnostics renderer for Sentry extras.
- Enrich Parakeet empty-result events with VAD/final-buffer, streaming finalize, and batch rescue diagnostics.
- Extend WhisperKit empty-result events with a comparable telemetry shape where the pipeline has matching signals.
- Preserve cancellation rethrow behavior so cancellations are not recorded as finalize failures.

## Validation
- `scripts/swift-test.sh` passed: 722 tests in 84 suites.
- `swift build -c release` passed.
- Debug rebuild passed.
- Synthetic Runtime UAT passed with `test_recording(sentence="quick note this is an audio telemetry safety test", expect="telemetry")`.

Closes #705