### PR TITLE
[codex] Add paste fallback target diagnostics

### DIFF
--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -295,7 +295,7 @@ internal final class PasteCascadeExecutor {
         err,
         category: .pasteFailed,
         stage: "paste",
-        extra: clipboardOnlyTelemetryExtra(
+        extra: Self.clipboardOnlyTelemetryExtra(
           tiersAttempted: tierStrings,
           focus: focus,
           targetBundleID: bundle,
@@ -331,7 +331,7 @@ internal final class PasteCascadeExecutor {
     }
   }
 
-  internal func clipboardOnlyTelemetryExtra(
+  internal static func clipboardOnlyTelemetryExtra(
     tiersAttempted: [String],
     focus: PasteFocusClassification,
     targetBundleID: String?,
@@ -349,6 +349,7 @@ internal final class PasteCascadeExecutor {
       "paste.target_element_role": targetDiagnostics.role ?? NSNull(),
       "paste.target_element_subrole": targetDiagnostics.subrole ?? NSNull(),
       "paste.target_element_role_source": targetDiagnostics.roleSource,
+      "paste.target_element_subrole_status": targetDiagnostics.subroleStatus,
     ]
   }
 

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -20,7 +20,9 @@ internal enum PasteDeliveryOutcome: Equatable, Sendable {
   case clipboardOnly(
     tiersAttempted: [PasteTier],
     focus: PasteFocusClassification,
-    targetBundleID: String?
+    targetBundleID: String?,
+    accessibilityTrusted: Bool,
+    targetDiagnostics: PasteElementDiagnostics
   )
   case clipboardOnlyAccessibilityDenied(targetBundleID: String?)
   case cgEventCreationFailed(accessibilityTrusted: Bool)
@@ -113,15 +115,20 @@ internal final class PasteCascadeExecutor {
     // keystrokes that go nowhere.
     let axTrusted = AXIsProcessTrusted()
     let classification: PasteFocusClassification
+    let targetDiagnostics: PasteElementDiagnostics
     if !axTrusted {
       classification = classifyPasteFocus(elementPresent: true, roleIsTextField: false)
+      targetDiagnostics = .unavailable
     } else if let element = request.targetElement {
       classification = classifyPasteFocus(
         elementPresent: true,
         roleIsTextField: PasteService.isTextFieldRole(element)
       )
+      // Role/subrole are read at paste time from the captured AXUIElement handle.
+      targetDiagnostics = PasteService.capturedElementDiagnostics(element)
     } else {
       classification = classifyPasteFocus(elementPresent: false, roleIsTextField: false)
+      targetDiagnostics = .missing
     }
     let canAttemptKeyPaste = classification.canAttemptKeyPaste
 
@@ -258,7 +265,9 @@ internal final class PasteCascadeExecutor {
       outcome = .clipboardOnly(
         tiersAttempted: tiersAttempted,
         focus: classification,
-        targetBundleID: request.targetApp?.bundleIdentifier
+        targetBundleID: request.targetApp?.bundleIdentifier,
+        accessibilityTrusted: axTrusted,
+        targetDiagnostics: targetDiagnostics
       )
     }
 
@@ -275,7 +284,7 @@ internal final class PasteCascadeExecutor {
     switch outcome {
     case .delivered:
       return
-    case .clipboardOnly(let tiers, let focus, let bundle):
+    case .clipboardOnly(let tiers, let focus, let bundle, let accessibilityTrusted, let diagnostics):
       let tierStrings = tiers.map(\.rawValue)
       let err = HeartPathError.pasteCascadeClipboardFallback(
         tiersAttempted: tierStrings,
@@ -286,13 +295,14 @@ internal final class PasteCascadeExecutor {
         err,
         category: .pasteFailed,
         stage: "paste",
-        extra: [
-          "paste.tiers_attempted": tierStrings,
-          "paste.focus_classification": focus.telemetryLabel,
-          "paste.target_bundle_id": bundle ?? NSNull(),
-          "paste.outcome": "clipboard_only",
-          "paste.tier_failures": tierFailures,
-        ]
+        extra: clipboardOnlyTelemetryExtra(
+          tiersAttempted: tierStrings,
+          focus: focus,
+          targetBundleID: bundle,
+          accessibilityTrusted: accessibilityTrusted,
+          targetDiagnostics: diagnostics,
+          tierFailures: tierFailures
+        )
       )
     case .cgEventCreationFailed(let accessibilityTrusted):
       let err = HeartPathError.pasteCGEventCreationFailed(
@@ -313,9 +323,33 @@ internal final class PasteCascadeExecutor {
         stage: "paste",
         message: "paste.outcome=clipboard_only_ax_denied",
         level: .info,
-        data: ["target_bundle_id": targetBundleID ?? "unknown"]
+        data: [
+          "target_bundle_id": targetBundleID ?? "unknown",
+          "paste.accessibility_trusted": false,
+        ]
       )
     }
+  }
+
+  internal func clipboardOnlyTelemetryExtra(
+    tiersAttempted: [String],
+    focus: PasteFocusClassification,
+    targetBundleID: String?,
+    accessibilityTrusted: Bool,
+    targetDiagnostics: PasteElementDiagnostics,
+    tierFailures: [String: String]
+  ) -> [String: Any] {
+    [
+      "paste.tiers_attempted": tiersAttempted,
+      "paste.focus_classification": focus.telemetryLabel,
+      "paste.target_bundle_id": targetBundleID ?? NSNull(),
+      "paste.outcome": "clipboard_only",
+      "paste.tier_failures": tierFailures,
+      "paste.accessibility_trusted": accessibilityTrusted,
+      "paste.target_element_role": targetDiagnostics.role ?? NSNull(),
+      "paste.target_element_subrole": targetDiagnostics.subrole ?? NSNull(),
+      "paste.target_element_role_source": targetDiagnostics.roleSource,
+    ]
   }
 
   /// Emit a non-blocking Sentry breadcrumb for a single tier failure. The

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -24,6 +24,23 @@ public enum PasteTier: String, Sendable {
   case clipboardOnly = "clipboard_only"
 }
 
+public struct PasteElementDiagnostics: Equatable, Sendable {
+  public let role: String?
+  public let subrole: String?
+  public let roleSource: String
+
+  public init(role: String?, subrole: String?, roleSource: String) {
+    self.role = role
+    self.subrole = subrole
+    self.roleSource = roleSource
+  }
+
+  public static let missing = PasteElementDiagnostics(
+    role: nil, subrole: nil, roleSource: "missing")
+  public static let unavailable = PasteElementDiagnostics(
+    role: nil, subrole: nil, roleSource: "unavailable")
+}
+
 /// Handles copying text to clipboard and pasting into the active app.
 public enum PasteService {
 
@@ -43,6 +60,32 @@ public enum PasteService {
     )
     guard err == .success, let role = roleRef as? String else { return false }
     return textRoles.contains(role)
+  }
+
+  /// Reads privacy-safe role metadata from the captured AX element handle.
+  /// This is queried at paste time, not snapshotted at recording start.
+  public static func capturedElementDiagnostics(_ element: AXUIElement?) -> PasteElementDiagnostics {
+    guard let element else { return .missing }
+
+    var roleRef: CFTypeRef?
+    let roleErr = AXUIElementCopyAttributeValue(
+      element, kAXRoleAttribute as CFString, &roleRef
+    )
+    guard roleErr == .success, let role = roleRef as? String else {
+      return .unavailable
+    }
+
+    var subroleRef: CFTypeRef?
+    let subroleErr = AXUIElementCopyAttributeValue(
+      element, kAXSubroleAttribute as CFString, &subroleRef
+    )
+    let subrole = subroleErr == .success ? subroleRef as? String : nil
+
+    return PasteElementDiagnostics(
+      role: role,
+      subrole: subrole,
+      roleSource: "captured_target"
+    )
   }
 
   /// Copy text to the system clipboard.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -25,20 +25,38 @@ public enum PasteTier: String, Sendable {
 }
 
 public struct PasteElementDiagnostics: Equatable, Sendable {
+  private static let maxAttributeLength = 128
+  private static let allowedAttributeCharacters = CharacterSet.alphanumerics.union(
+    CharacterSet(charactersIn: "._:-"))
+
   public let role: String?
   public let subrole: String?
   public let roleSource: String
+  public let subroleStatus: String
 
-  public init(role: String?, subrole: String?, roleSource: String) {
-    self.role = role
-    self.subrole = subrole
+  public init(role: String?, subrole: String?, roleSource: String, subroleStatus: String) {
+    self.role = Self.sanitizedAXAttribute(role)
+    self.subrole = Self.sanitizedAXAttribute(subrole)
     self.roleSource = roleSource
+    self.subroleStatus = subroleStatus
   }
 
   public static let missing = PasteElementDiagnostics(
-    role: nil, subrole: nil, roleSource: "missing")
+    role: nil, subrole: nil, roleSource: "missing", subroleStatus: "missing")
   public static let unavailable = PasteElementDiagnostics(
-    role: nil, subrole: nil, roleSource: "unavailable")
+    role: nil, subrole: nil, roleSource: "unavailable", subroleStatus: "unavailable")
+
+  public static func sanitizedAXAttribute(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let sanitizedScalars = trimmed.unicodeScalars.map { scalar in
+      Self.allowedAttributeCharacters.contains(scalar) ? Character(scalar) : "_"
+    }
+    let sanitized = String(sanitizedScalars).prefix(Self.maxAttributeLength)
+    return sanitized.isEmpty ? nil : String(sanitized)
+  }
 }
 
 /// Handles copying text to clipboard and pasting into the active app.
@@ -71,7 +89,10 @@ public enum PasteService {
     let roleErr = AXUIElementCopyAttributeValue(
       element, kAXRoleAttribute as CFString, &roleRef
     )
-    guard roleErr == .success, let role = roleRef as? String else {
+    guard
+      roleErr == .success,
+      let role = PasteElementDiagnostics.sanitizedAXAttribute(roleRef as? String)
+    else {
       return .unavailable
     }
 
@@ -79,12 +100,18 @@ public enum PasteService {
     let subroleErr = AXUIElementCopyAttributeValue(
       element, kAXSubroleAttribute as CFString, &subroleRef
     )
-    let subrole = subroleErr == .success ? subroleRef as? String : nil
+    let subrole = subroleErr == .success
+      ? PasteElementDiagnostics.sanitizedAXAttribute(subroleRef as? String)
+      : nil
+    let subroleStatus: String = subroleErr == .success
+      ? (subrole == nil ? "missing" : "present")
+      : "unavailable"
 
     return PasteElementDiagnostics(
       role: role,
       subrole: subrole,
-      roleSource: "captured_target"
+      roleSource: "captured_target",
+      subroleStatus: subroleStatus
     )
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
@@ -47,7 +47,9 @@ struct PasteDeliveryResultLabelTests {
         outcome: .clipboardOnly(
           tiersAttempted: [],
           focus: .missing,
-          targetBundleID: nil
+          targetBundleID: nil,
+          accessibilityTrusted: true,
+          targetDiagnostics: .missing
         )
       ),
       PasteDeliveryResult(

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+@MainActor
+@Suite("Paste telemetry payload")
+struct PasteTelemetryPayloadTests {
+
+  @Test("clipboard-only payload includes captured target diagnostics")
+  func clipboardOnlyPayloadIncludesTargetDiagnostics() {
+    let executor = PasteCascadeExecutor()
+
+    let extra = executor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [],
+      focus: .nonText,
+      targetBundleID: "us.zoom.xos",
+      accessibilityTrusted: true,
+      targetDiagnostics: PasteElementDiagnostics(
+        role: "AXGroup",
+        subrole: "AXUnknown",
+        roleSource: "captured_target"
+      ),
+      tierFailures: [:]
+    )
+
+    #expect(extra["paste.tiers_attempted"] as? [String] == [])
+    #expect(extra["paste.focus_classification"] as? String == "non_text")
+    #expect(extra["paste.target_bundle_id"] as? String == "us.zoom.xos")
+    #expect(extra["paste.outcome"] as? String == "clipboard_only")
+    #expect(extra["paste.accessibility_trusted"] as? Bool == true)
+    #expect(extra["paste.target_element_role"] as? String == "AXGroup")
+    #expect(extra["paste.target_element_subrole"] as? String == "AXUnknown")
+    #expect(extra["paste.target_element_role_source"] as? String == "captured_target")
+    assertNoContentLikeKeys(extra)
+  }
+
+  @Test("clipboard-only payload records missing target without changing fallback shape")
+  func clipboardOnlyPayloadRecordsMissingTarget() {
+    let executor = PasteCascadeExecutor()
+
+    let extra = executor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: ["cgevent"],
+      focus: .missing,
+      targetBundleID: nil,
+      accessibilityTrusted: true,
+      targetDiagnostics: .missing,
+      tierFailures: ["activation": "timeout_ms=1000"]
+    )
+
+    #expect(extra["paste.focus_classification"] as? String == "missing")
+    #expect(extra["paste.target_bundle_id"] is NSNull)
+    #expect(extra["paste.accessibility_trusted"] as? Bool == true)
+    #expect(extra["paste.target_element_role"] is NSNull)
+    #expect(extra["paste.target_element_subrole"] is NSNull)
+    #expect(extra["paste.target_element_role_source"] as? String == "missing")
+    #expect((extra["paste.tier_failures"] as? [String: String])?["activation"] == "timeout_ms=1000")
+  }
+
+  @Test("AX-denied path is distinguishable from trusted non-text fallback")
+  func axDeniedPathIsDistinguishable() {
+    let executor = PasteCascadeExecutor()
+
+    let extra = executor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [],
+      focus: .nonText,
+      targetBundleID: "com.example.target",
+      accessibilityTrusted: false,
+      targetDiagnostics: .unavailable,
+      tierFailures: [:]
+    )
+
+    #expect(extra["paste.focus_classification"] as? String == "non_text")
+    #expect(extra["paste.accessibility_trusted"] as? Bool == false)
+    #expect(extra["paste.target_element_role_source"] as? String == "unavailable")
+  }
+
+  private func assertNoContentLikeKeys(_ extra: [String: Any]) {
+    for key in extra.keys {
+      let lower = key.lowercased()
+      #expect(!lower.contains("text"))
+      #expect(!lower.contains("transcript"))
+      #expect(!lower.contains("content"))
+      #expect(!lower.contains("prompt"))
+      #expect(!lower.contains("output"))
+    }
+  }
+}
+

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -10,9 +10,7 @@ struct PasteTelemetryPayloadTests {
 
   @Test("clipboard-only payload includes captured target diagnostics")
   func clipboardOnlyPayloadIncludesTargetDiagnostics() {
-    let executor = PasteCascadeExecutor()
-
-    let extra = executor.clipboardOnlyTelemetryExtra(
+    let extra = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
       tiersAttempted: [],
       focus: .nonText,
       targetBundleID: "us.zoom.xos",
@@ -20,7 +18,8 @@ struct PasteTelemetryPayloadTests {
       targetDiagnostics: PasteElementDiagnostics(
         role: "AXGroup",
         subrole: "AXUnknown",
-        roleSource: "captured_target"
+        roleSource: "captured_target",
+        subroleStatus: "present"
       ),
       tierFailures: [:]
     )
@@ -33,14 +32,13 @@ struct PasteTelemetryPayloadTests {
     #expect(extra["paste.target_element_role"] as? String == "AXGroup")
     #expect(extra["paste.target_element_subrole"] as? String == "AXUnknown")
     #expect(extra["paste.target_element_role_source"] as? String == "captured_target")
+    #expect(extra["paste.target_element_subrole_status"] as? String == "present")
     assertNoContentLikeKeys(extra)
   }
 
   @Test("clipboard-only payload records missing target without changing fallback shape")
   func clipboardOnlyPayloadRecordsMissingTarget() {
-    let executor = PasteCascadeExecutor()
-
-    let extra = executor.clipboardOnlyTelemetryExtra(
+    let extra = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
       tiersAttempted: ["cgevent"],
       focus: .missing,
       targetBundleID: nil,
@@ -55,14 +53,13 @@ struct PasteTelemetryPayloadTests {
     #expect(extra["paste.target_element_role"] is NSNull)
     #expect(extra["paste.target_element_subrole"] is NSNull)
     #expect(extra["paste.target_element_role_source"] as? String == "missing")
+    #expect(extra["paste.target_element_subrole_status"] as? String == "missing")
     #expect((extra["paste.tier_failures"] as? [String: String])?["activation"] == "timeout_ms=1000")
   }
 
   @Test("AX-denied path is distinguishable from trusted non-text fallback")
   func axDeniedPathIsDistinguishable() {
-    let executor = PasteCascadeExecutor()
-
-    let extra = executor.clipboardOnlyTelemetryExtra(
+    let extra = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
       tiersAttempted: [],
       focus: .nonText,
       targetBundleID: "com.example.target",
@@ -74,6 +71,33 @@ struct PasteTelemetryPayloadTests {
     #expect(extra["paste.focus_classification"] as? String == "non_text")
     #expect(extra["paste.accessibility_trusted"] as? Bool == false)
     #expect(extra["paste.target_element_role_source"] as? String == "unavailable")
+    #expect(extra["paste.target_element_subrole_status"] as? String == "unavailable")
+  }
+
+  @Test("AX role diagnostics are capped and scrubbed before telemetry")
+  func axRoleDiagnosticsAreCappedAndScrubbed() {
+    let longRole = "AX" + String(repeating: "VeryLongRole", count: 20)
+    let extra = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [],
+      focus: .nonText,
+      targetBundleID: "com.example.target",
+      accessibilityTrusted: true,
+      targetDiagnostics: PasteElementDiagnostics(
+        role: longRole,
+        subrole: " AXSubrole With Spaces 🚨 ",
+        roleSource: "captured_target",
+        subroleStatus: "present"
+      ),
+      tierFailures: [:]
+    )
+
+    let role = extra["paste.target_element_role"] as? String
+    let subrole = extra["paste.target_element_subrole"] as? String
+
+    #expect(role?.count == 128)
+    #expect(subrole == "AXSubrole_With_Spaces__")
+    #expect(extra["paste.target_element_subrole_status"] as? String == "present")
+    assertNoContentLikeKeys(extra)
   }
 
   private func assertNoContentLikeKeys(_ extra: [String: Any]) {
@@ -87,4 +111,3 @@ struct PasteTelemetryPayloadTests {
     }
   }
 }
-

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
@@ -281,7 +281,9 @@ struct TranscriptFinalizerTests {
       outcome: .clipboardOnly(
         tiersAttempted: [],
         focus: .missing,
-        targetBundleID: nil
+        targetBundleID: nil,
+        accessibilityTrusted: true,
+        targetDiagnostics: .missing
       )
     )
   }


### PR DESCRIPTION
## Summary
- Add paste-time diagnostics for the captured AX target role/subrole/source.
- Include `paste.accessibility_trusted` and target role metadata on clipboard-only fallback telemetry.
- Cover both clipboard-only paths: AX denied and AX trusted with a non-text/missing target.
- Document that role/subrole values are read at paste time from the captured AXUIElement handle, not snapshotted at record start.

## Validation
- `scripts/swift-test.sh` passed: 723 tests in 84 suites.
- `swift build -c release` passed.
- Debug rebuild passed.
- Synthetic Runtime UAT passed with `test_recording(sentence="quick note this is an audio telemetry safety test", expect="telemetry")`.

Closes #703