### PR TITLE
[codex] Attach audio environment snapshots to Sentry errors

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -59,6 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// Constructed in `applicationDidFinishLaunching` after AppState is ready;
   /// torn down in `applicationWillTerminate` for clean observer removal.
   private var audioSystemEventReporter: AudioSystemEventReporter?
+  private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Hide dock icon on launch — we're a menu bar utility.
@@ -128,6 +129,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       guard let self else { return }
       self.updateIcon()
       self.updateCoordinator?.handlePipelineStateChange(isRecording: state == .recording)
+      if state == .recording {
+        self.audioEnvironmentSnapshotter?.recordingStarted()
+      }
     }
     appState.permissions.onAccessibilityChange = { [weak self] in
       self?.updateIcon()
@@ -213,6 +217,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     #endif
 
+    audioEnvironmentSnapshotter = AudioEnvironmentSnapshotter(
+      routeProvider: { [weak appState = self.appState] in
+        appState?.audioCapture.currentAudioRoute
+      }
+    )
+    SentryBreadcrumb.audioEnvironmentProvider = { [weak self] in
+      self?.audioEnvironmentSnapshotter?.latestForError()
+    }
+
     // Production telemetry: OS-level audio events (issue #574). Always on in
     // release; ships to all users so we get cross-user data on what real
     // devices/routes/connections users actually hit.
@@ -221,11 +234,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       asrManager: appState.asrManager,
       pipelineStateProvider: { [weak appState = self.appState] in
         appState?.pipelineState ?? .idle
+      },
+      onAudioDeviceEvent: { [weak self] in
+        self?.audioEnvironmentSnapshotter?.audioDeviceEventOccurred()
       }
     )
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {
+    audioEnvironmentSnapshotter?.applicationBecameActive()
+
     // Re-warm LLM backend when app comes to foreground.
     LLMNetworkSession.shared.preWarmModel(
       provider: appState.settings.llmProvider,
@@ -537,6 +555,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Issue #574: tear down audio-event observers cleanly.
     audioSystemEventReporter = nil
+    SentryBreadcrumb.audioEnvironmentProvider = nil
+    audioEnvironmentSnapshotter = nil
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Sources/EnviousWispr/App/AudioEnvironmentSnapshotter.swift
+++ b/Sources/EnviousWispr/App/AudioEnvironmentSnapshotter.swift
@@ -8,7 +8,7 @@ protocol AudioEnvironmentCollecting: Sendable {
     reason: AudioEnvironmentSnapshot.Reason,
     route: String?,
     frontmostAppBundleID: String?,
-    deviceEventRecentMs: Int?,
+    deviceEventAt: Date?,
     capturedAt: Date
   ) -> AudioEnvironmentSnapshot
 }
@@ -55,9 +55,7 @@ final class AudioEnvironmentSnapshotter {
     let capturedAt = now()
     let route = routeProvider()
     let frontmostAppBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-    let deviceEventRecentMs = lastDeviceEventAt.map {
-      max(0, Int(capturedAt.timeIntervalSince($0) * 1000))
-    }
+    let deviceEventAt = lastDeviceEventAt
     let collector = self.collector
 
     Task.detached(priority: .utility) { [weak self] in
@@ -65,12 +63,11 @@ final class AudioEnvironmentSnapshotter {
         reason: reason,
         route: route,
         frontmostAppBundleID: frontmostAppBundleID,
-        deviceEventRecentMs: deviceEventRecentMs,
+        deviceEventAt: deviceEventAt,
         capturedAt: capturedAt
       )
       await MainActor.run { [weak self] in
-        guard let self, generation >= self.latestGeneration else { return }
-        self.latestGeneration = generation
+        guard let self, generation == self.latestGeneration else { return }
         self.latestSnapshot = snapshot
       }
     }
@@ -82,7 +79,7 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
     reason: AudioEnvironmentSnapshot.Reason,
     route: String?,
     frontmostAppBundleID: String?,
-    deviceEventRecentMs: Int?,
+    deviceEventAt: Date?,
     capturedAt: Date
   ) -> AudioEnvironmentSnapshot {
     guard let processIDs = Self.processObjectIDs() else {
@@ -91,7 +88,7 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
         capturedAt: capturedAt,
         route: route,
         frontmostAppBundleID: frontmostAppBundleID,
-        deviceEventRecentMs: deviceEventRecentMs,
+        deviceEventAt: deviceEventAt,
         unavailableReason: "process_object_list_unavailable"
       )
     }
@@ -140,11 +137,11 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
       inputBundleIDs: inputBundles,
       outputBundleIDs: outputBundles,
       frontmostAppBundleID: frontmostAppBundleID,
-      inputDeviceUIDDefault: inputDeviceID.flatMap(Self.deviceUID),
-      outputDeviceUIDDefault: outputDeviceID.flatMap(Self.deviceUID),
+      inputDeviceTransport: inputDeviceID.flatMap(Self.deviceTransport),
+      outputDeviceTransport: outputDeviceID.flatMap(Self.deviceTransport),
       route: route,
       bluetoothOutputActive: outputDeviceID.map(Self.isBluetoothDevice) ?? false,
-      deviceEventRecentMs: deviceEventRecentMs
+      deviceEventAt: deviceEventAt
     )
   }
 
@@ -182,11 +179,43 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
     return deviceID
   }
 
-  private static func deviceUID(_ deviceID: AudioDeviceID) -> String? {
-    stringProperty(objectID: deviceID, selector: kAudioDevicePropertyDeviceUID)
+  private static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+    let transport = deviceTransportRaw(deviceID)
+    return transport == kAudioDeviceTransportTypeBluetooth
+      || transport == kAudioDeviceTransportTypeBluetoothLE
   }
 
-  private static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+  private static func deviceTransport(_ deviceID: AudioDeviceID) -> String? {
+    guard let transport = deviceTransportRaw(deviceID) else { return nil }
+    switch transport {
+    case kAudioDeviceTransportTypeBuiltIn:
+      return "built_in"
+    case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+      return "bluetooth"
+    case kAudioDeviceTransportTypeUSB:
+      return "usb"
+    case kAudioDeviceTransportTypeAggregate:
+      return "aggregate"
+    case kAudioDeviceTransportTypeVirtual:
+      return "virtual"
+    case kAudioDeviceTransportTypeDisplayPort:
+      return "display_port"
+    case kAudioDeviceTransportTypeHDMI:
+      return "hdmi"
+    case kAudioDeviceTransportTypeAirPlay:
+      return "air_play"
+    case kAudioDeviceTransportTypePCI:
+      return "pci"
+    case kAudioDeviceTransportTypeFireWire:
+      return "fire_wire"
+    case kAudioDeviceTransportTypeThunderbolt:
+      return "thunderbolt"
+    default:
+      return "unknown"
+    }
+  }
+
+  private static func deviceTransportRaw(_ deviceID: AudioDeviceID) -> UInt32? {
     var transport: UInt32 = 0
     var size = UInt32(MemoryLayout<UInt32>.size)
     var address = AudioObjectPropertyAddress(
@@ -194,9 +223,9 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
       mScope: kAudioObjectPropertyScopeGlobal,
       mElement: kAudioObjectPropertyElementMain
     )
-    AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transport)
-    return transport == kAudioDeviceTransportTypeBluetooth
-      || transport == kAudioDeviceTransportTypeBluetoothLE
+    let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transport)
+    guard status == noErr else { return nil }
+    return transport
   }
 
   private static func boolProperty(

--- a/Sources/EnviousWispr/App/AudioEnvironmentSnapshotter.swift
+++ b/Sources/EnviousWispr/App/AudioEnvironmentSnapshotter.swift
@@ -1,0 +1,247 @@
+import AppKit
+import CoreAudio
+import EnviousWisprServices
+import Foundation
+
+protocol AudioEnvironmentCollecting: Sendable {
+  func collect(
+    reason: AudioEnvironmentSnapshot.Reason,
+    route: String?,
+    frontmostAppBundleID: String?,
+    deviceEventRecentMs: Int?,
+    capturedAt: Date
+  ) -> AudioEnvironmentSnapshot
+}
+
+@MainActor
+final class AudioEnvironmentSnapshotter {
+  private let collector: any AudioEnvironmentCollecting
+  private let routeProvider: @MainActor () -> String?
+  private let now: @MainActor () -> Date
+  private var latestSnapshot: AudioEnvironmentSnapshot?
+  private var latestGeneration: UInt64 = 0
+  private var lastDeviceEventAt: Date?
+
+  init(
+    collector: any AudioEnvironmentCollecting = CoreAudioEnvironmentCollector(),
+    routeProvider: @escaping @MainActor () -> String?,
+    now: @escaping @MainActor () -> Date = Date.init
+  ) {
+    self.collector = collector
+    self.routeProvider = routeProvider
+    self.now = now
+  }
+
+  func recordingStarted() {
+    refresh(reason: .recordingStart)
+  }
+
+  func applicationBecameActive() {
+    refresh(reason: .appActive)
+  }
+
+  func audioDeviceEventOccurred() {
+    lastDeviceEventAt = now()
+    refresh(reason: .audioDeviceEvent)
+  }
+
+  func latestForError() -> [String: Any]? {
+    latestSnapshot?.sentryContext(now: now())
+  }
+
+  func refresh(reason: AudioEnvironmentSnapshot.Reason) {
+    latestGeneration &+= 1
+    let generation = latestGeneration
+    let capturedAt = now()
+    let route = routeProvider()
+    let frontmostAppBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    let deviceEventRecentMs = lastDeviceEventAt.map {
+      max(0, Int(capturedAt.timeIntervalSince($0) * 1000))
+    }
+    let collector = self.collector
+
+    Task.detached(priority: .utility) { [weak self] in
+      let snapshot = collector.collect(
+        reason: reason,
+        route: route,
+        frontmostAppBundleID: frontmostAppBundleID,
+        deviceEventRecentMs: deviceEventRecentMs,
+        capturedAt: capturedAt
+      )
+      await MainActor.run { [weak self] in
+        guard let self, generation >= self.latestGeneration else { return }
+        self.latestGeneration = generation
+        self.latestSnapshot = snapshot
+      }
+    }
+  }
+}
+
+struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
+  func collect(
+    reason: AudioEnvironmentSnapshot.Reason,
+    route: String?,
+    frontmostAppBundleID: String?,
+    deviceEventRecentMs: Int?,
+    capturedAt: Date
+  ) -> AudioEnvironmentSnapshot {
+    guard let processIDs = Self.processObjectIDs() else {
+      return .unavailable(
+        reason: reason,
+        capturedAt: capturedAt,
+        route: route,
+        frontmostAppBundleID: frontmostAppBundleID,
+        deviceEventRecentMs: deviceEventRecentMs,
+        unavailableReason: "process_object_list_unavailable"
+      )
+    }
+
+    var inputBundles: [String] = []
+    var outputBundles: [String] = []
+    var inputCount = 0
+    var outputCount = 0
+
+    for processID in processIDs {
+      let isRunningInput = Self.boolProperty(
+        objectID: processID,
+        selector: kAudioProcessPropertyIsRunningInput
+      )
+      let isRunningOutput = Self.boolProperty(
+        objectID: processID,
+        selector: kAudioProcessPropertyIsRunningOutput
+      )
+
+      guard isRunningInput || isRunningOutput else { continue }
+
+      let bundleID =
+        Self.stringProperty(objectID: processID, selector: kAudioProcessPropertyBundleID)
+        ?? Self.pidProperty(objectID: processID).flatMap { pid in
+          NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+        }
+
+      if isRunningInput {
+        inputCount += 1
+        if let bundleID { inputBundles.append(bundleID) }
+      }
+      if isRunningOutput {
+        outputCount += 1
+        if let bundleID { outputBundles.append(bundleID) }
+      }
+    }
+
+    let inputDeviceID = Self.defaultDeviceID(selector: kAudioHardwarePropertyDefaultInputDevice)
+    let outputDeviceID = Self.defaultDeviceID(selector: kAudioHardwarePropertyDefaultOutputDevice)
+
+    return AudioEnvironmentSnapshot(
+      reason: reason,
+      capturedAt: capturedAt,
+      inputProcessCount: inputCount,
+      outputProcessCount: outputCount,
+      inputBundleIDs: inputBundles,
+      outputBundleIDs: outputBundles,
+      frontmostAppBundleID: frontmostAppBundleID,
+      inputDeviceUIDDefault: inputDeviceID.flatMap(Self.deviceUID),
+      outputDeviceUIDDefault: outputDeviceID.flatMap(Self.deviceUID),
+      route: route,
+      bluetoothOutputActive: outputDeviceID.map(Self.isBluetoothDevice) ?? false,
+      deviceEventRecentMs: deviceEventRecentMs
+    )
+  }
+
+  private static func processObjectIDs() -> [AudioObjectID]? {
+    var address = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyProcessObjectList,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    var dataSize: UInt32 = 0
+    let sizeStatus = AudioObjectGetPropertyDataSize(
+      AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize)
+    guard sizeStatus == noErr, dataSize > 0 else { return nil }
+
+    let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+    var processIDs = [AudioObjectID](repeating: 0, count: count)
+    let dataStatus = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &processIDs)
+    guard dataStatus == noErr else { return nil }
+    return processIDs
+  }
+
+  private static func defaultDeviceID(selector: AudioObjectPropertySelector) -> AudioDeviceID? {
+    var address = AudioObjectPropertyAddress(
+      mSelector: selector,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var deviceID: AudioDeviceID = 0
+    var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &deviceID)
+    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return deviceID
+  }
+
+  private static func deviceUID(_ deviceID: AudioDeviceID) -> String? {
+    stringProperty(objectID: deviceID, selector: kAudioDevicePropertyDeviceUID)
+  }
+
+  private static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+    var transport: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var address = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyTransportType,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transport)
+    return transport == kAudioDeviceTransportTypeBluetooth
+      || transport == kAudioDeviceTransportTypeBluetoothLE
+  }
+
+  private static func boolProperty(
+    objectID: AudioObjectID,
+    selector: AudioObjectPropertySelector
+  ) -> Bool {
+    var value: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var address = AudioObjectPropertyAddress(
+      mSelector: selector,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, &value)
+    return status == noErr && value != 0
+  }
+
+  private static func pidProperty(objectID: AudioObjectID) -> pid_t? {
+    var pid: pid_t = 0
+    var size = UInt32(MemoryLayout<pid_t>.size)
+    var address = AudioObjectPropertyAddress(
+      mSelector: kAudioProcessPropertyPID,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, &pid)
+    guard status == noErr, pid > 0 else { return nil }
+    return pid
+  }
+
+  private static func stringProperty(
+    objectID: AudioObjectID,
+    selector: AudioObjectPropertySelector
+  ) -> String? {
+    var address = AudioObjectPropertyAddress(
+      mSelector: selector,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var dataSize = UInt32(MemoryLayout<CFString>.size)
+    var result: CFString? = nil
+    let status = withUnsafeMutablePointer(to: &result) { pointer in
+      AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, pointer)
+    }
+    guard status == noErr, let result else { return nil }
+    return result as String
+  }
+}

--- a/Sources/EnviousWispr/App/AudioSystemEventReporter.swift
+++ b/Sources/EnviousWispr/App/AudioSystemEventReporter.swift
@@ -41,6 +41,7 @@ final class AudioSystemEventReporter {
   private let audioCapture: any AudioCaptureInterface
   private let asrManager: any ASRManagerInterface
   private let pipelineStateProvider: @MainActor () -> PipelineState
+  private let onAudioDeviceEvent: @MainActor @Sendable () -> Void
 
   /// CoreAudio property listener blocks. Stored as instance state so the same
   /// reference can be passed to `AudioObjectRemovePropertyListenerBlock` in
@@ -63,11 +64,13 @@ final class AudioSystemEventReporter {
   init(
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
-    pipelineStateProvider: @escaping @MainActor () -> PipelineState
+    pipelineStateProvider: @escaping @MainActor () -> PipelineState,
+    onAudioDeviceEvent: @escaping @MainActor @Sendable () -> Void = {}
   ) {
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.pipelineStateProvider = pipelineStateProvider
+    self.onAudioDeviceEvent = onAudioDeviceEvent
     registerCoreAudioListeners()
     registerCaptureDeviceObservers()
   }
@@ -184,6 +187,8 @@ final class AudioSystemEventReporter {
   // MARK: - Emission
 
   private func emit(event: String, context: [String: String]) {
+    onAudioDeviceEvent()
+
     // Snapshot collaborators on MainActor.
     let route = audioCapture.currentAudioRoute  // built_in_mic / capture_session_bt / unknown
     let backend = asrManager.activeBackendType.rawValue  // parakeet / whisperKit

--- a/Sources/EnviousWisprServices/AudioAppCategory.swift
+++ b/Sources/EnviousWisprServices/AudioAppCategory.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Coarse app classes for audio-environment diagnostics.
+///
+/// This intentionally never exposes exact app identity. Bundle IDs are only used
+/// locally to collapse apps with similar audio behavior into a small category set.
+public enum AudioAppCategory: String, CaseIterable, Sendable {
+  case meeting
+  case media
+  case browser
+  case capture
+  case voiceInput = "voice_input"
+  case system
+  case unknown
+
+  public static func categorize(bundleID: String?) -> Self {
+    guard let bundleID else { return .unknown }
+    let normalized = bundleID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !normalized.isEmpty else { return .unknown }
+
+    if systemBundleIDs.contains(normalized)
+      || normalized.hasPrefix("com.apple.audio")
+      || normalized.hasPrefix("com.apple.coreaudio")
+    {
+      return .system
+    }
+    if meetingBundleIDs.contains(normalized) { return .meeting }
+    if mediaBundleIDs.contains(normalized) { return .media }
+    if browserBundleIDs.contains(normalized) { return .browser }
+    if captureBundleIDs.contains(normalized) { return .capture }
+    if voiceInputBundleIDs.contains(normalized) { return .voiceInput }
+    return .unknown
+  }
+
+  private static let meetingBundleIDs: Set<String> = [
+    "com.apple.facetime",
+    "com.cisco.webexmeetingsapp",
+    "com.cisco.webex",
+    "com.google.chrome.app.gpjlkieedgaklpjfjconbcdnfocfcegj", // Google Meet PWA
+    "com.microsoft.teams",
+    "com.microsoft.teams2",
+    "com.tinyspeck.slackmacgap",
+    "com.webex.meetingmanager",
+    "us.zoom.xos",
+    "com.zoom.xos",
+    "com.hnc.discord",
+  ]
+
+  private static let mediaBundleIDs: Set<String> = [
+    "com.apple.music",
+    "com.apple.quicktimeplayerx",
+    "com.apple.tv",
+    "com.google.chrome.app.cinhimbnkkaeohfgghhklpknlkffjgod", // YouTube PWA
+    "com.netflix.netflix",
+    "com.spotify.client",
+    "org.videolan.vlc",
+  ]
+
+  private static let browserBundleIDs: Set<String> = [
+    "app.zen-browser.zen",
+    "com.apple.safari",
+    "com.brave.browser",
+    "com.google.chrome",
+    "com.microsoft.edgemac",
+    "company.thebrowser.browser",
+    "org.mozilla.firefox",
+  ]
+
+  private static let captureBundleIDs: Set<String> = [
+    "com.globaldelight.vmaker",
+    "com.latenitesoft.screenflow",
+    "com.loom.desktop",
+    "com.obsproject.obs-studio",
+    "com.riverside.riverside",
+  ]
+
+  private static let voiceInputBundleIDs: Set<String> = [
+    "com.apple.siri",
+    "com.apple.speechrecognitioncorespeechd",
+    "com.enviouswispr.app",
+    "com.enviouswispr.app.dev",
+    "com.superwhisper.superwhisper",
+    "com.wisprflow.wisprflow",
+  ]
+
+  private static let systemBundleIDs: Set<String> = [
+    "com.apple.audiomxd",
+    "com.apple.audio.coreaudiod",
+    "com.apple.coreaudiod",
+    "com.apple.controlcenter",
+    "com.apple.systemuiserver",
+  ]
+}

--- a/Sources/EnviousWisprServices/AudioEnvironmentSnapshot.swift
+++ b/Sources/EnviousWisprServices/AudioEnvironmentSnapshot.swift
@@ -1,0 +1,151 @@
+import CryptoKit
+import Foundation
+
+/// Metadata-only view of the user's audio environment near dictation.
+///
+/// Privacy boundary: this value never renders raw bundle IDs, process names,
+/// window titles, URLs, file paths, audio samples, or dictated text.
+public struct AudioEnvironmentSnapshot: Sendable, Equatable {
+  public enum Status: String, Sendable {
+    case fresh
+    case stale
+    case unavailable
+  }
+
+  public enum Reason: String, Sendable {
+    case recordingStart = "recording_start"
+    case appActive = "app_active"
+    case audioDeviceEvent = "audio_device_event"
+    case manualTest = "manual_test"
+  }
+
+  public static let bundleHashCap = 8
+  public static let freshnessWindowMs = 10_000
+
+  public let reason: Reason
+  public let capturedAt: Date
+  public let inputProcessCount: Int
+  public let outputProcessCount: Int
+  public let inputBundleIDHashes: [String]
+  public let outputBundleIDHashes: [String]
+  public let frontmostAppBundleIDHash: String?
+  public let inputDeviceUIDDefault: String?
+  public let outputDeviceUIDDefault: String?
+  public let route: String?
+  public let bluetoothOutputActive: Bool
+  public let deviceEventRecentMs: Int?
+  public let unavailableReason: String?
+
+  public init(
+    reason: Reason,
+    capturedAt: Date,
+    inputProcessCount: Int = 0,
+    outputProcessCount: Int = 0,
+    inputBundleIDs: [String] = [],
+    outputBundleIDs: [String] = [],
+    frontmostAppBundleID: String? = nil,
+    inputDeviceUIDDefault: String? = nil,
+    outputDeviceUIDDefault: String? = nil,
+    route: String? = nil,
+    bluetoothOutputActive: Bool = false,
+    deviceEventRecentMs: Int? = nil,
+    unavailableReason: String? = nil
+  ) {
+    self.reason = reason
+    self.capturedAt = capturedAt
+    self.inputProcessCount = max(0, inputProcessCount)
+    self.outputProcessCount = max(0, outputProcessCount)
+    self.inputBundleIDHashes = Self.hashBundleIDs(inputBundleIDs)
+    self.outputBundleIDHashes = Self.hashBundleIDs(outputBundleIDs)
+    self.frontmostAppBundleIDHash = frontmostAppBundleID.flatMap(Self.hashBundleID)
+    self.inputDeviceUIDDefault = Self.sanitizedShortString(inputDeviceUIDDefault)
+    self.outputDeviceUIDDefault = Self.sanitizedShortString(outputDeviceUIDDefault)
+    self.route = Self.sanitizedShortString(route)
+    self.bluetoothOutputActive = bluetoothOutputActive
+    self.deviceEventRecentMs = deviceEventRecentMs.map { max(0, $0) }
+    self.unavailableReason = Self.sanitizedShortString(unavailableReason)
+  }
+
+  public static func unavailable(
+    reason: Reason,
+    capturedAt: Date,
+    route: String?,
+    frontmostAppBundleID: String?,
+    deviceEventRecentMs: Int?,
+    unavailableReason: String
+  ) -> Self {
+    Self(
+      reason: reason,
+      capturedAt: capturedAt,
+      frontmostAppBundleID: frontmostAppBundleID,
+      route: route,
+      deviceEventRecentMs: deviceEventRecentMs,
+      unavailableReason: unavailableReason
+    )
+  }
+
+  public func sentryContext(now: Date = Date()) -> [String: Any] {
+    let ageMs = max(0, Int(now.timeIntervalSince(capturedAt) * 1000))
+    let status: Status =
+      unavailableReason == nil
+      ? (ageMs <= Self.freshnessWindowMs ? .fresh : .stale)
+      : .unavailable
+
+    var context: [String: Any] = [
+      "snapshot_status": status.rawValue,
+      "snapshot_reason": reason.rawValue,
+      "snapshot_age_ms": ageMs,
+      "input_process_count": inputProcessCount,
+      "output_process_count": outputProcessCount,
+      "input_bundle_id_hashes": inputBundleIDHashes,
+      "output_bundle_id_hashes": outputBundleIDHashes,
+      "bluetooth_output_active": bluetoothOutputActive,
+    ]
+
+    if let frontmostAppBundleIDHash {
+      context["frontmost_app_bundle_id_hash"] = frontmostAppBundleIDHash
+    }
+    if let inputDeviceUIDDefault {
+      context["input_device_uid_default"] = inputDeviceUIDDefault
+    }
+    if let outputDeviceUIDDefault {
+      context["output_device_uid_default"] = outputDeviceUIDDefault
+    }
+    if let route {
+      context["route"] = route
+    }
+    if let deviceEventRecentMs {
+      context["device_event_recent_ms"] = deviceEventRecentMs
+    }
+    if let unavailableReason {
+      context["unavailable_reason"] = unavailableReason
+    }
+
+    return context
+  }
+
+  private static func hashBundleIDs(_ bundleIDs: [String]) -> [String] {
+    Array(Set(bundleIDs.compactMap(hashBundleID)).sorted().prefix(bundleHashCap))
+  }
+
+  private static func hashBundleID(_ bundleID: String) -> String? {
+    let trimmed = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let digest = SHA256.hash(data: Data(trimmed.utf8))
+    return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+  }
+
+  private static func sanitizedShortString(_ input: String?) -> String? {
+    guard let input else { return nil }
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-/")
+    let sanitizedScalars = trimmed.unicodeScalars.map { scalar -> Character in
+      allowed.contains(scalar) ? Character(scalar) : "_"
+    }
+    let sanitized = String(sanitizedScalars)
+    return String(sanitized.prefix(128))
+  }
+}

--- a/Sources/EnviousWisprServices/AudioEnvironmentSnapshot.swift
+++ b/Sources/EnviousWisprServices/AudioEnvironmentSnapshot.swift
@@ -1,10 +1,10 @@
-import CryptoKit
 import Foundation
 
 /// Metadata-only view of the user's audio environment near dictation.
 ///
-/// Privacy boundary: this value never renders raw bundle IDs, process names,
-/// window titles, URLs, file paths, audio samples, or dictated text.
+/// Privacy boundary: this value never renders raw bundle IDs, deterministic
+/// bundle hashes, process names, raw device IDs, window titles, URLs, file
+/// paths, audio samples, or dictated text.
 public struct AudioEnvironmentSnapshot: Sendable, Equatable {
   public enum Status: String, Sendable {
     case fresh
@@ -19,21 +19,20 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
     case manualTest = "manual_test"
   }
 
-  public static let bundleHashCap = 8
   public static let freshnessWindowMs = 10_000
 
   public let reason: Reason
   public let capturedAt: Date
   public let inputProcessCount: Int
   public let outputProcessCount: Int
-  public let inputBundleIDHashes: [String]
-  public let outputBundleIDHashes: [String]
-  public let frontmostAppBundleIDHash: String?
-  public let inputDeviceUIDDefault: String?
-  public let outputDeviceUIDDefault: String?
+  public let inputAppCategoryCounts: [AudioAppCategory: Int]
+  public let outputAppCategoryCounts: [AudioAppCategory: Int]
+  public let frontmostAppCategory: AudioAppCategory?
+  public let inputDeviceTransport: String?
+  public let outputDeviceTransport: String?
   public let route: String?
   public let bluetoothOutputActive: Bool
-  public let deviceEventRecentMs: Int?
+  public let deviceEventAt: Date?
   public let unavailableReason: String?
 
   public init(
@@ -44,25 +43,25 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
     inputBundleIDs: [String] = [],
     outputBundleIDs: [String] = [],
     frontmostAppBundleID: String? = nil,
-    inputDeviceUIDDefault: String? = nil,
-    outputDeviceUIDDefault: String? = nil,
+    inputDeviceTransport: String? = nil,
+    outputDeviceTransport: String? = nil,
     route: String? = nil,
     bluetoothOutputActive: Bool = false,
-    deviceEventRecentMs: Int? = nil,
+    deviceEventAt: Date? = nil,
     unavailableReason: String? = nil
   ) {
     self.reason = reason
     self.capturedAt = capturedAt
     self.inputProcessCount = max(0, inputProcessCount)
     self.outputProcessCount = max(0, outputProcessCount)
-    self.inputBundleIDHashes = Self.hashBundleIDs(inputBundleIDs)
-    self.outputBundleIDHashes = Self.hashBundleIDs(outputBundleIDs)
-    self.frontmostAppBundleIDHash = frontmostAppBundleID.flatMap(Self.hashBundleID)
-    self.inputDeviceUIDDefault = Self.sanitizedShortString(inputDeviceUIDDefault)
-    self.outputDeviceUIDDefault = Self.sanitizedShortString(outputDeviceUIDDefault)
+    self.inputAppCategoryCounts = Self.categoryCounts(inputBundleIDs)
+    self.outputAppCategoryCounts = Self.categoryCounts(outputBundleIDs)
+    self.frontmostAppCategory = frontmostAppBundleID.map(AudioAppCategory.categorize)
+    self.inputDeviceTransport = Self.sanitizedShortString(inputDeviceTransport)
+    self.outputDeviceTransport = Self.sanitizedShortString(outputDeviceTransport)
     self.route = Self.sanitizedShortString(route)
     self.bluetoothOutputActive = bluetoothOutputActive
-    self.deviceEventRecentMs = deviceEventRecentMs.map { max(0, $0) }
+    self.deviceEventAt = deviceEventAt
     self.unavailableReason = Self.sanitizedShortString(unavailableReason)
   }
 
@@ -71,7 +70,7 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
     capturedAt: Date,
     route: String?,
     frontmostAppBundleID: String?,
-    deviceEventRecentMs: Int?,
+    deviceEventAt: Date?,
     unavailableReason: String
   ) -> Self {
     Self(
@@ -79,7 +78,7 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
       capturedAt: capturedAt,
       frontmostAppBundleID: frontmostAppBundleID,
       route: route,
-      deviceEventRecentMs: deviceEventRecentMs,
+      deviceEventAt: deviceEventAt,
       unavailableReason: unavailableReason
     )
   }
@@ -97,25 +96,25 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
       "snapshot_age_ms": ageMs,
       "input_process_count": inputProcessCount,
       "output_process_count": outputProcessCount,
-      "input_bundle_id_hashes": inputBundleIDHashes,
-      "output_bundle_id_hashes": outputBundleIDHashes,
+      "input_app_category_counts": Self.renderCategoryCounts(inputAppCategoryCounts),
+      "output_app_category_counts": Self.renderCategoryCounts(outputAppCategoryCounts),
       "bluetooth_output_active": bluetoothOutputActive,
     ]
 
-    if let frontmostAppBundleIDHash {
-      context["frontmost_app_bundle_id_hash"] = frontmostAppBundleIDHash
+    if let frontmostAppCategory {
+      context["frontmost_app_category"] = frontmostAppCategory.rawValue
     }
-    if let inputDeviceUIDDefault {
-      context["input_device_uid_default"] = inputDeviceUIDDefault
+    if let inputDeviceTransport {
+      context["input_device_transport"] = inputDeviceTransport
     }
-    if let outputDeviceUIDDefault {
-      context["output_device_uid_default"] = outputDeviceUIDDefault
+    if let outputDeviceTransport {
+      context["output_device_transport"] = outputDeviceTransport
     }
     if let route {
       context["route"] = route
     }
-    if let deviceEventRecentMs {
-      context["device_event_recent_ms"] = deviceEventRecentMs
+    if let deviceEventAt {
+      context["device_event_recent_ms"] = max(0, Int(now.timeIntervalSince(deviceEventAt) * 1000))
     }
     if let unavailableReason {
       context["unavailable_reason"] = unavailableReason
@@ -124,16 +123,19 @@ public struct AudioEnvironmentSnapshot: Sendable, Equatable {
     return context
   }
 
-  private static func hashBundleIDs(_ bundleIDs: [String]) -> [String] {
-    Array(Set(bundleIDs.compactMap(hashBundleID)).sorted().prefix(bundleHashCap))
+  private static func categoryCounts(_ bundleIDs: [String]) -> [AudioAppCategory: Int] {
+    bundleIDs.reduce(into: [:]) { counts, bundleID in
+      counts[AudioAppCategory.categorize(bundleID: bundleID), default: 0] += 1
+    }
   }
 
-  private static func hashBundleID(_ bundleID: String) -> String? {
-    let trimmed = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-
-    let digest = SHA256.hash(data: Data(trimmed.utf8))
-    return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+  private static func renderCategoryCounts(
+    _ counts: [AudioAppCategory: Int]
+  ) -> [String: Int] {
+    counts.reduce(into: [:]) { rendered, item in
+      guard item.value > 0 else { return }
+      rendered[item.key.rawValue] = item.value
+    }
   }
 
   private static func sanitizedShortString(_ input: String?) -> String? {

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -46,11 +46,7 @@ public enum ObservabilityBootstrap {
       // This is a limb — must never throw or crash. Heart is unaffected if this fails.
       var redactedProperties: [String: Any] = [:]
       for (key, value) in event.properties {
-        if let str = value as? String {
-          redactedProperties[key] = ObservabilityBootstrap.redactString(str)
-        } else {
-          redactedProperties[key] = value
-        }
+        redactedProperties[key] = ObservabilityBootstrap.redactValue(value)
       }
       event.properties = redactedProperties
       return event
@@ -174,20 +170,29 @@ public enum ObservabilityBootstrap {
     }
   }
 
-  /// Redact every String value in a `[String: Any]` dictionary, leaving
-  /// non-string values untouched. Shared by Sentry beforeSend redaction
+  /// Redact every String value in a `[String: Any]` dictionary recursively,
+  /// leaving non-string scalar values untouched. Shared by Sentry beforeSend redaction
   /// of `event.extra`, `breadcrumb.data`, `event.context`, and
   /// `exception.mechanism.data`.
   static func redactDict(_ input: [String: Any]) -> [String: Any] {
     var output: [String: Any] = [:]
     for (key, value) in input {
-      if let str = value as? String {
-        output[key] = redactString(str)
-      } else {
-        output[key] = value
-      }
+      output[key] = redactValue(value)
     }
     return output
+  }
+
+  static func redactValue(_ value: Any) -> Any {
+    if let str = value as? String {
+      return redactString(str)
+    }
+    if let dict = value as? [String: Any] {
+      return redactDict(dict)
+    }
+    if let array = value as? [Any] {
+      return array.map(redactValue)
+    }
+    return value
   }
 
   /// Redacts a string if it matches known PII patterns:

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -151,12 +151,15 @@ public enum SentryBreadcrumb {
     for (key, value) in tags {
       eventTags[key] = value
     }
+
+    let eventExtra = mergedExtra(extra)
+
     // Test spy hooks — invoked synchronously before SDK dispatch. Production sets nil.
     Self.captureErrorTagsDelegate?(eventTags)
-    Self.captureErrorDelegate?(error, category, stage, extra)
+    Self.captureErrorDelegate?(error, category, stage, eventExtra)
     event.tags = eventTags
-    if let extra {
-      event.extra = extra
+    if let eventExtra {
+      event.extra = eventExtra
     }
 
     // Also add a breadcrumb so the error appears in the trail
@@ -164,7 +167,7 @@ public enum SentryBreadcrumb {
       stage: stage,
       message: "ERROR: \(category.rawValue)",
       level: .error,
-      data: extra
+      data: eventExtra
     )
 
     if let snapshot {
@@ -174,6 +177,17 @@ public enum SentryBreadcrumb {
     } else {
       SentrySDK.capture(event: event)
     }
+  }
+
+  private static func mergedExtra(_ extra: [String: Any]?) -> [String: Any]? {
+    let providedEnvironment = Self.audioEnvironmentProvider?()
+    guard let providedEnvironment, !providedEnvironment.isEmpty else { return extra }
+
+    var merged = extra ?? [:]
+    if merged["audio_environment"] == nil {
+      merged["audio_environment"] = providedEnvironment
+    }
+    return merged
   }
 
   /// Capture a post-router Apple Intelligence polish failure with router
@@ -264,6 +278,24 @@ public enum SentryBreadcrumb {
 // MARK: - Test Delegate Hook
 
 extension SentryBreadcrumb {
+  public typealias AudioEnvironmentProvider = @MainActor @Sendable () -> [String: Any]?
+
+  /// Cached audio-environment provider for handled Sentry errors.
+  ///
+  /// The provider must return already-collected plain data only. It must not
+  /// query Core Audio, await work, or take locks on the Sentry capture path.
+  public nonisolated(unsafe) static var audioEnvironmentProvider: AudioEnvironmentProvider?
+
+  public static func withAudioEnvironmentProvider<T>(
+    _ provider: AudioEnvironmentProvider?,
+    _ body: () throws -> T
+  ) rethrows -> T {
+    let prior = audioEnvironmentProvider
+    audioEnvironmentProvider = provider
+    defer { audioEnvironmentProvider = prior }
+    return try body()
+  }
+
   /// Optional test-only delegate invoked synchronously on every `captureError` call
   /// before the real Sentry SDK is touched. Tests set this in `setUp`, nil in
   /// `tearDown`. Production code never reads it. Cheap alternative to a full

--- a/Tests/EnviousWisprTests/App/AudioEnvironmentSnapshotterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEnvironmentSnapshotterTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprServices
+
+@Suite("AudioEnvironmentSnapshotter")
+@MainActor
+struct AudioEnvironmentSnapshotterTests {
+  private struct FakeCollector: AudioEnvironmentCollecting {
+    func collect(
+      reason: AudioEnvironmentSnapshot.Reason,
+      route: String?,
+      frontmostAppBundleID: String?,
+      deviceEventRecentMs: Int?,
+      capturedAt: Date
+    ) -> AudioEnvironmentSnapshot {
+      AudioEnvironmentSnapshot(
+        reason: reason,
+        capturedAt: capturedAt,
+        inputProcessCount: 1,
+        outputProcessCount: 2,
+        inputBundleIDs: ["com.example.input"],
+        outputBundleIDs: ["com.example.output"],
+        frontmostAppBundleID: frontmostAppBundleID,
+        inputDeviceUIDDefault: "InputDevice",
+        outputDeviceUIDDefault: "OutputDevice",
+        route: route,
+        bluetoothOutputActive: false,
+        deviceEventRecentMs: deviceEventRecentMs
+      )
+    }
+  }
+
+  @Test("recording start refresh publishes cached snapshot")
+  func recordingStartRefreshPublishesSnapshot() async throws {
+    let snapshotter = AudioEnvironmentSnapshotter(
+      collector: FakeCollector(),
+      routeProvider: { "built_in_mic" },
+      now: { Date(timeIntervalSince1970: 100) }
+    )
+
+    snapshotter.recordingStarted()
+    let context = try await latestContext(from: snapshotter)
+
+    #expect(context["snapshot_reason"] as? String == "recording_start")
+    #expect(context["snapshot_status"] as? String == "fresh")
+    #expect(context["route"] as? String == "built_in_mic")
+    #expect(context["input_process_count"] as? Int == 1)
+  }
+
+  @Test("device event refresh includes recent event age")
+  func deviceEventRefreshIncludesRecentEventAge() async throws {
+    var currentDate = Date(timeIntervalSince1970: 100)
+    let snapshotter = AudioEnvironmentSnapshotter(
+      collector: FakeCollector(),
+      routeProvider: { "bt_headset" },
+      now: { currentDate }
+    )
+
+    snapshotter.audioDeviceEventOccurred()
+    currentDate = Date(timeIntervalSince1970: 100.25)
+    let context = try await latestContext(from: snapshotter)
+
+    #expect(context["snapshot_reason"] as? String == "audio_device_event")
+    #expect(context["device_event_recent_ms"] as? Int == 0)
+  }
+
+  private func latestContext(
+    from snapshotter: AudioEnvironmentSnapshotter
+  ) async throws -> [String: Any] {
+    for _ in 0..<50 {
+      if let context = snapshotter.latestForError() {
+        return context
+      }
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    Issue.record("snapshot did not publish")
+    return [:]
+  }
+}

--- a/Tests/EnviousWisprTests/App/AudioEnvironmentSnapshotterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEnvironmentSnapshotterTests.swift
@@ -12,7 +12,7 @@ struct AudioEnvironmentSnapshotterTests {
       reason: AudioEnvironmentSnapshot.Reason,
       route: String?,
       frontmostAppBundleID: String?,
-      deviceEventRecentMs: Int?,
+      deviceEventAt: Date?,
       capturedAt: Date
     ) -> AudioEnvironmentSnapshot {
       AudioEnvironmentSnapshot(
@@ -20,14 +20,54 @@ struct AudioEnvironmentSnapshotterTests {
         capturedAt: capturedAt,
         inputProcessCount: 1,
         outputProcessCount: 2,
-        inputBundleIDs: ["com.example.input"],
-        outputBundleIDs: ["com.example.output"],
+        inputBundleIDs: ["com.zoom.xos"],
+        outputBundleIDs: ["com.spotify.client"],
         frontmostAppBundleID: frontmostAppBundleID,
-        inputDeviceUIDDefault: "InputDevice",
-        outputDeviceUIDDefault: "OutputDevice",
+        inputDeviceTransport: "built_in",
+        outputDeviceTransport: "bluetooth",
         route: route,
         bluetoothOutputActive: false,
-        deviceEventRecentMs: deviceEventRecentMs
+        deviceEventAt: deviceEventAt
+      )
+    }
+  }
+
+  private struct UnavailableCollector: AudioEnvironmentCollecting {
+    func collect(
+      reason: AudioEnvironmentSnapshot.Reason,
+      route: String?,
+      frontmostAppBundleID: String?,
+      deviceEventAt: Date?,
+      capturedAt: Date
+    ) -> AudioEnvironmentSnapshot {
+      .unavailable(
+        reason: reason,
+        capturedAt: capturedAt,
+        route: route,
+        frontmostAppBundleID: frontmostAppBundleID,
+        deviceEventAt: deviceEventAt,
+        unavailableReason: "process object list unavailable"
+      )
+    }
+  }
+
+  private final class OutOfOrderCollector: AudioEnvironmentCollecting, @unchecked Sendable {
+    func collect(
+      reason: AudioEnvironmentSnapshot.Reason,
+      route: String?,
+      frontmostAppBundleID: String?,
+      deviceEventAt: Date?,
+      capturedAt: Date
+    ) -> AudioEnvironmentSnapshot {
+      if reason == .recordingStart {
+        Thread.sleep(forTimeInterval: 0.2)
+      }
+      return AudioEnvironmentSnapshot(
+        reason: reason,
+        capturedAt: capturedAt,
+        inputBundleIDs: [reason == .recordingStart ? "com.zoom.xos" : "com.spotify.client"],
+        route: route,
+        deviceEventAt: deviceEventAt
       )
     }
   }
@@ -47,9 +87,11 @@ struct AudioEnvironmentSnapshotterTests {
     #expect(context["snapshot_status"] as? String == "fresh")
     #expect(context["route"] as? String == "built_in_mic")
     #expect(context["input_process_count"] as? Int == 1)
+    let inputCategories = context["input_app_category_counts"] as? [String: Int]
+    #expect(inputCategories?["meeting"] == 1)
   }
 
-  @Test("device event refresh includes recent event age")
+  @Test("device event age is computed at error render time")
   func deviceEventRefreshIncludesRecentEventAge() async throws {
     var currentDate = Date(timeIntervalSince1970: 100)
     let snapshotter = AudioEnvironmentSnapshotter(
@@ -59,11 +101,48 @@ struct AudioEnvironmentSnapshotterTests {
     )
 
     snapshotter.audioDeviceEventOccurred()
-    currentDate = Date(timeIntervalSince1970: 100.25)
+    currentDate = Date(timeIntervalSince1970: 100.5)
     let context = try await latestContext(from: snapshotter)
 
     #expect(context["snapshot_reason"] as? String == "audio_device_event")
-    #expect(context["device_event_recent_ms"] as? Int == 0)
+    #expect(context["device_event_recent_ms"] as? Int == 500)
+  }
+
+  @Test("unavailable collector result is cached")
+  func unavailableCollectorResultIsCached() async throws {
+    let snapshotter = AudioEnvironmentSnapshotter(
+      collector: UnavailableCollector(),
+      routeProvider: { "built_in_mic" },
+      now: { Date(timeIntervalSince1970: 100) }
+    )
+
+    snapshotter.recordingStarted()
+    let context = try await latestContext(from: snapshotter)
+
+    #expect(context["snapshot_status"] as? String == "unavailable")
+    #expect(context["unavailable_reason"] as? String == "process_object_list_unavailable")
+    #expect(context["route"] as? String == "built_in_mic")
+  }
+
+  @Test("older refresh completion cannot replace newer snapshot")
+  func olderRefreshCompletionCannotReplaceNewerSnapshot() async throws {
+    let snapshotter = AudioEnvironmentSnapshotter(
+      collector: OutOfOrderCollector(),
+      routeProvider: { "built_in_mic" },
+      now: { Date(timeIntervalSince1970: 100) }
+    )
+
+    snapshotter.recordingStarted()
+    snapshotter.applicationBecameActive()
+    let context = try await latestContext(from: snapshotter)
+
+    #expect(context["snapshot_reason"] as? String == "app_active")
+    let inputCategories = context["input_app_category_counts"] as? [String: Int]
+    #expect(inputCategories?["media"] == 1)
+
+    try await Task.sleep(nanoseconds: 250_000_000)
+    let laterContext = try #require(snapshotter.latestForError())
+    #expect(laterContext["snapshot_reason"] as? String == "app_active")
   }
 
   private func latestContext(

--- a/Tests/EnviousWisprTests/Services/AudioEnvironmentSnapshotTests.swift
+++ b/Tests/EnviousWisprTests/Services/AudioEnvironmentSnapshotTests.swift
@@ -5,38 +5,53 @@ import Testing
 
 @Suite("AudioEnvironmentSnapshot")
 struct AudioEnvironmentSnapshotTests {
-  @Test("renderer hashes bundle IDs and caps lists")
-  func rendererHashesAndCapsBundleIDs() {
+  @Test("renderer emits coarse app categories without identifiers")
+  func rendererEmitsCoarseAppCategoriesWithoutIdentifiers() {
     let snapshot = AudioEnvironmentSnapshot(
       reason: .recordingStart,
       capturedAt: Date(timeIntervalSince1970: 100),
       inputProcessCount: 10,
       outputProcessCount: 12,
-      inputBundleIDs: (0..<12).map { "com.example.input\($0)" },
-      outputBundleIDs: ["com.zoom.xos", "com.spotify.client", "com.zoom.xos"],
-      frontmostAppBundleID: "com.apple.TextEdit",
-      inputDeviceUIDDefault: "BuiltInMicrophoneDevice",
-      outputDeviceUIDDefault: "AirPods-Pro",
+      inputBundleIDs: ["com.zoom.xos", "com.microsoft.teams", "com.private.HealthcareClient"],
+      outputBundleIDs: ["com.spotify.client", "org.videolan.vlc", "com.zoom.xos"],
+      frontmostAppBundleID: "com.google.Chrome",
+      inputDeviceTransport: "built_in",
+      outputDeviceTransport: "bluetooth",
       route: "built_in_mic",
-      bluetoothOutputActive: true
+      bluetoothOutputActive: true,
+      deviceEventAt: Date(timeIntervalSince1970: 100.5)
     )
 
     let context = snapshot.sentryContext(now: Date(timeIntervalSince1970: 101))
+    let inputCategories = context["input_app_category_counts"] as? [String: Int]
+    let outputCategories = context["output_app_category_counts"] as? [String: Int]
 
     #expect(context["snapshot_status"] as? String == "fresh")
     #expect(context["snapshot_reason"] as? String == "recording_start")
     #expect(context["snapshot_age_ms"] as? Int == 1000)
     #expect(context["input_process_count"] as? Int == 10)
     #expect(context["output_process_count"] as? Int == 12)
-    #expect((context["input_bundle_id_hashes"] as? [String])?.count == 8)
-    #expect((context["output_bundle_id_hashes"] as? [String])?.count == 2)
-    #expect(context["frontmost_app_bundle_id_hash"] is String)
+    #expect(inputCategories?["meeting"] == 2)
+    #expect(inputCategories?["unknown"] == 1)
+    #expect(outputCategories?["media"] == 2)
+    #expect(outputCategories?["meeting"] == 1)
+    #expect(context["frontmost_app_category"] as? String == "browser")
+    #expect(context["input_device_transport"] as? String == "built_in")
+    #expect(context["output_device_transport"] as? String == "bluetooth")
     #expect(context["bluetooth_output_active"] as? Bool == true)
+    #expect(context["device_event_recent_ms"] as? Int == 500)
 
     let rendered = String(describing: context)
     #expect(!rendered.contains("com.zoom.xos"))
     #expect(!rendered.contains("com.spotify.client"))
-    #expect(!rendered.contains("com.apple.TextEdit"))
+    #expect(!rendered.contains("com.microsoft.teams"))
+    #expect(!rendered.contains("HealthcareClient"))
+    #expect(!rendered.contains("AirPods-Pro"))
+    #expect(context["input_bundle_id_hashes"] == nil)
+    #expect(context["output_bundle_id_hashes"] == nil)
+    #expect(context["frontmost_app_bundle_id_hash"] == nil)
+    #expect(context["input_device_uid_default"] == nil)
+    #expect(context["output_device_uid_default"] == nil)
   }
 
   @Test("stale status is explicit when cached snapshot ages out")
@@ -59,7 +74,7 @@ struct AudioEnvironmentSnapshotTests {
       capturedAt: Date(timeIntervalSince1970: 100),
       route: "built in mic",
       frontmostAppBundleID: "com.private.HealthcareClient",
-      deviceEventRecentMs: 42,
+      deviceEventAt: Date(timeIntervalSince1970: 99.5),
       unavailableReason: "process object list unavailable"
     )
 
@@ -67,7 +82,7 @@ struct AudioEnvironmentSnapshotTests {
 
     #expect(context["snapshot_status"] as? String == "unavailable")
     #expect(context["snapshot_reason"] as? String == "audio_device_event")
-    #expect(context["device_event_recent_ms"] as? Int == 42)
+    #expect(context["device_event_recent_ms"] as? Int == 500)
     #expect(context["unavailable_reason"] as? String == "process_object_list_unavailable")
     #expect(context["route"] as? String == "built_in_mic")
     #expect(!String(describing: context).contains("HealthcareClient"))

--- a/Tests/EnviousWisprTests/Services/AudioEnvironmentSnapshotTests.swift
+++ b/Tests/EnviousWisprTests/Services/AudioEnvironmentSnapshotTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@Suite("AudioEnvironmentSnapshot")
+struct AudioEnvironmentSnapshotTests {
+  @Test("renderer hashes bundle IDs and caps lists")
+  func rendererHashesAndCapsBundleIDs() {
+    let snapshot = AudioEnvironmentSnapshot(
+      reason: .recordingStart,
+      capturedAt: Date(timeIntervalSince1970: 100),
+      inputProcessCount: 10,
+      outputProcessCount: 12,
+      inputBundleIDs: (0..<12).map { "com.example.input\($0)" },
+      outputBundleIDs: ["com.zoom.xos", "com.spotify.client", "com.zoom.xos"],
+      frontmostAppBundleID: "com.apple.TextEdit",
+      inputDeviceUIDDefault: "BuiltInMicrophoneDevice",
+      outputDeviceUIDDefault: "AirPods-Pro",
+      route: "built_in_mic",
+      bluetoothOutputActive: true
+    )
+
+    let context = snapshot.sentryContext(now: Date(timeIntervalSince1970: 101))
+
+    #expect(context["snapshot_status"] as? String == "fresh")
+    #expect(context["snapshot_reason"] as? String == "recording_start")
+    #expect(context["snapshot_age_ms"] as? Int == 1000)
+    #expect(context["input_process_count"] as? Int == 10)
+    #expect(context["output_process_count"] as? Int == 12)
+    #expect((context["input_bundle_id_hashes"] as? [String])?.count == 8)
+    #expect((context["output_bundle_id_hashes"] as? [String])?.count == 2)
+    #expect(context["frontmost_app_bundle_id_hash"] is String)
+    #expect(context["bluetooth_output_active"] as? Bool == true)
+
+    let rendered = String(describing: context)
+    #expect(!rendered.contains("com.zoom.xos"))
+    #expect(!rendered.contains("com.spotify.client"))
+    #expect(!rendered.contains("com.apple.TextEdit"))
+  }
+
+  @Test("stale status is explicit when cached snapshot ages out")
+  func staleStatus() {
+    let snapshot = AudioEnvironmentSnapshot(
+      reason: .appActive,
+      capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let context = snapshot.sentryContext(now: Date(timeIntervalSince1970: 112))
+
+    #expect(context["snapshot_status"] as? String == "stale")
+    #expect(context["snapshot_age_ms"] as? Int == 12_000)
+  }
+
+  @Test("unavailable status keeps reason but no raw app identifiers")
+  func unavailableStatus() {
+    let snapshot = AudioEnvironmentSnapshot.unavailable(
+      reason: .audioDeviceEvent,
+      capturedAt: Date(timeIntervalSince1970: 100),
+      route: "built in mic",
+      frontmostAppBundleID: "com.private.HealthcareClient",
+      deviceEventRecentMs: 42,
+      unavailableReason: "process object list unavailable"
+    )
+
+    let context = snapshot.sentryContext(now: Date(timeIntervalSince1970: 100))
+
+    #expect(context["snapshot_status"] as? String == "unavailable")
+    #expect(context["snapshot_reason"] as? String == "audio_device_event")
+    #expect(context["device_event_recent_ms"] as? Int == 42)
+    #expect(context["unavailable_reason"] as? String == "process_object_list_unavailable")
+    #expect(context["route"] as? String == "built_in_mic")
+    #expect(!String(describing: context).contains("HealthcareClient"))
+  }
+}

--- a/Tests/EnviousWisprTests/Services/ObservabilityRedactionTests.swift
+++ b/Tests/EnviousWisprTests/Services/ObservabilityRedactionTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@Suite("Observability redaction")
+struct ObservabilityRedactionTests {
+  @Test("redactDict recurses through nested dictionaries and arrays")
+  func recursiveRedaction() {
+    let redacted = ObservabilityBootstrap.redactDict([
+      "audio_environment": [
+        "safe": "built_in_mic",
+        "nested": [
+          "email": "user@example.com",
+          "array": ["ok", "sk-abcdefghijklmnopqrstuvwxyz123456"],
+        ],
+      ],
+      "outer": "phc_abcdefghijklmnopqrstuvwxyz123456",
+    ])
+
+    let environment = redacted["audio_environment"] as? [String: Any]
+    let nested = environment?["nested"] as? [String: Any]
+    let array = nested?["array"] as? [Any]
+
+    #expect(environment?["safe"] as? String == "built_in_mic")
+    #expect(nested?["email"] as? String == "[REDACTED]")
+    #expect(array?[0] as? String == "ok")
+    #expect(array?[1] as? String == "[REDACTED]")
+    #expect(redacted["outer"] as? String == "[REDACTED]")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+@Suite("SentryBreadcrumb audio environment")
+@MainActor
+struct SentryAudioEnvironmentTests {
+  private struct DummyError: LocalizedError {
+    var errorDescription: String? { "dummy" }
+  }
+
+  private final class ExtraBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var extra: [String: Any]?
+
+    func set(_ value: [String: Any]?) {
+      lock.lock()
+      defer { lock.unlock() }
+      extra = value
+    }
+
+    func get() -> [String: Any]? {
+      lock.lock()
+      defer { lock.unlock() }
+      return extra
+    }
+  }
+
+  @Test("captureError merges provider audio environment before delegates")
+  func mergesProviderBeforeDelegates() {
+    let capturedExtra = ExtraBox()
+
+    SentryBreadcrumb.withAudioEnvironmentProvider({
+      ["snapshot_status": "fresh", "input_process_count": 1]
+    }) {
+      let prior = SentryBreadcrumb.captureErrorDelegate
+      SentryBreadcrumb.captureErrorDelegate = { _, _, _, extra in
+        capturedExtra.set(extra)
+      }
+      defer { SentryBreadcrumb.captureErrorDelegate = prior }
+
+      SentryBreadcrumb.captureError(
+        DummyError(),
+        category: .audioCaptureFailed,
+        stage: "audio",
+        extra: ["caller": "kept"]
+      )
+    }
+
+    let extra = capturedExtra.get()
+    #expect(extra?["caller"] as? String == "kept")
+    let environment = extra?["audio_environment"] as? [String: Any]
+    #expect(environment?["snapshot_status"] as? String == "fresh")
+    #expect(environment?["input_process_count"] as? Int == 1)
+  }
+
+  @Test("caller-provided audio environment wins")
+  func callerProvidedEnvironmentWins() {
+    let capturedExtra = ExtraBox()
+
+    SentryBreadcrumb.withAudioEnvironmentProvider({
+      ["snapshot_status": "fresh"]
+    }) {
+      let prior = SentryBreadcrumb.captureErrorDelegate
+      SentryBreadcrumb.captureErrorDelegate = { _, _, _, extra in
+        capturedExtra.set(extra)
+      }
+      defer { SentryBreadcrumb.captureErrorDelegate = prior }
+
+      SentryBreadcrumb.captureError(
+        DummyError(),
+        category: .audioCaptureFailed,
+        stage: "audio",
+        extra: ["audio_environment": ["snapshot_status": "caller"]]
+      )
+    }
+
+    let environment = capturedExtra.get()?["audio_environment"] as? [String: Any]
+    #expect(environment?["snapshot_status"] as? String == "caller")
+  }
+
+  @Test("scoped provider helper restores prior provider")
+  func providerScopeRestoresPriorProvider() {
+    SentryBreadcrumb.audioEnvironmentProvider = { ["snapshot_status": "outer"] }
+    defer { SentryBreadcrumb.audioEnvironmentProvider = nil }
+
+    SentryBreadcrumb.withAudioEnvironmentProvider({
+      ["snapshot_status": "inner"]
+    }) {
+      #expect(SentryBreadcrumb.audioEnvironmentProvider?()?["snapshot_status"] as? String == "inner")
+    }
+
+    #expect(SentryBreadcrumb.audioEnvironmentProvider?()?["snapshot_status"] as? String == "outer")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
@@ -80,6 +80,54 @@ struct SentryAudioEnvironmentTests {
     #expect(environment?["snapshot_status"] as? String == "caller")
   }
 
+  @Test("nil provider preserves caller extra without audio environment")
+  func nilProviderPreservesCallerExtra() {
+    let capturedExtra = ExtraBox()
+
+    SentryBreadcrumb.withAudioEnvironmentProvider(nil) {
+      let prior = SentryBreadcrumb.captureErrorDelegate
+      SentryBreadcrumb.captureErrorDelegate = { _, _, _, extra in
+        capturedExtra.set(extra)
+      }
+      defer { SentryBreadcrumb.captureErrorDelegate = prior }
+
+      SentryBreadcrumb.captureError(
+        DummyError(),
+        category: .audioCaptureFailed,
+        stage: "audio",
+        extra: ["caller": "kept"]
+      )
+    }
+
+    let extra = capturedExtra.get()
+    #expect(extra?["caller"] as? String == "kept")
+    #expect(extra?["audio_environment"] == nil)
+  }
+
+  @Test("empty provider preserves baseline extra")
+  func emptyProviderPreservesBaselineExtra() {
+    let capturedExtra = ExtraBox()
+
+    SentryBreadcrumb.withAudioEnvironmentProvider({ [:] }) {
+      let prior = SentryBreadcrumb.captureErrorDelegate
+      SentryBreadcrumb.captureErrorDelegate = { _, _, _, extra in
+        capturedExtra.set(extra)
+      }
+      defer { SentryBreadcrumb.captureErrorDelegate = prior }
+
+      SentryBreadcrumb.captureError(
+        DummyError(),
+        category: .audioCaptureFailed,
+        stage: "audio",
+        extra: ["caller": "kept"]
+      )
+    }
+
+    let extra = capturedExtra.get()
+    #expect(extra?["caller"] as? String == "kept")
+    #expect(extra?["audio_environment"] == nil)
+  }
+
   @Test("scoped provider helper restores prior provider")
   func providerScopeRestoresPriorProvider() {
     SentryBreadcrumb.audioEnvironmentProvider = { ["snapshot_status": "outer"] }


### PR DESCRIPTION
## Summary
- Add a cached audio-environment snapshotter and wire it at app startup, recording start, app activation, and CoreAudio device-change events.
- Attach sanitized `audio_environment` metadata to Sentry error captures through a scoped provider hook.
- Hash bundle IDs instead of sending raw running-app bundle IDs.
- Add recursive observability redaction plus a sanitized audio-environment renderer.
- Avoid arbitrary timeout fallbacks; this version uses immediate refresh plus signal-based refresh only.

## Validation
- `scripts/swift-test.sh` passed: 729 tests in 87 suites.
- `swift build -c release` passed.
- Debug rebuild passed.
- Synthetic Runtime UAT passed with Spotify and Zoom running in the background.
- Fault-injection UAT: `A5_proxy_buffer_drop_watchdog` produced fresh Sentry event `a35fed369402435f89f7b747cbaeac32` at `2026-05-09T14:17:37.186Z`; confirmed `audio_environment` is present in event context and breadcrumb data with hashed bundle IDs.

Closes #704