### PR TITLE
ci: move PR + post-merge CI to GitHub-hosted macos-26 runners (#384)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -10,14 +10,19 @@ concurrency:
 
 jobs:
   main-post-merge-build:
-    runs-on: [self-hosted, enviouswispr-release]
-    timeout-minutes: 15
+    runs-on: macos-26
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
 
       - name: Detect code changes
         id: changes

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,14 +10,19 @@ concurrency:
 
 jobs:
   build-check:
-    runs-on: [self-hosted, enviouswispr-release]
-    timeout-minutes: 30
+    runs-on: macos-26
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
 
       - name: Detect code changes
         id: changes


### PR DESCRIPTION
## Summary

- Switches `pr-check.yml` and `main-post-merge.yml` from `[self-hosted, enviouswispr-release]` to `macos-26` (GitHub-hosted Apple Silicon)
- Bumps timeout to 45 minutes in both to account for cold-runner SPM fetch overhead
- Adds `maxim-lobanov/setup-xcode` (SHA-pinned) with `xcode-version: latest-stable` so CI auto-tracks the latest stable Xcode as GitHub updates their images

`release.yml` is explicitly out of scope — self-hosted runner stays registered until the release pipeline is separately migrated.

Plan: `docs/feature-requests/issue-384-2026-05-09-hosted-runners.md`

Closes #384 (Step 1 of 2 — PR/post-merge CI only)

## Test plan

- [ ] `build-check` goes green on a GitHub-hosted runner (confirms provisioning + Xcode selection; Swift build skipped for `.github/`-only diff per change-detection step)
- [ ] CI job UI shows runner as `GitHub Actions`, not `Self-hosted`
- [ ] `Select Xcode` step log confirms `latest-stable` resolved to Xcode 26.4.x
- [ ] `ci-drift-check` passes (SHA-pinned action)
- [ ] Next code-touching PR is the full proof that Swift build + tests pass on hosted
