### PR TITLE
chore(release): bump version to 2.0.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,18 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.0.1
+
+    Entry(
+      id: "better-error-logging",
+      icon: "doc.text.magnifyingglass",
+      title: "Better error logging",
+      description:
+        "Improved our error logging so we can spot issues and enhance your experience faster.",
+      category: .fasterAndMoreReliable,
+      version: "2.0.1"
+    ),
+
     // MARK: - v2.0.0
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.0.0"
+  public static let currentContentVersion = "2.0.1"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary
- Bump app version 2.0.0 → 2.0.1
- Add What's New entry: "Better error logging — Improved our error logging so we can spot issues and enhance your experience faster."

## Why
Patch release covering recent diagnostics + telemetry work landed on main since v2.0.0:
- #707 input device divergence telemetry fix
- #708 ASR empty-result diagnostics
- #709 paste fallback target diagnostics
- #710 audio environment snapshots in Sentry errors
- #711 Swift 6 concurrency warnings silenced
- #712 PR + post-merge CI moved to GitHub-hosted macos-26

## Test plan
- [x] `swift build` clean (warnings only, no errors)
- [ ] CI `build-check` green
- [ ] Tag `v2.0.1` after merge → release.yml triggers on self-hosted runner