### PR TITLE
docs: strip .claude/ doc-link references from ship-path files

### DIFF
--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -20,10 +20,10 @@ import Foundation
 /// Sentry payload shapes (category, tags, extras keys, breadcrumb messages)
 /// are reproduced exactly from the prior in-pipeline implementations so the
 /// triage Routine that polls Sentry every 4 hours continues filing GitHub
-/// issues with stable grouping. See `.claude/knowledge/sentry-triage-pipeline.md`.
+/// issues with stable grouping.
 ///
 /// The Sentry sink is injected as a closure callback rather than a protocol
-/// (per `.claude/rules/swift-patterns.md` § Hot-path Existentials), keeping the
+/// to avoid existential dispatch on a `@MainActor` hot path, keeping the
 /// emitter concrete and the test seam recording-closure-shaped.
 @MainActor
 final class HeartPathTelemetryEmitter {

--- a/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
@@ -8,8 +8,8 @@ import Testing
 /// constructing an AppState instance — AppState's init pulls in real audio
 /// capture, ASR, pipelines, and Tasks that should not run inside a unit test.
 ///
-/// Ceilings are documented in `.claude/rules/architecture-rules.md` under
-/// `Architectural Ceilings`. Raising a ceiling requires a Bible changelog entry.
+/// Ceilings: concrete-collaborator count ≤ 19, total line count ≤ 1050.
+/// Raising a ceiling requires a Bible changelog entry, not a silent bump.
 @Suite struct AppStateCeilingsTests {
 
   /// Concrete-collaborator count ceiling. Locked at post-Phase-F baseline = 19.
@@ -22,7 +22,7 @@ import Testing
       count <= 19,
       """
       AppState concrete-collaborator ceiling exceeded: \(count) > 19. \
-      See .claude/rules/architecture-rules.md `Architectural Ceilings`.
+      Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }
 
@@ -36,7 +36,7 @@ import Testing
       lineCount <= 1050,
       """
       AppState line count exceeded: \(lineCount) > 1050. \
-      See .claude/rules/architecture-rules.md `Architectural Ceilings`.
+      Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }
 }

--- a/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
@@ -7,8 +7,8 @@ import Testing
 ///
 /// Cases drawn from live OpenAI + Gemini API validation
 /// (`docs/audits/2026-05-04-issue-617-classifier-validation.txt`) plus the
-/// adversarial set Codex grounded review demanded for matcher-broadening
-/// tests (`.claude/rules/workflow-process.md §9`).
+/// adversarial set required for matcher-broadening tests (exercise each
+/// entry in its non-intended semantic class, not just the happy path).
 @Suite("AIPolishModelClassifier — recommended-for-cleanup classifier")
 struct AIPolishClassifierTests {
 

--- a/Tests/RuntimeUAT/README.md
+++ b/Tests/RuntimeUAT/README.md
@@ -57,9 +57,9 @@ The `uat_runner.py run` command **must** be invoked with `run_in_background: tru
 
 ## How this fits the workflow
 
-- Phase 3 validation (`scripts/validate-pr.sh`) Live UAT step calls into this harness for the Code lane. See `.claude/knowledge/pr498-phase3-validation.md`.
-- Tier rules in `.claude/rules/validation-discipline.md §6` mandate runtime UAT before declaring a feature ship-ready.
-- Tool boundaries are documented in `.claude/rules/tools-and-apps.md §2`.
+- Phase 3 validation (`scripts/validate-pr.sh`) Live UAT step calls into this harness for the Code lane.
+- Runtime UAT is mandatory before declaring a feature ship-ready.
+- Drive UAT directly via `wispr_eyes.py` from the main thread; agent-dispatched UAT is not reliable for end-to-end dictation flows.
 
 ## Why this directory is tracked
 

--- a/Tests/RuntimeUAT/ui_helpers.py
+++ b/Tests/RuntimeUAT/ui_helpers.py
@@ -21,19 +21,6 @@ from ApplicationServices import (
 )
 
 
-# =============================================================================
-# Knowledge Files (for test generation context)
-# =============================================================================
-# These project knowledge files provide codebase context without reading source:
-#   .claude/knowledge/architecture.md  — app structure, views, pipeline states
-#   .claude/knowledge/file-index.md    — every Swift file, types, purpose
-#   .claude/knowledge/type-index.md    — type → file reverse lookup
-#   .claude/knowledge/gotchas.md       — known pitfalls and patterns
-# The uat-generator agent should receive summaries from these files
-# instead of exploring the codebase from scratch each run.
-# =============================================================================
-
-
 # ---------------------------------------------------------------------------
 # Process helpers
 # ---------------------------------------------------------------------------

--- a/workers/sentry-triage/routine-prompt-tik-sentry.md
+++ b/workers/sentry-triage/routine-prompt-tik-sentry.md
@@ -3,7 +3,7 @@ Reference copy of the TIK Routine prompt (Sentry-only, daily morning).
 
 Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
 This file may drift from the live prompt. To sync, copy from the Routine
-edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+edit dialog.
 
 Live schedule: once daily on cron `7 13 * * *` (9:07am ET / 13:07 UTC).
 

--- a/workers/sentry-triage/routine-prompt-tok-codex.md
+++ b/workers/sentry-triage/routine-prompt-tok-codex.md
@@ -3,7 +3,7 @@ Reference copy of the TOK Routine prompt (Codex PR triage, daily evening).
 
 Source of truth: the Routine config in claude.ai/code/routines/<NEW_TRIGGER_ID>
 This file may drift from the live prompt. To sync, copy from the Routine
-edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+edit dialog.
 
 Live schedule: once daily on cron `7 1 * * *` (9:07pm ET / 01:07 UTC next day,
 12 hours after TIK).

--- a/workers/sentry-triage/routine-prompt-v3.1-backup-2026-05-02.md
+++ b/workers/sentry-triage/routine-prompt-v3.1-backup-2026-05-02.md
@@ -3,11 +3,11 @@ Reference copy of the Sentry Triage Routine prompt (v3 interim, 2026-04-25).
 
 Source of truth: the Routine config in claude.ai/code/routines/trig_01Crr6qjS5HyQ1i3KbrezPfK
 This file may drift from the live prompt. To sync, copy from the Routine
-edit dialog. Documented in .claude/knowledge/sentry-triage-pipeline.md.
+edit dialog.
 
 Live schedule: every 4 hours on cron `7 */4 * * *`.
 
-v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md and .claude/knowledge/sentry-triage-redesign-research-2026-04-25.md.
+v3 changes (interim, 2026-04-25): all GitHub reads via authenticated MCP (was unauthenticated curl); MCP-auth-expiry hard policy; identity marker carries decision + severity + last_seen for durable memory across runs; Step 2.5 cross-reference search; per-run idempotency key; banned tools (mcp__github__authenticate, Discord); Sentry Issue Alert handles raw P0 fast-path independently. See docs/audits/2026-04-25-routine-triage-full-audit.md.
 
 v3.1 changes (2026-04-25, fixes #459 + Codex grounded-review revisions): (1) replaced absolute fail-fast rule with typed default-vs-per-step recovery list — single transient errors no longer terminate the whole run when the prompt documents skip-and-continue, list is exhaustive and authoritative; auth-expiry remains the one BROADER policy that exits the run; (2) Step 2.5 now gates on issue-state BEFORE applying the throttle — closed-issue regressions route to Path C (reopen) instead of being silently swallowed; (3) Step 2.6 cross-reference search now uses Sentry list-time fields (`metadata.function`, `metadata.filename`, `metadata.type`, `culprit`) that are bound at this step, with explicit per-field non-empty guards and a non-elif fallback to `culprit` only when all three metadata keys are empty; Step 1 field doc expanded to document these; (4) Per-run idempotency reframed as branch-entry check (not per-write) so multi-step branches don't self-block; Path A and Path C reordered to add the idempotency key at end-of-sequence; (5) Path C now fetches the Sentry event BEFORE reopen with explicit fail-soft regression-comment template when the event fetch fails or evidence is insufficient, so reopens never leave an issue without the regression comment.
 -->


### PR DESCRIPTION
## Summary

`.claude/` is gitignored. Any shipped file that points into it produces a broken link for anyone reading the repo on GitHub or a fresh clone. This PR removes those broken cross-refs across 8 ship-path files:

- Inlines the salient sentence where the reference was load-bearing (e.g. `AppState` ceiling policy, hot-path existential rationale).
- Deletes the cross-ref where it was decorative.
- Cleans worker Routine prompts that ran in the cloud and could not resolve `.claude/` paths.

## Files

| File | Action |
|---|---|
| `Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift` | Inlined hot-path-existential rationale. |
| `Tests/RuntimeUAT/README.md` | Replaced three See-`.claude/...` lines with inline workflow context. |
| `Tests/RuntimeUAT/ui_helpers.py` | Dropped comment block referencing knowledge files. |
| `Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift` | Inlined the ceiling policy in doc comment and both assertion messages. |
| `Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift` | Inlined adversarial-set rationale in place of the citation. |
| `workers/sentry-triage/routine-prompt-tik-sentry.md` | Removed obsolete provenance line. |
| `workers/sentry-triage/routine-prompt-tok-codex.md` | Removed obsolete provenance line. |
| `workers/sentry-triage/routine-prompt-v3.1-backup-2026-05-02.md` | Removed two obsolete provenance lines. |

## Intentionally left alone

- `workers/crisp-kb/*` — runtime calls to `~/.claude/bin/get-key`. Real binary, not a doc link.
- `.github/workflows/*.yml` — path-allowlist regex patterns, functional.
- `website/src/content/blog/building-commercial-software-solo-with-claude-code.md` — blog post about the `.claude/` folder.

## Validation

- `swift build -c release`: pass
- `scripts/swift-test.sh`: 745 tests / 89 suites green
- Codex grounded review: PROCEED — all 8 files PASS
- No runtime behavior change

## Test plan

- [x] Release build green
- [x] Full test suite green
- [x] No `.claude/` doc-link references remain in `Sources/`, `Tests/`, `workers/sentry-triage/`
- [x] Codex grounded review verdict PROCEED
