### PR TITLE
ci(release): drop actions/cache to prevent cross-runner contamination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,14 +230,6 @@ jobs:
 
           echo "==> FoundationModels compile probe PASSED"
 
-      - name: Cache SPM dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
       - name: Install create-dmg
         run: brew install create-dmg
 


### PR DESCRIPTION
## Summary

- `release.yml` (self-hosted `enviouswispr-release`) shared the same `${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}` cache key with `pr-check.yml` and `main-post-merge.yml` (hosted `macos-26`).
- Hosted runs wrote `/Users/runner/work/...` absolute paths into `.build/workspace-state.json`; restoring that cache on self-hosted made SwiftPM look for the Sentry XCFramework at a path that doesn't exist there, failing the v2.0.1 release run.
- Removes the `Cache SPM dependencies` step from `release.yml`. The GitHub-side cache is now hosted-only (homogeneous, no contamination in either direction). The self-hosted runner still has its persistent on-disk `.build/` between runs, so cold-resolve cost only hits on a fresh runner disk.

## Test plan

- [ ] PR CI green (`build-check`).
- [ ] Next tagged release runs `release.yml` cleanly without manual cache-deletion recovery.

Closes #715.
