### PR TITLE
test(telemetry): serialize dictation.invoked hook suite (follow-up to #719)

### DIFF
--- a/Tests/EnviousWisprTests/Services/DictationInvokedTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationInvokedTelemetryTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 #if DEBUG
 
-  @Suite("Dictation invoked telemetry")
+  @Suite("Dictation invoked telemetry", .serialized)
   struct DictationInvokedTelemetryTests {
 
     final class EventBox: @unchecked Sendable {


### PR DESCRIPTION
## Why

Codex adversarial-review on PR #719 flagged the test:

> The new lock only protects EventBox.stored. The test still assigns and clears TelemetryService.shared.testEventHook, a process-wide singleton hook, without serializing against the other telemetry-hook tests in the suite. Inference: under parallel Swift Testing execution, another test can overwrite this hook between assignment and capture, causing this test or the other hook tests to miss their event despite the local box lock.

DualModePolishTelemetryTests also mutates testEventHook, so the race is real.

## Fix

Add .serialized to the @Suite. One-line change. Tests still pass deterministically.

## Validation

scripts/swift-test.sh --filter DictationInvoked - 5 tests, all pass.