### PR TITLE
feat(hotkey): default PTT to bare Right Option (#733)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
@@ -1,3 +1,4 @@
+import EnviousWisprServices
 import SwiftUI
 
 /// Global hotkey configuration.
@@ -13,8 +14,8 @@ struct ShortcutsSettingsView: View {
           HotkeyRecorderView(
             keyCode: $state.settings.toggleKeyCode,
             modifiers: $state.settings.toggleModifiers,
-            defaultKeyCode: 49,
-            defaultModifiers: .control,
+            defaultKeyCode: ModifierKeyCodes.rightOption,
+            defaultModifiers: [],
             label: "Shortcut"
           )
         }

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -84,11 +84,11 @@ public final class HotkeyService {
 
   public var recordingMode: RecordingMode = .toggle
 
-  /// Toggle-mode hotkey key code (default: Space = 49).
-  public var toggleKeyCode: UInt16 = 49
+  /// Toggle-mode hotkey key code (default: Right Option = 61, modifier-only).
+  public var toggleKeyCode: UInt16 = ModifierKeyCodes.rightOption
 
-  /// Toggle-mode required modifiers (default: Control).
-  public var toggleModifiers: NSEvent.ModifierFlags = [.control]
+  /// Toggle-mode required modifiers (default: none — modifier-only hotkey).
+  public var toggleModifiers: NSEvent.ModifierFlags = []
 
   /// Key code for the cancel hotkey. Default: Escape (53).
   public var cancelKeyCode: UInt16 = 53

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -375,11 +375,10 @@ public final class SettingsManager {
     cancelModifiers = NSEvent.ModifierFlags(rawValue: savedCancelModRaw ?? 0)
 
     let savedToggleKeyCode = defaults.object(forKey: "toggleKeyCode") as? Int
-    toggleKeyCode = UInt16(savedToggleKeyCode ?? 49)
+    toggleKeyCode = UInt16(savedToggleKeyCode ?? Int(ModifierKeyCodes.rightOption))
 
     let savedToggleModRaw = defaults.object(forKey: "toggleModifiersRaw") as? UInt
-    toggleModifiers = NSEvent.ModifierFlags(
-      rawValue: savedToggleModRaw ?? NSEvent.ModifierFlags.control.rawValue)
+    toggleModifiers = NSEvent.ModifierFlags(rawValue: savedToggleModRaw ?? 0)
 
     // PTT migration: old modifier-only → new key+modifier format
     let legacyPTTModRaw = defaults.object(forKey: "pushToTalkModifierRaw") as? UInt


### PR DESCRIPTION
## Summary

- Changes the out-of-the-box dictation hotkey from Control+Space to bare Right Option (keycode 61, modifier-only).
- Existing users keep their saved hotkey. Only fresh installs and "Reset to default" pick up the new value.
- Three files, nine-line diff (one new import + six default-value swaps).

Closes #733.

## Why

Persona consensus (Aaron / Meera / Frank / Diana) explicitly need single-key triggers. Industry-standard dictation apps ship single-modifier holds. Bare Fn is blocked by the Globe-key conflict on modern Macs. Right Option has near-zero conflict for the right-handed Left-Option-for-modifiers majority and is one click to rebind for users who use Right Option directly (left-handed, AltGr international layouts).

## Process trail

- Persona-roleplay council (7 personas x 2 providers): 10 WIN / 4 LOSE. The 4 LOSE votes conflated Left vs Right Option; once specifics were verified, the Right Option case held up for the majority.
- Codex grounded review on plan: PIVOT initially (caught import miss in ShortcutsSettingsView, overstated "no visible side effect", understated toggle-mode regression). Revised plan addressed all three findings.
- Codex code-diff review: needs-attention on a real Accessibility dependency. The NSEvent global flagsChanged monitor that powers modifier-only hotkeys requires Accessibility trust to fire on events from other apps. Captured as follow-up #735.
- PostHog data confirms Accessibility is already a friction floor today (21 denied / 1 granted at in-app prompt across 60 days; 3 of 18 onboarding-completers never dictated, 100% of them denied Accessibility).

## Release coordination

This is **safe to merge to main** now. No release impact until a tag is cut. **#735 (Accessibility-mandatory onboarding) must land before the next tagged release** so the modifier-only hotkey works for fresh installs that haven't yet granted Accessibility.

## Test plan

- [x] `swift build -c release` exit 0
- [x] `scripts/swift-test.sh` — 764 tests pass
- [x] Bundle assembled and launched from worktree (`bundle-dev.sh`)
- [x] Fresh-install onboarding test — Saurabh walked through manually, keycap displays the Right Option symbol and dictation works end-to-end
- [ ] CI build-check on PR
