### PR TITLE
fix(update-banner): widget stays visible until install completes (#739)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -27,6 +27,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem?
   private(set) var updaterController: SPUStandardUpdaterController?
   private(set) var updateCoordinator: UpdateCoordinator?
+  /// Issue #739: stable env-carrier — non-optional `@Observable` holder
+  /// whose `coordinator` property is set once the AppDelegate finishes init.
+  /// SwiftUI captures THIS instance in env; the inner coordinator flip
+  /// (nil → non-nil) triggers re-evaluation of dependent views.
+  let updateCoordinatorHolder = UpdateCoordinatorHolder()
   private let iconAnimator = MenuBarIconAnimator()
   private weak var mainWindow: NSWindow?
   private var windowCloseObserver: (any NSObjectProtocol)?
@@ -60,6 +65,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// torn down in `applicationWillTerminate` for clean observer removal.
   private var audioSystemEventReporter: AudioSystemEventReporter?
   private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
+
+  /// Issue #739: instantiate the updater + update-banner coordinator BEFORE
+  /// SwiftUI mounts the App's scenes. SwiftUI snapshots the env value
+  /// `\.updateCoordinator` (bound to `appDelegate.updateCoordinator` in
+  /// `EnviousWisprApp.swift`) when the scene body is first evaluated, and
+  /// that snapshot is final — the App struct's `@State` doesn't change, so
+  /// SwiftUI never re-fetches. If we wait until `applicationDidFinishLaunching`,
+  /// the env value is nil forever and the banner never renders.
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    updaterController = SPUStandardUpdaterController(
+      startingUpdater: true,
+      updaterDelegate: self,
+      userDriverDelegate: self
+    )
+    updateCoordinator = UpdateCoordinator(updaterController: updaterController)
+    // Issue #739: publish the coordinator into the @Observable holder so any
+    // SwiftUI view bound to the holder's env value sees the flip from nil to
+    // non-nil and re-renders. The holder itself is created inline as a stable
+    // stored property, so SwiftUI's first env capture is non-nil.
+    updateCoordinatorHolder.coordinator = updateCoordinator
+    // Cross-launch correlation runs here (was in didFinishLaunching) so the
+    // attribution event fires before any UI is shown.
+    evaluateUpdateInstallAttemptOnLaunch()
+  }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Hide dock icon on launch — we're a menu bar utility.
@@ -109,20 +138,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     }
 
-    updaterController = SPUStandardUpdaterController(
-      startingUpdater: true,
-      updaterDelegate: self,
-      userDriverDelegate: self
-    )
-
-    // Issue #343: in-app update banner. Constructed AFTER the updater so the
-    // install closure can capture it. Limb classification — does NOT live on
-    // AppState (collaborator ceiling).
-    updateCoordinator = UpdateCoordinator(updaterController: updaterController)
-
-    // Issue #343: cross-launch correlation. Fire install_completed /
-    // install_cancelled if the prior launch attempted an install.
-    evaluateUpdateInstallAttemptOnLaunch()
+    // Issue #739: updaterController + updateCoordinator + cross-launch
+    // correlation moved to applicationWillFinishLaunching so SwiftUI's env
+    // value snapshot is non-nil when the App body first evaluates.
 
     setupStatusItem()
 
@@ -132,7 +150,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     appState.onPipelineStateChange = { [weak self] state in
       guard let self else { return }
       self.updateIcon()
-      self.updateCoordinator?.handlePipelineStateChange(isRecording: state == .recording)
+      // Issue #739: do NOT forward pipeline state to the update widget. The
+      // widget is now bundle-version-driven only — visible whenever an update
+      // is pending, period. Matches Claude Desktop / Slack / Cursor update-prompt
+      // conventions (no auto-hide during active work).
       if state == .recording {
         self.audioEnvironmentSnapshotter?.recordingStarted()
       }
@@ -660,11 +681,13 @@ extension AppDelegate: @preconcurrency SPUStandardUserDriverDelegate {
     // Else: banner owns UX; source set by `triggerInstall` when user clicks.
   }
 
-  /// Issue #343: dismiss our banner when the user has engaged with Sparkle's
-  /// UI directly (e.g., used the menu while the banner was visible).
-  /// Prevents two competing UIs for the same update.
+  /// Issue #739: Sparkle fires this on alert focus AND user choice; it is NOT
+  /// a dismissal signal. Widget visibility is governed solely by bundle
+  /// version on disk. User engagement with the Sparkle alert does not hide
+  /// the widget. Method retained as no-op so Sparkle's delegate conformance
+  /// continues to register interest in the callback (needsToObserveUserAttention
+  /// gates other Sparkle internals; see SPUStandardUserDriver.m:370).
   func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
-    updateCoordinator?.service.dismissForSession()
   }
 }
 
@@ -743,7 +766,12 @@ extension AppDelegate: SPUUpdaterDelegate {
         errorCode: errorCode ?? "unknown"
       )
     }
-    updateCoordinator?.service.noteResolved(installedVersion: nil)
+    // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"
+    // fires on cancel/skip/error/install-on-quit-scheduled alike. Widget state
+    // is cleared only when bundle version catches up (rehydratePendingIfNewer
+    // on next launch). In-session, the existing 5s resolvingWatchdog in
+    // triggerInstall restores .available if the user clicked the widget but
+    // did not complete an install.
     updateCoordinator?.lastInstallSource = nil
   }
 }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -20,7 +20,7 @@ struct EnviousWisprApp: App {
       UnifiedWindowView()
         .frame(minWidth: 580, minHeight: 400)
         .environment(appDelegate.appState)
-        .environment(\.updateCoordinator, appDelegate.updateCoordinator)
+        .environment(appDelegate.updateCoordinatorHolder)
         .background(
           ActionWirer(
             appDelegate: appDelegate,

--- a/Sources/EnviousWispr/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWispr/App/UpdateCoordinator.swift
@@ -40,15 +40,6 @@ final class UpdateCoordinator {
     )
   }
 
-  // MARK: - Pipeline-state forwarding
-
-  /// Called from the AppDelegate `onPipelineStateChange` callback (next to
-  /// the existing icon-update path). Forwards to the service so the banner
-  /// hides during recording + 3s post-recording grace.
-  func handlePipelineStateChange(isRecording: Bool) {
-    service.handlePipelineStateChange(isRecording: isRecording)
-  }
-
   // MARK: - Install-attempt persistence (cross-launch correlation)
 
   /// Persists "we just kicked off an install" so the next launch can decide
@@ -130,16 +121,6 @@ final class UpdateCoordinator {
     service.triggerInstall()
   }
 
-  /// Banner dismissed via context menu.
-  func handleBannerDismissed(version: String, isCritical: Bool, secondsVisible: Int) {
-    TelemetryService.shared.updateBannerDismissed(
-      version: version,
-      isCritical: isCritical,
-      secondsVisible: secondsVisible
-    )
-    service.dismissForSession()
-  }
-
   enum InstallAttemptOutcome: Equatable {
     case none
     case completed(version: String, source: String)
@@ -149,15 +130,19 @@ final class UpdateCoordinator {
   }
 }
 
-// MARK: - SwiftUI Environment injection
+// MARK: - SwiftUI Environment injection (issue #739)
 
-private struct UpdateCoordinatorKey: EnvironmentKey {
-  static let defaultValue: UpdateCoordinator? = nil
-}
-
-extension EnvironmentValues {
-  var updateCoordinator: UpdateCoordinator? {
-    get { self[UpdateCoordinatorKey.self] }
-    set { self[UpdateCoordinatorKey.self] = newValue }
-  }
+/// Stable `@Observable` wrapper around the coordinator instance. We can't pass
+/// the optional coordinator directly into SwiftUI's environment because
+/// `appDelegate.updateCoordinator` is nil at the moment SwiftUI evaluates the
+/// App body and captures the env value (delegate methods run after scene
+/// construction). The holder is a stable instance whose `coordinator`
+/// property goes from nil → non-nil once AppDelegate finishes init; the
+/// `@Observable` macro guarantees SwiftUI re-evaluates dependent views when
+/// the property changes.
+@Observable
+@MainActor
+public final class UpdateCoordinatorHolder {
+  var coordinator: UpdateCoordinator?
+  public init() {}
 }

--- a/Sources/EnviousWispr/Views/Components/UpdateAvailableBanner.swift
+++ b/Sources/EnviousWispr/Views/Components/UpdateAvailableBanner.swift
@@ -2,11 +2,13 @@ import EnviousWisprServices
 import SwiftUI
 
 /// In-app banner shown at the bottom of the Settings sidebar when Sparkle has
-/// downloaded a non-critical update (issue #343). Click-anywhere installs;
-/// right-click for Dismiss. 3pt rainbow stripe along the top edge matches the
+/// downloaded a non-critical update (issue #343). Click-anywhere installs.
+/// Stays visible until the bundle version on disk catches up to the pending
+/// version (issue #739). 3pt rainbow stripe along the top edge matches the
 /// EnviousWispr brand mark.
 struct UpdateAvailableBanner: View {
-  @Environment(\.updateCoordinator) private var coordinator
+  @Environment(UpdateCoordinatorHolder.self) private var coordinatorHolder
+  private var coordinator: UpdateCoordinator? { coordinatorHolder.coordinator }
   let update: UpdateAvailabilityService.AvailableUpdate
 
   // Telemetry: track when the banner first appeared (for `seconds_visible`
@@ -45,14 +47,6 @@ struct UpdateAvailableBanner: View {
         version: update.versionString,
         isCritical: update.isCriticalUpdate,
         secondsVisible: secondsVisible())
-    }
-    .contextMenu {
-      Button(LocalizedStringResource("Dismiss")) {
-        coordinator?.handleBannerDismissed(
-          version: update.versionString,
-          isCritical: update.isCriticalUpdate,
-          secondsVisible: secondsVisible())
-      }
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 12)

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Unified single-window view: History + all settings tabs in one sidebar.
 struct UnifiedWindowView: View {
   @Environment(AppState.self) private var appState
-  @Environment(\.updateCoordinator) private var updateCoordinator
+  @Environment(UpdateCoordinatorHolder.self) private var updateCoordinatorHolder
   @State private var selectedSection: SettingsSection = .history
 
   var body: some View {
@@ -32,7 +32,7 @@ struct UnifiedWindowView: View {
         // Issue #343: in-app update banner. Fixed sibling of the sidebar List
         // (NOT a list-footer row, which would scroll). Bottom-leading mount
         // per Saurabh's mockup v2.
-        if let coordinator = updateCoordinator,
+        if let coordinator = updateCoordinatorHolder.coordinator,
           coordinator.service.shouldShowBanner,
           case .available(let u) = coordinator.service.state
         {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -602,17 +602,6 @@ public final class TelemetryService {
     )
   }
 
-  public func updateBannerDismissed(version: String, isCritical: Bool, secondsVisible: Int) {
-    PostHogSDK.shared.capture(
-      "update.banner_dismissed",
-      properties: [
-        "version": version,
-        "is_critical": isCritical,
-        "seconds_visible": secondsVisible,
-      ]
-    )
-  }
-
   public func updateSparkleDefaultShown(version: String, isCritical: Bool, reason: String) {
     PostHogSDK.shared.capture(
       "update.sparkle_default_shown",

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -37,7 +37,6 @@ public final class UpdateAvailabilityService {
 
   // MARK: - Constants
 
-  public static let postRecordingGraceDuration: TimeInterval = 3.0
   static let resolvingWatchdogDuration: TimeInterval = 5.0
 
   // Namespaced UserDefaults keys (issue #343).
@@ -45,17 +44,19 @@ public final class UpdateAvailabilityService {
   public static let kPendingBuild = "com.enviouswispr.updateBanner.pendingBuild"
   public static let kPendingTimestamp = "com.enviouswispr.updateBanner.pendingTimestamp"
   public static let kDismissedVersion = "com.enviouswispr.updateBanner.dismissedVersion"
+  /// Issue #739: persist the critical-update flag so rehydrate on next launch
+  /// can correctly leave the UX to Sparkle (banner is suppressed for critical
+  /// updates per `shouldShowBanner`). Pre-#739 the flag was lost across
+  /// launches and a critical update could surface as a gentle banner.
+  public static let kPendingCritical = "com.enviouswispr.updateBanner.pendingCritical"
 
   // MARK: - Observable state
 
   public private(set) var state: UpdateState = .none
   public private(set) var dismissedForSession: Bool = false
-  public private(set) var inPostRecordingGrace: Bool = false
-  public private(set) var isRecording: Bool = false
 
   // MARK: - Internal storage (not observed)
 
-  @ObservationIgnored private var graceTask: Task<Void, Never>?
   @ObservationIgnored private var resolvingWatchdog: Task<Void, Never>?
   @ObservationIgnored private let installAction: @MainActor () -> Void
   @ObservationIgnored private let defaults: UserDefaults
@@ -79,7 +80,11 @@ public final class UpdateAvailabilityService {
   public var shouldShowBanner: Bool {
     guard case .available(let u) = state else { return false }
     if u.isCriticalUpdate { return false }  // critical → Sparkle owns UX
-    return !dismissedForSession && !inPostRecordingGrace && !isRecording
+    // Issue #739: widget visibility is bundle-version-driven only. No
+    // recording-hide, no grace timer, no flicker. dismissedForSession is
+    // retained as defense-in-depth against legacy kDismissedVersion residue
+    // (rehydratePendingIfNewer purges it on launch).
+    return !dismissedForSession
   }
 
   // MARK: - Sparkle-driven mutations
@@ -105,13 +110,12 @@ public final class UpdateAvailabilityService {
     persist(update)
   }
 
-  /// Called from `updater(_:didFinishUpdateCycleForUpdateCheck:error:)`.
+  /// Public API retained for tests; no in-app caller post-#739. Sparkle's
+  /// cycle-finish callback no longer invokes this — widget state is cleared by
+  /// `rehydratePendingIfNewer` when the bundle version catches up to pending.
   public func noteResolved(installedVersion: String?) {
     state = .none
     dismissedForSession = false
-    inPostRecordingGrace = false
-    graceTask?.cancel()
-    graceTask = nil
     resolvingWatchdog?.cancel()
     resolvingWatchdog = nil
     clearPersisted()
@@ -144,47 +148,28 @@ public final class UpdateAvailabilityService {
     }
   }
 
-  // MARK: - Pipeline-state hook (called from AppDelegate's onPipelineStateChange)
-
-  public func handlePipelineStateChange(isRecording: Bool) {
-    self.isRecording = isRecording
-
-    if isRecording {
-      graceTask?.cancel()
-      graceTask = nil
-      inPostRecordingGrace = false
-      return
-    }
-
-    graceTask?.cancel()
-    inPostRecordingGrace = true
-    graceTask = Task { [weak self] in
-      try? await Task.sleep(for: .seconds(Self.postRecordingGraceDuration))
-      guard !Task.isCancelled else { return }
-      await MainActor.run { self?.inPostRecordingGrace = false }
-    }
-  }
-
-  func waitForPostRecordingGraceForTesting() async {
-    await graceTask?.value
-  }
-
   // MARK: - Persistence helpers
 
   func persist(_ update: AvailableUpdate) {
     defaults.set(update.versionString, forKey: Self.kPendingVersion)
     defaults.set(update.displayVersion, forKey: Self.kPendingBuild)
     defaults.set(Date().timeIntervalSince1970, forKey: Self.kPendingTimestamp)
+    // Issue #739: persist the critical flag so Sparkle's heavy UX path is
+    // preserved across launches; the gentle banner stays suppressed.
+    defaults.set(update.isCriticalUpdate, forKey: Self.kPendingCritical)
   }
 
   func persistedPending() -> AvailableUpdate? {
     guard let v = defaults.string(forKey: Self.kPendingVersion) else { return nil }
     let display = defaults.string(forKey: Self.kPendingBuild) ?? v
+    // Issue #739: rehydrate the critical flag. Defaults to false if the key
+    // is absent (older builds, never-persisted updates) — keeps backward-compat.
+    let isCritical = defaults.bool(forKey: Self.kPendingCritical)
     return AvailableUpdate(
       versionString: v,
       displayVersion: display,
       buildString: v,
-      isCriticalUpdate: false  // critical-flag not persisted; rehydrated state is non-critical
+      isCriticalUpdate: isCritical
     )
   }
 
@@ -193,6 +178,7 @@ public final class UpdateAvailabilityService {
     defaults.removeObject(forKey: Self.kPendingBuild)
     defaults.removeObject(forKey: Self.kPendingTimestamp)
     defaults.removeObject(forKey: Self.kDismissedVersion)
+    defaults.removeObject(forKey: Self.kPendingCritical)
   }
 
   func rehydratePendingIfNewer() {
@@ -200,8 +186,12 @@ public final class UpdateAvailabilityService {
     let cmp = compareVersions(pending.versionString, currentBundleVersion)
     if cmp > 0 {
       state = .available(pending)
-      dismissedForSession =
-        (defaults.string(forKey: Self.kDismissedVersion) == pending.versionString)
+      // Issue #739: post-#739 no in-app caller invokes dismissForSession, so
+      // kDismissedVersion can only exist as residue from a pre-#739 buggy
+      // didReceiveUserAttention callback. Purge it on rehydrate so the widget
+      // is not silently suppressed by historical state.
+      defaults.removeObject(forKey: Self.kDismissedVersion)
+      dismissedForSession = false
     } else {
       // Bundle has caught up to or surpassed pending — user installed by some path.
       clearPersisted()

--- a/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
@@ -127,34 +127,20 @@ struct UpdateAvailabilityServiceTests {
     #expect(d.string(forKey: UpdateAvailabilityService.kDismissedVersion) == nil)
   }
 
-  @Test("init seeds dismissedForSession when persisted dismissed matches pending")
-  func rehydrateSeedsDismissal() {
+  @Test(
+    "rehydratePendingIfNewer clears kDismissedVersion and forces dismissedForSession=false when pending > current (issue #739)"
+  )
+  func rehydrateClearsDismissalWhenPendingGreater() {
     let d = Self.freshDefaults()
     d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingVersion)
     d.set("2.4.0", forKey: UpdateAvailabilityService.kPendingBuild)
     d.set(Date().timeIntervalSince1970, forKey: UpdateAvailabilityService.kPendingTimestamp)
+    // Pre-#739 buggy didReceiveUserAttention callback could persist this.
     d.set("2.4.0", forKey: UpdateAvailabilityService.kDismissedVersion)
     let (s, _) = Self.makeService(bundle: "1.9.4", defaults: d)
-    #expect(s.dismissedForSession == true)
-  }
-
-  // MARK: - Pipeline-state guard
-
-  @Test("handlePipelineStateChange(true) cancels grace and clears flag")
-  func recordingCancelsGrace() {
-    let (s, _) = Self.makeService()
-    s.handlePipelineStateChange(isRecording: true)
-    #expect(s.inPostRecordingGrace == false)
-    #expect(s.isRecording == true)
-  }
-
-  @Test("handlePipelineStateChange(false) sets grace; clears after duration")
-  func graceClearsAfterDuration() async throws {
-    let (s, _) = Self.makeService()
-    s.handlePipelineStateChange(isRecording: false)
-    #expect(s.inPostRecordingGrace == true)
-    await s.waitForPostRecordingGraceForTesting()
-    #expect(s.inPostRecordingGrace == false)
+    // Post-#739: rehydrate purges the historical dismissal.
+    #expect(s.dismissedForSession == false)
+    #expect(d.string(forKey: UpdateAvailabilityService.kDismissedVersion) == nil)
   }
 
   // MARK: - shouldShowBanner predicate
@@ -177,14 +163,6 @@ struct UpdateAvailabilityServiceTests {
     let (s, _) = Self.makeService()
     s.noteAvailable(Self.makeUpdate())
     s.dismissForSession()
-    #expect(s.shouldShowBanner == false)
-  }
-
-  @Test("shouldShowBanner is false during recording")
-  func predicateRecording() {
-    let (s, _) = Self.makeService()
-    s.noteAvailable(Self.makeUpdate())
-    s.handlePipelineStateChange(isRecording: true)
     #expect(s.shouldShowBanner == false)
   }
 


### PR DESCRIPTION
## Summary

Three latent bugs in the in-app update widget (originally shipped in #639), all surfacing as "widget doesn't behave like users expect":

1. **Widget vanishes after click + cancel.** Sparkle's `didReceiveUserAttention` was misused as a dismissal signal (it fires on alert focus, not user choice), and `didFinishUpdateCycleForUpdateCheck` cleared persisted state on every cycle-end including cancel. Net effect: clicking the widget then cancelling Sparkle's modal hid the widget for that version forever.

2. **Widget never spawned at all.** SwiftUI captures the env value `\.updateCoordinator` when the App body first evaluates, but `appDelegate.updateCoordinator` was nil until `applicationDidFinishLaunching`. The captured nil persisted because the App's `@State` didn't change. Saurabh's "widget never appeared on the work laptop" report was this bug.

3. **Widget hid during recording with ~10s flicker.** Pipeline-state plumbing on the service hid the widget on recording and used a 3s grace timer that reset on every non-recording state transition (recording → finalizing → polishing → idle = ~10s hidden). Misapplied limb-tier discipline: the widget lives in the unified app window's sidebar, not competing with the dictation flow.

## Fixes

- **#1**: removed `dismissForSession()` from `standardUserDriverDidReceiveUserAttention`; removed `noteResolved()` from `didFinishUpdateCycleForUpdateCheck`. Widget visibility now driven by bundle-version-change on next launch. Right-click Dismiss removed too (founder intent: stay until installed). Dead `handleBannerDismissed` + `updateBannerDismissed` plumbing deleted.
- **#2**: introduced `UpdateCoordinatorHolder` (`@Observable @MainActor` stable wrapper) initialized inline as an AppDelegate stored property. SwiftUI captures the holder; the inner coordinator flips nil → non-nil after AppDelegate init, and `@Observable` triggers re-evaluation. Also persists `kPendingCritical` flag so critical updates stay in Sparkle's heavy UX across launches.
- **#3**: removed the entire pipeline-state plumbing (`isRecording`, `inPostRecordingGrace`, `graceTask`, `postRecordingGraceDuration`, `handlePipelineStateChange`, AppDelegate forwarder). Widget is visible whenever an update is pending. Matches Claude Desktop / Slack / Cursor conventions.

## Test plan

- [x] `swift build -c release` clean
- [x] `scripts/swift-test.sh` — all 761 tests pass
- [x] Codex grounded-review on plan: PROCEED-AS-PLANNED (R1: PROCEED-WITH-REVISIONS, incorporated; R2: PROCEED-AS-PLANNED; R3 holder refactor: 1 finding fixed in this PR — critical-flag persistence)
- [x] Codex code-diff review: app-side changes clean
- [x] Founder Live UAT 2026-05-15:
  - [x] Widget appears immediately on launch with pending update state
  - [x] Widget stays visible during recording, no flicker
  - [x] Widget survives clicking it + cancelling Sparkle's modal

## Net stats

- 8 files changed, +106 / −142 (net deletion)
- 1 new type (`UpdateCoordinatorHolder`, ~15 lines)
- Heart path untouched

Closes #739. Refs #343 / PR #639 (original widget design).
