### PR TITLE
chore(release): bump version to 2.0.2

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,45 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.0.2
+
+    Entry(
+      id: "right-option-push-to-talk",
+      icon: "keyboard",
+      title: "One key to talk",
+      description:
+        "Push-to-talk now defaults to a single tap of Right Option. Faster to reach than a two-key combo, and easier to remember. You can still remap it in Settings.",
+      category: .qualityOfLife,
+      version: "2.0.2"
+    ),
+    Entry(
+      id: "ai-polish-keys-in-keychain",
+      icon: "lock.shield",
+      title: "AI Polish keys live in your keychain",
+      description:
+        "Your API keys for AI Polish are now stored in your Mac's keychain, the same secure place your other passwords live. Existing keys were moved over automatically.",
+      category: .privacyAndSecurity,
+      version: "2.0.2"
+    ),
+    Entry(
+      id: "cleaner-audio-settings",
+      icon: "slider.horizontal.3",
+      title: "Cleaner audio settings",
+      description:
+        "Removed the noise suppression toggle. It wasn't doing what its name suggested, and a quieter settings panel is one less thing to wonder about.",
+      category: .qualityOfLife,
+      version: "2.0.2"
+    ),
+    Entry(
+      id: "update-banner-stays-put",
+      icon: "arrow.down.circle",
+      title: "Update reminder stays put",
+      description:
+        "When a new version is ready, the in-app banner now stays visible until you install. No more dismissing it and forgetting it was there.",
+      category: .qualityOfLife,
+      version: "2.0.2"
+    ),
+
     // MARK: - v2.0.1
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.0.1"
+  public static let currentContentVersion = "2.0.2"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.0.2 with What's New entries for four user-visible changes shipped since v2.0.1:

- **One key to talk** — push-to-talk defaults to Right Option (#736)
- **AI Polish keys live in your keychain** — migrated from plaintext (#720)
- **Cleaner audio settings** — noise suppression toggle removed (#737)
- **Update reminder stays put** — banner persists until install (#739)

Codex review of full `v2.0.1..main` delta: clean. Only finding was the website CSP issue for blog comments, already tracked as #740 (website-only, not a release blocker).

## Test plan

- [x] `swift build -c release --arch arm64` — passed locally
- [ ] `build-check` CI passes on this PR
- [ ] Tag `v2.0.2` after merge triggers release pipeline
