### PR TITLE
chore(gitignore): drop dead release-preflight.sh unignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,6 @@ scripts/*
 !scripts/build-dmg.sh
 !scripts/bundle-dev.sh
 !scripts/check-xpc-error-hygiene.sh
-!scripts/release-preflight.sh
 !scripts/swift-test.sh
 !scripts/indexnow-submit.py
 # UAT scripts — required by workflow tooling (workflow-process.md §1 step 9 + §11)


### PR DESCRIPTION
Follow-up cleanup to #744. The `\!scripts/release-preflight.sh` line was inert once the script was deleted; Codex review flagged it as a remaining reference. Single-line removal.