### PR TITLE
fix(logger): consolidate AppLogger launch seed in PipelineSettingsSync (#728)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -422,11 +422,9 @@ final class AppState {
       coordinator: customWordsCoordinator
     )
 
-    // Initialize logger
-    Task {
-      await AppLogger.shared.setLogLevel(settings.debugLogLevel)
-      await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled)
-    }
+    // AppLogger initial seed lives in PipelineSettingsSync.applyInitialSettings
+    // (called above at line 238) — single owner for settings-driven side effects.
+    // See #728.
 
     // Restore persisted backend selection synchronously (no race with first record).
     // setInitialBackendType is safe at startup: nothing loaded, no unload needed.

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -78,6 +78,19 @@ final class PipelineSettingsSync {
     lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
       provider: settings.llmProvider, model: resolvedModel(settings)
     )
+
+    // #728: AppLogger defaults to debug=off / level=.info. Sync the persisted
+    // values at launch so the file handle opens (or stays closed) according
+    // to the user's saved preference instead of requiring a toggle off-then-on.
+    // Capture values upfront so the unstructured Task is not racing settings
+    // mutation. Level is set first so the file-open log line in `setDebugMode`
+    // is not filtered out when the saved level is more permissive than .info.
+    let logLevel = settings.debugLogLevel
+    let debugEnabled = settings.isDebugModeEnabled
+    Task {
+      await AppLogger.shared.setLogLevel(logLevel)
+      await AppLogger.shared.setDebugMode(debugEnabled)
+    }
   }
 
   /// Handle a settings change by forwarding to the appropriate subsystem.

--- a/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
+++ b/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
@@ -1,0 +1,146 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprPipeline
+
+/// Regression test for #728.
+///
+/// Before the fix, `AppLogger.shared.setDebugMode` was only called inside
+/// `PipelineSettingsSync.handleSettingChanged`'s `.isDebugModeEnabled` case,
+/// which fires on toggle changes — not on initial settings load. The result:
+/// an app launched with the persisted toggle ON never opened the file sink
+/// until the user toggled OFF then back ON.
+///
+/// `PipelineSettingsSync.applyInitialSettings` now seeds AppLogger's debug
+/// mode and log level once at launch. This test exercises that path.
+@MainActor
+@Suite("AppLogger launch-time sync")
+struct AppLoggerLaunchSyncTests {
+
+  @Test("applyInitialSettings seeds AppLogger debug mode + log level from persisted settings")
+  func applyInitialSettingsSeedsAppLogger() async throws {
+    // Save prior AppLogger state so suite ordering does not leak.
+    let priorMode = await AppLogger.shared.isDebugModeEnabled
+    let priorLevel = await AppLogger.shared.logLevel
+
+    // Save prior UserDefaults — SettingsManager setters below write through to
+    // `UserDefaults.standard`, so we must restore them in defer or other tests
+    // (and the developer's persisted state) would see the leak.
+    let defaults = UserDefaults.standard
+    let priorIsDebugModeEnabled = defaults.object(forKey: "isDebugModeEnabled")
+    let priorDebugLogLevel = defaults.object(forKey: "debugLogLevel")
+
+    // Force the logger to a known baseline that differs from the test target.
+    await AppLogger.shared.setDebugMode(false)
+    await AppLogger.shared.setLogLevel(.info)
+
+    let fixture = try SyntheticAudioFixture.make(
+      fileName: "issue-728-applogger-launch.wav",
+      pattern: .toneBurst
+    )
+    let audioCapture = try FixtureAudioCapture(fixtureURL: fixture.url)
+    let asrManager = MockASRManager(
+      transcribeBehavior: .success(
+        ASRResult(
+          text: "unused",
+          language: "en",
+          duration: fixture.durationSeconds,
+          processingTime: 0.01,
+          backendType: .parakeet
+        )
+      )
+    )
+    let transcriptStore = TranscriptStore()
+    let keychain = KeychainManager()
+    let pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: transcriptStore
+    )
+    let whisperKitPipeline = WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: transcriptStore,
+      keychainManager: keychain
+    )
+    let polishService = TranscriptPolishService(
+      keychainManager: keychain,
+      transcriptStore: transcriptStore
+    )
+    let hotkeyService = HotkeyService()
+    let whisperKitSetup = WhisperKitSetupService()
+
+    let sync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: hotkeyService,
+      whisperKitSetup: whisperKitSetup
+    )
+
+    // Configure persisted state: debug=on, level=.debug (the values that should
+    // be reflected on the global logger after applyInitialSettings).
+    let settings = SettingsManager()
+    settings.isDebugModeEnabled = true
+    settings.debugLogLevel = .debug
+
+    sync.applyInitialSettings(settings)
+
+    // applyInitialSettings spawns a Task to call into the AppLogger actor.
+    // Poll up to 1s for the state to settle before asserting.
+    let modeSettled = await pollAsync(timeout: .seconds(1)) {
+      await AppLogger.shared.isDebugModeEnabled == true
+    }
+    let levelSettled = await pollAsync(timeout: .seconds(1)) {
+      await AppLogger.shared.logLevel == .debug
+    }
+
+    #expect(
+      modeSettled,
+      "AppLogger.isDebugModeEnabled must reflect persisted setting after launch sync")
+    #expect(
+      levelSettled,
+      "AppLogger.logLevel must reflect persisted setting after launch sync")
+
+    // Restore prior AppLogger state — never assume default false, so suite
+    // ordering does not depend on this test.
+    await AppLogger.shared.setDebugMode(priorMode)
+    await AppLogger.shared.setLogLevel(priorLevel)
+
+    // Restore prior UserDefaults.
+    if let priorIsDebugModeEnabled {
+      defaults.set(priorIsDebugModeEnabled, forKey: "isDebugModeEnabled")
+    } else {
+      defaults.removeObject(forKey: "isDebugModeEnabled")
+    }
+    if let priorDebugLogLevel {
+      defaults.set(priorDebugLogLevel, forKey: "debugLogLevel")
+    } else {
+      defaults.removeObject(forKey: "debugLogLevel")
+    }
+  }
+}
+
+@MainActor
+private func pollAsync(
+  timeout: Duration,
+  interval: Duration = .milliseconds(10),
+  condition: @escaping () async -> Bool
+) async -> Bool {
+  let deadline = ContinuousClock.now + timeout
+  while ContinuousClock.now < deadline {
+    if await condition() { return true }
+    try? await Task.sleep(for: interval)
+  }
+  return await condition()
+}


### PR DESCRIPTION
## Summary

Closes #728 — addresses the underlying ownership concern.

**Scope clarification (added during walkthrough):** AppLogger file output is compile-gated `#if DEBUG` (see `Sources/EnviousWisprCore/AppLogger.swift:73`). The toggle is decorative in shipped release builds — no file ever gets written there. This PR's user-visible value lands in **debug builds only** (the `wispr-rebuild-debug` skill, local dev builds). It is best characterized as a **developer-experience / UAT-reliability fix**, not an end-user fix.

The issue analysis was incomplete: it claimed \`setDebugMode\` was never called at launch because \`PipelineSettingsSync\` only calls it on toggle changes. That part is true, but it missed an existing launch seed at \`AppState.init\` (added 2026-04-15 in commit \`b8345c2\`) that already calls \`setLogLevel\` + \`setDebugMode\` from a Task. So the empirical bug ("file handle stays closed until toggle off-then-on") may not reproduce on current main — but the **split ownership** of settings-driven side effects (one site in AppState, the rest in PipelineSettingsSync) is the real underlying problem that caused this issue to be filed in the first place.

This PR consolidates: removes the AppState seed and adds the equivalent seed in \`PipelineSettingsSync.applyInitialSettings\` — the single owner for settings-driven side effects, matching the live handler at line 174 already there. Picked up two additional improvements from Codex during review:

- Capture \`logLevel\` and \`debugEnabled\` into locals before spawning the Task so the unstructured Task is not racing settings mutation.
- Set log level **before** debug mode so the \`setDebugMode\` bootstrap log line ("Debug mode enabled") is not filtered out if the saved level is more permissive than .info.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments on the issue). \`grep -nE "#728([^0-9]|$)" .claude/knowledge/session-log.md\` returned one entry treating this as a "latent bug — file handle stays closed until toggle off-then-on." Issue was filed 2026-05-12; existing launch seed in AppState was added 2026-04-15 — the issue analysis missed it.

**Lane: Code.** \`Sources/EnviousWispr/App/*\`. Full workflow process required.

**Council skip rationale.** \`council-skip: codex-grounded-review settled the only structural fork (single-owner choice: PipelineSettingsSync vs AppState — both valid; Codex recommended the former); no new user surface; behavior is idempotent equivalent of prior shipped code.\` Per \`.claude/rules/workflow-process.md §1\` narrow exception: pure architectural placement question, \`User Rubric: N/A\` (no user-facing behavior change), no design ambiguity once Codex grep-confirmed both sites exist.

**Codex grounded review.** Two rounds.
- Round 1: caught (a) duplicate launch sync (existing seed in AppState that the issue analysis missed); (b) test leaked persisted UserDefaults; (c) ordering preference (level before debug); (d) recommendation to capture upfront. All four addressed.
- Round 2: **Greenlight.** No new findings.

## Validation

- \`scripts/swift-test.sh --filter AppLoggerLaunchSync\` → 1 test passes
- \`swift build -c release\` → clean
- \`swift build -c debug\` → clean
- Test verified to fail without the new seed (by inspection — the test sets AppLogger baseline to off and asserts it flips to on; only the new code path drives that flip when \`applyInitialSettings\` runs in isolation)

## Known risks

- **Behavior equivalence.** This is a refactor in shape but not in user-facing behavior. The Task that runs at launch does the same two awaits in the same order (level, then mode). The only difference is where the Task is created.
- **DEBUG-build-only effect.** Per scope clarification above, this affects developer/UAT log capture, not shipped-release-build users.

## Test plan

- [x] Unit test (\`AppLoggerLaunchSyncTests\`) passes
- [x] Release + debug builds green
- [x] Codex Greenlight after fixing all findings
- [ ] Manual UAT: launch debug build with \`isDebugModeEnabled=true\` persisted, confirm \`~/Library/Logs/EnviousWispr/app.log\` exists immediately and contains the bootstrap line
