### PR TITLE
feat(settings): surface Keychain-migration cleanup failure in AI Polish (#725)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -47,6 +47,10 @@ struct AIPolishSettingsView: View {
   @State private var geminiKey: String = ""
   @State private var validationStatus: String = ""
 
+  /// Snapshot of the most recent unresolved Keychain-migration cleanup failure.
+  /// Read on appear; reset to nil when no failure is recorded. See #725.
+  @State private var cleanupFailure: KeychainCleanupDiagnostics.FailureRecord?
+
   private var isCloudProvider: Bool {
     appState.settings.llmProvider == .openAI || appState.settings.llmProvider == .gemini
   }
@@ -70,6 +74,19 @@ struct AIPolishSettingsView: View {
     @Bindable var state = appState
 
     SettingsContentView {
+      // ── Banner: legacy-plaintext cleanup still pending (#725) ────
+      // Shown when a previous Keychain migration left the plaintext file on
+      // disk. Non-blocking: polish is unaffected; the security goal is what
+      // is at risk. The banner clears the moment any successful cleanup
+      // happens (next retrieve or explicit Save/Clear in this view).
+      if let failure = cleanupFailure {
+        BrandedSection(header: "Security") {
+          BrandedRow(showDivider: false) {
+            keychainCleanupBanner(failure: failure)
+          }
+        }
+      }
+
       // ── Section 1: LLM Provider ───────────────────────────────
       BrandedSection(
         header: "LLM Provider",
@@ -217,8 +234,12 @@ struct AIPolishSettingsView: View {
       }
     }
     .onAppear {
+      // Read keys first — the retrieve calls below may resolve a pending
+      // legacy-file cleanup, which would clear the diagnostics flag. Re-read
+      // after, so the banner reflects the post-resolution state.
       openAIKey = (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) ?? ""
       geminiKey = (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) ?? ""
+      cleanupFailure = KeychainCleanupDiagnostics.latestFailure()
       if appState.settings.llmProvider == .ollama {
         appState.llmDiscovery.loadCachedModels(for: .ollama)
         Task {
@@ -286,6 +307,71 @@ struct AIPolishSettingsView: View {
         appState.setup.ollamaSetup.warmUpModel(newModel)
       }
     }
+  }
+
+  // MARK: - Keychain cleanup banner (#725)
+
+  /// Non-blocking warning shown when a previous Keychain migration write
+  /// succeeded but the legacy plaintext file could not be deleted. The polish
+  /// path keeps working from the Keychain value; the banner exists because the
+  /// security goal of the migration was not met until the file is gone.
+  ///
+  /// "Restart the app" is the retry path: on next launch, the polish path
+  /// retrieves the key from the Keychain and calls `deleteLegacyFileOrLog`
+  /// again, which clears the flag on success.
+  @ViewBuilder
+  private func keychainCleanupBanner(
+    failure: KeychainCleanupDiagnostics.FailureRecord
+  ) -> some View {
+    let providerName: String = {
+      switch failure.keyID {
+      case KeychainManager.openAIKeyID: return "OpenAI"
+      case KeychainManager.geminiKeyID: return "Google Gemini"
+      default: return failure.keyID
+      }
+    }()
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: "exclamationmark.shield.fill")
+        .foregroundStyle(.orange)
+        .imageScale(.medium)
+        .padding(.top, 2)
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(
+          "\(providerName) API key was saved to the Keychain, but a previous plaintext copy could not be removed."
+        )
+        .font(.callout)
+        .foregroundStyle(.primary)
+        .fixedSize(horizontal: false, vertical: true)
+        Text(
+          "Polish still works. To complete the cleanup, restart EnviousWispr. The app retries on the next launch."
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Spacer(minLength: 12)
+
+      Button("Retry now") {
+        // Re-attempt retrieve which triggers the cleanup retry path. Update
+        // the local snapshot immediately so the banner clears on success.
+        _ = try? appState.keychainManager.retrieve(key: failure.keyID)
+        cleanupFailure = KeychainCleanupDiagnostics.latestFailure()
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(.orange.opacity(0.12))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(.orange.opacity(0.3), lineWidth: 1)
+        )
+    )
   }
 
   // MARK: - API Key Row
@@ -887,6 +973,9 @@ struct AIPolishSettingsView: View {
     do {
       try appState.keychainManager.store(key: keychainId, value: key)
       validationStatus = "Saved!"
+      // #725: store success path clears any prior cleanup-failure marker for
+      // this key. Refresh the banner so it disappears immediately.
+      cleanupFailure = KeychainCleanupDiagnostics.latestFailure()
       Task {
         try? await Task.sleep(for: .seconds(2))
         validationStatus = ""
@@ -903,6 +992,9 @@ struct AIPolishSettingsView: View {
     do {
       try appState.keychainManager.delete(key: keychainId)
       validationStatus = ""
+      // #725: delete success path clears any prior cleanup-failure marker for
+      // this key. Refresh the banner so it disappears immediately.
+      cleanupFailure = KeychainCleanupDiagnostics.latestFailure()
       return true
     } catch {
       validationStatus = "Failed: \(error.localizedDescription)"

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -57,6 +57,7 @@ public struct KeychainManager: Sendable {
       try keychainStore.store(service: service, account: key, value: value)
       do {
         try legacyStore.delete(key: key)
+        KeychainCleanupDiagnostics.recordSuccess(keyID: key)
       } catch let cleanupError {
         do {
           try restoreKeychainValue(previousValue, service: service, key: key)
@@ -100,6 +101,7 @@ public struct KeychainManager: Sendable {
     case .keychain(let service):
       try ensureReleaseKeySupported(key)
       try legacyStore.delete(key: key)
+      KeychainCleanupDiagnostics.recordSuccess(keyID: key)
       try keychainStore.delete(service: service, account: key)
     }
   }
@@ -136,10 +138,12 @@ public struct KeychainManager: Sendable {
   private func deleteLegacyFileOrLog(key: String) {
     do {
       try legacyStore.delete(key: key)
+      KeychainCleanupDiagnostics.recordSuccess(keyID: key)
     } catch {
       Self.logger.error(
         "Legacy plaintext API key file remained on disk after Keychain migration; user-visible polish is unaffected but the security goal is not met. Will retry on next retrieve. account=\(key, privacy: .public) error=\(String(describing: error), privacy: .public)"
       )
+      KeychainCleanupDiagnostics.recordFailure(keyID: key, error: error)
     }
   }
 
@@ -188,6 +192,75 @@ public struct KeychainManager: Sendable {
 enum KeyStorageBackend: Sendable {
   case legacyFiles
   case keychain(service: String)
+}
+
+/// Persistent diagnostics for the legacy-plaintext-cleanup step of the API-key
+/// migration. After a successful Keychain write, if the legacy plaintext file
+/// cannot be deleted, the user-visible polish path keeps working from the new
+/// Keychain value — but the security goal is not met. The unified-log error
+/// line is easy to miss, so we also persist a marker per key that the AI Polish
+/// settings view reads to surface a non-blocking warning. See #725.
+///
+/// Storage is `UserDefaults.standard` — small, simple, no new actors needed.
+/// Keys are namespaced with the `kcCleanupFail.` prefix so they do not collide
+/// with `SettingsManager` keys (which use unprefixed names).
+public enum KeychainCleanupDiagnostics {
+  private static let dateKeyPrefix = "kcCleanupFail.date."
+  private static let summaryKeyPrefix = "kcCleanupFail.summary."
+
+  /// Snapshot of a single cleanup-failure record.
+  public struct FailureRecord: Sendable, Equatable {
+    public let keyID: String
+    public let date: Date
+    public let summary: String
+
+    public init(keyID: String, date: Date, summary: String) {
+      self.keyID = keyID
+      self.date = date
+      self.summary = summary
+    }
+  }
+
+  /// Returns the most recent unresolved cleanup failure across all supported
+  /// API-key IDs, or nil if every key cleaned up successfully or was never
+  /// migrated. The settings banner uses this as the single read.
+  public static func latestFailure(
+    defaults: UserDefaults = .standard,
+    keyIDs: [String] = [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID]
+  ) -> FailureRecord? {
+    var latest: FailureRecord?
+    for keyID in keyIDs {
+      guard let date = defaults.object(forKey: dateKeyPrefix + keyID) as? Date else { continue }
+      let summary = defaults.string(forKey: summaryKeyPrefix + keyID) ?? "Unknown error"
+      let record = FailureRecord(keyID: keyID, date: date, summary: summary)
+      if let existing = latest, existing.date >= date { continue }
+      latest = record
+    }
+    return latest
+  }
+
+  /// Records a cleanup failure for `keyID`. Truncates the error description
+  /// to bound UserDefaults growth even for pathological error strings.
+  static func recordFailure(
+    keyID: String,
+    error: any Error,
+    now: Date = Date(),
+    defaults: UserDefaults = .standard
+  ) {
+    let summary = String(String(describing: error).prefix(240))
+    defaults.set(now, forKey: dateKeyPrefix + keyID)
+    defaults.set(summary, forKey: summaryKeyPrefix + keyID)
+  }
+
+  /// Records that cleanup succeeded for `keyID` — clears any prior failure
+  /// marker so the banner does not stick after a successful retry. Idempotent.
+  static func recordSuccess(
+    keyID: String,
+    defaults: UserDefaults = .standard
+  ) {
+    defaults.removeObject(forKey: dateKeyPrefix + keyID)
+    defaults.removeObject(forKey: summaryKeyPrefix + keyID)
+  }
 }
 
 protocol LegacyKeyFileStorage: Sendable {

--- a/Tests/EnviousWisprTests/LLM/KeychainCleanupDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainCleanupDiagnosticsTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// Tests for the persistent diagnostics surface added in #725. Verifies the
+/// namespace records failure/success markers correctly AND that
+/// `KeychainManager` wires them on the cleanup paths so the AI Polish settings
+/// banner reflects real on-disk state.
+@Suite("KeychainCleanupDiagnostics", .serialized)
+struct KeychainCleanupDiagnosticsTests {
+
+  // MARK: - Direct namespace behavior
+
+  @Test("recordFailure writes a marker readable via latestFailure")
+  func recordFailureWritesMarker() {
+    let suite = makeIsolatedSuite()
+    defer { tearDown(suite) }
+
+    let now = Date()
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.openAIKeyID,
+      error: TestError.cleanupFailed,
+      now: now,
+      defaults: suite
+    )
+
+    let latest = KeychainCleanupDiagnostics.latestFailure(
+      defaults: suite,
+      keyIDs: [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID]
+    )
+
+    #expect(latest?.keyID == KeychainManager.openAIKeyID)
+    #expect(latest?.date == now)
+    #expect(latest?.summary.contains("cleanupFailed") == true)
+  }
+
+  @Test("recordSuccess clears the marker for that key")
+  func recordSuccessClearsMarker() {
+    let suite = makeIsolatedSuite()
+    defer { tearDown(suite) }
+
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.openAIKeyID,
+      error: TestError.cleanupFailed,
+      defaults: suite
+    )
+
+    KeychainCleanupDiagnostics.recordSuccess(
+      keyID: KeychainManager.openAIKeyID,
+      defaults: suite
+    )
+
+    let latest = KeychainCleanupDiagnostics.latestFailure(
+      defaults: suite,
+      keyIDs: [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID]
+    )
+    #expect(latest == nil)
+  }
+
+  @Test("latestFailure returns the more recent record when both keys have failed")
+  func latestFailureAcrossKeys() {
+    let suite = makeIsolatedSuite()
+    defer { tearDown(suite) }
+
+    let older = Date(timeIntervalSinceReferenceDate: 100_000)
+    let newer = Date(timeIntervalSinceReferenceDate: 200_000)
+
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.openAIKeyID,
+      error: TestError.cleanupFailed,
+      now: older,
+      defaults: suite
+    )
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.geminiKeyID,
+      error: TestError.cleanupFailed,
+      now: newer,
+      defaults: suite
+    )
+
+    let latest = KeychainCleanupDiagnostics.latestFailure(
+      defaults: suite,
+      keyIDs: [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID]
+    )
+
+    #expect(latest?.keyID == KeychainManager.geminiKeyID)
+    #expect(latest?.date == newer)
+  }
+
+  @Test("clearing only one of two failures leaves the remaining one as latest")
+  func clearingOneLeavesOther() {
+    let suite = makeIsolatedSuite()
+    defer { tearDown(suite) }
+
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.openAIKeyID,
+      error: TestError.cleanupFailed,
+      defaults: suite
+    )
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.geminiKeyID,
+      error: TestError.cleanupFailed,
+      defaults: suite
+    )
+
+    KeychainCleanupDiagnostics.recordSuccess(
+      keyID: KeychainManager.geminiKeyID,
+      defaults: suite
+    )
+
+    let latest = KeychainCleanupDiagnostics.latestFailure(
+      defaults: suite,
+      keyIDs: [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID]
+    )
+    #expect(latest?.keyID == KeychainManager.openAIKeyID)
+  }
+
+  // MARK: - KeychainManager wiring (uses .standard; save + restore)
+
+  @Test("KeychainManager retrieve cleanup failure records diagnostics in standard defaults")
+  func retrieveCleanupFailureRecordsDiagnostics() throws {
+    let priorDate = UserDefaults.standard.object(
+      forKey: "kcCleanupFail.date." + KeychainManager.openAIKeyID)
+    let priorSummary = UserDefaults.standard.object(
+      forKey: "kcCleanupFail.summary." + KeychainManager.openAIKeyID)
+    defer {
+      restoreDefault(
+        key: "kcCleanupFail.date." + KeychainManager.openAIKeyID, value: priorDate)
+      restoreDefault(
+        key: "kcCleanupFail.summary." + KeychainManager.openAIKeyID, value: priorSummary)
+    }
+
+    UserDefaults.standard.removeObject(
+      forKey: "kcCleanupFail.date." + KeychainManager.openAIKeyID)
+    UserDefaults.standard.removeObject(
+      forKey: "kcCleanupFail.summary." + KeychainManager.openAIKeyID)
+
+    let legacyStore = FailingDeleteLegacyStore(value: "leaked-key-value")
+    let keychainStore = CleanupDiagnosticsInMemoryKeychainStore()
+    let manager = KeychainManager(
+      backend: .keychain(service: "com.enviouswispr.tests.kc.\(UUID().uuidString)"),
+      legacyStore: legacyStore,
+      keychainStore: keychainStore
+    )
+
+    // Retrieve triggers retrieveLegacyAndMigrate: stores in keychain (success),
+    // then calls deleteLegacyFileOrLog which fails (FailingDeleteLegacyStore
+    // throws on delete). The retrieve still returns the value so polish keeps
+    // working; the diagnostics flag should be set.
+    let value = try manager.retrieve(key: KeychainManager.openAIKeyID)
+    #expect(value == "leaked-key-value")
+
+    let latest = KeychainCleanupDiagnostics.latestFailure()
+    #expect(latest?.keyID == KeychainManager.openAIKeyID)
+    #expect(latest?.summary.isEmpty == false)
+  }
+
+  @Test("KeychainManager retrieve cleanup success clears prior diagnostics")
+  func retrieveCleanupSuccessClearsDiagnostics() throws {
+    let priorDate = UserDefaults.standard.object(
+      forKey: "kcCleanupFail.date." + KeychainManager.openAIKeyID)
+    let priorSummary = UserDefaults.standard.object(
+      forKey: "kcCleanupFail.summary." + KeychainManager.openAIKeyID)
+    defer {
+      restoreDefault(
+        key: "kcCleanupFail.date." + KeychainManager.openAIKeyID, value: priorDate)
+      restoreDefault(
+        key: "kcCleanupFail.summary." + KeychainManager.openAIKeyID, value: priorSummary)
+    }
+
+    // Pre-populate diagnostics as if a previous launch failed cleanup.
+    KeychainCleanupDiagnostics.recordFailure(
+      keyID: KeychainManager.openAIKeyID,
+      error: TestError.cleanupFailed
+    )
+    #expect(KeychainCleanupDiagnostics.latestFailure() != nil)
+
+    let dir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let legacyStore = FileLegacyKeyStore(storageDirectory: dir)
+    try legacyStore.store(key: KeychainManager.openAIKeyID, value: "secret-value")
+    let keychainStore = CleanupDiagnosticsInMemoryKeychainStore()
+    let manager = KeychainManager(
+      backend: .keychain(service: "com.enviouswispr.tests.kc.\(UUID().uuidString)"),
+      legacyStore: legacyStore,
+      keychainStore: keychainStore
+    )
+
+    let value = try manager.retrieve(key: KeychainManager.openAIKeyID)
+    #expect(value == "secret-value")
+
+    // Migration ran: keychain stored + legacy deleted successfully → flag cleared.
+    #expect(KeychainCleanupDiagnostics.latestFailure() == nil)
+  }
+
+  // MARK: - Helpers
+
+  private enum TestError: Error { case cleanupFailed }
+
+  private func makeIsolatedSuite() -> UserDefaults {
+    let name = "kcCleanupTests.\(UUID().uuidString)"
+    return UserDefaults(suiteName: name)!
+  }
+
+  private func tearDown(_ suite: UserDefaults) {
+    for keyID in [KeychainManager.openAIKeyID, KeychainManager.geminiKeyID] {
+      suite.removeObject(forKey: "kcCleanupFail.date." + keyID)
+      suite.removeObject(forKey: "kcCleanupFail.summary." + keyID)
+    }
+  }
+
+  private func restoreDefault(key: String, value: Any?) {
+    if let value {
+      UserDefaults.standard.set(value, forKey: key)
+    } else {
+      UserDefaults.standard.removeObject(forKey: key)
+    }
+  }
+}
+
+/// LegacyStore stub that returns a fixed value on retrieve but throws on delete,
+/// emulating the post-migration cleanup-failure window described in #725.
+private final class FailingDeleteLegacyStore: LegacyKeyFileStorage {
+  private let value: String
+  init(value: String) { self.value = value }
+  func store(key: String, value: String) throws {}
+  func retrieve(key: String) throws -> String { value }
+  func delete(key: String) throws { throw DeleteError.simulated }
+
+  enum DeleteError: Error { case simulated }
+}
+
+/// In-memory KeychainItemStorage stub, scoped to this test file so the test
+/// does not depend on the real Apple Keychain. Mirrors the existing private
+/// `InMemoryKeychainStore` in `KeychainManagerTests.swift`; kept here to avoid
+/// raising that one to internal visibility just for #725.
+private final class CleanupDiagnosticsInMemoryKeychainStore: KeychainItemStorage,
+  @unchecked Sendable
+{
+  private var values: [String: String] = [:]
+  private let lock = NSLock()
+
+  func store(service: String, account: String, value: String) throws {
+    lock.lock()
+    defer { lock.unlock() }
+    values["\(service):\(account)"] = value
+  }
+
+  func retrieve(service: String, account: String) throws -> String {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let value = values["\(service):\(account)"] else {
+      throw KeyStoreError.retrieveFailed(errSecItemNotFound)
+    }
+    return value
+  }
+
+  func delete(service: String, account: String) throws {
+    lock.lock()
+    defer { lock.unlock() }
+    values.removeValue(forKey: "\(service):\(account)")
+  }
+}
+
+private func makeTempDirectory() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent("kc-cleanup-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}


### PR DESCRIPTION
## Summary

Fixes #725.

When the Keychain migration's post-write legacy-file delete fails (the file remains on disk, plaintext intact), polish keeps working from the Keychain value — so the only signal is an ERROR log line that's easy to miss. This PR adds a persistent diagnostics surface and a non-blocking amber banner in AI Polish settings.

The whole point of the migration was to get plaintext API keys off disk. If cleanup keeps failing silently across launches, the security goal does not actually land for that user, and we have no easy way to detect it.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments on the issue). `.claude/knowledge/session-log.md` had a one-line entry treating this as the follow-up to #720. Reviewed `KeychainManager.deleteLegacyFileOrLog` comment which explicitly references #725 as the surfacing follow-up.

**Lane: Code.** `Sources/EnviousWisprLLM/` + `Sources/EnviousWispr/Views/Settings/` + tests. Full workflow process required.

**Council skip rationale.** `council-skip: codex-grounded-review settled the only structural fork. Design alternatives (actor singleton vs UserDefaults vs published flag on KeychainManager) all converge to similar UX surface; UserDefaults wins on simplicity (synchronous, no new types, fits existing patterns). Codex round 1 confirmed no design ambiguity remaining; surfaced two implementation findings instead.` Per `.claude/rules/workflow-process.md §1` narrow exception: no workflow gate, no new metric, persona perspective unchanged from #720's plan.

**Codex grounded review.** Round 1 caught (a) banner could stay stale after Save/Clear succeeded; (b) test suite not `.serialized` despite mutating `UserDefaults.standard`. Both addressed in the same diff before push.

## Implementation

* **New `KeychainCleanupDiagnostics` enum namespace** in `KeychainManager.swift`. `recordFailure` / `recordSuccess` / `latestFailure`. Persisted in `UserDefaults.standard` under `kcCleanupFail.{date,summary}.<keyID>` keys (distinct namespace from `SettingsManager`). Error description truncated to 240 chars.
* **`KeychainManager` wiring** (3 sites):
  - `deleteLegacyFileOrLog`: `recordSuccess` on success, `recordFailure` on catch
  - `store(...)` success branch: `recordSuccess`
  - `delete(...)` success branch: `recordSuccess`
* **`AIPolishSettingsView` banner section** (`keychainCleanupBanner`). Amber styling matching `AccessibilityWarningBanner`. Shows provider name, short explanation, "Retry now" button. State refreshes on `.onAppear`, after `saveKey` success, after `clearKey` success, and after `Retry now`.

## Validation

- `scripts/swift-test.sh --filter KeychainCleanup` → 6 tests pass (serialized suite)
- `swift build -c release` → clean
- `swift build -c debug` → clean
- Codex round 1: 2 findings addressed before push

## Known risks

- **UserDefaults.standard mutation in `KeychainManager`.** Tests that share `UserDefaults.standard` could conflict. My tests use a `.serialized` suite and save+restore.
- **Banner stale across multiple settings windows.** If two Settings windows are open simultaneously, the banner in one won't refresh when the other clears state.
- **No PostHog signal.** Issue mentioned an optional PostHog event for population-scale tracking; deferred to keep scope SMALL.

## Test plan

- [x] Unit tests pass
- [x] Release + debug builds clean
- [x] Codex round 1 findings addressed
- [ ] Manual UAT: simulate cleanup failure, verify banner shows; click Retry now, verify behavior matches state
