### PR TITLE
feat(settings): friendlier Keychain failure UX in AI Polish (#724)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -1,7 +1,101 @@
 import AppKit
 import EnviousWisprCore
 import EnviousWisprLLM
+import OSLog
+import Security
 import SwiftUI
+
+/// Unified log for Save/Clear key failures in the AI Polish settings UI.
+/// The user-facing badge intentionally omits the raw OSStatus (#724), so this
+/// log keeps the numeric code observable for support and Sentry triage. Never
+/// log the key value itself.
+private let aiPolishKeychainUILog = Logger(
+  subsystem: "com.enviouswispr.app", category: "AIPolishSettings")
+
+// MARK: - Keychain failure → user-facing message (#724)
+
+/// Maps `KeyStoreError` (and the OSStatus values it wraps) to short, action-
+/// oriented user-facing text for the API-key field's validation badge.
+///
+/// Lives at file scope (not private to `AIPolishSettingsView`) so the unit
+/// test in `AIPolishKeychainFailureMessageTests` can reach it via
+/// `@testable import EnviousWispr`. No other consumers inside the app module;
+/// do not adopt elsewhere without revisiting placement.
+///
+/// Background: `KeyStoreError.errorDescription` returns engineering text like
+/// `"Key delete failed: -25291"` which is meaningless to end users. The raw
+/// codes still log via Sentry/OSLog from the underlying call sites; the badge
+/// only needs to tell the user what to try next. Per #724 / PR #720 review.
+enum AIPolishKeychainFailureMessage {
+  /// Returns a single short sentence prefixed with `"Failed: "` so existing
+  /// `validationStatus.hasPrefix("Failed")` checks in the view still light up
+  /// the error styling.
+  static func text(for error: any Error, action: Action) -> String {
+    "Failed: " + body(for: error, action: action)
+  }
+
+  /// The verb the message should suggest. `clear` is the Clear button path;
+  /// `save` is the Save button path. The verb only matters for the generic
+  /// fallback; specific OSStatus mappings are action-agnostic.
+  enum Action {
+    case save
+    case clear
+  }
+
+  private static func body(for error: any Error, action: Action) -> String {
+    if let keyStoreError = error as? KeyStoreError {
+      switch keyStoreError {
+      case .storeFailed(let status), .retrieveFailed(let status), .deleteFailed(let status):
+        return message(for: status, action: action)
+      case .unsupportedKey:
+        // Internal misuse — only the two supported keys ever pass the gate. If
+        // a user-facing message ever appears here, it is an engineering bug,
+        // not a Keychain state the user can fix.
+        return "This key store item is not supported. Please contact support."
+      case .rollbackFailed:
+        return "We could not finish saving. Restart EnviousWispr and try again."
+      }
+    }
+    // Unexpected error type — generic fallback.
+    return genericMessage(for: action)
+  }
+
+  /// Maps known Keychain OSStatus values to user-actionable copy. Anything
+  /// outside this allowlist falls back to a generic message that omits the
+  /// numeric code.
+  private static func message(for status: OSStatus, action: Action) -> String {
+    switch status {
+    case errSecUserCanceled:
+      return "Cancelled."
+    case errSecAuthFailed:
+      return "Could not access the Keychain. Unlock it from Keychain Access and try again."
+    case errSecInteractionNotAllowed, errSecInteractionRequired:
+      return "Keychain is locked. Unlock it and try again."
+    case errSecMissingEntitlement:
+      return "EnviousWispr is missing Keychain entitlements. Reinstall the app."
+    case errSecNotAvailable:
+      return "Keychain is unavailable. Restart EnviousWispr and try again."
+    case errSecItemNotFound:
+      // Hit only on Save (retrieve path during store's previous-value lookup);
+      // the delete path treats not-found as success, so Clear cannot reach
+      // here in normal flows.
+      return "Key not found. Try again."
+    case errSecDuplicateItem:
+      return "A duplicate key is already saved. Clear it and try again."
+    default:
+      return genericMessage(for: action)
+    }
+  }
+
+  private static func genericMessage(for action: Action) -> String {
+    switch action {
+    case .save:
+      return "Could not save the key. Try again, or restart the app."
+    case .clear:
+      return "Could not clear the saved key. Try again, or restart the app."
+    }
+  }
+}
 
 // MARK: - Model Recommendation Classifier (#617)
 
@@ -302,10 +396,16 @@ struct AIPolishSettingsView: View {
           SecureField("sk-proj-…", text: $openAIKey)
             .textFieldStyle(.roundedBorder)
             .accessibilityLabel("OpenAI API Key")
+            .onChange(of: openAIKey) { _, _ in
+              dismissStaleFailureStatus()
+            }
         } else {
           SecureField("AI…", text: $geminiKey)
             .textFieldStyle(.roundedBorder)
             .accessibilityLabel("Google Gemini API Key")
+            .onChange(of: geminiKey) { _, _ in
+              dismissStaleFailureStatus()
+            }
         }
 
         validationBadge
@@ -893,8 +993,21 @@ struct AIPolishSettingsView: View {
       }
       return true
     } catch {
-      validationStatus = "Failed: \(error.localizedDescription)"
+      aiPolishKeychainUILog.error(
+        "Save key failed action=save keyID=\(keychainId, privacy: .public) error=\(String(describing: error), privacy: .public)"
+      )
+      validationStatus = AIPolishKeychainFailureMessage.text(for: error, action: .save)
       return false
+    }
+  }
+
+  /// Clears any "Failed: …" validation badge the moment the user resumes
+  /// typing in either key field. Without this, a stale clear-failure from a
+  /// prior attempt sits next to fresh input until the next save/clear runs.
+  /// See #724.
+  private func dismissStaleFailureStatus() {
+    if validationStatus.hasPrefix("Failed") {
+      validationStatus = ""
     }
   }
 
@@ -905,7 +1018,10 @@ struct AIPolishSettingsView: View {
       validationStatus = ""
       return true
     } catch {
-      validationStatus = "Failed: \(error.localizedDescription)"
+      aiPolishKeychainUILog.error(
+        "Clear key failed action=clear keyID=\(keychainId, privacy: .public) error=\(String(describing: error), privacy: .public)"
+      )
+      validationStatus = AIPolishKeychainFailureMessage.text(for: error, action: .clear)
       return false
     }
   }

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -357,7 +357,7 @@ struct SecurityKeychainItemStore: KeychainItemStorage {
   }
 }
 
-enum KeyStoreError: LocalizedError, Sendable {
+package enum KeyStoreError: LocalizedError, Sendable {
   case storeFailed(OSStatus)
   case retrieveFailed(OSStatus)
   case deleteFailed(OSStatus)
@@ -368,7 +368,7 @@ enum KeyStoreError: LocalizedError, Sendable {
   /// rollback; `rollback` is the secondary failure from the restore attempt.
   case rollbackFailed(cleanup: Error, rollback: Error)
 
-  var errorDescription: String? {
+  package var errorDescription: String? {
     switch self {
     case .storeFailed(let s): return "Key store failed: \(s)"
     case .retrieveFailed(let s): return "Key retrieve failed: \(s)"

--- a/Tests/EnviousWisprTests/Settings/AIPolishKeychainFailureMessageTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishKeychainFailureMessageTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Security
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprLLM
+
+/// Regression tests for #724 — keychain failure → user-facing message mapping.
+///
+/// The previous behavior surfaced raw `OSStatus` codes like `"Failed: Key delete
+/// failed: -25291"` directly in the validation badge. After the fix, the badge
+/// shows a short action-oriented sentence and never includes a numeric code.
+@Suite("AIPolishKeychainFailureMessage")
+struct AIPolishKeychainFailureMessageTests {
+
+  // MARK: - Known OSStatus mappings
+
+  @Test("errSecUserCanceled maps to Cancelled")
+  func userCanceledMapsToCancelled() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.deleteFailed(errSecUserCanceled),
+      action: .clear
+    )
+    #expect(result == "Failed: Cancelled.")
+  }
+
+  @Test("errSecAuthFailed gives Keychain Access guidance")
+  func authFailedGivesKeychainAccessGuidance() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.storeFailed(errSecAuthFailed),
+      action: .save
+    )
+    #expect(result.hasPrefix("Failed: "))
+    #expect(result.contains("Keychain Access"))
+    #expect(!result.contains("-"))  // no negative numeric codes leaked
+  }
+
+  @Test("errSecInteractionNotAllowed prompts unlock")
+  func interactionNotAllowedPromptsUnlock() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.deleteFailed(errSecInteractionNotAllowed),
+      action: .clear
+    )
+    #expect(result.contains("locked"))
+    #expect(!result.contains("-25308"))
+  }
+
+  @Test("errSecMissingEntitlement suggests reinstall")
+  func missingEntitlementSuggestsReinstall() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.storeFailed(errSecMissingEntitlement),
+      action: .save
+    )
+    #expect(result.contains("entitlement") || result.contains("Reinstall"))
+    #expect(!result.contains("-34018"))
+  }
+
+  @Test("errSecItemNotFound on save reads as Key not found")
+  func itemNotFoundOnSaveReadsAsKeyNotFound() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.retrieveFailed(errSecItemNotFound),
+      action: .save
+    )
+    #expect(result.contains("Key not found") || result.contains("not found"))
+  }
+
+  @Test("errSecNotAvailable maps to restart prompt")
+  func notAvailableMapsToRestart() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.storeFailed(errSecNotAvailable),
+      action: .save
+    )
+    #expect(result.contains("unavailable") || result.contains("Restart"))
+    #expect(!result.contains("-25291"))
+  }
+
+  @Test("errSecInteractionRequired prompts unlock (same as errSecInteractionNotAllowed)")
+  func interactionRequiredPromptsUnlock() {
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.storeFailed(errSecInteractionRequired),
+      action: .save
+    )
+    #expect(result.contains("locked"))
+  }
+
+  // MARK: - rollbackFailed case (no numeric code)
+
+  @Test("rollbackFailed reads as restart-and-try-again")
+  func rollbackFailedReadsAsRestart() {
+    let inner = NSError(
+      domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "fake-cleanup-error"])
+    let outer = NSError(
+      domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "fake-rollback-error"])
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.rollbackFailed(cleanup: inner, rollback: outer),
+      action: .save
+    )
+    #expect(result.contains("Restart"))
+    #expect(!result.contains("fake-cleanup-error"))  // engineering details not leaked
+    #expect(!result.contains("fake-rollback-error"))
+  }
+
+  // MARK: - Unknown OSStatus falls back, no numeric leak
+
+  @Test("unknown OSStatus on save falls back to generic save copy")
+  func unknownStatusOnSaveFallsBackToGenericSaveCopy() {
+    let bogus: OSStatus = -99999
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.storeFailed(bogus),
+      action: .save
+    )
+    #expect(result.contains("save"))
+    #expect(!result.contains("99999"))
+    #expect(!result.contains("-99999"))
+  }
+
+  @Test("unknown OSStatus on clear falls back to generic clear copy")
+  func unknownStatusOnClearFallsBackToGenericClearCopy() {
+    let bogus: OSStatus = -99999
+    let result = AIPolishKeychainFailureMessage.text(
+      for: KeyStoreError.deleteFailed(bogus),
+      action: .clear
+    )
+    #expect(result.contains("clear"))
+    #expect(!result.contains("99999"))
+  }
+
+  // MARK: - Non-KeyStoreError fallback
+
+  @Test("non-KeyStoreError falls back to generic action-specific copy")
+  func nonKeyStoreErrorFallsBack() {
+    struct WeirdError: Error {}
+    let result = AIPolishKeychainFailureMessage.text(
+      for: WeirdError(),
+      action: .clear
+    )
+    #expect(result.hasPrefix("Failed: "))
+    #expect(result.contains("clear"))
+  }
+
+  // MARK: - No raw OSStatus ever appears in output
+
+  @Test("no message includes a raw negative number for any known code")
+  func noMessageIncludesRawNegativeNumberForKnownCodes() {
+    let knownStatuses: [OSStatus] = [
+      errSecUserCanceled,
+      errSecAuthFailed,
+      errSecInteractionNotAllowed,
+      errSecInteractionRequired,
+      errSecMissingEntitlement,
+      errSecNotAvailable,
+      errSecItemNotFound,
+      errSecDuplicateItem,
+    ]
+    for status in knownStatuses {
+      for action in [AIPolishKeychainFailureMessage.Action.save, .clear] {
+        let result = AIPolishKeychainFailureMessage.text(
+          for: KeyStoreError.storeFailed(status),
+          action: action
+        )
+        #expect(
+          !result.contains("\(status)"),
+          "OSStatus \(status) leaked into message: \(result)"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #724.

The Keychain Save/Clear validation badge previously showed raw OSStatus codes like `"Failed: Key delete failed: -25291"`. After this PR it shows short action-oriented sentences mapped per known OSStatus. The numeric code is still logged via the unified log so support and Sentry triage retain observability.

Stale `"Failed: …"` text also clears the moment the user starts typing a fresh key, instead of sitting next to fresh input until the next Save/Clear.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments). `.claude/knowledge/session-log.md` had a one-line entry treating this as PR #720 adversarial-review follow-up. Reviewed the adjacent #725 PR I just opened (PR #751) — both touch `AIPolishSettingsView` and `KeychainManager`; this PR's banner-state changes are independent from #725's diagnostic state.

**Lane: Code.** `Sources/EnviousWispr/Views/Settings/` + `Sources/EnviousWisprLLM/` + tests. Full workflow process required.

**Council skip rationale.** `council-skip: codex-grounded-review settled the only structural fork (UI-level mapping vs error-type method vs separate localized strings). Codex confirmed file-scope helper is the right placement. No new user-facing copy framework, no telemetry schema, no architectural shift — pure UX wording + observability path that was already in spirit (raw codes were already logged before being shown). Per workflow-process.md §1 narrow exception.`

**Codex grounded review.** Two rounds.
- Round 1: Medium — unknown OSStatus not logged from Save/Clear UI paths; Low — `public KeyStoreError` broader than needed; recommended `errSecNotAvailable` mapping; flagged `errSecItemNotFound on clear` as semantically odd. All addressed.
- Round 2: pending after this commit; will follow up in PR comments if findings.

## Implementation

1. **`AIPolishKeychainFailureMessage` namespace** at file scope in `AIPolishSettingsView.swift`. Static `text(for:action:) -> String` maps:
   - `errSecUserCanceled` → "Cancelled."
   - `errSecAuthFailed` → "Could not access the Keychain. Unlock it from Keychain Access and try again."
   - `errSecInteractionNotAllowed` / `errSecInteractionRequired` → "Keychain is locked. Unlock it and try again."
   - `errSecMissingEntitlement` → "EnviousWispr is missing Keychain entitlements. Reinstall the app."
   - `errSecNotAvailable` → "Keychain is unavailable. Restart EnviousWispr and try again."
   - `errSecItemNotFound` → "Key not found. Try again." (Save only — Clear cannot reach here)
   - `errSecDuplicateItem` → "A duplicate key is already saved. Clear it and try again."
   - `rollbackFailed` → "We could not finish saving. Restart EnviousWispr and try again."
   - Unknown / non-`KeyStoreError` → action-specific generic copy without numeric code

2. **Observability.** `saveKey` and `clearKey` error paths emit a unified-log line (`com.enviouswispr.app/AIPolishSettings`) with the keyID + raw error before assigning friendly UI copy. Numeric code stays observable for support/Sentry triage.

3. **Stale-failure dismissal.** `.onChange(of: openAIKey)` and `.onChange(of: geminiKey)` fire `dismissStaleFailureStatus()` which clears `validationStatus` only if it has the `"Failed"` prefix — preserves `"Saved!"`/`"Validating…"`/`"Valid"`/`"Invalid API key"` statuses.

4. **API tightening.** `KeyStoreError` and its `errorDescription` moved from internal to `package` so the view module can pattern-match without exposing the type to external SPM consumers.

## Validation

- `scripts/swift-test.sh --filter AIPolishKeychainFailureMessage` → 12 tests pass
- `swift build -c release` → clean
- `swift build -c debug` → clean
- Codex round 1: 4 findings (2 medium/low + 2 recommendations) all addressed

## Known risks

- **`dismissStaleFailureStatus` not unit-tested directly.** It is a private view method that mutates `@State`. Code path is two lines (`hasPrefix("Failed")` then `validationStatus = ""`). Manual UAT covered in test plan.
- **Unknown OSStatus codes still surface as generic copy.** The unified-log line captures them for triage but users see no numeric code. Acceptable per #724's intent.
- **`errSecItemNotFound on Clear` removed.** Codex confirmed the keychain delete wrapper at `KeychainManager:343` treats not-found as success, so this branch is unreachable in normal flow. If it ever does surface, the unknown-OSStatus generic fallback fires.

## Test plan

- [x] Unit tests pass
- [x] Release + debug builds clean
- [x] Codex round 1 findings addressed
- [ ] Manual UAT: lock Keychain via Keychain Access, click Save, verify badge says "Keychain is locked. Unlock it and try again." (not "-25308")
- [ ] Manual UAT: trigger a Save failure, then type a fresh char; verify the "Failed: …" badge clears immediately
