### PR TITLE
test(asr): regression coverage for progress-polling cleanup invariant (#586)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -158,7 +158,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
     launchPreloadReporter?(backend, result, ms)
   }
 
-  private func startProgressPolling() {
+  /// Whether the progress-polling timer is currently scheduled. Internal only
+  /// for the #586 regression test that exercises the polling lifecycle without
+  /// going through the (XPC-coupled) `loadModel` happy path. Tests reach it
+  /// via `@testable import EnviousWisprASR`.
+  internal var isProgressPollingActiveForTesting: Bool { progressPollTimer != nil }
+
+  internal func startProgressPolling() {
     stopProgressPolling()
     // Read progress from shared file — bypasses XPC entirely.
     // XPC serializes replies, so polling via XPC is blocked behind loadModel's pending reply.
@@ -186,7 +192,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
     progressPollTimer = timer
   }
 
-  private func stopProgressPolling() {
+  internal func stopProgressPolling() {
     progressPollTimer?.invalidate()
     progressPollTimer = nil
   }

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+/// Regression coverage for #586 — ASR XPC progress-polling lifecycle.
+///
+/// The senior audit flagged that `ASRManagerProxy.loadModel()` previously
+/// stopped progress polling only on the success path, so an XPC error left
+/// the 8 Hz `Timer` alive forever. The fix (PR #696 round 1, 2026-05-07)
+/// wraps `stopProgressPolling()` in a `defer` so cleanup runs on every exit.
+///
+/// These tests cover the cleanup invariant that the `defer` relies on:
+/// `startProgressPolling` / `stopProgressPolling` must keep
+/// `isProgressPollingActiveForTesting` honest, so a future refactor cannot
+/// silently break the defer guarantee.
+///
+/// Full failure-path coverage through real `loadModel()` requires a
+/// fake-XPC service infrastructure; that is intentionally not built tonight.
+/// See issue thread for follow-up.
+@MainActor
+@Suite("ASRManagerProxy progress polling")
+struct ASRManagerProxyProgressPollingTests {
+
+  @Test("startProgressPolling activates the timer")
+  func startActivates() {
+    let proxy = ASRManagerProxy()
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+
+    proxy.startProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == true)
+
+    proxy.stopProgressPolling()
+  }
+
+  @Test("stopProgressPolling clears the timer (the defer-cleanup invariant)")
+  func stopClears() {
+    let proxy = ASRManagerProxy()
+    proxy.startProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == true)
+
+    proxy.stopProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+  }
+
+  @Test("re-arming via startProgressPolling does not leak the prior timer")
+  func reArmingDoesNotLeak() {
+    let proxy = ASRManagerProxy()
+    proxy.startProgressPolling()
+    let firstActive = proxy.isProgressPollingActiveForTesting
+    #expect(firstActive == true)
+
+    // start without an explicit stop in between should still result in a
+    // single active timer — startProgressPolling's first line calls
+    // stopProgressPolling() to invalidate any prior timer before scheduling.
+    proxy.startProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == true)
+
+    proxy.stopProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+  }
+
+  @Test("stopProgressPolling is idempotent — calling twice is safe")
+  func stopIsIdempotent() {
+    let proxy = ASRManagerProxy()
+    proxy.startProgressPolling()
+    proxy.stopProgressPolling()
+    proxy.stopProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+  }
+
+  @Test("stopProgressPolling on a never-started proxy is a no-op")
+  func stopOnNeverStartedProxy() {
+    let proxy = ASRManagerProxy()
+    proxy.stopProgressPolling()
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+  }
+
+  @Test("polling state survives a simulated loadModel throw (defer-wrap pattern)")
+  func deferWrapPatternSimulation() {
+    // Mirrors the exact pattern at ASRManagerProxy.swift:77-81. If a future
+    // refactor removes the defer-stop, this test still passes only because
+    // the test itself calls stopProgressPolling — that is intentional: the
+    // test documents the contract; the regression risk is in the call site.
+    let proxy = ASRManagerProxy()
+
+    func simulateThrowingLoad() throws {
+      proxy.startProgressPolling()
+      defer { proxy.stopProgressPolling() }
+      throw SimulatedXPCError.serviceUnreachable
+    }
+
+    do {
+      try simulateThrowingLoad()
+      Issue.record("expected simulateThrowingLoad to throw")
+    } catch {
+      // expected
+    }
+
+    #expect(proxy.isProgressPollingActiveForTesting == false)
+  }
+
+  private enum SimulatedXPCError: Error {
+    case serviceUnreachable
+  }
+}


### PR DESCRIPTION
## Summary

Partial close of #586 — adds the regression-test layer the audit asked for. The production code fix (defer-wrap around `stopProgressPolling`) already shipped in PR #696 round 1 on 2026-05-07.

The senior audit's full ask had two parts: (a) wrap `startProgressPolling()` in defer; (b) add fake-XPC lifecycle test for model-load failure paths. (a) is done. (b) requires fake-XPC infrastructure that is out of scope for tonight; this PR delivers the next best thing — a polling state-machine regression suite that documents the cleanup contract.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments). Reviewed `ASRManagerProxy.swift` lines 77-81 — the defer-wrap is already in production, added 2026-05-07 (line 78-81 comment cites that Codex finding). The audit's #586 "fix" is partially already shipped.

**Lane: Code (tests).** `Sources/EnviousWisprASR/` + `Tests/EnviousWisprASRTests/`. Full workflow process required.

**Council skip rationale.** `council-skip: codex-grounded-review settled the only structural fork (test-seam shape — internal access vs package vs full XPC fake). No design ambiguity remaining; behavior is regression coverage of an already-shipped fix. No new user surface, no telemetry change, no architectural shift.` Per `.claude/rules/workflow-process.md §1` narrow exception.

**Codex grounded review.** One round.
- Finding 1: Test #6 does not protect the production regression (it simulates the defer-throw shape rather than calling real `loadModel`). Accepted and labeled as partial coverage in commit/PR body; full coverage requires fake-XPC infra deferred.
- Finding 2: `package var` is wider than needed when `@testable` gives `internal` access. Addressed (changed to `internal`).
- Finding 3 (answer to my question about "progress reset"): code does NOT reset `downloadProgress` fields on failure. Not changed in this PR — that is a separate design decision; flagged for follow-up.

## Implementation

* Promoted `startProgressPolling` and `stopProgressPolling` from `private` to `internal`. Tests reach them via `@testable import EnviousWisprASR`.
* Added `internal var isProgressPollingActiveForTesting: Bool { progressPollTimer != nil }` for state inspection.
* 6 tests in new suite `ASRManagerProxy progress polling`:
  1. `startProgressPolling` activates the timer
  2. `stopProgressPolling` clears it (the defer-cleanup invariant)
  3. re-arming does not leak the prior timer
  4. `stopProgressPolling` is idempotent — calling twice is safe
  5. `stopProgressPolling` on a never-started proxy is a no-op
  6. polling state survives a simulated `loadModel` throw (defer-wrap pattern)

## Validation

- `scripts/swift-test.sh --filter ASRManagerProxyProgressPolling` → 6 tests pass
- `swift build -c release` → clean
- `swift build -c debug` → clean
- Codex round 1 findings addressed (`package` → `internal`; partial-coverage acknowledged)

## Known risks

- **Partial coverage.** Test #6 simulates the defer-throw shape rather than exercising real `loadModel` through fake XPC. If someone removes the production `defer { self.stopProgressPolling() }` from `loadModel()` (currently at `ASRManagerProxy.swift:78-81`), this suite still passes. Full regression protection requires building an `XPCServiceProtocol` fake, which sprawls beyond tonight's scope. Tracking as follow-up.
- **Progress reset on failure.** Codex pointed out that `downloadProgress` / `downloadPhase` / `downloadDetail` are NOT cleared on failure — only on success. Not addressed in this PR (out of scope for the polling-cleanup ask). Worth a separate issue if we want failure paths to reset the UI banner.

## Test plan

- [x] Unit tests pass
- [x] Release + debug builds clean
- [x] Codex findings addressed
