### PR TITLE
test(finalizer): clipboard wiring coverage for #726

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
@@ -10,7 +11,7 @@ import Testing
 // fail. See `docs/feature-requests/issue-326-2026-04-18-transcript-finalizer-contract-tests.md`.
 
 @MainActor
-@Suite("TranscriptFinalizer contracts")
+@Suite("TranscriptFinalizer contracts", .serialized)
 struct TranscriptFinalizerTests {
 
   // MARK: - 1. Step failures do not prevent finalization
@@ -228,6 +229,11 @@ struct TranscriptFinalizerTests {
 
   @Test("PasteCompletionEvent NOT emitted on copy-only branch")
   func pasteCompleteSilentOnCopyOnly() async throws {
+    // Copy-only path writes to NSPasteboard.general — snapshot + restore so
+    // a developer's clipboard isn't replaced with the test text.
+    let priorSnapshot = PasteService.saveClipboard()
+    var endChangeCount = NSPasteboard.general.changeCount
+    defer { Self.restorePasteboard(priorSnapshot, expectedChangeCount: endChangeCount) }
     let registry = PasteCompletionRegistry()
     let observer = CapturingObserver()
     registry.subscribe(observer)
@@ -240,16 +246,150 @@ struct TranscriptFinalizerTests {
       pasteCompletionRegistry: registry
     )
     _ = try await finalizer.finalize(
-      Self.request(asrText: "hello", steps: [], autoPaste: false))
+      Self.request(asrText: "hello", steps: [], autoPaste: false, autoCopy: true))
+    endChangeCount = NSPasteboard.general.changeCount
     #expect(observer.events.isEmpty, "Copy-only path must not emit")
+  }
+
+  // MARK: - #726: Clipboard wiring — settings → finalizer → PasteService
+
+  /// Verifies the auto-paste path forwards `restoreClipboardAfterPaste` from
+  /// the request into the `PasteDeliveryRequest`. The PasteCascadeExecutor
+  /// itself honors the flag; this asserts the wiring upstream of it.
+  @Test("autoPasteToActiveApp ON + restoreClipboardAfterPaste ON forwards restore=true to paste")
+  func restoreFlagForwardsToPasteRequestWhenOn() async throws {
+    let captured = Box<Bool?>(nil)
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { request in
+        captured.value = request.restoreClipboardAfterPaste
+        return Self.deliveredResult()
+      }
+    )
+    _ = try await finalizer.finalize(
+      Self.request(
+        asrText: "hello", steps: [], autoPaste: true,
+        autoCopy: false, restore: true))
+    #expect(captured.value == true)
+  }
+
+  @Test("autoPasteToActiveApp ON + restoreClipboardAfterPaste OFF forwards restore=false to paste")
+  func restoreFlagForwardsToPasteRequestWhenOff() async throws {
+    let captured = Box<Bool?>(nil)
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { request in
+        captured.value = request.restoreClipboardAfterPaste
+        return Self.deliveredResult()
+      }
+    )
+    _ = try await finalizer.finalize(
+      Self.request(
+        asrText: "hello", steps: [], autoPaste: true,
+        autoCopy: true, restore: false))
+    #expect(captured.value == false)
+  }
+
+  /// Verifies the copy-only branch: when `autoPasteToActiveApp` is false and
+  /// `autoCopyToClipboard` is true, the finalizer writes the polished text to
+  /// the system clipboard (skipping the paste cascade entirely).
+  @Test("autoPaste OFF + autoCopy ON writes the polished text to the system clipboard")
+  func autoCopyOnlyWritesPolishedTextToClipboard() async throws {
+    // Capture full pasteboard contents (images, file URLs, rich text — not just
+    // .string) so a developer's clipboard isn't destroyed when this test runs.
+    let pasteboard = NSPasteboard.general
+    let priorSnapshot = PasteService.saveClipboard()
+    let sentinel = "issue-726-prior-\(UUID().uuidString)"
+    pasteboard.clearContents()
+    pasteboard.setString(sentinel, forType: .string)
+    var endChangeCount = pasteboard.changeCount
+    defer { Self.restorePasteboard(priorSnapshot, expectedChangeCount: endChangeCount) }
+
+    // Inject a fake polish step that emits a value distinct from the raw ASR
+    // text — proves the finalizer copies `transcript.displayText` (polished),
+    // not `transcript.text` (raw). Without this distinction, a regression to
+    // raw-text copy would silently pass.
+    let polishedSentinel = "POLISHED-\(UUID().uuidString)"
+    let polishStep = FakeStep(name: "FakePolish") { ctx in
+      var copy = ctx
+      copy.polishedText = polishedSentinel
+      return copy
+    }
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { _ in
+        Issue.record("deliverPaste must not be called when autoPaste is OFF")
+        return Self.deliveredResult()
+      }
+    )
+    _ = try await finalizer.finalize(
+      Self.request(
+        asrText: "raw input", steps: [polishStep], autoPaste: false,
+        autoCopy: true, restore: false))
+    endChangeCount = pasteboard.changeCount
+
+    let after = pasteboard.string(forType: .string)
+    #expect(
+      after == polishedSentinel, "clipboard should contain the POLISHED text, not the raw ASR text")
+    #expect(after != "raw input", "raw ASR text must NOT land on the clipboard")
+    #expect(after != sentinel, "sentinel should have been replaced")
+  }
+
+  @Test("autoPaste OFF + autoCopy OFF leaves the clipboard untouched")
+  func neitherFlagLeavesClipboardUntouched() async throws {
+    // Full snapshot — defer restores every pasteboard type, not just .string.
+    let pasteboard = NSPasteboard.general
+    let priorSnapshot = PasteService.saveClipboard()
+    let sentinel = "issue-726-untouched-\(UUID().uuidString)"
+    pasteboard.clearContents()
+    pasteboard.setString(sentinel, forType: .string)
+    var endChangeCount = pasteboard.changeCount
+    defer { Self.restorePasteboard(priorSnapshot, expectedChangeCount: endChangeCount) }
+
+    let finalizer = TranscriptFinalizer(
+      save: { _ in },
+      deliverPaste: { _ in
+        Issue.record("deliverPaste must not be called when autoPaste is OFF")
+        return Self.deliveredResult()
+      }
+    )
+    _ = try await finalizer.finalize(
+      Self.request(
+        asrText: "hello", steps: [], autoPaste: false,
+        autoCopy: false, restore: false))
+    endChangeCount = pasteboard.changeCount
+
+    #expect(
+      pasteboard.string(forType: .string) == sentinel,
+      "clipboard must remain at the sentinel when both flags are off")
   }
 
   // MARK: - Helpers
 
+  /// Restore the pasteboard to a previously captured snapshot, ONLY if no
+  /// third-party tool wrote to it after our last test mutation. Mirrors the
+  /// production `restoreClipboard` guard: if the change count has advanced
+  /// past what we expected, leave the new content alone.
+  ///
+  /// When the prior snapshot was empty (developer's clipboard had nothing),
+  /// we clear contents instead of no-oping — so our sentinel doesn't persist.
+  private static func restorePasteboard(
+    _ snapshot: ClipboardSnapshot, expectedChangeCount: Int
+  ) {
+    let pasteboard = NSPasteboard.general
+    if snapshot.items.isEmpty {
+      if pasteboard.changeCount == expectedChangeCount { pasteboard.clearContents() }
+      return
+    }
+    PasteService.restoreClipboard(snapshot, changeCountAfterPaste: expectedChangeCount)
+  }
+
   private static func request(
     asrText: String,
     steps: [any TextProcessingStep],
-    autoPaste: Bool = true
+    autoPaste: Bool = true,
+    autoCopy: Bool = false,
+    restore: Bool = false
   ) -> FinalizationRequest {
     FinalizationRequest(
       asrText: asrText,
@@ -259,9 +399,9 @@ struct TranscriptFinalizerTests {
       backendType: .parakeet,
       targetApp: nil,
       targetElement: nil,
-      autoCopyToClipboard: false,
+      autoCopyToClipboard: autoCopy,
       autoPasteToActiveApp: autoPaste,
-      restoreClipboardAfterPaste: false,
+      restoreClipboardAfterPaste: restore,
       steps: steps
     )
   }


### PR DESCRIPTION
## Summary

Fixes #726.

Existing `PasteServiceClipboardTests` covered the restore helper in isolation. This adds the integration coverage the issue asked for: from the settings-flag layer through `TranscriptFinalizer` to either the paste cascade (`restoreClipboardAfterPaste` forwarding) or the system clipboard (`autoCopyToClipboard` branch).

The issue proposed a Python `wispr_eyes` E2E test. I went with the Swift integration shape instead — it covers the same code path (settings → FinalizationRequest → finalizer → PasteService) and runs in the standard test target without needing a debug bundle, mic, or speakers.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments). Verified the issue's claims against current code: `PasteServiceClipboardTests` does test the restore helper but not the wiring; `uat_runner.py:1370` is the placeholder the issue references.

**Lane: Code (tests).** `Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift`. Full workflow process required.

**Council skip rationale.** `council-skip: codex-grounded-review settled the only structural fork (Python E2E vs Swift integration). No new product behavior, no new metric, no architectural shift — pure test coverage extension.` Per `.claude/rules/workflow-process.md §1` narrow exception.

**Codex grounded review.** One round, two findings (both addressed):
- P2: my expanded `request()` helper changed the default for `autoCopy` to false, which silently broke `pasteCompleteSilentOnCopyOnly()` — that test was no longer on the copy-only branch. Fixed by passing `autoCopy: true` explicitly.
- P2/P3: NSPasteboard assertions are race-prone without `.serialized` (Swift Testing runs tests in parallel by default). Promoted `TranscriptFinalizerTests` to `.serialized`. Cross-suite races with `PasteServiceClipboardTests` are still theoretically possible (both suites mutate the global pasteboard) but each suite uses unique-UUID sentinels so collision is improbable in practice; flagged as a follow-up if flake appears.

## Implementation

Four new tests covering the full matrix:

- `autoPaste ON + restore ON` → `deliverPaste` receives `restoreClipboardAfterPaste = true`
- `autoPaste ON + restore OFF` → `deliverPaste` receives `restoreClipboardAfterPaste = false`
- `autoPaste OFF + autoCopy ON` → `NSPasteboard` contains the polished text; `deliverPaste` is not called
- `autoPaste OFF + autoCopy OFF` → `NSPasteboard` remains at the seeded sentinel; `deliverPaste` is not called

The two NSPasteboard tests follow `PasteServiceClipboardTests`'s pattern (sentinel, defer-restore, no dependency on starting state). Suite is `.serialized` so Swift Testing does not run the four pasteboard-touching tests in parallel within this suite.

The `request()` helper grew two parameters (`autoCopy`, `restore`) with defaults that match the existing tests; the previously-broken-but-passing `pasteCompleteSilentOnCopyOnly` got an explicit `autoCopy: true` so it actually tests the copy-only path now.

## Validation

- `scripts/swift-test.sh --filter TranscriptFinalizer` → 13 tests pass (4 new + 9 existing)
- `swift build -c release` → clean
- `swift build -c debug` → clean
- Codex round 1 findings addressed

## Known risks

- **Cross-suite pasteboard race.** `PasteServiceClipboardTests` (`.serialized` itself) and my suite both mutate `NSPasteboard.general`. Swift Testing serializes within each suite but can run different `.serialized` suites in parallel. Each test uses a UUID sentinel so collision is improbable. If CI flake appears, the fix is a shared cross-suite lock (or a single combined suite); both can be deferred.
- **Not literally E2E.** Python `wispr_eyes` would add Settings UI gating + real dictation + cross-process pasteboard visibility. Swift integration covers the code path; #726 can accept this as the resolution OR keep the Python test as a follow-up.

## Test plan

- [x] Build + tests pass
- [x] Codex round 1 findings addressed
- [ ] Optional follow-up: Python `wispr_eyes.test_clipboard_settings(...)` for the visual / Settings-UI / cross-process layer
