### PR TITLE
feat(onboarding): require Accessibility before GET STARTED (#735)

### DIFF
--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -29,7 +29,6 @@ final class OnboardingV2ViewModel {
 
   var micGranted = false
   var accessibilityGranted = false
-  var showSkipLink = false
 
   var downloadError: String?
   /// Raw error details for support diagnostics (hidden behind "Copy error details" button).
@@ -679,12 +678,59 @@ private struct PermissionsPhaseView: View {
           isGranted: viewModel.accessibilityGranted,
           onGrant: { viewModel.openAccessibilitySettings(permissions: appState.permissions) }
         )
+
+        // #735: trust-builder banner. "Accessibility" is the scariest-sounding
+        // permission on macOS for non-technical users — same flag a keylogger
+        // would request. Defuse the fear by saying exactly what we use it for
+        // and exactly what we don't. Shown only while AX is ungranted; vanishes
+        // the moment the user grants it.
+        if !viewModel.accessibilityGranted {
+          VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+              Image(systemName: "exclamationmark.shield.fill")
+                .foregroundStyle(Color.obWarning)
+                .font(.system(size: 16, weight: .semibold))
+              VStack(alignment: .leading, spacing: 6) {
+                Text("Required to paste your dictation")
+                  .font(.obLabel)
+                  .foregroundStyle(Color.obTextPrimary)
+                Text(
+                  "macOS calls this permission \"Accessibility,\" but EnviousWispr uses it for exactly one thing: pasting your transcript into the app you're typing in. Without it, every dictation lands in the clipboard and you'd have to paste manually."
+                )
+                .font(.obCaption)
+                .foregroundStyle(Color.obTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                Text(
+                  "We only use Accessibility at the moment we paste your transcript. Never to read your keystrokes, never to watch what happens in other apps."
+                )
+                .font(.obCaption)
+                .foregroundStyle(Color.obTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+              }
+            }
+          }
+          .padding(14)
+          .background(Color.obWarning.opacity(0.10), in: RoundedRectangle(cornerRadius: 12))
+          .overlay(
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(Color.obWarning.opacity(0.25), lineWidth: 1)
+          )
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
       }
       .padding(.bottom, 20)
+      .animation(.easeInOut(duration: 0.30), value: viewModel.accessibilityGranted)
 
       Spacer()
 
+      // #735: gate Continue on BOTH mic AND accessibility. PostHog (60d prod)
+      // showed 17% of completers (3 of 18) denied accessibility, pressed past,
+      // and never dictated again — auto-paste fails silently without AX. The
+      // "Skip for now" backdoor and the no-AX-required Continue both fed that
+      // silent-failure population. Gate the user here, never on the Ready
+      // screen — by then they've committed to a hotkey.
       VStack(spacing: 8) {
+        let bothGranted = viewModel.micGranted && viewModel.accessibilityGranted
         Button {
           viewModel.currentScreen = .ready
         } label: {
@@ -694,22 +740,12 @@ private struct PermissionsPhaseView: View {
             .frame(maxWidth: 360)
             .padding(.vertical, 13)
             .background(
-              viewModel.micGranted ? Color.obTextPrimary : Color.obTextPrimary.opacity(0.4),
+              bothGranted ? Color.obTextPrimary : Color.obTextPrimary.opacity(0.4),
               in: RoundedRectangle(cornerRadius: 12)
             )
         }
         .buttonStyle(.plain)
-        .disabled(!viewModel.micGranted)
-
-        if viewModel.showSkipLink && !viewModel.accessibilityGranted {
-          Button("Skip for now") {
-            viewModel.currentScreen = .ready
-          }
-          .font(.obCaption)
-          .foregroundStyle(Color.obTextTertiary)
-          .buttonStyle(.plain)
-          .transition(.opacity)
-        }
+        .disabled(!bothGranted)
       }
     }
     .onAppear {
@@ -724,7 +760,7 @@ private struct PermissionsPhaseView: View {
   }
 
   /// Polls both mic and accessibility status every 2 seconds.
-  /// Shows "Skip for now" link after 10 seconds if accessibility not granted.
+  /// Continue gates on BOTH grants (#735) — no Skip backdoor.
   /// Auto-cancelled when the view disappears via .task modifier.
   private func pollPermissions() async {
     var elapsed = 0
@@ -746,10 +782,9 @@ private struct PermissionsPhaseView: View {
         viewModel.micGranted = true
         TelemetryService.shared.onboardingStepCompleted(step: "mic_permission", result: "granted")
       }
-
-      if elapsed >= 10 && !viewModel.showSkipLink {
-        withAnimation { viewModel.showSkipLink = true }
-      }
+      // #735: showSkipLink no longer used (Skip-for-now backdoor removed); `elapsed` retained
+      // so future telemetry can re-attach a "time-on-permissions-screen" event if needed.
+      _ = elapsed
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #735.

PostHog (60d production) showed **17% of completers (3 of 18) denied Accessibility, pressed past anyway, tried to dictate once, saw nothing happen** (auto-paste silently fails without AX), and never came back. This PR stops that drop-off at the source by gating the Continue button on the Permissions screen on BOTH mic AND Accessibility.

## Design (revised after founder live-UAT on 2026-05-16)

The original Round-1 PR gated GET STARTED on the Ready screen. Founder walkthrough rejected that placement: by the Ready screen the user has already committed to a hotkey, and being told "one more thing" lands worse than not being allowed to advance from the permissions screen in the first place. Rewired to gate at the right step.

**Final shape:**

1. **Gate at the Permissions screen.** Continue is now disabled until BOTH mic AND Accessibility are granted (was: mic only).
2. **"Skip for now" backdoor removed.** This 10-second-delayed link was the primary feeder of the silent-failure population. Gone.
3. **Yellow trust banner under the Accessibility row** when ungranted. "Accessibility" is the scariest-sounding macOS permission for non-technical users (same flag a keylogger would request). Banner defuses the fear with what's actually true: macOS calls it "Accessibility," EW uses it only at the moment we paste, never for keystrokes or other apps.
4. **Ready screen unchanged.** Original Pro-Tip callout retained from prior code. No polling there — user can't reach Ready without AX granted.

## Trust-banner copy

> ⚠️  **Required to paste your dictation**
>
> macOS calls this permission "Accessibility," but EnviousWispr uses it for exactly one thing: pasting your transcript into the app you're typing in. Without it, every dictation lands in the clipboard and you'd have to paste manually.
>
> We only use Accessibility at the moment we paste your transcript. Never to read your keystrokes, never to watch what happens in other apps.

The second sentence was Codex Round 2's catch — prior draft said "never run in the background when you're not dictating" which was literally false (EW is an `LSUIElement` menu-bar agent listening for the global hotkey at all times). Hotkey listening uses Carbon `RegisterEventHotKey` + `NSEvent flagsChanged` monitors, neither of which require AX. AX is invoked only at the paste step.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled (no comments). PostHog data in issue body. Cross-referenced #733 (Right-Option PTT default) — both depend on AX.

**Lane: Code.** \`Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift\`. Full workflow process required.

**Codex grounded reviews — three rounds.**
- Round 1 (original Ready-screen design): Greenlight. But founder live-UAT rejected the placement.
- Round 2 (rewired Permissions-screen design + trust banner): P2 — banner's "never run in the background" claim contradicted EW's actual menu-bar-agent behavior.
- Round 3 (corrected copy): Greenlight. *"No actionable regression. Gating and trust banner consistent with intended AX-required behavior."*

**Live UAT (founder, 2026-05-16).**
- Revoked AX for "EnviousWispr Local" (dev bundle) → Permissions row flipped to ungranted within ~2s → Continue dimmed to 40% opacity and became unresponsive → yellow trust banner appeared below the row → copy approved on visual review.
- Re-granted AX → Continue brightened and became clickable → banner faded out.

## Validation

- \`swift build -c release\` → clean
- \`swift build -c debug\` → clean
- Codex Round 3 → Greenlight
- Founder visual + behavioral live UAT → approved

## Known follow-up

- **Trust-builder animation** (short looping video walking through the macOS grant flow) — separate issue (#735-follow-up TBD). Founder agreed to ship the gate + banner now, animation later.
