### PR TITLE
feat(telemetry): surface recording duration on XPC interrupt/invalidate (#455)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -310,12 +310,20 @@ final class AppState {
         }
       }()
       let wasCapturing = ctx.kind != .invalidateIdle
+      // #455: surface recording_duration_ms when the interrupt/invalidate
+      // fired during active capture, so triage can separate "fired
+      // immediately after start" (likely device-binding race) from "fired
+      // mid-dictation" (likely launchd kill under memory pressure or
+      // system event).
+      let recordingDurationMs: Any =
+        ctx.recordingDurationNs.map { Int($0 / 1_000_000) } ?? NSNull()
       let extras: [String: Any] = [
         "xpc.handler": handlerKind.rawValue,
         "xpc.was_capturing": wasCapturing,
         "xpc.kind": ctx.kind.rawValue,
         "capture_session_id": ctx.sessionID.map { Int($0) } ?? NSNull(),
         "capture.route": self.audioCapture.currentAudioRoute,
+        "audio.recording_duration_ms": recordingDurationMs,
       ]
       SentryBreadcrumb.captureError(
         HeartPathError.audioXPCInterrupted(

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -86,6 +86,13 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// Set in beginCapturePhase, compared in audioBufferCaptured.
   private var activeCaptureGeneration: UInt64 = 0
 
+  /// #455: uptime-ns at the moment `beginCapturePhase` flipped `isCapturing`
+  /// to true. Read in the XPC interrupt/invalidate handlers to surface
+  /// `recording_duration_ms` in the captureError breadcrumb. Reset to 0 on
+  /// every clean stop / interrupt / invalidate so a stale value cannot bleed
+  /// into the next session.
+  private var captureStartUptimeNs: UInt64 = 0
+
   // MARK: - Capture-liveness watchdog (issue #285)
 
   /// Private serial queue that fires the stall `DispatchWorkItem`.
@@ -187,6 +194,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
 
     isCapturing = true
+    captureStartUptimeNs = DispatchTime.now().uptimeNanoseconds  // #455
     hasReceivedBufferThisSession = false
     armCaptureStallWatchdog()
     return stream
@@ -291,6 +299,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
 
     isCapturing = false
+    captureStartUptimeNs = 0  // #455
     audioLevel = 0
     bufferContinuation?.finish()
     bufferContinuation = nil
@@ -511,7 +520,14 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           proxy.stallWorkItem?.cancel()
           proxy.stallWorkItem = nil
           let endingSession = proxy.activeCaptureGeneration
+          // #455: compute duration BEFORE flipping isCapturing / resetting
+          // captureStartUptimeNs so the breadcrumb has a real number.
+          let firedAt = DispatchTime.now().uptimeNanoseconds
+          let durationNs: UInt64? =
+            proxy.captureStartUptimeNs > 0 && firedAt >= proxy.captureStartUptimeNs
+            ? (firedAt - proxy.captureStartUptimeNs) : nil
           proxy.isCapturing = false
+          proxy.captureStartUptimeNs = 0  // #455
           proxy.audioLevel = 0
           proxy.captureGeneration &+= 1
           proxy.bufferContinuation?.finish()
@@ -522,7 +538,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
             XPCErrorContext(
               kind: .interruptCapturing,
               sessionID: endingSession,
-              timestampNs: DispatchTime.now().uptimeNanoseconds
+              timestampNs: firedAt,
+              recordingDurationNs: durationNs
             )
           )
         }
@@ -543,10 +560,19 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         proxy.connection = nil
         let wasCapturing = proxy.isCapturing
         let endingSession = proxy.activeCaptureGeneration
+        // #455: compute duration BEFORE flipping isCapturing / resetting
+        // captureStartUptimeNs so the breadcrumb has a real number. Idle
+        // invalidations have no active session and so no duration to report.
+        let firedAt = DispatchTime.now().uptimeNanoseconds
+        let durationNs: UInt64? =
+          wasCapturing && proxy.captureStartUptimeNs > 0
+            && firedAt >= proxy.captureStartUptimeNs
+          ? (firedAt - proxy.captureStartUptimeNs) : nil
         if wasCapturing {
           proxy.stallWorkItem?.cancel()
           proxy.stallWorkItem = nil
           proxy.isCapturing = false
+          proxy.captureStartUptimeNs = 0  // #455
           proxy.audioLevel = 0
           proxy.captureGeneration &+= 1
           proxy.bufferContinuation?.finish()
@@ -559,7 +585,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           XPCErrorContext(
             kind: wasCapturing ? .invalidateCapturing : .invalidateIdle,
             sessionID: wasCapturing ? endingSession : nil,
-            timestampNs: DispatchTime.now().uptimeNanoseconds
+            timestampNs: firedAt,
+            recordingDurationNs: durationNs
           )
         )
       }
@@ -751,6 +778,7 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         self.stallWorkItem?.cancel()
         self.stallWorkItem = nil
         self.isCapturing = false
+        self.captureStartUptimeNs = 0  // #455
         self.audioLevel = 0
         self.captureGeneration &+= 1
         self.bufferContinuation?.finish()

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -125,10 +125,24 @@ public struct XPCErrorContext: Sendable {
   public let kind: XPCErrorKind
   public let sessionID: UInt64?
   public let timestampNs: UInt64
+  /// #455: when the interrupt/invalidate fired while a capture session was
+  /// active, this is `timestampNs - capture-start-uptime-ns`. Nil for idle
+  /// interrupts. Surfaces in the Sentry breadcrumb as
+  /// `audio.recording_duration_ms` so triage can distinguish "fired
+  /// immediately after start" (likely device binding race) from "fired
+  /// mid-dictation" (likely launchd kill under memory pressure or system
+  /// event).
+  public let recordingDurationNs: UInt64?
 
-  public init(kind: XPCErrorKind, sessionID: UInt64?, timestampNs: UInt64) {
+  public init(
+    kind: XPCErrorKind,
+    sessionID: UInt64?,
+    timestampNs: UInt64,
+    recordingDurationNs: UInt64? = nil
+  ) {
     self.kind = kind
     self.sessionID = sessionID
     self.timestampNs = timestampNs
+    self.recordingDurationNs = recordingDurationNs
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/XPCErrorContextRecordingDurationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/XPCErrorContextRecordingDurationTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import EnviousWisprCore
+
+/// #455 — verifies the `recordingDurationNs` field added to `XPCErrorContext`
+/// surfaces correctly for the three call sites in `AudioCaptureProxy`:
+/// interrupt-during-capture, invalidate-during-capture, and invalidate-idle.
+///
+/// The proxy itself is not directly testable in isolation (the XPC handlers
+/// run inside its private static factory functions), so this asserts the
+/// CONTRACT — the struct preserves the field and defaults to nil. Together
+/// with the AppState breadcrumb wiring tests, this guards the diagnostic path
+/// from `Recording started → ...ms → XPC interrupt` to Sentry.
+@Suite("XPCErrorContext recordingDurationNs (#455)")
+struct XPCErrorContextRecordingDurationTests {
+
+  @Test("default init omits recordingDurationNs (back-compat for idle invalidate)")
+  func defaultInitOmitsField() {
+    let ctx = XPCErrorContext(
+      kind: .invalidateIdle, sessionID: nil, timestampNs: 100)
+    #expect(ctx.recordingDurationNs == nil)
+  }
+
+  @Test("explicit nil recordingDurationNs is preserved")
+  func explicitNilIsPreserved() {
+    let ctx = XPCErrorContext(
+      kind: .invalidateIdle, sessionID: nil, timestampNs: 100,
+      recordingDurationNs: nil)
+    #expect(ctx.recordingDurationNs == nil)
+  }
+
+  @Test("explicit value is preserved for interruptCapturing")
+  func valuePreservedForInterruptCapturing() {
+    let ctx = XPCErrorContext(
+      kind: .interruptCapturing, sessionID: 42, timestampNs: 2_000_000_000,
+      recordingDurationNs: 1_500_000_000)
+    #expect(ctx.kind == .interruptCapturing)
+    #expect(ctx.recordingDurationNs == 1_500_000_000)
+  }
+
+  @Test("explicit value is preserved for invalidateCapturing")
+  func valuePreservedForInvalidateCapturing() {
+    let ctx = XPCErrorContext(
+      kind: .invalidateCapturing, sessionID: 7, timestampNs: 500_000_000,
+      recordingDurationNs: 250_000_000)
+    #expect(ctx.kind == .invalidateCapturing)
+    #expect(ctx.recordingDurationNs == 250_000_000)
+  }
+
+  /// Demonstrates the duration conversion that AppState.onXPCServiceError
+  /// uses to populate the `audio.recording_duration_ms` breadcrumb extra.
+  /// This isn't AppState itself but documents the exact math; if AppState's
+  /// conversion drifts, this test still passes — making the drift visible at
+  /// review time, where the Sentry breadcrumb field name has to match.
+  @Test("nanosecond → millisecond conversion shape used by the breadcrumb")
+  func nsToMsConversion() {
+    let ctx = XPCErrorContext(
+      kind: .interruptCapturing, sessionID: 1, timestampNs: 1_000_000_000,
+      recordingDurationNs: 1_500_000_000)
+    let ms = ctx.recordingDurationNs.map { Int($0 / 1_000_000) }
+    #expect(ms == 1500)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #455 (diagnostic enrichment — not the recovery fix the audit also calls for).

The existing XPC interrupt/invalidate breadcrumb captures handler kind, was_capturing, capture session ID, and route. What it cannot tell you: how long the recording had been running before the XPC handler fired. That signal splits the failure into two very different fix paths:

- **Fired immediately after start** → device-binding race (related to #701's `input_device_divergence` cluster).
- **Fired mid-dictation** → launchd kill under memory pressure or system event.

Same `captureError`, different root cause, different fix.

## Workflow process proof

**Gate 0 — Prior context.** Issue fetched with comments enabled. Issue was closed-then-reopened (closed prematurely 2026-05-02 on stale data, reopened 2026-05-02 after Sentry recheck showed fingerprint ENVIOUSWISPR-N still hitting v1.9.4). Reopen note explicitly says "if count grows, the v1.9.x XPC retry/fallback path may need hardening" — this PR is the prerequisite telemetry to triage that grow, not the recovery work itself.

**Lane: Code.** Audio danger zone per `.claude/rules/architecture-rules.md`. Diagnostic-only, no behavior change. Full workflow process required.

**Council skip rationale.** `council-skip: codex-grounded-review settled the only structural fork (store start timestamp on proxy vs reconstruct from sessionID-keyed history). No new user surface, no recovery behavior change, no architectural shift — pure additive telemetry field with default-nil back-compat.` Per `.claude/rules/workflow-process.md §1` narrow exception.

**Codex grounded review.** One round, Greenlight with one low finding addressed:
- Low: `engineInterrupted()` ended capture but didn't clear `captureStartUptimeNs`. Pipeline cleanup later called `stopCapture()` which cleared it, so not a blocker — but I cleared it in `engineInterrupted()` too so the invariant is true everywhere.
- Confirmed no breadcrumb-key collision (`audio.recording_duration_ms` is new).
- Confirmed no required constructor updates (default-nil init).

## Implementation

- `Sources/EnviousWisprCore/CaptureStallContext.swift` — added optional `recordingDurationNs: UInt64?` to `XPCErrorContext`. Default-nil init preserves back-compat.
- `Sources/EnviousWisprAudio/AudioCaptureProxy.swift`:
  - New private `captureStartUptimeNs: UInt64 = 0`, set in `beginCapturePhase` right after `isCapturing = true`.
  - Cleared in `stopCapture` (clean stop), `engineInterrupted()`, `makeInterruptionHandler`, `makeInvalidationHandler`.
  - Interrupt/invalidate handlers compute `firedAt - captureStartUptimeNs` BEFORE flipping `isCapturing` / resetting `captureStartUptimeNs`. Guarded with `captureStartUptimeNs > 0 && firedAt >= captureStartUptimeNs` so a stale or backwards value falls to nil.
- `Sources/EnviousWispr/App/AppState.swift` — `onXPCServiceError` breadcrumb extras now include `audio.recording_duration_ms` (Int milliseconds when present, NSNull for idle invalidate).
- `Tests/EnviousWisprTests/Pipeline/XPCErrorContextRecordingDurationTests.swift` — 5 tests for the struct contract: default-init omits the field, explicit nil preserved, value preserved for both `interruptCapturing` and `invalidateCapturing`, ns→ms conversion shape matches the AppState math.

## Validation

- `scripts/swift-test.sh --filter XPCErrorContextRecordingDuration` → 5 tests pass
- `swift build -c release` → clean
- `swift build -c debug` → clean
- Codex round 1 finding (engineInterrupted cleanup) addressed

## Known risks

- **Audio danger zone.** Per `architecture-rules.md`, audio changes optimize for stability, blast-radius reduction, rollback clarity, and measured impact. This PR's blast radius: zero behavior change (diagnostic-only), one new property on a Sendable struct, one new state field on a single proxy, one new breadcrumb extras key. Rollback is a single revert.
- **No proxy wiring test.** The interrupt/invalidate handlers are inside private static factories; their wiring isn't directly testable in isolation. The struct/contract tests guard the field shape; Codex grounded review verified the proxy wiring. A future fake-XPC fixture (paired with #586's polling regression test infrastructure) could close this gap.
- **Diagnostic-only — does not fix the underlying interruption.** The issue's larger ask ("graceful re-init on XPC-interrupted vs current abort-and-surface") is medium-tier audio recovery work and remains deferred until more volume justifies that rebuild path. This PR is the prerequisite to make that volume measurable.

## Test plan

- [x] Unit tests pass
- [x] Release + debug builds clean
- [x] Codex round 1 finding addressed
- [ ] Post-merge: confirm Sentry breadcrumbs on the next ENVIOUSWISPR-N event include `audio.recording_duration_ms` with a sensible millisecond value
