### PR TITLE
chore(content): canonicalize IndexNow key in submit script

### DIFF
--- a/website/scripts/indexnow-submit.sh
+++ b/website/scripts/indexnow-submit.sh
@@ -10,9 +10,16 @@
 
 set -euo pipefail
 HOST="enviouswispr.com"
-KEY="92397c9600e144958cb267c661aedfab"
+# Canonical key per .claude/knowledge/seo-operations.md.
+# Older keys (92397c9..., 3e345c..., cfdd789a...) remain live in website/public/
+# and stay valid under the IndexNow protocol, but new manual pings and tooling
+# should standardize on the key below to match the recipe in the knowledge file.
+KEY="6fc34b01458140c49f7781aea4ada3bf"
 KEY_LOCATION="https://${HOST}/${KEY}.txt"
-ENDPOINT="https://api.indexnow.org/IndexNow"
+# Lowercase endpoint path is what api.indexnow.org documents and what Bing's
+# IndexNow tab attributes to "Self" submissions. The previous mixed-case form
+# also works but matches no public example.
+ENDPOINT="https://api.indexnow.org/indexnow"
 
 submit_one() {
   local url="$1"


### PR DESCRIPTION
## Summary
- Update `website/scripts/indexnow-submit.sh` key value from `92397c9...` to `6fc34b01...` to match the canonical key documented in `.claude/knowledge/seo-operations.md`. Eliminates split attribution between script-driven and curl-recipe-driven pings.
- Lowercase the endpoint path (`/IndexNow` → `/indexnow`) to match api.indexnow.org docs and Bing's `Source: Self` attribution behavior.

Closes #532. Older key files (`92397c9...`, `3e345c...`, `cfdd789a...`) stay live in `website/public/` — IndexNow allows multiple keys per host; deletion risks breaking cached Bing trust.

## Test plan
- [x] `bash website/scripts/indexnow-submit.sh https://enviouswispr.com/blog/welcome-to-enviouswispr/` returns `200`
- [x] Submission appears in Bing Webmaster Tools IndexNow tab as `Source: Self`
- [x] Bing dashboard now shows 43 URLs discovered after 2026-05-16 leaf sitemap submission
