### PR TITLE
refactor(navigation): extract NavigationCoordinator from AppState (#765)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -39,6 +39,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// Shared app state — created here so it's available before any SwiftUI scene loads.
   let appState = AppState()
 
+  /// Owns the "open this settings tab next" handoff for menu actions and in-app shortcuts.
+  let navigationCoordinator = NavigationCoordinator()
+
   /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
   var openMainWindowAction: (() -> Void)?
 
@@ -519,12 +522,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   @objc private func openSettings() {
-    appState.pendingNavigationSection = .speechEngine
+    navigationCoordinator.request(.speechEngine)
     showWindow()
   }
 
   @objc private func openPermissionsSettings() {
-    appState.pendingNavigationSection = .permissions
+    navigationCoordinator.request(.permissions)
     showWindow()
   }
 

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -93,7 +93,6 @@ final class AppState {
 
   // Transcript history — delegated to coordinator
   let transcriptCoordinator: TranscriptCoordinator
-  var pendingNavigationSection: SettingsSection?
 
   /// True when recording is in hands-free (locked) mode via double-press.
   /// Read by the overlay to switch to the expanded lips visual.

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -20,6 +20,7 @@ struct EnviousWisprApp: App {
       UnifiedWindowView()
         .frame(minWidth: 580, minHeight: 400)
         .environment(appDelegate.appState)
+        .environment(appDelegate.navigationCoordinator)
         .environment(appDelegate.updateCoordinatorHolder)
         .background(
           ActionWirer(
@@ -36,6 +37,7 @@ struct EnviousWisprApp: App {
         appDelegate.closeOnboardingWindow()
       })
       .environment(appDelegate.appState)
+      .environment(appDelegate.navigationCoordinator)
     }
     .windowResizability(.contentSize)
     .defaultSize(width: 500, height: 550)

--- a/Sources/EnviousWispr/App/NavigationCoordinator.swift
+++ b/Sources/EnviousWispr/App/NavigationCoordinator.swift
@@ -1,0 +1,18 @@
+import Observation
+
+/// Owns the "open this settings tab next" signal that menu actions and
+/// in-app shortcuts hand off to the sidebar. Extracted from AppState per
+/// epic #763 (PR2, issue #765).
+@MainActor
+@Observable
+final class NavigationCoordinator {
+  private(set) var pendingSection: SettingsSection?
+
+  func request(_ section: SettingsSection) {
+    pendingSection = section
+  }
+
+  func consume() {
+    pendingSection = nil
+  }
+}

--- a/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
+++ b/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// Permissions settings tab and a "Dismiss" button to hide it for the session.
 struct AccessibilityWarningBanner: View {
   @Environment(AppState.self) private var appState
+  @Environment(NavigationCoordinator.self) private var navigationCoordinator
 
   var body: some View {
     HStack(spacing: 10) {
@@ -20,7 +21,7 @@ struct AccessibilityWarningBanner: View {
       Spacer()
 
       Button("Fix Now") {
-        appState.pendingNavigationSection = .permissions
+        navigationCoordinator.request(.permissions)
       }
       .buttonStyle(.borderedProminent)
       .tint(.orange)

--- a/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct TranscriptDetailView: View {
   let transcript: Transcript
   @Environment(AppState.self) private var appState
+  @Environment(NavigationCoordinator.self) private var navigationCoordinator
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -28,7 +29,7 @@ struct TranscriptDetailView: View {
               PasteService.simulatePaste()
             }
           } else {
-            appState.pendingNavigationSection = .permissions
+            navigationCoordinator.request(.permissions)
           }
         } label: {
           Label("Paste", systemImage: "arrow.right.doc.on.clipboard")

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Unified single-window view: History + all settings tabs in one sidebar.
 struct UnifiedWindowView: View {
   @Environment(AppState.self) private var appState
+  @Environment(NavigationCoordinator.self) private var navigationCoordinator
   @Environment(UpdateCoordinatorHolder.self) private var updateCoordinatorHolder
   @State private var selectedSection: SettingsSection = .history
 
@@ -59,10 +60,10 @@ struct UnifiedWindowView: View {
       }
     }
     .preferredColorScheme(.light)
-    .onChange(of: appState.pendingNavigationSection) { _, newSection in
+    .onChange(of: navigationCoordinator.pendingSection) { _, newSection in
       if let section = newSection {
         selectedSection = section
-        appState.pendingNavigationSection = nil
+        navigationCoordinator.consume()
       }
     }
   }

--- a/Tests/EnviousWisprTests/App/NavigationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/NavigationCoordinatorTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import EnviousWispr
+
+/// Issue #765 (PR2 of epic #763) — pins the `NavigationCoordinator` contract
+/// that was extracted from `AppState.pendingNavigationSection`.
+@MainActor
+@Suite("NavigationCoordinator — pending settings tab handoff")
+struct NavigationCoordinatorTests {
+
+  @Test("initial pending section is nil")
+  func initialPendingSectionIsNil() {
+    let coordinator = NavigationCoordinator()
+    #expect(coordinator.pendingSection == nil)
+  }
+
+  @Test("request sets pending section")
+  func requestSetsPendingSection() {
+    let coordinator = NavigationCoordinator()
+    coordinator.request(.permissions)
+    #expect(coordinator.pendingSection == .permissions)
+  }
+
+  @Test("consume clears pending section")
+  func consumeClearsPending() {
+    let coordinator = NavigationCoordinator()
+    coordinator.request(.speechEngine)
+    coordinator.consume()
+    #expect(coordinator.pendingSection == nil)
+  }
+
+  @Test("request replaces a prior unconsumed value")
+  func requestReplacesPriorUnconsumed() {
+    let coordinator = NavigationCoordinator()
+    coordinator.request(.speechEngine)
+    coordinator.request(.permissions)
+    #expect(coordinator.pendingSection == .permissions)
+  }
+
+  @Test("consume when nil is a no-op")
+  func consumeWhenNilIsNoop() {
+    let coordinator = NavigationCoordinator()
+    coordinator.consume()
+    #expect(coordinator.pendingSection == nil)
+  }
+}


### PR DESCRIPTION
## Summary

PR2 of epic #763 (AppState deletion migration). Closes #765.

Moves `pendingNavigationSection` off the AppState god object into a small `@MainActor @Observable` class owned by AppDelegate and injected into both Window scenes via SwiftUI environment. Pure UI plumbing refactor.

- New: `Sources/EnviousWispr/App/NavigationCoordinator.swift` (request / consume API, `private(set) var pendingSection`)
- Removed: `var pendingNavigationSection: SettingsSection?` from `AppState.swift:96`
- Rewired 5 call sites: AppDelegate menu actions (×2), UnifiedWindowView observer, AccessibilityWarningBanner "Fix Now", TranscriptDetailView paste-fallback
- Wired into both Window scenes (main + onboarding) via `.environment(appDelegate.navigationCoordinator)`
- 5 new unit tests for the coordinator contract

No user-visible behavior change. No telemetry, no persistence, no shim. AppState collaborator count unchanged (`pendingNavigationSection` was a `var`, doesn't count against the `let`-only ceiling regex).

## Validation

- 838 unit tests pass (`scripts/swift-test.sh`)
- Codex code-diff review against `origin/main`: no actionable issues
- Codex grounded review of plan: YES_WITH_REVISIONS (both applied)
- Release build clean
- Founder UAT (debug build): menu → Transcription, menu → Permissions, "Fix Now" → Permissions, paste-fallback → Permissions, sidebar selection all behave normally

## Ship criteria (greps)

- `grep -rn "pendingNavigationSection" Sources Tests` → only doc-comment reference in NavigationCoordinatorTests.swift
- `grep -nE '\.environment\(appDelegate\.navigationCoordinator\)' Sources/EnviousWispr/App/EnviousWisprApp.swift` → 2 lines (both Window scenes)
- `grep -rnE '@Environment\(NavigationCoordinator\.self\)' Sources/EnviousWispr/Views Sources/EnviousWispr/App` → 3 consumer hits

## Test plan

- [x] Unit tests green
- [x] Release build green
- [x] Codex code-diff review clean
- [x] Founder UAT navigation flows pass
- [ ] CI `build-check` green
- [ ] Post-merge main green
