### PR TITLE
refactor(app): install App-struct composition root (PR-A of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -27,79 +27,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem?
   private(set) var updaterController: SPUStandardUpdaterController?
   private(set) var updateCoordinator: UpdateCoordinator?
-  /// Issue #739: stable env-carrier — non-optional `@Observable` holder
-  /// whose `coordinator` property is set once the AppDelegate finishes init.
-  /// SwiftUI captures THIS instance in env; the inner coordinator flip
-  /// (nil → non-nil) triggers re-evaluation of dependent views.
-  let updateCoordinatorHolder = UpdateCoordinatorHolder()
   private let iconAnimator = MenuBarIconAnimator()
   private weak var mainWindow: NSWindow?
   private var windowCloseObserver: (any NSObjectProtocol)?
 
-  /// Shared app state — created here so it's available before any SwiftUI scene loads.
-  let appState = AppState()
+  // PR-A of #763: App-owned homes. `EnviousWisprApp` owns these as `@State`
+  // and pushes them into AppDelegate via `attach(...)` synchronously during
+  // `EnviousWisprApp.init()`, before any `NSApplicationDelegate` callback
+  // fires. Weak refs so AppDelegate is not a retention root.
+  private weak var appState: AppState?
+  private weak var navigationCoordinator: NavigationCoordinator?
+  /// Issue #739: stable env-carrier — non-optional `@Observable` holder
+  /// owned by `EnviousWisprApp` as `@State`. AppDelegate publishes its
+  /// Sparkle-derived `updateCoordinator` into the holder once Sparkle is
+  /// initialized; `@Observable` flips dependent views.
+  private weak var updateCoordinatorHolder: UpdateCoordinatorHolder?
 
-  /// Owns the "open this settings tab next" handoff for menu actions and in-app shortcuts.
-  let navigationCoordinator = NavigationCoordinator()
-
-  /// Owns the diagnostics-tab benchmark surface (Settings → Diagnostics).
-  let diagnosticsCoordinator = DiagnosticsCoordinator()
-
-  /// PR4 of #763 (#252 fold-in): owns the passive language-detection chip
-  /// lifecycle. Initialized in `init()` (must run after `appState` is constructed
-  /// so the presenter can capture `appState.recordingOverlay` in its narrow
-  /// closures). Setter-injected onto `appState` post-super-init so AppState's
-  /// chip-handler closure and pipeline state-change closures can dispatch to it.
-  /// Views inject directly via `@Environment(LanguageSuggestionPresenter.self)`.
-  /// Per swift-patterns.md SwiftUI env rule: non-optional `let` ensures SwiftUI
-  /// captures a non-nil instance at App-body eval time (no holder pattern needed).
-  let languageSuggestionPresenter: LanguageSuggestionPresenter
-
-  override init() {
-    // `appState` was already initialized via its declaration default (Swift
-    // initializes stored properties with defaults BEFORE the init body runs),
-    // so `appState.recordingOverlay` is accessible here.
-    let overlay = appState.recordingOverlay
-    self.languageSuggestionPresenter = LanguageSuggestionPresenter(
-      showOverlay: { [weak overlay] intent in overlay?.show(intent: intent) },
-      readCurrentIntent: { [weak overlay] in overlay?.currentIntent ?? .hidden },
-      // Silent hide for chip dismissal — bypasses the .hidden case's
-      // "Recording complete" AX announcement (Codex code-diff r5 [P3]).
-      hideOverlay: { [weak overlay] in overlay?.hide() }
-    )
-    super.init()
-    // Setter injection: appState now holds a reference to the presenter for
-    // dispatching from its chip-handler closure and pipeline state-change closures.
-    appState.attachLanguageSuggestionPresenter(languageSuggestionPresenter)
-    // Wire RecordingOverlayPanel chip handler closures into the presenter.
-    // PR9/PR10 absorb these along with the rest of AppState's chip dispatching.
-    appState.recordingOverlay.setPassiveChipHandlers(
-      onLock: { [weak appState, presenter = languageSuggestionPresenter] in
-        if let lang = presenter.accept(), let appState = appState {
-          // Capture prior mode for telemetry before mutating settings.
-          let priorMode = appState.settings.languageMode
-          let fromLang: String
-          switch priorMode {
-          case .auto: fromLang = "auto"
-          case .locked(let prev): fromLang = prev
-          }
-          appState.settings.languageMode = .locked(lang)
-          // Codex code-diff r6 [P2]: chip-driven locks must emit the same
-          // language.manual_lock_used event as Settings-driven locks so the
-          // chip CTA is visible in analytics. "after_bad_detect" is the
-          // reserved reason for this surface (TelemetryService.swift:483).
-          TelemetryService.shared.trackManualLockUsed(
-            fromLang: fromLang, toLang: lang, reason: "after_bad_detect")
-        }
-        // presenter.accept() already hid the overlay; no extra hide needed.
-      },
-      onDismiss: { [presenter = languageSuggestionPresenter] in
-        presenter.dismissExplicit()
-      },
-      onAutoDismiss: { [presenter = languageSuggestionPresenter] generation in
-        presenter.autoDismiss(generation: generation)
-      }
-    )
+  /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
+  /// before delegate callbacks fire. If `updateCoordinator` is already
+  /// initialized (Sparkle came up before attach — defensive only, not a real
+  /// path), replay it into the holder immediately.
+  func attach(
+    appState: AppState,
+    navigationCoordinator: NavigationCoordinator,
+    updateCoordinatorHolder: UpdateCoordinatorHolder
+  ) {
+    self.appState = appState
+    self.navigationCoordinator = navigationCoordinator
+    self.updateCoordinatorHolder = updateCoordinatorHolder
+    if let existing = self.updateCoordinator {
+      updateCoordinatorHolder.coordinator = existing
+    }
   }
 
   /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
@@ -143,17 +101,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       userDriverDelegate: self
     )
     updateCoordinator = UpdateCoordinator(updaterController: updaterController)
-    // Issue #739: publish the coordinator into the @Observable holder so any
-    // SwiftUI view bound to the holder's env value sees the flip from nil to
-    // non-nil and re-renders. The holder itself is created inline as a stable
-    // stored property, so SwiftUI's first env capture is non-nil.
-    updateCoordinatorHolder.coordinator = updateCoordinator
+    // Issue #739 / PR-A: publish the coordinator into the App-owned holder
+    // so SwiftUI views bound to its env value see the flip from nil → non-nil
+    // and re-render. The holder itself is a stable `@State` on
+    // `EnviousWisprApp`, attached to AppDelegate via `attach(...)` during
+    // App.init() — before this delegate callback fires.
+    updateCoordinatorHolder?.coordinator = updateCoordinator
     // Cross-launch correlation runs here (was in didFinishLaunching) so the
     // attribution event fires before any UI is shown.
     evaluateUpdateInstallAttemptOnLaunch()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    // PR-A: appState is App-owned; we hold a weak ref attached during
+    // EnviousWisprApp.init() (before any delegate callback fires).
+    guard let appState = self.appState else { return }
     // Hide dock icon on launch — we're a menu bar utility.
     // If onboarding is needed, stay .regular so SwiftUI creates the main window hierarchy
     // and ActionWirer can wire callbacks before opening the onboarding window.
@@ -297,7 +259,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           parakeetPipeline: appState.pipeline,
           whisperKitPipeline: appState.whisperKitPipeline,
           activeBackend: { [weak self] in
-            self?.appState.settings.selectedBackend ?? .parakeet
+            self?.appState?.settings.selectedBackend ?? .parakeet
           }
         )
         endpoint.start()
@@ -306,8 +268,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     #endif
 
     audioEnvironmentSnapshotter = AudioEnvironmentSnapshotter(
-      routeProvider: { [weak appState = self.appState] in
-        appState?.audioCapture.currentAudioRoute
+      routeProvider: { [weak self] in
+        self?.appState?.audioCapture.currentAudioRoute
       }
     )
     SentryBreadcrumb.audioEnvironmentProvider = { [weak self] in
@@ -320,8 +282,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     audioSystemEventReporter = AudioSystemEventReporter(
       audioCapture: appState.audioCapture,
       asrManager: appState.asrManager,
-      pipelineStateProvider: { [weak appState = self.appState] in
-        appState?.pipelineState ?? .idle
+      pipelineStateProvider: { [weak self] in
+        self?.appState?.pipelineState ?? .idle
       },
       onAudioDeviceEvent: { [weak self] in
         self?.audioEnvironmentSnapshotter?.audioDeviceEventOccurred()
@@ -333,6 +295,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     audioEnvironmentSnapshotter?.applicationBecameActive()
 
     // Re-warm LLM backend when app comes to foreground.
+    guard let appState = self.appState else { return }
     LLMNetworkSession.shared.preWarmModel(
       provider: appState.settings.llmProvider,
       model: appState.settings.llmModel,
@@ -344,6 +307,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   /// Open the onboarding window and begin monitoring for early close (abort flow).
   func openOnboardingWindow() {
+    guard let appState = self.appState else { return }
     guard appState.settings.onboardingState != .completed else { return }
     openOnboardingAction?()
     NSApp.setActivationPolicy(.regular)
@@ -390,7 +354,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           guard isOnboardingWindow else { return }
           self.onboardingWindow = nil
           // Only treat as abort if onboarding not yet completed.
-          if self.appState.settings.onboardingState != .completed {
+          if self.appState?.settings.onboardingState != .completed {
             self.updateIcon()
           }
         }
@@ -411,7 +375,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     guard let button = statusItem?.button else { return }
 
     iconAnimator.configure(button: button)
-    iconAnimator.audioLevelProvider = { [weak self] in self?.appState.audioCapture.audioLevel ?? 0 }
+    iconAnimator.audioLevelProvider = { [weak self] in self?.appState?.audioCapture.audioLevel ?? 0 }
 
     let menu = NSMenu()
     menu.delegate = self
@@ -432,6 +396,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private func populateMenu(_ menu: NSMenu) {
     menu.removeAllItems()
 
+    guard let appState = self.appState else { return }
     let state = appState.pipelineState
     let onboardingIncomplete = appState.settings.onboardingState != .completed
 
@@ -538,6 +503,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   /// Update the status item icon based on pipeline state.
   func updateIcon() {
+    guard let appState = self.appState else { return }
     let state = appState.pipelineState
     let needsAccessWarning = state == .idle && appState.permissions.shouldShowAccessibilityWarning
     let onboardingIncomplete = appState.settings.onboardingState != .completed
@@ -560,6 +526,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   @objc private func toggleRecording() {
+    guard let appState = self.appState else { return }
     Task {
       await appState.toggleRecording(source: .menuBar)
       updateIcon()
@@ -582,12 +549,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   @objc private func openSettings() {
-    navigationCoordinator.request(.speechEngine)
+    navigationCoordinator?.request(.speechEngine)
     showWindow()
   }
 
   @objc private func openPermissionsSettings() {
-    navigationCoordinator.request(.permissions)
+    navigationCoordinator?.request(.permissions)
     showWindow()
   }
 
@@ -632,8 +599,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       NotificationCenter.default.removeObserver(observer)
       onboardingCloseObserver = nil
     }
-    appState.setup.ollamaSetup.cleanup()
-    appState.hotkeyService.stop()
+    appState?.setup.ollamaSetup.cleanup()
+    appState?.hotkeyService.stop()
     LLMNetworkSession.shared.invalidate()
 
     #if DEBUG

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -5,10 +5,92 @@ import SwiftUI
 @main
 struct EnviousWisprApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+  // PR-A of #763: SwiftUI App struct is the composition root. App-owned homes
+  // live here as `@State` and are injected into views via `.environment(...)`.
+  // AppDelegate is a temporary AppKit adapter holding weak refs to a subset
+  // (appState, navigationCoordinator, updateCoordinatorHolder) so its
+  // NSApplicationDelegate callbacks can read them. PR-B shrinks AppDelegate
+  // further; PR11 deletes AppState.
+  @State private var appState: AppState
+  @State private var navigationCoordinator: NavigationCoordinator
+  @State private var diagnosticsCoordinator: DiagnosticsCoordinator
+  @State private var languageSuggestionPresenter: LanguageSuggestionPresenter
+  @State private var updateCoordinatorHolder: UpdateCoordinatorHolder
+
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
 
   init() {
+    // Construct App-owned homes in dependency order. Closure-capture targets
+    // (overlay) must exist before the closures are built; AppState's chip
+    // handlers must be wired exactly once.
+    let appState = AppState()
+    let navigationCoordinator = NavigationCoordinator()
+    let diagnosticsCoordinator = DiagnosticsCoordinator()
+
+    // PR4 of #763 construction-order constraint preserved: LanguageSuggestionPresenter
+    // captures `appState.recordingOverlay` through narrow closures. Build
+    // overlay reference first, then presenter, then attach to AppState.
+    let overlay = appState.recordingOverlay
+    let languageSuggestionPresenter = LanguageSuggestionPresenter(
+      showOverlay: { [weak overlay] intent in overlay?.show(intent: intent) },
+      readCurrentIntent: { [weak overlay] in overlay?.currentIntent ?? .hidden },
+      // Silent hide for chip dismissal — bypasses the .hidden case's
+      // "Recording complete" AX announcement (PR4 Codex code-diff r5 [P3]).
+      hideOverlay: { [weak overlay] in overlay?.hide() }
+    )
+    // Setter injection: appState now holds a reference to the presenter for
+    // dispatching from its chip-handler closure and pipeline state-change closures.
+    appState.attachLanguageSuggestionPresenter(languageSuggestionPresenter)
+    // Wire RecordingOverlayPanel chip handler closures into the presenter.
+    // PR9/PR10 absorb these along with the rest of AppState's chip dispatching.
+    appState.recordingOverlay.setPassiveChipHandlers(
+      onLock: { [weak appState, presenter = languageSuggestionPresenter] in
+        if let lang = presenter.accept(), let appState = appState {
+          // Capture prior mode for telemetry before mutating settings.
+          let priorMode = appState.settings.languageMode
+          let fromLang: String
+          switch priorMode {
+          case .auto: fromLang = "auto"
+          case .locked(let prev): fromLang = prev
+          }
+          appState.settings.languageMode = .locked(lang)
+          // PR4 Codex code-diff r6 [P2]: chip-driven locks must emit the same
+          // language.manual_lock_used event as Settings-driven locks so the
+          // chip CTA is visible in analytics. "after_bad_detect" is the
+          // reserved reason for this surface (TelemetryService.swift:483).
+          TelemetryService.shared.trackManualLockUsed(
+            fromLang: fromLang, toLang: lang, reason: "after_bad_detect")
+        }
+        // presenter.accept() already hid the overlay; no extra hide needed.
+      },
+      onDismiss: { [presenter = languageSuggestionPresenter] in
+        presenter.dismissExplicit()
+      },
+      onAutoDismiss: { [presenter = languageSuggestionPresenter] generation in
+        presenter.autoDismiss(generation: generation)
+      }
+    )
+
+    let updateCoordinatorHolder = UpdateCoordinatorHolder()
+
+    _appState = State(initialValue: appState)
+    _navigationCoordinator = State(initialValue: navigationCoordinator)
+    _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
+    _languageSuggestionPresenter = State(initialValue: languageSuggestionPresenter)
+    _updateCoordinatorHolder = State(initialValue: updateCoordinatorHolder)
+
+    // PR-A: push App-owned homes into AppDelegate before any
+    // NSApplicationDelegate callback fires. `@NSApplicationDelegateAdaptor`
+    // exposes the delegate synchronously here; NSApplication.run() (which
+    // dispatches delegate callbacks) starts only after App.init() returns.
+    appDelegate.attach(
+      appState: appState,
+      navigationCoordinator: navigationCoordinator,
+      updateCoordinatorHolder: updateCoordinatorHolder
+    )
+
     // Initialize observability (PostHog + Sentry) unconditionally at launch —
     // captures install/open/update lifecycle events, startup crashes, and the
     // full onboarding funnel. Anonymous from first launch.
@@ -19,14 +101,15 @@ struct EnviousWisprApp: App {
     Window(AppConstants.appName, id: "main") {
       UnifiedWindowView()
         .frame(minWidth: 580, minHeight: 400)
-        .environment(appDelegate.appState)
-        .environment(appDelegate.navigationCoordinator)
-        .environment(appDelegate.diagnosticsCoordinator)
-        .environment(appDelegate.languageSuggestionPresenter)
-        .environment(appDelegate.updateCoordinatorHolder)
+        .environment(appState)
+        .environment(navigationCoordinator)
+        .environment(diagnosticsCoordinator)
+        .environment(languageSuggestionPresenter)
+        .environment(updateCoordinatorHolder)
         .background(
           ActionWirer(
             appDelegate: appDelegate,
+            appState: appState,
             isOnboardingPresented: $isOnboardingPresented
           )
         )
@@ -38,9 +121,9 @@ struct EnviousWisprApp: App {
       OnboardingV2View(onComplete: {
         appDelegate.closeOnboardingWindow()
       })
-      .environment(appDelegate.appState)
-      .environment(appDelegate.navigationCoordinator)
-      .environment(appDelegate.languageSuggestionPresenter)
+      .environment(appState)
+      .environment(navigationCoordinator)
+      .environment(languageSuggestionPresenter)
     }
     .windowResizability(.contentSize)
     .defaultSize(width: 500, height: 550)
@@ -51,6 +134,10 @@ struct EnviousWisprApp: App {
 /// Must live inside a SwiftUI view hierarchy to access @Environment.
 private struct ActionWirer: View {
   let appDelegate: AppDelegate
+  /// PR-A: App-owned AppState passed in directly. AppDelegate no longer
+  /// exposes `appState`; reading it through the delegate would have to go
+  /// through its weak ref and risk a stale read during teardown.
+  let appState: AppState
   @Binding var isOnboardingPresented: Bool
   @Environment(\.openWindow) private var openWindow
   @Environment(\.dismissWindow) private var dismissWindow
@@ -71,7 +158,7 @@ private struct ActionWirer: View {
         // Auto-open onboarding if needed (first launch).
         // ActionWirer runs inside the main Window scene which is always created,
         // so the callbacks are wired before we attempt to open the onboarding window.
-        if appDelegate.appState.settings.onboardingState != .completed {
+        if appState.settings.onboardingState != .completed {
           appDelegate.openOnboardingWindow()
         }
       }

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+
+/// Mechanical guard: AppDelegate must not declare stored properties that
+/// match the named-home pattern (`*Coordinator`, `*State`, `*Presenter`,
+/// `*Runtime`, `*Manager`) unless either (a) the property is `weak`, or
+/// (b) the property name is on the named allowlist.
+///
+/// PR-A of #763 installs this guard so that the App-struct composition root
+/// stays the home for App-owned state. Re-introducing
+/// `let appState = AppState()` on AppDelegate would silently revert the move
+/// — this test fails first.
+///
+/// Allowlist shrinks over time:
+/// - `updateCoordinator` (UpdateCoordinator?) — Sparkle integration; sunsets
+///   in PR-B when SparkleUpdateController extracts. After PR-B, allowlist is
+///   expected to be empty.
+@Suite struct AppDelegateOwnershipTests {
+
+  static let namedHomeAllowlist: Set<String> = ["updateCoordinator"]
+
+  /// AppDelegate.swift must not declare a non-weak `let|var` whose type name
+  /// matches the named-home pattern, unless the property is on the allowlist.
+  @Test func appDelegateOwnsNoNamedHomes() throws {
+    let body = try classBodyOfAppDelegate()
+    let violations = findNamedHomeViolations(in: body, allowlist: Self.namedHomeAllowlist)
+    #expect(
+      violations.isEmpty,
+      """
+      AppDelegate declared non-weak named-home stored properties: \
+      \(violations.map { "\($0.name): \($0.type)" }.joined(separator: ", ")). \
+      AppDelegate is a temporary AppKit adapter (PR-A of #763). \
+      App-owned homes belong on EnviousWisprApp as @State, injected via \
+      `.environment(home)`. If a property is a legitimate AppKit-coupled \
+      strong ref, add it to `AppDelegateOwnershipTests.namedHomeAllowlist` \
+      and document the sunset PR. If it's a weak ref, declare it `weak`.
+      """)
+  }
+
+  /// Deliberate-reintroduction fixture: the test verifies the parser flags
+  /// the exact regression we want to prevent. If this fixture stops failing,
+  /// the parser has weakened — the real guard above is no longer trustworthy.
+  @Test func parserCatchesReintroducedAppState() {
+    let fixture = """
+      private var statusItem: NSStatusItem?
+      let appState = AppState()
+      private weak var mainWindow: NSWindow?
+      """
+    let violations = findNamedHomeViolations(in: fixture, allowlist: [])
+    #expect(
+      violations.contains(where: { $0.name == "appState" && $0.type == "AppState" }),
+      """
+      Parser failed to flag the canonical regression (`let appState = AppState()`). \
+      The mechanical guard cannot be trusted until this is fixed.
+      """
+    )
+  }
+
+  /// Allowlist gate: a property on the allowlist must NOT be flagged even if
+  /// it matches the regex, so we don't false-positive Sparkle's
+  /// `updateCoordinator`.
+  @Test func allowlistSuppressesFlagging() {
+    let fixture = """
+      private(set) var updateCoordinator: UpdateCoordinator?
+      """
+    let violations = findNamedHomeViolations(in: fixture, allowlist: ["updateCoordinator"])
+    #expect(violations.isEmpty, "Allowlist entry `updateCoordinator` should suppress the flag.")
+  }
+
+  /// Weak gate: a `weak` property matching the regex must NOT be flagged.
+  /// `weak` is not ownership.
+  @Test func weakSuppressesFlagging() {
+    let fixture = """
+      private weak var appState: AppState?
+      private weak var navigationCoordinator: NavigationCoordinator?
+      """
+    let violations = findNamedHomeViolations(in: fixture, allowlist: [])
+    #expect(violations.isEmpty, "Weak properties must not be flagged — weak is not ownership.")
+  }
+}
+
+private struct NamedHomeViolation: Equatable {
+  let name: String
+  let type: String
+}
+
+private func appDelegateURL() -> URL {
+  URL(fileURLWithPath: "Sources/EnviousWispr/App/AppDelegate.swift")
+}
+
+private func classBodyOfAppDelegate() throws -> String {
+  let source = try String(contentsOf: appDelegateURL(), encoding: .utf8)
+  guard let openRange = source.range(of: "final class AppDelegate: NSObject, NSApplicationDelegate {")
+  else {
+    Issue.record("AppDelegate declaration not found at expected path/shape")
+    throw POSIXError(.ENOENT)
+  }
+  let openIdx = source.index(before: openRange.upperBound)  // points at '{'
+  var depth = 0
+  var idx = openIdx
+  while idx < source.endIndex {
+    let c = source[idx]
+    if c == "{" { depth += 1 }
+    if c == "}" {
+      depth -= 1
+      if depth == 0 { return String(source[source.index(after: openIdx)..<idx]) }
+    }
+    idx = source.index(after: idx)
+  }
+  Issue.record("AppDelegate class body has unbalanced braces")
+  throw POSIXError(.EILSEQ)
+}
+
+/// Scans the AppDelegate class body for top-level (depth 0) `let|var`
+/// declarations whose declared or inferred type name matches the named-home
+/// pattern, returning violations after filtering out:
+/// - Properties declared `weak`.
+/// - Properties whose name is on the allowlist.
+private func findNamedHomeViolations(
+  in body: String,
+  allowlist: Set<String>
+) -> [NamedHomeViolation] {
+  var depth = 0
+  var violations: [NamedHomeViolation] = []
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      if let match = matchPropertyDeclaration(s),
+        !match.isWeak,
+        !allowlist.contains(match.name),
+        typeNameMatchesNamedHomePattern(match.typeName)
+      {
+        violations.append(NamedHomeViolation(name: match.name, type: match.typeName))
+      }
+    }
+    depth += opens - closes
+  }
+  return violations
+}
+
+private struct PropertyMatch {
+  let name: String
+  let typeName: String
+  let isWeak: Bool
+}
+
+/// Matches `[attrs] [access] [weak] [let|var] <name>[: <Type>][?] [= <Type>(...)]`.
+/// Captures the declared type from explicit annotation when present,
+/// otherwise falls back to the initializer constructor's type name.
+private func matchPropertyDeclaration(_ line: String) -> PropertyMatch? {
+  // Quick filter: must contain `let ` or `var ` at top level.
+  guard line.range(of: #"\b(let|var)\b"#, options: .regularExpression) != nil else { return nil }
+
+  let isWeak = line.range(of: #"\bweak\b"#, options: .regularExpression) != nil
+
+  // Capture: name, optional `: TypeName`, optional `= TypeName(`.
+  // Pattern handles `let name: Type?` and `var name = Type()` and `let name: Type = Type()`.
+  let pattern = #"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:\s*:\s*([A-Za-z_][A-Za-z0-9_]*))?(?:\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\()?"#
+  guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+  let ns = line as NSString
+  let range = NSRange(location: 0, length: ns.length)
+  guard let m = regex.firstMatch(in: line, options: [], range: range), m.numberOfRanges >= 4
+  else { return nil }
+  let name = ns.substring(with: m.range(at: 1))
+  let annotatedType = m.range(at: 2).location != NSNotFound ? ns.substring(with: m.range(at: 2)) : ""
+  let initType = m.range(at: 3).location != NSNotFound ? ns.substring(with: m.range(at: 3)) : ""
+  let typeName = !annotatedType.isEmpty ? annotatedType : initType
+  guard !typeName.isEmpty else { return nil }
+  return PropertyMatch(name: name, typeName: typeName, isWeak: isWeak)
+}
+
+private func typeNameMatchesNamedHomePattern(_ typeName: String) -> Bool {
+  // Suffix-only — `Coordinator`, `State`, `Presenter`, `Runtime`, `Manager`.
+  let suffixes = ["Coordinator", "State", "Presenter", "Runtime", "Manager"]
+  for suffix in suffixes {
+    if typeName.hasSuffix(suffix) { return true }
+  }
+  return false
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+
+/// Architecture regression tests for `EnviousWisprApp`.
+///
+/// PR-A of #763 installs `EnviousWisprApp` as the SwiftUI composition root.
+/// This test caps it before PR5+ start adding more App-owned homes, so the
+/// composition root cannot quietly accrete domain methods or imports.
+///
+/// Tests parse the source file directly — App-struct initialization mounts
+/// the real app and is not unit-testable.
+///
+/// Ratchet wording: lower-is-free, raise-needs-Bible §30 entry.
+@Suite struct EnviousWisprAppCeilingsTests {
+
+  /// Stored-property ceiling on the App struct.
+  /// Locked at PR-A baseline (#779, 2026-05-18) = 7:
+  /// appDelegate + isOnboardingPresented + appState + navigationCoordinator +
+  /// diagnosticsCoordinator + languageSuggestionPresenter + updateCoordinatorHolder.
+  /// Counts both `let` and `var` top-level declarations (property wrappers
+  /// included). Primitives (`: Bool`, `: Int`, `: String`, `: Double`) are
+  /// excluded so the bool-typed `isOnboardingPresented` does count via the
+  /// `@State` wrapper presence rather than the type alone.
+  @Test func envWisprAppStoredPropertyCeilingHolds() throws {
+    let body = try structBodyOfEnviousWisprApp()
+    let count = countTopLevelStoredProperties(in: body)
+    #expect(
+      count <= 7,
+      """
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 7. \
+      Raising the ceiling requires a Bible changelog entry. \
+      New App-owned homes belong on EnviousWisprApp by design — this cap is \
+      a thermostat: raise it deliberately, do not silently bump.
+      """)
+  }
+
+  /// Non-private method ceiling — the App struct is composition-only. The
+  /// only required member is the SwiftUI-protocol `body: some Scene` (computed
+  /// property, not a method) and the `init()`. No callable public/internal
+  /// methods are allowed because views and other types must not depend on
+  /// methods of the App struct.
+  @Test func envWisprAppNonPrivateMethodCeilingHolds() throws {
+    let body = try structBodyOfEnviousWisprApp()
+    let count = countTopLevelNonPrivateMethods(in: body)
+    #expect(
+      count <= 0,
+      """
+      EnviousWisprApp non-private method ceiling exceeded: \(count) > 0. \
+      The App struct is the composition root. Methods belong on the
+      individual @State homes (NavigationCoordinator, DictationRuntime, ...).
+      """)
+  }
+
+  /// Line-count trip-wire (5x of current). Soft backstop against accidental
+  /// file explosions; entanglement signals (stored properties, methods,
+  /// imports) are the primary mechanical constraints.
+  @Test func envWisprAppLineCountCeilingHolds() throws {
+    let url = envWisprAppURL()
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      lineCount <= 250,
+      """
+      EnviousWisprApp line count exceeded: \(lineCount) > 250. \
+      Raising the ceiling requires a Bible changelog entry.
+      """)
+  }
+
+  /// Allowed-imports ceiling. The composition root must NOT depend on lower
+  /// modules like EnviousWisprPipeline / EnviousWisprAudio / EnviousWisprASR /
+  /// EnviousWisprLLM directly — that would couple SwiftUI mounting to engine
+  /// implementation details. AppDelegate already carries those imports.
+  @Test func envWisprAppImportsCeilingHolds() throws {
+    let url = envWisprAppURL()
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let allowed: Set<String> = ["SwiftUI", "EnviousWisprCore", "EnviousWisprServices"]
+    let actual = parseImports(in: source)
+    let unexpected = actual.subtracting(allowed)
+    #expect(
+      unexpected.isEmpty,
+      """
+      EnviousWisprApp imports outside allowlist: \(unexpected.sorted()). \
+      Allowed: \(allowed.sorted()). Lower-tier modules belong on AppDelegate \
+      or on specific @State home types, not on the composition root.
+      """)
+  }
+}
+
+private func envWisprAppURL() -> URL {
+  URL(fileURLWithPath: "Sources/EnviousWispr/App/EnviousWisprApp.swift")
+}
+
+private func structBodyOfEnviousWisprApp() throws -> String {
+  let source = try String(contentsOf: envWisprAppURL(), encoding: .utf8)
+  guard let openRange = source.range(of: "struct EnviousWisprApp: App {") else {
+    Issue.record("EnviousWisprApp declaration not found at expected path/shape")
+    throw POSIXError(.ENOENT)
+  }
+  let openIdx = source.index(before: openRange.upperBound)  // points at '{'
+  var depth = 0
+  var idx = openIdx
+  while idx < source.endIndex {
+    let c = source[idx]
+    if c == "{" { depth += 1 }
+    if c == "}" {
+      depth -= 1
+      if depth == 0 { return String(source[source.index(after: openIdx)..<idx]) }
+    }
+    idx = source.index(after: idx)
+  }
+  Issue.record("EnviousWisprApp struct body has unbalanced braces")
+  throw POSIXError(.EILSEQ)
+}
+
+/// Counts top-level (depth 0) `let` and `var` declarations on the App struct.
+/// Stored properties include those marked with SwiftUI property wrappers
+/// (`@State`, `@NSApplicationDelegateAdaptor`).
+private func countTopLevelStoredProperties(in body: String) -> Int {
+  var depth = 0
+  var count = 0
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      if isStoredPropertyDeclaration(s) {
+        count += 1
+      }
+    }
+    depth += opens - closes
+  }
+  return count
+}
+
+private let storedPropertyPattern: String = {
+  // Match `let|var <ident>` at the top level, allowing property wrappers
+  // (with optional parenthesized args) and access modifiers in any order
+  // before the declaration keyword.
+  let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+  let access = #"(public|internal|private|fileprivate|package|open)?"#
+  return "^[[:space:]]*\(attrs)\(access)[[:space:]]*(let|var)[[:space:]]+[A-Za-z_]"
+}()
+
+private func isStoredPropertyDeclaration(_ line: String) -> Bool {
+  guard line.range(of: storedPropertyPattern, options: .regularExpression) != nil
+  else { return false }
+  // Exclude computed properties — these have an opening `{` on the same line
+  // as the declaration (e.g. `var body: some Scene {`). Stored properties
+  // never have a trailing `{` on the declaration line.
+  if line.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
+    return false
+  }
+  return true
+}
+
+/// Counts top-level non-private `func` declarations. The `body` computed
+/// property is intentionally not a `func` and is excluded.
+private func countTopLevelNonPrivateMethods(in body: String) -> Int {
+  var depth = 0
+  var count = 0
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      if isNonPrivateMethodDeclaration(s) {
+        count += 1
+      }
+    }
+    depth += opens - closes
+  }
+  return count
+}
+
+private let nonPrivateMethodPattern: String =
+  #"^[[:space:]]*(public|internal|package|open)?[[:space:]]*func[[:space:]]+[A-Za-z_]"#
+
+private func isNonPrivateMethodDeclaration(_ line: String) -> Bool {
+  guard line.range(of: nonPrivateMethodPattern, options: .regularExpression) != nil
+  else { return false }
+  // Reject if the line declares `private func` or `fileprivate func`.
+  if line.range(of: #"^[[:space:]]*(private|fileprivate)[[:space:]]+func"#, options: .regularExpression)
+    != nil
+  {
+    return false
+  }
+  return true
+}
+
+/// Parses `import <Module>` declarations at the top of the file (depth 0
+/// outside any type body). Returns the module names.
+private func parseImports(in source: String) -> Set<String> {
+  var result: Set<String> = []
+  let pattern = #"^[[:space:]]*import[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+  let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+  let ns = source as NSString
+  let range = NSRange(location: 0, length: ns.length)
+  regex?.enumerateMatches(in: source, options: [], range: range) { match, _, _ in
+    guard let m = match, m.numberOfRanges > 1 else { return }
+    result.insert(ns.substring(with: m.range(at: 1)))
+  }
+  return result
+}

--- a/Tests/RuntimeUAT/uat_runner.py
+++ b/Tests/RuntimeUAT/uat_runner.py
@@ -1304,7 +1304,7 @@ def test_settings_tabs(ctx):
     if settings_win is None:
         raise AssertionError("Settings window did not appear")
 
-    expected_tabs = ["Shortcuts", "AI Polish", "Permissions", "Speech Engine"]
+    expected_tabs = ["Shortcuts", "AI Polish", "Permissions", "Transcription"]
     sidebar_texts = find_all_elements(settings_win, role="AXStaticText")
     sidebar_values = [get_attr(el, "AXValue") or "" for el in sidebar_texts]
     ctx.log(f"Sidebar text values: {sidebar_values[:20]}")
@@ -1332,7 +1332,7 @@ def test_settings_tab_switch(ctx):
         raise AssertionError("Settings sidebar outline not found")
 
     rows = get_attr(outline, "AXChildren") or []
-    tabs_to_click = ["AI Polish", "Permissions", "Speech Engine", "Shortcuts"]
+    tabs_to_click = ["AI Polish", "Permissions", "Transcription", "Shortcuts"]
     clicked = 0
 
     for tab_name in tabs_to_click:

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -16,6 +16,39 @@ _TTS_PATH = "/tmp/wispr_eyes_tts.aiff"
 _OPENAI_TTS_PATH = "/tmp/wispr_eyes_tts.mp3"
 _OPENAI_KEY_FILE = os.path.expanduser("~/.enviouswispr-keys/openai-api-key")
 
+# Bundle IDs the harness might attach to (dev first, prod fallback).
+_PTT_BUNDLE_IDS = ["com.enviouswispr.app.dev", "com.enviouswispr.app"]
+# Reverse map of simulate_input.KEY_CODES for modifier keycodes we hold for PTT.
+# 54=rcmd, 55=lcmd, 58=lopt, 61=ropt. Keep in sync with
+# `Tests/RuntimeUAT/simulate_input.py` MODIFIER_KEYS table.
+_PTT_KEYCODE_TO_NAME = {54: "rcmd", 55: "lcmd", 58: "lopt", 61: "ropt"}
+
+
+def _resolve_ptt_key(fallback="rcmd"):
+    """Read the active PTT keycode from EnviousWispr's UserDefaults
+    (`toggleKeyCode`) and map it back to the simulate_input key name.
+
+    PR-A of #763 fix: harness was hardcoded to `rcmd` (Right Command). When the
+    founder rebinds PTT to a different modifier (e.g. Right Option = 61), the
+    hardcoded harness presses the wrong key and the recording never engages.
+    This resolver keeps the harness aligned with whatever the app is configured
+    for. Falls back to `fallback` (default 'rcmd') if neither bundle responds.
+    """
+    for bundle_id in _PTT_BUNDLE_IDS:
+        try:
+            result = subprocess.run(
+                ["defaults", "read", bundle_id, "toggleKeyCode"],
+                capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode != 0:
+                continue
+            keycode = int(result.stdout.strip())
+            if keycode in _PTT_KEYCODE_TO_NAME:
+                return _PTT_KEYCODE_TO_NAME[keycode]
+        except (subprocess.SubprocessError, ValueError, OSError):
+            continue
+    return fallback
+
 
 def tts(sentence="The quick brown fox jumps over the lazy dog", voice="echo", engine="openai"):
     """Generate audio from text. engine='openai' (natural) or 'say' (local fallback). Returns file path."""
@@ -1506,7 +1539,7 @@ def test_hands_free(audio=None, sentence=None, hold=4.0, expect=None, timeout=30
     return overall_pass
 
 
-def test_ptt(key="rcmd", audio=None, sentence=None, expect=None, timeout=10.0):
+def test_ptt(key=None, audio=None, sentence=None, expect=None, timeout=10.0):
     """End-to-end PTT (push-to-talk) recording test via key hold.
 
     Precisely times key hold to match audio duration:
@@ -1518,8 +1551,10 @@ def test_ptt(key="rcmd", audio=None, sentence=None, expect=None, timeout=10.0):
     6. Monitor pipeline via state polling + clipboard delta
 
     Args:
-        key:      Key to hold (default 'rcmd'). Any key in simulate_input.MODIFIER_KEYS
-                  or KEY_CODES (e.g. 'rcmd', 'space', 'f5').
+        key:      Key to hold. None (default) auto-detects from EnviousWispr's
+                  UserDefaults `toggleKeyCode`. Override with any key in
+                  simulate_input.MODIFIER_KEYS or KEY_CODES (e.g. 'rcmd',
+                  'space', 'f5').
         audio:    Path to audio file to play (or None to use TTS).
         sentence: Text to speak via TTS. Ignored if audio is provided.
         expect:   Optional substring expected in transcription.
@@ -1532,6 +1567,11 @@ def test_ptt(key="rcmd", audio=None, sentence=None, expect=None, timeout=10.0):
         test_ptt(audio='/path/to/clip.wav', expect='keyword')
     """
     connect()
+
+    # Resolve PTT key from app settings if caller didn't override.
+    if key is None:
+        key = _resolve_ptt_key()
+        print(f"PTT key auto-detected from settings: {key}")
 
     if audio is None:
         if sentence is None:
@@ -1621,7 +1661,7 @@ def test_ptt(key="rcmd", audio=None, sentence=None, expect=None, timeout=10.0):
     return overall_pass
 
 
-def record_tts(sentence="The quick brown fox jumps over the lazy dog", key="rcmd",
+def record_tts(sentence="The quick brown fox jumps over the lazy dog", key=None,
                voice="echo", wait=10.0, focus_app=None):
     """Generate TTS, hold PTT key, read raw ASR and polished output from app log.
 
@@ -1631,7 +1671,9 @@ def record_tts(sentence="The quick brown fox jumps over the lazy dog", key="rcmd
 
     Args:
         sentence: Text to speak via TTS.
-        key:      PTT key to hold (default 'rcmd' = right command).
+        key:      PTT key to hold. None (default) auto-detects from
+                  EnviousWispr's UserDefaults `toggleKeyCode`. Override with
+                  'rcmd', 'lcmd', 'lopt', 'ropt' to force a key.
         voice:    OpenAI TTS voice (echo, alloy, fable, onyx, nova, shimmer).
         wait:     Seconds to wait after key release for pipeline to complete.
         focus_app: App to focus before recording (paste target). None to skip.
@@ -1652,6 +1694,11 @@ def record_tts(sentence="The quick brown fox jumps over the lazy dog", key="rcmd
             print(f"  OUT: {r['polished']}")
     """
     import simulate_input as _si
+
+    # Resolve PTT key from app settings if caller didn't override.
+    if key is None:
+        key = _resolve_ptt_key()
+        print(f"PTT key auto-detected from settings: {key}")
 
     # Focus paste target app
     if focus_app:


### PR DESCRIPTION
## Summary

PR-A of epic #763 (closes #779). Move five App-owned homes (`appState`, `navigationCoordinator`, `diagnosticsCoordinator`, `languageSuggestionPresenter`, `updateCoordinatorHolder`) off `AppDelegate` and onto `@State` declarations on `EnviousWisprApp`. The SwiftUI App struct is now the composition root; AppDelegate is a temporary AppKit adapter holding weak refs (training wheels — die by PR-B/PR11).

PR4 chip-handler construction order preserved exactly: overlay → presenter (with closures) → `appState.attachLanguageSuggestionPresenter(...)` → `setPassiveChipHandlers(...)`. All telemetry (`language.manual_lock_used`) closures copy-pasted verbatim from `AppDelegate.init()` to `EnviousWisprApp.init()`. `UpdateCoordinatorHolder` env-capture-of-nil fix preserved via `attach(...)` bridging the holder ref before `applicationWillFinishLaunching` publishes Sparkle's `updateCoordinator` into it.

`ActionWirer` reshaped to take `appState` directly so it no longer reads through `AppDelegate.appState` (now `private weak`).

## Durable architecture (survive PR11)

- **`EnviousWisprApp` composition root** — the shape PR5+ extends.
- **`AppDelegateOwnershipTests`** — mechanical regex guard. AppDelegate may not declare a non-weak `*Coordinator|*State|*Presenter|*Runtime|*Manager`-typed stored property outside the named allowlist (just `updateCoordinator` until PR-B). Ships with a deliberate-reintroduction fixture that verifies the parser catches the canonical regression.
- **`EnviousWisprAppCeilingsTests`** — composition root capped at 7 stored properties, 0 non-private methods, 250-line trip-wire, 3-module import allowlist (`SwiftUI`, `EnviousWisprCore`, `EnviousWisprServices`).

## UAT harness fixes (surfaced during PR-A validation)

- `Tests/RuntimeUAT/uat_runner.py` — stale `Speech Engine` tab name updated to user-visible `Transcription` (matches `SettingsSection.swift:25`). Settings UAT suite is 3/3 again.
- `Tests/RuntimeUAT/wispr_eyes.py` — `_resolve_ptt_key()` reads `toggleKeyCode` from EnviousWispr's `UserDefaults` so `record_tts`/`test_ptt` follow the user's actual PTT binding instead of hardcoded `rcmd`. Default changed to `None` (auto-detect); explicit `key=` still overrides.

## Test plan

- [x] Codex grounded review on plan — GREEN (3 rounds: YELLOW → YELLOW → GREEN)
- [x] Codex code-diff review on implementation — GREEN (2 rounds: RED on `body`-counted-as-stored-property → GREEN)
- [x] `swift build -c release` — clean
- [x] `swift build -c debug` — clean
- [x] `scripts/swift-test.sh` — 903/903 unit + 10/10 architecture (`AppDelegateOwnershipTests` 4/4, `EnviousWisprAppCeilingsTests` 4/4, `AppStateCeilingsTests` 2/2)
- [x] Synthetic UAT — `app_basics` 4/4, `main_window` 1/1, `settings` 3/3
- [x] Runtime UAT — live PTT → recording confirmed firing through new composition root (`PTT-to-recording: total=295ms preWarm=189ms startRecording=106ms backend=whisperkit`)
