### PR TITLE
test(services): inject clock into CaptureTelemetryState to kill 1.1s sleep (#784 PR1)

### DIFF
--- a/Sources/EnviousWisprServices/CaptureTelemetryState.swift
+++ b/Sources/EnviousWisprServices/CaptureTelemetryState.swift
@@ -15,13 +15,19 @@ public final class CaptureTelemetryState {
   private var lastSuccessfulRecordingAt: ContinuousClock.Instant?
   private(set) public var configurationChangeCount: Int = 0
 
-  public init() {}
+  private let currentInstant: @MainActor () -> ContinuousClock.Instant
+
+  public init(
+    currentInstant: @escaping @MainActor () -> ContinuousClock.Instant = { .now }
+  ) {
+    self.currentInstant = currentInstant
+  }
 
   /// Called at transcript save (not paste end) so clipboard-only users are
   /// covered. Resets zombie dedupe so a successful recording sandwiched
   /// between two zombie events still surfaces the second event.
   public func recordSuccessfulRecording() {
-    lastSuccessfulRecordingAt = .now
+    lastSuccessfulRecordingAt = currentInstant()
     lastZombieEmittedAt = nil
     lastZombieRoute = nil
   }
@@ -33,14 +39,14 @@ public final class CaptureTelemetryState {
     guard let last = lastZombieEmittedAt, lastZombieRoute == route else {
       return true
     }
-    return .now - last >= window
+    return currentInstant() - last >= window
   }
 
   /// Marks that a zombie event was observed (regardless of whether it emitted
   /// to Sentry). The 30s window is relative to the most recent observation,
   /// not the most recent emission, so rapid retries stay suppressed.
   public func markZombieEmitted(route: String) {
-    lastZombieEmittedAt = .now
+    lastZombieEmittedAt = currentInstant()
     lastZombieRoute = route
   }
 
@@ -52,7 +58,7 @@ public final class CaptureTelemetryState {
   /// has never produced a successful recording yet.
   public func timeSinceLastSuccessfulRecordingMs() -> Int? {
     guard let last = lastSuccessfulRecordingAt else { return nil }
-    let elapsed = ContinuousClock.now - last
+    let elapsed = currentInstant() - last
     let (seconds, attoseconds) = elapsed.components
     return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
   }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -368,33 +368,33 @@ struct HeartPathTelemetryEmitterTests {
 
   // MARK: - Codex code-review additions (2026-04-30)
 
-  /// Codex round-3 (2026-04-30) — replaces the round-2 theater test with a
-  /// time-based probe that distinguishes "old mark still active" from
+  /// Time-based probe that distinguishes "old mark still active" from
   /// "suppressed call refreshed the window". `CaptureTelemetryState`
   /// exposes a caller-specified window on `shouldEmitZombie(route:window:)`,
-  /// so we can use a SHORT probe window after a sleep to test the
-  /// invariant without widening the production API:
+  /// so we can use a SHORT probe window after advancing a fake clock to
+  /// test the invariant without widening the production API:
   ///
   ///   1. Emit once — fires (returns true), marks at T₀.
-  ///   2. Sleep ~1.1s.
+  ///   2. Advance fake clock past the probe window.
   ///   3. Call `zombieZeroPeak` again — suppressed by the emitter's 30s
   ///      dedup window (still well within 30s of T₀).
   ///   4. Probe `shouldEmitZombie(route:, window: 1s)`.
   ///
   /// If the suppressed path correctly called `markZombieEmitted`: the
-  /// mark timestamp is fresh (just now < 1s ago), `shouldEmitZombie` with
-  /// a 1s window returns FALSE.
+  /// mark is fresh on the fake clock and `shouldEmitZombie` returns FALSE.
   ///
   /// If the suppressed path skipped `markZombieEmitted` (the regression
-  /// we are guarding against): the mark timestamp is from T₀ (>1.1s ago),
-  /// `shouldEmitZombie` with a 1s window returns TRUE — and the test
-  /// fails.
+  /// we are guarding against): the mark stays at T₀, the fake clock is
+  /// past the 1s probe window, and `shouldEmitZombie` returns TRUE —
+  /// the assertion fails.
   ///
-  /// ~1.1s real-time sleep is the cost of the honest probe; one test run.
+  /// Migrated from a 1.1s real-time `Task.sleep` to a fake clock in
+  /// PR for issue #784 (2026-05-18). Same diagnostic power, ~0ms cost.
   @Test("zombieZeroPeak refreshes the dedup window on every observation, not just emits")
-  func zombieZeroPeakSuppressedRefreshesWindow() async throws {
+  func zombieZeroPeakSuppressedRefreshesWindow() {
+    let clock = ManualInstantClock()
     let recorder = Recorder()
-    let captureTelemetry = CaptureTelemetryState()
+    let captureTelemetry = CaptureTelemetryState(currentInstant: { clock.now })
     let emitter = Self.makeEmitter(
       backend: .parakeet, captureTelemetry: captureTelemetry, recorder: recorder)
 
@@ -402,17 +402,18 @@ struct HeartPathTelemetryEmitterTests {
     let firstFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext())
     #expect(firstFired)
 
-    // Sleep just past the probe window.
-    try await Task.sleep(for: .milliseconds(1_100))
+    // Advance past the 1s probe window (still well inside the emitter's 30s dedup).
+    clock.advance(by: .milliseconds(1_100))
 
     // Second emit on same route — suppressed by emitter's 30s dedup.
     let secondFired = emitter.zombieZeroPeak(ctx: Self.zeroPeakContext(sessionID: 100))
     #expect(!secondFired)
 
     // Probe with a 1s window. If the suppressed call advanced the mark
-    // (correct behavior), the route is still in-window and shouldEmit
-    // returns false. If it didn't advance (regression), the original
-    // T₀ mark is >1.1s old and shouldEmit returns true.
+    // (correct behavior), mark is at T₀+1.1s, clock is at T₀+1.1s,
+    // elapsed = 0 < 1s → shouldEmit returns false.
+    // If it didn't advance (regression), mark stays at T₀, elapsed = 1.1s
+    // ≥ 1s window → shouldEmit returns true and the assertion fails.
     let shouldEmitNow = captureTelemetry.shouldEmitZombie(
       route: "bt_headset", window: .seconds(1))
     #expect(
@@ -577,5 +578,19 @@ struct HeartPathTelemetryEmitterTests {
     #expect(
       actualKeys == Self.zombieExtraKeys,
       "zombie extras key-set drift: \(actualKeys.symmetricDifference(Self.zombieExtraKeys))")
+  }
+}
+
+/// Fake monotonic instant clock for tests that need deterministic
+/// `ContinuousClock.Instant` arithmetic without real wall-clock sleeps.
+/// Snapshots `.now` at construction; subsequent `advance(by:)` calls move
+/// the snapshot forward via `.advanced(by:)`. Same shape duplicated in
+/// `CaptureTelemetryStateTests.swift` per #784 PR1 plan — DRY violation is
+/// cheaper than introducing a shared test-utilities target for 5 lines.
+@MainActor
+private final class ManualInstantClock {
+  private(set) var now: ContinuousClock.Instant = .now
+  func advance(by duration: Duration) {
+    now = now.advanced(by: duration)
   }
 }

--- a/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
+++ b/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
@@ -61,4 +61,62 @@ struct CaptureTelemetryStateTests {
     state.incrementConfigChange()
     #expect(state.configurationChangeCount == 3)
   }
+
+  // MARK: - Injected-clock boundary tests (#784 PR1, 2026-05-18)
+  //
+  // `shouldEmitZombie` returns true iff `currentInstant() - last >= window`.
+  // The `>=` comparator means equality is at-threshold (emit allowed) and
+  // strict-below is suppressed. These three tests pin both edges of `>=`
+  // and the at-equality case using a fake clock.
+
+  @Test("shouldEmitZombie returns true at exactly the window boundary")
+  func emitsAtExactWindow() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+    state.markZombieEmitted(route: "bt")
+    clock.advance(by: .seconds(30))
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == true)
+  }
+
+  @Test("shouldEmitZombie returns false just below the window boundary")
+  func doesNotEmitJustBelowWindow() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+    state.markZombieEmitted(route: "bt")
+    clock.advance(by: .milliseconds(29_999))
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == false)
+  }
+
+  @Test("shouldEmitZombie returns true just above the window boundary")
+  func emitsJustAboveWindow() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+    state.markZombieEmitted(route: "bt")
+    clock.advance(by: .milliseconds(30_001))
+    #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == true)
+  }
+
+  @Test("timeSinceLastSuccessfulRecordingMs uses the injected clock")
+  func timeSinceLastSuccessfulRecordingUsesInjectedClock() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+    #expect(state.timeSinceLastSuccessfulRecordingMs() == nil)
+    state.recordSuccessfulRecording()
+    clock.advance(by: .milliseconds(2_500))
+    #expect(state.timeSinceLastSuccessfulRecordingMs() == 2_500)
+  }
+}
+
+/// Fake monotonic instant clock for tests that need deterministic
+/// `ContinuousClock.Instant` arithmetic without real wall-clock sleeps.
+/// Snapshots `.now` at construction; subsequent `advance(by:)` calls move
+/// the snapshot forward via `.advanced(by:)`. Same shape duplicated in
+/// `HeartPathTelemetryEmitterTests.swift` per #784 PR1 plan — DRY violation
+/// is cheaper than introducing a shared test-utilities target for 5 lines.
+@MainActor
+private final class ManualInstantClock {
+  private(set) var now: ContinuousClock.Instant = .now
+  func advance(by duration: Duration) {
+    now = now.advanced(by: duration)
+  }
 }


### PR DESCRIPTION
First migration PR in the #784 sweep. Mirrors PR #783's clock-injection shape onto a second SUT.

## What this fixes

`HeartPathTelemetryEmitterTests.zombieZeroPeakSuppressedRefreshesWindow` fed a real 1.1-second `Task.sleep` into `CaptureTelemetryState`, which measured `ContinuousClock.now - last >= window` deltas. Same flake-shape pattern PR #783 isolated for `LoadProgressWatcher`: test sleep drives synthetic time gaps, SUT measures real-clock deltas, contended CI scheduler precision = flake risk.

This single test was also the wall-clock cost dominant in the file (1.1s out of ~1.3s).

## Fix

Defaulted-init clock seam on `CaptureTelemetryState`:

```swift
public init(
  currentInstant: @escaping @MainActor () -> ContinuousClock.Instant = { .now }
) { ... }
```

- 4 production callers (AppState.swift:31 plus 3 defaulted pipeline params) unchanged. Runtime behavior unchanged.
- Migrated test passes a `{ clock.now }` closure from a `@MainActor` `ManualInstantClock` helper; advances via `clock.advance(by: .milliseconds(1_100))` instead of sleeping.

## What's covered now that wasn't before

The migration replaces 4 time-reads but the migrated test only directly exercises 2 of them. Added 4 new tests in `CaptureTelemetryStateTests.swift` (SUT-direct placement per council coverage + Codex grounded review consensus):

- `emitsAtExactWindow` — pins the `>=` at equality
- `doesNotEmitJustBelowWindow` — pins just-below as suppress
- `emitsJustAboveWindow` — pins just-above as emit
- `timeSinceLastSuccessfulRecordingUsesInjectedClock` — covers the 4th replaced time-read (line 55) and the success-recording write (line 24)

## Process record

- **Plan:** `docs/feature-requests/issue-784-pr1-2026-05-18-capture-telemetry-clock-injection.md` (gitignored)
- **Council coverage review** (GPT gpt-5.5 + Gemini gemini-3.1-pro, session `issue-784-pr1-coverage-review-2026-05-18`, 2026-05-18): both YES_WITH_REVISIONS, both converged on "move boundary tests to SUT-direct file". GPT also flagged the missed 4th time-read coverage. All revisions folded into plan.
- **Codex grounded review on plan** (`docs/audits/2026-05-18-issue-784-pr1-grounded-review.txt`, gitignored): YES_WITH_REVISIONS. Caught a stale `@Test` count in the plan (13 → real 18). Plan corrected.
- **Codex code-diff review:** clean pass, "No actionable correctness issues in the diff"
- **Pre-existing directional rule** at `.claude/rules/swift-patterns.md` (added in PR #783) already covers this pattern; no rule update needed.

## Validation

Local on M4 Pro:
- `swift build` clean
- `swift build -c release` clean (83.73s)
- `scripts/swift-test.sh --filter "HeartPathTelemetryEmitter|CaptureTelemetryState"`: 29/29 pass in 0.001s
- `scripts/swift-test.sh` full suite: 910/910 pass (was 906 + 4 new)
- 30-iteration sanity loop on target filter: 30/30 pass
- Diagnostic-power verification: deliberately removed `markZombieEmitted` from suppressed path → migrated test failed as expected → restored → passes

Wall-clock: migrated test body drops from ~1.1s to 0.001s.

CI:
- `build-check` green (required, this PR)

## Follow-ups (still in #784)

10 of the remaining 11 files were classified as actor-settling / polling / harmless and don't need migration. The one remaining load-bearing file is `TextProcessingRunnerTests.swift` (3 sleeps racing `TaskTimeout.withThrowingTimeout`) — bigger structural fix (refactors a shared utility), separate PR.

Closes part of #784. Issue stays open for the remaining `TextProcessingRunner` PR.

## Test plan

- [ ] `build-check` passes on CI
- [ ] Founder UAT not required (test-only + DI seam with default = no app surface — Live UAT: N declared in plan)