### PR TITLE
test(pipeline): inject timeout-executor seam into TextProcessingRunner (#784)

### DIFF
--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -25,10 +25,36 @@ internal struct TextProcessingRunResult {
 @MainActor
 internal final class TextProcessingRunner {
 
-  private let logger: any PipelineLogging
+  /// Per-step timeout-executor seam (#784, 2026-05-18). Production default
+  /// delegates to `withThrowingTimeout`; tests inject a deterministic fake
+  /// that decides per call whether to run the operation or throw
+  /// `TimeoutError`. Specialized to `TextProcessingContext` because the
+  /// runner only ever times out step operations of that return type.
+  typealias TimeoutExecutor = @MainActor (
+    Double,
+    @escaping @MainActor () async throws -> TextProcessingContext
+  ) async throws -> TextProcessingContext
 
-  init(logger: any PipelineLogging = AppLoggerAdapter()) {
+  private let logger: any PipelineLogging
+  private let timeoutExecutor: TimeoutExecutor
+
+  init(
+    logger: any PipelineLogging = AppLoggerAdapter(),
+    timeoutExecutor: @escaping TimeoutExecutor = { seconds, op in
+      // nonisolated(unsafe) bridges @MainActor `op` to withThrowingTimeout's
+      // @Sendable contract. Safety: op is @MainActor and its return value
+      // (TextProcessingContext) is Sendable, so when op runs inside the
+      // task group's child task and returns to the parent, the result
+      // crosses isolation safely. Same bridge pattern as the existing
+      // `unsafeStep` use below.
+      nonisolated(unsafe) let unsafeOp = op
+      return try await withThrowingTimeout(seconds: seconds) {
+        try await unsafeOp()
+      }
+    }
+  ) {
     self.logger = logger
+    self.timeoutExecutor = timeoutExecutor
   }
 
   func run(
@@ -60,7 +86,7 @@ internal final class TextProcessingRunner {
         Double(unsafeStep.maxDuration.components.seconds)
         + Double(unsafeStep.maxDuration.components.attoseconds) / 1e18
       do {
-        context = try await withThrowingTimeout(seconds: budgetSeconds) {
+        context = try await timeoutExecutor(budgetSeconds) {
           try await unsafeStep.process(input)
         }
         let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
@@ -247,7 +247,13 @@ struct TextProcessingRunnerTests {
 
   @Test("skips a timed-out non-LLM step and continues without polishError")
   func skipsTimedOutNonLLMStep() async throws {
-    let runner = TextProcessingRunner()
+    // #784 (2026-05-18): migrated from real `Task.sleep(300ms)` racing a
+    // 50ms `withThrowingTimeout` deadline to a deterministic
+    // `FakeTimeoutExecutor`. The fake runs normal-budget steps and throws
+    // `TimeoutError` for budgets below 0.1s — sitting between the 50ms
+    // slow-step budget and the 5s default budget.
+    let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 0.1)
+    let runner = TextProcessingRunner(timeoutExecutor: fakeTimeout.run)
 
     let first = RecordingStep(name: "A") { context in
       var next = context
@@ -256,7 +262,6 @@ struct TextProcessingRunnerTests {
     }
 
     let slow = RecordingStep(name: "Filler Removal", maxDuration: .milliseconds(50)) { context in
-      try await Task.sleep(for: .milliseconds(300))
       var next = context
       next.text += "-slow"
       return next
@@ -276,17 +281,21 @@ struct TextProcessingRunnerTests {
     )
 
     #expect(first.runCount == 1)
-    #expect(slow.runCount == 1)
+    #expect(slow.runCount == 0)  // executor short-circuited before invoking op()
     #expect(third.runCount == 1)
     #expect(third.seenInputs.count == 1)
     #expect(third.seenInputs[0].text == "start-A")
     #expect(result.context.text == "start-A-C")
     #expect(result.polishError == nil)
+    #expect(fakeTimeout.callCount == 3)
+    #expect(fakeTimeout.capturedBudgets == [5.0, 0.05, 5.0])
   }
 
   @Test("records polishError when LLM Polish times out and continues with prior text")
   func recordsPolishErrorWhenLLMPolishTimesOut() async throws {
-    let runner = TextProcessingRunner()
+    // #784 (2026-05-18): see `skipsTimedOutNonLLMStep` for migration shape.
+    let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 0.1)
+    let runner = TextProcessingRunner(timeoutExecutor: fakeTimeout.run)
 
     let first = RecordingStep(name: "A") { context in
       var next = context
@@ -297,7 +306,6 @@ struct TextProcessingRunnerTests {
     let slowLLM = RecordingStep(
       name: "LLM Polish", maxDuration: .milliseconds(50), errorSurfacePolicy: .surface
     ) { context in
-      try await Task.sleep(for: .milliseconds(300))
       var next = context
       next.text += "-slow"
       return next
@@ -316,12 +324,15 @@ struct TextProcessingRunnerTests {
       steps: [first, slowLLM, third]
     )
 
-    #expect(slowLLM.runCount == 1)
+    #expect(first.runCount == 1)
+    #expect(slowLLM.runCount == 0)  // executor short-circuited before invoking op()
     #expect(third.runCount == 1)
     #expect(third.seenInputs.count == 1)
     #expect(third.seenInputs[0].text == "start-A")
     #expect(result.context.text == "start-A-C")
     #expect(result.polishError == TimeoutError(seconds: 0.05).localizedDescription)
+    #expect(fakeTimeout.callCount == 3)
+    #expect(fakeTimeout.capturedBudgets == [5.0, 0.05, 5.0])
   }
 
   @Test("rethrows CancellationError and does not run later steps")
@@ -473,11 +484,12 @@ struct TextProcessingRunnerTests {
 
   @Test("Step timeout emits a TextProcessing 'timed out' entry via injected logger")
   func timeoutLogsTextProcessingWarning() async throws {
+    // #784 (2026-05-18): see `skipsTimedOutNonLLMStep` for migration shape.
     let recorder = RecordingPipelineLogger()
-    let runner = TextProcessingRunner(logger: recorder)
+    let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 0.1)
+    let runner = TextProcessingRunner(logger: recorder, timeoutExecutor: fakeTimeout.run)
 
     let slow = RecordingStep(name: "Slow", maxDuration: .milliseconds(50)) { context in
-      try await Task.sleep(for: .milliseconds(300))
       return context
     }
 
@@ -492,6 +504,9 @@ struct TextProcessingRunnerTests {
       category: "TextProcessing", messageContains: "Slow timed out")
     #expect(
       entries.contains { $0.category == "TextProcessing" && $0.message.contains("Slow timed out") })
+    #expect(slow.runCount == 0)  // executor short-circuited before invoking op()
+    #expect(fakeTimeout.callCount == 1)
+    #expect(fakeTimeout.capturedBudgets == [0.05])
   }
 }
 
@@ -573,4 +588,44 @@ final class RecordingPipelineLogger: PipelineLogging, @unchecked Sendable {
 private struct StepFailure: LocalizedError, Equatable {
   let message: String
   var errorDescription: String? { message }
+}
+
+/// Deterministic `TextProcessingRunner.TimeoutExecutor` (#784, 2026-05-18).
+///
+/// The runner calls its executor once per enabled step. A fake that always
+/// throws would time out the first normal-budget step before reaching the
+/// intended slow step in multi-step tests. So this fake discriminates by
+/// budget: throws `TimeoutError(seconds:)` for budgets STRICTLY BELOW
+/// `throwBelowSeconds`, runs the operation otherwise. Threshold is required
+/// at init (no default) so each test makes the discriminator explicit.
+@MainActor
+private final class FakeTimeoutExecutor {
+  let throwBelowSeconds: Double
+
+  private(set) var callCount: Int = 0
+  private(set) var capturedBudgets: [Double] = []
+
+  init(throwBelowSeconds: Double) {
+    self.throwBelowSeconds = throwBelowSeconds
+  }
+
+  func run(
+    _ seconds: Double,
+    _ op: @escaping @MainActor () async throws -> TextProcessingContext
+  ) async throws -> TextProcessingContext {
+    callCount += 1
+    capturedBudgets.append(seconds)
+    if seconds < throwBelowSeconds {
+      // Yield once before throwing so the fake mirrors the real
+      // `withThrowingTimeout`'s yielding behavior (production always
+      // suspends inside its task-group `Task.sleep` deadline). Without
+      // this yield, the runner returns to the test without giving its
+      // prior fire-and-forget logger Tasks a chance to run; under
+      // full-suite MainActor saturation, those Tasks can fail to drain
+      // inside the test's 500ms `awaitEntry` polling window.
+      await Task.yield()
+      throw TimeoutError(seconds: seconds)
+    }
+    return try await op()
+  }
 }


### PR DESCRIPTION
Final migration in the #784 sweep. Closes the issue.

## What this fixes

Three tests in `TextProcessingRunnerTests` created `RecordingStep` instances with `maxDuration: .milliseconds(50)` and an inner `try await Task.sleep(for: .milliseconds(300))`, racing the runner's `withThrowingTimeout(0.05)` deadline. 6x safety margin against contended CI scheduler precision — same flake-shape pattern PR #783 and PR #787 fixed for `LoadProgressWatcher` and `CaptureTelemetryState`.

## Approach (Codex-recommended over two alternatives)

A direction-check ran 2026-05-18. Codex explicitly rejected:

- **Approach A (clock injection on the shared `withThrowingTimeout`):** widens a Core utility's API for a flake isolated to one consumer's tests; requires a custom Swift `Clock`-conforming `TestClock` implementation; propagates clock awareness to 3 unrelated production callers. Future debt.
- **Approach B (widen body sleep to 60s):** leaves the 50ms deadline as real wall-clock; pragmatic but incomplete.

**Approach C selected:** add a defaulted `timeoutExecutor` closure to `TextProcessingRunner.init`, next to the existing `logger` seam. Production keeps the default closure (delegates to `withThrowingTimeout`); runtime byte-equivalent. Tests inject `FakeTimeoutExecutor(throwBelowSeconds: 0.1)` which discriminates by budget — runs `op()` for normal 5s budgets and throws `TimeoutError(seconds: 0.05)` for the 50ms slow-step budgets.

## Why a discriminator and not "always throws"

Codex grounded review caught the blocker: the runner calls `timeoutExecutor` once per enabled step, not just for the slow step. An always-throws fake would time out the first normal step before the slow step is reached in multi-step tests. The `throwBelowSeconds: 0.1` threshold sits between 0.05 (slow) and 5.0 (default normal), so only the slow step trips.

## New coverage added

Each migrated test now asserts the full `capturedBudgets: [Double]` list (e.g., `[5.0, 0.05, 5.0]` for multi-step; `[0.05]` for single-step) and `callCount`. Stronger statements about the runner's actual contract (threading `maxDuration` correctly to the timeout primitive) than the prior `runCount == 1` side-effect signal.

## Coverage lost

`slow.runCount == 1` → `slow.runCount == 0`. The fake short-circuits before invoking `op()`, so we no longer exercise the "step started, then cancelled mid-flight" path in these tests. That path is still covered by `TextProcessingChainRacesTests.cancellationMidStepRethrowsAndStopsLaterSteps` (real cancellation, real suspension, real `CancellationError`). The runner has no partial-state recovery logic that depends on this signal. Council coverage review (GPT + Gemini) accepted the trade-off.

## Subtle fix during validation

During full-suite testing, `timeoutLogsTextProcessingWarning` failed because the fake's synchronous throw never yielded MainActor, and the runner's catch-block fire-and-forget logger Tasks couldn't drain inside the test's 500ms `awaitEntry` polling window under full-suite MainActor saturation. Added `await Task.yield()` in the fake before throwing — mirrors the real `withThrowingTimeout`'s natural yielding behavior. Full suite now 929/929 green.

## Process record

- **Plan:** `docs/feature-requests/issue-784-textprocessing-runner-2026-05-18.md` (gitignored)
- **Codex direction-check** (`docs/audits/2026-05-18-issue-784-textprocessing-direction.txt`, gitignored): PROCEED-WITH-C
- **Council coverage review** (GPT gpt-5.5 + Gemini gemini-3.1-pro, session `issue-784-textprocessing-coverage-2026-05-18`, 2026-05-18): both YES_WITH_REVISIONS. Both converged on explicit `throwBelowSeconds` (was: hidden default), honest trade-off framing (was: claimed "strict upgrade"), Gemini caught stale `14/14` in §13 ship criteria.
- **Codex grounded review on plan** (`docs/audits/2026-05-18-issue-784-textprocessing-grounded-review.txt`, gitignored): YES_WITH_REVISIONS. Caught the "always-throws fake" blocker; corrected test count 14 → 16; tightened `nonisolated(unsafe)` rationale.
- **All revisions applied** before code.
- **Codex code-diff review:** clean pass, "did not find a concrete regression in the changed code"

## Validation

Local on M4 Pro:
- `swift build` clean
- `swift build -c release` clean
- `scripts/swift-test.sh --filter TextProcessingRunner`: 16/16 pass in 0.016s
- `scripts/swift-test.sh` full suite: 929/929 pass
- 30-iteration sanity loop on target filter: 30/30 pass

CI:
- `build-check` (required, this PR)

## Sweep close-out

After this PR merges, #784 closes. The other 10 files in the classification were non-load-bearing (actor-settling / polling / harmless) — see classification report linked from #784 comments.

## Test plan

- [ ] `build-check` passes on CI
- [ ] Founder UAT not required (test-only + DI seam with defaulted production behavior — Live UAT: N declared in plan)