### PR TITLE
refactor(appstate): extract TranscriptWorkflowCoordinator (PR6 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -1013,33 +1013,6 @@ final class AppState {
     }
   }
 
-  /// Enhancement error from the transcript detail view's re-polish service.
-  /// Separate from `lastPolishError` which tracks live-dictation polish failures.
-  var lastEnhancementError: EnhancementError? {
-    polishService.lastEnhancementError
-  }
-
-  /// Re-polish an existing transcript via the standalone polish service.
-  /// Decoupled from pipeline state: does not touch pipeline.state, currentTranscript, or lastPolishError.
-  func polishTranscript(_ transcript: Transcript) async {
-    do {
-      let updated = try await polishService.polish(transcript)
-      if let idx = transcriptCoordinator.transcripts.firstIndex(where: { $0.id == updated.id }) {
-        transcriptCoordinator.transcripts[idx] = updated
-      }
-      // Ensure detail view refreshes even when activeTranscript falls back to pipeline.currentTranscript
-      transcriptCoordinator.selectedTranscriptID = updated.id
-    } catch {
-      // Error already captured in polishService.lastEnhancementError
-      Task {
-        await AppLogger.shared.log(
-          "Transcript enhancement failed: \(error.localizedDescription)",
-          level: .info, category: "Enhancement"
-        )
-      }
-    }
-  }
-
   // Phase 5 B.1 validated 2026-03-16: batch round-trip 51-60ms across XPC.
   // Cold model load: 13,966ms. 3 warm back-to-back runs stable.
   // Test function in git history.

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -17,6 +17,11 @@ struct EnviousWisprApp: App {
   @State private var diagnosticsCoordinator: DiagnosticsCoordinator
   @State private var languageSuggestionPresenter: LanguageSuggestionPresenter
   @State private var updateCoordinatorHolder: UpdateCoordinatorHolder
+  // PR6 of #763: TranscriptWorkflowCoordinator owns re-polish workflow.
+  // Holds references to AppState's TranscriptCoordinator + TranscriptPolishService
+  // (Shape 4 cascade: those references' storage stays on AppState until
+  // PR9/PR11 absorb their pipeline/PSS/custom-words callers).
+  @State private var transcriptWorkflowCoordinator: TranscriptWorkflowCoordinator
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -75,11 +80,21 @@ struct EnviousWisprApp: App {
 
     let updateCoordinatorHolder = UpdateCoordinatorHolder()
 
+    // PR6 of #763. Build TWC after appState so it can read appState's
+    // transcriptCoordinator + polishService refs. Shape 4: TWC holds the
+    // references, AppState retains storage through PR6 (cascades out
+    // PR9/PR11).
+    let transcriptWorkflowCoordinator = TranscriptWorkflowCoordinator(
+      transcriptCoordinator: appState.transcriptCoordinator,
+      polishService: appState.polishService
+    )
+
     _appState = State(initialValue: appState)
     _navigationCoordinator = State(initialValue: navigationCoordinator)
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
     _languageSuggestionPresenter = State(initialValue: languageSuggestionPresenter)
     _updateCoordinatorHolder = State(initialValue: updateCoordinatorHolder)
+    _transcriptWorkflowCoordinator = State(initialValue: transcriptWorkflowCoordinator)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires. `@NSApplicationDelegateAdaptor`
@@ -106,6 +121,7 @@ struct EnviousWisprApp: App {
         .environment(diagnosticsCoordinator)
         .environment(languageSuggestionPresenter)
         .environment(updateCoordinatorHolder)
+        .environment(transcriptWorkflowCoordinator)
         .background(
           ActionWirer(
             appDelegate: appDelegate,

--- a/Sources/EnviousWispr/App/TranscriptWorkflowCoordinator.swift
+++ b/Sources/EnviousWispr/App/TranscriptWorkflowCoordinator.swift
@@ -1,0 +1,81 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Foundation
+import Observation
+
+/// PR6 of epic #763. Owns transcript re-polish workflow: the user-triggered
+/// Enhance action on a history transcript, and the workflow state that
+/// `TranscriptDetailView` surfaces (error banner, in-flight transcript ID).
+///
+/// Shape 4 cascade decision (2026-05-18): TWC ships in its final post-PR11
+/// shape — `@State` on `EnviousWisprApp`, holds references to
+/// `TranscriptCoordinator` + `TranscriptPolishService` injected by
+/// `EnviousWisprApp.init()`. The references' storage stays on `AppState`
+/// through PR6 (TC cascades out in PR9, TPS in PR11) because pipelines,
+/// `PipelineSettingsSync`, and the custom-words propagator still call them
+/// at construction time — moving storage in PR6 would require forwarding
+/// shims that violate the no-half-done-handoffs rule.
+///
+/// **Anti-service-locator guardrail.** TWC exposes `transcriptCoordinator`
+/// solely so the four transcript-history view consumers
+/// (`TranscriptDetailView`, `HistoryContentView`, `TranscriptHistoryView`,
+/// `SidebarStatsHeader`) can resolve list/count/delete/load/filter through
+/// a single environment surface during the AppState deletion cascade. No new
+/// domain APIs, no unrelated transcript surfaces, no non-transcript
+/// consumers. `TranscriptWorkflowCoordinatorCeilingsTests` enforces ≤2
+/// stored properties and ≤1 non-private method as the structural backstop.
+///
+/// **Scene injection.** Any SwiftUI scene that renders any of the four
+/// transcript-history views MUST also `.environment(transcriptWorkflowCoordinator)`
+/// on its hierarchy or the view body will crash on
+/// `@Environment(TranscriptWorkflowCoordinator.self)` lookup. Today only the
+/// main `Window` scene renders these views; onboarding does not.
+@Observable @MainActor
+final class TranscriptWorkflowCoordinator {
+  let transcriptCoordinator: TranscriptCoordinator
+  let polishService: TranscriptPolishService
+
+  init(transcriptCoordinator: TranscriptCoordinator, polishService: TranscriptPolishService) {
+    self.transcriptCoordinator = transcriptCoordinator
+    self.polishService = polishService
+  }
+
+  /// Re-polish an existing transcript via the standalone polish service.
+  /// Decoupled from pipeline state: does not touch pipeline.state, currentTranscript, or lastPolishError.
+  ///
+  /// Idempotency: no internal guard. UI gate is the Enhance button disabling
+  /// on `polishingTranscriptID != nil`. Direct-call guard is
+  /// `TranscriptPolishService.polish` itself, which sets/checks its own
+  /// `polishingTranscriptID`. PR6 preserves this two-layer guard exactly as
+  /// pre-PR6 AppState had it.
+  func polishTranscript(_ transcript: Transcript) async {
+    do {
+      let updated = try await polishService.polish(transcript)
+      if let idx = transcriptCoordinator.transcripts.firstIndex(where: { $0.id == updated.id }) {
+        transcriptCoordinator.transcripts[idx] = updated
+      }
+      // Ensure detail view refreshes even when activeTranscript falls back to pipeline.currentTranscript
+      transcriptCoordinator.selectedTranscriptID = updated.id
+    } catch {
+      // Error already captured in polishService.lastEnhancementError
+      Task {
+        await AppLogger.shared.log(
+          "Transcript enhancement failed: \(error.localizedDescription)",
+          level: .info, category: "Enhancement"
+        )
+      }
+    }
+  }
+
+  /// Enhancement error from the re-polish service, surfaced to TranscriptDetailView.
+  var lastEnhancementError: EnhancementError? {
+    polishService.lastEnhancementError
+  }
+
+  /// ID of the transcript currently being re-polished. TranscriptDetailView
+  /// reads this to disable the Enhance button while polish is in flight.
+  /// Computed pass-through; do NOT expose `polishService` directly to views.
+  var polishingTranscriptID: UUID? {
+    polishService.polishingTranscriptID
+  }
+}

--- a/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
+++ b/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Inner content for the History tab: transcript list (left) + detail/status (right).
 struct HistoryContentView: View {
   @Environment(AppState.self) private var appState
+  @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
 
   var body: some View {
     VStack(spacing: 0) {
@@ -28,7 +29,7 @@ struct HistoryContentView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .task {
-      appState.transcriptCoordinator.load()
+      transcriptWorkflowCoordinator.transcriptCoordinator.load()
     }
   }
 }

--- a/Sources/EnviousWispr/Views/Main/SidebarStatsHeader.swift
+++ b/Sources/EnviousWispr/Views/Main/SidebarStatsHeader.swift
@@ -4,13 +4,14 @@ import SwiftUI
 /// Stats header shown above the transcript list in the sidebar.
 struct SidebarStatsHeader: View {
   @Environment(AppState.self) private var appState
+  @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
 
   private var isRecording: Bool {
     appState.pipelineState == .recording
   }
 
   var body: some View {
-    @Bindable var tc = appState.transcriptCoordinator
+    @Bindable var tc = transcriptWorkflowCoordinator.transcriptCoordinator
 
     VStack(spacing: 10) {
       // Search bar + transcript count row
@@ -26,7 +27,7 @@ struct SidebarStatsHeader: View {
         .padding(.vertical, 5)
         .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 6))
 
-        Text("\(appState.transcriptCoordinator.transcriptCount)")
+        Text("\(transcriptWorkflowCoordinator.transcriptCoordinator.transcriptCount)")
           .font(.caption.bold())
           .foregroundStyle(.secondary)
           .monospacedDigit()

--- a/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
@@ -7,6 +7,7 @@ struct TranscriptDetailView: View {
   let transcript: Transcript
   @Environment(AppState.self) private var appState
   @Environment(NavigationCoordinator.self) private var navigationCoordinator
+  @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -43,19 +44,19 @@ struct TranscriptDetailView: View {
 
         if transcript.polishedText == nil && appState.settings.llmProvider != .none {
           Button {
-            Task { await appState.polishTranscript(transcript) }
+            Task { await transcriptWorkflowCoordinator.polishTranscript(transcript) }
           } label: {
             Label("Enhance", systemImage: "sparkles")
           }
           .controlSize(.small)
-          .disabled(appState.polishService.polishingTranscriptID != nil)
+          .disabled(transcriptWorkflowCoordinator.polishingTranscriptID != nil)
           .help("Polish with AI")
         }
 
         Spacer()
 
         Button(role: .destructive) {
-          appState.transcriptCoordinator.delete(transcript)
+          transcriptWorkflowCoordinator.transcriptCoordinator.delete(transcript)
         } label: {
           Image(systemName: "trash")
         }
@@ -98,7 +99,7 @@ struct TranscriptDetailView: View {
               .frame(maxWidth: .infinity, alignment: .leading)
           }
 
-          if let enhError = appState.lastEnhancementError,
+          if let enhError = transcriptWorkflowCoordinator.lastEnhancementError,
             enhError.transcriptID == transcript.id
           {
             HStack(spacing: 6) {

--- a/Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Sidebar list of past transcripts with stats header and search.
 struct TranscriptHistoryView: View {
   @Environment(AppState.self) private var appState
+  @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
   @State private var showDeleteAllConfirmation = false
 
   private var isRecording: Bool {
@@ -11,22 +12,24 @@ struct TranscriptHistoryView: View {
   }
 
   var body: some View {
-    @Bindable var tc = appState.transcriptCoordinator
+    @Bindable var tc = transcriptWorkflowCoordinator.transcriptCoordinator
 
     VStack(spacing: 0) {
       SidebarStatsHeader()
 
       Divider()
 
-      List(appState.transcriptCoordinator.filteredTranscripts, selection: $tc.selectedTranscriptID)
-      { transcript in
+      List(
+        transcriptWorkflowCoordinator.transcriptCoordinator.filteredTranscripts,
+        selection: $tc.selectedTranscriptID
+      ) { transcript in
         TranscriptRowView(transcript: transcript)
           .tag(transcript.id)
       }
       .opacity(isRecording ? 0.4 : 1.0)
       .animation(.easeInOut(duration: 0.3), value: isRecording)
       .overlay {
-        if appState.transcriptCoordinator.transcripts.isEmpty {
+        if transcriptWorkflowCoordinator.transcriptCoordinator.transcripts.isEmpty {
           ContentUnavailableView(
             "No Transcripts Yet",
             systemImage: "doc.text",
@@ -35,7 +38,7 @@ struct TranscriptHistoryView: View {
         }
       }
 
-      if !appState.transcriptCoordinator.transcripts.isEmpty {
+      if !transcriptWorkflowCoordinator.transcriptCoordinator.transcripts.isEmpty {
         Divider()
         Button(role: .destructive) {
           showDeleteAllConfirmation = true
@@ -52,11 +55,11 @@ struct TranscriptHistoryView: View {
     .alert("Delete All Transcripts?", isPresented: $showDeleteAllConfirmation) {
       Button("Cancel", role: .cancel) {}
       Button("Delete All", role: .destructive) {
-        appState.transcriptCoordinator.deleteAll()
+        transcriptWorkflowCoordinator.transcriptCoordinator.deleteAll()
       }
     } message: {
       Text(
-        "This will permanently delete all \(appState.transcriptCoordinator.transcriptCount) transcripts. This action cannot be undone."
+        "This will permanently delete all \(transcriptWorkflowCoordinator.transcriptCoordinator.transcriptCount) transcripts. This action cannot be undone."
       )
     }
   }

--- a/Tests/EnviousWisprTests/App/TranscriptWorkflowCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptWorkflowCoordinatorTests.swift
@@ -1,0 +1,82 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprPipeline
+
+/// Unit tests for `TranscriptWorkflowCoordinator` (PR6 of epic #763).
+///
+/// Scope is narrow on purpose. `TranscriptPolishService` constructs
+/// `LLMPolishStep` internally and the real polish flow needs a configured
+/// LLM provider; success-path validation is Live UAT territory (see plan
+/// §11.1). These tests cover what is unit-reachable:
+///
+/// 1. TWC initializes with the two required references.
+/// 2. Fresh TPS state pass-throughs return nil.
+/// 3. When TPS throws (no LLM provider configured), TWC's `polishTranscript`
+///    fails closed: no transcript mutation, no selection change, no crash.
+///    The catch block's `AppLogger.shared.log` call is exercised but its
+///    parity (verbatim message + category) is asserted at code-review time
+///    against `Sources/EnviousWispr/App/AppState.swift:1035-1038` not by an
+///    AppLogger sink seam (the seam would require a refactor outside PR6
+///    scope; Codex grounded review accepted the narrowing).
+@MainActor
+@Suite("TranscriptWorkflowCoordinator")
+struct TranscriptWorkflowCoordinatorTests {
+
+  @Test("init wires both references; fresh-TPS pass-throughs are nil")
+  func initialStatePassThroughs() async throws {
+    let twc = makeCoordinator()
+    #expect(twc.lastEnhancementError == nil)
+    #expect(twc.polishingTranscriptID == nil)
+  }
+
+  @Test("polishTranscript on disabled-polish TPS fails closed: TC untouched")
+  func polishWithDisabledServiceLeavesTranscriptsUntouched() async throws {
+    let twc = makeCoordinator()
+    let originalTranscript = Transcript(
+      text: "hello world",
+      duration: 1.0,
+      backendType: .parakeet
+    )
+    twc.transcriptCoordinator.transcripts = [originalTranscript]
+    twc.transcriptCoordinator.selectedTranscriptID = originalTranscript.id
+    let priorIDs = twc.transcriptCoordinator.transcripts.map(\.id)
+    let priorTexts = twc.transcriptCoordinator.transcripts.map(\.text)
+    let priorSelection = twc.transcriptCoordinator.selectedTranscriptID
+
+    // No LLM provider is configured, so TPS throws `LLMError.providerUnavailable`.
+    // TWC's catch block swallows the error and logs via AppLogger.shared. The
+    // logger Task is fire-and-forget; we do not await it. The contract this
+    // test enforces: TC array + selection are NOT mutated on failure.
+    await twc.polishTranscript(originalTranscript)
+
+    #expect(twc.transcriptCoordinator.transcripts.map(\.id) == priorIDs)
+    #expect(twc.transcriptCoordinator.transcripts.map(\.text) == priorTexts)
+    #expect(twc.transcriptCoordinator.selectedTranscriptID == priorSelection)
+    // lastEnhancementError state is not asserted here: TPS only sets it on
+    // *runtime* polish errors (LLMPolishStep failure), not on the early-exit
+    // `providerUnavailable` throw. That branch is exercised by Live UAT with
+    // a configured provider that's then forced to fail.
+  }
+
+  // MARK: - Fixture
+
+  private func makeCoordinator() -> TranscriptWorkflowCoordinator {
+    let transcriptStore = TranscriptStore()
+    let keychain = KeychainManager()
+    let polishService = TranscriptPolishService(
+      keychainManager: keychain,
+      transcriptStore: transcriptStore
+    )
+    let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    return TranscriptWorkflowCoordinator(
+      transcriptCoordinator: transcriptCoordinator,
+      polishService: polishService
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
@@ -34,7 +34,7 @@ import Testing
       """)
   }
 
-  /// File line-count ceiling. Locked at post-PR5 (#771) baseline = 1073.
+  /// File line-count ceiling. Locked at post-PR6 (#772) baseline = 1046.
   /// Soft backstop against scope creep.
   ///
   /// Ratcheted history:
@@ -50,14 +50,20 @@ import Testing
   ///   `makeDictationSessionConfig(triggerSource:)` into `DictationSessionConfigFactory`.
   ///   Method body + doc removed 55 lines; two call sites grew 13 lines for the
   ///   multi-line factory invocation. Net delta: -42. 1071 actual + 2-line margin.
+  /// - 1073 → 1046 in PR6 of epic #763 (2026-05-18, #772) after extracting
+  ///   `lastEnhancementError` computed + `polishTranscript(_:)` method into
+  ///   `TranscriptWorkflowCoordinator`. Removed 27 lines (5 + 20 + 2 blank).
+  ///   1044 actual + 2-line margin. Collaborator ceiling stays at 18 — Shape 4
+  ///   keeps `let polishService` and `let transcriptCoordinator` on AppState
+  ///   through PR6 (cascade out in PR11 / PR9 respectively).
   @Test func appStateLineCountCeilingHolds() throws {
     let url = appStateURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1073,
+      lineCount <= 1046,
       """
-      AppState line count exceeded: \(lineCount) > 1073. \
+      AppState line count exceeded: \(lineCount) > 1046. \
       Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -14,20 +14,28 @@ import Testing
 @Suite struct EnviousWisprAppCeilingsTests {
 
   /// Stored-property ceiling on the App struct.
-  /// Locked at PR-A baseline (#779, 2026-05-18) = 7:
+  /// Locked at post-PR6 baseline (#772, 2026-05-18) = 8:
   /// appDelegate + isOnboardingPresented + appState + navigationCoordinator +
-  /// diagnosticsCoordinator + languageSuggestionPresenter + updateCoordinatorHolder.
+  /// diagnosticsCoordinator + languageSuggestionPresenter + updateCoordinatorHolder
+  /// + transcriptWorkflowCoordinator (PR6).
   /// Counts both `let` and `var` top-level declarations (property wrappers
   /// included). Primitives (`: Bool`, `: Int`, `: String`, `: Double`) are
   /// excluded so the bool-typed `isOnboardingPresented` does count via the
   /// `@State` wrapper presence rather than the type alone.
+  ///
+  /// Ratchet history:
+  /// - 7 → 8 in PR6 of epic #763 (2026-05-18, #772) for `TranscriptWorkflowCoordinator`.
+  ///   Bible §30 entry: PR6 adds one App-owned `@State` home for the re-polish
+  ///   workflow extracted from AppState. By design, new App-owned homes from
+  ///   epic #763 PRs land here; lifting the ceiling is the explicit acknowledgement
+  ///   that the composition root grew (versus AppState shrinking).
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 7,
+      count <= 8,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 7. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 8. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -181,7 +189,8 @@ private func isNonPrivateMethodDeclaration(_ line: String) -> Bool {
   guard line.range(of: nonPrivateMethodPattern, options: .regularExpression) != nil
   else { return false }
   // Reject if the line declares `private func` or `fileprivate func`.
-  if line.range(of: #"^[[:space:]]*(private|fileprivate)[[:space:]]+func"#, options: .regularExpression)
+  if line.range(
+    of: #"^[[:space:]]*(private|fileprivate)[[:space:]]+func"#, options: .regularExpression)
     != nil
   {
     return false

--- a/Tests/EnviousWisprTests/Architecture/TranscriptWorkflowCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/TranscriptWorkflowCoordinatorCeilingsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+/// Architecture ceiling for `TranscriptWorkflowCoordinator` (PR6 of epic #763).
+///
+/// Locks the home as the canonical transcript-workflow coordinator:
+/// - 2 stored properties (`transcriptCoordinator` + `polishService` refs)
+/// - exactly 1 non-private method (`polishTranscript(_:)`)
+/// - ≤90 lines
+/// - imports ⊆ {EnviousWisprCore, EnviousWisprPipeline, Foundation, Observation}
+///
+/// `TranscriptCoordinator` is App-local (same target as TWC); no Services
+/// import needed. `EnhancementError` is re-exported from `EnviousWisprCore`.
+///
+/// Lowering any cap is free; raising requires a Bible §30 changelog entry.
+///
+/// Anti-service-locator guardrail (Codex grounded review 2026-05-18): TWC
+/// must not accrete new domain APIs or non-transcript surfaces. The method
+/// ceiling of exactly 1 enforces that structurally.
+@Suite struct TranscriptWorkflowCoordinatorCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/TranscriptWorkflowCoordinator.swift"
+
+  @Test func storedPropertyCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let bodies = try CeilingsTestSupport.typeBodies(
+      named: "TranscriptWorkflowCoordinator", in: source)
+    let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countTopLevelLetCollaborators(in: $1) }
+    #expect(
+      total == 2,
+      """
+      TranscriptWorkflowCoordinator stored-property count mismatch: \
+      expected exactly 2 (transcriptCoordinator + polishService), found \(total). \
+      Adding a stored property requires a Bible §30 entry; if this dropped \
+      to 0 or 1, the parser may have stopped matching `let` collaborator \
+      declarations.
+      """)
+  }
+
+  @Test func nonPrivateMethodCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let bodies = try CeilingsTestSupport.typeBodies(
+      named: "TranscriptWorkflowCoordinator", in: source)
+    let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countNonPrivateMethods(in: $1) }
+    // Exact-match. Computed properties (lastEnhancementError, polishingTranscriptID)
+    // are NOT counted by the parser. Only `polishTranscript(_:)` is a `func`
+    // declaration, so the method count must be 1. The exact-match also guards
+    // against the anti-service-locator rule: a new non-private method on TWC
+    // is the structural signal of scope creep.
+    #expect(
+      total == 1,
+      """
+      TranscriptWorkflowCoordinator non-private method count mismatch: \
+      expected exactly 1 (`polishTranscript(_:)`), found \(total). \
+      Adding a new outward method requires a Bible §30 entry — TWC must not \
+      become a generic transcript service locator. If this dropped to 0, the \
+      shared parser at CeilingsTestSupport may have stopped matching `func` \
+      declarations.
+      """)
+  }
+
+  @Test func lineCountCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let count = CeilingsTestSupport.lineCount(in: source)
+    #expect(
+      count <= 90,
+      """
+      TranscriptWorkflowCoordinator line count exceeded: \(count) > 90. \
+      Ratchet down if implementation came in lower; raise only via Bible §30.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let actual = CeilingsTestSupport.imports(in: source)
+    let allowed: Set<String> = [
+      "EnviousWisprCore", "EnviousWisprPipeline",
+      "Foundation", "Observation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      TranscriptWorkflowCoordinator imports outside the allowed set: \
+      \(extras.sorted()). Allowed: \(allowed.sorted()). TranscriptCoordinator \
+      is App-local (same target, no import needed); EnhancementError lives in \
+      EnviousWisprCore. New imports require a Bible §30 entry.
+      """)
+  }
+}


### PR DESCRIPTION
## Summary

PR6 of epic #763 (AppState deletion). Extracts re-polish workflow from `AppState` into a new top-level `@State` home on `EnviousWisprApp` called `TranscriptWorkflowCoordinator` (TWC), per the Shape 4 cascade decision settled by Codex on 2026-05-18.

- Moves `var lastEnhancementError` (computed) and `func polishTranscript(_:)` out of AppState into TWC.
- Keeps `let polishService` and `let transcriptCoordinator` ON AppState through PR6 — their pipeline / PipelineSettingsSync / custom-words callers cascade out in PR8/PR9/PR10/PR11. No forwarding shim (no-half-done-handoffs).
- Rewires 4 view files to read through `@Environment(TranscriptWorkflowCoordinator.self).transcriptCoordinator.X` instead of `appState.X` — single environment surface so PR9 (TC ownership absorption) requires no view-side changes.
- `appState.activeTranscript` at `HistoryContentView:19` is UNCHANGED in PR6 — PR7 absorbs it.
- TPS's internal `polishingTranscriptID` guard preserved; TWC adds no idempotency guard (two-layer guard kept exactly as pre-PR6).
- Polish call path byte-identical: same `polishService.polish(transcript)`, same `transcripts[idx] = updated` + selection update, same `AppLogger` message + category on catch.

## Plan + reviews

- Plan: `docs/feature-requests/issue-772-2026-05-18-pr6-transcript-workflow.md`
- Council coverage (GPT + Gemini): COVERAGE-GAPS — addressed in revision
- Codex grounded review: PROCEED-WITH-REVISIONS — all revisions applied (including catching that `TranscriptCoordinator` is App-local not Services, dropping a stale import from TWC)
- Codex code-diff review: clean, no actionable regressions

## Ceilings

- New `TranscriptWorkflowCoordinatorCeilingsTests`: exactly 2 stored, exactly 1 non-private method (anti-service-locator guard), ≤90 lines, imports ⊆ {Foundation, Observation, EnviousWisprCore, EnviousWisprPipeline}.
- `EnviousWisprAppCeilingsTests` stored-property cap 7 → 8 (Bible §30 entry inline).
- `AppStateCeilingsTests` line-count cap 1073 → 1046 (1044 actual + 2-line margin).
- AppState collaborator ceiling stays at 18 (no `let` decls removed in PR6).

## Test plan

- [x] `swift build -c debug` exits 0
- [x] `swift build -c release` exits 0
- [x] `scripts/swift-test.sh` — 935/935 pass
- [x] Codex code-diff review clean
- [x] Bundle rebuild + relaunch — app running
- [x] wispr-eyes verification: History view renders with TWC env (sidebar count 8,727 visible, search field, list of 90+ transcripts, model status bar — all read through `transcriptWorkflowCoordinator.transcriptCoordinator.X` post-PR6). No body-eval crash from env lookup.
- [ ] CI `build-check` green (auto)
- [ ] Founder smoke pass on Enhance flow at convenience

## Closes

#772
