### PR TITLE
refactor(appstate): extract AudioEventRouter + ASREventRouter + WedgeRecoveryRouter under DictationRuntime (PR8 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -303,154 +303,16 @@ final class AppState {
       }
     }
 
-    // Unified engine interruption handler — routes to whichever pipeline is actively recording.
-    // Both pipelines share the same audioCapture instance. When the audio engine/XPC service
-    // is interrupted, we must notify the pipeline that's currently recording, not the one
-    // that happened to set onEngineInterrupted last.
-    audioCapture.onEngineInterrupted = { [weak self] in
-      guard let self else { return }
-      let pState = self.pipeline.state
-      let wkState = self.whisperKitPipeline.state
-      Task {
-        await AppLogger.shared.log(
-          "[AppState] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
-          level: .info, category: "XPC"
-        )
-      }
-      SentryBreadcrumb.add(
-        stage: "audio", message: "Audio XPC interrupted", level: .error,
-        data: [
-          "parakeet_state": "\(pState)",
-          "whisperkit_state": "\(wkState)",
-        ])
-      // Issue #285 — route to the pipeline that owns the shared capture
-      // right now. Uses the same owner-selection as `activeTelemetryTarget()`
-      // so the two paths cannot drift when both pipelines are active
-      // (overlap during backend switch: one polishing while the other starts
-      // a new recording).
-      switch self.activeCaptureBackend() {
-      case .parakeet:
-        self.pipeline.handleEngineInterruption()
-      case .whisperKit:
-        self.whisperKitPipeline.handleEngineInterruption()
-      case nil:
-        break  // neither pipeline active — nothing to clean up
-      }
-      // Do NOT hide the overlay here. The pipeline's handleEngineInterruption()
-      // sets state = .error(...), which fires onStateChange and shows the error
-      // overlay. Calling hide() immediately after would dismiss it before the
-      // user can read it. The error overlay auto-dismisses after 3 seconds.
-    }
+    // PR8 of #763 — heart-path event-routing callbacks (seven `audioCapture.on*`
+    // closures + `asrManager.onServiceInterrupted` + AVAudioEngineConfigurationChange
+    // observer) moved to `DictationRuntime` and its three private routers
+    // (`AudioEventRouter`, `ASREventRouter`, `WedgeRecoveryRouter`). Constructed
+    // in `EnviousWisprApp.init()` after `let appState = AppState()`. Resolver
+    // helpers (`activeCaptureBackend()`, `isCurrentSession(_:)`,
+    // `activeTelemetryTarget()`, `LastCapturingBackend`) stay here through
+    // PR8 and migrate with the rest of `pipeline.onStateChange` in PR9
+    // (DictationLifecycleCoordinator).
 
-    // Issue #285 — XPC transport telemetry. Proxy fires this from its
-    // interruption and invalidation handlers; idle interrupts stay silent.
-    // We emit a single captureError per channel with enough context for
-    // Sentry to classify and alert.
-    audioCapture.onXPCServiceError = { [weak self] ctx in
-      guard let self else { return }
-      let handlerKind: XPCHandlerKind = {
-        switch ctx.kind {
-        case .interruptCapturing: return .interrupt
-        case .invalidateCapturing, .invalidateIdle: return .invalidate
-        }
-      }()
-      let wasCapturing = ctx.kind != .invalidateIdle
-      // #455: surface recording_duration_ms when the interrupt/invalidate
-      // fired during active capture, so triage can separate "fired
-      // immediately after start" (likely device-binding race) from "fired
-      // mid-dictation" (likely launchd kill under memory pressure or
-      // system event).
-      let recordingDurationMs: Any =
-        ctx.recordingDurationNs.map { Int($0 / 1_000_000) } ?? NSNull()
-      let extras: [String: Any] = [
-        "xpc.handler": handlerKind.rawValue,
-        "xpc.was_capturing": wasCapturing,
-        "xpc.kind": ctx.kind.rawValue,
-        "capture_session_id": ctx.sessionID.map { Int($0) } ?? NSNull(),
-        "capture.route": self.audioCapture.currentAudioRoute,
-        "audio.recording_duration_ms": recordingDurationMs,
-      ]
-      SentryBreadcrumb.captureError(
-        HeartPathError.audioXPCInterrupted(
-          handler: handlerKind, wasCapturing: wasCapturing),
-        category: .xpcServiceError,
-        stage: "audio",
-        extra: extras
-      )
-    }
-
-    // (see `activeTelemetryTarget()` at end of init for dispatch logic).
-    // Issue #285 — centralized routing for heart-path telemetry callbacks.
-    // `audioCapture` is a single instance shared by both pipelines, so these
-    // closure properties are single-owner — per-pipeline wiring would let the
-    // last-initialized pipeline silently steal the callbacks. Same pattern as
-    // `onEngineInterrupted` above: route to whichever pipeline is currently
-    // recording so the right backend's dedup flags get set.
-    audioCapture.onCaptureStalled = { [weak self] ctx in
-      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
-      self.activeTelemetryTarget()?.handleCaptureStall(ctx)
-    }
-    audioCapture.onXPCReplyFailed = { [weak self] ctx in
-      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
-      self.activeTelemetryTarget()?.handleXPCReplyFailed(ctx)
-    }
-    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
-      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
-      self.activeTelemetryTarget()?.handleCaptureSessionInterruption(ctx)
-    }
-
-    // Observe audio route changes for Sentry context enrichment.
-    // AVAudioEngineSource fires AVAudioEngineConfigurationChange internally and handles
-    // recovery, but breadcrumbs live in EnviousWisprServices (unavailable in the audio module).
-    // AppState observes here to stay within module boundary rules.
-    NotificationCenter.default.addObserver(
-      forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
-    ) { [weak self] _ in
-      Task { @MainActor in
-        guard let self else { return }
-        self.captureTelemetry.incrementConfigChange()
-        let route = self.audioCapture.currentAudioRoute
-        SentryBreadcrumb.add(
-          stage: "audio", message: "Audio route changed", level: .warning,
-          data: [
-            "audio_route": route
-          ])
-        SentryBreadcrumb.updateAudioRoute(route)
-      }
-    }
-
-    // Unified ASR service crash handler — routes to whichever pipeline is active.
-    // Fires when the XPC ASR service dies mid-session (streaming or batch).
-    asrManager.onServiceInterrupted = { [weak self] in
-      guard let self else { return }
-      let pState = self.pipeline.state
-      let wkState = self.whisperKitPipeline.state
-      Task {
-        await AppLogger.shared.log(
-          "[AppState] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
-          level: .info, category: "XPC"
-        )
-      }
-      if pState == .loadingModel || pState == .recording || pState == .transcribing {
-        self.pipeline.handleASRServiceInterruption()
-      } else if wkState == .recording || wkState == .transcribing {
-        self.whisperKitPipeline.handleASRServiceInterruption()
-      }
-      // Do NOT hide the overlay here. Same reasoning as onEngineInterrupted:
-      // the pipeline sets .error(...) state which shows the error overlay via
-      // onStateChange. The error overlay auto-dismisses after 3 seconds.
-    }
-
-    // Unified VAD auto-stop handler — routes to whichever pipeline is actively recording.
-    // Fired by service-side VAD (XPC mode only). Same routing pattern as onEngineInterrupted.
-    audioCapture.onVADAutoStop = { [weak self] in
-      guard let self else { return }
-      if self.pipeline.state == .recording {
-        Task { await self.pipeline.stopAndTranscribe() }
-      } else if self.whisperKitPipeline.state == .recording {
-        Task { await self.whisperKitPipeline.stopAndTranscribe() }
-      }
-    }
     settingsSync.onNeedsPreloadObservation = { [weak setup] in
       setup?.startPreloadObservation()
     }
@@ -864,8 +726,12 @@ final class AppState {
   /// other begins a new capture). Updated on any active-state entry, not just
   /// `.recording`, so stall watchdog and interruption callbacks that fire
   /// pre-recording resolve to the correct backend.
-  private enum LastCapturingBackend { case parakeet, whisperKit }
-  private var lastCapturingBackend: LastCapturingBackend = .parakeet
+  /// PR8 of #763: promoted private→internal so `DictationRuntime`'s
+  /// injected resolver closures can type their return value. PR9
+  /// (`DictationLifecycleCoordinator`) absorbs this enum + the three
+  /// resolver helpers + the writer-side flips out of AppState.
+  enum LastCapturingBackend { case parakeet, whisperKit }
+  var lastCapturingBackend: LastCapturingBackend = .parakeet
   // Previous active-state of each pipeline, tracked so we flip
   // `lastCapturingBackend` only on inactive→active transitions. Without this,
   // `.transcribing → .polishing` (active → active) would re-steal ownership
@@ -881,7 +747,7 @@ final class AppState {
   /// now. Returns nil when both pipelines are fully idle. Shared helper for
   /// both telemetry routing and engine-interrupt routing so the two paths
   /// cannot drift.
-  private func activeCaptureBackend() -> LastCapturingBackend? {
+  func activeCaptureBackend() -> LastCapturingBackend? {
     let pActive = pipeline.state.isActive
     let wkActive = whisperKitPipeline.state.isActive
     if pActive && wkActive { return lastCapturingBackend }
@@ -895,11 +761,11 @@ final class AppState {
   /// backend switch. Dropping a stale callback is safer than misrouting it to
   /// a new session's dedup state. Source-level guards normally catch this;
   /// this is a second line of defense for the backend-overlap window.
-  private func isCurrentSession(_ sessionID: UInt64) -> Bool {
+  func isCurrentSession(_ sessionID: UInt64) -> Bool {
     sessionID == audioCapture.currentCaptureSessionID
   }
 
-  private func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
+  func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
     switch activeCaptureBackend() {
     case .whisperKit: return whisperKitPipeline
     case .parakeet: return pipeline

--- a/Sources/EnviousWispr/App/DictationRuntime/ASREventRouter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/ASREventRouter.swift
@@ -1,0 +1,42 @@
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Foundation
+
+/// PR8 of #763 — routes ASR service-interruption events to whichever
+/// pipeline is currently active. Reads pipeline state directly; no
+/// resolver-helper closure needed.
+@MainActor
+final class ASREventRouter {
+  let asrManager: any ASRManagerInterface
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
+
+  init(
+    asrManager: any ASRManagerInterface,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline
+  ) {
+    self.asrManager = asrManager
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+
+    asrManager.onServiceInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[ASREventRouter] ASR onServiceInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
+        )
+      }
+      if pState == .loadingModel || pState == .recording || pState == .transcribing {
+        self.pipeline.handleASRServiceInterruption()
+      } else if wkState == .recording || wkState == .transcribing {
+        self.whisperKitPipeline.handleASRServiceInterruption()
+      }
+    }
+  }
+
+}

--- a/Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift
@@ -1,0 +1,119 @@
+import AVFAudio
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// PR8 of #763 — routes audio engine + VAD + route-change events to the
+/// active pipeline. Installs three callbacks on `audioCapture` and one
+/// `AVAudioEngineConfigurationChange` observer at construction time.
+///
+/// Lifetime: held by `DictationRuntime`, which is `@State` on
+/// `EnviousWisprApp`, so the router lives for the app's lifetime. No `deinit`
+/// cleanup: same shape as the prior AppState code, where these observer
+/// blocks and callback slots persisted for the full app lifetime. Tests
+/// construct fresh routers against spy mocks, so test-side cleanup is not
+/// required either.
+@MainActor
+final class AudioEventRouter {
+  let audioCapture: any AudioCaptureInterface
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
+  let captureTelemetry: CaptureTelemetryState
+
+  let resolveActiveCaptureBackend: @MainActor () -> AppState.LastCapturingBackend?
+
+  init(
+    audioCapture: any AudioCaptureInterface,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    captureTelemetry: CaptureTelemetryState,
+    resolveActiveCaptureBackend: @escaping @MainActor () -> AppState.LastCapturingBackend?
+  ) {
+    self.audioCapture = audioCapture
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.captureTelemetry = captureTelemetry
+    self.resolveActiveCaptureBackend = resolveActiveCaptureBackend
+
+    NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange, object: nil, queue: nil
+    ) { [weak self] _ in
+      Task { @MainActor in
+        guard let self else { return }
+        self.captureTelemetry.incrementConfigChange()
+        let route = self.audioCapture.currentAudioRoute
+        SentryBreadcrumb.add(
+          stage: "audio", message: "Audio route changed", level: .warning,
+          data: [
+            "audio_route": route
+          ])
+        SentryBreadcrumb.updateAudioRoute(route)
+      }
+    }
+
+    audioCapture.onEngineInterrupted = { [weak self] in
+      guard let self else { return }
+      let pState = self.pipeline.state
+      let wkState = self.whisperKitPipeline.state
+      Task {
+        await AppLogger.shared.log(
+          "[AudioEventRouter] Audio onEngineInterrupted — parakeet=\(pState), whisperKit=\(wkState)",
+          level: .info, category: "XPC"
+        )
+      }
+      SentryBreadcrumb.add(
+        stage: "audio", message: "Audio XPC interrupted", level: .error,
+        data: [
+          "parakeet_state": "\(pState)",
+          "whisperkit_state": "\(wkState)",
+        ])
+      switch self.resolveActiveCaptureBackend() {
+      case .parakeet:
+        self.pipeline.handleEngineInterruption()
+      case .whisperKit:
+        self.whisperKitPipeline.handleEngineInterruption()
+      case nil:
+        break
+      }
+    }
+
+    audioCapture.onXPCServiceError = { [weak self] ctx in
+      guard let self else { return }
+      let handlerKind: XPCHandlerKind = {
+        switch ctx.kind {
+        case .interruptCapturing: return .interrupt
+        case .invalidateCapturing, .invalidateIdle: return .invalidate
+        }
+      }()
+      let wasCapturing = ctx.kind != .invalidateIdle
+      let recordingDurationMs: Any =
+        ctx.recordingDurationNs.map { Int($0 / 1_000_000) } ?? NSNull()
+      let extras: [String: Any] = [
+        "xpc.handler": handlerKind.rawValue,
+        "xpc.was_capturing": wasCapturing,
+        "xpc.kind": ctx.kind.rawValue,
+        "capture_session_id": ctx.sessionID.map { Int($0) } ?? NSNull(),
+        "capture.route": self.audioCapture.currentAudioRoute,
+        "audio.recording_duration_ms": recordingDurationMs,
+      ]
+      SentryBreadcrumb.captureError(
+        HeartPathError.audioXPCInterrupted(
+          handler: handlerKind, wasCapturing: wasCapturing),
+        category: .xpcServiceError,
+        stage: "audio",
+        extra: extras
+      )
+    }
+
+    audioCapture.onVADAutoStop = { [weak self] in
+      guard let self else { return }
+      if self.pipeline.state == .recording {
+        Task { await self.pipeline.stopAndTranscribe() }
+      } else if self.whisperKitPipeline.state == .recording {
+        Task { await self.whisperKitPipeline.stopAndTranscribe() }
+      }
+    }
+  }
+}

--- a/Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift
@@ -1,0 +1,50 @@
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// PR8 of #763 — App-level home composing the heart-path event routers.
+/// Holds three private collaborators (`AudioEventRouter`, `ASREventRouter`,
+/// `WedgeRecoveryRouter`) that install their callbacks on `audioCapture` /
+/// `asrManager` at construction. Not environment-injected, not consumed by
+/// AppDelegate or any view. PR10 expands this home with hotkey controller +
+/// recording starter/finalizer.
+@MainActor
+final class DictationRuntime {
+  private let audioEventRouter: AudioEventRouter
+  private let asrEventRouter: ASREventRouter
+  private let wedgeRecoveryRouter: WedgeRecoveryRouter
+
+  init(
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    captureTelemetry: CaptureTelemetryState,
+    resolveActiveCaptureBackend: @escaping @MainActor () -> AppState.LastCapturingBackend?,
+    resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?,
+    isCurrentSession: @escaping @MainActor (UInt64) -> Bool
+  ) {
+    self.audioEventRouter = AudioEventRouter(
+      audioCapture: audioCapture,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      captureTelemetry: captureTelemetry,
+      resolveActiveCaptureBackend: resolveActiveCaptureBackend
+    )
+    self.asrEventRouter = ASREventRouter(
+      asrManager: asrManager,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline
+    )
+    self.wedgeRecoveryRouter = WedgeRecoveryRouter(
+      audioCapture: audioCapture,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      isCurrentSession: isCurrentSession,
+      resolveActiveTelemetryTarget: resolveActiveTelemetryTarget
+    )
+  }
+}

--- a/Sources/EnviousWispr/App/DictationRuntime/WedgeRecoveryRouter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/WedgeRecoveryRouter.swift
@@ -1,0 +1,46 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// PR8 of #763 — routes capture-stall, XPC reply timeout, and capture-session
+/// interruption events to the active pipeline's telemetry target. Filters
+/// stale callbacks via `isCurrentSession` before dispatching.
+@MainActor
+final class WedgeRecoveryRouter {
+  let audioCapture: any AudioCaptureInterface
+  let pipeline: TranscriptionPipeline
+  let whisperKitPipeline: WhisperKitPipeline
+
+  let isCurrentSession: @MainActor (UInt64) -> Bool
+  let resolveActiveTelemetryTarget: @MainActor () -> (any HeartPathTelemetryTarget)?
+
+  init(
+    audioCapture: any AudioCaptureInterface,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    isCurrentSession: @escaping @MainActor (UInt64) -> Bool,
+    resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?
+  ) {
+    self.audioCapture = audioCapture
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.isCurrentSession = isCurrentSession
+    self.resolveActiveTelemetryTarget = resolveActiveTelemetryTarget
+
+    audioCapture.onCaptureStalled = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.resolveActiveTelemetryTarget()?.handleCaptureStall(ctx)
+    }
+    audioCapture.onXPCReplyFailed = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.resolveActiveTelemetryTarget()?.handleXPCReplyFailed(ctx)
+    }
+    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
+      guard let self, self.isCurrentSession(ctx.sessionID) else { return }
+      self.resolveActiveTelemetryTarget()?.handleCaptureSessionInterruption(ctx)
+    }
+  }
+
+}

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -31,6 +31,11 @@ struct EnviousWisprApp: App {
   @State private var liveRecordingState: LiveRecordingState
   @State private var lastRecordingResult: LastRecordingResult
   @State private var backendMetadata: BackendMetadata
+  // PR8 of #763: heart-path event-routing home. Holds three private routers
+  // (`AudioEventRouter`, `ASREventRouter`, `WedgeRecoveryRouter`) that install
+  // their callbacks on `audioCapture`/`asrManager` at construction. Not
+  // environment-injected and not consumed by AppDelegate.
+  @State private var dictationRuntime: DictationRuntime
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -119,6 +124,28 @@ struct EnviousWisprApp: App {
     appState.attachLastRecordingResult(lastRecordingResult)
     appState.attachBackendMetadata(backendMetadata)
 
+    // PR8 of #763: construct heart-path event-routing home. Routers install
+    // their `audioCapture.on*` / `asrManager.onServiceInterrupted` slots +
+    // the `AVAudioEngineConfigurationChange` observer at init. Resolver
+    // helpers stay on AppState through PR8; PR9 absorbs them into
+    // DictationLifecycleCoordinator and rewires the closures.
+    let dictationRuntime = DictationRuntime(
+      audioCapture: appState.audioCapture,
+      asrManager: appState.asrManager,
+      pipeline: appState.pipeline,
+      whisperKitPipeline: appState.whisperKitPipeline,
+      captureTelemetry: appState.captureTelemetry,
+      resolveActiveCaptureBackend: { [weak appState] in
+        appState?.activeCaptureBackend()
+      },
+      resolveActiveTelemetryTarget: { [weak appState] in
+        appState?.activeTelemetryTarget()
+      },
+      isCurrentSession: { [weak appState] sessionID in
+        appState?.isCurrentSession(sessionID) ?? false
+      }
+    )
+
     _appState = State(initialValue: appState)
     _navigationCoordinator = State(initialValue: navigationCoordinator)
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
@@ -128,6 +155,7 @@ struct EnviousWisprApp: App {
     _liveRecordingState = State(initialValue: liveRecordingState)
     _lastRecordingResult = State(initialValue: lastRecordingResult)
     _backendMetadata = State(initialValue: backendMetadata)
+    _dictationRuntime = State(initialValue: dictationRuntime)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires. `@NSApplicationDelegateAdaptor`

--- a/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprASR
+@testable import EnviousWisprPipeline
+
+/// PR8 of #763 — unit tests for `ASREventRouter`.
+@MainActor
+@Suite("ASREventRouter")
+struct ASREventRouterTests {
+
+  @Test("init installs onServiceInterrupted on the ASR manager")
+  func installsServiceInterruptedCallback() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+
+    #expect(asr.onServiceInterrupted == nil)
+
+    let router = ASREventRouter(
+      asrManager: asr,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit
+    )
+
+    #expect(asr.onServiceInterrupted != nil)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("onServiceInterrupted is invokable without crashing when both pipelines idle")
+  func serviceInterruptedSafeWhenIdle() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+
+    let router = ASREventRouter(
+      asrManager: asr,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit
+    )
+
+    // Both pipelines are idle (.idle is the default state). The callback
+    // should no-op without dispatching to either pipeline. The test passes
+    // as long as no precondition fires.
+    asr.onServiceInterrupted?()
+    withExtendedLifetime(router) {}
+  }
+}

--- a/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
@@ -1,0 +1,107 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+
+/// PR8 of #763 — unit tests for `AudioEventRouter`.
+///
+/// Verifies callback installation on construction and that the route-change
+/// observer invokes `captureTelemetry.incrementConfigChange()`. End-to-end
+/// pipeline-state-flip routing under engine-interruption is covered by Live
+/// UAT; here we lock the shape and the most catchable regressions.
+@MainActor
+@Suite("AudioEventRouter")
+struct AudioEventRouterTests {
+
+  @Test("init installs onEngineInterrupted, onXPCServiceError, and onVADAutoStop")
+  func installsAudioCallbacks() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+    let telemetry = CaptureTelemetryState()
+
+    #expect(audio.onEngineInterrupted == nil)
+    #expect(audio.onXPCServiceError == nil)
+    #expect(audio.onVADAutoStop == nil)
+
+    let router = AudioEventRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      captureTelemetry: telemetry,
+      resolveActiveCaptureBackend: { nil }
+    )
+
+    #expect(audio.onEngineInterrupted != nil)
+    #expect(audio.onXPCServiceError != nil)
+    #expect(audio.onVADAutoStop != nil)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("AVAudioEngineConfigurationChange observer increments the config-change counter")
+  func routeChangeObserverIncrementsTelemetry() async {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+    let telemetry = CaptureTelemetryState()
+
+    let router = AudioEventRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      captureTelemetry: telemetry,
+      resolveActiveCaptureBackend: { nil }
+    )
+
+    let baseline = telemetry.configurationChangeCount
+    NotificationCenter.default.post(
+      name: .AVAudioEngineConfigurationChange, object: nil)
+    // The observer hops to @MainActor via Task — yield so the hop runs.
+    await Task.yield()
+    await Task.yield()
+
+    #expect(telemetry.configurationChangeCount == baseline + 1)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("resolveActiveCaptureBackend closure is invoked on engine interruption")
+  func engineInterruptionCallsResolver() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+    let telemetry = CaptureTelemetryState()
+
+    var resolverCallCount = 0
+    let router = AudioEventRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      captureTelemetry: telemetry,
+      resolveActiveCaptureBackend: {
+        resolverCallCount += 1
+        return nil
+      }
+    )
+
+    audio.onEngineInterrupted?()
+
+    #expect(resolverCallCount == 1)
+    withExtendedLifetime(router) {}
+  }
+}

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -1,0 +1,169 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+
+@testable import EnviousWispr
+@testable import EnviousWisprASR
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprStorage
+
+/// PR8 of #763 — shared spies for the three router unit tests. Identical
+/// shape to the existing `SettableAudioCapture` / `NoOpASRManager` fixtures
+/// used elsewhere; centralised here so the three router test files don't
+/// each redeclare a 40-line stub.
+@MainActor
+final class RouterTestAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "built_in_mic"
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "av_audio_engine"
+  var noiseSuppressionEnabled: Bool = false
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func buildEngine(noiseSuppression: Bool) {}
+  func preWarm() async throws {}
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    ([], 0)
+  }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}
+
+@MainActor
+final class RouterTestASRManager: ASRManagerInterface {
+  var activeBackendType: ASRBackendType = .parakeet
+  var isModelLoaded: Bool = false
+  var isStreaming: Bool = false
+  var downloadProgress: Double = 0
+  var downloadPhase: String = "idle"
+  var downloadDetail: String = ""
+  var onServiceInterrupted: (() -> Void)?
+  var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
+
+  func loadModel() async throws {}
+  func loadModelSilently() async {}
+  func unloadModel() async {}
+  func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
+  func switchBackend(to type: ASRBackendType) async { activeBackendType = type }
+
+  var activeBackendSupportsStreaming: Bool { get async { false } }
+
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
+    throw RouterTestError.unexpected
+  }
+  func startStreaming(options: TranscriptionOptions) async throws {
+    throw RouterTestError.unexpected
+  }
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {
+    throw RouterTestError.unexpected
+  }
+  func finalizeStreaming() async throws -> ASRResult { throw RouterTestError.unexpected }
+  func cancelStreaming() async {}
+  func noteTranscriptionComplete(policy: ModelUnloadPolicy) {}
+  func cancelIdleTimer() {}
+  func cancelInFlightLoad() {}
+}
+
+enum RouterTestError: Error { case unexpected }
+
+@MainActor
+enum DictationRuntimeFixtures {
+  static func tempStore() -> TranscriptStore {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("router-tests-\(UUID().uuidString)")
+    return TranscriptStore(directory: tempDir)
+  }
+
+  static func makeParakeetPipeline(
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    store: TranscriptStore
+  ) -> TranscriptionPipeline {
+    TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: store
+    )
+  }
+
+  static func makeWhisperKitPipeline(
+    audioCapture: any AudioCaptureInterface,
+    store: TranscriptStore
+  ) -> WhisperKitPipeline {
+    WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: store,
+      keychainManager: KeychainManager()
+    )
+  }
+
+  static func captureStallContext(sessionID: UInt64) -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: sessionID,
+      armedAtUptimeNs: 1_000,
+      firedAtUptimeNs: 2_000,
+      route: "built_in_mic",
+      sourceType: "av_audio_engine",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil
+    )
+  }
+
+  static func xpcReplyFailureContext(sessionID: UInt64) -> XPCReplyFailureContext {
+    XPCReplyFailureContext(
+      replyStage: "stopCapture",
+      errorDomain: "TestDomain",
+      errorCode: 1,
+      errorDescription: "test",
+      sessionID: sessionID
+    )
+  }
+
+  static func captureSessionInterruptionContext(
+    sessionID: UInt64
+  ) -> CaptureSessionInterruptionContext {
+    CaptureSessionInterruptionContext(
+      kind: .wasInterrupted,
+      reasonCode: 1,
+      reasonLabel: "test",
+      errorDomain: nil,
+      errorCode: nil,
+      errorDescription: nil,
+      sessionID: sessionID,
+      isActivelyCapturing: true
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/App/WedgeRecoveryRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/WedgeRecoveryRouterTests.swift
@@ -1,0 +1,112 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+
+/// PR8 of #763 — unit tests for `WedgeRecoveryRouter`.
+@MainActor
+@Suite("WedgeRecoveryRouter")
+struct WedgeRecoveryRouterTests {
+
+  @Test("init installs the three wedge callbacks on audioCapture")
+  func installsWedgeCallbacks() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+
+    #expect(audio.onCaptureStalled == nil)
+    #expect(audio.onXPCReplyFailed == nil)
+    #expect(audio.onCaptureSessionInterruption == nil)
+
+    let router = WedgeRecoveryRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      isCurrentSession: { _ in true },
+      resolveActiveTelemetryTarget: { nil }
+    )
+
+    #expect(audio.onCaptureStalled != nil)
+    #expect(audio.onXPCReplyFailed != nil)
+    #expect(audio.onCaptureSessionInterruption != nil)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("isCurrentSession filter drops stale callbacks (resolver not consulted)")
+  func staleCallbacksDropped() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+
+    var sessionFilterCalls: [UInt64] = []
+    var resolverCallCount = 0
+
+    let router = WedgeRecoveryRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      isCurrentSession: { sessionID in
+        sessionFilterCalls.append(sessionID)
+        return false  // always stale
+      },
+      resolveActiveTelemetryTarget: {
+        resolverCallCount += 1
+        return nil
+      }
+    )
+
+    audio.onCaptureStalled?(DictationRuntimeFixtures.captureStallContext(sessionID: 7))
+    audio.onXPCReplyFailed?(
+      DictationRuntimeFixtures.xpcReplyFailureContext(sessionID: 8))
+    audio.onCaptureSessionInterruption?(
+      DictationRuntimeFixtures.captureSessionInterruptionContext(sessionID: 9))
+
+    #expect(sessionFilterCalls == [7, 8, 9])
+    #expect(resolverCallCount == 0)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("isCurrentSession=true forwards to resolveActiveTelemetryTarget")
+  func freshCallbacksReachResolver() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+
+    var resolverCallCount = 0
+
+    let router = WedgeRecoveryRouter(
+      audioCapture: audio,
+      pipeline: parakeet,
+      whisperKitPipeline: whisperKit,
+      isCurrentSession: { _ in true },
+      resolveActiveTelemetryTarget: {
+        resolverCallCount += 1
+        return nil
+      }
+    )
+
+    audio.onCaptureStalled?(DictationRuntimeFixtures.captureStallContext(sessionID: 1))
+    audio.onXPCReplyFailed?(
+      DictationRuntimeFixtures.xpcReplyFailureContext(sessionID: 1))
+    audio.onCaptureSessionInterruption?(
+      DictationRuntimeFixtures.captureSessionInterruptionContext(sessionID: 1))
+
+    #expect(resolverCallCount == 3)
+    withExtendedLifetime(router) {}
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks `ASREventRouter`'s entanglement shape.
+@Suite struct ASREventRouterCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/DictationRuntime/ASREventRouter.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "ASREventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 3,
+      """
+      ASREventRouter collaborator-slot ceiling exceeded: \(count) > 3. \
+      Allowed: asrManager, pipeline, whisperKitPipeline.
+      """)
+  }
+
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "ASREventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count == 0,
+      """
+      ASREventRouter must not take closure-injected dependencies (found \(count)). \
+      Reads pipeline state directly; no resolver helper required.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "ASREventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    // Parser counts `func`, not `init`. Codex code-diff r1 [P3].
+    #expect(
+      count == 0,
+      """
+      ASREventRouter non-private method ceiling exceeded: \(count) > 0 \
+      non-private `func` declarations. Only `init(...)` permitted.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 65,
+      """
+      ASREventRouter line count exceeded: \(count) > 65. Raise via Bible §30 only.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "EnviousWisprASR", "EnviousWisprCore", "EnviousWisprPipeline", "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      ASREventRouter imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
@@ -34,7 +34,7 @@ import Testing
       """)
   }
 
-  /// File line-count ceiling. Locked at post-PR7 (#773) baseline = 1038.
+  /// File line-count ceiling. Locked at post-PR8 (#774) baseline = 904.
   /// Soft backstop against scope creep.
   ///
   /// Ratcheted history:
@@ -67,14 +67,29 @@ import Testing
   ///   ceiling stays at 18 — the three new outlets are `var`, not `let`, and
   ///   the parser matches only `let`. The three temporary outlets sunset
   ///   in PR9 / PR11.
+  /// - 1038 → 904 in PR8 of epic #763 (2026-05-19, #774) after extracting the
+  ///   seven heart-path event-routing closures (`audioCapture.on*` ×6 +
+  ///   `asrManager.onServiceInterrupted`) plus the
+  ///   `AVAudioEngineConfigurationChange` observer block into
+  ///   `AudioEventRouter` / `ASREventRouter` / `WedgeRecoveryRouter` under
+  ///   `DictationRuntime`. Net: -134 (144 lines of closures + comments removed;
+  ///   ~10 lines of explanatory comment added in their place). 902 actual +
+  ///   2-line margin. Collaborator ceiling stays at 18 — no `let`s added or
+  ///   removed on AppState. The resolver helpers (`LastCapturingBackend`,
+  ///   `lastCapturingBackend`, `prevParakeetActive`, `prevWhisperKitActive`,
+  ///   `activeCaptureBackend()`, `isCurrentSession(_:)`,
+  ///   `activeTelemetryTarget()`) stay on AppState through PR8 — promoted
+  ///   `private` → `internal` so the router-injected closures can read them.
+  ///   PR9 absorbs them into `DictationLifecycleCoordinator` (same-PR
+  ///   grep-test `AppStateNoLongerOwnsBackendResolverTests` enforces).
   @Test func appStateLineCountCeilingHolds() throws {
     let url = appStateURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1038,
+      lineCount <= 904,
       """
-      AppState line count exceeded: \(lineCount) > 1038. \
+      AppState line count exceeded: \(lineCount) > 904. \
       Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/AppStateNoLongerInstallsHeartPathCallbacksTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateNoLongerInstallsHeartPathCallbacksTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks the no-shim rule by asserting AppState no longer
+/// installs heart-path event-routing closures. Fails the build if any of
+/// the seven `audioCapture.on*` slots, `asrManager.onServiceInterrupted`, or
+/// the `AVAudioEngineConfigurationChange` observer block reappears in
+/// AppState. The closures now live in `AudioEventRouter`, `ASREventRouter`,
+/// or `WedgeRecoveryRouter`.
+@Suite struct AppStateNoLongerInstallsHeartPathCallbacksTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/AppState.swift"
+
+  /// Assignment patterns that MUST NOT appear in AppState.swift post-PR8.
+  private static let forbiddenAssignments: [String] = [
+    "audioCapture.onEngineInterrupted =",
+    "audioCapture.onXPCServiceError =",
+    "audioCapture.onCaptureStalled =",
+    "audioCapture.onXPCReplyFailed =",
+    "audioCapture.onCaptureSessionInterruption =",
+    "audioCapture.onVADAutoStop =",
+    "asrManager.onServiceInterrupted =",
+  ]
+
+  /// The AVAudioEngineConfigurationChange observer needs a two-part guard:
+  /// (1) any addObserver call inside AppState.swift, AND (2) any reference to
+  /// .AVAudioEngineConfigurationChange. If BOTH appear in AppState, the
+  /// observer has been reintroduced. Codex code-diff r1 [P3] flagged that a
+  /// single-line pattern would miss the multiline shape the original AppState
+  /// used (`addObserver(` on one line, `forName:` on the next).
+  private static let observerInstallSentinels: [String] = [
+    "NotificationCenter.default.addObserver",
+    ".AVAudioEngineConfigurationChange",
+  ]
+
+  @Test func forbiddenAssignmentsAbsent() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    var present: [String] = []
+    for pattern in Self.forbiddenAssignments {
+      if source.contains(pattern) {
+        present.append(pattern)
+      }
+    }
+    #expect(
+      present.isEmpty,
+      """
+      AppState still installs heart-path event-routing callbacks: \(present). \
+      PR8 of #763 moved these to AudioEventRouter / ASREventRouter / \
+      WedgeRecoveryRouter under DictationRuntime. The no-shim rule (epic \
+      #763 Decision 4) prohibits AppState from re-installing them.
+      """)
+  }
+
+  /// Locks the AVAudioEngineConfigurationChange observer move regardless of
+  /// formatting. Fails if AppState contains BOTH an `addObserver` call AND a
+  /// reference to the configuration-change notification name. Either signal
+  /// alone is benign; the conjunction proves the observer is back.
+  @Test func configChangeObserverNotReinstalled() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let hasAllSentinels = Self.observerInstallSentinels.allSatisfy {
+      source.contains($0)
+    }
+    #expect(
+      !hasAllSentinels,
+      """
+      AppState.swift contains both `NotificationCenter.default.addObserver` \
+      and `.AVAudioEngineConfigurationChange` — the heart-path route-change \
+      observer has been reinstalled. PR8 of #763 moved this to \
+      AudioEventRouter.init. The no-shim rule (epic #763 Decision 4) \
+      prohibits AppState from owning this observer.
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks `AudioEventRouter`'s entanglement shape.
+///
+/// Counts honestly: BOTH `let` and `var` instance stored properties count,
+/// sub-binned into collaborator / closure-injected / observer-token slots so
+/// the test fails with a specific message. Caps lower-is-free, raise via the
+/// Bible §30 changelog.
+@Suite struct AudioEventRouterCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "AudioEventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 4,
+      """
+      AudioEventRouter collaborator-slot ceiling exceeded: \(count) > 4. \
+      Allowed: audioCapture, pipeline, whisperKitPipeline, captureTelemetry.
+      """)
+  }
+
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "AudioEventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count <= 1,
+      """
+      AudioEventRouter closure-injected-dependency ceiling exceeded: \
+      \(count) > 1. Allowed: resolveActiveCaptureBackend.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(named: "AudioEventRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    // Parser counts `func` declarations, not `init`. The router exposes
+    // only `init(...)`; any additional non-private `func` (e.g. `start()`)
+    // breaks the no-public-control-surface invariant. Codex code-diff r1
+    // [P3]: a `<= 1` ceiling would allow the first violation to pass.
+    #expect(
+      count == 0,
+      """
+      AudioEventRouter non-private method ceiling exceeded: \(count) > 0 \
+      non-private `func` declarations. Only `init(...)` (not counted as a \
+      `func`) is permitted; no public `start()` / `stop()`.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 125,
+      """
+      AudioEventRouter line count exceeded: \(count) > 125. \
+      Raise via Bible §30 only.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "AVFAudio", "EnviousWisprAudio", "EnviousWisprCore",
+      "EnviousWisprPipeline", "EnviousWisprServices", "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      AudioEventRouter imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks `DictationRuntime`'s initial shape so the new
+/// runtime-internals home does not silently accrete domain state before
+/// PR10 expands it with HotkeyController / RecordingStarter / RecordingFinalizer.
+@Suite struct DictationRuntimeCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationRuntime", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 3,
+      """
+      DictationRuntime collaborator ceiling exceeded: \(count) > 3. \
+      Allowed: audioEventRouter, asrEventRouter, wedgeRecoveryRouter.
+      PR10 raises this when hotkey/start/finalize land.
+      """)
+  }
+
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationRuntime", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count == 0,
+      """
+      DictationRuntime must not store closure-injected dependencies (found \(count)). \
+      Resolver closures pass through init to the routers; they are not held \
+      on DictationRuntime itself.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationRuntime", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    // Parser counts `func`, not `init`. Codex code-diff r1 [P3].
+    #expect(
+      count == 0,
+      """
+      DictationRuntime non-private method ceiling exceeded: \(count) > 0 \
+      non-private `func` declarations. Only `init(...)` permitted at the PR8 \
+      stage; PR10 may add more.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 80,
+      """
+      DictationRuntime line count exceeded: \(count) > 80. \
+      Raise via Bible §30 only.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "Foundation", "EnviousWisprAudio", "EnviousWisprASR",
+      "EnviousWisprPipeline", "EnviousWisprServices", "EnviousWisprCore",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      DictationRuntime imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -34,13 +34,20 @@ import Testing
   ///   `liveRecordingState` and `lastRecordingResult` sunset to 9 in PR9
   ///   (DictationLifecycleCoordinator absorbs the push sites);
   ///   `backendMetadata` sunsets to 8 in PR11 (with AppState deletion).
+  /// - 11 → 12 in PR8 of epic #763 (2026-05-19, #774) for `DictationRuntime`.
+  ///   Bible §30 entry: PR8 lifts the seven heart-path event-routing closures +
+  ///   the AVAudioEngineConfigurationChange observer off AppState into a new
+  ///   App-owned `@State` home (`DictationRuntime`) whose three private routers
+  ///   install the callbacks. AppState shrinks ~134 lines; the composition root
+  ///   grows by one. `DictationRuntime` is NOT environment-injected and not
+  ///   consumed by AppDelegate; it persists for the lifetime of the App.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 11,
+      count <= 12,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 11. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 12. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -64,17 +71,20 @@ import Testing
       """)
   }
 
-  /// Line-count trip-wire (5x of current). Soft backstop against accidental
-  /// file explosions; entanglement signals (stored properties, methods,
-  /// imports) are the primary mechanical constraints.
+  /// Line-count trip-wire. Soft backstop against accidental file explosions;
+  /// entanglement signals (stored properties, methods, imports) are the
+  /// primary mechanical constraints. Ratcheted 250→270 in PR8 of epic #763
+  /// (2026-05-19, #774) to absorb DictationRuntime construction (15 lines:
+  /// @State decl + closure-injected init block + State(initialValue:)).
+  /// 259 actual + 2-line margin then rounded to the next ratchet step.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 250,
+      lineCount <= 270,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 250. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 270. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/HeartPathBreadcrumbLiteralsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/HeartPathBreadcrumbLiteralsTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks the heart-path Sentry breadcrumb / error / extras
+/// string literals at unit-test layer, replacing the manual MCP post-merge
+/// check. Reads the three router source files plus AppState, asserts every
+/// known literal still appears at least once. Fails the build locally if a
+/// refactor renames or removes one.
+///
+/// AppLogger log prefixes flipped 2026-05-19 from `[AppState]` →
+/// `[AudioEventRouter]` / `[ASREventRouter]` / `[WedgeRecoveryRouter]` per
+/// founder decision Q4. The new prefixes are asserted here; the old ones are
+/// asserted ABSENT so a regression rename does not slip back in.
+@Suite struct HeartPathBreadcrumbLiteralsTests {
+  private static let routerSourcePaths = [
+    "Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift",
+    "Sources/EnviousWispr/App/DictationRuntime/ASREventRouter.swift",
+    "Sources/EnviousWispr/App/DictationRuntime/WedgeRecoveryRouter.swift",
+  ]
+  private static let appStateSourcePath =
+    "Sources/EnviousWispr/App/AppState.swift"
+
+  /// Literal strings that MUST appear at least once in the union of the
+  /// router source files. These are the Sentry breadcrumb messages,
+  /// error-type spellings, category strings, and extras-dict keys consumed
+  /// by Sentry triage queries. Drift here breaks PostHog/Sentry dashboards.
+  private static let requiredLiterals: [String] = [
+    "\"Audio XPC interrupted\"",
+    "\"Audio route changed\"",
+    ".audioXPCInterrupted",
+    ".xpcServiceError",
+    "\"xpc.handler\"",
+    "\"xpc.was_capturing\"",
+    "\"xpc.kind\"",
+    "\"capture_session_id\"",
+    "\"capture.route\"",
+    "\"audio.recording_duration_ms\"",
+    "\"parakeet_state\"",
+    "\"whisperkit_state\"",
+    "\"audio_route\"",
+    "[AudioEventRouter] Audio onEngineInterrupted",
+    "[ASREventRouter] ASR onServiceInterrupted",
+  ]
+
+  /// Old log prefixes that MUST NOT reappear in router source files. Locked
+  /// 2026-05-19 to prevent a refactor from quietly restoring `[AppState]`
+  /// prefixes (which would re-merge log clusters in Sentry and undo the
+  /// founder's Q4 decision).
+  private static let forbiddenInRouters: [String] = [
+    "[AppState] Audio onEngineInterrupted",
+    "[AppState] ASR onServiceInterrupted",
+  ]
+
+  @Test func requiredLiteralsPresent() throws {
+    let union = try Self.routerSourcePaths
+      .map { try String(contentsOf: URL(fileURLWithPath: $0), encoding: .utf8) }
+      .joined(separator: "\n")
+    var missing: [String] = []
+    for literal in Self.requiredLiterals {
+      if !union.contains(literal) {
+        missing.append(literal)
+      }
+    }
+    #expect(
+      missing.isEmpty,
+      """
+      Heart-path breadcrumb literals missing from router source files: \
+      \(missing). These strings are consumed by Sentry triage queries and \
+      PostHog dashboards; renaming them silently breaks observability. \
+      If the rename is intentional, update both this test and the \
+      downstream consumer dashboards in the same PR.
+      """)
+  }
+
+  @Test func forbiddenLogPrefixesAbsent() throws {
+    let union = try Self.routerSourcePaths
+      .map { try String(contentsOf: URL(fileURLWithPath: $0), encoding: .utf8) }
+      .joined(separator: "\n")
+    var present: [String] = []
+    for literal in Self.forbiddenInRouters {
+      if union.contains(literal) {
+        present.append(literal)
+      }
+    }
+    #expect(
+      present.isEmpty,
+      """
+      Forbidden `[AppState] …` log prefixes detected in router source files: \
+      \(present). Per founder Q4 decision 2026-05-19, routers emit \
+      per-router prefixes. Restoring `[AppState]` prefixes would re-merge \
+      Sentry clusters and undo the rename.
+      """)
+  }
+
+  @Test func appStateNoLongerEmitsHeartPathLogPrefixes() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.appStateSourcePath), encoding: .utf8)
+    let forbidden = [
+      "[AppState] Audio onEngineInterrupted",
+      "[AppState] ASR onServiceInterrupted",
+    ]
+    var present: [String] = []
+    for literal in forbidden {
+      if source.contains(literal) {
+        present.append(literal)
+      }
+    }
+    #expect(
+      present.isEmpty,
+      """
+      AppState still emits heart-path log prefixes: \(present). \
+      PR8 moved these to the routers; their presence in AppState means a \
+      regression re-added the routing logic to the old home.
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — strict source parser for `*EventRouter` and
+/// `WedgeRecoveryRouter` ceiling tests. Counts BOTH `let` and `var` instance
+/// stored properties, sub-binned into:
+///   - collaborator slot: non-primitive non-closure non-NSObjectProtocol `let`s
+///   - closure-injected slot: `let`s typed as `(...) -> ...`
+///   - NSObjectProtocol-observer-token slot: handled as a sub-bin (PR8 plan
+///     allowed up to one for AudioEventRouter; the router currently does not
+///     hold one because cleanup is app-lifetime).
+///
+/// The shared `CeilingsTestSupport` counts only `let` collaborators and
+/// excludes closures — too permissive for routers which can game the metric
+/// via `var observerToken` or closure-typed `let`s. This parser is stricter
+/// on purpose.
+enum RouterCeilingParser {
+
+  static func classBody(named typeName: String, at path: String) throws -> String {
+    let source = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+    let declarations = [
+      "final class \(typeName) {",
+      "final class \(typeName):",
+      "class \(typeName) {",
+      "class \(typeName):",
+    ]
+    guard
+      let openRange = declarations.compactMap({ source.range(of: $0) }).min(by: {
+        $0.lowerBound < $1.lowerBound
+      })
+    else {
+      Issue.record("\(typeName) declaration not found at \(path)")
+      throw POSIXError(.ENOENT)
+    }
+    guard
+      let openBrace = source[openRange.upperBound...].firstIndex(of: "{")
+        ?? source[openRange.lowerBound...].firstIndex(of: "{")
+    else {
+      Issue.record("\(typeName) declaration has no opening brace")
+      throw POSIXError(.EILSEQ)
+    }
+    var depth = 0
+    var idx = openBrace
+    while idx < source.endIndex {
+      let c = source[idx]
+      if c == "{" { depth += 1 }
+      if c == "}" {
+        depth -= 1
+        if depth == 0 {
+          return String(source[source.index(after: openBrace)..<idx])
+        }
+      }
+      idx = source.index(after: idx)
+    }
+    Issue.record("\(typeName) class body has unbalanced braces")
+    throw POSIXError(.EILSEQ)
+  }
+
+  /// Collaborator slot: non-primitive non-closure non-NSObjectProtocol `let`
+  /// or `var` stored properties at brace-depth 0 inside the class body.
+  static func collaboratorCount(in body: String) -> Int {
+    countTopLevelStoredProperties(in: body) { line in
+      !isPrimitiveTyped(line) && !isClosureTyped(line) && !isNSObjectProtocolTyped(line)
+    }
+  }
+
+  /// Closure-injected slot: instance `let`/`var` whose declared type is a
+  /// closure (`(...) -> ...`) at brace-depth 0.
+  static func closureInjectedCount(in body: String) -> Int {
+    countTopLevelStoredProperties(in: body) { line in isClosureTyped(line) }
+  }
+
+  /// Non-private `func` declarations at brace-depth 0.
+  static func nonPrivateMethodCount(in body: String) -> Int {
+    var depth = 0
+    var count = 0
+    for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+      let opens = line.filter { $0 == "{" }.count
+      let closes = line.filter { $0 == "}" }.count
+      let depthForThisLine = depth - max(0, closes - opens)
+      if depthForThisLine == 0, isNonPrivateMethodDeclaration(String(line)) {
+        count += 1
+      }
+      depth += opens - closes
+    }
+    return count
+  }
+
+  static func imports(in source: String) -> Set<String> {
+    var result: Set<String> = []
+    let pattern = #"^[[:space:]]*import[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+    let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    let ns = source as NSString
+    regex?.enumerateMatches(
+      in: source, options: [],
+      range: NSRange(location: 0, length: ns.length)
+    ) { match, _, _ in
+      guard let m = match, m.numberOfRanges > 1 else { return }
+      result.insert(ns.substring(with: m.range(at: 1)))
+    }
+    return result
+  }
+
+  // MARK: - Private
+
+  private static func countTopLevelStoredProperties(
+    in body: String, where predicate: (String) -> Bool
+  ) -> Int {
+    var depth = 0
+    var count = 0
+    for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+      let opens = line.filter { $0 == "{" }.count
+      let closes = line.filter { $0 == "}" }.count
+      let depthForThisLine = depth - max(0, closes - opens)
+      if depthForThisLine == 0 {
+        let s = String(line)
+        if isStoredPropertyDeclaration(s), predicate(s) {
+          count += 1
+        }
+      }
+      depth += opens - closes
+    }
+    return count
+  }
+
+  private static let storedPropertyPattern: String = {
+    let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+    let access = #"(public|internal|private|fileprivate|package|open)?"#
+    return "^[[:space:]]*\(attrs)\(access)[[:space:]]*(let|var)[[:space:]]+[A-Za-z_]"
+  }()
+
+  private static func isStoredPropertyDeclaration(_ line: String) -> Bool {
+    guard line.range(of: storedPropertyPattern, options: .regularExpression) != nil
+    else { return false }
+    // Reject computed properties (line ends with `{`).
+    if line.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
+      return false
+    }
+    return true
+  }
+
+  private static func isPrimitiveTyped(_ line: String) -> Bool {
+    let primitives = [
+      ": Bool", ": Int", ": String", ": Double", ": Float", ": UInt64",
+      "Task<", "= false", "= true",
+    ]
+    return primitives.contains { line.contains($0) }
+  }
+
+  private static func isClosureTyped(_ line: String) -> Bool {
+    // Matches a declared closure type signature: `: (...) -> ...`
+    // (with optional `@MainActor` / `@Sendable` attributes before the
+    // paren). Excludes plain method invocations on initializers.
+    line.range(
+      of: #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)[[:space:]]*->[[:space:]]"#,
+      options: .regularExpression) != nil
+  }
+
+  private static func isNSObjectProtocolTyped(_ line: String) -> Bool {
+    line.contains(": NSObjectProtocol")
+  }
+
+  private static let nonPrivateMethodPattern: String =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*(nonisolated[[:space:]]+)?(public|internal|package|open)?[[:space:]]*(static[[:space:]]+)?(class[[:space:]]+)?func[[:space:]]+[A-Za-z_]"#
+
+  private static let privateMethodPattern: String =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*(private|fileprivate)[[:space:]]+(static[[:space:]]+)?(class[[:space:]]+)?func[[:space:]]+[A-Za-z_]"#
+
+  private static func isNonPrivateMethodDeclaration(_ line: String) -> Bool {
+    if line.range(of: privateMethodPattern, options: .regularExpression) != nil {
+      return false
+    }
+    return line.range(of: nonPrivateMethodPattern, options: .regularExpression) != nil
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+/// PR8 of #763 — locks `WedgeRecoveryRouter`'s entanglement shape.
+@Suite struct WedgeRecoveryRouterCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/DictationRuntime/WedgeRecoveryRouter.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "WedgeRecoveryRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 3,
+      """
+      WedgeRecoveryRouter collaborator-slot ceiling exceeded: \(count) > 3. \
+      Allowed: audioCapture, pipeline, whisperKitPipeline.
+      """)
+  }
+
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "WedgeRecoveryRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count <= 2,
+      """
+      WedgeRecoveryRouter closure-injected-dependency ceiling exceeded: \
+      \(count) > 2. Allowed: isCurrentSession, resolveActiveTelemetryTarget.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "WedgeRecoveryRouter", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    // Parser counts `func`, not `init`. Codex code-diff r1 [P3].
+    #expect(
+      count == 0,
+      """
+      WedgeRecoveryRouter non-private method ceiling exceeded: \(count) > 0 \
+      non-private `func` declarations. Only `init(...)` permitted.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 115,
+      """
+      WedgeRecoveryRouter line count exceeded: \(count) > 115. \
+      Raise via Bible §30 only.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "EnviousWisprAudio", "EnviousWisprCore", "EnviousWisprPipeline",
+      "EnviousWisprServices", "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      WedgeRecoveryRouter imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+}


### PR DESCRIPTION
## Summary

PR8 of the AppState deletion epic (#763) splits the seven heart-path event-routing closures plus the AVAudioEngineConfigurationChange observer out of `AppState.init()` into three narrow private collaborators of a new App-level home `DictationRuntime`.

- **AudioEventRouter** — engine interruption, XPC service error, VAD auto-stop, and AVAudioEngineConfigurationChange observer.
- **ASREventRouter** — ASR service interruption.
- **WedgeRecoveryRouter** — capture stall, XPC reply failure, capture-session interruption (with `isCurrentSession` freshness filter).

`DictationRuntime` is constructed in `EnviousWisprApp.init()` after `AppState` and is NOT environment-injected (per the cascade plan locked-homes list). Resolver helpers (`LastCapturingBackend`, `activeCaptureBackend()`, `isCurrentSession(_:)`, `activeTelemetryTarget()`) stay on AppState through PR8, promoted `private`→`internal` so the router-injected closures can read them. PR9 absorbs them into `DictationLifecycleCoordinator` (same-PR grep-test `AppStateNoLongerOwnsBackendResolverTests` enforces).

**Counts:**
- AppState collaborator count: 18 → 18 (cascade promise).
- AppState line count: 1038 → 902 (-134; ceiling ratcheted to 904).
- EnviousWisprApp stored properties: 11 → 12 (+1 for `dictationRuntime`).
- EnviousWisprApp line count: 232 → 259 (ceiling 250 → 270).

Per founder decision Q4 (2026-05-19), AppLogger log prefixes flip `[AppState]` → `[AudioEventRouter]` / `[ASREventRouter]` / `[WedgeRecoveryRouter]`. Sentry cluster split accepted at 5-active-user scale for clearer log labels. `HeartPathBreadcrumbLiteralsTests` asserts the new prefixes are present AND the old prefixes are absent.

## What changed

- 4 new source files under `Sources/EnviousWispr/App/DictationRuntime/`.
- 32 new tests (8 router unit tests with spy mocks + 24 architecture tests including 6 router/runtime ceilings tests, `HeartPathBreadcrumbLiteralsTests`, and `AppStateNoLongerInstallsHeartPathCallbacksTests` with both single-line and multi-line observer detection).
- AppState.swift: removed 144 lines of closure setup, promoted 4 symbols `private`→`internal`.
- EnviousWisprApp.swift: added `@State private var dictationRuntime` + construction in `init()`.
- Ceiling-test ratchets: AppState 1038→904, EnviousWisprApp props 11→12, EnviousWisprApp lines 250→270.

## Test plan

- [x] Council coverage review (GPT + Gemini, 2026-05-19)
- [x] Codex grounded review on plan (2026-05-19) — PROCEED-WITH-REVISIONS, revisions applied
- [x] Plan saved at `docs/feature-requests/issue-774-2026-05-19-pr8-event-router-split.md`
- [x] `swift build -c release` exit 0
- [x] `scripts/swift-test.sh` — 1003 tests in 126 suites, all passing
- [x] All 6 new architecture tests green on first commit
- [x] Codex code-diff review — round 1 found 2 P3 guardrail bugs in tests, fixed; round 2 clean
- [x] Live UAT (debug build) — Fast English (Parakeet) ✓, Multi-Language (WhisperKit) ✓
- [x] Live UAT route-change scenarios — two real OS-level Bluetooth disconnects mid-recording, heart path survived both (422k samples + 729k samples captured cleanly through route invalidation)

Closes #774.
