### PR TITLE
refactor(appstate): extract DictationLifecycleCoordinator + absorb PR8 deferred resolver helpers (PR9 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -49,6 +49,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   // sunset on the timeline noted at AppState's `attach…` methods.
   private weak var liveRecordingState: LiveRecordingState?
   private weak var backendMetadata: BackendMetadata?
+  /// PR9 of #763: the pipeline state-change callback (icon updates,
+  /// audio-environment snapshot triggers) lives on the new lifecycle home now.
+  /// AppDelegate sets `dictationLifecycleCoordinator.onPipelineStateChange`
+  /// in `applicationDidFinishLaunching`. Weak ref — strong owner is
+  /// `DictationRuntime` via `EnviousWisprApp`'s `@State`.
+  private weak var dictationLifecycleCoordinator: DictationLifecycleCoordinator?
 
   /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
   /// before delegate callbacks fire. If `updateCoordinator` is already
@@ -57,18 +63,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   ///
   /// PR7 of #763: additionally receive `liveRecordingState` and
   /// `backendMetadata` for the menu-bar reads.
+  ///
+  /// PR9 of #763: additionally receive `dictationLifecycleCoordinator` so the
+  /// icon-update callback can be installed on the new home (was on AppState
+  /// pre-PR9).
   func attach(
     appState: AppState,
     navigationCoordinator: NavigationCoordinator,
     updateCoordinatorHolder: UpdateCoordinatorHolder,
     liveRecordingState: LiveRecordingState,
-    backendMetadata: BackendMetadata
+    backendMetadata: BackendMetadata,
+    dictationLifecycleCoordinator: DictationLifecycleCoordinator
   ) {
     self.appState = appState
     self.navigationCoordinator = navigationCoordinator
     self.updateCoordinatorHolder = updateCoordinatorHolder
     self.liveRecordingState = liveRecordingState
     self.backendMetadata = backendMetadata
+    self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     if let existing = self.updateCoordinator {
       updateCoordinatorHolder.coordinator = existing
     }
@@ -186,7 +198,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Update menu bar icon whenever pipeline state or accessibility changes.
     // Also forwards recording state to the update coordinator so the banner
     // hides during recording + 3s post-recording grace (issue #343).
-    appState.onPipelineStateChange = { [weak self] state in
+    // PR9 of #763: callback lives on `DictationLifecycleCoordinator` now.
+    dictationLifecycleCoordinator?.onPipelineStateChange = { [weak self] state in
       guard let self else { return }
       self.updateIcon()
       // Issue #739: do NOT forward pipeline state to the update widget. The

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -29,69 +29,29 @@ final class AppState {
   let audioDeviceList = AudioDeviceList()
   let captureTelemetry = CaptureTelemetryState()
 
-  /// Cancellable task for showing a deferred post-completion warning (e.g. polish failed).
-  /// Cancelled when a new recording starts or a higher-priority notification is shown.
-  private var postCompletionWarningTask: Task<Void, Never>?
-
   // Pipelines — initialized after sub-systems
   let pipeline: TranscriptionPipeline
   let whisperKitPipeline: WhisperKitPipeline
 
-  // Phase A (#196) — per-pipeline state-change behavior absorbed from the
-  // onStateChange closures. Each handler owns the effect execution; AppState
-  // still owns the cross-pipeline warning Task + tiebreaker + hotkey ordering.
-  // Lazy so the callback closures can capture `self` after stored-property
-  // assignment completes. First access is inside `onStateChange`, well after
-  // `init()` returns.
-  @ObservationIgnored
-  private lazy var parakeetStateHandler: PipelineStateChangeHandler = {
-    makeStateChangeHandler(backendLabel: "parakeet")
-  }()
-  @ObservationIgnored
-  private lazy var whisperKitStateHandler: PipelineStateChangeHandler = {
-    makeStateChangeHandler(backendLabel: "whisperKit")
-  }()
-
-  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
-    PipelineStateChangeHandler(
-      showOverlay: { [weak self] intent in
-        guard let self else { return }
-        self.recordingOverlay.show(
-          intent: intent,
-          audioLevelProvider: { [weak self] in self?.audioCapture.audioLevel ?? 0 },
-          isRecordingLocked: self.isRecordingLocked
-        )
-      },
-      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
-      schedulePolishFailedWarning: { [weak self] in
-        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-      },
-      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
-      reportDictationCompleted: { [weak self] t in
-        guard let self else { return }
-        TelemetryService.shared.reportDictationCompleted(
-          transcript: t, inputMode: self.settings.recordingMode.rawValue)
-      },
-      reportPipelineFailed: { msg in
-        TelemetryService.shared.pipelineFailed(
-          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: backendLabel)
-      }
-    )
-  }
+  // PR9 of #763 — pipeline state-change side effects (overlay, hotkey
+  // arbitration, telemetry, chip lifecycle, terminal settings sync) moved to
+  // `DictationLifecycleCoordinator` under DictationRuntime. The factory +
+  // lazy handlers + post-completion warning Task all sunset here. The icon
+  // callback property also moved to the new home; AppDelegate sets it on the
+  // coordinator now.
 
   /// Standalone service for re-polishing saved transcripts from the detail view.
   /// Completely decoupled from pipeline state machines.
   let polishService: TranscriptPolishService
 
   /// Forwards settings changes to pipelines and subsystems.
-  private let settingsSync: PipelineSettingsSync
+  let settingsSync: PipelineSettingsSync
 
-  /// Called when pipeline state changes — set by AppDelegate for icon updates.
-  var onPipelineStateChange: ((PipelineState) -> Void)?
-
-  // Transcript history — delegated to coordinator
-  let transcriptCoordinator: TranscriptCoordinator
+  // PR9 of #763 — transcript-coordinator storage moved off AppState. The
+  // composition root constructs it once and threads it into both the new
+  // lifecycle home (caller of append) and `TranscriptWorkflowCoordinator`
+  // (view-facing surface). AppState's init takes `TranscriptStore` so the
+  // pipelines + polish service can still receive the shared store reference.
 
   /// True when recording is in hands-free (locked) mode via double-press.
   /// Read by the overlay to switch to the expanded lips visual.
@@ -146,6 +106,18 @@ final class AppState {
     self.backendMetadata = metadata
   }
 
+  /// PR9 of #763 — weak ref to the new lifecycle home. AppState's PR10-scope
+  /// start paths (`hotkeyService.onStartRecording`, `toggleRecording(source:)`)
+  /// still need to call `cancelPendingWarning()` before a new recording
+  /// overlay shows. PR10 retires this when start/stop/cancel migrate into
+  /// `RecordingStarter` / `RecordingFinalizer`. Setter-injected `var` —
+  /// uncounted by the ceiling parser (matches the pattern used for the four
+  /// outlets above).
+  private(set) weak var dictationLifecycleCoordinator: DictationLifecycleCoordinator?
+  func attachDictationLifecycleCoordinator(_ coordinator: DictationLifecycleCoordinator) {
+    self.dictationLifecycleCoordinator = coordinator
+  }
+
   // Feature #8: custom word management — delegated to coordinator
   let customWordsCoordinator = CustomWordsCoordinator()
 
@@ -171,7 +143,12 @@ final class AppState {
       self?.asrManager.activeBackendType == .whisperKit ? "whisperkit" : "parakeet"
     })
 
-  init() {
+  /// PR9 of #763 — `transcriptStore` is constructed by the composition root
+  /// (`EnviousWisprApp.init`) and injected. This lets `TranscriptCoordinator`
+  /// move off AppState (the composition root threads the same TC instance to
+  /// the lifecycle coordinator + the transcript workflow coordinator). The
+  /// pipelines + polish service still receive `transcriptStore` via this init.
+  init(transcriptStore: TranscriptStore) {
     // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
     // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
     // Read directly from UserDefaults because `settings` is not yet available (stored
@@ -195,14 +172,6 @@ final class AppState {
       asrManager = ASRManager()
     }
 
-    // Composition-root for transcript storage. One `TranscriptStore` is threaded
-    // to every consumer (coordinator + both pipelines + polish service); AppState
-    // does NOT retain it. Invariant: exactly one `TranscriptStore(` call in
-    // `Sources/` outside `EnviousWisprStorage/TranscriptStore.swift`.
-    let transcriptStore = TranscriptStore()
-    // Transcripts always live at AppConstants.appSupportURL/transcripts.
-    // No legacy path, no group container, no iCloud. Default init creates dir on miss.
-    transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
     llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
     // Phase 0 (#640) — single shared paste-completion registry. Constructed
@@ -307,11 +276,9 @@ final class AppState {
     // closures + `asrManager.onServiceInterrupted` + AVAudioEngineConfigurationChange
     // observer) moved to `DictationRuntime` and its three private routers
     // (`AudioEventRouter`, `ASREventRouter`, `WedgeRecoveryRouter`). Constructed
-    // in `EnviousWisprApp.init()` after `let appState = AppState()`. Resolver
-    // helpers (`activeCaptureBackend()`, `isCurrentSession(_:)`,
-    // `activeTelemetryTarget()`, `LastCapturingBackend`) stay here through
-    // PR8 and migrate with the rest of `pipeline.onStateChange` in PR9
-    // (DictationLifecycleCoordinator).
+    // in `EnviousWisprApp.init()` after AppState is constructed. PR9
+    // absorbed the resolver helpers + warning Task into the new lifecycle
+    // home; routers' injected closures now resolve through it.
 
     settingsSync.onNeedsPreloadObservation = { [weak setup] in
       setup?.startPreloadObservation()
@@ -353,132 +320,12 @@ final class AppState {
       self.settingsSync.handleSettingChanged(key, settings: self.settings)
     }
 
-    // Wire pipeline state changes to overlay and icon.
-    // The behavioral contract (overlay resolution, warning scheduling /
-    // cancellation, telemetry, history reload) is owned by the per-pipeline
-    // PipelineStateChangeHandler. The closure still owns AppState-local
-    // concerns: external observer fan-out, hotkey register/unregister,
-    // isRecordingLocked reset, and the inactive→active tiebreaker (#285).
-    pipeline.onStateChange = { [weak self] newState in
-      guard let self else { return }
-      self.onPipelineStateChange?(newState)
-      switch newState {
-      case .recording:
-        self.hotkeyService.registerCancelHotkey()
-        // PR7 of #763 — clear the prior recording's polish error on every
-        // new recording start. Reset matrix locked in PR7 plan: cancel
-        // does NOT clear (prior error stays cleared by next start). Sunset
-        // PR9 with the rest of this closure.
-        self.lastRecordingResult?.polishError = nil
-      case .loadingModel, .transcribing, .polishing:
-        self.isRecordingLocked = false
-        self.hotkeyService.unregisterCancelHotkey()
-      case .error, .idle, .complete:
-        self.isRecordingLocked = false
-        self.hotkeyService.unregisterCancelHotkey()
-        // Session ended — retry any Ollama eviction deferred because the
-        // frozen session pinned the old model.
-        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
-      }
-      let nowActive = newState.isActive
-      if nowActive && !self.prevParakeetActive {
-        self.lastCapturingBackend = .parakeet
-      }
-      self.prevParakeetActive = nowActive
-      self.parakeetStateHandler.handle(
-        to: newState,
-        pipelineOverlayIntent: self.pipeline.overlayIntent,
-        lastPolishError: self.pipeline.lastPolishError,
-        currentTranscript: self.pipeline.currentTranscript
-      )
-      // PR7 of #763 — push polish error to the post-recording result home so
-      // views can read `lastRecordingResult.polishError` without reaching
-      // through AppState. Sunset PR9 (DictationLifecycleCoordinator owns
-      // this push site).
-      self.lastRecordingResult?.polishError = self.pipeline.lastPolishError
-      // PR4 of #763 (#252): dispatch chip lifecycle to LanguageSuggestionPresenter.
-      // Sunset in PR9: moves with the rest of this closure into DictationLifecycleCoordinator.
-      //
-      // Codex r2 [P2]: skip surface when polish failed — the warning overlay
-      //   races and overwrites the chip otherwise.
-      // Codex r3 [P2]: when skipping, also clearBuffer — a stale trigger from
-      //   a polish-failed dictation must not surface on a later recording.
-      // Codex r7 [P2]: clearBuffer on .recording to drain any stale trigger
-      //   that arrived late (detector handler uses Task @MainActor; if it ran
-      //   AFTER prior .complete's surface, the trigger could otherwise attach
-      //   to this new recording's eventual .complete and misattribute).
-      switch newState {
-      case .recording:
-        self.languageSuggestionPresenter?.clearBuffer()
-      case .complete:
-        if self.pipeline.lastPolishError == nil {
-          self.languageSuggestionPresenter?.surfaceBufferedChipIfPossible(
-            currentLanguageMode: self.settings.languageMode)
-        } else {
-          self.languageSuggestionPresenter?.clearBuffer()
-        }
-      case .error:
-        self.languageSuggestionPresenter?.clearCurrentChip()
-        self.languageSuggestionPresenter?.clearBuffer()
-      default:
-        break
-      }
-    }
-
-    // Wire WhisperKit pipeline state changes to overlay and icon.
-    whisperKitPipeline.onStateChange = { [weak self] newState in
-      guard let self else { return }
-      // PR7 of #763: route the WhisperKit state to unified PipelineState
-      // inline; the prior `self.pipelineState` getter is gone.
-      self.onPipelineStateChange?(newState.asPipelineState)
-      switch newState {
-      case .recording:
-        self.hotkeyService.registerCancelHotkey()
-        // PR7 of #763 — clear prior recording's polish error on new start.
-        // Mirrors the Parakeet arm above. Sunset PR9.
-        self.lastRecordingResult?.polishError = nil
-      case .startingUp, .loadingModel, .transcribing, .polishing:
-        self.isRecordingLocked = false
-        self.hotkeyService.unregisterCancelHotkey()
-      case .error, .idle, .ready, .complete:
-        self.isRecordingLocked = false
-        self.hotkeyService.unregisterCancelHotkey()
-        self.settingsSync.retryDeferredOllamaEviction(settings: self.settings)
-      }
-      let nowActive = newState.isActive
-      if nowActive && !self.prevWhisperKitActive {
-        self.lastCapturingBackend = .whisperKit
-      }
-      self.prevWhisperKitActive = nowActive
-      self.whisperKitStateHandler.handle(
-        to: newState,
-        pipelineOverlayIntent: self.whisperKitPipeline.overlayIntent,
-        lastPolishError: self.whisperKitPipeline.lastPolishError,
-        currentTranscript: self.whisperKitPipeline.currentTranscript
-      )
-      // PR7 of #763 — push WhisperKit polish error to the post-recording
-      // result home. Same shape as the Parakeet arm above. Sunset PR9.
-      self.lastRecordingResult?.polishError = self.whisperKitPipeline.lastPolishError
-      // PR4 of #763 (#252): chip lifecycle dispatch. WhisperKit has both
-      // .complete and .ready as terminal-completion states. Same race guards
-      // as the parakeet arm (Codex P2 r2+r3+r7).
-      switch newState {
-      case .recording:
-        self.languageSuggestionPresenter?.clearBuffer()
-      case .complete, .ready:
-        if self.whisperKitPipeline.lastPolishError == nil {
-          self.languageSuggestionPresenter?.surfaceBufferedChipIfPossible(
-            currentLanguageMode: self.settings.languageMode)
-        } else {
-          self.languageSuggestionPresenter?.clearBuffer()
-        }
-      case .error:
-        self.languageSuggestionPresenter?.clearCurrentChip()
-        self.languageSuggestionPresenter?.clearBuffer()
-      default:
-        break
-      }
-    }
+    // PR9 of #763 — pipeline state-change closures moved to
+    // `DictationLifecycleCoordinator.install()`, called once by the
+    // composition root (`EnviousWisprApp.init`) after the coordinator is
+    // constructed. The coordinator owns: overlay show/clear, hotkey
+    // arbitration, telemetry, chip lifecycle, terminal settings sync,
+    // backend-resolver state + helpers, post-completion warning Task.
 
     // Wire hotkey callbacks
     hotkeyService.recordingMode = settings.recordingMode
@@ -492,9 +339,12 @@ final class AppState {
     }
     hotkeyService.onStartRecording = { [weak self] in
       guard let self else { return }
-      // Cancel any pending post-completion warning from the previous session
-      // before showing the new recording overlay.
-      self.postCompletionWarningTask?.cancel()
+      // PR9 of #763 — cancel any pending post-completion warning from the
+      // previous session before showing the new recording overlay. Task lives
+      // on `DictationLifecycleCoordinator` now; AppState holds a weak ref via
+      // `attachDictationLifecycleCoordinator`. PR10 inlines this when start
+      // migrates into `RecordingStarter`.
+      self.dictationLifecycleCoordinator?.cancelPendingWarning()
       let isWhisperKit = self.asrManager.activeBackendType == .whisperKit
       let active = self.activePipeline
 
@@ -717,77 +567,14 @@ final class AppState {
     asrManager.activeBackendType == .whisperKit ? whisperKitPipeline : pipeline
   }
 
-  /// Schedule a deferred post-completion warning overlay. Cancellable and session-scoped:
-  /// cancelled if a new recording starts (any non-complete state change cancels it).
-  /// Uses the pipeline's current state as a guard to avoid showing stale warnings.
-  /// Issue #285 — which backend most recently entered an active state
-  /// (startup, loading, or recording). Used as a tiebreaker when both
-  /// pipelines are active simultaneously (e.g. one still polishing while the
-  /// other begins a new capture). Updated on any active-state entry, not just
-  /// `.recording`, so stall watchdog and interruption callbacks that fire
-  /// pre-recording resolve to the correct backend.
-  /// PR8 of #763: promoted private→internal so `DictationRuntime`'s
-  /// injected resolver closures can type their return value. PR9
-  /// (`DictationLifecycleCoordinator`) absorbs this enum + the three
-  /// resolver helpers + the writer-side flips out of AppState.
-  enum LastCapturingBackend { case parakeet, whisperKit }
-  var lastCapturingBackend: LastCapturingBackend = .parakeet
-  // Previous active-state of each pipeline, tracked so we flip
-  // `lastCapturingBackend` only on inactive→active transitions. Without this,
-  // `.transcribing → .polishing` (active → active) would re-steal ownership
-  // after a different backend acquired the shared capture.
-  private var prevParakeetActive: Bool = false
-  private var prevWhisperKitActive: Bool = false
-
   /// Issue #445: most recent user stop/cancel timestamp; suppresses the
   /// post-condition wedge guard when the user released PTT mid-start.
   private var lastUserStopRequest: ContinuousClock.Instant?
 
-  /// Issue #285 — resolve which backend owns the shared audio capture right
-  /// now. Returns nil when both pipelines are fully idle. Shared helper for
-  /// both telemetry routing and engine-interrupt routing so the two paths
-  /// cannot drift.
-  func activeCaptureBackend() -> LastCapturingBackend? {
-    let pActive = pipeline.state.isActive
-    let wkActive = whisperKitPipeline.state.isActive
-    if pActive && wkActive { return lastCapturingBackend }
-    if pActive { return .parakeet }
-    if wkActive { return .whisperKit }
-    return nil
-  }
-
-  /// Issue #285 — belt-and-suspenders filter for late callbacks that somehow
-  /// slip past the per-source `isCapturing` / observer-removal guards during a
-  /// backend switch. Dropping a stale callback is safer than misrouting it to
-  /// a new session's dedup state. Source-level guards normally catch this;
-  /// this is a second line of defense for the backend-overlap window.
-  func isCurrentSession(_ sessionID: UInt64) -> Bool {
-    sessionID == audioCapture.currentCaptureSessionID
-  }
-
-  func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
-    switch activeCaptureBackend() {
-    case .whisperKit: return whisperKitPipeline
-    case .parakeet: return pipeline
-    case nil:
-      // Idle → attribute to the backend that most recently owned a session.
-      return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
-    }
-  }
-
-  private func schedulePostCompletionWarning(message: String) {
-    postCompletionWarningTask?.cancel()
-    postCompletionWarningTask = Task { @MainActor [weak self] in
-      try? await Task.sleep(for: .milliseconds(400))
-      guard !Task.isCancelled, let self else { return }
-      // Only show if we're still in the completed state (no new recording started)
-      let parakeetComplete = self.pipeline.state == .complete
-      let whisperKitComplete =
-        self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
-      guard parakeetComplete || whisperKitComplete else { return }
-      self.recordingOverlay.show(intent: .warning(message: message))
-    }
-  }
+  // PR9 of #763 — backend-resolver state + helpers + the deferred warning
+  // scheduler moved to `DictationLifecycleCoordinator`. PR8's DictationRuntime
+  // resolver closures now capture the new home instead of AppState. Same-PR
+  // grep-test gate (`AppStateNoLongerOwnsBackendResolverTests`) enforces.
 
   /// Reset the currently active pipeline to idle. Used by UI "dismiss" actions.
   func resetActivePipeline() {
@@ -804,7 +591,8 @@ final class AppState {
   /// (issue #723). Production callers MUST specify; there is no default to prevent
   /// silent fallthrough to a generic value.
   func toggleRecording(source: TriggerSource) async {
-    postCompletionWarningTask?.cancel()
+    // PR9 of #763 — see comment in `hotkeyService.onStartRecording`.
+    dictationLifecycleCoordinator?.cancelPendingWarning()
     let active = activePipeline
     // PR7 of #763 — match the hotkey path: clear prior polish error before
     // dispatch when this toggle is a START. Sunset PR9.

--- a/Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/AudioEventRouter.swift
@@ -22,14 +22,16 @@ final class AudioEventRouter {
   let whisperKitPipeline: WhisperKitPipeline
   let captureTelemetry: CaptureTelemetryState
 
-  let resolveActiveCaptureBackend: @MainActor () -> AppState.LastCapturingBackend?
+  let resolveActiveCaptureBackend:
+    @MainActor () -> DictationLifecycleCoordinator.LastCapturingBackend?
 
   init(
     audioCapture: any AudioCaptureInterface,
     pipeline: TranscriptionPipeline,
     whisperKitPipeline: WhisperKitPipeline,
     captureTelemetry: CaptureTelemetryState,
-    resolveActiveCaptureBackend: @escaping @MainActor () -> AppState.LastCapturingBackend?
+    resolveActiveCaptureBackend: @escaping @MainActor () -> DictationLifecycleCoordinator
+      .LastCapturingBackend?
   ) {
     self.audioCapture = audioCapture
     self.pipeline = pipeline

--- a/Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -1,0 +1,335 @@
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+
+/// PR9 of #763 — Lifecycle home for pipeline state-change side effects plus the
+/// seven PR8 backend-resolver symbols that PR8 left on AppState (`LastCapturingBackend`
+/// enum, the three resolver-state vars, and the three resolver helpers).
+///
+/// Owns three responsibilities the AppState god-object held:
+///   1. Pipeline `onStateChange` side effects (overlay show/clear, hotkey
+///      arbitration, telemetry, chip lifecycle, terminal settings sync).
+///   2. Backend-resolver state + helpers for `DictationRuntime`'s routers
+///      (`activeCaptureBackend()`, `isCurrentSession(_:)`).
+///   3. Post-completion warning Task (cancellable, shared across backends).
+///
+/// Private to `DictationRuntime`'s composition — not environment-injected and
+/// not consumed directly by views or AppDelegate. AppDelegate gets a weak
+/// reference solely to wire `onPipelineStateChange` (icon updates).
+@MainActor
+final class DictationLifecycleCoordinator {
+  // MARK: - Collaborators (let-counted by CeilingsTestSupport)
+  //
+  // Ceiling 11 (raised from parent migration plan's 10; see
+  // `DictationLifecycleCoordinatorCeilingsTests` Bible-changelog comment).
+  // The 11th slot is `recordingLockedAccess`, a get/set closure-pair struct
+  // that lets the coordinator read AND write AppState's `isRecordingLocked`
+  // without storing an AppState reference. PR10 absorbs `isRecordingLocked`
+  // ownership into the recording-state homes and ratchets this back down.
+
+  let pipeline: TranscriptionPipeline  // 1
+  let whisperKitPipeline: WhisperKitPipeline  // 2
+  let recordingOverlay: RecordingOverlayPanel  // 3
+  let hotkeyService: HotkeyService  // 4
+  let settingsSync: PipelineSettingsSync  // 5
+  let audioCapture: any AudioCaptureInterface  // 6
+  let transcriptCoordinator: TranscriptCoordinator  // 7
+  let settings: SettingsManager  // 8
+  let lastRecordingResult: LastRecordingResult  // 9
+  let languageSuggestionPresenter: LanguageSuggestionPresenter?  // 10
+  let recordingLockedAccess: RecordingLockedAccess  // 11
+
+  /// Bidirectional accessor for `AppState.isRecordingLocked`. PR9 keeps the
+  /// stored property on AppState (PR10 absorbs it into the recording-state
+  /// homes). The state-change closure both READS the lock state (to pass into
+  /// `recordingOverlay.show(...)` so hands-free visuals render correctly) AND
+  /// WRITES it (to clear hands-free on any transition out of `.recording`).
+  /// Packaging the pair as one struct keeps the cap at 11.
+  struct RecordingLockedAccess {
+    let get: @MainActor () -> Bool
+    let set: @MainActor (Bool) -> Void
+  }
+
+  // MARK: - Owned mutable state (var; excluded from collaborator cap)
+
+  /// #285 tiebreaker — which backend most recently entered an active state
+  /// (startup, loading, or recording). Used when both pipelines are active
+  /// simultaneously (e.g. one still polishing while the other begins a new
+  /// capture).
+  enum LastCapturingBackend { case parakeet, whisperKit }
+  var lastCapturingBackend: LastCapturingBackend = .parakeet
+
+  /// Previous active-state of each pipeline, tracked so we flip
+  /// `lastCapturingBackend` only on inactive→active transitions. Without this,
+  /// `.transcribing → .polishing` (active → active) would re-steal ownership
+  /// after a different backend acquired the shared capture.
+  private var prevParakeetActive: Bool = false
+  private var prevWhisperKitActive: Bool = false
+
+  /// Cancellable Task for the deferred polish-failed warning overlay. Cancelled
+  /// on every new recording start. Shared across both backends because the
+  /// 400ms-delayed guard checks `.complete` on Parakeet OR `.complete`/`.ready`
+  /// on WhisperKit — moving this into a per-pipeline handler would split a
+  /// shared lifecycle (see `PipelineStateChangeHandler.swift:13-22`).
+  private var postCompletionWarningTask: Task<Void, Never>?
+
+  /// AppDelegate sets this to update the menu-bar icon + drive update-banner
+  /// suppression. Setter-injected post-init like AppState's
+  /// `var languageSuggestionPresenter` precedent (see
+  /// `AppStateCeilingsTests.swift:19-25` ratchet history).
+  var onPipelineStateChange: ((PipelineState) -> Void)?
+
+  /// Per-pipeline side-effect executors. Lazy so the closures can capture
+  /// `self` after all stored properties are initialized.
+  private lazy var parakeetStateHandler: PipelineStateChangeHandler =
+    makeStateChangeHandler(backendLabel: "parakeet")
+  private lazy var whisperKitStateHandler: PipelineStateChangeHandler =
+    makeStateChangeHandler(backendLabel: "whisperKit")
+
+  init(
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    recordingOverlay: RecordingOverlayPanel,
+    hotkeyService: HotkeyService,
+    settingsSync: PipelineSettingsSync,
+    audioCapture: any AudioCaptureInterface,
+    transcriptCoordinator: TranscriptCoordinator,
+    settings: SettingsManager,
+    lastRecordingResult: LastRecordingResult,
+    languageSuggestionPresenter: LanguageSuggestionPresenter?,
+    recordingLockedAccess: RecordingLockedAccess
+  ) {
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.recordingOverlay = recordingOverlay
+    self.hotkeyService = hotkeyService
+    self.settingsSync = settingsSync
+    self.audioCapture = audioCapture
+    self.transcriptCoordinator = transcriptCoordinator
+    self.settings = settings
+    self.lastRecordingResult = lastRecordingResult
+    self.languageSuggestionPresenter = languageSuggestionPresenter
+    self.recordingLockedAccess = recordingLockedAccess
+  }
+
+  /// Wire the two pipelines' `onStateChange` callbacks. Called once by the
+  /// composition root (`EnviousWisprApp.init`) after `DictationLifecycleCoordinator`
+  /// and the routers are constructed.
+  func install() {
+    pipeline.onStateChange = { [weak self] newState in
+      guard let self else { return }
+      self.handleParakeet(newState: newState)
+    }
+    whisperKitPipeline.onStateChange = { [weak self] newState in
+      guard let self else { return }
+      self.handleWhisperKit(newState: newState)
+    }
+  }
+
+  // MARK: - Per-pipeline state-change handling
+
+  private func handleParakeet(newState: PipelineState) {
+    onPipelineStateChange?(newState)
+    switch newState {
+    case .recording:
+      hotkeyService.registerCancelHotkey()
+      // PR7 of #763 — clear the prior recording's polish error on every new
+      // recording start. Reset matrix locked in PR7 plan: cancel does NOT
+      // clear (prior error stays cleared by next start). Sunset PR11.
+      lastRecordingResult.polishError = nil
+    case .loadingModel, .transcribing, .polishing:
+      recordingLockedAccess.set(false)
+      hotkeyService.unregisterCancelHotkey()
+    case .error, .idle, .complete:
+      recordingLockedAccess.set(false)
+      hotkeyService.unregisterCancelHotkey()
+      // Session ended — retry any Ollama eviction deferred because the
+      // frozen session pinned the old model.
+      settingsSync.retryDeferredOllamaEviction(settings: settings)
+    }
+    let nowActive = newState.isActive
+    if nowActive && !prevParakeetActive {
+      lastCapturingBackend = .parakeet
+    }
+    prevParakeetActive = nowActive
+    parakeetStateHandler.handle(
+      to: newState,
+      pipelineOverlayIntent: pipeline.overlayIntent,
+      lastPolishError: pipeline.lastPolishError,
+      currentTranscript: pipeline.currentTranscript
+    )
+    // PR7 of #763 — push polish error to the post-recording result home so
+    // views can read `lastRecordingResult.polishError` without reaching
+    // through AppState. Sunset PR11.
+    lastRecordingResult.polishError = pipeline.lastPolishError
+    dispatchChipLifecycle(newState: newState, lastPolishError: pipeline.lastPolishError)
+  }
+
+  private func handleWhisperKit(newState: WhisperKitPipelineState) {
+    onPipelineStateChange?(newState.asPipelineState)
+    switch newState {
+    case .recording:
+      hotkeyService.registerCancelHotkey()
+      lastRecordingResult.polishError = nil
+    case .startingUp, .loadingModel, .transcribing, .polishing:
+      recordingLockedAccess.set(false)
+      hotkeyService.unregisterCancelHotkey()
+    case .error, .idle, .ready, .complete:
+      recordingLockedAccess.set(false)
+      hotkeyService.unregisterCancelHotkey()
+      settingsSync.retryDeferredOllamaEviction(settings: settings)
+    }
+    let nowActive = newState.isActive
+    if nowActive && !prevWhisperKitActive {
+      lastCapturingBackend = .whisperKit
+    }
+    prevWhisperKitActive = nowActive
+    whisperKitStateHandler.handle(
+      to: newState,
+      pipelineOverlayIntent: whisperKitPipeline.overlayIntent,
+      lastPolishError: whisperKitPipeline.lastPolishError,
+      currentTranscript: whisperKitPipeline.currentTranscript
+    )
+    lastRecordingResult.polishError = whisperKitPipeline.lastPolishError
+    dispatchChipLifecycleWhisperKit(
+      newState: newState,
+      lastPolishError: whisperKitPipeline.lastPolishError
+    )
+  }
+
+  // PR4 of #763 (#252): dispatch chip lifecycle to LanguageSuggestionPresenter.
+  // Race guards (Codex P2 r2+r3+r7) preserved verbatim: skip surface when
+  // polish failed; clearBuffer on .recording to drain stale triggers.
+  private func dispatchChipLifecycle(newState: PipelineState, lastPolishError: String?) {
+    switch newState {
+    case .recording:
+      languageSuggestionPresenter?.clearBuffer()
+    case .complete:
+      if lastPolishError == nil {
+        languageSuggestionPresenter?.surfaceBufferedChipIfPossible(
+          currentLanguageMode: settings.languageMode)
+      } else {
+        languageSuggestionPresenter?.clearBuffer()
+      }
+    case .error:
+      languageSuggestionPresenter?.clearCurrentChip()
+      languageSuggestionPresenter?.clearBuffer()
+    default:
+      break
+    }
+  }
+
+  private func dispatchChipLifecycleWhisperKit(
+    newState: WhisperKitPipelineState, lastPolishError: String?
+  ) {
+    switch newState {
+    case .recording:
+      languageSuggestionPresenter?.clearBuffer()
+    case .complete, .ready:
+      if lastPolishError == nil {
+        languageSuggestionPresenter?.surfaceBufferedChipIfPossible(
+          currentLanguageMode: settings.languageMode)
+      } else {
+        languageSuggestionPresenter?.clearBuffer()
+      }
+    case .error:
+      languageSuggestionPresenter?.clearCurrentChip()
+      languageSuggestionPresenter?.clearBuffer()
+    default:
+      break
+    }
+  }
+
+  // MARK: - PR8 deferred resolver helpers
+
+  /// #285 — resolve which backend owns the shared audio capture right now.
+  /// Returns nil when both pipelines are fully idle. Shared helper for both
+  /// telemetry routing and engine-interrupt routing so the two paths cannot
+  /// drift.
+  func activeCaptureBackend() -> LastCapturingBackend? {
+    let pActive = pipeline.state.isActive
+    let wkActive = whisperKitPipeline.state.isActive
+    if pActive && wkActive { return lastCapturingBackend }
+    if pActive { return .parakeet }
+    if wkActive { return .whisperKit }
+    return nil
+  }
+
+  /// #285 — belt-and-suspenders filter for late callbacks that somehow slip
+  /// past the per-source `isCapturing` / observer-removal guards during a
+  /// backend switch.
+  func isCurrentSession(_ sessionID: UInt64) -> Bool {
+    sessionID == audioCapture.currentCaptureSessionID
+  }
+
+  func activeTelemetryTarget() -> (any HeartPathTelemetryTarget)? {
+    switch activeCaptureBackend() {
+    case .whisperKit: return whisperKitPipeline
+    case .parakeet: return pipeline
+    case nil:
+      // Idle → attribute to the backend that most recently owned a session.
+      return lastCapturingBackend == .whisperKit ? whisperKitPipeline : pipeline
+    }
+  }
+
+  // MARK: - Post-completion warning
+
+  /// Cancel any pending deferred polish-failed warning. Called by AppState's
+  /// PR10-scope start paths (`hotkeyService.onStartRecording`,
+  /// `toggleRecording(source:)`) BEFORE a new recording overlay shows, so a
+  /// stale warning from the previous session cannot race the new dictation's
+  /// visual feedback. PR10 will inline this when start/stop/cancel migrate
+  /// into the recording-state homes; this method retires with it.
+  func cancelPendingWarning() {
+    postCompletionWarningTask?.cancel()
+  }
+
+  private func schedulePostCompletionWarning(message: String) {
+    postCompletionWarningTask?.cancel()
+    postCompletionWarningTask = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: .milliseconds(400))
+      guard !Task.isCancelled, let self else { return }
+      // Only show if we're still in the completed state (no new recording started)
+      let parakeetComplete = self.pipeline.state == .complete
+      let whisperKitComplete =
+        self.whisperKitPipeline.state == .complete || self.whisperKitPipeline.state == .ready
+      guard parakeetComplete || whisperKitComplete else { return }
+      self.recordingOverlay.show(intent: .warning(message: message))
+    }
+  }
+
+  // MARK: - State-handler factory
+
+  private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { [weak self] intent in
+        guard let self else { return }
+        let audioCapture = self.audioCapture
+        self.recordingOverlay.show(
+          intent: intent,
+          audioLevelProvider: { audioCapture.audioLevel },
+          isRecordingLocked: self.recordingLockedAccess.get()
+        )
+      },
+      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+      schedulePolishFailedWarning: { [weak self] in
+        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
+      },
+      appendCompletedTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
+      reportDictationCompleted: { [weak self] t in
+        guard let self else { return }
+        TelemetryService.shared.reportDictationCompleted(
+          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+      },
+      reportPipelineFailed: { msg in
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backendLabel)
+      }
+    )
+  }
+}

--- a/Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift
@@ -9,10 +9,20 @@ import Foundation
 /// Holds three private collaborators (`AudioEventRouter`, `ASREventRouter`,
 /// `WedgeRecoveryRouter`) that install their callbacks on `audioCapture` /
 /// `asrManager` at construction. Not environment-injected, not consumed by
-/// AppDelegate or any view. PR10 expands this home with hotkey controller +
-/// recording starter/finalizer.
+/// AppDelegate or any view.
+///
+/// PR9 of #763 — gains `dictationLifecycleCoordinator` as a fourth private
+/// collaborator. The lifecycle home owns pipeline state-change side effects,
+/// the post-completion warning Task, and the backend-resolver state + helpers
+/// that the routers' injected closures consume via the resolver closures
+/// below. The closure signatures stay byte-for-byte from PR8 (`LastCapturingBackend?`,
+/// `(any HeartPathTelemetryTarget)?`, `(UInt64) -> Bool`); only the closure
+/// CAPTURES change — from `[weak appState]` to `[weak dictationLifecycleCoordinator]`.
+///
+/// PR10 expands this home with hotkey controller + recording starter/finalizer.
 @MainActor
 final class DictationRuntime {
+  private let dictationLifecycleCoordinator: DictationLifecycleCoordinator
   private let audioEventRouter: AudioEventRouter
   private let asrEventRouter: ASREventRouter
   private let wedgeRecoveryRouter: WedgeRecoveryRouter
@@ -23,10 +33,13 @@ final class DictationRuntime {
     pipeline: TranscriptionPipeline,
     whisperKitPipeline: WhisperKitPipeline,
     captureTelemetry: CaptureTelemetryState,
-    resolveActiveCaptureBackend: @escaping @MainActor () -> AppState.LastCapturingBackend?,
+    dictationLifecycleCoordinator: DictationLifecycleCoordinator,
+    resolveActiveCaptureBackend: @escaping @MainActor () -> DictationLifecycleCoordinator
+      .LastCapturingBackend?,
     resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?,
     isCurrentSession: @escaping @MainActor (UInt64) -> Bool
   ) {
+    self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     self.audioEventRouter = AudioEventRouter(
       audioCapture: audioCapture,
       pipeline: pipeline,

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -1,5 +1,6 @@
 import EnviousWisprCore
 import EnviousWisprServices
+import EnviousWisprStorage
 import SwiftUI
 
 @main
@@ -44,7 +45,18 @@ struct EnviousWisprApp: App {
     // Construct App-owned homes in dependency order. Closure-capture targets
     // (overlay) must exist before the closures are built; AppState's chip
     // handlers must be wired exactly once.
-    let appState = AppState()
+    //
+    // PR9 of #763 — `TranscriptStore` + `TranscriptCoordinator` constructed
+    // here (was inside AppState.init pre-PR9). AppState's init takes
+    // `transcriptStore` so the pipelines + polish service still receive the
+    // shared store reference. `TranscriptCoordinator` is threaded into both
+    // the new lifecycle home (caller of `append`) AND
+    // `TranscriptWorkflowCoordinator` (view-facing surface). Invariant:
+    // exactly one `TranscriptStore()` call in `Sources/` outside
+    // `EnviousWisprStorage/TranscriptStore.swift`.
+    let transcriptStore = TranscriptStore()
+    let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    let appState = AppState(transcriptStore: transcriptStore)
     let navigationCoordinator = NavigationCoordinator()
     let diagnosticsCoordinator = DiagnosticsCoordinator()
 
@@ -99,7 +111,7 @@ struct EnviousWisprApp: App {
     // references, AppState retains storage through PR6 (cascades out
     // PR9/PR11).
     let transcriptWorkflowCoordinator = TranscriptWorkflowCoordinator(
-      transcriptCoordinator: appState.transcriptCoordinator,
+      transcriptCoordinator: transcriptCoordinator,
       polishService: appState.polishService
     )
 
@@ -124,25 +136,58 @@ struct EnviousWisprApp: App {
     appState.attachLastRecordingResult(lastRecordingResult)
     appState.attachBackendMetadata(backendMetadata)
 
+    // PR9 of #763: construct the lifecycle home BEFORE DictationRuntime.
+    // The coordinator owns pipeline state-change side effects + the
+    // post-completion warning Task + the seven backend-resolver symbols PR8
+    // deferred. `install()` wires `pipeline.onStateChange` and
+    // `whisperKitPipeline.onStateChange` to its `handleParakeet` /
+    // `handleWhisperKit` methods. The recordingLockedAccess struct lets the
+    // coordinator read AND write AppState's still-owned `isRecordingLocked`
+    // (PR10 absorbs it).
+    let dictationLifecycleCoordinator = DictationLifecycleCoordinator(
+      pipeline: appState.pipeline,
+      whisperKitPipeline: appState.whisperKitPipeline,
+      recordingOverlay: appState.recordingOverlay,
+      hotkeyService: appState.hotkeyService,
+      settingsSync: appState.settingsSync,
+      audioCapture: appState.audioCapture,
+      transcriptCoordinator: transcriptCoordinator,
+      settings: appState.settings,
+      lastRecordingResult: lastRecordingResult,
+      languageSuggestionPresenter: languageSuggestionPresenter,
+      recordingLockedAccess: .init(
+        get: { [weak appState] in appState?.isRecordingLocked ?? false },
+        set: { [weak appState] locked in appState?.isRecordingLocked = locked }
+      )
+    )
+    dictationLifecycleCoordinator.install()
+    // PR9 of #763: AppState's PR10-scope start paths
+    // (`hotkeyService.onStartRecording`, `toggleRecording(source:)`) call
+    // `coordinator.cancelPendingWarning()` before showing the new recording
+    // overlay. Weak setter avoids a strong cycle through AppState.
+    appState.attachDictationLifecycleCoordinator(dictationLifecycleCoordinator)
+
     // PR8 of #763: construct heart-path event-routing home. Routers install
     // their `audioCapture.on*` / `asrManager.onServiceInterrupted` slots +
-    // the `AVAudioEngineConfigurationChange` observer at init. Resolver
-    // helpers stay on AppState through PR8; PR9 absorbs them into
-    // DictationLifecycleCoordinator and rewires the closures.
+    // the `AVAudioEngineConfigurationChange` observer at init.
+    // PR9 of #763: resolver closures now capture
+    // `[weak dictationLifecycleCoordinator]` instead of `[weak appState]`.
+    // Closure signatures unchanged.
     let dictationRuntime = DictationRuntime(
       audioCapture: appState.audioCapture,
       asrManager: appState.asrManager,
       pipeline: appState.pipeline,
       whisperKitPipeline: appState.whisperKitPipeline,
       captureTelemetry: appState.captureTelemetry,
-      resolveActiveCaptureBackend: { [weak appState] in
-        appState?.activeCaptureBackend()
+      dictationLifecycleCoordinator: dictationLifecycleCoordinator,
+      resolveActiveCaptureBackend: { [weak dictationLifecycleCoordinator] in
+        dictationLifecycleCoordinator?.activeCaptureBackend()
       },
-      resolveActiveTelemetryTarget: { [weak appState] in
-        appState?.activeTelemetryTarget()
+      resolveActiveTelemetryTarget: { [weak dictationLifecycleCoordinator] in
+        dictationLifecycleCoordinator?.activeTelemetryTarget()
       },
-      isCurrentSession: { [weak appState] sessionID in
-        appState?.isCurrentSession(sessionID) ?? false
+      isCurrentSession: { [weak dictationLifecycleCoordinator] sessionID in
+        dictationLifecycleCoordinator?.isCurrentSession(sessionID) ?? false
       }
     )
 
@@ -169,7 +214,8 @@ struct EnviousWisprApp: App {
       navigationCoordinator: navigationCoordinator,
       updateCoordinatorHolder: updateCoordinatorHolder,
       liveRecordingState: liveRecordingState,
-      backendMetadata: backendMetadata
+      backendMetadata: backendMetadata,
+      dictationLifecycleCoordinator: dictationLifecycleCoordinator
     )
 
     // Initialize observability (PostHog + Sentry) unconditionally at launch —

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -1,0 +1,132 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprASR
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprStorage
+
+/// PR9 of #763 — smoke + behavior tests for `DictationLifecycleCoordinator`.
+///
+/// Most lifecycle behavior is exercised end-to-end by the founder/automated
+/// UAT (real audio drives real pipeline state transitions through the
+/// installed `onStateChange` closures). These unit tests verify the
+/// stand-alone helpers + construction + idempotent operations that don't
+/// require driving pipeline state transitions from the test:
+///   - construction does not crash
+///   - `cancelPendingWarning()` is safe to call when no task is pending
+///   - `activeCaptureBackend()` returns nil when both pipelines are idle
+///   - `isCurrentSession(_:)` matches `audioCapture.currentCaptureSessionID`
+@MainActor
+@Suite struct DictationLifecycleCoordinatorTests {
+
+  private static func makeCoordinator() -> (
+    coordinator: DictationLifecycleCoordinator,
+    audio: RouterTestAudioCapture,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    recordingLocked: TestRecordingLockedBox
+  ) {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let pipeline = DictationRuntimeFixtures.makeParakeetPipeline(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKitPipeline = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+    let settings = SettingsManager()
+    let overlay = RecordingOverlayPanel()
+    let hotkey = HotkeyService()
+    let settingsSync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: TranscriptPolishService(
+        keychainManager: KeychainManager(),
+        transcriptStore: store),
+      audioCapture: audio,
+      asrManager: asr,
+      hotkeyService: hotkey,
+      whisperKitSetup: WhisperKitSetupService()
+    )
+    let transcriptCoordinator = TranscriptCoordinator(store: store)
+    let lastRecordingResult = LastRecordingResult()
+    let lockBox = TestRecordingLockedBox()
+    let coordinator = DictationLifecycleCoordinator(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      recordingOverlay: overlay,
+      hotkeyService: hotkey,
+      settingsSync: settingsSync,
+      audioCapture: audio,
+      transcriptCoordinator: transcriptCoordinator,
+      settings: settings,
+      lastRecordingResult: lastRecordingResult,
+      languageSuggestionPresenter: nil,
+      recordingLockedAccess: .init(
+        get: { lockBox.isLocked },
+        set: { lockBox.isLocked = $0 }
+      )
+    )
+    return (coordinator, audio, pipeline, whisperKitPipeline, lockBox)
+  }
+
+  @Test func constructionDoesNotCrash() {
+    _ = Self.makeCoordinator()
+  }
+
+  @Test func cancelPendingWarningIsSafeWhenNoTaskPending() {
+    let fixtures = Self.makeCoordinator()
+    // No `install()`, no recording — nothing scheduled a warning Task.
+    // Cancel should be a clean no-op.
+    fixtures.coordinator.cancelPendingWarning()
+    fixtures.coordinator.cancelPendingWarning()  // repeated calls also fine
+  }
+
+  @Test func activeCaptureBackendReturnsNilWhenBothPipelinesIdle() {
+    let fixtures = Self.makeCoordinator()
+    // Both pipelines start in `.idle`; no `install()` so no transitions fired.
+    #expect(fixtures.pipeline.state.isActive == false)
+    #expect(fixtures.whisperKitPipeline.state.isActive == false)
+    #expect(fixtures.coordinator.activeCaptureBackend() == nil)
+  }
+
+  @Test func activeTelemetryTargetReturnsParakeetByDefaultWhenIdle() {
+    let fixtures = Self.makeCoordinator()
+    // Initial `lastCapturingBackend = .parakeet`; both pipelines idle →
+    // helper resolves to "the backend that most recently owned a session,"
+    // which is parakeet at first launch.
+    let target = fixtures.coordinator.activeTelemetryTarget()
+    #expect(target != nil)
+    #expect(target as AnyObject === fixtures.pipeline as AnyObject)
+  }
+
+  @Test func isCurrentSessionMatchesAudioCaptureSessionID() {
+    let fixtures = Self.makeCoordinator()
+    fixtures.audio.currentCaptureSessionID = 42
+    #expect(fixtures.coordinator.isCurrentSession(42) == true)
+    #expect(fixtures.coordinator.isCurrentSession(7) == false)
+    #expect(fixtures.coordinator.isCurrentSession(0) == false)
+  }
+
+  @Test func installSetsBothPipelineCallbacks() {
+    let fixtures = Self.makeCoordinator()
+    #expect(fixtures.pipeline.onStateChange == nil)
+    #expect(fixtures.whisperKitPipeline.onStateChange == nil)
+    fixtures.coordinator.install()
+    #expect(fixtures.pipeline.onStateChange != nil)
+    #expect(fixtures.whisperKitPipeline.onStateChange != nil)
+  }
+}
+
+/// PR9 of #763 — mutable lock-state stand-in used by the
+/// `recordingLockedAccess` closure pair in tests. Lets the test verify both
+/// the getter (read by `showOverlay`) and the setter (written by state-change
+/// closures) round-trip through the same value.
+@MainActor
+final class TestRecordingLockedBox {
+  var isLocked: Bool = false
+}

--- a/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateCeilingsTests.swift
@@ -8,28 +8,35 @@ import Testing
 /// constructing an AppState instance — AppState's init pulls in real audio
 /// capture, ASR, pipelines, and Tasks that should not run inside a unit test.
 ///
-/// Ceilings: concrete-collaborator count ≤ 18, total line count ≤ 1115.
+/// Ceilings: concrete-collaborator count ≤ 17, total line count ≤ 692.
 /// Raising a ceiling requires a Bible changelog entry, not a silent bump.
 @Suite struct AppStateCeilingsTests {
 
-  /// Concrete-collaborator count ceiling. Locked at post-PR3 (#769) baseline = 18.
+  /// Concrete-collaborator count ceiling. Locked at post-PR9 (#775) baseline = 17.
   /// Counts top-level `let` declarations on AppState whose type is non-primitive.
   /// Existentials (`any X`) count as collaborators.
   ///
-  /// Ratcheted 19 → 18 in PR3 of epic #763 (2026-05-18, #769) after extracting
-  /// BenchmarkSuite into DiagnosticsCoordinator. PR4 of epic #763 (#770) ships
-  /// `var languageSuggestionPresenter` which is intentionally a `var` (setter-
-  /// injected post-init) and is therefore NOT counted by this parser — the
-  /// ceiling stays at 18. Per Codex code-diff r4 [P3]: keeping the ceiling at
-  /// 18 preserves the parser-aligned guard rather than weakening it to 19 for
-  /// a collaborator the parser would not count anyway.
+  /// Ratchet history:
+  /// - 19 → 18 in PR3 of epic #763 (2026-05-18, #769) after extracting
+  ///   BenchmarkSuite into DiagnosticsCoordinator. PR4 of epic #763 (#770)
+  ///   ships `var languageSuggestionPresenter` which is intentionally a
+  ///   `var` (setter-injected post-init) and is therefore NOT counted by
+  ///   this parser — the ceiling stays at 18.
+  /// - 18 → 17 in PR9 of epic #763 (2026-05-19, #775) after extracting
+  ///   `let transcriptCoordinator` off AppState. The new lifecycle home
+  ///   (`DictationLifecycleCoordinator`) is the caller of `append`; views
+  ///   read through `TranscriptWorkflowCoordinator`. The composition root
+  ///   (`EnviousWisprApp.init`) constructs `TranscriptCoordinator` once and
+  ///   threads the same instance to both. AppState's init now takes
+  ///   `TranscriptStore` so the pipelines + polish service still receive
+  ///   the shared store reference.
   @Test func appStateConcreteCollaboratorCeilingHolds() throws {
     let body = try classBodyOfAppState()
     let count = countTopLevelLetCollaborators(in: body)
     #expect(
-      count <= 18,
+      count <= 17,
       """
-      AppState concrete-collaborator ceiling exceeded: \(count) > 18. \
+      AppState concrete-collaborator ceiling exceeded: \(count) > 17. \
       Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }
@@ -70,26 +77,31 @@ import Testing
   /// - 1038 → 904 in PR8 of epic #763 (2026-05-19, #774) after extracting the
   ///   seven heart-path event-routing closures (`audioCapture.on*` ×6 +
   ///   `asrManager.onServiceInterrupted`) plus the
-  ///   `AVAudioEngineConfigurationChange` observer block into
-  ///   `AudioEventRouter` / `ASREventRouter` / `WedgeRecoveryRouter` under
-  ///   `DictationRuntime`. Net: -134 (144 lines of closures + comments removed;
-  ///   ~10 lines of explanatory comment added in their place). 902 actual +
-  ///   2-line margin. Collaborator ceiling stays at 18 — no `let`s added or
-  ///   removed on AppState. The resolver helpers (`LastCapturingBackend`,
-  ///   `lastCapturingBackend`, `prevParakeetActive`, `prevWhisperKitActive`,
-  ///   `activeCaptureBackend()`, `isCurrentSession(_:)`,
-  ///   `activeTelemetryTarget()`) stay on AppState through PR8 — promoted
-  ///   `private` → `internal` so the router-injected closures can read them.
-  ///   PR9 absorbs them into `DictationLifecycleCoordinator` (same-PR
-  ///   grep-test `AppStateNoLongerOwnsBackendResolverTests` enforces).
+  ///   `AVAudioEngineConfigurationChange` observer block into the three
+  ///   routers under `DictationRuntime`. Net: -134. The resolver helpers
+  ///   stayed on AppState through PR8 — promoted `private` → `internal` so
+  ///   the router-injected closures could read them — and PR9 owns the
+  ///   cleanup.
+  /// - 904 → 692 in PR9 of epic #763 (2026-05-19, #775) after extracting:
+  ///   the two pipeline `onStateChange` closure bodies (~120 lines), the
+  ///   lazy state-handler factory (~37 lines), the post-completion warning
+  ///   Task + scheduler (~13 lines), the seven PR8 deferred resolver
+  ///   symbols (~47 lines), the `let transcriptCoordinator` + local
+  ///   `transcriptStore` construction (~5 lines), the `onPipelineStateChange`
+  ///   var (~2 lines). New code added: the `attachDictationLifecycleCoordinator`
+  ///   weak ref setter (~10 lines), the `init(transcriptStore:)` parameter
+  ///   change (~2 lines), explanatory comments at the deletion sites
+  ///   (~25 lines). Net: ~-212. 690 actual + 2-line margin. Same-PR
+  ///   grep-test `AppStateNoLongerOwnsBackendResolverTests` enforces no
+  ///   PR8-deferred symbol survives.
   @Test func appStateLineCountCeilingHolds() throws {
     let url = appStateURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 904,
+      lineCount <= 692,
       """
-      AppState line count exceeded: \(lineCount) > 904. \
+      AppState line count exceeded: \(lineCount) > 692. \
       Raising the ceiling requires a Bible changelog entry, not a silent bump.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/AppStateNoLongerOwnsBackendResolverTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateNoLongerOwnsBackendResolverTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+/// PR9 of #763 — same-PR ship gate for the PR8 deferred-cleanup obligation.
+///
+/// PR8 promoted seven AppState symbols from `private` to `internal` so
+/// `DictationRuntime`'s router-injected resolver closures could read them
+/// via `[weak appState]` captures. PR8 explicitly deferred the move (would
+/// have broken its 18→18 collaborator-count cascade promise). PR9 absorbs
+/// all seven into `DictationLifecycleCoordinator` and rewires the routers'
+/// resolver closures to capture `[weak dictationLifecycleCoordinator]`
+/// instead.
+///
+/// This test reads `Sources/EnviousWispr/App/AppState.swift` and asserts
+/// NONE of the seven identifiers appear anywhere in the file — code or
+/// comments. The intentionally-strict check fails the build if a stray
+/// PR8 leftover survives.
+///
+/// PR9 plan: `docs/feature-requests/issue-775-2026-05-19-pr9-lifecycle-coordinator.md`.
+@Suite struct AppStateNoLongerOwnsBackendResolverTests {
+
+  @Test func appStateDoesNotContainAnyPR8DeferredSymbol() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: "Sources/EnviousWispr/App/AppState.swift"),
+      encoding: .utf8
+    )
+
+    // Exact identifier strings — must NOT appear anywhere in AppState.swift.
+    // Includes the bare enum name + the three resolver-state vars + the three
+    // resolver helper methods. The enum-name freeze (see issue #775 body and
+    // parent migration plan §PR9) requires `LastCapturingBackend` to be
+    // preserved byte-for-byte inside the new home, so we look for that exact
+    // spelling here.
+    let bannedIdentifiers: [String] = [
+      "LastCapturingBackend",
+      "lastCapturingBackend",
+      "prevParakeetActive",
+      "prevWhisperKitActive",
+      "activeCaptureBackend",
+      "isCurrentSession",
+      "activeTelemetryTarget",
+    ]
+
+    var found: [String] = []
+    for identifier in bannedIdentifiers where source.contains(identifier) {
+      found.append(identifier)
+    }
+
+    #expect(
+      found.isEmpty,
+      """
+      AppState.swift still contains PR8 deferred-cleanup identifiers: \
+      \(found.joined(separator: ", ")). PR9 must remove all seven from \
+      AppState in the same PR (no shim, no deferral). The owning home is \
+      `DictationLifecycleCoordinator` under DictationRuntime; the routers' \
+      injected resolver closures capture the new home. See PR9 plan \
+      `docs/feature-requests/issue-775-2026-05-19-pr9-lifecycle-coordinator.md`.
+      """
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+/// PR9 of #763 — locks `DictationLifecycleCoordinator`'s shape so the new
+/// lifecycle home does not silently accrete domain state.
+///
+/// Bible-changelog (ratchet history):
+/// - PR9 (#775): baseline. The cap is 11 `let` collaborators — raised from
+///   the parent migration plan §PR9's named "10" after parser-grounded
+///   analysis of `CeilingsTestSupport.swift` revealed two facts:
+///   (a) the ceiling parser counts only top-level `let` declarations with
+///       non-primitive types; `var`-typed resolver state (`lastCapturingBackend`,
+///       `prevParakeetActive`, `prevWhisperKitActive`, `postCompletionWarningTask`,
+///       lazy state handlers, `onPipelineStateChange`) is therefore free
+///       against the cap.
+///   (b) the lifecycle home needs BOTH a getter and a setter for AppState's
+///       still-owned `isRecordingLocked` — getter feeds
+///       `recordingOverlay.show(...)` so the hands-free lock visual renders
+///       correctly during state transitions; setter clears locked on
+///       transitions out of `.recording`. Packaging the get/set pair into a
+///       single nested `RecordingLockedAccess` struct holds the cap at exactly
+///       11. Alternatives rejected: `weak var appState` back-reference
+///       (banned forwarding shim per migration Hard Constraint #2 and
+///       `~/.claude/rules/no-half-done-handoffs.md`); expanding PR9 scope to
+///       absorb `isRecordingLocked` state ownership entirely (collides with
+///       PR10's `RecordingFinalizer` plan).
+///   PR10 ratchets back down when `RecordingFinalizer` absorbs the
+///   lock-state writes (the closure-pair retires).
+///
+/// Var-exclusion rationale (per category, locked here so a future PR cannot
+/// argue "var anything is free"):
+///   1. OWNED MUTABLE STATE (`lastCapturingBackend`, `prevParakeetActive`,
+///      `prevWhisperKitActive`, `postCompletionWarningTask`, lazy state
+///      handlers): genuine in-flight state owned by the coordinator, mutated
+///      by the state-change closures and Task scheduling. Not collaborators —
+///      no external owner, no architectural dependency.
+///   2. EXTERNAL CALLBACK (`var onPipelineStateChange`): setter-injected
+///      post-init by AppDelegate. Same precedent as PR4's
+///      `var languageSuggestionPresenter` on AppState (see
+///      `AppStateCeilingsTests.swift:19-25` doc).
+@Suite struct DictationLifecycleCoordinatorCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationLifecycleCoordinator", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 11,
+      """
+      DictationLifecycleCoordinator collaborator ceiling exceeded: \(count) > 11. \
+      Allowed (PR9 baseline): pipeline, whisperKitPipeline, recordingOverlay, \
+      hotkeyService, settingsSync, audioCapture, transcriptCoordinator, settings, \
+      lastRecordingResult, languageSuggestionPresenter, recordingLockedAccess. \
+      PR10 ratchets down when RecordingFinalizer absorbs the lock-state writes.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationLifecycleCoordinator", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 5,
+      """
+      DictationLifecycleCoordinator non-private method ceiling exceeded: \
+      \(count) > 5 non-private `func` declarations. Allowed (PR9 baseline): \
+      `install()`, `cancelPendingWarning()`, `activeCaptureBackend()`, \
+      `isCurrentSession(_:)`, `activeTelemetryTarget()`.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 350,
+      """
+      DictationLifecycleCoordinator line count exceeded: \(count) > 350. \
+      Raise via Bible §30 only.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "EnviousWisprASR",
+      "EnviousWisprAudio",
+      "EnviousWisprCore",
+      "EnviousWisprPipeline",
+      "EnviousWisprServices",
+      "EnviousWisprStorage",
+      "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      DictationLifecycleCoordinator imports outside allowed set: \
+      \(extras.sorted()). Allowed: \(allowed.sorted()).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -4,6 +4,17 @@ import Testing
 /// PR8 of #763 — locks `DictationRuntime`'s initial shape so the new
 /// runtime-internals home does not silently accrete domain state before
 /// PR10 expands it with HotkeyController / RecordingStarter / RecordingFinalizer.
+///
+/// Bible-changelog (ratchet history):
+/// - PR8 (#774): baseline = 3 collaborators (audio/asr/wedge routers), 0
+///   non-private methods, ≤ 80 lines.
+/// - PR9 (#775): collaborator cap 3 → 4 (added `dictationLifecycleCoordinator`
+///   as a private property — the routers' injected resolver closures now
+///   capture the lifecycle home instead of AppState; co-locating it here
+///   makes DictationRuntime the single composition root for the heart-path
+///   event-handling layer). Line cap 80 → 100 (new property + init parameter
+///   + Bible-changelog header comment). PR10 ratchets up to ~120 for
+///   HotkeyController + RecordingStarter + RecordingFinalizer.
 @Suite struct DictationRuntimeCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWispr/App/DictationRuntime/DictationRuntime.swift"
@@ -13,11 +24,12 @@ import Testing
       named: "DictationRuntime", at: Self.sourcePath)
     let count = RouterCeilingParser.collaboratorCount(in: body)
     #expect(
-      count <= 3,
+      count <= 4,
       """
-      DictationRuntime collaborator ceiling exceeded: \(count) > 3. \
-      Allowed: audioEventRouter, asrEventRouter, wedgeRecoveryRouter.
-      PR10 raises this when hotkey/start/finalize land.
+      DictationRuntime collaborator ceiling exceeded: \(count) > 4. \
+      Allowed (PR9 baseline): dictationLifecycleCoordinator, audioEventRouter, \
+      asrEventRouter, wedgeRecoveryRouter. PR10 raises this when \
+      hotkey/start/finalize land.
       """)
   }
 
@@ -53,10 +65,11 @@ import Testing
       contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      count <= 80,
+      count <= 100,
       """
-      DictationRuntime line count exceeded: \(count) > 80. \
-      Raise via Bible §30 only.
+      DictationRuntime line count exceeded: \(count) > 100. \
+      Raise via Bible §30 only. PR9 ratcheted 80 → 100 to budget for the new \
+      `dictationLifecycleCoordinator` property + init parameter + header note.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -74,17 +74,20 @@ import Testing
   /// Line-count trip-wire. Soft backstop against accidental file explosions;
   /// entanglement signals (stored properties, methods, imports) are the
   /// primary mechanical constraints. Ratcheted 250→270 in PR8 of epic #763
-  /// (2026-05-19, #774) to absorb DictationRuntime construction (15 lines:
-  /// @State decl + closure-injected init block + State(initialValue:)).
-  /// 259 actual + 2-line margin then rounded to the next ratchet step.
+  /// (2026-05-19, #774) to absorb DictationRuntime construction (15 lines).
+  /// Ratcheted 270→310 in PR9 of epic #763 (2026-05-19, #775) to absorb
+  /// `DictationLifecycleCoordinator` construction (~25 lines: 11-collaborator
+  /// init block + recordingLockedAccess struct literal + install() call +
+  /// attachDictationLifecycleCoordinator call) and the hoisted
+  /// `TranscriptStore` + `TranscriptCoordinator` construction (~3 lines).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 270,
+      lineCount <= 310,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 270. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 310. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }
@@ -93,10 +96,20 @@ import Testing
   /// modules like EnviousWisprPipeline / EnviousWisprAudio / EnviousWisprASR /
   /// EnviousWisprLLM directly — that would couple SwiftUI mounting to engine
   /// implementation details. AppDelegate already carries those imports.
+  ///
+  /// PR9 of #763 added EnviousWisprStorage to construct `TranscriptStore`
+  /// directly in the composition root (hoisted out of `AppState.init` so the
+  /// composition root can thread the same `TranscriptCoordinator` instance
+  /// to both the lifecycle home and the transcript workflow coordinator).
+  /// `TranscriptStore` is a small, dependency-free persistence wrapper — not
+  /// an engine internal — so allowing it on the composition root is
+  /// consistent with the rule's intent.
   @Test func envWisprAppImportsCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
-    let allowed: Set<String> = ["SwiftUI", "EnviousWisprCore", "EnviousWisprServices"]
+    let allowed: Set<String> = [
+      "SwiftUI", "EnviousWisprCore", "EnviousWisprServices", "EnviousWisprStorage",
+    ]
     let actual = parseImports(in: source)
     let unexpected = actual.subtracting(allowed)
     #expect(

--- a/Tests/EnviousWisprTests/Services/V2/HandsFreeLockTests.swift
+++ b/Tests/EnviousWisprTests/Services/V2/HandsFreeLockTests.swift
@@ -4,39 +4,39 @@ import Testing
 
 /// V2 fault-injection — Lane C invariant C4 (issue #291).
 ///
-/// Asserts that AppState's pipeline-state observer resets `isRecordingLocked`
-/// for every terminal state (.complete, .error, .idle). This is what closes
-/// the hands-free lock loop: the user double-presses to lock, dictates, and
+/// Asserts that the pipeline-state observer resets `isRecordingLocked` for
+/// every terminal state (.complete, .error, .idle). This closes the
+/// hands-free lock loop: the user double-presses to lock, dictates, and
 /// when the pipeline reaches a terminal state the lock must clear so the
 /// next recording starts in normal PTT mode.
 ///
-/// Tests the source-level wiring contract rather than constructing a full
-/// `AppState` (per `AppStateCeilingsTests`: "AppState's init pulls in real
-/// audio capture, ASR, pipelines, and Tasks that should not run inside a
-/// unit test"). A regression that drops `isRecordingLocked = false` from any
-/// terminal arm of the pipeline observer will be caught here.
+/// PR9 of #763: the observer moved from `AppState` to
+/// `DictationLifecycleCoordinator`. AppState still owns `isRecordingLocked`
+/// state; the coordinator clears it via the injected `recordingLockedAccess.set`
+/// closure. The test now scans the coordinator's per-pipeline `switch newState`
+/// blocks and asserts each terminal arm calls `recordingLockedAccess.set(false)`.
 @Suite("V2 Lane C — hands-free lock cleared on every terminal pipeline state")
 struct HandsFreeLockTests {
 
-  @Test("Parakeet pipeline observer resets isRecordingLocked on .error / .idle / .complete")
+  @Test("Parakeet observer resets isRecordingLocked on .error / .idle / .complete")
   func testHandsFreeLockClearedOnComplete_parakeet() throws {
-    let body = try Self.classBodyOfAppState()
+    let body = try Self.classBodyOfCoordinator()
     let parakeetSwitch = try Self.extractSwitch(
       in: body,
       switchedOn: "newState",
-      after: "pipeline.onStateChange = { [weak self] newState in"
+      after: "private func handleParakeet(newState: PipelineState) {"
     )
     Self.assertResetsLockForCases(parakeetSwitch, cases: [".error", ".idle", ".complete"])
   }
 
   @Test(
-    "WhisperKit pipeline observer resets isRecordingLocked on .error / .idle / .ready / .complete")
+    "WhisperKit observer resets isRecordingLocked on .error / .idle / .ready / .complete")
   func testHandsFreeLockClearedOnComplete_whisperKit() throws {
-    let body = try Self.classBodyOfAppState()
+    let body = try Self.classBodyOfCoordinator()
     let whisperKitSwitch = try Self.extractSwitch(
       in: body,
       switchedOn: "newState",
-      after: "whisperKitPipeline.onStateChange = { [weak self] newState in"
+      after: "private func handleWhisperKit(newState: WhisperKitPipelineState) {"
     )
     Self.assertResetsLockForCases(
       whisperKitSwitch, cases: [".error", ".idle", ".ready", ".complete"])
@@ -44,7 +44,7 @@ struct HandsFreeLockTests {
 
   // MARK: - Source-level helpers
 
-  private static func appStateURL() -> URL {
+  private static func coordinatorURL() -> URL {
     let here = URL(fileURLWithPath: #filePath)
     return
       here
@@ -53,11 +53,12 @@ struct HandsFreeLockTests {
       .deletingLastPathComponent()  // EnviousWisprTests/
       .deletingLastPathComponent()  // Tests/
       .deletingLastPathComponent()  // <repo root>/
-      .appendingPathComponent("Sources/EnviousWispr/App/AppState.swift")
+      .appendingPathComponent(
+        "Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift")
   }
 
-  private static func classBodyOfAppState() throws -> String {
-    try String(contentsOf: appStateURL(), encoding: .utf8)
+  private static func classBodyOfCoordinator() throws -> String {
+    try String(contentsOf: coordinatorURL(), encoding: .utf8)
   }
 
   /// Extract the body of the `switch` statement that follows `marker`. Cheap
@@ -118,9 +119,9 @@ struct HandsFreeLockTests {
       if let arm = matchingArm {
         let armBody = arm.body.joined(separator: "\n")
         #expect(
-          armBody.contains("isRecordingLocked = false"),
+          armBody.contains("recordingLockedAccess.set(false)"),
           """
-          AppState observer arm `\(arm.header)` must reset `isRecordingLocked = false` for `\(caseToken)`. \
+          Coordinator arm `\(arm.header)` must call `recordingLockedAccess.set(false)` for `\(caseToken)`. \
           Removing this reset breaks hands-free lock cleanup on terminal pipeline state.
           Arm body:
           \(armBody)


### PR DESCRIPTION
## Summary

- Extracts pipeline state-change side effects, post-completion warning Task, and the seven PR8-deferred backend-resolver symbols from AppState into a new private `DictationRuntime` collaborator (`DictationLifecycleCoordinator`).
- Hoists `let transcriptCoordinator` off AppState (cascade from PR6); composition root constructs it once and threads to both the lifecycle home and `TranscriptWorkflowCoordinator`. AppState collaborator count drops 18 → 17.
- Same-PR ship gate `AppStateNoLongerOwnsBackendResolverTests` greps AppState.swift and fails the build if any of the seven PR8-deferred identifiers survive.

Closes #775. Part of #763.

## Plan

`docs/feature-requests/issue-775-2026-05-19-pr9-lifecycle-coordinator.md` (gitignored; lives in the working tree).

## Reviewer artifacts

- Codex grounded review on plan: PROCEED-WITH-REVISIONS → all 6 revisions applied (plan-file copy to main checkout, ceiling normalized to 11 with Bible-changelog, line refs corrected, AppDelegate wiring clarified, DictationRuntime cap 3→4, council exception narrowed). Output: `.codex/2026-05-19-pr9-grounded-review-output.txt`.
- Council coverage review (GPT + Gemini): five additional findings applied — `cancelPendingWarning()` public method + weak ref from AppState to coordinator, `recordingLockedAccess` get/set via `[weak appState]`, and explicit AppDelegate callback ordering note. Output: `/tmp/pr9-council-output.txt`.
- Codex code-diff review on commit: clean. *"The moved pipeline lifecycle behavior appears to preserve the prior AppState side effects while rewiring ownership through DictationLifecycleCoordinator."*

## Pre-design ceilings (DictationLifecycleCoordinator)

| Cap | Value | Rationale |
|---|---|---|
| `let` collaborators | 11 | 10 concrete + 1 closure-pair struct (`recordingLockedAccess`). Raised from parent plan's named "10" after parser-grounded analysis (var resolver state is free). Bible-changelog inline in the ceiling test. PR10 ratchets back down when `RecordingFinalizer` absorbs `isRecordingLocked`. |
| Non-private methods | 5 | `install()`, `cancelPendingWarning()`, `activeCaptureBackend()`, `isCurrentSession(_:)`, `activeTelemetryTarget()`. |
| Line count | 350 | Trip-wire only. |
| Imports | `EnviousWisprASR`, `EnviousWisprAudio`, `EnviousWisprCore`, `EnviousWisprPipeline`, `EnviousWisprServices`, `EnviousWisprStorage`, `Foundation` | |

## Ceiling ratchets

- AppState collaborators 18 → 17 (transcriptCoordinator removed)
- AppState lines 904 → 692
- EnviousWisprApp lines 270 → 310; +`EnviousWisprStorage` to allowed imports
- DictationRuntime collaborators 3 → 4; lines 80 → 100

## Live UAT

Founder ran on local debug build:
- Parakeet: "This is me testing parakeet one two three." → ASR + polish + paste clean
- WhisperKit: "This is testing Whisper Kit 1, 2, 3." → TOTAL 2.426s (ASR 0.472s, polish 1.214s, paste 0.256s)
- Cancel + restart: "Okay, no problems for the cancel." → 30ms PTT-to-recording cold-start, full lifecycle fired

Scenario 4 (audio-route swap mid-recording) deferred — founder on Bluetooth meeting; static review (Codex grounded + code-diff) verified PR8 routers' resolver closures rewire correctly to the new owner.

## Test plan

- [x] swift build -c release
- [x] swift build --build-tests
- [x] Full unit suite: 1014/1015 pass (1 pre-existing TextProcessingRunner timeout flake under MainActor saturation, documented in `swift-patterns.md`; passes in isolation)
- [x] New architecture tests pass: `AppStateNoLongerOwnsBackendResolverTests`, `DictationLifecycleCoordinatorCeilingsTests`, `DictationLifecycleCoordinatorTests` (6 behavior tests), `DictationRuntimeCeilingsTests` (ratchet update), `AppStateCeilingsTests` (ratchet down), `EnviousWisprAppCeilingsTests` (ratchet up), `HandsFreeLockTests` (relocated to coordinator source)
- [x] Founder UAT (Parakeet + WhisperKit + cancel)
- [ ] CI build-check green (auto-merge will gate on this)
