### PR TITLE
fix(llm-discovery): use max_completion_tokens in OpenAI probe (#795)

### DIFF
--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -200,12 +200,7 @@ public struct LLMModelDiscovery: Sendable {
   }
 
   private func probeOpenAI(modelID: String, apiKey: String) async -> Bool {
-    let body: [String: Any] = [
-      "model": modelID,
-      "messages": [["role": "user", "content": "Hi"]],
-      "max_tokens": 5,
-      "store": false,
-    ]
+    let body = Self.makeOpenAIProbeRequestBody(modelID: modelID)
 
     guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
       return false
@@ -222,6 +217,15 @@ public struct LLMModelDiscovery: Sendable {
     else { return false }
 
     return httpResponse.statusCode == 200
+  }
+
+  static func makeOpenAIProbeRequestBody(modelID: String) -> [String: Any] {
+    [
+      "model": modelID,
+      "messages": [["role": "user", "content": "Hi"]],
+      "max_completion_tokens": 5,
+      "store": false,
+    ]
   }
 
   // MARK: - Ollama

--- a/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+@Suite("OpenAI request body")
+struct OpenAIRequestBodyTests {
+  @Test func modelProbeRequestBodyUsesMaxCompletionTokens() {
+    let body = LLMModelDiscovery.makeOpenAIProbeRequestBody(modelID: "gpt-5")
+    #expect(body["max_completion_tokens"] as? Int == 5)
+  }
+
+  @Test func modelProbeRequestBodyDoesNotUseDeprecatedMaxTokens() {
+    let body = LLMModelDiscovery.makeOpenAIProbeRequestBody(modelID: "gpt-5")
+    #expect(body["max_tokens"] == nil)
+  }
+
+  @Test func modelProbeRequestBodyDisablesProviderLogging() {
+    let body = LLMModelDiscovery.makeOpenAIProbeRequestBody(modelID: "gpt-5")
+    #expect(body["store"] as? Bool == false)
+  }
+
+  @Test func modelProbeRequestBodyEchoesModelID() {
+    let body = LLMModelDiscovery.makeOpenAIProbeRequestBody(modelID: "gpt-5-mini")
+    #expect(body["model"] as? String == "gpt-5-mini")
+  }
+}


### PR DESCRIPTION
Closes #795.

## What changed for users

OpenAI's GPT-5 family (plain `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.2`, `gpt-5.4`, `gpt-5.5`, and all their dated variants) was incorrectly appearing under **"Not available with your API key"** with a lock icon in Settings → AI Polish → OpenAI, even for users whose key has full access. After this fix and a Refresh, those 16 rows move into the available section and become selectable.

## Root cause

The model-availability probe in `LLMModelDiscovery.probeOpenAI` was sending the deprecated `max_tokens` parameter in the chat-completions request body. OpenAI deprecated `max_tokens` in favor of `max_completion_tokens`; the new parameter is required for GPT-5 family and o-series models, and the old one returns HTTP 400 for them. The probe interpreted the 400 as "unavailable" and the picker labeled the row locked.

Production polish (`OpenAIConnector.swift:29`) and pre-warm (`LLMNetworkSession.swift:108`) already used `max_completion_tokens`. Only the discovery probe was stale.

## Fix

One-line parameter swap, extracted into a static testable helper `makeOpenAIProbeRequestBody(modelID:)` mirroring the existing `makeGeminiProbeRequestBody` pattern. New `OpenAIRequestBodyTests` suite asserts the body contains `max_completion_tokens`, does NOT contain `max_tokens`, has `store: false`, and echoes the model ID — locking the fix against silent reintroduction.

## What stays locked (intentional, NOT a regression)

These remain locked after the fix; this is correct behavior, not a bug:

- `gpt-5.1`, `gpt-5.1-2025-11-13` — reasoning model; the 5-token probe budget is consumed before any response can be generated (HTTP 400 "max_tokens limit reached"). We don't want users picking heavy reasoning models for sub-second dictation polish anyway (same logic as Gemini "thinking" off by default).
- `gpt-5-pro`, `gpt-5-codex`, `gpt-5.1-codex*`, `gpt-5.2-pro/codex`, `gpt-5.3-codex`, `gpt-5.4-pro`, `gpt-5.5-pro`, `o1-pro`, `o3-pro` — only available on `/v1/responses` (HTTP 404 "This model is only supported in v1/responses..."), not chat completions. Genuinely incompatible with the polish path.
- `gpt-3.5-turbo-instruct*` — legacy `/v1/completions` endpoint. Same shape, called out in the issue body as a separate-scope cleanup.

## Existing-user behavior note

`LLMModelInfo` results are cached to `UserDefaults` under `cachedModels_<provider>`. Settings-view open only loads the cache; it does not trigger discovery. Existing users on the buggy build will continue to see GPT-5 family as locked **until they press the Refresh button next to the model picker** (or re-Save the key, or switch provider away and back). New installs / fresh caches will discover with the patched probe directly.

If your previously-selected polish model was a GPT-5 variant that got auto-bumped to (say) `gpt-3.5-turbo` when the bug locked it, the fix does NOT auto-revert your selection. You'll see the bumped model in the picker after Refresh and need to re-select GPT-5 manually once.

## Validation

- `swift build -c release` ✓
- `scripts/swift-test.sh --filter OpenAIRequestBody` → 4/4 pass
- Codex grounded review on the plan: clean (2 rounds, R2 PROCEED after one doc-precision fix)
- Codex code-diff review on the branch: `"The diff cleanly switches the OpenAI probe body to max_completion_tokens and adds focused tests for that request body. I did not find a discrete regression in the changed code."`
- Live UAT (this machine, real OpenAI key with GPT-5 access):
  - Before fix: 0 GPT-5 family entries available (all 32 locked)
  - After fix: 16 GPT-5 family entries available; `Gpt 5 Mini`, `Gpt 5 Nano`, `Gpt 5.4 Mini`, `Gpt 5.4 Nano` confirmed in the picker's "Recommended for cleanup" section via AX inspection
  - GPT-4 family unchanged (regression check ✓)