### PR TITLE
refactor(appstate): extract SparkleUpdateController from AppDelegate (PR-B.1 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -4,7 +4,6 @@ import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
-@preconcurrency import Sparkle
 import SwiftUI
 
 // Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` were previously
@@ -25,8 +24,6 @@ import SwiftUI
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem?
-  private(set) var updaterController: SPUStandardUpdaterController?
-  private(set) var updateCoordinator: UpdateCoordinator?
   private let iconAnimator = MenuBarIconAnimator()
   private weak var mainWindow: NSWindow?
   private var windowCloseObserver: (any NSObjectProtocol)?
@@ -37,11 +34,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   // fires. Weak refs so AppDelegate is not a retention root.
   private weak var appState: AppState?
   private weak var navigationCoordinator: NavigationCoordinator?
-  /// Issue #739: stable env-carrier — non-optional `@Observable` holder
-  /// owned by `EnviousWisprApp` as `@State`. AppDelegate publishes its
-  /// Sparkle-derived `updateCoordinator` into the holder once Sparkle is
-  /// initialized; `@Observable` flips dependent views.
-  private weak var updateCoordinatorHolder: UpdateCoordinatorHolder?
+  /// PR-B.1 of #763: App-owned home for the Sparkle integration. Strong
+  /// owner is `EnviousWisprApp`'s `@State`. AppDelegate's relationship
+  /// is reduced to invoking `startUpdater()` from
+  /// `applicationWillFinishLaunching` and gating the menu's
+  /// "Check for Updates" item.
+  private weak var sparkleUpdateController: SparkleUpdateController?
   // PR7 of #763: weak refs to the two App-owned homes AppDelegate's
   // menu-bar reads now route through. `liveRecordingState` replaces
   // the old `appState.pipelineState` getter; `backendMetadata` replaces
@@ -67,9 +65,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private weak var hotkeyService: HotkeyService?
 
   /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
-  /// before delegate callbacks fire. If `updateCoordinator` is already
-  /// initialized (Sparkle came up before attach — defensive only, not a real
-  /// path), replay it into the holder immediately.
+  /// before delegate callbacks fire.
   ///
   /// PR7 of #763: additionally receive `liveRecordingState` and
   /// `backendMetadata` for the menu-bar reads.
@@ -77,10 +73,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// PR9 of #763: additionally receive `dictationLifecycleCoordinator` so the
   /// icon-update callback can be installed on the new home (was on AppState
   /// pre-PR9).
+  ///
+  /// PR-B.1 of #763: replace the `updateCoordinatorHolder` parameter with
+  /// `sparkleUpdateController`. AppDelegate no longer owns the holder ref —
+  /// the controller does, and the controller publishes into it from
+  /// `startUpdater()`.
   func attach(
     appState: AppState,
     navigationCoordinator: NavigationCoordinator,
-    updateCoordinatorHolder: UpdateCoordinatorHolder,
+    sparkleUpdateController: SparkleUpdateController,
     liveRecordingState: LiveRecordingState,
     backendMetadata: BackendMetadata,
     dictationLifecycleCoordinator: DictationLifecycleCoordinator,
@@ -89,15 +90,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   ) {
     self.appState = appState
     self.navigationCoordinator = navigationCoordinator
-    self.updateCoordinatorHolder = updateCoordinatorHolder
+    self.sparkleUpdateController = sparkleUpdateController
     self.liveRecordingState = liveRecordingState
     self.backendMetadata = backendMetadata
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     self.dictationRuntime = dictationRuntime
     self.hotkeyService = hotkeyService
-    if let existing = self.updateCoordinator {
-      updateCoordinatorHolder.coordinator = existing
-    }
   }
 
   /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
@@ -127,29 +125,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var audioSystemEventReporter: AudioSystemEventReporter?
   private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
 
-  /// Issue #739: instantiate the updater + update-banner coordinator BEFORE
-  /// SwiftUI mounts the App's scenes. SwiftUI snapshots the env value
-  /// `\.updateCoordinator` (bound to `appDelegate.updateCoordinator` in
-  /// `EnviousWisprApp.swift`) when the scene body is first evaluated, and
-  /// that snapshot is final — the App struct's `@State` doesn't change, so
-  /// SwiftUI never re-fetches. If we wait until `applicationDidFinishLaunching`,
-  /// the env value is nil forever and the banner never renders.
+  /// Issue #739: instantiate the Sparkle updater + update-banner coordinator
+  /// BEFORE SwiftUI mounts the App's scenes. PR-B.1 of #763 moves the body
+  /// into `SparkleUpdateController.startUpdater()`; this method now only
+  /// forwards. Loud nil-guard (not silent optional chain): if the weak ref
+  /// is nil at this point, debug crashes with `assertionFailure` and
+  /// release logs the skip — the update mechanism must never silently
+  /// dormant.
   func applicationWillFinishLaunching(_ notification: Notification) {
-    updaterController = SPUStandardUpdaterController(
-      startingUpdater: true,
-      updaterDelegate: self,
-      userDriverDelegate: self
-    )
-    updateCoordinator = UpdateCoordinator(updaterController: updaterController)
-    // Issue #739 / PR-A: publish the coordinator into the App-owned holder
-    // so SwiftUI views bound to its env value see the flip from nil → non-nil
-    // and re-render. The holder itself is a stable `@State` on
-    // `EnviousWisprApp`, attached to AppDelegate via `attach(...)` during
-    // App.init() — before this delegate callback fires.
-    updateCoordinatorHolder?.coordinator = updateCoordinator
-    // Cross-launch correlation runs here (was in didFinishLaunching) so the
-    // attribution event fires before any UI is shown.
-    evaluateUpdateInstallAttemptOnLaunch()
+    guard let controller = sparkleUpdateController else {
+      assertionFailure(
+        "SparkleUpdateController must be attached before applicationWillFinishLaunching fires."
+      )
+      Task {
+        await AppLogger.shared.log(
+          "Sparkle startup skipped: controller ref is nil. Update banner will not render this session.",
+          level: .info,
+          category: "AppDelegate"
+        )
+      }
+      return
+    }
+    controller.startUpdater()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
@@ -203,8 +200,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     }
 
-    // Issue #739: updaterController + updateCoordinator + cross-launch
-    // correlation moved to applicationWillFinishLaunching so SwiftUI's env
+    // Issue #739 / PR-B.1 of #763: Sparkle updater, update coordinator, and
+    // cross-launch correlation all live on `SparkleUpdateController` now and
+    // are invoked from `applicationWillFinishLaunching` so SwiftUI's env
     // value snapshot is non-nil when the App body first evaluates.
 
     setupStatusItem()
@@ -530,15 +528,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     settingsItem.target = self
     menu.addItem(settingsItem)
 
-    // Check for Updates — retargeted to AppDelegate wrapper so we can tag
-    // the install source as "menu" for telemetry attribution (issue #343).
-    if updaterController != nil {
+    // Check for Updates — retargets to SparkleUpdateController so it can
+    // tag the install source as "menu" for telemetry attribution (issue #343).
+    // PR-B.1 of #763: target/action both moved to the controller.
+    if sparkleUpdateController?.hasUpdater == true {
       let updateItem = NSMenuItem(
         title: "Check for Updates…",
-        action: #selector(openUpdateCheckFromMenu(_:)), keyEquivalent: "")
+        action: #selector(SparkleUpdateController.openUpdateCheckFromMenu(_:)),
+        keyEquivalent: "")
       updateItem.image = NSImage(
         systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
-      updateItem.target = self
+      updateItem.target = sparkleUpdateController
       menu.addItem(updateItem)
     }
 
@@ -611,38 +611,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     showWindow()
   }
 
-  /// Issue #343: menu-bar "Check for Updates…" wrapper. Tags the install source
-  /// as "menu" so cross-launch correlation can attribute install_completed /
-  /// install_cancelled correctly, then forwards to Sparkle's standard handler.
-  @objc private func openUpdateCheckFromMenu(_ sender: Any?) {
-    updateCoordinator?.lastInstallSource = "menu"
-    updaterController?.checkForUpdates(sender)
-  }
-
-  /// Issue #343: cross-launch correlation entry point. Called from
-  /// applicationDidFinishLaunching after the coordinator is constructed.
-  /// Compares the current bundle version to a persisted "we just attempted
-  /// to install" marker and fires install_completed / install_cancelled
-  /// telemetry. Independent of whether the click-time event made it through.
-  private func evaluateUpdateInstallAttemptOnLaunch() {
-    guard let coordinator = updateCoordinator else { return }
-    let outcome = coordinator.evaluateLastInstallAttempt(
-      currentBundleVersion: AppConstants.appVersion
-    )
-    switch outcome {
-    case .completed(let version, let source):
-      TelemetryService.shared.updateInstallCompleted(
-        version: version, isCritical: false, source: source
-      )
-    case .cancelled(let version, let source):
-      TelemetryService.shared.updateInstallCancelled(
-        version: version, isCritical: false, source: source
-      )
-    case .none, .unattributable, .stale:
-      break
-    }
-  }
-
   func applicationWillTerminate(_ notification: Notification) {
     if let observer = windowCloseObserver {
       NotificationCenter.default.removeObserver(observer)
@@ -692,171 +660,5 @@ extension AppDelegate: NSMenuDelegate {
       }
       self.updateIcon()
     }
-  }
-}
-
-// MARK: - SPUStandardUserDriverDelegate
-
-extension AppDelegate: @preconcurrency SPUStandardUserDriverDelegate {
-  /// Issue #343: declares support for gentle scheduled update reminders.
-  /// Sparkle logs an error if a background app does not declare this.
-  /// (sparkle-project.org/documentation/gentle-reminders)
-  var supportsGentleScheduledUpdateReminders: Bool { true }
-
-  /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
-  func standardUserDriverWillShowModalAlert() {
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate()
-  }
-
-  /// Return to accessory mode when the entire update session ends.
-  func standardUserDriverWillFinishUpdateSession() {
-    NSApp.setActivationPolicy(.accessory)
-  }
-
-  /// Issue #343: pure yes/no decision per Sparkle's documented gentle-reminder
-  /// pattern. NO side effects — all state mutation happens in
-  /// `standardUserDriverWillHandleShowingUpdate`.
-  /// Sparkle's contract: YES = Sparkle handles, NO = delegate handles.
-  func standardUserDriverShouldHandleShowingScheduledUpdate(
-    _ update: SUAppcastItem,
-    andInImmediateFocus immediateFocus: Bool
-  ) -> Bool {
-    let hasMainWindow = NSApp.windows.contains { $0.isVisible && $0.canBecomeMain }
-    if !hasMainWindow { return true }  // no banner mount → Sparkle handles
-    if update.isCriticalUpdate { return true }  // critical → Sparkle's full UX
-    if immediateFocus { return true }  // Sparkle wants front-and-center
-    return false  // we own the gentle UX via the banner
-  }
-
-  /// Issue #343: side-effect callback that fires after the yes/no decision.
-  /// Captures availability state into the service and (if Sparkle handles)
-  /// tags the install source for telemetry attribution.
-  /// Sparkle's contract: handleShowingUpdate == true → Sparkle handles,
-  /// false → delegate (us) handles.
-  func standardUserDriverWillHandleShowingUpdate(
-    _ handleShowingUpdate: Bool,
-    forUpdate update: SUAppcastItem,
-    state: SPUUserUpdateState
-  ) {
-    let available = UpdateAvailabilityService.AvailableUpdate(
-      versionString: update.versionString,
-      displayVersion: update.displayVersionString,
-      buildString: update.versionString,
-      isCriticalUpdate: update.isCriticalUpdate
-    )
-    updateCoordinator?.service.noteAvailable(available)
-
-    if handleShowingUpdate {
-      // Sparkle owns UX. Tag source + fire diagnostic event.
-      let reason: String = {
-        if !NSApp.windows.contains(where: { $0.isVisible && $0.canBecomeMain }) {
-          return "no_main_window"
-        }
-        if update.isCriticalUpdate { return "critical" }
-        return "immediate_focus"
-      }()
-      updateCoordinator?.lastInstallSource = "sparkle_default"
-      TelemetryService.shared.updateSparkleDefaultShown(
-        version: update.versionString,
-        isCritical: update.isCriticalUpdate,
-        reason: reason
-      )
-    }
-    // Else: banner owns UX; source set by `triggerInstall` when user clicks.
-  }
-
-  /// Issue #739: Sparkle fires this on alert focus AND user choice; it is NOT
-  /// a dismissal signal. Widget visibility is governed solely by bundle
-  /// version on disk. User engagement with the Sparkle alert does not hide
-  /// the widget. Method retained as no-op so Sparkle's delegate conformance
-  /// continues to register interest in the callback (needsToObserveUserAttention
-  /// gates other Sparkle internals; see SPUStandardUserDriver.m:370).
-  func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
-  }
-}
-
-// MARK: - SPUUpdaterDelegate
-
-extension AppDelegate: SPUUpdaterDelegate {
-  /// Issue #343: fires when the user has accepted an update and Sparkle is
-  /// about to begin install. Persists the install attempt for cross-launch
-  /// correlation, fires `update.install_started`, flushes telemetry so the
-  /// event survives Sparkle's relaunch.
-  func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
-    let source = updateCoordinator?.lastInstallSource ?? "unknown"
-    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: source)
-    TelemetryService.shared.updateInstallStarted(
-      version: item.versionString,
-      isCritical: item.isCriticalUpdate,
-      source: source
-    )
-    TelemetryService.shared.flushTelemetry()
-  }
-
-  /// Issue #343: silent install-on-quit path. This is a separate Sparkle
-  /// driver from `willInstallUpdate` — for automatically-downloaded updates
-  /// that install when the user quits. Tag source explicitly so we can
-  /// distinguish it from banner / menu / sparkle_default attribution.
-  func updater(
-    _ updater: SPUUpdater,
-    willInstallUpdateOnQuit item: SUAppcastItem,
-    immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
-  ) -> Bool {
-    updateCoordinator?.lastInstallSource = "install_on_quit"
-    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: "install_on_quit")
-    TelemetryService.shared.updateInstallStarted(
-      version: item.versionString,
-      isCritical: item.isCriticalUpdate,
-      source: "install_on_quit"
-    )
-    TelemetryService.shared.flushTelemetry()
-    // Returning false lets Sparkle's automatic install-on-quit proceed normally.
-    return false
-  }
-
-  /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
-  /// resolves service state, clears install-source.
-  func updater(
-    _ updater: SPUUpdater,
-    didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
-    error: (any Error)?
-  ) {
-    let source = updateCoordinator?.lastInstallSource ?? "unknown"
-    let pendingVersion: String? = {
-      if case .available(let u) = updateCoordinator?.service.state ?? .none {
-        return u.versionString
-      }
-      return nil
-    }()
-    let version = pendingVersion ?? "unknown"
-    let isCritical: Bool = {
-      if case .available(let u) = updateCoordinator?.service.state ?? .none {
-        return u.isCriticalUpdate
-      }
-      return false
-    }()
-    let errorCode = (error as NSError?).map { "\($0.domain).\($0.code)" }
-    TelemetryService.shared.updateSparkleCycleFinished(
-      version: version,
-      isCritical: isCritical,
-      source: source,
-      errorCode: errorCode
-    )
-    if error != nil {
-      TelemetryService.shared.updateInstallFailed(
-        version: version,
-        isCritical: isCritical,
-        source: source,
-        errorCode: errorCode ?? "unknown"
-      )
-    }
-    // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"
-    // fires on cancel/skip/error/install-on-quit-scheduled alike. Widget state
-    // is cleared only when bundle version catches up (rehydratePendingIfNewer
-    // on next launch). In-session, the existing 5s resolvingWatchdog in
-    // triggerInstall restores .available if the user clicked the widget but
-    // did not complete an install.
-    updateCoordinator?.lastInstallSource = nil
   }
 }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -14,6 +14,11 @@ struct EnviousWisprApp: App {
   @State private var diagnosticsCoordinator: DiagnosticsCoordinator
   @State private var languageSuggestionPresenter: LanguageSuggestionPresenter
   @State private var updateCoordinatorHolder: UpdateCoordinatorHolder
+  /// PR-B.1 of #763 — App-owned Sparkle integration. Constructed in `init()`
+  /// from `updateCoordinatorHolder` so `startUpdater()` can publish the
+  /// coordinator into the env carrier synchronously during
+  /// `applicationWillFinishLaunching` (Issue #739 env-capture invariant).
+  @State private var sparkleUpdateController: SparkleUpdateController
   @State private var transcriptWorkflowCoordinator: TranscriptWorkflowCoordinator
   @State private var liveRecordingState: LiveRecordingState
   @State private var lastRecordingResult: LastRecordingResult
@@ -92,6 +97,7 @@ struct EnviousWisprApp: App {
     )
 
     let updateCoordinatorHolder = UpdateCoordinatorHolder()
+    let sparkleUpdateController = SparkleUpdateController(holder: updateCoordinatorHolder)
 
     let transcriptWorkflowCoordinator = TranscriptWorkflowCoordinator(
       transcriptCoordinator: transcriptCoordinator,
@@ -174,6 +180,7 @@ struct EnviousWisprApp: App {
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
     _languageSuggestionPresenter = State(initialValue: languageSuggestionPresenter)
     _updateCoordinatorHolder = State(initialValue: updateCoordinatorHolder)
+    _sparkleUpdateController = State(initialValue: sparkleUpdateController)
     _transcriptWorkflowCoordinator = State(initialValue: transcriptWorkflowCoordinator)
     _liveRecordingState = State(initialValue: liveRecordingState)
     _lastRecordingResult = State(initialValue: lastRecordingResult)
@@ -191,7 +198,7 @@ struct EnviousWisprApp: App {
     appDelegate.attach(
       appState: appState,
       navigationCoordinator: navigationCoordinator,
-      updateCoordinatorHolder: updateCoordinatorHolder,
+      sparkleUpdateController: sparkleUpdateController,
       liveRecordingState: liveRecordingState,
       backendMetadata: backendMetadata,
       dictationLifecycleCoordinator: dictationLifecycleCoordinator,

--- a/Sources/EnviousWispr/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWispr/App/SparkleUpdateController.swift
@@ -1,0 +1,287 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+@preconcurrency import Sparkle
+
+/// PR-B.1 of #763 — App-owned home for the Sparkle integration. Replaces
+/// the AppDelegate-owned `updaterController` + `updateCoordinator` storage
+/// and the two Sparkle delegate extensions.
+///
+/// Lifecycle is driven by `AppDelegate.applicationWillFinishLaunching`, which
+/// calls `startUpdater()` synchronously on the same call stack so the
+/// `UpdateCoordinatorHolder` env-carrier (Issue #739) is published BEFORE
+/// SwiftUI evaluates the App's first scene body. The invariant is identical
+/// to the pre-PR-B.1 inline-AppDelegate code: writing
+/// `holder.coordinator = updateCoordinator` synchronously inside
+/// `applicationWillFinishLaunching`, before any scene body evaluates.
+/// Packages the Sparkle updater-construction closure into a single
+/// dependency slot. Mirrors the PR9 `RecordingLockedAccess` shape so the
+/// architecture ceiling parser scores it as one collaborator instead of
+/// flagging a multi-line closure-typed `let`.
+struct SparkleUpdaterFactory: Sendable {
+  let make:
+    @MainActor (any SPUUpdaterDelegate, any SPUStandardUserDriverDelegate) ->
+      SPUStandardUpdaterController?
+}
+
+@MainActor
+final class SparkleUpdateController: NSObject {
+  private let holder: UpdateCoordinatorHolder
+  private(set) var updaterController: SPUStandardUpdaterController?
+  private(set) var updateCoordinator: UpdateCoordinator?
+  private let bundleVersionProvider: () -> String
+  private let updaterFactory: SparkleUpdaterFactory
+
+  /// Production factory. Constructed once; the closure builds a real
+  /// `SPUStandardUpdaterController` with both delegates wired to the
+  /// owning controller.
+  static let defaultUpdaterFactory = SparkleUpdaterFactory { delegate, userDriver in
+    SPUStandardUpdaterController(
+      startingUpdater: true,
+      updaterDelegate: delegate,
+      userDriverDelegate: userDriver
+    )
+  }
+
+  /// Test-only seam so `SparkleUpdateControllerTests` can verify the
+  /// idempotency contract without crashing the debug test runner.
+  /// Production default routes to `assertionFailure` — dev signal unchanged.
+  static var assertionHandler: (String) -> Void = { message in
+    assertionFailure(message)
+  }
+
+  init(
+    holder: UpdateCoordinatorHolder,
+    bundleVersionProvider: @escaping () -> String = { AppConstants.appVersion },
+    updaterFactory: SparkleUpdaterFactory = SparkleUpdateController.defaultUpdaterFactory
+  ) {
+    self.holder = holder
+    self.bundleVersionProvider = bundleVersionProvider
+    self.updaterFactory = updaterFactory
+    super.init()
+  }
+
+  /// Construct the Sparkle updater + the in-app update coordinator, publish
+  /// the coordinator into the env-carrier, and run cross-launch correlation.
+  /// Idempotent: second invocation is a debug `assertionFailure` and a
+  /// release no-op so a future regression in launch sequencing cannot
+  /// silently re-init Sparkle (which does not support multiple
+  /// `SPUStandardUpdaterController` instances).
+  func startUpdater() {
+    // Idempotency: guard on `updateCoordinator` (not `updaterController`)
+    // because the updater factory MAY return nil in tests, while the
+    // coordinator is always constructed on the first successful call.
+    guard updateCoordinator == nil else {
+      Self.assertionHandler("SparkleUpdateController.startUpdater() invoked more than once")
+      return
+    }
+    let controller = updaterFactory.make(self, self)
+    updaterController = controller
+    let coordinator = UpdateCoordinator(updaterController: controller)
+    updateCoordinator = coordinator
+    holder.coordinator = coordinator
+    evaluateInstallAttemptOnLaunch()
+  }
+
+  /// Menu-gating read. AppDelegate's `populateMenu(_:)` uses this to decide
+  /// whether to render the "Check for Updates" item.
+  var hasUpdater: Bool {
+    updaterController != nil
+  }
+
+  /// Menu action target. `@objc` because `NSMenuItem.action` binds to an
+  /// Objective-C selector.
+  @objc func openUpdateCheckFromMenu(_ sender: Any?) {
+    updateCoordinator?.lastInstallSource = "menu"
+    updaterController?.checkForUpdates(sender)
+  }
+
+  /// Issue #343 cross-launch correlation. Compares the current bundle version
+  /// to a persisted "we just attempted to install" marker and fires
+  /// `update.install_completed` / `update.install_cancelled` telemetry.
+  private func evaluateInstallAttemptOnLaunch() {
+    guard let coordinator = updateCoordinator else { return }
+    let outcome = coordinator.evaluateLastInstallAttempt(
+      currentBundleVersion: bundleVersionProvider()
+    )
+    switch outcome {
+    case .completed(let version, let source):
+      TelemetryService.shared.updateInstallCompleted(
+        version: version, isCritical: false, source: source
+      )
+    case .cancelled(let version, let source):
+      TelemetryService.shared.updateInstallCancelled(
+        version: version, isCritical: false, source: source
+      )
+    case .none, .unattributable, .stale:
+      break
+    }
+  }
+}
+
+// MARK: - SPUStandardUserDriverDelegate
+
+extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate {
+  /// Issue #343: declares support for gentle scheduled update reminders.
+  /// Sparkle logs an error if a background app does not declare this.
+  /// (sparkle-project.org/documentation/gentle-reminders)
+  var supportsGentleScheduledUpdateReminders: Bool { true }
+
+  /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
+  func standardUserDriverWillShowModalAlert() {
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate()
+  }
+
+  /// Return to accessory mode when the entire update session ends.
+  func standardUserDriverWillFinishUpdateSession() {
+    NSApp.setActivationPolicy(.accessory)
+  }
+
+  /// Issue #343: pure yes/no decision per Sparkle's documented gentle-reminder
+  /// pattern. NO side effects. All state mutation happens in
+  /// `standardUserDriverWillHandleShowingUpdate`.
+  /// Sparkle's contract: YES = Sparkle handles, NO = delegate handles.
+  func standardUserDriverShouldHandleShowingScheduledUpdate(
+    _ update: SUAppcastItem,
+    andInImmediateFocus immediateFocus: Bool
+  ) -> Bool {
+    let hasMainWindow = NSApp.windows.contains { $0.isVisible && $0.canBecomeMain }
+    if !hasMainWindow { return true }  // no banner mount → Sparkle handles
+    if update.isCriticalUpdate { return true }  // critical → Sparkle's full UX
+    if immediateFocus { return true }  // Sparkle wants front-and-center
+    return false  // we own the gentle UX via the banner
+  }
+
+  /// Issue #343: side-effect callback that fires after the yes/no decision.
+  /// Captures availability state into the service and (if Sparkle handles)
+  /// tags the install source for telemetry attribution.
+  /// Sparkle's contract: handleShowingUpdate == true → Sparkle handles,
+  /// false → delegate (us) handles.
+  func standardUserDriverWillHandleShowingUpdate(
+    _ handleShowingUpdate: Bool,
+    forUpdate update: SUAppcastItem,
+    state: SPUUserUpdateState
+  ) {
+    let available = UpdateAvailabilityService.AvailableUpdate(
+      versionString: update.versionString,
+      displayVersion: update.displayVersionString,
+      buildString: update.versionString,
+      isCriticalUpdate: update.isCriticalUpdate
+    )
+    updateCoordinator?.service.noteAvailable(available)
+
+    if handleShowingUpdate {
+      // Sparkle owns UX. Tag source + fire diagnostic event.
+      let reason: String = {
+        if !NSApp.windows.contains(where: { $0.isVisible && $0.canBecomeMain }) {
+          return "no_main_window"
+        }
+        if update.isCriticalUpdate { return "critical" }
+        return "immediate_focus"
+      }()
+      updateCoordinator?.lastInstallSource = "sparkle_default"
+      TelemetryService.shared.updateSparkleDefaultShown(
+        version: update.versionString,
+        isCritical: update.isCriticalUpdate,
+        reason: reason
+      )
+    }
+    // Else: banner owns UX; source set by `triggerInstall` when user clicks.
+  }
+
+  /// Issue #739: Sparkle fires this on alert focus AND user choice; it is NOT
+  /// a dismissal signal. Widget visibility is governed solely by bundle
+  /// version on disk. User engagement with the Sparkle alert does not hide
+  /// the widget. Method retained as no-op so Sparkle's delegate conformance
+  /// continues to register interest in the callback (needsToObserveUserAttention
+  /// gates other Sparkle internals; see SPUStandardUserDriver.m:370).
+  func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+  }
+}
+
+// MARK: - SPUUpdaterDelegate
+
+extension SparkleUpdateController: SPUUpdaterDelegate {
+  /// Issue #343: fires when the user has accepted an update and Sparkle is
+  /// about to begin install. Persists the install attempt for cross-launch
+  /// correlation, fires `update.install_started`, flushes telemetry so the
+  /// event survives Sparkle's relaunch.
+  func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+    let source = updateCoordinator?.lastInstallSource ?? "unknown"
+    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: source)
+    TelemetryService.shared.updateInstallStarted(
+      version: item.versionString,
+      isCritical: item.isCriticalUpdate,
+      source: source
+    )
+    TelemetryService.shared.flushTelemetry()
+  }
+
+  /// Issue #343: silent install-on-quit path. This is a separate Sparkle
+  /// driver from `willInstallUpdate` — for automatically-downloaded updates
+  /// that install when the user quits. Tag source explicitly so we can
+  /// distinguish it from banner / menu / sparkle_default attribution.
+  func updater(
+    _ updater: SPUUpdater,
+    willInstallUpdateOnQuit item: SUAppcastItem,
+    immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+  ) -> Bool {
+    updateCoordinator?.lastInstallSource = "install_on_quit"
+    updateCoordinator?.recordInstallAttempt(version: item.versionString, source: "install_on_quit")
+    TelemetryService.shared.updateInstallStarted(
+      version: item.versionString,
+      isCritical: item.isCriticalUpdate,
+      source: "install_on_quit"
+    )
+    TelemetryService.shared.flushTelemetry()
+    // Returning false lets Sparkle's automatic install-on-quit proceed normally.
+    return false
+  }
+
+  /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
+  /// resolves service state, clears install-source.
+  func updater(
+    _ updater: SPUUpdater,
+    didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+    error: (any Error)?
+  ) {
+    let source = updateCoordinator?.lastInstallSource ?? "unknown"
+    let pendingVersion: String? = {
+      if case .available(let u) = updateCoordinator?.service.state ?? .none {
+        return u.versionString
+      }
+      return nil
+    }()
+    let version = pendingVersion ?? "unknown"
+    let isCritical: Bool = {
+      if case .available(let u) = updateCoordinator?.service.state ?? .none {
+        return u.isCriticalUpdate
+      }
+      return false
+    }()
+    let errorCode = (error as NSError?).map { "\($0.domain).\($0.code)" }
+    TelemetryService.shared.updateSparkleCycleFinished(
+      version: version,
+      isCritical: isCritical,
+      source: source,
+      errorCode: errorCode
+    )
+    if error != nil {
+      TelemetryService.shared.updateInstallFailed(
+        version: version,
+        isCritical: isCritical,
+        source: source,
+        errorCode: errorCode ?? "unknown"
+      )
+    }
+    // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"
+    // fires on cancel/skip/error/install-on-quit-scheduled alike. Widget state
+    // is cleared only when bundle version catches up (rehydratePendingIfNewer
+    // on next launch). In-session, the existing 5s resolvingWatchdog in
+    // triggerInstall restores .available if the user clicked the widget but
+    // did not complete an install.
+    updateCoordinator?.lastInstallSource = nil
+  }
+}

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -603,6 +603,14 @@ public final class TelemetryService {
   }
 
   public func updateSparkleDefaultShown(version: String, isCritical: Bool, reason: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.sparkle_default_shown",
+          stringProps: ["version": version, "reason": reason],
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     PostHogSDK.shared.capture(
       "update.sparkle_default_shown",
       properties: [
@@ -614,6 +622,14 @@ public final class TelemetryService {
   }
 
   public func updateInstallStarted(version: String, isCritical: Bool, source: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.install_started",
+          stringProps: ["version": version, "source": source],
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     PostHogSDK.shared.capture(
       "update.install_started",
       properties: [
@@ -630,6 +646,16 @@ public final class TelemetryService {
     source: String,
     errorCode: String?
   ) {
+    #if DEBUG
+      var hookStringProps: [String: String] = ["version": version, "source": source]
+      if let errorCode { hookStringProps["error_code"] = errorCode }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.sparkle_cycle_finished",
+          stringProps: hookStringProps,
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     var props: [String: Any] = [
       "version": version,
       "is_critical": isCritical,
@@ -640,6 +666,14 @@ public final class TelemetryService {
   }
 
   public func updateInstallCompleted(version: String, isCritical: Bool, source: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.install_completed",
+          stringProps: ["version": version, "source": source],
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     PostHogSDK.shared.capture(
       "update.install_completed",
       properties: [
@@ -656,6 +690,14 @@ public final class TelemetryService {
     source: String,
     errorCode: String
   ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.install_failed",
+          stringProps: ["version": version, "source": source, "error_code": errorCode],
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     PostHogSDK.shared.capture(
       "update.install_failed",
       properties: [
@@ -668,6 +710,14 @@ public final class TelemetryService {
   }
 
   public func updateInstallCancelled(version: String, isCritical: Bool, source: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.install_cancelled",
+          stringProps: ["version": version, "source": source],
+          boolProps: ["is_critical": isCritical]
+        ))
+    #endif
     PostHogSDK.shared.capture(
       "update.install_cancelled",
       properties: [

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -1,0 +1,222 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+
+/// PR-B.1 of #763 — unit tests for `SparkleUpdateController`.
+///
+/// All tests use a fake `updaterFactory` returning `nil` so the real
+/// `SPUStandardUpdaterController` never instantiates inside the test
+/// process. The real one writes to `UserDefaults`, fetches the appcast
+/// feed, and runs signing checks at init — none of that should boot
+/// during `swift test`.
+@MainActor
+@Suite("SparkleUpdateController", .serialized)
+struct SparkleUpdateControllerTests {
+
+  // MARK: - Env-capture: synchronous publish into the holder
+
+  @Test("startUpdater publishes coordinator into holder synchronously")
+  func startUpdaterPublishesCoordinatorIntoHolderSynchronously() {
+    let holder = UpdateCoordinatorHolder()
+    let controller = SparkleUpdateController(
+      holder: holder,
+      bundleVersionProvider: { "v-test-1.0" },
+      updaterFactory: SparkleUpdaterFactory { _, _ in nil }
+    )
+
+    #expect(holder.coordinator == nil, "Precondition: holder starts empty.")
+
+    controller.startUpdater()
+
+    // The publish MUST be synchronous. Issue #739 env-capture invariant:
+    // no await, no Task, no DispatchQueue hop between `startUpdater()` and
+    // the assertion below. SwiftUI's first scene-body evaluation runs on
+    // the same call stack right after `applicationWillFinishLaunching`.
+    #expect(
+      holder.coordinator != nil,
+      "startUpdater() must publish UpdateCoordinator into the holder synchronously.")
+  }
+
+  // MARK: - Idempotency contract
+
+  @Test("startUpdater is idempotent (second call preserves first coordinator)")
+  func startUpdaterIsIdempotent() {
+    // Sendable storage box so the @Sendable assertionHandler closure can
+    // ferry the captured message back onto the MainActor.
+    @MainActor final class AssertionBox { var message: String? }
+    let box = AssertionBox()
+
+    // Neutralize the production `assertionFailure` so debug test runs do
+    // not crash on the intentional second-call regression.
+    let originalHandler = SparkleUpdateController.assertionHandler
+    SparkleUpdateController.assertionHandler = { @Sendable message in
+      Task { @MainActor in box.message = message }
+    }
+    defer { SparkleUpdateController.assertionHandler = originalHandler }
+
+    let holder = UpdateCoordinatorHolder()
+    let controller = SparkleUpdateController(
+      holder: holder,
+      bundleVersionProvider: { "v-test-1.0" },
+      updaterFactory: SparkleUpdaterFactory { _, _ in nil }
+    )
+
+    controller.startUpdater()
+    let firstCoordinator = controller.updateCoordinator
+    #expect(firstCoordinator != nil, "First startUpdater must construct a coordinator.")
+
+    controller.startUpdater()
+    #expect(
+      controller.updateCoordinator === firstCoordinator,
+      "Second startUpdater must NOT replace the existing coordinator.")
+  }
+
+  // MARK: - Bundle-version-aware install-attempt evaluation
+
+  // The next two tests rely on the DEBUG-only `testEventHook` seam, so they
+  // compile only in debug. CI also builds tests in release; gating preserves
+  // both lanes.
+  #if DEBUG
+
+    /// Sendable storage box for the testEventHook closure. The hook is
+    /// `@Sendable`; storage stays MainActor-isolated.
+    @MainActor final class EventBox { var events: [CapturedTelemetryEvent] = [] }
+
+    @Test("evaluateInstallAttemptOnLaunch uses provided bundleVersionProvider")
+    func evaluateInstallAttemptOnLaunchUsesProvidedBundleVersion() async {
+      // Prime UserDefaults.standard with a `completed`-shaped install attempt
+      // marker. UpdateCoordinator owns the key names; we replicate them here
+      // because UpdateCoordinator constructs its own UserDefaults reference
+      // and we cannot inject a suite without expanding the controller's
+      // public surface beyond the PR-B.1 ceiling budget.
+      let attemptVersion = "v-test-pr-b1-attempt"
+      let defaults = UserDefaults.standard
+      let kVersion = "com.enviouswispr.updateBanner.lastAttemptVersion"
+      let kTimestamp = "com.enviouswispr.updateBanner.lastAttemptTimestamp"
+      let kSource = "com.enviouswispr.updateBanner.lastAttemptSource"
+      let snapshotVersion = defaults.string(forKey: kVersion)
+      let snapshotTimestamp = defaults.double(forKey: kTimestamp)
+      let snapshotSource = defaults.string(forKey: kSource)
+      defaults.set(attemptVersion, forKey: kVersion)
+      defaults.set(Date().timeIntervalSince1970, forKey: kTimestamp)
+      defaults.set("menu", forKey: kSource)
+      defer {
+        if let v = snapshotVersion {
+          defaults.set(v, forKey: kVersion)
+        } else {
+          defaults.removeObject(forKey: kVersion)
+        }
+        if snapshotTimestamp == 0 {
+          defaults.removeObject(forKey: kTimestamp)
+        } else {
+          defaults.set(snapshotTimestamp, forKey: kTimestamp)
+        }
+        if let s = snapshotSource {
+          defaults.set(s, forKey: kSource)
+        } else {
+          defaults.removeObject(forKey: kSource)
+        }
+      }
+
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      let holder = UpdateCoordinatorHolder()
+      let controller = SparkleUpdateController(
+        holder: holder,
+        // Provider returns the SAME version as the persisted attempt.
+        // `evaluateLastInstallAttempt` should resolve to `.completed` and
+        // fire `update.install_completed`.
+        bundleVersionProvider: { attemptVersion },
+        updaterFactory: SparkleUpdaterFactory { _, _ in nil }
+      )
+
+      controller.startUpdater()
+
+      // Let the Task hop deliver the captured event onto MainActor storage.
+      await Task.yield()
+
+      let captured = box.events
+      #expect(
+        captured.contains(where: { $0.name == "update.install_completed" }),
+        """
+        Expected `update.install_completed` to fire because the persisted attempt \
+        version matches the bundleVersionProvider's return. Captured: \
+        \(captured.map(\.name)).
+        """
+      )
+      if let completed = captured.first(where: { $0.name == "update.install_completed" }) {
+        #expect(completed.stringProps["version"] == attemptVersion)
+        #expect(completed.stringProps["source"] == "menu")
+      }
+    }
+
+    // MARK: - Telemetry call-site parity
+
+    @Test("Sparkle telemetry methods fire testEventHook with expected names and keys")
+    func sparkleTelemetryCallSiteParity() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateSparkleDefaultShown(
+        version: "v1", isCritical: false, reason: "immediate_focus")
+      TelemetryService.shared.updateInstallStarted(
+        version: "v1", isCritical: true, source: "menu")
+      TelemetryService.shared.updateSparkleCycleFinished(
+        version: "v1", isCritical: false, source: "menu", errorCode: nil)
+      TelemetryService.shared.updateInstallCompleted(
+        version: "v1", isCritical: false, source: "menu")
+      TelemetryService.shared.updateInstallCancelled(
+        version: "v1", isCritical: false, source: "banner")
+      TelemetryService.shared.updateInstallFailed(
+        version: "v1", isCritical: false, source: "menu", errorCode: "NSURLErrorDomain.-1009")
+
+      // Drain the Task hops scheduled by each test hook firing.
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let expectedNames: Set<String> = [
+        "update.sparkle_default_shown",
+        "update.install_started",
+        "update.sparkle_cycle_finished",
+        "update.install_completed",
+        "update.install_cancelled",
+        "update.install_failed",
+      ]
+      let actualNames = Set(captured.map(\.name))
+      #expect(
+        actualNames.isSuperset(of: expectedNames),
+        """
+        Telemetry hook missed names. Expected superset of \(expectedNames), \
+        got \(actualNames).
+        """)
+
+      // Per-event key parity with what `PostHogSDK.capture` sees in production.
+      if let evt = captured.first(where: { $0.name == "update.sparkle_default_shown" }) {
+        #expect(evt.stringProps.keys.sorted() == ["reason", "version"])
+        #expect(evt.boolProps.keys.sorted() == ["is_critical"])
+      }
+      if let evt = captured.first(where: { $0.name == "update.install_started" }) {
+        #expect(evt.stringProps.keys.sorted() == ["source", "version"])
+        #expect(evt.boolProps.keys.sorted() == ["is_critical"])
+      }
+      if let evt = captured.first(where: { $0.name == "update.install_failed" }) {
+        #expect(evt.stringProps.keys.sorted() == ["error_code", "source", "version"])
+        #expect(evt.boolProps.keys.sorted() == ["is_critical"])
+      }
+    }
+
+  #endif  // DEBUG
+}

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
@@ -12,12 +12,12 @@ import Testing
 /// — this test fails first.
 ///
 /// Allowlist shrinks over time:
-/// - `updateCoordinator` (UpdateCoordinator?) — Sparkle integration; sunsets
-///   in PR-B when SparkleUpdateController extracts. After PR-B, allowlist is
-///   expected to be empty.
+/// - `updateCoordinator` (UpdateCoordinator?) — Sparkle integration. SUNSET
+///   in PR-B.1 of #763. SparkleUpdateController now owns the Sparkle
+///   integration; AppDelegate holds only a weak ref.
 @Suite struct AppDelegateOwnershipTests {
 
-  static let namedHomeAllowlist: Set<String> = ["updateCoordinator"]
+  static let namedHomeAllowlist: Set<String> = []
 
   /// AppDelegate.swift must not declare a non-weak `let|var` whose type name
   /// matches the named-home pattern, unless the property is on the allowlist.
@@ -90,7 +90,8 @@ private func appDelegateURL() -> URL {
 
 private func classBodyOfAppDelegate() throws -> String {
   let source = try String(contentsOf: appDelegateURL(), encoding: .utf8)
-  guard let openRange = source.range(of: "final class AppDelegate: NSObject, NSApplicationDelegate {")
+  guard
+    let openRange = source.range(of: "final class AppDelegate: NSObject, NSApplicationDelegate {")
   else {
     Issue.record("AppDelegate declaration not found at expected path/shape")
     throw POSIXError(.ENOENT)
@@ -158,14 +159,16 @@ private func matchPropertyDeclaration(_ line: String) -> PropertyMatch? {
 
   // Capture: name, optional `: TypeName`, optional `= TypeName(`.
   // Pattern handles `let name: Type?` and `var name = Type()` and `let name: Type = Type()`.
-  let pattern = #"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:\s*:\s*([A-Za-z_][A-Za-z0-9_]*))?(?:\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\()?"#
+  let pattern =
+    #"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:\s*:\s*([A-Za-z_][A-Za-z0-9_]*))?(?:\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\()?"#
   guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
   let ns = line as NSString
   let range = NSRange(location: 0, length: ns.length)
   guard let m = regex.firstMatch(in: line, options: [], range: range), m.numberOfRanges >= 4
   else { return nil }
   let name = ns.substring(with: m.range(at: 1))
-  let annotatedType = m.range(at: 2).location != NSNotFound ? ns.substring(with: m.range(at: 2)) : ""
+  let annotatedType =
+    m.range(at: 2).location != NSNotFound ? ns.substring(with: m.range(at: 2)) : ""
   let initType = m.range(at: 3).location != NSNotFound ? ns.substring(with: m.range(at: 3)) : ""
   let typeName = !annotatedType.isEmpty ? annotatedType : initType
   guard !typeName.isEmpty else { return nil }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -43,13 +43,20 @@ import Testing
   ///   is being deleted (epic #763 freeze). The App-owned `@State` is the
   ///   only composition root that survives PR11. Threaded into `AppState.init`,
   ///   DLC.init, DR.init, and `appDelegate.attach(...)`.
+  /// - 13 → 14 in PR-B.1 of epic #763 (2026-05-19, #796) for
+  ///   `SparkleUpdateController`. Bible §30 entry: PR-B.1 lifts the Sparkle
+  ///   integration off AppDelegate into a dedicated App-owned home. The
+  ///   `@State` instance is constructed from `updateCoordinatorHolder` and
+  ///   threaded into `appDelegate.attach(...)` so `applicationWillFinishLaunching`
+  ///   can invoke `startUpdater()` synchronously before any SwiftUI scene
+  ///   body evaluates (Issue #739 env-capture invariant).
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 13,
+      count <= 14,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 13. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 14. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+/// PR-B.1 of #763 — locks `SparkleUpdateController`'s initial shape so the
+/// extracted Sparkle home does not silently accrete domain state. The home
+/// owns Sparkle lifecycle + the in-app update coordinator publish; anything
+/// else is a sign that the home is becoming a god object.
+///
+/// Bible-changelog (ratchet history):
+/// - PR-B.1: baseline declared by the home is 5 stored — `holder`,
+///   `updaterController`, `updateCoordinator`, `bundleVersionProvider`,
+///   `updaterFactory`. The shared `RouterCeilingParser` does not match
+///   `private(set)` access modifiers (it filters access tokens before
+///   `let|var`) so `updaterController` and `updateCoordinator` are
+///   uncounted by design of the existing parser. Parser-visible:
+///     - 2 collaborators (`holder`, `updaterFactory`).
+///     - 1 closure-injected slot (`bundleVersionProvider`).
+///     - 3 total parser-visible stored.
+///   `updaterFactory` is wrapped in a `SparkleUpdaterFactory` Sendable
+///   struct (PR9 `RecordingLockedAccess` pattern) so multi-line closure
+///   types do not get misclassified.
+///   3 non-private methods in the class body (init, startUpdater,
+///   openUpdateCheckFromMenu); the two Sparkle delegate conformances live
+///   in file-local extensions and are intentionally excluded from the
+///   in-class non-private method count. Line cap 800 (generous soft
+///   trip-wire — actual file ~280 lines).
+@Suite struct SparkleUpdateControllerCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/SparkleUpdateController.swift"
+
+  @Test func collaboratorCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "SparkleUpdateController", at: Self.sourcePath)
+    let count = RouterCeilingParser.collaboratorCount(in: body)
+    #expect(
+      count <= 2,
+      """
+      SparkleUpdateController collaborator ceiling exceeded: \(count) > 2 \
+      (parser-visible). Allowed (PR-B.1 baseline): holder, updaterFactory. \
+      The Sparkle-owned `updaterController` and `updateCoordinator` are \
+      `private(set)` and intentionally invisible to the shared parser. \
+      Raising requires a Bible §30 entry.
+      """)
+  }
+
+  @Test func closureInjectedCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "SparkleUpdateController", at: Self.sourcePath)
+    let count = RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      count <= 1,
+      """
+      SparkleUpdateController closure-injected slot ceiling exceeded: \(count) > 1 \
+      (parser-visible). Allowed (PR-B.1 baseline): bundleVersionProvider. \
+      `updaterFactory` is wrapped in a `SparkleUpdaterFactory` Sendable struct so \
+      it counts as a collaborator rather than a closure.
+      """)
+  }
+
+  @Test func totalStoredCeiling() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "SparkleUpdateController", at: Self.sourcePath)
+    let total =
+      RouterCeilingParser.collaboratorCount(in: body)
+      + RouterCeilingParser.closureInjectedCount(in: body)
+    #expect(
+      total <= 3,
+      """
+      SparkleUpdateController total stored-property ceiling exceeded: \(total) > 3 \
+      (parser-visible). The home publishes the coordinator into the env-carrier \
+      and routes Sparkle delegate callbacks. Additional state is a sign of \
+      scope creep.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "SparkleUpdateController", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 10,
+      """
+      SparkleUpdateController non-private method ceiling exceeded: \(count) > 10 \
+      non-private `func` declarations in the class body. PR-B.1 baseline: \
+      init, startUpdater, openUpdateCheckFromMenu (Sparkle delegate conformances \
+      live in extensions, not in this count).
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 800,
+      """
+      SparkleUpdateController line count exceeded: \(count) > 800 (soft trip-wire). \
+      File should stay focused on Sparkle lifecycle + the two delegate extensions.
+      """)
+  }
+
+  @Test func allowedExtensionConformances() throws {
+    // Guard against smuggling behavior through a third extension that escapes
+    // the in-class non-private method count. Only the two Sparkle delegate
+    // conformances are sanctioned.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let pattern = #"^[[:space:]]*extension[[:space:]]+SparkleUpdateController\b"#
+    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    #expect(
+      matches.count == 2,
+      """
+      SparkleUpdateController has \(matches.count) extensions; expected exactly 2 \
+      (SPUStandardUserDriverDelegate, SPUUpdaterDelegate). Adding a third \
+      extension is a route for scope creep that escapes the in-class method ceiling.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "AppKit", "EnviousWisprCore", "EnviousWisprServices", "Foundation", "Sparkle",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      SparkleUpdateController imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+}


### PR DESCRIPTION
## Summary

PR-B.1 of #763 (meta-tracker #780). Lifts the Sparkle integration off `AppDelegate` into a dedicated App-owned home. Identity-preserving: same Issue #739 env-capture invariant, same telemetry shapes, same menu behavior. No forwarding shims (epic #763 Decision 4).

- New `Sources/EnviousWispr/App/SparkleUpdateController.swift` (~280 lines) owns the Sparkle `SPUStandardUpdaterController` + `UpdateCoordinator` lifecycle and the two Sparkle delegate conformances.
- `AppDelegate.swift` shrinks 862 → 663 lines (-199): three stored properties removed, two delegate extensions deleted, `applicationWillFinishLaunching` collapsed to a loud nil-guard + forwarder.
- `EnviousWisprApp.swift` constructs the controller from the App-owned `UpdateCoordinatorHolder` so `startUpdater()` publishes the coordinator into the env carrier synchronously before SwiftUI's first scene body evaluates.
- Menu's "Check for Updates" item retargets to the controller in the same PR.

## Loud failure surface

- Nil `sparkleUpdateController` at `applicationWillFinishLaunching`: debug `assertionFailure`, release `AppLogger` error. Never a silent no-op.
- `startUpdater()` idempotent. Second call routes through hookable `static var assertionHandler` (defaults to `assertionFailure`); release no-op preserves the first coordinator.

## Telemetry parity

`TelemetryService.testEventHook` extended (DEBUG-only) to fire for the six Sparkle update methods. Unit test `sparkleTelemetryCallSiteParity` asserts event-name + property-key parity at layer 3 instead of via PostHog read-back.

## Architecture ceilings

- `AppDelegateOwnershipTests.namedHomeAllowlist`: `["updateCoordinator"]` → `[]` (sunset entry).
- New `SparkleUpdateControllerCeilingsTests` (7 cases) caps stored / closure-injected / total / method count / line count / extension count / imports.
- `EnviousWisprAppCeilingsTests` ratcheted 13 → 14 with Bible §30 entry (PR-B.1).

## Verification

- `swift build` + `swift build -c release` both exit 0.
- 19 targeted tests pass in debug AND release modes (DEBUG-gated tests cleanly excluded in release).
- Two Codex code-diff rounds: round 1 flagged shared-state parallelism (fixed with `.serialized` suite trait), round 2 flagged multi-line closure parser misclassification (fixed by wrapping the factory in a `SparkleUpdaterFactory` Sendable struct, PR9 `RecordingLockedAccess` pattern), round 3 clean.

## Test plan

- [ ] CI build-check green.
- [ ] Live UAT Leg A: dictate "Quick post-Sparkle dictation check today." end to end via `wispr_eyes.test_recording`, transcript reaches clipboard.
- [ ] Live UAT Leg B (founder): menu bar → "Check for Updates" opens Sparkle dialog, cancels cleanly.
- [ ] Live UAT Leg C (founder): patch local `CFBundleShortVersionString` to `0.0.1-pr-b1-test`, re-codesign with production SUFeedURL intact, launch, confirm in-app banner renders in Settings → About.

Plan: `docs/feature-requests/issue-796-2026-05-19-pr-b1-sparkle.md`
Council: `/tmp/pr-b1-sparkle/{gpt,gemini}-critique.md`
Grounded review: `.codex/2026-05-19-pr-b1-sparkle-grounded-review-output.txt`

Closes #796
