### PR TITLE
test(pipeline): signal-based spy logger + fake-timeout sweep to kill CI flake (#794)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/FakeTimeoutExecutor.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FakeTimeoutExecutor.swift
@@ -1,0 +1,50 @@
+import EnviousWisprCore
+import Foundation
+
+@testable import EnviousWisprPipeline
+
+/// Deterministic `TextProcessingRunner.TimeoutExecutor` (#784, 2026-05-18).
+///
+/// The runner calls its executor once per enabled step. A fake that always
+/// throws would time out the first normal-budget step before reaching the
+/// intended slow step in multi-step tests. So this fake discriminates by
+/// budget: throws `TimeoutError(seconds:)` for budgets STRICTLY BELOW
+/// `throwBelowSeconds`, runs the operation otherwise. Threshold is required
+/// at init (no default) so each test makes the discriminator explicit.
+///
+/// #794 (2026-05-19): extracted from `TextProcessingRunnerTests` to a shared
+/// file so `HeartPathIntegrationTests` can inject the same deterministic
+/// executor. Runner tests construct it with `throwBelowSeconds: 0.0` (never
+/// throws — every step runs) unless the test is specifically about timeout
+/// behavior, in which case `0.1` discriminates the 50ms slow-step budget
+/// from the 5s default budget.
+@MainActor
+final class FakeTimeoutExecutor {
+  let throwBelowSeconds: Double
+
+  private(set) var callCount: Int = 0
+  private(set) var capturedBudgets: [Double] = []
+
+  init(throwBelowSeconds: Double) {
+    self.throwBelowSeconds = throwBelowSeconds
+  }
+
+  func run(
+    _ seconds: Double,
+    _ op: @escaping @MainActor () async throws -> TextProcessingContext
+  ) async throws -> TextProcessingContext {
+    callCount += 1
+    capturedBudgets.append(seconds)
+    if seconds < throwBelowSeconds {
+      // Yield once before throwing so the fake mirrors the real
+      // `withThrowingTimeout`'s yielding behavior (production always
+      // suspends inside its task-group `Task.sleep` deadline). Without
+      // this yield, the runner returns to the test without giving its
+      // prior fire-and-forget logger Tasks a chance to run; under
+      // full-suite MainActor saturation, those Tasks can fail to drain.
+      await Task.yield()
+      throw TimeoutError(seconds: seconds)
+    }
+    return try await op()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -186,6 +186,11 @@ struct HeartPathIntegrationTests {
       )
     )
     let pasteSink = CapturingPasteSink()
+    // #794: the mock's 50ms `maxDuration` becomes a 0.05s budget; the
+    // 0.1 discriminator throws `TimeoutError` for it deterministically,
+    // so the test no longer races the mock's 250ms sleep against a real
+    // wall clock. The `.sleepThenSuccess` body never runs — the fake
+    // intercepts before `op()`.
     let polish = MockPolishStep(
       maxDuration: .milliseconds(50),
       mode: .sleepThenSuccess(.milliseconds(250), "Hello, world.")
@@ -195,7 +200,8 @@ struct HeartPathIntegrationTests {
       audioCapture: audioCapture,
       asrManager: asrManager,
       pasteSink: pasteSink,
-      steps: [polish]
+      steps: [polish],
+      textProcessingRunner: finalizerRunner(throwBelowSeconds: 0.1)
     )
 
     let result = try await harness.run()
@@ -220,23 +226,42 @@ private struct HeartPathHarnessResult {
   let usedASRFallback: Bool
 }
 
+/// A `TextProcessingRunner` whose timeout executor is deterministic.
+///
+/// #794 (2026-05-19): the default `TextProcessingRunner()` delegates to the
+/// real `withThrowingTimeout`, which races a wall clock. On a contended CI
+/// runner a polish step's 5s budget can expire and the runner silently
+/// degrades to raw ASR text — a false failure unrelated to the test's
+/// intent. `throwBelowSeconds: 0.0` never throws (every step runs);
+/// `throwBelowSeconds: 0.1` discriminates a 50ms slow-step budget from the
+/// 5s default so the `polishTimeoutFallsBackToRawASR` test can exercise the
+/// real timeout-degradation path deterministically.
+@MainActor
+private func finalizerRunner(throwBelowSeconds: Double = 0.0) -> TextProcessingRunner {
+  TextProcessingRunner(
+    timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: throwBelowSeconds).run)
+}
+
 @MainActor
 private final class HeartPathHarness {
   private let audioCapture: FixtureAudioCapture
   private let asrManager: MockASRManager
   private let pasteSink: CapturingPasteSink
   private let steps: [any TextProcessingStep]
+  private let textProcessingRunner: TextProcessingRunner
 
   init(
     audioCapture: FixtureAudioCapture,
     asrManager: MockASRManager,
     pasteSink: CapturingPasteSink,
-    steps: [any TextProcessingStep]
+    steps: [any TextProcessingStep],
+    textProcessingRunner: TextProcessingRunner = finalizerRunner()
   ) {
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.pasteSink = pasteSink
     self.steps = steps
+    self.textProcessingRunner = textProcessingRunner
   }
 
   func run() async throws -> HeartPathHarnessResult {
@@ -253,6 +278,7 @@ private final class HeartPathHarness {
 
     let finalizer = TranscriptFinalizer(
       save: { _ in },
+      textProcessingRunner: textProcessingRunner,
       deliverPaste: { [pasteSink] request in
         await pasteSink.deliver(request)
       }

--- a/Tests/EnviousWisprTests/Pipeline/SignalPipelineLogger.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SignalPipelineLogger.swift
@@ -1,0 +1,79 @@
+import EnviousWisprCore
+import Foundation
+
+@testable import EnviousWisprPipeline
+
+/// Test-only `PipelineLogging` conformer that lets a test `await` a specific
+/// log entry instead of polling for it.
+///
+/// `TextProcessingRunner` emits log calls from inside fire-and-forget
+/// `Task { logger.log(...) }` envelopes. The previous `RecordingPipelineLogger`
+/// forced tests to poll (`Task.sleep(10ms)` for up to 500ms) for those
+/// envelopes to drain. Under a contended CI runner the envelopes can stall
+/// past the 500ms window, so the poll-based assertion flaked (#794).
+///
+/// `waitForEntry(matching:)` resolves a `CheckedContinuation` the instant a
+/// matching entry is logged — no real-time dependency. `@MainActor` isolation
+/// makes the "already present?" check and the waiter append atomic, so no
+/// entry can slip between them.
+@MainActor
+final class SignalPipelineLogger: PipelineLogging {
+  struct Entry: Equatable {
+    let message: String
+    let level: DebugLogLevel
+    let category: String
+  }
+
+  private struct Waiter {
+    let id: UUID
+    let predicate: (Entry) -> Bool
+    let timeoutSeconds: Double
+    let continuation: CheckedContinuation<Entry, Error>
+  }
+
+  private(set) var entries: [Entry] = []
+  private var waiters: [Waiter] = []
+
+  func log(_ message: String, level: DebugLogLevel, category: String) async {
+    let entry = Entry(message: message, level: level, category: category)
+    entries.append(entry)
+
+    // Resume every waiter whose predicate now matches, removing them first so
+    // a later entry cannot resume the same continuation twice.
+    let matching = waiters.filter { $0.predicate(entry) }
+    waiters.removeAll { waiter in matching.contains { $0.id == waiter.id } }
+    for waiter in matching {
+      waiter.continuation.resume(returning: entry)
+    }
+  }
+
+  /// Await the next entry matching `predicate`. Resolves immediately if a
+  /// matching entry already exists. Throws `TimeoutError` if no match arrives
+  /// within `timeout`.
+  func waitForEntry(
+    matching predicate: @escaping (Entry) -> Bool,
+    timeout: Duration = .seconds(5)
+  ) async throws -> Entry {
+    if let existing = entries.last(where: predicate) { return existing }
+
+    let id = UUID()
+    let seconds =
+      Double(timeout.components.seconds)
+      + Double(timeout.components.attoseconds) / 1e18
+    return try await withCheckedThrowingContinuation { continuation in
+      waiters.append(
+        Waiter(id: id, predicate: predicate, timeoutSeconds: seconds, continuation: continuation)
+      )
+      Task { [weak self] in
+        try? await Task.sleep(for: timeout)
+        await self?.timeoutWaiter(id)
+      }
+    }
+  }
+
+  private func timeoutWaiter(_ id: UUID) {
+    guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+    let waiter = waiters.remove(at: index)
+    waiter.continuation.resume(throwing: TimeoutError(seconds: waiter.timeoutSeconds))
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/SignalPipelineLoggerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SignalPipelineLoggerTests.swift
@@ -1,0 +1,71 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@MainActor
+@Suite("SignalPipelineLogger")
+struct SignalPipelineLoggerTests {
+
+  @Test("resolves immediately when a matching entry was already logged")
+  func resolvesImmediatelyForExistingEntry() async throws {
+    let logger = SignalPipelineLogger()
+    await logger.log("step done", level: .info, category: "PipelineTiming")
+
+    let entry = try await logger.waitForEntry { $0.category == "PipelineTiming" }
+
+    #expect(entry.message == "step done")
+  }
+
+  @Test("resolves the continuation when a matching entry arrives later")
+  func resolvesWhenEntryArrivesLater() async throws {
+    let logger = SignalPipelineLogger()
+
+    // The spawned Task body cannot run until `waitForEntry` below suspends,
+    // so the waiter is guaranteed registered before the log fires.
+    Task { await logger.log("late arrival", level: .info, category: "TextProcessing") }
+
+    let entry = try await logger.waitForEntry(
+      matching: { $0.message == "late arrival" },
+      timeout: .seconds(2)
+    )
+
+    #expect(entry.category == "TextProcessing")
+  }
+
+  @Test("throws TimeoutError when no matching entry ever arrives")
+  func throwsTimeoutWhenNoMatch() async {
+    let logger = SignalPipelineLogger()
+    await logger.log("unrelated", level: .info, category: "Other")
+
+    await #expect(throws: TimeoutError.self) {
+      _ = try await logger.waitForEntry(
+        matching: { $0.category == "NeverLogged" },
+        timeout: .milliseconds(100)
+      )
+    }
+  }
+
+  @Test("resumes each waiter exactly once even when multiple entries match")
+  func resumesWaiterExactlyOnce() async throws {
+    let logger = SignalPipelineLogger()
+
+    // Two entries match the same predicate. If the waiter were resumed twice
+    // the second `continuation.resume` would crash the process — this test
+    // passing is the proof that removal-before-resume holds.
+    let logTask = Task {
+      await logger.log("match one", level: .info, category: "CorrectionDebug")
+      await logger.log("match two", level: .info, category: "CorrectionDebug")
+    }
+
+    let entry = try await logger.waitForEntry(
+      matching: { $0.category == "CorrectionDebug" },
+      timeout: .seconds(2)
+    )
+    await logTask.value
+
+    #expect(entry.message == "match one")
+    #expect(logger.entries.count == 2)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
@@ -2,7 +2,6 @@ import EnviousWisprCore
 import EnviousWisprLLM
 import Foundation
 import Testing
-import os
 
 @testable import EnviousWisprPipeline
 
@@ -12,7 +11,7 @@ struct TextProcessingRunnerTests {
 
   @Test("returns the seeded context unchanged when there are no steps")
   func returnsSeededContextWhenThereAreNoSteps() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let result = try await runner.run(
       rawText: "hello world",
@@ -32,7 +31,7 @@ struct TextProcessingRunnerTests {
 
   @Test("passes raw text, language, target app, and prior mutations through the real runner")
   func passesSeededAndMutatedContextThroughTheChain() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let first = RecordingStep(name: "Normalize") { context in
       var next = context
@@ -85,7 +84,7 @@ struct TextProcessingRunnerTests {
 
   @Test("skips disabled steps and keeps running enabled ones in order")
   func skipsDisabledSteps() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let first = RecordingStep(name: "A") { context in
       var next = context
@@ -121,7 +120,7 @@ struct TextProcessingRunnerTests {
 
   @Test("continues after a non-LLM step failure and does not set polishError")
   func continuesAfterNonLLMStepFailure() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let first = RecordingStep(name: "Word Correction") { context in
       var next = context
@@ -157,7 +156,7 @@ struct TextProcessingRunnerTests {
 
   @Test("captures LLM polish failures in polishError and continues with prior text")
   func capturesLLMPolishFailures() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let first = RecordingStep(name: "Word Correction") { context in
       var next = context
@@ -189,7 +188,7 @@ struct TextProcessingRunnerTests {
 
   @Test("suppresses polishError for unsupported input language skips from LLM Polish")
   func suppressesPolishErrorForUnsupportedInputLanguage() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
       throw LLMError.unsupportedInputLanguage("de")
@@ -218,7 +217,7 @@ struct TextProcessingRunnerTests {
 
   @Test("suppresses polishError for output language drift skips from LLM Polish")
   func suppressesPolishErrorForOutputLanguageDrift() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
       throw LLMError.outputLanguageDrift(expected: "de", actual: "en")
@@ -337,7 +336,7 @@ struct TextProcessingRunnerTests {
 
   @Test("rethrows CancellationError and does not run later steps")
   func rethrowsCancellationError() async {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let first = RecordingStep(name: "A") { context in
       var next = context
@@ -378,7 +377,7 @@ struct TextProcessingRunnerTests {
     "Renaming the polish step does NOT affect polishError when the policy stays .surface"
   )
   func policyDispatchSurvivesRename() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     let renamed = RecordingStep(
       name: "Polish",  // intentionally NOT "LLM Polish"
@@ -399,7 +398,7 @@ struct TextProcessingRunnerTests {
 
   @Test(".swallow policy never sets polishError, even for a step named 'LLM Polish'")
   func swallowPolicyHidesErrorEvenForCollidingName() async throws {
-    let runner = TextProcessingRunner()
+    let runner = deterministicRunner()
 
     // Same legacy name but explicit .swallow policy: the runner must read the
     // policy, not the name. This is the symmetric guarantee for
@@ -431,8 +430,8 @@ struct TextProcessingRunnerTests {
 
   @Test("Step success emits a PipelineTiming entry into the injected logger")
   func successLogsPipelineTimingEntry() async throws {
-    let recorder = RecordingPipelineLogger()
-    let runner = TextProcessingRunner(logger: recorder)
+    let signalLogger = SignalPipelineLogger()
+    let runner = deterministicRunner(logger: signalLogger)
 
     let step = RecordingStep(name: "A") { context in
       var next = context
@@ -447,18 +446,18 @@ struct TextProcessingRunnerTests {
       steps: [step]
     )
 
-    // Logger work runs in fire-and-forget Task envelopes; bounded-poll for it.
-    let entries = await recorder.awaitEntry(
-      category: "PipelineTiming", messageContains: "A completed in")
-    #expect(
-      entries.contains { $0.category == "PipelineTiming" && $0.message.hasPrefix("A completed in") }
-    )
+    // Logger work runs in fire-and-forget Task envelopes; await the exact
+    // entry instead of polling — resolves the instant the envelope fires.
+    let entry = try await signalLogger.waitForEntry {
+      $0.category == "PipelineTiming" && $0.message.hasPrefix("A completed in")
+    }
+    #expect(entry.category == "PipelineTiming")
   }
 
   @Test("Step that mutates text emits CorrectionDebug IN/OUT lines via injected logger")
   func mutatingStepLogsCorrectionDebug() async throws {
-    let recorder = RecordingPipelineLogger()
-    let runner = TextProcessingRunner(logger: recorder)
+    let signalLogger = SignalPipelineLogger()
+    let runner = deterministicRunner(logger: signalLogger)
 
     let step = RecordingStep(name: "Renamer") { context in
       var next = context
@@ -473,21 +472,25 @@ struct TextProcessingRunnerTests {
       steps: [step]
     )
 
-    // OUT is emitted right after IN inside the same Task envelope; awaiting OUT
-    // implicitly drains until both have landed.
-    let entries = await recorder.awaitEntry(
-      category: "CorrectionDebug", messageContains: "[Renamer] OUT: polished")
-    let cd = entries.filter { $0.category == "CorrectionDebug" }
-    #expect(cd.contains { $0.message.contains("[Renamer] IN:  raw") })
-    #expect(cd.contains { $0.message.contains("[Renamer] OUT: polished") })
+    // OUT is emitted right after IN inside the same Task envelope, so once
+    // OUT has been signalled IN is already in `entries`.
+    let out = try await signalLogger.waitForEntry {
+      $0.category == "CorrectionDebug" && $0.message.contains("[Renamer] OUT: polished")
+    }
+    #expect(out.message.contains("[Renamer] OUT: polished"))
+    #expect(
+      signalLogger.entries.contains {
+        $0.category == "CorrectionDebug" && $0.message.contains("[Renamer] IN:  raw")
+      }
+    )
   }
 
   @Test("Step timeout emits a TextProcessing 'timed out' entry via injected logger")
   func timeoutLogsTextProcessingWarning() async throws {
     // #784 (2026-05-18): see `skipsTimedOutNonLLMStep` for migration shape.
-    let recorder = RecordingPipelineLogger()
+    let signalLogger = SignalPipelineLogger()
     let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 0.1)
-    let runner = TextProcessingRunner(logger: recorder, timeoutExecutor: fakeTimeout.run)
+    let runner = TextProcessingRunner(logger: signalLogger, timeoutExecutor: fakeTimeout.run)
 
     let slow = RecordingStep(name: "Slow", maxDuration: .milliseconds(50)) { context in
       return context
@@ -500,10 +503,10 @@ struct TextProcessingRunnerTests {
       steps: [slow]
     )
 
-    let entries = await recorder.awaitEntry(
-      category: "TextProcessing", messageContains: "Slow timed out")
-    #expect(
-      entries.contains { $0.category == "TextProcessing" && $0.message.contains("Slow timed out") })
+    let entry = try await signalLogger.waitForEntry {
+      $0.category == "TextProcessing" && $0.message.contains("Slow timed out")
+    }
+    #expect(entry.message.contains("Slow timed out"))
     #expect(slow.runCount == 0)  // executor short-circuited before invoking op()
     #expect(fakeTimeout.callCount == 1)
     #expect(fakeTimeout.capturedBudgets == [0.05])
@@ -543,89 +546,27 @@ private final class RecordingStep: TextProcessingStep {
   }
 }
 
-/// Test-only PipelineLogging conformer. Records every log call in memory so
-/// G2 tests can assert log side effects that the prior global-singleton
-/// `AppLogger.shared` design hid behind disk-only writes.
-final class RecordingPipelineLogger: PipelineLogging, @unchecked Sendable {
-  struct Entry: Equatable {
-    let message: String
-    let level: DebugLogLevel
-    let category: String
-  }
-
-  // OSAllocatedUnfairLock rather than NSLock — Swift 6 strict concurrency
-  // forbids NSLock.lock/unlock from async contexts.
-  private let storage = OSAllocatedUnfairLock<[Entry]>(initialState: [])
-
-  func log(_ message: String, level: DebugLogLevel, category: String) async {
-    storage.withLock { state in
-      state.append(Entry(message: message, level: level, category: category))
-    }
-  }
-
-  func snapshot() -> [Entry] {
-    storage.withLock { $0 }
-  }
-
-  /// Waits up to ~500ms for an entry whose category matches `category` and
-  /// whose message contains `messageContains` to appear. Returns the full
-  /// recorded buffer afterwards. The runner emits log calls from inside
-  /// fire-and-forget `Task { ... }` envelopes; cooperative yield alone is
-  /// not deterministic because the detached Tasks have no parent the test
-  /// can await. A bounded poll is a robust and cheap workaround.
-  func awaitEntry(category: String, messageContains needle: String) async -> [Entry] {
-    for _ in 0..<50 {
-      let current = snapshot()
-      if current.contains(where: { $0.category == category && $0.message.contains(needle) }) {
-        return current
-      }
-      try? await Task.sleep(for: .milliseconds(10))
-    }
-    return snapshot()
-  }
-}
-
 private struct StepFailure: LocalizedError, Equatable {
   let message: String
   var errorDescription: String? { message }
 }
 
-/// Deterministic `TextProcessingRunner.TimeoutExecutor` (#784, 2026-05-18).
+/// Builds a runner whose timeout executor never throws — every step runs to
+/// completion regardless of how long the CI scheduler takes.
 ///
-/// The runner calls its executor once per enabled step. A fake that always
-/// throws would time out the first normal-budget step before reaching the
-/// intended slow step in multi-step tests. So this fake discriminates by
-/// budget: throws `TimeoutError(seconds:)` for budgets STRICTLY BELOW
-/// `throwBelowSeconds`, runs the operation otherwise. Threshold is required
-/// at init (no default) so each test makes the discriminator explicit.
+/// #794 (2026-05-19): replaces bare `TextProcessingRunner()` across this
+/// suite. The default `TextProcessingRunner()` delegates to the real
+/// `withThrowingTimeout`, which races a wall clock; on a contended CI runner
+/// a step's 5s budget can expire and the runner silently degrades to prior
+/// input. Tests that ARE about timeout behavior keep their own explicit
+/// `FakeTimeoutExecutor(throwBelowSeconds: 0.1)` discriminator.
 @MainActor
-private final class FakeTimeoutExecutor {
-  let throwBelowSeconds: Double
-
-  private(set) var callCount: Int = 0
-  private(set) var capturedBudgets: [Double] = []
-
-  init(throwBelowSeconds: Double) {
-    self.throwBelowSeconds = throwBelowSeconds
+private func deterministicRunner(
+  logger: SignalPipelineLogger? = nil
+) -> TextProcessingRunner {
+  let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
+  if let logger {
+    return TextProcessingRunner(logger: logger, timeoutExecutor: executor.run)
   }
-
-  func run(
-    _ seconds: Double,
-    _ op: @escaping @MainActor () async throws -> TextProcessingContext
-  ) async throws -> TextProcessingContext {
-    callCount += 1
-    capturedBudgets.append(seconds)
-    if seconds < throwBelowSeconds {
-      // Yield once before throwing so the fake mirrors the real
-      // `withThrowingTimeout`'s yielding behavior (production always
-      // suspends inside its task-group `Task.sleep` deadline). Without
-      // this yield, the runner returns to the test without giving its
-      // prior fire-and-forget logger Tasks a chance to run; under
-      // full-suite MainActor saturation, those Tasks can fail to drain
-      // inside the test's 500ms `awaitEntry` polling window.
-      await Task.yield()
-      throw TimeoutError(seconds: seconds)
-    }
-    return try await op()
-  }
+  return TextProcessingRunner(timeoutExecutor: executor.run)
 }


### PR DESCRIPTION
## Summary

Eliminates the CI flake in `TextProcessingRunnerTests` and `HeartPathIntegrationTests` that parked PR #800 for three consecutive runs. Test-only change, no production code.

Two anti-patterns removed:
- **Polling spy logger.** `RecordingPipelineLogger.awaitEntry` polled (`Task.sleep(10ms)` x 50) for fire-and-forget log emissions. Under a contended GitHub-hosted `macos-26` runner the envelope drained past the 500ms window. Replaced by `SignalPipelineLogger.waitForEntry(matching:)` — a `CheckedContinuation`-based wait that resolves the instant the SUT's `Task { logger.log(...) }` fires.
- **Real-clock timeout in tests.** Most runner-test cases built `TextProcessingRunner()` with the real `withThrowingTimeout`. On a busy runner a step's 5s budget expired and the runner silently degraded to prior input, so assertions saw pre-transform text. All 12 default-timeout constructions across both suites now inject the deterministic `FakeTimeoutExecutor` (extracted from `TextProcessingRunnerTests` to its own file so the heart-path suite can share it).

Scope confirmed by Codex grounded scoping + grounded review + council coverage review (all 2026-05-19). Production seams on `WordCorrectionStep` / `WordSuggestionService` are deliberately deferred — see #794 and the follow-up filed under epic #385.

## Files

- NEW `SignalPipelineLogger.swift` — UUID-keyed waiters (no double-resume), internal timeout task (no orphaned continuation), `@MainActor` isolation closes the missed-entry window.
- NEW `SignalPipelineLoggerTests.swift` — 4 unit tests for the logger itself.
- NEW `FakeTimeoutExecutor.swift` — extracted verbatim from `TextProcessingRunnerTests`, `await Task.yield()` before-throw preserved.
- MOD `TextProcessingRunnerTests.swift` — sweep + 3 logger tests migrated to signal waits.
- MOD `HeartPathIntegrationTests.swift` — `HeartPathHarness` wired to a deterministic runner.

## Validation

- Filtered suite: 24/24 pass.
- 50/50 debug stress loop, 30/30 release stress loop (filtered).
- Full suite: 1054/1054 pass.
- Codex code-diff review: clean, zero findings.

## Test plan

- [ ] `build-check` passes on CI (first run)
- [ ] After merge: rebase PR #800 and confirm its CI passes without rerun

Closes #794.
