### PR TITLE
ci: rolling SwiftPM build cache + post-merge warming (#804)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -38,18 +38,96 @@ jobs:
             echo "==> Non-code changes only — skipping build"
           fi
 
-      - name: Cache SPM dependencies
+      - name: Compute SwiftPM cache key
+        id: spm-cache-key
         if: steps.changes.outputs.needs_build == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        run: |
+          set -euo pipefail
+          TOOLCHAIN_ID="$(
+            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; } |
+            shasum -a 256 | cut -c1-12
+          )"
+          echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
+
+      # main-post-merge.yml is the cache WRITER: it restores the freshest
+      # compatible cache, runs the full debug+release build+test matrix, then
+      # saves a new cache under the rolling commit-keyed primary key. Every PR
+      # then restores this fresh default-branch cache (see issue #804).
+      - name: Restore SwiftPM build cache
+        id: spm-cache
+        if: steps.changes.outputs.needs_build == 'true'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-
+            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
             ${{ runner.os }}-spm-
+
+      - name: Build (debug)
+        if: steps.changes.outputs.needs_build == 'true'
+        run: swift build
 
       - name: Build (release)
         if: steps.changes.outputs.needs_build == 'true'
         run: swift build -c release --arch arm64
+
+      - name: Run logic tests
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          OUTPUT=$(scripts/swift-test.sh 2>&1) || true
+          echo "$OUTPUT"
+          # Fail on actual test failures
+          if echo "$OUTPUT" | grep -q "✘"; then
+            echo "::error::Swift tests have failures"
+            exit 1
+          fi
+          # Verify tests actually started (guard against silent no-op)
+          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
+          if [ "$STARTED" -eq 0 ]; then
+            echo "::error::No tests started — possible compilation failure"
+            exit 1
+          fi
+          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
+          echo "==> $STARTED test entries started, $PASSED reported passed, 0 failures"
+
+      - name: Run logic tests (release config)
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          set +e
+          OUTPUT=$(scripts/swift-test.sh -c release 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::scripts/swift-test.sh -c release exited $STATUS"
+            exit "$STATUS"
+          fi
+          if echo "$OUTPUT" | grep -q "✘"; then
+            echo "::error::Swift tests have failures (release config)"
+            exit 1
+          fi
+          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
+          if [ "$STARTED" -eq 0 ]; then
+            echo "::error::No tests started in release config — possible compilation failure"
+            exit 1
+          fi
+          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
+          echo "==> release: $STARTED test entries started, $PASSED reported passed, 0 failures"
+
+      # Save only when the build/tests succeeded and the restore was not an exact
+      # hit. The primary key carries github.sha, so a first run for this commit
+      # always saves; a rerun of the same commit exact-hits and skips (re-saving
+      # an existing key errors). Uses the restore step's resolved primary key.
+      - name: Save SwiftPM build cache
+        if: steps.changes.outputs.needs_build == 'true' && success() && steps.spm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build
+          key: ${{ steps.spm-cache.outputs.cache-primary-key }}
 
       - name: Post result
         if: always()
@@ -59,5 +137,5 @@ jobs:
           if [ "$NEEDS_BUILD" != "true" ]; then
             echo "Non-code push (appcast, docs, etc.) — no build needed"
           else
-            echo "Post-merge release build passed"
+            echo "Post-merge full validation passed"
           fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -60,13 +60,31 @@ jobs:
             exit 1
           fi
 
-      - name: Cache SPM dependencies
+      - name: Compute SwiftPM cache key
+        id: spm-cache-key
         if: steps.changes.outputs.needs_build == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        run: |
+          set -euo pipefail
+          TOOLCHAIN_ID="$(
+            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; } |
+            shasum -a 256 | cut -c1-12
+          )"
+          echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
+
+      # Rolling cache key: the github.sha suffix makes the primary key unique per
+      # commit so the cache is never an exact hit here. pr-check.yml is restore-only
+      # by design — main-post-merge.yml is the sole writer (see issue #804). The
+      # restore-keys prefixes fall back to the freshest compatible cache.
+      - name: Restore SwiftPM build cache
+        id: spm-cache
+        if: steps.changes.outputs.needs_build == 'true'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-
+            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
             ${{ runner.os }}-spm-
 
       - name: Build (debug)
@@ -104,31 +122,6 @@ jobs:
           fi
           PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
           echo "==> $STARTED test entries started, $PASSED reported passed, 0 failures"
-
-      - name: Run logic tests (release config)
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          set +e
-          OUTPUT=$(scripts/swift-test.sh -c release 2>&1)
-          STATUS=$?
-          set -e
-          echo "$OUTPUT"
-          if [ "$STATUS" -ne 0 ]; then
-            echo "::error::scripts/swift-test.sh -c release exited $STATUS"
-            exit "$STATUS"
-          fi
-          if echo "$OUTPUT" | grep -q "✘"; then
-            echo "::error::Swift tests have failures (release config)"
-            exit 1
-          fi
-          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
-          if [ "$STARTED" -eq 0 ]; then
-            echo "::error::No tests started in release config — possible compilation failure"
-            exit 1
-          fi
-          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
-          echo "==> release: $STARTED test entries started, $PASSED reported passed, 0 failures"
 
       - name: Verify FoundationModels compile probe
         if: steps.changes.outputs.needs_build == 'true'

--- a/Sources/EnviousWispr/App/LastRecordingResult.swift
+++ b/Sources/EnviousWispr/App/LastRecordingResult.swift
@@ -32,3 +32,7 @@ final class LastRecordingResult {
     self.polishError = nil
   }
 }
+
+// CI build-gate trigger for #804 (cache-first CI-speedup PR): a CI-workflow-only
+// change otherwise sets needs_build=false and skips the build steps, so this PR
+// could not self-test. This inert line forces needs_build=true. Safe to remove.


### PR DESCRIPTION
## Summary

Closes #804 (re-scoped from the original job-split study — see below).

The PR `build-check` ran 7-8 min median (5-14 min range) because the SwiftPM `.build` cache was keyed only on `Package.resolved`. `actions/cache` never re-saves on an exact-key hit, so the cache froze on its creation date and every PR recompiled ~9 days of first-party code drift against a stale `.build`.

This applies the established cache-first CI-speedup playbook:

- **Rolling cache key** — `<os>-spm-<toolchain-id>-<Package.resolved hash>-<commit sha>` with `restore-keys` fallback, split into `actions/cache/restore` + `actions/cache/save`. The commit-sha suffix means a fresh cache is saved every run instead of freezing.
- **`main-post-merge.yml` becomes the sole cache writer + heavy-validation lane** — restores, runs debug + release build and debug + release tests, then saves a fresh cache that every PR restores. `pr-check.yml` is restore-only (avoids PR-branch cache churn evicting the shared `main` cache).
- **Release-config test execution moves off the PR gate** to post-merge. The PR gate keeps release *compilation* (catches Swift 6 release-vs-debug divergence); only release *test execution* moves. Deliberate quality-for-latency tradeoff.
- **`pr-check.yml` checkout shallowed** from full history to `fetch-depth: 2`.
- The standalone debug `swift build` is **kept** — it is the only debug-config compile of the two XPC service executables, which no test target depends on.

The one-line comment in `LastRecordingResult.swift` is an inert CI build-gate trigger: a workflow-only PR sets `needs_build=false` and skips the build steps, so without it this PR could not self-test the new logic.

## Re-scope note

#804 was originally an empirical job-split study (2/3/4-way). Two web-grounded council reviewers + three Codex finalize runs unanimously found job-splitting is a second-order lever, premature before caching is fixed. The job-split is deferred to a conditional follow-up, measured against the post-fix baseline.

## Review trail

- Plan: council (GPT + Gemini, web-grounded) → 3 Codex plan-review rounds → `READY TO IMPLEMENT`.
- Implementation: Codex code-diff review → `CLEAN`.

## Test plan

- [ ] This PR's `build-check` goes green (self-tests the new `pr-check.yml` via the trigger; restores via the `<os>-spm-` fallback since no new-format cache exists yet).
- [ ] First post-merge `main-post-merge.yml` run restores, runs the full matrix, and saves a fresh new-format cache.
- [ ] Over the next 10-20 PRs, re-measure `build-check` median vs the 7-8 min baseline.
