### PR TITLE
refactor(appstate): extract AppWindowCoordinator from AppDelegate (PR-B.2 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -25,8 +25,6 @@ import SwiftUI
 final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem?
   private let iconAnimator = MenuBarIconAnimator()
-  private weak var mainWindow: NSWindow?
-  private var windowCloseObserver: (any NSObjectProtocol)?
 
   // PR-A of #763: App-owned homes. `EnviousWisprApp` owns these as `@State`
   // and pushes them into AppDelegate via `attach(...)` synchronously during
@@ -63,6 +61,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// hotkey registration is cleaned up before the run loop tears down.
   /// Replaces the pre-PR10 `appState.hotkeyService.stop()` call.
   private weak var hotkeyService: HotkeyService?
+  /// PR-B.2 of #763: App-owned home for window lifecycle (main + onboarding
+  /// window identity, the two `NSWindow.willCloseNotification` observers, the
+  /// SwiftUI open/dismiss bridges, activation-policy transitions). Weak ref —
+  /// strong owner is `EnviousWisprApp`'s `@State`. AppDelegate routes
+  /// `installOnLaunch()` / `tearDown()` from its lifecycle callbacks and the
+  /// menu actions through it.
+  private weak var appWindowCoordinator: AppWindowCoordinator?
 
   /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
   /// before delegate callbacks fire.
@@ -78,6 +83,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// `sparkleUpdateController`. AppDelegate no longer owns the holder ref —
   /// the controller does, and the controller publishes into it from
   /// `startUpdater()`.
+  ///
+  /// PR-B.2 of #763: additionally receive `appWindowCoordinator` so the
+  /// lifecycle callbacks can install/tear down the window observers and the
+  /// menu actions can route window opens through it. `attach()` also wires the
+  /// `onOnboardingDismissed` icon-refresh seam (PR-B.3 retargets it).
   func attach(
     appState: AppState,
     navigationCoordinator: NavigationCoordinator,
@@ -86,7 +96,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     backendMetadata: BackendMetadata,
     dictationLifecycleCoordinator: DictationLifecycleCoordinator,
     dictationRuntime: DictationRuntime,
-    hotkeyService: HotkeyService
+    hotkeyService: HotkeyService,
+    appWindowCoordinator: AppWindowCoordinator
   ) {
     self.appState = appState
     self.navigationCoordinator = navigationCoordinator
@@ -96,20 +107,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     self.dictationRuntime = dictationRuntime
     self.hotkeyService = hotkeyService
+    self.appWindowCoordinator = appWindowCoordinator
+    // Icon-refresh seam: the coordinator's two onboarding-dismiss callsites
+    // route through this closure instead of reaching into AppDelegate's
+    // menu-icon logic. PR-B.3 retargets the seam to MenuBarController.
+    appWindowCoordinator.onOnboardingDismissed = { [weak self] in
+      self?.updateIcon()
+    }
   }
-
-  /// Callback set by SwiftUI to open the main window (since openWindow env is only available in views).
-  var openMainWindowAction: (() -> Void)?
-
-  /// Callback set by SwiftUI to open the onboarding window.
-  var openOnboardingAction: (() -> Void)?
-
-  /// Callback set by SwiftUI to dismiss the onboarding window (state-driven).
-  var dismissOnboardingAction: (() -> Void)?
-
-  /// Weak reference to the onboarding window so we can detect when user closes it early.
-  private weak var onboardingWindow: NSWindow?
-  private var onboardingCloseObserver: (any NSObjectProtocol)?
 
   #if DEBUG
     /// V2 fault-injection control surface (issue #291). Started only when
@@ -177,26 +182,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     }
 
-    // When the unified window closes, revert to .accessory immediately.
-    // There's only one window now, so no need for the 200ms re-check delay.
-    // Store token so we can remove on termination (H11 observer leak fix).
-    windowCloseObserver = NotificationCenter.default.addObserver(
-      forName: NSWindow.willCloseNotification,
-      object: nil,
-      queue: .main
-    ) { [weak self] notification in
-      guard let window = notification.object as? NSWindow else { return }
-      MainActor.assumeIsolated {
-        guard let self else { return }
-        // Capture the main window reference on first titled window appearance.
-        if self.mainWindow == nil, window.styleMask.contains(.titled),
-          window.title == AppConstants.appName
-        {
-          self.mainWindow = window
-        }
-        // Match by identity so status-bar/panel windows never trigger the reset.
-        guard window === self.mainWindow else { return }
-        NSApp.setActivationPolicy(.accessory)
+    // PR-B.2 of #763: the window-close observer lives on AppWindowCoordinator
+    // now. Loud nil-guard, but NOT a method-wide early return — the rest of
+    // `applicationDidFinishLaunching` (status item, hotkey start, telemetry,
+    // permissions, LLM pre-warm, audio reporters) must always run. Window
+    // observation is a limb; app startup is not. Position preserved: same
+    // mid-method point the inline observer block occupied before PR-B.2.
+    if let appWindowCoordinator {
+      appWindowCoordinator.installOnLaunch()
+    } else {
+      assertionFailure(
+        "AppWindowCoordinator must be attached before applicationDidFinishLaunching fires."
+      )
+      Task {
+        await AppLogger.shared.log(
+          "Window observer install skipped: coordinator ref is nil. Activation-policy revert on window close will not work this session.",
+          level: .info,
+          category: "AppDelegate"
+        )
       }
     }
 
@@ -343,73 +346,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       model: appState.settings.llmModel,
       keychainManager: appState.keychainManager
     )
-  }
-
-  // MARK: - Onboarding Window
-
-  /// Open the onboarding window and begin monitoring for early close (abort flow).
-  func openOnboardingWindow() {
-    guard let appState = self.appState else { return }
-    guard appState.settings.onboardingState != .completed else { return }
-    openOnboardingAction?()
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
-    // Hide the main window so only the onboarding window is visible during setup.
-    if let mainWin = self.mainWindow {
-      mainWin.orderOut(nil)
-    }
-
-    // Capture the onboarding NSWindow by identity on first open.
-    // We defer one run-loop cycle so SwiftUI has time to create/order the window
-    // before we search NSApp.windows.
-    DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
-      // SwiftUI Window(id: "onboarding") sets the title to the scene name ("Setup").
-      // We capture by identity here so the close observer can match by reference,
-      // not by title — title matching would fail if the scene name ever changes.
-      if self.onboardingWindow == nil {
-        self.onboardingWindow = NSApp.windows.first {
-          $0.title == AppConstants.onboardingWindowTitle
-        }
-      }
-      // Ensure the window is visible — openWindow(id:) is a silent no-op when
-      // reopening a single-instance Window scene that was previously dismissed.
-      self.onboardingWindow?.makeKeyAndOrderFront(nil)
-    }
-
-    // Monitor for user closing the onboarding window before completion.
-    // Match by window identity (captured above), not by title string.
-    if onboardingCloseObserver == nil {
-      onboardingCloseObserver = NotificationCenter.default.addObserver(
-        forName: NSWindow.willCloseNotification,
-        object: nil,
-        queue: .main
-      ) { [weak self] notification in
-        guard let window = notification.object as? NSWindow else { return }
-        MainActor.assumeIsolated {
-          guard let self else { return }
-          // Match by captured identity; fall back to title if not yet captured.
-          let isOnboardingWindow =
-            (self.onboardingWindow != nil)
-            ? window === self.onboardingWindow
-            : window.title == AppConstants.onboardingWindowTitle
-          guard isOnboardingWindow else { return }
-          self.onboardingWindow = nil
-          // Only treat as abort if onboarding not yet completed.
-          if self.appState?.settings.onboardingState != .completed {
-            self.updateIcon()
-          }
-        }
-      }
-    }
-  }
-
-  /// Called by the onboarding Done button via the onComplete callback.
-  /// State-driven: flips isOnboardingPresented to false, ActionWirer's onChange dismisses the window.
-  func closeOnboardingWindow() {
-    dismissOnboardingAction?()
-    NSApp.setActivationPolicy(.accessory)
-    updateIcon()
   }
 
   private func setupStatusItem() {
@@ -574,7 +510,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   @objc private func continueOnboarding() {
-    openOnboardingWindow()
+    appWindowCoordinator?.openOnboardingWindow()
   }
 
   @objc private func toggleRecording() {
@@ -586,40 +522,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
   }
 
-  /// Show the unified window: bring it to front, set .regular, activate.
-  private func showWindow() {
-    if let action = openMainWindowAction {
-      action()
-    } else {
-      // Fallback: find and show an existing window
-      for window in NSApp.windows where window.title == AppConstants.appName {
-        window.makeKeyAndOrderFront(nil)
-        break
-      }
-    }
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
-  }
-
   @objc private func openSettings() {
     navigationCoordinator?.request(.speechEngine)
-    showWindow()
+    appWindowCoordinator?.showWindow()
   }
 
   @objc private func openPermissionsSettings() {
     navigationCoordinator?.request(.permissions)
-    showWindow()
+    appWindowCoordinator?.showWindow()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
-    if let observer = windowCloseObserver {
-      NotificationCenter.default.removeObserver(observer)
-      windowCloseObserver = nil
-    }
-    if let observer = onboardingCloseObserver {
-      NotificationCenter.default.removeObserver(observer)
-      onboardingCloseObserver = nil
-    }
+    // PR-B.2 of #763: both window-close observers are torn down by the
+    // coordinator now.
+    appWindowCoordinator?.tearDown()
     appState?.setup.ollamaSetup.cleanup()
     // PR10 of #763 — shared HotkeyService is owned by EnviousWisprApp as
     // `@State`; AppDelegate holds a weak ref pushed via `attach(...)`.

--- a/Sources/EnviousWispr/App/AppWindowCoordinator.swift
+++ b/Sources/EnviousWispr/App/AppWindowCoordinator.swift
@@ -1,0 +1,197 @@
+import AppKit
+import EnviousWisprCore
+import Observation
+
+/// PR-B.2 of #763 — App-owned home for main + onboarding window identity,
+/// the two `NSWindow.willCloseNotification` observers, the SwiftUI
+/// open/dismiss bridges, and activation-policy transitions. Extracted from
+/// `AppDelegate` so the AppKit adapter shrinks toward its ≤120-line target.
+///
+/// Strong owner is `EnviousWisprApp` as `@State`; `AppDelegate` holds a weak
+/// ref pushed via `attach(...)`. Injected into both Window scenes via
+/// `.environment(...)` so `DiagnosticsSettingsView` reaches it through
+/// `@Environment` instead of an `NSApp.delegate` downcast.
+@MainActor
+@Observable
+final class AppWindowCoordinator {
+  /// Open-eligibility seam. Returns `true` only when onboarding state exists
+  /// and is not `.completed`. Folds today's stacked `guard let appState` +
+  /// `guard onboardingState != .completed` into one closure, preserving the
+  /// `appState`-nil → no-open behavior.
+  private let canOpenOnboarding: @MainActor () -> Bool
+  /// Onboarding-completed seam. Used by the onboarding-close observer's abort
+  /// gate; `appState`-nil → `false`.
+  private let isOnboardingComplete: @MainActor () -> Bool
+
+  /// Main window, captured lazily on first titled-window appearance.
+  private weak var mainWindow: NSWindow?
+  /// `NSWindow.willCloseNotification` observer token for the main window.
+  private var windowCloseObserver: (any NSObjectProtocol)?
+  /// Onboarding window, captured lazily on first open so the close observer
+  /// can match by identity rather than title.
+  private weak var onboardingWindow: NSWindow?
+  /// `NSWindow.willCloseNotification` observer token for the onboarding window.
+  private var onboardingCloseObserver: (any NSObjectProtocol)?
+
+  /// SwiftUI `openWindow(id: "main")` bridge, set by `ActionWirer`.
+  var openMainWindowAction: (() -> Void)?
+  /// SwiftUI `openWindow(id: "onboarding")` bridge, set by `ActionWirer`.
+  var openOnboardingAction: (() -> Void)?
+  /// SwiftUI `dismissWindow(id: "onboarding")` bridge, set by `ActionWirer`.
+  var dismissOnboardingAction: (() -> Void)?
+  /// Icon-refresh seam, set by `AppDelegate.attach(...)`. PR-B.3 retargets it
+  /// to `MenuBarController`; the seam keeps the coordinator from reaching back
+  /// into AppDelegate's menu-icon logic.
+  var onOnboardingDismissed: (() -> Void)?
+
+  /// Defensive race flag: set when `openOnboardingWindow()` is called before
+  /// `openOnboardingAction` is wired; drained by `consumePendingOpenOnboarding()`.
+  private var pendingOpenOnboarding: Bool = false
+
+  init(
+    canOpenOnboarding: @escaping @MainActor () -> Bool,
+    isOnboardingComplete: @escaping @MainActor () -> Bool
+  ) {
+    self.canOpenOnboarding = canOpenOnboarding
+    self.isOnboardingComplete = isOnboardingComplete
+  }
+
+  /// Install the main-window close observer. Called once from
+  /// `AppDelegate.applicationDidFinishLaunching` at the same position the
+  /// inline observer block occupied before PR-B.2.
+  func installOnLaunch() {
+    // When the unified window closes, revert to .accessory immediately.
+    // There's only one window now, so no need for the 200ms re-check delay.
+    // Store token so we can remove on termination (H11 observer leak fix).
+    windowCloseObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] notification in
+      guard let window = notification.object as? NSWindow else { return }
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        // Capture the main window reference on first titled window appearance.
+        if self.mainWindow == nil, window.styleMask.contains(.titled),
+          window.title == AppConstants.appName
+        {
+          self.mainWindow = window
+        }
+        // Match by identity so status-bar/panel windows never trigger the reset.
+        guard window === self.mainWindow else { return }
+        NSApp.setActivationPolicy(.accessory)
+      }
+    }
+  }
+
+  /// Remove both window-close observers. Called once from
+  /// `AppDelegate.applicationWillTerminate`.
+  func tearDown() {
+    if let observer = windowCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      windowCloseObserver = nil
+    }
+    if let observer = onboardingCloseObserver {
+      NotificationCenter.default.removeObserver(observer)
+      onboardingCloseObserver = nil
+    }
+  }
+
+  /// Show the unified window: bring it to front, set .regular, activate.
+  func showWindow() {
+    if let action = openMainWindowAction {
+      action()
+    } else {
+      // Fallback: find and show an existing window
+      for window in NSApp.windows where window.title == AppConstants.appName {
+        window.makeKeyAndOrderFront(nil)
+        break
+      }
+    }
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  /// Open the onboarding window and begin monitoring for early close (abort flow).
+  func openOnboardingWindow() {
+    // (1) Eligibility — was `guard let appState` + `guard != .completed`.
+    guard canOpenOnboarding() else { return }
+    // (2) Not-yet-wired queue guard: if the SwiftUI bridge has not been wired
+    // yet, queue the request instead of dropping it. Drained by
+    // `consumePendingOpenOnboarding()` once `ActionWirer.task` runs.
+    guard openOnboardingAction != nil else {
+      pendingOpenOnboarding = true
+      return
+    }
+    openOnboardingAction?()
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+    // Hide the main window so only the onboarding window is visible during setup.
+    if let mainWin = self.mainWindow {
+      mainWin.orderOut(nil)
+    }
+
+    // Capture the onboarding NSWindow by identity on first open.
+    // We defer one run-loop cycle so SwiftUI has time to create/order the window
+    // before we search NSApp.windows.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      // SwiftUI Window(id: "onboarding") sets the title to the scene name ("Setup").
+      // We capture by identity here so the close observer can match by reference,
+      // not by title — title matching would fail if the scene name ever changes.
+      if self.onboardingWindow == nil {
+        self.onboardingWindow = NSApp.windows.first {
+          $0.title == AppConstants.onboardingWindowTitle
+        }
+      }
+      // Ensure the window is visible — openWindow(id:) is a silent no-op when
+      // reopening a single-instance Window scene that was previously dismissed.
+      self.onboardingWindow?.makeKeyAndOrderFront(nil)
+    }
+
+    // Monitor for user closing the onboarding window before completion.
+    // Match by window identity (captured above), not by title string.
+    if onboardingCloseObserver == nil {
+      onboardingCloseObserver = NotificationCenter.default.addObserver(
+        forName: NSWindow.willCloseNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] notification in
+        guard let window = notification.object as? NSWindow else { return }
+        MainActor.assumeIsolated {
+          guard let self else { return }
+          // Match by captured identity; fall back to title if not yet captured.
+          let isOnboardingWindow =
+            (self.onboardingWindow != nil)
+            ? window === self.onboardingWindow
+            : window.title == AppConstants.onboardingWindowTitle
+          guard isOnboardingWindow else { return }
+          self.onboardingWindow = nil
+          // Only treat as abort if onboarding not yet completed.
+          if !self.isOnboardingComplete() {
+            self.onOnboardingDismissed?()
+          }
+        }
+      }
+    }
+  }
+
+  /// Called by the onboarding Done button via the onComplete callback.
+  /// State-driven: flips isOnboardingPresented to false, ActionWirer's onChange
+  /// dismisses the window.
+  func closeOnboardingWindow() {
+    dismissOnboardingAction?()
+    NSApp.setActivationPolicy(.accessory)
+    onOnboardingDismissed?()
+  }
+
+  /// Drain a queued onboarding-open request. Returns `true` iff it replayed a
+  /// queued open. Called by `ActionWirer.task` after the three SwiftUI bridge
+  /// closures are wired; the return value lets `ActionWirer` avoid a double-open.
+  func consumePendingOpenOnboarding() -> Bool {
+    guard pendingOpenOnboarding else { return false }
+    pendingOpenOnboarding = false
+    openOnboardingWindow()
+    return true
+  }
+}

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -33,6 +33,11 @@ struct EnviousWisprApp: App {
   /// three consumers mutate it; multiple instances would silently lose
   /// settings changes.
   @State private var hotkeyService: HotkeyService
+  /// PR-B.2 of #763: App-owned home for window lifecycle. Strong owner is this
+  /// `@State`; `AppDelegate` holds a weak ref. Injected into both Window
+  /// scenes via `.environment(...)` so `DiagnosticsSettingsView` reaches it
+  /// through `@Environment` instead of an `NSApp.delegate` downcast.
+  @State private var appWindowCoordinator: AppWindowCoordinator
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -175,6 +180,21 @@ struct EnviousWisprApp: App {
       }
     )
 
+    // PR-B.2 of #763: window-lifecycle home. The two closures encode today's
+    // two distinct onboarding guards exactly (`canOpenOnboarding` folds the
+    // stacked `guard let appState` + `!= .completed`; `isOnboardingComplete`
+    // is the close-observer abort gate). Both capture `appState` weakly so the
+    // coordinator carries no `AppState` import or stored reference.
+    let appWindowCoordinator = AppWindowCoordinator(
+      canOpenOnboarding: { [weak appState] in
+        guard let appState else { return false }
+        return appState.settings.onboardingState != .completed
+      },
+      isOnboardingComplete: { [weak appState] in
+        appState?.settings.onboardingState == .completed
+      }
+    )
+
     _appState = State(initialValue: appState)
     _navigationCoordinator = State(initialValue: navigationCoordinator)
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
@@ -187,6 +207,7 @@ struct EnviousWisprApp: App {
     _backendMetadata = State(initialValue: backendMetadata)
     _dictationRuntime = State(initialValue: dictationRuntime)
     _hotkeyService = State(initialValue: hotkeyService)
+    _appWindowCoordinator = State(initialValue: appWindowCoordinator)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires.
@@ -203,7 +224,8 @@ struct EnviousWisprApp: App {
       backendMetadata: backendMetadata,
       dictationLifecycleCoordinator: dictationLifecycleCoordinator,
       dictationRuntime: dictationRuntime,
-      hotkeyService: hotkeyService
+      hotkeyService: hotkeyService,
+      appWindowCoordinator: appWindowCoordinator
     )
 
     // Initialize observability (PostHog + Sentry) unconditionally at launch —
@@ -226,10 +248,12 @@ struct EnviousWisprApp: App {
         .environment(lastRecordingResult)
         .environment(backendMetadata)
         .environment(dictationRuntime)
+        .environment(appWindowCoordinator)
         .background(
           ActionWirer(
             appDelegate: appDelegate,
             appState: appState,
+            appWindowCoordinator: appWindowCoordinator,
             isOnboardingPresented: $isOnboardingPresented
           )
         )
@@ -239,12 +263,13 @@ struct EnviousWisprApp: App {
     // Onboarding window — non-resizable, centered, auto-opens on first launch.
     Window(AppConstants.onboardingWindowTitle, id: "onboarding") {
       OnboardingV2View(onComplete: {
-        appDelegate.closeOnboardingWindow()
+        appWindowCoordinator.closeOnboardingWindow()
       })
       .environment(appState)
       .environment(navigationCoordinator)
       .environment(languageSuggestionPresenter)
       .environment(dictationRuntime)
+      .environment(appWindowCoordinator)
     }
     .windowResizability(.contentSize)
     .defaultSize(width: 500, height: 550)
@@ -259,6 +284,9 @@ private struct ActionWirer: View {
   /// exposes `appState`; reading it through the delegate would have to go
   /// through its weak ref and risk a stale read during teardown.
   let appState: AppState
+  /// PR-B.2 of #763: the three SwiftUI window bridges are wired onto the
+  /// coordinator now, not AppDelegate.
+  let appWindowCoordinator: AppWindowCoordinator
   @Binding var isOnboardingPresented: Bool
   @Environment(\.openWindow) private var openWindow
   @Environment(\.dismissWindow) private var dismissWindow
@@ -267,20 +295,26 @@ private struct ActionWirer: View {
     Color.clear
       .frame(width: 0, height: 0)
       .task {
-        appDelegate.openMainWindowAction = { [openWindow] in
+        appWindowCoordinator.openMainWindowAction = { [openWindow] in
           openWindow(id: "main")
         }
-        appDelegate.openOnboardingAction = { [openWindow] in
+        appWindowCoordinator.openOnboardingAction = { [openWindow] in
           openWindow(id: "onboarding")
         }
-        appDelegate.dismissOnboardingAction = { [dismissWindow] in
+        appWindowCoordinator.dismissOnboardingAction = { [dismissWindow] in
           dismissWindow(id: "onboarding")
         }
-        // Auto-open onboarding if needed (first launch).
-        // ActionWirer runs inside the main Window scene which is always created,
-        // so the callbacks are wired before we attempt to open the onboarding window.
-        if appState.settings.onboardingState != .completed {
-          appDelegate.openOnboardingWindow()
+        // PR-B.2 of #763: drain any queued onboarding-open request FIRST. On a
+        // normal fresh-install launch nothing was queued (no caller runs before
+        // this task), so `replayed` is false and the auto-open below fires
+        // exactly once — identical to today. Draining first prevents a
+        // double-open if a queued request exists.
+        let replayed = appWindowCoordinator.consumePendingOpenOnboarding()
+        // Auto-open onboarding if needed (first launch), only if nothing was
+        // already replayed. ActionWirer runs inside the main Window scene which
+        // is always created, so the callbacks are wired before this point.
+        if !replayed, appState.settings.onboardingState != .completed {
+          appWindowCoordinator.openOnboardingWindow()
         }
       }
       .onChange(of: isOnboardingPresented) { _, newValue in

--- a/Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift
@@ -6,6 +6,9 @@ struct DiagnosticsSettingsView: View {
   @Environment(DiagnosticsCoordinator.self) private var diagnostics
   // PR7 of #763: live phase resolves through LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState
+  // PR-B.2 of #763: "Restart Onboarding" reaches the window coordinator
+  // through the environment instead of an `NSApp.delegate` downcast.
+  @Environment(AppWindowCoordinator.self) private var appWindowCoordinator
 
   var body: some View {
     @Bindable var state = appState
@@ -34,9 +37,7 @@ struct DiagnosticsSettingsView: View {
             VStack(alignment: .leading, spacing: 4) {
               Button("Restart Onboarding…") {
                 appState.settings.onboardingState = .notStarted
-                if let delegate = NSApp.delegate as? AppDelegate {
-                  delegate.openOnboardingWindow()
-                }
+                appWindowCoordinator.openOnboardingWindow()
               }
               .disabled(liveRecordingState.pipelineState != .idle)
               Text(

--- a/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
@@ -1,0 +1,123 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+
+/// PR-B.2 of #763 — unit tests for `AppWindowCoordinator`.
+///
+/// These tests exercise the coordinator's internal logic with spy closures:
+/// the pending-open queue/replay path, the eligibility guard ordering, and
+/// the onboarding-dismiss icon-refresh seam. They do NOT instantiate a real
+/// `NSWindow` scene graph — the SwiftUI `.environment()` injection and the
+/// real activation-policy / window-server behavior are proven at Live UAT
+/// (plan §3a layer 4), not here.
+@MainActor
+@Suite("AppWindowCoordinator")
+struct AppWindowCoordinatorTests {
+
+  /// `showWindow()` / `openOnboardingWindow()` / `closeOnboardingWindow()`
+  /// touch the `NSApp` global (`setActivationPolicy`, `activate`). `NSApp` is
+  /// an implicitly-unwrapped optional that is nil until `NSApplication.shared`
+  /// is first accessed — which never happens in a bare test process. Accessing
+  /// it here populates the global so the coordinator's verbatim-from-AppDelegate
+  /// `NSApp` calls do not crash. Production code is unaffected: the real app
+  /// always has a live `NSApp`.
+  init() {
+    _ = NSApplication.shared
+  }
+
+  /// An out-of-order `openOnboardingWindow()` call (before `openOnboardingAction`
+  /// is wired) queues the request; `consumePendingOpenOnboarding()` replays it
+  /// exactly once and clears the flag.
+  @Test("pending open queues then replays once")
+  func pendingOpenOnboardingQueuesAndReplays() {
+    var openCount = 0
+    let coordinator = AppWindowCoordinator(
+      canOpenOnboarding: { true },
+      isOnboardingComplete: { false }
+    )
+
+    // No openOnboardingAction wired yet → the call must queue, not open.
+    coordinator.openOnboardingWindow()
+    #expect(openCount == 0, "no action wired → open is queued, not fired")
+
+    // Wire the spy, then drain.
+    coordinator.openOnboardingAction = { openCount += 1 }
+    let replayed = coordinator.consumePendingOpenOnboarding()
+    #expect(replayed, "consume must replay the queued open")
+    #expect(openCount == 1, "replay fires the open exactly once")
+
+    // Flag cleared after the first drain → a second consume is a no-op.
+    let secondReplay = coordinator.consumePendingOpenOnboarding()
+    #expect(!secondReplay, "flag cleared after first drain")
+    #expect(openCount == 1, "no double-fire on a second consume")
+  }
+
+  /// `consumePendingOpenOnboarding()` with the flag clear returns `false` and
+  /// does not fire an open.
+  @Test("consume no-ops when nothing queued")
+  func consumePendingOpenOnboardingNoOpsWhenFlagClear() {
+    var openCount = 0
+    let coordinator = AppWindowCoordinator(
+      canOpenOnboarding: { true },
+      isOnboardingComplete: { false }
+    )
+    coordinator.openOnboardingAction = { openCount += 1 }
+
+    let replayed = coordinator.consumePendingOpenOnboarding()
+    #expect(!replayed, "nothing queued → returns false")
+    #expect(openCount == 0, "no open fired")
+  }
+
+  /// Council Risk 1 guard: a call made while onboarding is already complete
+  /// must NOT queue a stale open — the eligibility guard runs before the queue
+  /// guard.
+  @Test("completed onboarding never queues a stale open")
+  func completedOnboardingDoesNotQueue() {
+    var openCount = 0
+    let coordinator = AppWindowCoordinator(
+      canOpenOnboarding: { false },  // onboarding complete → ineligible
+      isOnboardingComplete: { true }
+    )
+
+    // No action wired. If the queue guard ran first this would queue.
+    coordinator.openOnboardingWindow()
+
+    // Wire a spy and drain — a wrongly-queued request would replay here.
+    coordinator.openOnboardingAction = { openCount += 1 }
+    let replayed = coordinator.consumePendingOpenOnboarding()
+    #expect(!replayed, "completed-onboarding call must not queue a stale open")
+    #expect(openCount == 0, "no open fired")
+  }
+
+  /// The eligibility guard short-circuits `openOnboardingWindow()` even when
+  /// the SwiftUI bridge is wired.
+  @Test("eligibility guard blocks open when ineligible")
+  func openOnboardingWindowRespectsEligibilityGuard() {
+    var openCount = 0
+    let coordinator = AppWindowCoordinator(
+      canOpenOnboarding: { false },
+      isOnboardingComplete: { true }
+    )
+    coordinator.openOnboardingAction = { openCount += 1 }
+
+    coordinator.openOnboardingWindow()
+    #expect(openCount == 0, "ineligible → open must not fire")
+  }
+
+  /// `closeOnboardingWindow()` fires the `onOnboardingDismissed` icon-refresh
+  /// seam without reaching back into AppDelegate's menu logic.
+  @Test("close fires the onboarding-dismissed seam")
+  func closeOnboardingWindowFiresOnboardingDismissedSeam() {
+    var dismissedCount = 0
+    let coordinator = AppWindowCoordinator(
+      canOpenOnboarding: { true },
+      isOnboardingComplete: { false }
+    )
+    coordinator.onOnboardingDismissed = { dismissedCount += 1 }
+
+    coordinator.closeOnboardingWindow()
+    #expect(dismissedCount == 1, "close fires the icon-refresh seam exactly once")
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+
+/// PR-B.2 of #763 — locks `AppWindowCoordinator`'s initial shape so the
+/// extracted window home does not silently accrete domain state.
+///
+/// The shape gate here is an EXACT stored-property-name allowlist, not a
+/// parser-visible count. Council §3 of the PR-B.2 plan flagged a count gate as
+/// coverage theater: the shared `CeilingsTestSupport` parser counts only
+/// non-primitive `let`s and would see 2 of the 11 fields. This test instead
+/// parses every stored declaration in the class body (`let` and `var`, all
+/// access levels, primitives included) and asserts the name set EQUALS the
+/// 11-name allowlist. Adding a 12th field fails the test — that is the real
+/// god-object-drift gate.
+///
+/// Bible §30 ratchet: baseline declared by the home is 11 stored
+/// (`canOpenOnboarding`, `isOnboardingComplete`, `mainWindow`,
+/// `windowCloseObserver`, `onboardingWindow`, `onboardingCloseObserver`,
+/// `openMainWindowAction`, `openOnboardingAction`, `dismissOnboardingAction`,
+/// `onOnboardingDismissed`, `pendingOpenOnboarding`), 6 non-private `func`s
+/// (`installOnLaunch`, `tearDown`, `showWindow`, `openOnboardingWindow`,
+/// `closeOnboardingWindow`, `consumePendingOpenOnboarding`; `init` is not a
+/// `func`). Line cap 300 (generous soft trip-wire — actual file ~200 lines).
+@Suite struct AppWindowCoordinatorCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/AppWindowCoordinator.swift"
+
+  private static let storedPropertyAllowlist: Set<String> = [
+    "canOpenOnboarding",
+    "isOnboardingComplete",
+    "mainWindow",
+    "windowCloseObserver",
+    "onboardingWindow",
+    "onboardingCloseObserver",
+    "openMainWindowAction",
+    "openOnboardingAction",
+    "dismissOnboardingAction",
+    "onOnboardingDismissed",
+    "pendingOpenOnboarding",
+  ]
+
+  @Test func storedPropertyNamesMatchAllowlist() throws {
+    let body = try classBodyOfAppWindowCoordinator()
+    let names = storedPropertyNames(in: body)
+    let extras = names.subtracting(Self.storedPropertyAllowlist)
+    let missing = Self.storedPropertyAllowlist.subtracting(names)
+    #expect(
+      extras.isEmpty && missing.isEmpty,
+      """
+      AppWindowCoordinator stored-property set drifted from the PR-B.2 \
+      11-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      \(missing.sorted()). Adding a stored property is god-object drift — \
+      raising the allowlist requires a Bible §30 entry. Removing one means \
+      this test's allowlist must shrink in the same PR.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try classBodyOfAppWindowCoordinator()
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 10,
+      """
+      AppWindowCoordinator non-private method ceiling exceeded: \(count) > 10 \
+      non-private `func` declarations in the class body. PR-B.2 baseline: \
+      installOnLaunch, tearDown, showWindow, openOnboardingWindow, \
+      closeOnboardingWindow, consumePendingOpenOnboarding.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 300,
+      """
+      AppWindowCoordinator line count exceeded: \(count) > 300 (soft trip-wire). \
+      File should stay focused on window lifecycle.
+      """)
+  }
+
+  @Test func noBehaviorExtensions() throws {
+    // Guard against smuggling methods through an extension that escapes the
+    // in-class non-private method count.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let pattern = #"^[[:space:]]*extension[[:space:]]+AppWindowCoordinator\b"#
+    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    #expect(
+      matches.isEmpty,
+      """
+      AppWindowCoordinator has \(matches.count) extension(s); expected 0. \
+      Methods belong in the class body so the non-private method ceiling sees them.
+      """)
+  }
+
+  @Test func noAppStateReference() throws {
+    // The coordinator must carry no `AppState` import or type reference — the
+    // two onboarding-guard closures capture `appState` weakly at the
+    // construction site in `EnviousWisprApp.init()`, not here.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let pattern = #"\bAppState\b"#
+    let regex = try NSRegularExpression(pattern: pattern)
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    #expect(
+      matches.isEmpty,
+      """
+      AppWindowCoordinator.swift references `AppState` \(matches.count) time(s); \
+      expected 0. The coordinator must stay AppState-free — onboarding state is \
+      read through the injected `canOpenOnboarding` / `isOnboardingComplete` \
+      closures, which capture `appState` weakly in EnviousWisprApp.init().
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = ["AppKit", "EnviousWisprCore", "Observation"]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      AppWindowCoordinator imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+
+  /// Parser self-test: a fixture body with a 12th stored property must be
+  /// flagged. If this stops failing, the real gate above is untrustworthy.
+  @Test func parserCatchesExtraStoredProperty() {
+    let fixture = """
+        private let canOpenOnboarding: @MainActor () -> Bool
+        private weak var mainWindow: NSWindow?
+        var openMainWindowAction: (() -> Void)?
+        private var pendingOpenOnboarding: Bool = false
+        private var smuggledExtraField: Int = 0
+      """
+    let names = storedPropertyNames(in: fixture)
+    #expect(
+      names.contains("smuggledExtraField"),
+      "Parser failed to detect a smuggled stored property — the gate cannot be trusted.")
+  }
+}
+
+/// Extracts the `AppWindowCoordinator` class body — the text between the
+/// class's own braces. Uses the brace-balanced scan that
+/// `EnviousWisprAppCeilingsTests.structBodyOfEnviousWisprApp` uses (anchor on
+/// the declaration's `{`, NOT the first inner brace). `RouterCeilingParser`'s
+/// `classBody` anchors on the first inner `{` instead, which returns a method
+/// body; its consumers never caught this because they assert `<= N` and `0`
+/// satisfies any cap. This test asserts an exact name set, so it needs the
+/// real body.
+private func classBodyOfAppWindowCoordinator() throws -> String {
+  let source = try String(
+    contentsOf: URL(fileURLWithPath: "Sources/EnviousWispr/App/AppWindowCoordinator.swift"),
+    encoding: .utf8)
+  guard let openRange = source.range(of: "final class AppWindowCoordinator {") else {
+    Issue.record("AppWindowCoordinator declaration not found at expected path/shape")
+    throw POSIXError(.ENOENT)
+  }
+  let openIdx = source.index(before: openRange.upperBound)  // points at '{'
+  var depth = 0
+  var idx = openIdx
+  while idx < source.endIndex {
+    let c = source[idx]
+    if c == "{" { depth += 1 }
+    if c == "}" {
+      depth -= 1
+      if depth == 0 { return String(source[source.index(after: openIdx)..<idx]) }
+    }
+    idx = source.index(after: idx)
+  }
+  Issue.record("AppWindowCoordinator class body has unbalanced braces")
+  throw POSIXError(.EILSEQ)
+}
+
+/// Extracts the names of top-level (brace-depth 0) `let`/`var` stored-property
+/// declarations in a class body. Includes all access levels and primitive
+/// types; excludes computed properties (declaration line ends with `{`).
+private func storedPropertyNames(in body: String) -> Set<String> {
+  let declPattern =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+    + #"(public|internal|private|fileprivate|package|open)?[[:space:]]*"#
+    + #"(weak[[:space:]]+)?(let|var)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+  guard let regex = try? NSRegularExpression(pattern: declPattern) else { return [] }
+
+  var depth = 0
+  var names: Set<String> = []
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      // Exclude computed properties (declaration line ends with `{`).
+      let isComputed =
+        s.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil
+      if !isComputed {
+        let ns = s as NSString
+        // Capture groups: 1 attr-outer, 2 attr-inner, 3 access, 4 weak,
+        // 5 let|var, 6 NAME.
+        if let m = regex.firstMatch(
+          in: s, range: NSRange(location: 0, length: ns.length)),
+          m.numberOfRanges > 6, m.range(at: 6).location != NSNotFound
+        {
+          names.insert(ns.substring(with: m.range(at: 6)))
+        }
+      }
+    }
+    depth += opens - closes
+  }
+  return names
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -50,13 +50,21 @@ import Testing
   ///   threaded into `appDelegate.attach(...)` so `applicationWillFinishLaunching`
   ///   can invoke `startUpdater()` synchronously before any SwiftUI scene
   ///   body evaluates (Issue #739 env-capture invariant).
+  /// - 14 → 15 in PR-B.2 of epic #763 (2026-05-19, #797) for
+  ///   `AppWindowCoordinator`. Bible §30 entry: PR-B.2 lifts window lifecycle
+  ///   (main + onboarding window identity, the two close observers, the
+  ///   SwiftUI open/dismiss bridges, activation-policy transitions) off
+  ///   AppDelegate into a dedicated App-owned home. The `@State` instance is
+  ///   constructed in `init()` with two onboarding-guard closures and threaded
+  ///   into `appDelegate.attach(...)` plus injected into both Window scenes
+  ///   via `.environment(...)`.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 14,
+      count <= 15,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 14. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 15. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -89,14 +97,20 @@ import Testing
   /// init block + recordingLockedAccess struct literal + install() call +
   /// attachDictationLifecycleCoordinator call) and the hoisted
   /// `TranscriptStore` + `TranscriptCoordinator` construction (~3 lines).
+  /// Ratcheted 310→340 in PR-B.2 of epic #763 (2026-05-19, #797) to absorb
+  /// `AppWindowCoordinator` construction (~14 lines: two onboarding-guard
+  /// closures), the `@State` declaration, the 9th `attach(...)` argument, the
+  /// two `.environment(...)` injections, and the `ActionWirer` drain-before-
+  /// auto-open rewrite. Soft trip-wire only — the stored-property cap is the
+  /// primary entanglement signal.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 310,
+      lineCount <= 340,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 310. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 340. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }


### PR DESCRIPTION
## Summary

PR-B.2 of the AppState deletion epic (#763). Extracts window lifecycle out of `AppDelegate` into a new App-owned `AppWindowCoordinator`.

- New `Sources/EnviousWispr/App/AppWindowCoordinator.swift` — `@Observable @MainActor final class` owning main + onboarding window identity, the two `NSWindow.willCloseNotification` observers, the three SwiftUI open/dismiss bridge closures, activation-policy transitions, and a defensive `pendingOpenOnboarding` queue.
- `AppDelegate` drops 7 window stored properties + 3 window methods (~84 lines lighter); holds a `weak` ref via a 9-arg `attach(...)`; the inline window-observer block becomes a non-early-return `if let … else { assertionFailure; log }` guard calling `installOnLaunch()`; `applicationWillTerminate` calls `tearDown()`.
- `DiagnosticsSettingsView` reach-through (`NSApp.delegate as? AppDelegate`) is retired in favour of `@Environment(AppWindowCoordinator.self)` — no shim.
- `ActionWirer` drains `consumePendingOpenOnboarding()` before the conditional auto-open so a queued request cannot double-open; the onboarding-eligibility guard runs before the queue guard so a completed-onboarding call never queues a stale open.

Resolves #797.

## Validation

- `swift build -c release` exit 0; full `scripts/swift-test.sh` suite green (1081 tests).
- New `AppWindowCoordinatorCeilingsTests` (exact 11-name stored-property allowlist) + `AppWindowCoordinatorTests` (5 unit cases) pass. `EnviousWisprAppCeilingsTests` ratcheted 14→15 stored / 310→340 lines with changelog lines.
- Codex code-diff review: **SHIP** — no defects (guard order, drain-before-auto-open, non-early-return launch guard, no stale references all verified).
- Live UAT leg A (heart-path): dictation end-to-end, transcript exact-match, pipeline 1.65s, no crash.

## Test plan

- [x] Release build + full test suite
- [x] Codex code-diff review clean
- [x] Live UAT leg A — heart-path dictation
- [ ] Live UAT leg B — window surface (Settings open/close, Dock icon, Restart Onboarding)
- [ ] Live UAT leg C — fresh-install onboarding auto-opens exactly once
