### PR TITLE
test: CI-speedup post-fix measurement (#804) — DO NOT MERGE

### DIFF
--- a/Sources/EnviousWispr/App/LastRecordingResult.swift
+++ b/Sources/EnviousWispr/App/LastRecordingResult.swift
@@ -36,3 +36,4 @@ final class LastRecordingResult {
 // CI build-gate trigger for #804 (cache-first CI-speedup PR): a CI-workflow-only
 // change otherwise sets needs_build=false and skips the build steps, so this PR
 // could not self-test. This inert line forces needs_build=true. Safe to remove.
+// CI-speedup post-fix measurement marker — throwaway, not for merge (#804).


### PR DESCRIPTION
Throwaway measurement PR for #804. **Do not merge — will be closed once `build-check` timing is captured.**

One inert comment line forces `needs_build=true` so `build-check` runs against the fresh post-#805 SwiftPM cache. Measures the post-fix PR build wall-clock vs the 7-8 min pre-fix baseline.
