### PR TITLE
test(architecture): fix RouterCeilingParser brace anchor, let-only counting, multi-line fold (#808)

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
@@ -3,9 +3,10 @@ import Testing
 
 /// PR8 of #763 — locks `AudioEventRouter`'s entanglement shape.
 ///
-/// Counts honestly: BOTH `let` and `var` instance stored properties count,
-/// sub-binned into collaborator / closure-injected / observer-token slots so
-/// the test fails with a specific message. Caps lower-is-free, raise via the
+/// Counts top-level `let` stored properties only (per
+/// `.claude/rules/architecture-rules.md`; `var` is owned mutable state, not a
+/// collaborator), sub-binned into collaborator / closure-injected slots so the
+/// test fails with a specific message. Caps lower-is-free, raise via the
 /// Bible §30 changelog.
 @Suite struct AudioEventRouterCeilingsTests {
   private static let sourcePath =

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -1,19 +1,24 @@
 import Foundation
 import Testing
 
-/// PR8 of #763 — strict source parser for `*EventRouter` and
-/// `WedgeRecoveryRouter` ceiling tests. Counts BOTH `let` and `var` instance
-/// stored properties, sub-binned into:
-///   - collaborator slot: non-primitive non-closure non-NSObjectProtocol `let`s
-///   - closure-injected slot: `let`s typed as `(...) -> ...`
-///   - NSObjectProtocol-observer-token slot: handled as a sub-bin (PR8 plan
-///     allowed up to one for AudioEventRouter; the router currently does not
-///     hold one because cleanup is app-lifetime).
+/// PR8 of #763 — strict source parser for `*EventRouter` / `WedgeRecoveryRouter`
+/// and the `DictationRuntime`-family ceiling tests.
 ///
-/// The shared `CeilingsTestSupport` counts only `let` collaborators and
-/// excludes closures — too permissive for routers which can game the metric
-/// via `var observerToken` or closure-typed `let`s. This parser is stricter
-/// on purpose.
+/// Counts ONLY top-level `let` stored properties, matching the governing rule
+/// in `.claude/rules/architecture-rules.md` ("How the ceiling parser counts")
+/// and the sibling parser `CeilingsTestSupport`. `var` declarations (owned
+/// mutable state, lazy properties, setter-injected outlets, callback closures)
+/// are NOT collaborators and are excluded.
+///
+/// `let` stored properties at brace-depth 0 are sub-binned into:
+///   - collaborator slot: non-primitive, non-closure, non-NSObjectProtocol
+///   - closure-injected slot: typed as `(...) -> ...`
+///
+/// `classBody` anchors the brace-balanced scan on the class declaration's OWN
+/// `{` (found by scanning forward from the start of `final class`), not the
+/// first inner method/init brace. A continuation-line fold (`foldContinuationLines`)
+/// joins a declaration whose type annotation wraps across physical lines, so a
+/// multi-line closure-typed `let` classifies correctly. Fixed in #808.
 enum RouterCeilingParser {
 
   static func classBody(named typeName: String, at path: String) throws -> String {
@@ -32,10 +37,12 @@ enum RouterCeilingParser {
       Issue.record("\(typeName) declaration not found at \(path)")
       throw POSIXError(.ENOENT)
     }
-    guard
-      let openBrace = source[openRange.upperBound...].firstIndex(of: "{")
-        ?? source[openRange.lowerBound...].firstIndex(of: "{")
-    else {
+    // Anchor on the class's OWN `{`: scan forward from the start of the
+    // declaration (`final class TypeName` / `class TypeName`). Between that
+    // start and the class brace the source holds only the type name and an
+    // optional `: Conformance, ...` list — never a `{` — so the first `{`
+    // found is unambiguously the class brace, for every declaration shape.
+    guard let openBrace = source[openRange.lowerBound...].firstIndex(of: "{") else {
       Issue.record("\(typeName) declaration has no opening brace")
       throw POSIXError(.EILSEQ)
     }
@@ -57,15 +64,15 @@ enum RouterCeilingParser {
   }
 
   /// Collaborator slot: non-primitive non-closure non-NSObjectProtocol `let`
-  /// or `var` stored properties at brace-depth 0 inside the class body.
+  /// stored properties at brace-depth 0 inside the class body.
   static func collaboratorCount(in body: String) -> Int {
     countTopLevelStoredProperties(in: body) { line in
       !isPrimitiveTyped(line) && !isClosureTyped(line) && !isNSObjectProtocolTyped(line)
     }
   }
 
-  /// Closure-injected slot: instance `let`/`var` whose declared type is a
-  /// closure (`(...) -> ...`) at brace-depth 0.
+  /// Closure-injected slot: instance `let` whose declared type is a closure
+  /// (`(...) -> ...`) at brace-depth 0.
   static func closureInjectedCount(in body: String) -> Int {
     countTopLevelStoredProperties(in: body) { line in isClosureTyped(line) }
   }
@@ -74,11 +81,11 @@ enum RouterCeilingParser {
   static func nonPrivateMethodCount(in body: String) -> Int {
     var depth = 0
     var count = 0
-    for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    for line in foldContinuationLines(body) {
       let opens = line.filter { $0 == "{" }.count
       let closes = line.filter { $0 == "}" }.count
       let depthForThisLine = depth - max(0, closes - opens)
-      if depthForThisLine == 0, isNonPrivateMethodDeclaration(String(line)) {
+      if depthForThisLine == 0, isNonPrivateMethodDeclaration(line) {
         count += 1
       }
       depth += opens - closes
@@ -108,13 +115,12 @@ enum RouterCeilingParser {
   ) -> Int {
     var depth = 0
     var count = 0
-    for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    for line in foldContinuationLines(body) {
       let opens = line.filter { $0 == "{" }.count
       let closes = line.filter { $0 == "}" }.count
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0 {
-        let s = String(line)
-        if isStoredPropertyDeclaration(s), predicate(s) {
+        if isStoredPropertyDeclaration(line), predicate(line) {
           count += 1
         }
       }
@@ -123,17 +129,123 @@ enum RouterCeilingParser {
     return count
   }
 
+  /// Joins each top-level declaration whose type annotation wraps across
+  /// physical lines into a single logical line, so the per-line classifiers
+  /// (`isClosureTyped`, `isPrimitiveTyped`, ...) see the full type signature.
+  /// Folding is applied only at brace-depth 0; the folded logical line carries
+  /// the summed `{`/`}` counts of all merged physical lines, so depth tracking
+  /// downstream is unchanged.
+  private static func foldContinuationLines(_ body: String) -> [String] {
+    let physical = body.split(separator: "\n", omittingEmptySubsequences: false)
+      .map(String.init)
+    var result: [String] = []
+    var depth = 0
+    var i = 0
+    while i < physical.count {
+      var buffer = physical[i]
+      let opens = buffer.filter { $0 == "{" }.count
+      let closes = buffer.filter { $0 == "}" }.count
+      let depthForThisLine = depth - max(0, closes - opens)
+      if depthForThisLine == 0 {
+        while isUnterminatedDeclaration(buffer), i + 1 < physical.count {
+          i += 1
+          buffer += "\n" + physical[i]
+        }
+      }
+      result.append(buffer)
+      depth += buffer.filter { $0 == "{" }.count - buffer.filter { $0 == "}" }.count
+      i += 1
+    }
+    return result
+  }
+
+  /// A logical buffer is unterminated (its next physical line continues it)
+  /// when, in its code view (string literals and `//` comments removed), round
+  /// or square brackets are unbalanced-open, or the last non-whitespace
+  /// character is a continuation operator (`:` `,` `&`, or it ends with `->`).
+  /// Angle brackets are deliberately not tracked — `>` is ambiguous with `->`
+  /// and comparison.
+  private static func isUnterminatedDeclaration(_ buffer: String) -> Bool {
+    let code = codeView(buffer)
+    var paren = 0
+    var bracket = 0
+    for ch in code {
+      switch ch {
+      case "(": paren += 1
+      case ")": paren -= 1
+      case "[": bracket += 1
+      case "]": bracket -= 1
+      default: break
+      }
+    }
+    if paren > 0 || bracket > 0 { return true }
+    let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.hasSuffix("->") { return true }
+    if let last = trimmed.last, last == ":" || last == "," || last == "&" {
+      return true
+    }
+    return false
+  }
+
+  /// Returns `buffer` with string-literal contents and `//` line comments
+  /// removed, so bracket-balance and trailing-operator checks see only code.
+  /// A `//` or a bracket inside a `"..."` literal must not be read as syntax
+  /// (a `let x = "https://"` is a complete declaration, not a continuation).
+  /// Handles single-line `"..."` with `\` escapes; multi-line (`"""`) and raw
+  /// (`#"..."#`) string literals are out of scope — no ceiling-tested class
+  /// declaration uses them.
+  private static func codeView(_ buffer: String) -> String {
+    let chars = Array(buffer)
+    var result: [Character] = []
+    var inString = false
+    var i = 0
+    while i < chars.count {
+      let c = chars[i]
+      if inString {
+        if c == "\\" {
+          i += 2  // skip the escaped character
+          continue
+        }
+        if c == "\"" {
+          inString = false
+        } else if c == "\n" {
+          inString = false  // a single-line literal cannot cross a newline
+          result.append(c)
+        }
+        i += 1
+        continue
+      }
+      if c == "\"" {
+        inString = true
+        i += 1
+        continue
+      }
+      if c == "/", i + 1 < chars.count, chars[i + 1] == "/" {
+        while i < chars.count, chars[i] != "\n" { i += 1 }  // drop to EOL
+        continue
+      }
+      result.append(c)
+      i += 1
+    }
+    return String(result)
+  }
+
   private static let storedPropertyPattern: String = {
     let attrs = #"(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
     let access = #"(public|internal|private|fileprivate|package|open)?"#
-    return "^[[:space:]]*\(attrs)\(access)[[:space:]]*(let|var)[[:space:]]+[A-Za-z_]"
+    return "^[[:space:]]*\(attrs)\(access)[[:space:]]*let[[:space:]]+[A-Za-z_]"
   }()
 
   private static func isStoredPropertyDeclaration(_ line: String) -> Bool {
     guard line.range(of: storedPropertyPattern, options: .regularExpression) != nil
     else { return false }
-    // Reject computed properties (line ends with `{`).
-    if line.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
+    // Reject a `let` whose first physical line ends with `{` (trailing-closure
+    // initializer body). A Swift computed property is always `var`, so a `let`
+    // never reaches here as a computed property.
+    let firstLine =
+      line.split(separator: "\n", omittingEmptySubsequences: false).first
+      .map(String.init) ?? line
+    if firstLine.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil {
       return false
     }
     return true
@@ -150,7 +262,8 @@ enum RouterCeilingParser {
   private static func isClosureTyped(_ line: String) -> Bool {
     // Matches a declared closure type signature: `: (...) -> ...`
     // (with optional `@MainActor` / `@Sendable` attributes before the
-    // paren). Excludes plain method invocations on initializers.
+    // paren). `line` may be a folded multi-line declaration; `[[:space:]]`
+    // already includes the join newline, so the signature matches across it.
     line.range(
       of: #":[[:space:]]*(@[A-Za-z]+[[:space:]]+)*\([^)]*\)[[:space:]]*->[[:space:]]"#,
       options: .regularExpression) != nil

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+
+/// Self-test for `RouterCeilingParser` (issue #808). The parser feeds nine
+/// architecture-ceiling suites; before #808 it anchored on the first inner
+/// brace and returned a method body, so every `count <= N` consumer assertion
+/// passed on `0`. These tests assert exact counts against synthetic source so
+/// that regression — and the `let`-only / multi-line-fold behavior — cannot
+/// return silently.
+@Suite struct RouterCeilingParserTests {
+
+  /// Writes `source` to a temp `.swift` file and returns the parsed class body.
+  private func classBody(
+    of source: String, named typeName: String = "Probe"
+  ) throws -> String {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("rcp-\(UUID().uuidString).swift")
+    try source.write(to: url, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: url) }
+    return try RouterCeilingParser.classBody(named: typeName, at: url.path)
+  }
+
+  @Test func classBody_returnsClassBody_notInnerMethodBody() throws {
+    // The `init` body holds its own `{` and a local `let`. The pre-#808 bug
+    // anchored on that inner brace and returned the init body, counting the
+    // local `let` (→ 1) instead of the two real collaborators (→ 2).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let beta: BetaDep
+          init() {
+            let local: LocalThing = makeThing()
+            _ = local
+          }
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  @Test func classBody_handlesConformanceListDeclaration() throws {
+    // `final class X: Protocol {` — the `:`-conformance shape.
+    let body = try classBody(
+      of: """
+        final class Probe: SomeProtocol, AnotherProtocol {
+          let gamma: GammaDep
+          init() {}
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func collaboratorCount_excludesVarStoredProperty() throws {
+    // `var` is owned mutable state, not a collaborator (architecture-rules.md).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          var mutableState: SomeState
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func collaboratorCount_excludesVarComputedProperty() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          var computed: AlphaDep { alpha }
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func collaboratorCount_excludesPrimitiveLet() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let flag: Bool
+          let count: Int
+          let name: String
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func closureCount_countsSingleLineClosure() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let onEvent: @MainActor (Int) -> Bool
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+  }
+
+  @Test func closureCount_countsMultiLineClosureDeclaration() throws {
+    // A closure-typed `let` whose signature wraps onto a second physical line
+    // (the `AudioEventRouter.resolveActiveCaptureBackend` shape). Without the
+    // continuation fold, line 1 (`let resolve:`) misclassifies as a
+    // collaborator and the closure is missed.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          let resolve:
+            @MainActor () -> SomeNamespace.SomeResult?
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+    #expect(RouterCeilingParser.closureInjectedCount(in: body) == 1)
+  }
+
+  @Test func nonPrivateMethodCount_countsNonPrivateExcludesPrivateAndInit() throws {
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let alpha: AlphaDep
+          init() {}
+          func publicWork() {}
+          private func hidden() {}
+          func moreWork() -> Bool { true }
+        }
+        """)
+    #expect(RouterCeilingParser.nonPrivateMethodCount(in: body) == 2)
+  }
+
+  @Test func collaboratorCount_stringLiteralPunctuationDoesNotTriggerFold() throws {
+    // A `//` and brackets inside a string literal must not be read as a
+    // comment or unbalanced bracket. If they were, `endpoint` would look
+    // unterminated, fold in the next line, and `realDep` would silently
+    // vanish from the count — a false-green ceiling.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let endpoint: String = "https://example.com/[v1]"
+          let realDep: AlphaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+}


### PR DESCRIPTION
Fixes #808.

## Problem

`RouterCeilingParser.classBody` anchored its brace-balanced scan on the first inner brace (a method/init body) instead of the class's own brace, so every collaborator/closure/method count came back near-zero. Nine architecture-ceiling suites assert `count <= N`, which `0` trivially satisfies — the guardrails were passing as false negatives.

## Fix

Three defects, all bringing `RouterCeilingParser` to the governing rule (`.claude/rules/architecture-rules.md`, "How the ceiling parser counts" — `let`-only) and the sibling parser `CeilingsTestSupport`:

1. **Brace anchor** — `classBody` scans for the class's own `{` from `openRange.lowerBound`; handles all four declaration shapes. Dead `??` fallback dropped.
2. **`let`-only counting** — `storedPropertyPattern` was `(let|var)`; now `let`. `var` is owned mutable state, not a collaborator.
3. **Multi-line declaration fold** — new `foldContinuationLines` joins a stored-property declaration whose type annotation wraps across physical lines (the `AudioEventRouter.resolveActiveCaptureBackend` two-line closure shape). `codeView` makes the fold heuristic string-literal-aware so a `//` or bracket inside a `"..."` cannot mis-trigger it.

After the fix the parser reads honestly and **all nine consumer ceiling suites pass at their existing caps — no cap changed**.

New `RouterCeilingParserTests` self-test pins anchor + `let`-only + fold behavior with exact-equality assertions so the regression cannot return silently. `AudioEventRouterCeilingsTests` doc comment corrected.

## Validation

- `scripts/swift-test.sh --filter Ceiling`: 97 tests in 20 suites pass (nine consumer suites + new self-test).
- `swift build -c release`: clean.
- Tier: SMALL, test-infrastructure only — no ship-path code.
- Grounded review: 3 rounds (PROCEED). Code-diff review: 2 rounds (SHIP).
