### PR TITLE
refactor(appstate): extract MenuBarController from AppDelegate (PR-B.3 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -23,28 +23,22 @@ import SwiftUI
 /// native approach that reliably handles clicks on all macOS versions.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-  private var statusItem: NSStatusItem?
-  private let iconAnimator = MenuBarIconAnimator()
-
   // PR-A of #763: App-owned homes. `EnviousWisprApp` owns these as `@State`
   // and pushes them into AppDelegate via `attach(...)` synchronously during
   // `EnviousWisprApp.init()`, before any `NSApplicationDelegate` callback
   // fires. Weak refs so AppDelegate is not a retention root.
   private weak var appState: AppState?
-  private weak var navigationCoordinator: NavigationCoordinator?
   /// PR-B.1 of #763: App-owned home for the Sparkle integration. Strong
   /// owner is `EnviousWisprApp`'s `@State`. AppDelegate's relationship
   /// is reduced to invoking `startUpdater()` from
   /// `applicationWillFinishLaunching` and gating the menu's
   /// "Check for Updates" item.
   private weak var sparkleUpdateController: SparkleUpdateController?
-  // PR7 of #763: weak refs to the two App-owned homes AppDelegate's
-  // menu-bar reads now route through. `liveRecordingState` replaces
-  // the old `appState.pipelineState` getter; `backendMetadata` replaces
-  // `appState.activeModelName` / `appState.activeLLMDisplayName`. Both
-  // sunset on the timeline noted at AppState's `attach…` methods.
+  /// PR7 of #763: weak ref to the App-owned live-recording home.
+  /// `AudioSystemEventReporter.pipelineStateProvider` reads `pipelineState`
+  /// from it (see `applicationDidFinishLaunching`). The menu-bar reads that
+  /// previously routed through here moved to `MenuBarController` in PR-B.3.
   private weak var liveRecordingState: LiveRecordingState?
-  private weak var backendMetadata: BackendMetadata?
   /// PR9 of #763: the pipeline state-change callback (icon updates,
   /// audio-environment snapshot triggers) lives on the new lifecycle home now.
   /// AppDelegate sets `dictationLifecycleCoordinator.onPipelineStateChange`
@@ -65,15 +59,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// window identity, the two `NSWindow.willCloseNotification` observers, the
   /// SwiftUI open/dismiss bridges, activation-policy transitions). Weak ref —
   /// strong owner is `EnviousWisprApp`'s `@State`. AppDelegate routes
-  /// `installOnLaunch()` / `tearDown()` from its lifecycle callbacks and the
-  /// menu actions through it.
+  /// `installOnLaunch()` / `tearDown()` from its lifecycle callbacks.
   private weak var appWindowCoordinator: AppWindowCoordinator?
+  /// PR-B.3 of #763: App-owned home for the menu bar surface (status item,
+  /// dropdown menu, animated icon, menu actions). Weak ref — strong owner is
+  /// `EnviousWisprApp`'s `@State`. AppDelegate calls `installStatusItem()`
+  /// from launch and routes the three external icon-refresh seams here.
+  private weak var menuBarController: MenuBarController?
 
   /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
   /// before delegate callbacks fire.
-  ///
-  /// PR7 of #763: additionally receive `liveRecordingState` and
-  /// `backendMetadata` for the menu-bar reads.
   ///
   /// PR9 of #763: additionally receive `dictationLifecycleCoordinator` so the
   /// icon-update callback can be installed on the new home (was on AppState
@@ -85,34 +80,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// `startUpdater()`.
   ///
   /// PR-B.2 of #763: additionally receive `appWindowCoordinator` so the
-  /// lifecycle callbacks can install/tear down the window observers and the
-  /// menu actions can route window opens through it. `attach()` also wires the
-  /// `onOnboardingDismissed` icon-refresh seam (PR-B.3 retargets it).
+  /// lifecycle callbacks can install/tear down the window observers.
+  ///
+  /// PR-B.3 of #763: additionally receive `menuBarController`; drop
+  /// `navigationCoordinator` and `backendMetadata` (both were only read by the
+  /// menu code that moved to `MenuBarController`). The `onOnboardingDismissed`
+  /// icon-refresh seam now targets `menuBarController`.
   func attach(
     appState: AppState,
-    navigationCoordinator: NavigationCoordinator,
     sparkleUpdateController: SparkleUpdateController,
     liveRecordingState: LiveRecordingState,
-    backendMetadata: BackendMetadata,
     dictationLifecycleCoordinator: DictationLifecycleCoordinator,
     dictationRuntime: DictationRuntime,
     hotkeyService: HotkeyService,
-    appWindowCoordinator: AppWindowCoordinator
+    appWindowCoordinator: AppWindowCoordinator,
+    menuBarController: MenuBarController
   ) {
     self.appState = appState
-    self.navigationCoordinator = navigationCoordinator
     self.sparkleUpdateController = sparkleUpdateController
     self.liveRecordingState = liveRecordingState
-    self.backendMetadata = backendMetadata
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     self.dictationRuntime = dictationRuntime
     self.hotkeyService = hotkeyService
     self.appWindowCoordinator = appWindowCoordinator
+    self.menuBarController = menuBarController
     // Icon-refresh seam: the coordinator's two onboarding-dismiss callsites
-    // route through this closure instead of reaching into AppDelegate's
-    // menu-icon logic. PR-B.3 retargets the seam to MenuBarController.
-    appWindowCoordinator.onOnboardingDismissed = { [weak self] in
-      self?.updateIcon()
+    // route through this closure. PR-B.3 retargets it to MenuBarController.
+    appWindowCoordinator.onOnboardingDismissed = { [weak menuBarController] in
+      menuBarController?.updateIcon()
     }
   }
 
@@ -208,15 +203,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // are invoked from `applicationWillFinishLaunching` so SwiftUI's env
     // value snapshot is non-nil when the App body first evaluates.
 
-    setupStatusItem()
+    // PR-B.3 of #763: the menu bar surface lives on `MenuBarController` now.
+    menuBarController?.installStatusItem()
 
-    // Update menu bar icon whenever pipeline state or accessibility changes.
-    // Also forwards recording state to the update coordinator so the banner
-    // hides during recording + 3s post-recording grace (issue #343).
-    // PR9 of #763: callback lives on `DictationLifecycleCoordinator` now.
+    // Update menu bar icon whenever pipeline state changes. PR9 of #763: the
+    // callback lives on `DictationLifecycleCoordinator`. PR-B.3 of #763: the
+    // icon call targets `MenuBarController`. The closure stays here because it
+    // is composite — it also triggers the audio-environment snapshotter, which
+    // does not move off AppDelegate until PR-B.4.
     dictationLifecycleCoordinator?.onPipelineStateChange = { [weak self] state in
       guard let self else { return }
-      self.updateIcon()
+      self.menuBarController?.updateIcon()
       // Issue #739: do NOT forward pipeline state to the update widget. The
       // widget is now bundle-version-driven only — visible whenever an update
       // is pending, period. Matches Claude Desktop / Slack / Cursor update-prompt
@@ -225,9 +222,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.audioEnvironmentSnapshotter?.recordingStarted()
       }
     }
-    appState.permissions.onAccessibilityChange = { [weak self] in
-      self?.updateIcon()
-    }
+    // PR-B.3 of #763: the accessibility-change icon-refresh seam moved into
+    // `MenuBarController.installStatusItem()`.
 
     // Start hotkeys now that the event loop is running.
     // Carbon RegisterEventHotKey requires an active run loop for event delivery.
@@ -278,7 +274,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Check Accessibility permission on launch (query only — never auto-prompt).
     appState.permissions.refreshOnLaunch()
-    updateIcon()  // Reflect accessibility warning state in menu bar icon
+    menuBarController?.updateIcon()  // Reflect accessibility warning state in menu bar icon
 
     // Begin smart polling if Accessibility is not yet granted.
     appState.permissions.startMonitoring()
@@ -348,190 +344,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
   }
 
-  private func setupStatusItem() {
-    statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    guard let button = statusItem?.button else { return }
-
-    iconAnimator.configure(button: button)
-    iconAnimator.audioLevelProvider = { [weak self] in self?.appState?.audioCapture.audioLevel ?? 0
-    }
-
-    let menu = NSMenu()
-    menu.delegate = self
-    statusItem?.menu = menu
-    populateMenu(menu)
-  }
-
-  /// Load a menu bar icon from the app bundle's Resources directory.
-  /// At runtime the bundle is a proper .app with Contents/Resources/;
-  /// during development we fall back to the source Resources/ directory.
-  ///
-  /// Resolution order:
-  ///   1. Bundle.main.resourceURL  (production .app bundle)
-  ///   2. Derived from executable path (fallback when Bundle.main mis-resolves)
-  ///   3. Source tree via #filePath (development / bare binary)
-  ///   4. SF Symbol "mic" (last resort)
-  /// Populate the given menu with items reflecting current AppState.
-  private func populateMenu(_ menu: NSMenu) {
-    menu.removeAllItems()
-
-    guard let appState = self.appState else { return }
-    // PR7 of #763: live pipeline phase + display labels now resolve through
-    // App-owned homes attached during `EnviousWisprApp.init()`. Fall back
-    // to `.idle` / empty strings if a home is unavailable (only possible
-    // during very-early teardown — never on a live path).
-    let state = liveRecordingState?.pipelineState ?? .idle
-    let onboardingIncomplete = appState.settings.onboardingState != .completed
-
-    // Onboarding abort item — shown at the very top when setup is incomplete.
-    if onboardingIncomplete {
-      let setupItem = NSMenuItem(
-        title: "Setup Required: Continue Setup…",
-        action: #selector(continueOnboarding),
-        keyEquivalent: ""
-      )
-      setupItem.image = NSImage(
-        systemSymbolName: "exclamationmark.circle.fill", accessibilityDescription: "Setup required")
-      setupItem.target = self
-      menu.addItem(setupItem)
-      menu.addItem(.separator())
-    }
-
-    // Status: ASR model — LLM model
-    // PR7 of #763: display labels resolve through `backendMetadata`. Fall
-    // back to empty strings if the home is unavailable (defensive only).
-    let asrModel = backendMetadata?.modelLabel ?? ""
-    let llmInfo = backendMetadata?.llmLabel ?? ""
-    let statusTitle = "\(asrModel) — \(llmInfo)"
-    let statusItem = NSMenuItem(title: statusTitle, action: nil, keyEquivalent: "")
-    statusItem.isEnabled = false
-    menu.addItem(statusItem)
-
-    // Version
-    let versionItem = NSMenuItem(
-      title: "Version: \(AppConstants.appVersion)", action: nil, keyEquivalent: "")
-    versionItem.isEnabled = false
-    menu.addItem(versionItem)
-
-    menu.addItem(.separator())
-
-    // Record / Stop
-    let recordTitle = state == .recording ? "Stop Recording" : "Start Recording"
-    let recordSymbol = state == .recording ? "stop.circle" : "mic.fill"
-    let recordDescription = state == .recording ? "Stop" : "Record"
-    let recordItem = NSMenuItem(
-      title: recordTitle, action: #selector(toggleRecording), keyEquivalent: "")
-    recordItem.image = NSImage(
-      systemSymbolName: recordSymbol, accessibilityDescription: recordDescription)
-    recordItem.target = self
-    recordItem.isEnabled = !(state.isActive && state != .recording)
-    menu.addItem(recordItem)
-
-    // Auto-stop on silence indicator
-    if appState.settings.vadAutoStop {
-      let autoStopTitle =
-        state == .recording
-        ? "Auto-stop: Active (\(String(format: "%.1fs", appState.settings.vadSilenceTimeout)) silence)"
-        : "Auto-stop on silence: On"
-      let autoStopItem = NSMenuItem(title: autoStopTitle, action: nil, keyEquivalent: "")
-      autoStopItem.image = NSImage(
-        systemSymbolName: "waveform.badge.minus", accessibilityDescription: "Auto-stop on silence")
-      autoStopItem.isEnabled = false
-      menu.addItem(autoStopItem)
-    }
-
-    // Accessibility warning — shown only when paste is unavailable and not dismissed.
-    if appState.permissions.shouldShowAccessibilityWarning {
-      let warningItem = NSMenuItem(
-        title: "Paste disabled — Accessibility required",
-        action: #selector(openPermissionsSettings),
-        keyEquivalent: ""
-      )
-      warningItem.image = NSImage(
-        systemSymbolName: "exclamationmark.shield.fill",
-        accessibilityDescription: "Accessibility required")
-      warningItem.target = self
-      menu.addItem(warningItem)
-    }
-
-    menu.addItem(.separator())
-
-    // Settings (opens unified window to Speech Engine tab)
-    let settingsItem = NSMenuItem(
-      title: "Settings...", action: #selector(openSettings), keyEquivalent: ",")
-    settingsItem.image = NSImage(
-      systemSymbolName: "gearshape", accessibilityDescription: "Settings")
-    settingsItem.target = self
-    menu.addItem(settingsItem)
-
-    // Check for Updates — retargets to SparkleUpdateController so it can
-    // tag the install source as "menu" for telemetry attribution (issue #343).
-    // PR-B.1 of #763: target/action both moved to the controller.
-    if sparkleUpdateController?.hasUpdater == true {
-      let updateItem = NSMenuItem(
-        title: "Check for Updates…",
-        action: #selector(SparkleUpdateController.openUpdateCheckFromMenu(_:)),
-        keyEquivalent: "")
-      updateItem.image = NSImage(
-        systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
-      updateItem.target = sparkleUpdateController
-      menu.addItem(updateItem)
-    }
-
-    menu.addItem(.separator())
-
-    // Quit
-    let quitItem = NSMenuItem(
-      title: "Quit \(AppConstants.appName)", action: #selector(quitApp), keyEquivalent: "q")
-    quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")
-    quitItem.target = self
-    menu.addItem(quitItem)
-  }
-
-  /// Update the status item icon based on pipeline state.
-  func updateIcon() {
-    guard let appState = self.appState else { return }
-    // PR7 of #763: live pipeline phase resolves through `liveRecordingState`.
-    let state = liveRecordingState?.pipelineState ?? .idle
-    let needsAccessWarning = state == .idle && appState.permissions.shouldShowAccessibilityWarning
-    let onboardingIncomplete = appState.settings.onboardingState != .completed
-
-    if needsAccessWarning || (onboardingIncomplete && state == .idle) {
-      iconAnimator.transition(to: .error)
-    } else if case .error = state {
-      iconAnimator.transition(to: .error)
-    } else if state == .recording {
-      iconAnimator.transition(to: .recording)
-    } else if state == .transcribing || state == .polishing || state == .loadingModel {
-      iconAnimator.transition(to: .processing)
-    } else {
-      iconAnimator.transition(to: .idle)
-    }
-  }
-
-  @objc private func continueOnboarding() {
-    appWindowCoordinator?.openOnboardingWindow()
-  }
-
-  @objc private func toggleRecording() {
-    // PR10 of #763 — façade pass-through to RecordingStarter via DictationRuntime.
-    guard let dictationRuntime = self.dictationRuntime else { return }
-    Task {
-      await dictationRuntime.toggleRecording(source: .menuBar)
-      updateIcon()
-    }
-  }
-
-  @objc private func openSettings() {
-    navigationCoordinator?.request(.speechEngine)
-    appWindowCoordinator?.showWindow()
-  }
-
-  @objc private func openPermissionsSettings() {
-    navigationCoordinator?.request(.permissions)
-    appWindowCoordinator?.showWindow()
-  }
-
   func applicationWillTerminate(_ notification: Notification) {
     // PR-B.2 of #763: both window-close observers are torn down by the
     // coordinator now.
@@ -557,24 +369,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Menu bar app — keep running when windows close.
     // User quits via "Quit EnviousWispr" in the status bar menu.
     return false
-  }
-
-  @objc private func quitApp() {
-    NSApp.terminate(nil)
-  }
-}
-
-// MARK: - NSMenuDelegate
-
-extension AppDelegate: NSMenuDelegate {
-  /// Repopulate menu items each time the menu opens so state is fresh.
-  /// NSMenu delegate methods are always called on the main thread.
-  nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
-    MainActor.assumeIsolated {
-      if let currentMenu = self.statusItem?.menu {
-        self.populateMenu(currentMenu)
-      }
-      self.updateIcon()
-    }
   }
 }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -38,6 +38,11 @@ struct EnviousWisprApp: App {
   /// scenes via `.environment(...)` so `DiagnosticsSettingsView` reaches it
   /// through `@Environment` instead of an `NSApp.delegate` downcast.
   @State private var appWindowCoordinator: AppWindowCoordinator
+  /// PR-B.3 of #763: App-owned home for the menu bar surface (status item,
+  /// dropdown menu, animated icon). Strong owner is this `@State`;
+  /// `AppDelegate` holds a weak ref pushed via `attach(...)`. Not
+  /// `.environment(...)`-injected — no SwiftUI view consumes the menu surface.
+  @State private var menuBarController: MenuBarController
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -195,6 +200,32 @@ struct EnviousWisprApp: App {
       }
     )
 
+    // PR-B.3 of #763: menu bar surface home. The five menu-action closures
+    // compose the previously inline `@objc` AppDelegate action bodies. The
+    // controller reads display facts through narrow PR11-survivor refs
+    // (`liveRecordingState`, `backendMetadata`, `sparkleUpdateController`,
+    // `appState.settings`, `appState.permissions`) — no AppState reference.
+    let menuBarController = MenuBarController(
+      liveRecordingState: liveRecordingState,
+      backendMetadata: backendMetadata,
+      sparkleUpdateController: sparkleUpdateController,
+      settings: appState.settings,
+      permissions: appState.permissions,
+      actions: MenuBarActions(
+        continueOnboarding: { appWindowCoordinator.openOnboardingWindow() },
+        openSettings: {
+          navigationCoordinator.request(.speechEngine)
+          appWindowCoordinator.showWindow()
+        },
+        openPermissions: {
+          navigationCoordinator.request(.permissions)
+          appWindowCoordinator.showWindow()
+        },
+        toggleRecording: { await dictationRuntime.toggleRecording(source: .menuBar) },
+        quit: { NSApp.terminate(nil) }
+      )
+    )
+
     _appState = State(initialValue: appState)
     _navigationCoordinator = State(initialValue: navigationCoordinator)
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
@@ -208,6 +239,7 @@ struct EnviousWisprApp: App {
     _dictationRuntime = State(initialValue: dictationRuntime)
     _hotkeyService = State(initialValue: hotkeyService)
     _appWindowCoordinator = State(initialValue: appWindowCoordinator)
+    _menuBarController = State(initialValue: menuBarController)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires.
@@ -218,14 +250,13 @@ struct EnviousWisprApp: App {
     // reaching through the deleted `appState.hotkeyService` path).
     appDelegate.attach(
       appState: appState,
-      navigationCoordinator: navigationCoordinator,
       sparkleUpdateController: sparkleUpdateController,
       liveRecordingState: liveRecordingState,
-      backendMetadata: backendMetadata,
       dictationLifecycleCoordinator: dictationLifecycleCoordinator,
       dictationRuntime: dictationRuntime,
       hotkeyService: hotkeyService,
-      appWindowCoordinator: appWindowCoordinator
+      appWindowCoordinator: appWindowCoordinator,
+      menuBarController: menuBarController
     )
 
     // Initialize observability (PostHog + Sentry) unconditionally at launch —
@@ -251,9 +282,9 @@ struct EnviousWisprApp: App {
         .environment(appWindowCoordinator)
         .background(
           ActionWirer(
-            appDelegate: appDelegate,
             appState: appState,
             appWindowCoordinator: appWindowCoordinator,
+            menuBarController: menuBarController,
             isOnboardingPresented: $isOnboardingPresented
           )
         )
@@ -276,17 +307,16 @@ struct EnviousWisprApp: App {
   }
 }
 
-/// Hidden view that wires SwiftUI environment actions to the AppDelegate.
+/// Hidden view that wires SwiftUI environment actions into App-owned homes.
 /// Must live inside a SwiftUI view hierarchy to access @Environment.
 private struct ActionWirer: View {
-  let appDelegate: AppDelegate
-  /// PR-A: App-owned AppState passed in directly. AppDelegate no longer
-  /// exposes `appState`; reading it through the delegate would have to go
-  /// through its weak ref and risk a stale read during teardown.
+  /// PR-A: App-owned AppState passed in directly.
   let appState: AppState
   /// PR-B.2 of #763: the three SwiftUI window bridges are wired onto the
   /// coordinator now, not AppDelegate.
   let appWindowCoordinator: AppWindowCoordinator
+  /// PR-B.3 of #763: onboarding-dismissal icon refresh targets the menu home.
+  let menuBarController: MenuBarController
   @Binding var isOnboardingPresented: Bool
   @Environment(\.openWindow) private var openWindow
   @Environment(\.dismissWindow) private var dismissWindow
@@ -322,7 +352,7 @@ private struct ActionWirer: View {
           // State-driven dismissal: binding flipped to false → close window.
           dismissWindow(id: "onboarding")
           NSApp.setActivationPolicy(.accessory)
-          appDelegate.updateIcon()
+          menuBarController.updateIcon()
         }
       }
   }

--- a/Sources/EnviousWispr/App/MenuBarController.swift
+++ b/Sources/EnviousWispr/App/MenuBarController.swift
@@ -1,0 +1,303 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+/// PR-B.3 of #763 — App-owned home for the menu bar surface: the
+/// `NSStatusItem`, the dropdown menu, the animated icon, the `NSMenuDelegate`
+/// conformance, and the five menu actions. Extracted from `AppDelegate` so the
+/// AppKit adapter shrinks toward its ≤120-line target.
+///
+/// Strong owner is `EnviousWisprApp` as `@State`; `AppDelegate` holds a weak
+/// ref pushed via `attach(...)`. Not environment-injected — no SwiftUI view
+/// consumes the menu surface.
+///
+/// Menu rendering and icon mapping are PURE functions over a `MenuBarViewState`
+/// value (`renderMenu(into:state:)`, `iconState(_:)`). The impure
+/// `currentViewState()` reads the live homes; the split makes the menu surface
+/// deterministically golden-testable (`LiveRecordingState` / `PermissionsService`
+/// are `final` with `private(set)` state and cannot be posed in a unit test).
+@MainActor
+final class MenuBarController: NSObject {
+  /// Private collaborator — moved from `AppDelegate` unchanged.
+  private let iconAnimator = MenuBarIconAnimator()
+
+  /// Narrow read dependencies — all PR11-survivors, injected at construction.
+  /// This home reads display facts only through these refs — never through the
+  /// frozen god-object the epic is deleting.
+  private let liveRecordingState: LiveRecordingState
+  private let backendMetadata: BackendMetadata
+  private let sparkleUpdateController: SparkleUpdateController
+  private let settings: SettingsManager
+  private let permissions: PermissionsService
+
+  /// Menu action callbacks, packaged into one `Sendable` struct.
+  private let actions: MenuBarActions
+
+  /// The status item. `var` Optional — created in `installStatusItem()`.
+  private var statusItem: NSStatusItem?
+
+  init(
+    liveRecordingState: LiveRecordingState,
+    backendMetadata: BackendMetadata,
+    sparkleUpdateController: SparkleUpdateController,
+    settings: SettingsManager,
+    permissions: PermissionsService,
+    actions: MenuBarActions
+  ) {
+    self.liveRecordingState = liveRecordingState
+    self.backendMetadata = backendMetadata
+    self.sparkleUpdateController = sparkleUpdateController
+    self.settings = settings
+    self.permissions = permissions
+    self.actions = actions
+  }
+
+  // MARK: - Status item lifecycle
+
+  /// Create the status item, configure the icon animator, build the menu, and
+  /// install the accessibility-change icon-refresh seam. Called once from
+  /// `AppDelegate.applicationDidFinishLaunching` (was `setupStatusItem()`).
+  func installStatusItem() {
+    statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    guard let button = statusItem?.button else { return }
+
+    iconAnimator.configure(button: button)
+    iconAnimator.audioLevelProvider = { [weak self] in self?.liveRecordingState.audioLevel ?? 0 }
+
+    let menu = NSMenu()
+    menu.delegate = self
+    statusItem?.menu = menu
+    renderMenu(into: menu, state: currentViewState())
+
+    // PR-B.3 of #763: the accessibility-change icon-refresh trigger moves here
+    // from `AppDelegate.applicationDidFinishLaunching`. `AppDelegate.swift:228`
+    // was the sole assigner of this single-slot closure — a verified 1:1
+    // transfer. The owner of the icon owns the trigger.
+    permissions.onAccessibilityChange = { [weak self] in self?.updateIcon() }
+  }
+
+  // MARK: - Icon
+
+  /// Update the status item icon for the current pipeline / permission state.
+  func updateIcon() {
+    iconAnimator.transition(to: Self.iconState(currentViewState()))
+  }
+
+  /// Pure icon-state mapping. Logic byte-identical to the pre-PR-B.3
+  /// `AppDelegate.updateIcon()`.
+  static func iconState(_ state: MenuBarViewState) -> MenuBarIconAnimator.IconState {
+    let needsAccessWarning = state.pipelineState == .idle && state.showAccessibilityWarning
+    let onboardingIncomplete = !state.onboardingComplete
+
+    if needsAccessWarning || (onboardingIncomplete && state.pipelineState == .idle) {
+      return .error
+    } else if case .error = state.pipelineState {
+      return .error
+    } else if state.pipelineState == .recording {
+      return .recording
+    } else if state.pipelineState == .transcribing || state.pipelineState == .polishing
+      || state.pipelineState == .loadingModel
+    {
+      return .processing
+    } else {
+      return .idle
+    }
+  }
+
+  // MARK: - Menu rendering
+
+  /// Pure menu builder. Fills `menu` from `state`. Logic byte-identical to the
+  /// pre-PR-B.3 `AppDelegate.populateMenu(_:)`. Internal (not private) so
+  /// `MenuBarControllerTests` can drive it with `MenuBarViewState` fixtures.
+  func renderMenu(into menu: NSMenu, state: MenuBarViewState) {
+    menu.removeAllItems()
+
+    // Onboarding abort item — shown at the very top when setup is incomplete.
+    if !state.onboardingComplete {
+      let setupItem = NSMenuItem(
+        title: "Setup Required: Continue Setup…",
+        action: #selector(continueOnboardingAction),
+        keyEquivalent: ""
+      )
+      setupItem.image = NSImage(
+        systemSymbolName: "exclamationmark.circle.fill", accessibilityDescription: "Setup required")
+      setupItem.target = self
+      menu.addItem(setupItem)
+      menu.addItem(.separator())
+    }
+
+    // Status: ASR model — LLM model
+    let statusTitle = "\(state.asrLabel) — \(state.llmLabel)"
+    let statusLineItem = NSMenuItem(title: statusTitle, action: nil, keyEquivalent: "")
+    statusLineItem.isEnabled = false
+    menu.addItem(statusLineItem)
+
+    // Version
+    let versionItem = NSMenuItem(
+      title: "Version: \(AppConstants.appVersion)", action: nil, keyEquivalent: "")
+    versionItem.isEnabled = false
+    menu.addItem(versionItem)
+
+    menu.addItem(.separator())
+
+    // Record / Stop
+    let isRecording = state.pipelineState == .recording
+    let recordTitle = isRecording ? "Stop Recording" : "Start Recording"
+    let recordSymbol = isRecording ? "stop.circle" : "mic.fill"
+    let recordDescription = isRecording ? "Stop" : "Record"
+    let recordItem = NSMenuItem(
+      title: recordTitle, action: #selector(toggleRecordingAction), keyEquivalent: "")
+    recordItem.image = NSImage(
+      systemSymbolName: recordSymbol, accessibilityDescription: recordDescription)
+    recordItem.target = self
+    recordItem.isEnabled = !(state.pipelineState.isActive && !isRecording)
+    menu.addItem(recordItem)
+
+    // Auto-stop on silence indicator
+    if state.vadAutoStop {
+      let autoStopTitle =
+        isRecording
+        ? "Auto-stop: Active (\(String(format: "%.1fs", state.vadSilenceTimeout)) silence)"
+        : "Auto-stop on silence: On"
+      let autoStopItem = NSMenuItem(title: autoStopTitle, action: nil, keyEquivalent: "")
+      autoStopItem.image = NSImage(
+        systemSymbolName: "waveform.badge.minus", accessibilityDescription: "Auto-stop on silence")
+      autoStopItem.isEnabled = false
+      menu.addItem(autoStopItem)
+    }
+
+    // Accessibility warning — shown only when paste is unavailable and not dismissed.
+    if state.showAccessibilityWarning {
+      let warningItem = NSMenuItem(
+        title: "Paste disabled — Accessibility required",
+        action: #selector(openPermissionsAction),
+        keyEquivalent: ""
+      )
+      warningItem.image = NSImage(
+        systemSymbolName: "exclamationmark.shield.fill",
+        accessibilityDescription: "Accessibility required")
+      warningItem.target = self
+      menu.addItem(warningItem)
+    }
+
+    menu.addItem(.separator())
+
+    // Settings (opens unified window to Speech Engine tab)
+    let settingsItem = NSMenuItem(
+      title: "Settings...", action: #selector(openSettingsAction), keyEquivalent: ",")
+    settingsItem.image = NSImage(
+      systemSymbolName: "gearshape", accessibilityDescription: "Settings")
+    settingsItem.target = self
+    menu.addItem(settingsItem)
+
+    // Check for Updates — targets SparkleUpdateController so it can tag the
+    // install source as "menu" for telemetry attribution (issue #343).
+    // PR-B.1 of #763 retargeted target/action to the controller; PR-B.3
+    // preserves that wiring verbatim.
+    if state.hasUpdater {
+      let updateItem = NSMenuItem(
+        title: "Check for Updates…",
+        action: #selector(SparkleUpdateController.openUpdateCheckFromMenu(_:)),
+        keyEquivalent: "")
+      updateItem.image = NSImage(
+        systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: "Update")
+      updateItem.target = sparkleUpdateController
+      menu.addItem(updateItem)
+    }
+
+    menu.addItem(.separator())
+
+    // Quit
+    let quitItem = NSMenuItem(
+      title: "Quit \(AppConstants.appName)", action: #selector(quitAction), keyEquivalent: "q")
+    quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")
+    quitItem.target = self
+    menu.addItem(quitItem)
+  }
+
+  /// Snapshot the live homes into a value the pure renderer/mapper consume.
+  /// Reads are byte-identical to the pre-PR-B.3 `AppDelegate.populateMenu` /
+  /// `updateIcon` reads.
+  private func currentViewState() -> MenuBarViewState {
+    MenuBarViewState(
+      pipelineState: liveRecordingState.pipelineState,
+      asrLabel: backendMetadata.modelLabel,
+      llmLabel: backendMetadata.llmLabel,
+      onboardingComplete: settings.onboardingState == .completed,
+      vadAutoStop: settings.vadAutoStop,
+      vadSilenceTimeout: settings.vadSilenceTimeout,
+      showAccessibilityWarning: permissions.shouldShowAccessibilityWarning,
+      hasUpdater: sparkleUpdateController.hasUpdater
+    )
+  }
+
+  // MARK: - Menu actions
+
+  @objc private func continueOnboardingAction() {
+    actions.continueOnboarding()
+  }
+
+  @objc private func toggleRecordingAction() {
+    Task {
+      await actions.toggleRecording()
+      updateIcon()
+    }
+  }
+
+  @objc private func openSettingsAction() {
+    actions.openSettings()
+  }
+
+  @objc private func openPermissionsAction() {
+    actions.openPermissions()
+  }
+
+  @objc private func quitAction() {
+    actions.quit()
+  }
+}
+
+// MARK: - NSMenuDelegate
+
+extension MenuBarController: NSMenuDelegate {
+  /// Repopulate menu items each time the menu opens so state is fresh.
+  /// `NSMenu` delegate methods are always called on the main thread.
+  ///
+  /// The `menu` parameter is not captured into the `MainActor` closure (that
+  /// would be a Swift 6 `sending` data-race: `menu` is task-isolated). Instead
+  /// `statusItem?.menu` — the same object, MainActor-isolated — is re-fetched
+  /// inside, exactly as the pre-PR-B.3 `AppDelegate.menuNeedsUpdate` did.
+  nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
+    MainActor.assumeIsolated {
+      if let currentMenu = statusItem?.menu {
+        renderMenu(into: currentMenu, state: currentViewState())
+      }
+      updateIcon()
+    }
+  }
+}
+
+/// The five menu-action callbacks, packaged into one `Sendable` struct so the
+/// architecture ceiling parser scores them as a single collaborator slot.
+struct MenuBarActions: Sendable {
+  let continueOnboarding: @MainActor () -> Void
+  let openSettings: @MainActor () -> Void
+  let openPermissions: @MainActor () -> Void
+  let toggleRecording: @MainActor () async -> Void
+  let quit: @MainActor () -> Void
+}
+
+/// Immutable snapshot the menu and icon render from. Extracting it makes
+/// `renderMenu` / `iconState` pure functions over a value, which is what makes
+/// the menu surface deterministically golden-testable.
+struct MenuBarViewState: Equatable {
+  let pipelineState: PipelineState
+  let asrLabel: String
+  let llmLabel: String
+  let onboardingComplete: Bool
+  let vadAutoStop: Bool
+  let vadSilenceTimeout: Double
+  let showAccessibilityWarning: Bool
+  let hasUpdater: Bool
+}

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -1,0 +1,308 @@
+@preconcurrency import AVFoundation
+import AppKit
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWispr
+@testable import EnviousWisprASR
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprStorage
+
+/// PR-B.3 of #763 — unit tests for `MenuBarController`.
+///
+/// The identity-preservation gate. `renderMenu(into:state:)` and
+/// `iconState(_:)` are pure functions over a `MenuBarViewState`, so the menu
+/// surface is golden-tested deterministically against fixtures without posing
+/// the concrete `final` homes. Action dispatch is exercised through the real
+/// `@objc` selector wired into each rendered menu item.
+@MainActor
+@Suite("MenuBarController")
+struct MenuBarControllerTests {
+
+  /// Populates the `NSApp` global before any SUT line touches it
+  /// (swift-patterns.md — `NSApp`-touching coordinator test rule).
+  init() { _ = NSApplication.shared }
+
+  // MARK: - iconState (pure mapping)
+
+  @Test("iconState: idle + no warning + onboarding complete → idle")
+  func iconStateIdle() {
+    #expect(MenuBarController.iconState(fixture(pipelineState: .idle)) == .idle)
+  }
+
+  @Test("iconState: recording → recording")
+  func iconStateRecording() {
+    #expect(MenuBarController.iconState(fixture(pipelineState: .recording)) == .recording)
+  }
+
+  @Test("iconState: transcribing / polishing / loadingModel → processing")
+  func iconStateProcessing() {
+    #expect(MenuBarController.iconState(fixture(pipelineState: .transcribing)) == .processing)
+    #expect(MenuBarController.iconState(fixture(pipelineState: .polishing)) == .processing)
+    #expect(MenuBarController.iconState(fixture(pipelineState: .loadingModel)) == .processing)
+  }
+
+  @Test("iconState: error → error")
+  func iconStateError() {
+    #expect(MenuBarController.iconState(fixture(pipelineState: .error("boom"))) == .error)
+  }
+
+  @Test("iconState: complete → idle (no special icon)")
+  func iconStateComplete() {
+    #expect(MenuBarController.iconState(fixture(pipelineState: .complete)) == .idle)
+  }
+
+  @Test("iconState: idle + accessibility warning → error")
+  func iconStateAccessibilityWarning() {
+    let s = fixture(pipelineState: .idle, showAccessibilityWarning: true)
+    #expect(MenuBarController.iconState(s) == .error)
+  }
+
+  @Test("iconState: accessibility warning ignored while recording")
+  func iconStateWarningIgnoredWhileRecording() {
+    // needsAccessWarning requires `pipelineState == .idle`; recording wins.
+    let s = fixture(pipelineState: .recording, showAccessibilityWarning: true)
+    #expect(MenuBarController.iconState(s) == .recording)
+  }
+
+  @Test("iconState: idle + onboarding incomplete → error")
+  func iconStateOnboardingIncomplete() {
+    let s = fixture(pipelineState: .idle, onboardingComplete: false)
+    #expect(MenuBarController.iconState(s) == .error)
+  }
+
+  // MARK: - renderMenu golden fixtures
+
+  @Test("renderMenu (a): idle, onboarding complete, no warning, no updater")
+  func renderMenuIdle() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .idle))
+
+    let titles = menu.items.map(\.title)
+    #expect(
+      titles == [
+        "Parakeet v3 — LLM Deactivated",  // status line
+        "Version: \(AppConstants.appVersion)",
+        "",  // separator
+        "Start Recording",
+        "",  // separator
+        "Settings...",
+        "",  // separator
+        "Quit \(AppConstants.appName)",
+      ],
+      "Idle menu structure drifted. Got: \(titles)")
+
+    // Status + version items are disabled labels.
+    #expect(menu.items[0].isEnabled == false)
+    #expect(menu.items[1].isEnabled == false)
+    // Separators are separators.
+    #expect(menu.items[2].isSeparatorItem)
+    #expect(menu.items[4].isSeparatorItem)
+    #expect(menu.items[6].isSeparatorItem)
+    // Settings carries the comma key-equivalent; Quit carries "q".
+    #expect(item(menu, "Settings...")?.keyEquivalent == ",")
+    #expect(item(menu, "Quit \(AppConstants.appName)")?.keyEquivalent == "q")
+    // Every actionable item targets the controller.
+    for actionable in menu.items where actionable.action != nil {
+      #expect(
+        actionable.target as AnyObject? === controller,
+        "\(actionable.title) should target the MenuBarController")
+    }
+  }
+
+  @Test("renderMenu (b): recording → Stop Recording, record item enabled")
+  func renderMenuRecording() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .recording))
+
+    #expect(item(menu, "Stop Recording") != nil)
+    #expect(item(menu, "Start Recording") == nil)
+    // Record item is enabled while recording (so the user can stop).
+    #expect(item(menu, "Stop Recording")?.isEnabled == true)
+  }
+
+  @Test("renderMenu: record item disabled mid-pipeline (transcribing)")
+  func renderMenuRecordDisabledWhileTranscribing() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .transcribing))
+    // isActive && !isRecording → record item disabled.
+    #expect(item(menu, "Start Recording")?.isEnabled == false)
+  }
+
+  @Test("renderMenu (c): onboarding incomplete → Setup Required item on top")
+  func renderMenuOnboardingIncomplete() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, onboardingComplete: false))
+
+    #expect(menu.items.first?.title == "Setup Required: Continue Setup…")
+    #expect(menu.items.first?.target as AnyObject? === controller)
+    #expect(menu.items[1].isSeparatorItem)
+  }
+
+  @Test("renderMenu (d): accessibility warning → Paste disabled item")
+  func renderMenuAccessibilityWarning() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, showAccessibilityWarning: true))
+
+    let warning = item(menu, "Paste disabled — Accessibility required")
+    #expect(warning != nil)
+    #expect(warning?.target as AnyObject? === controller)
+  }
+
+  @Test("renderMenu (e): hasUpdater → Check for Updates targets SparkleUpdateController")
+  func renderMenuCheckForUpdates() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .idle, hasUpdater: true))
+
+    let updateItem = item(menu, "Check for Updates…")
+    #expect(updateItem != nil, "hasUpdater=true must render the Check for Updates item")
+    // PR-B.1 wiring preserved: the item targets the Sparkle controller, NOT
+    // the MenuBarController.
+    #expect(updateItem?.target is SparkleUpdateController)
+    #expect(updateItem?.target as AnyObject? !== controller)
+    #expect(
+      updateItem?.action == #selector(SparkleUpdateController.openUpdateCheckFromMenu(_:)))
+  }
+
+  @Test("renderMenu: auto-stop indicator appears when vadAutoStop is on")
+  func renderMenuAutoStop() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .idle, vadAutoStop: true))
+    #expect(item(menu, "Auto-stop on silence: On") != nil)
+  }
+
+  // MARK: - Action dispatch
+
+  @Test("menu actions dispatch into the injected MenuBarActions closures")
+  func actionsDispatch() async {
+    let spy = ActionSpy()
+    let controller = makeController(spy: spy)
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, onboardingComplete: false))
+
+    perform(item(menu, "Setup Required: Continue Setup…"))
+    #expect(spy.fired == ["continueOnboarding"])
+
+    perform(item(menu, "Settings..."))
+    #expect(spy.fired == ["continueOnboarding", "openSettings"])
+
+    perform(item(menu, "Quit \(AppConstants.appName)"))
+    #expect(spy.fired == ["continueOnboarding", "openSettings", "quit"])
+
+    // toggleRecording dispatches through an async Task — yield so it runs.
+    perform(item(menu, "Start Recording"))
+    await Task.yield()
+    await Task.yield()
+    #expect(spy.fired.contains("toggleRecording"))
+  }
+
+  @Test("accessibility-warning item dispatches openPermissions")
+  func warningItemDispatchesPermissions() {
+    let spy = ActionSpy()
+    let controller = makeController(spy: spy)
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, showAccessibilityWarning: true))
+    perform(item(menu, "Paste disabled — Accessibility required"))
+    #expect(spy.fired == ["openPermissions"])
+  }
+
+  // MARK: - Fixtures
+
+  private func fixture(
+    pipelineState: PipelineState,
+    onboardingComplete: Bool = true,
+    vadAutoStop: Bool = false,
+    showAccessibilityWarning: Bool = false,
+    hasUpdater: Bool = false
+  ) -> MenuBarViewState {
+    MenuBarViewState(
+      pipelineState: pipelineState,
+      asrLabel: "Parakeet v3",
+      llmLabel: "LLM Deactivated",
+      onboardingComplete: onboardingComplete,
+      vadAutoStop: vadAutoStop,
+      vadSilenceTimeout: 2.0,
+      showAccessibilityWarning: showAccessibilityWarning,
+      hasUpdater: hasUpdater
+    )
+  }
+
+  private func makeController(spy: ActionSpy = ActionSpy()) -> MenuBarController {
+    let asrManager = ASRManager()
+    // Shared lightweight audio fake from DictationRuntimeTestSupport (same
+    // test target). MenuBarController never reads `audioLevel` in these tests
+    // (the icon animator's level closure is only wired by `installStatusItem`,
+    // which the unit tests do not call).
+    let audioCapture: any AudioCaptureInterface = RouterTestAudioCapture()
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("menu-bar-controller-tests-\(UUID().uuidString)")
+    let store = TranscriptStore(directory: tempDir)
+    let parakeet = TranscriptionPipeline(
+      audioCapture: audioCapture, asrManager: asrManager, transcriptStore: store)
+    let whisperKit = WhisperKitPipeline(
+      audioCapture: audioCapture, backend: WhisperKitBackend(),
+      transcriptStore: store, keychainManager: KeychainManager())
+    let liveRecordingState = LiveRecordingState(
+      pipeline: parakeet, whisperKitPipeline: whisperKit,
+      audioCapture: audioCapture, asrManager: asrManager)
+    let settings = SettingsManager()
+    let backendMetadata = BackendMetadata(
+      settings: settings, asrManager: asrManager,
+      llmDiscovery: LLMModelDiscoveryCoordinator(keychainManager: KeychainManager()))
+    // Nil-fake updater factory — no real Sparkle boot in the test process.
+    let sparkle = SparkleUpdateController(
+      holder: UpdateCoordinatorHolder(),
+      bundleVersionProvider: { "v-test" },
+      updaterFactory: SparkleUpdaterFactory { _, _ in nil })
+    let controller = MenuBarController(
+      liveRecordingState: liveRecordingState,
+      backendMetadata: backendMetadata,
+      sparkleUpdateController: sparkle,
+      settings: settings,
+      permissions: PermissionsService(),
+      actions: MenuBarActions(
+        continueOnboarding: { spy.fired.append("continueOnboarding") },
+        openSettings: { spy.fired.append("openSettings") },
+        openPermissions: { spy.fired.append("openPermissions") },
+        toggleRecording: { spy.fired.append("toggleRecording") },
+        quit: { spy.fired.append("quit") }
+      )
+    )
+    return controller
+  }
+
+  private func item(_ menu: NSMenu, _ title: String) -> NSMenuItem? {
+    menu.items.first { $0.title == title }
+  }
+
+  private func perform(_ menuItem: NSMenuItem?) {
+    guard let menuItem, let action = menuItem.action,
+      let target = menuItem.target as? NSObject
+    else {
+      Issue.record("Menu item missing target/action")
+      return
+    }
+    target.perform(action, with: menuItem)
+  }
+}
+
+/// Records which `MenuBarActions` closure fired, in order.
+@MainActor
+final class ActionSpy {
+  var fired: [String] = []
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -58,13 +58,20 @@ import Testing
   ///   constructed in `init()` with two onboarding-guard closures and threaded
   ///   into `appDelegate.attach(...)` plus injected into both Window scenes
   ///   via `.environment(...)`.
+  /// - 15 → 16 in PR-B.3 of epic #763 (2026-05-20, #798) for
+  ///   `MenuBarController`. Bible §30 entry: PR-B.3 lifts the menu bar surface
+  ///   (status item, dropdown menu, animated icon, `NSMenuDelegate`, five menu
+  ///   actions) off AppDelegate into a dedicated App-owned home. The `@State`
+  ///   instance is constructed in `init()` with five menu-action closures and
+  ///   threaded into `appDelegate.attach(...)`. Not `.environment(...)`-injected
+  ///   — no SwiftUI view consumes the menu surface.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 15,
+      count <= 16,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 15. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 16. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -103,14 +110,18 @@ import Testing
   /// two `.environment(...)` injections, and the `ActionWirer` drain-before-
   /// auto-open rewrite. Soft trip-wire only — the stored-property cap is the
   /// primary entanglement signal.
+  /// Ratcheted 340→370 in PR-B.3 of epic #763 (2026-05-20, #798) to absorb
+  /// `MenuBarController` construction (~22 lines: five menu-action closures),
+  /// the `@State` declaration, and the `_menuBarController` assignment. The
+  /// `attach(...)` arg count is unchanged (drops two, adds one).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 340,
+      lineCount <= 370,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 340. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 370. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/MenuBarControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/MenuBarControllerCeilingsTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+/// PR-B.3 of #763 — locks `MenuBarController`'s initial shape so the extracted
+/// menu home does not silently accrete domain state.
+///
+/// The shape gate is an EXACT stored-property-name allowlist, not a
+/// parser-visible count (PR-B.2 §3a established that a count alone is coverage
+/// theater — the shared parser counts only non-primitive `let`s). This test
+/// parses every stored declaration in the class body (`let` and `var`, all
+/// access levels, primitives included) and asserts the name set EQUALS the
+/// 8-name allowlist. Adding a 9th field fails the test.
+///
+/// Bible §30 baseline: 8 stored (`iconAnimator`, `liveRecordingState`,
+/// `backendMetadata`, `sparkleUpdateController`, `settings`, `permissions`,
+/// `actions`, `statusItem`); non-private `func`s `installStatusItem`,
+/// `updateIcon`, `renderMenu`, `iconState` (`init` is not a `func`,
+/// `currentViewState` is private). One allowed extension — `NSMenuDelegate`.
+@Suite struct MenuBarControllerCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/MenuBarController.swift"
+
+  private static let storedPropertyAllowlist: Set<String> = [
+    "iconAnimator",
+    "liveRecordingState",
+    "backendMetadata",
+    "sparkleUpdateController",
+    "settings",
+    "permissions",
+    "actions",
+    "statusItem",
+  ]
+
+  @Test func storedPropertyNamesMatchAllowlist() throws {
+    let body = try classBodyOfMenuBarController()
+    let names = storedPropertyNames(in: body)
+    let extras = names.subtracting(Self.storedPropertyAllowlist)
+    let missing = Self.storedPropertyAllowlist.subtracting(names)
+    #expect(
+      extras.isEmpty && missing.isEmpty,
+      """
+      MenuBarController stored-property set drifted from the PR-B.3 8-name \
+      allowlist. Unexpected: \(extras.sorted()). Missing: \(missing.sorted()). \
+      Adding a stored property is god-object drift — raising the allowlist \
+      requires a Bible §30 entry. Removing one means this allowlist must \
+      shrink in the same PR.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try classBodyOfMenuBarController()
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 8,
+      """
+      MenuBarController non-private method ceiling exceeded: \(count) > 8 \
+      non-private `func` declarations in the class body. PR-B.3 baseline: \
+      installStatusItem, updateIcon, renderMenu, iconState.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 600,
+      """
+      MenuBarController line count exceeded: \(count) > 600 (soft trip-wire). \
+      File should stay focused on the menu bar surface.
+      """)
+  }
+
+  @Test func onlyTheNSMenuDelegateExtension() throws {
+    // Guard against smuggling methods through an extension that escapes the
+    // in-class non-private method count. The `NSMenuDelegate` conformance is
+    // the one allowed extension.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let pattern = #"^[[:space:]]*extension[[:space:]]+MenuBarController\b[^\n]*"#
+    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    let declarations = matches.map { ns.substring(with: $0.range) }
+    let disallowed = declarations.filter { !$0.contains("NSMenuDelegate") }
+    #expect(
+      disallowed.isEmpty,
+      """
+      MenuBarController has extension(s) other than the NSMenuDelegate \
+      conformance: \(disallowed). Methods belong in the class body so the \
+      non-private method ceiling sees them.
+      """)
+  }
+
+  @Test func noAppStateReference() throws {
+    // The controller must carry no `AppState` import or type reference — its
+    // read dependencies are narrow PR11-survivor refs injected at construction.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let regex = try NSRegularExpression(pattern: #"\bAppState\b"#)
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    #expect(
+      matches.isEmpty,
+      """
+      MenuBarController.swift references `AppState` \(matches.count) time(s); \
+      expected 0. The menu home must stay AppState-free — it reads display \
+      facts through `liveRecordingState` / `backendMetadata` / `settings` / \
+      `permissions` / `sparkleUpdateController`.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = [
+      "AppKit", "EnviousWisprCore", "EnviousWisprServices", "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      MenuBarController imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+
+  /// Parser self-test: a fixture body with a 9th stored property must be
+  /// flagged. If this stops failing, the real gate above is untrustworthy.
+  @Test func parserCatchesExtraStoredProperty() {
+    let fixture = """
+        private let iconAnimator = MenuBarIconAnimator()
+        private let liveRecordingState: LiveRecordingState
+        private let actions: MenuBarActions
+        private var statusItem: NSStatusItem?
+        private var smuggledExtraField: Int = 0
+      """
+    let names = storedPropertyNames(in: fixture)
+    #expect(
+      names.contains("smuggledExtraField"),
+      "Parser failed to detect a smuggled stored property — the gate cannot be trusted.")
+  }
+}
+
+/// Extracts the `MenuBarController` class body — the text between the class's
+/// own braces. Brace-balanced scan anchored on the declaration's `{` (NOT the
+/// first inner brace).
+private func classBodyOfMenuBarController() throws -> String {
+  let source = try String(
+    contentsOf: URL(fileURLWithPath: "Sources/EnviousWispr/App/MenuBarController.swift"),
+    encoding: .utf8)
+  guard let openRange = source.range(of: "final class MenuBarController: NSObject {") else {
+    Issue.record("MenuBarController declaration not found at expected path/shape")
+    throw POSIXError(.ENOENT)
+  }
+  let openIdx = source.index(before: openRange.upperBound)  // points at '{'
+  var depth = 0
+  var idx = openIdx
+  while idx < source.endIndex {
+    let c = source[idx]
+    if c == "{" { depth += 1 }
+    if c == "}" {
+      depth -= 1
+      if depth == 0 { return String(source[source.index(after: openIdx)..<idx]) }
+    }
+    idx = source.index(after: idx)
+  }
+  Issue.record("MenuBarController class body has unbalanced braces")
+  throw POSIXError(.EILSEQ)
+}
+
+/// Extracts the names of top-level (brace-depth 0) `let`/`var` stored-property
+/// declarations in a class body. Includes all access levels and primitive
+/// types; excludes computed properties (declaration line ends with `{`).
+private func storedPropertyNames(in body: String) -> Set<String> {
+  let declPattern =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+    + #"(public|internal|private|fileprivate|package|open)?[[:space:]]*"#
+    + #"(weak[[:space:]]+)?(let|var)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+  guard let regex = try? NSRegularExpression(pattern: declPattern) else { return [] }
+
+  var depth = 0
+  var names: Set<String> = []
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      let isComputed =
+        s.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil
+      if !isComputed {
+        let ns = s as NSString
+        if let m = regex.firstMatch(
+          in: s, range: NSRange(location: 0, length: ns.length)),
+          m.numberOfRanges > 6, m.range(at: 6).location != NSNotFound
+        {
+          names.insert(ns.substring(with: m.range(at: 6)))
+        }
+      }
+    }
+    depth += opens - closes
+  }
+  return names
+}


### PR DESCRIPTION
## Summary

PR-B.3 of the AppState-deletion epic (#763), third of four child PRs under #780. Extracts the menu bar surface — status item, dropdown menu, animated icon, `NSMenuDelegate`, and the five `@objc` menu actions — out of `AppDelegate` into a new App-owned `MenuBarController`. After PR-B.3, `AppDelegate` owns the launch sequence only.

- `MenuBarController` is `@State` on `EnviousWisprApp`, weak ref on `AppDelegate` via `attach(...)`. Reads display facts through narrow PR11-survivor refs (`LiveRecordingState`, `BackendMetadata`, `SparkleUpdateController`, `SettingsManager`, `PermissionsService`) — no `AppState` reference.
- Menu rendering and icon mapping are pure functions over a `MenuBarViewState` value (`renderMenu`, `iconState`); `currentViewState()` snapshots the live homes. Identity-preserving — menu items, separators, key equivalents, targets, and icon transitions are byte-identical to the pre-PR code.
- The "Check for Updates" item keeps the PR-B.1 `SparkleUpdateController` target/action wiring verbatim. The accessibility-change icon-refresh seam moves into `installStatusItem()`. The audio-level reader switches from the broad `AppState` reach-through to the narrow `LiveRecordingState.audioLevel`.
- `attach(...)` drops `navigationCoordinator` + `backendMetadata`, adds `menuBarController` (8 params).

Closes #798.

## Review trail

- Plan: `docs/feature-requests/issue-798-2026-05-20-pr-b3-menubar.md` — council (GPT + Gemini) + 5 Codex grounded-review rounds (`PROCEED-AS-PLANNED`).
- Codex code-diff review: `SHIP`, no defects.

## Test plan

- [x] `swift build -c release` clean.
- [x] Full suite green — 1105 tests, including new `MenuBarControllerTests` (golden menu fixtures + `iconState` + action dispatch) and `MenuBarControllerCeilingsTests`.
- [x] Live UAT, debug build: menu-driven dictation passes on both backends (Parakeet 1.7s, WhisperKit 3.6s) — "Start Recording"/"Stop Recording" menu items, pipeline complete, exact transcript, clipboard verified.
