### PR TITLE
refactor(appstate): extract AppLifecycleCoordinator from AppDelegate (PR-B.4 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppDelegate.swift
+++ b/Sources/EnviousWispr/App/AppDelegate.swift
@@ -1,373 +1,75 @@
 import AppKit
-import EnviousWisprASR
-import EnviousWisprAudio
-import EnviousWisprCore
-import EnviousWisprLLM
 import EnviousWisprServices
-import SwiftUI
+import Foundation
 
-// Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` were previously
-// DEBUG-only here for `DebugFaultEndpoint`. They are now needed in release
-// builds too because `AudioSystemEventReporter` (production telemetry)
-// references `AudioCaptureInterface` and `ASRManagerInterface` types from
-// those modules.
-
-#if DEBUG
-  import EnviousWisprPipeline
-#endif
-
-/// AppDelegate that manages the menu bar status item using NSStatusItem.
+/// AppDelegate manages the menu bar status item lifecycle via AppKit.
 ///
-/// SwiftUI's MenuBarExtra has known click-routing issues when launched
-/// outside Xcode or as a bare binary. NSStatusItem is the battle-tested
-/// native approach that reliably handles clicks on all macOS versions.
+/// SwiftUI's MenuBarExtra has known click-routing issues when launched outside
+/// Xcode or as a bare binary, so the app uses an `NSApplicationDelegate`.
+///
+/// PR-B of #763: `AppDelegate` is a thin AppKit adapter. It owns no app state
+/// — `EnviousWisprApp` owns the App-owned homes as `@State` and pushes two
+/// weak refs in via `attach(...)` synchronously during `EnviousWisprApp.init()`,
+/// before any `NSApplicationDelegate` callback fires. The five forced delegate
+/// callbacks forward to `SparkleUpdateController` and `AppLifecycleCoordinator`.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-  // PR-A of #763: App-owned homes. `EnviousWisprApp` owns these as `@State`
-  // and pushes them into AppDelegate via `attach(...)` synchronously during
-  // `EnviousWisprApp.init()`, before any `NSApplicationDelegate` callback
-  // fires. Weak refs so AppDelegate is not a retention root.
-  private weak var appState: AppState?
-  /// PR-B.1 of #763: App-owned home for the Sparkle integration. Strong
-  /// owner is `EnviousWisprApp`'s `@State`. AppDelegate's relationship
-  /// is reduced to invoking `startUpdater()` from
-  /// `applicationWillFinishLaunching` and gating the menu's
-  /// "Check for Updates" item.
   private weak var sparkleUpdateController: SparkleUpdateController?
-  /// PR7 of #763: weak ref to the App-owned live-recording home.
-  /// `AudioSystemEventReporter.pipelineStateProvider` reads `pipelineState`
-  /// from it (see `applicationDidFinishLaunching`). The menu-bar reads that
-  /// previously routed through here moved to `MenuBarController` in PR-B.3.
-  private weak var liveRecordingState: LiveRecordingState?
-  /// PR9 of #763: the pipeline state-change callback (icon updates,
-  /// audio-environment snapshot triggers) lives on the new lifecycle home now.
-  /// AppDelegate sets `dictationLifecycleCoordinator.onPipelineStateChange`
-  /// in `applicationDidFinishLaunching`. Weak ref — strong owner is
-  /// `DictationRuntime` via `EnviousWisprApp`'s `@State`.
-  private weak var dictationLifecycleCoordinator: DictationLifecycleCoordinator?
-  /// PR10 of #763: the recording-control façade (start hotkey service,
-  /// menu-bar toggle). Weak ref — strong owner is `EnviousWisprApp`'s
-  /// `@State`. Used by `applicationDidFinishLaunching` (hotkey start) and
-  /// the `@objc toggleRecording` menu-bar action.
-  private weak var dictationRuntime: DictationRuntime?
-  /// PR10 of #763: shared `HotkeyService` owned by `EnviousWisprApp` as
-  /// `@State`. AppDelegate calls `.stop()` on termination so the Carbon
-  /// hotkey registration is cleaned up before the run loop tears down.
-  /// Replaces the pre-PR10 `appState.hotkeyService.stop()` call.
-  private weak var hotkeyService: HotkeyService?
-  /// PR-B.2 of #763: App-owned home for window lifecycle (main + onboarding
-  /// window identity, the two `NSWindow.willCloseNotification` observers, the
-  /// SwiftUI open/dismiss bridges, activation-policy transitions). Weak ref —
-  /// strong owner is `EnviousWisprApp`'s `@State`. AppDelegate routes
-  /// `installOnLaunch()` / `tearDown()` from its lifecycle callbacks.
-  private weak var appWindowCoordinator: AppWindowCoordinator?
-  /// PR-B.3 of #763: App-owned home for the menu bar surface (status item,
-  /// dropdown menu, animated icon, menu actions). Weak ref — strong owner is
-  /// `EnviousWisprApp`'s `@State`. AppDelegate calls `installStatusItem()`
-  /// from launch and routes the three external icon-refresh seams here.
-  private weak var menuBarController: MenuBarController?
+  private weak var appLifecycleCoordinator: AppLifecycleCoordinator?
 
-  /// PR-A of #763: receive App-owned home refs from `EnviousWisprApp.init()`
-  /// before delegate callbacks fire.
-  ///
-  /// PR9 of #763: additionally receive `dictationLifecycleCoordinator` so the
-  /// icon-update callback can be installed on the new home (was on AppState
-  /// pre-PR9).
-  ///
-  /// PR-B.1 of #763: replace the `updateCoordinatorHolder` parameter with
-  /// `sparkleUpdateController`. AppDelegate no longer owns the holder ref —
-  /// the controller does, and the controller publishes into it from
-  /// `startUpdater()`.
-  ///
-  /// PR-B.2 of #763: additionally receive `appWindowCoordinator` so the
-  /// lifecycle callbacks can install/tear down the window observers.
-  ///
-  /// PR-B.3 of #763: additionally receive `menuBarController`; drop
-  /// `navigationCoordinator` and `backendMetadata` (both were only read by the
-  /// menu code that moved to `MenuBarController`). The `onOnboardingDismissed`
-  /// icon-refresh seam now targets `menuBarController`.
+  /// Receive App-owned home refs from `EnviousWisprApp.init()` before any
+  /// delegate callback fires.
   func attach(
-    appState: AppState,
     sparkleUpdateController: SparkleUpdateController,
-    liveRecordingState: LiveRecordingState,
-    dictationLifecycleCoordinator: DictationLifecycleCoordinator,
-    dictationRuntime: DictationRuntime,
-    hotkeyService: HotkeyService,
-    appWindowCoordinator: AppWindowCoordinator,
-    menuBarController: MenuBarController
+    appLifecycleCoordinator: AppLifecycleCoordinator
   ) {
-    self.appState = appState
     self.sparkleUpdateController = sparkleUpdateController
-    self.liveRecordingState = liveRecordingState
-    self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
-    self.dictationRuntime = dictationRuntime
-    self.hotkeyService = hotkeyService
-    self.appWindowCoordinator = appWindowCoordinator
-    self.menuBarController = menuBarController
-    // Icon-refresh seam: the coordinator's two onboarding-dismiss callsites
-    // route through this closure. PR-B.3 retargets it to MenuBarController.
-    appWindowCoordinator.onOnboardingDismissed = { [weak menuBarController] in
-      menuBarController?.updateIcon()
-    }
+    self.appLifecycleCoordinator = appLifecycleCoordinator
   }
 
-  #if DEBUG
-    /// V2 fault-injection control surface (issue #291). Started only when
-    /// `EW_FAULT_INJECTION=1` is set in the launching environment. Stopped in
-    /// `applicationWillTerminate`. Compiled out of release entirely.
-    private var debugFaultEndpoint: DebugFaultEndpoint?
-  #endif
-
-  /// Production telemetry observer for OS-level audio events (issue #574).
-  /// Sentry breadcrumb on every fire; PostHog event on fire-during-recording.
-  /// Constructed in `applicationDidFinishLaunching` after AppState is ready;
-  /// torn down in `applicationWillTerminate` for clean observer removal.
-  private var audioSystemEventReporter: AudioSystemEventReporter?
-  private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
-
-  /// Issue #739: instantiate the Sparkle updater + update-banner coordinator
-  /// BEFORE SwiftUI mounts the App's scenes. PR-B.1 of #763 moves the body
-  /// into `SparkleUpdateController.startUpdater()`; this method now only
-  /// forwards. Loud nil-guard (not silent optional chain): if the weak ref
-  /// is nil at this point, debug crashes with `assertionFailure` and
-  /// release logs the skip — the update mechanism must never silently
-  /// dormant.
+  /// Issue #739: Sparkle's cross-launch correlation must run at this earliest
+  /// callback, before SwiftUI mounts the App's scenes (PR-B.1 of #763).
   func applicationWillFinishLaunching(_ notification: Notification) {
-    guard let controller = sparkleUpdateController else {
-      assertionFailure(
-        "SparkleUpdateController must be attached before applicationWillFinishLaunching fires."
-      )
-      Task {
-        await AppLogger.shared.log(
-          "Sparkle startup skipped: controller ref is nil. Update banner will not render this session.",
-          level: .info,
-          category: "AppDelegate"
-        )
-      }
-      return
-    }
-    controller.startUpdater()
+    assertAttached(sparkleUpdateController, "sparkleUpdateController")
+    sparkleUpdateController?.startUpdater()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
-    // PR-A: appState is App-owned; we hold a weak ref attached during
-    // EnviousWisprApp.init() (before any delegate callback fires).
-    guard let appState = self.appState else { return }
-    // Hide dock icon on launch — we're a menu bar utility.
-    // If onboarding is needed, stay .regular so SwiftUI creates the main window hierarchy
-    // and ActionWirer can wire callbacks before opening the onboarding window.
-    if appState.settings.onboardingState == .completed {
-      NSApp.setActivationPolicy(.accessory)
-    }
-
-    // Issue #445: launch-time telemetry callback wiring. Single line, no
-    // AppState collaborator growth. ASRManagerProxy/ASRManager fire this
-    // closure from inside `loadModelSilently()` so the launch-warming path
-    // (previously silent on success by design) becomes visible in PostHog.
-    ASRManagerProxy.launchPreloadReporter = { backend, result, durationMs in
-      Task { @MainActor in
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: backend, result: result, durationMs: durationMs)
-      }
-    }
-    ASRManager.launchPreloadReporter = { backend, result, durationMs in
-      Task { @MainActor in
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: backend, result: result, durationMs: durationMs)
-      }
-    }
-
-    // PR-B.2 of #763: the window-close observer lives on AppWindowCoordinator
-    // now. Loud nil-guard, but NOT a method-wide early return — the rest of
-    // `applicationDidFinishLaunching` (status item, hotkey start, telemetry,
-    // permissions, LLM pre-warm, audio reporters) must always run. Window
-    // observation is a limb; app startup is not. Position preserved: same
-    // mid-method point the inline observer block occupied before PR-B.2.
-    if let appWindowCoordinator {
-      appWindowCoordinator.installOnLaunch()
-    } else {
-      assertionFailure(
-        "AppWindowCoordinator must be attached before applicationDidFinishLaunching fires."
-      )
-      Task {
-        await AppLogger.shared.log(
-          "Window observer install skipped: coordinator ref is nil. Activation-policy revert on window close will not work this session.",
-          level: .info,
-          category: "AppDelegate"
-        )
-      }
-    }
-
-    // Issue #739 / PR-B.1 of #763: Sparkle updater, update coordinator, and
-    // cross-launch correlation all live on `SparkleUpdateController` now and
-    // are invoked from `applicationWillFinishLaunching` so SwiftUI's env
-    // value snapshot is non-nil when the App body first evaluates.
-
-    // PR-B.3 of #763: the menu bar surface lives on `MenuBarController` now.
-    menuBarController?.installStatusItem()
-
-    // Update menu bar icon whenever pipeline state changes. PR9 of #763: the
-    // callback lives on `DictationLifecycleCoordinator`. PR-B.3 of #763: the
-    // icon call targets `MenuBarController`. The closure stays here because it
-    // is composite — it also triggers the audio-environment snapshotter, which
-    // does not move off AppDelegate until PR-B.4.
-    dictationLifecycleCoordinator?.onPipelineStateChange = { [weak self] state in
-      guard let self else { return }
-      self.menuBarController?.updateIcon()
-      // Issue #739: do NOT forward pipeline state to the update widget. The
-      // widget is now bundle-version-driven only — visible whenever an update
-      // is pending, period. Matches Claude Desktop / Slack / Cursor update-prompt
-      // conventions (no auto-hide during active work).
-      if state == .recording {
-        self.audioEnvironmentSnapshotter?.recordingStarted()
-      }
-    }
-    // PR-B.3 of #763: the accessibility-change icon-refresh seam moved into
-    // `MenuBarController.installStatusItem()`.
-
-    // Start hotkeys now that the event loop is running.
-    // Carbon RegisterEventHotKey requires an active run loop for event delivery.
-    // PR10 of #763 — façade pass-through; HotkeyController owns the
-    // `settings.hotkeyEnabled` gate and the `hotkeyService.start()` call.
-    dictationRuntime?.startHotkeyServiceIfEnabled()
-
-    if appState.settings.onboardingState == .completed {
-      let s = appState.settings
-      let hasKeys =
-        (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
-        || (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
-      TelemetryService.shared.settingsSnapshot(
-        asrBackend: s.selectedBackend.rawValue,
-        llmProvider: s.llmProvider.rawValue,
-        recordingMode: s.recordingMode.rawValue,
-        fillerRemoval: s.fillerRemovalEnabled,
-        customWordsCount: appState.customWordsCoordinator.customWords.count,
-        hasApiKeys: hasKeys,
-        noiseSuppression: s.noiseSuppression
-      )
-    }
-
-    // Run Apple Intelligence diagnostics via coordinator.
-    // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
-    let isFreshInstall = appState.settings.onboardingState != .completed
-    if isFreshInstall {
-      appState.aiAvailability.firstLaunchCheck()
-    } else {
-      Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
-    }
-
-    // Fire structured app.launched event — uses cached report (loaded from UserDefaults in coordinator init).
-    // No async wait needed — cached snapshot is available synchronously.
-    let version =
-      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-    let osVer = ProcessInfo.processInfo.operatingSystemVersion
-    let cachedReport = appState.aiAvailability.latestReport
-    TelemetryService.shared.appLaunched(
-      version: version,
-      build: build,
-      osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
-      hardware: cachedReport?.hardwareClass ?? "unknown",
-      isFreshInstall: isFreshInstall,
-      aiAvailable: cachedReport?.overallStatus == .available
-    )
-
-    // Check Accessibility permission on launch (query only — never auto-prompt).
-    appState.permissions.refreshOnLaunch()
-    menuBarController?.updateIcon()  // Reflect accessibility warning state in menu bar icon
-
-    // Begin smart polling if Accessibility is not yet granted.
-    appState.permissions.startMonitoring()
-
-    // Pre-warm LLM backend with a real inference request.
-    LLMNetworkSession.shared.preWarmModel(
-      provider: appState.settings.llmProvider,
-      model: appState.settings.llmModel,
-      keychainManager: appState.keychainManager
-    )
-
-    // Onboarding auto-open is handled by ActionWirer inside the main Window scene.
-    // ActionWirer wires all callbacks first, then calls openOnboardingWindow() if needed.
-    // No deferred dispatch required here.
-
-    #if DEBUG
-      // V2 fault-injection (issue #291). Only when explicitly opted in via env var.
-      if DebugFaultEndpoint.isRequested {
-        let endpoint = DebugFaultEndpoint(
-          audioProxy: appState.audioCapture as? AudioCaptureProxy,
-          asrProxy: appState.asrManager as? ASRManagerProxy,
-          parakeetPipeline: appState.pipeline,
-          whisperKitPipeline: appState.whisperKitPipeline,
-          activeBackend: { [weak self] in
-            self?.appState?.settings.selectedBackend ?? .parakeet
-          }
-        )
-        endpoint.start()
-        debugFaultEndpoint = endpoint
-      }
-    #endif
-
-    audioEnvironmentSnapshotter = AudioEnvironmentSnapshotter(
-      routeProvider: { [weak self] in
-        self?.appState?.audioCapture.currentAudioRoute
-      }
-    )
-    SentryBreadcrumb.audioEnvironmentProvider = { [weak self] in
-      self?.audioEnvironmentSnapshotter?.latestForError()
-    }
-
-    // Production telemetry: OS-level audio events (issue #574). Always on in
-    // release; ships to all users so we get cross-user data on what real
-    // devices/routes/connections users actually hit.
-    audioSystemEventReporter = AudioSystemEventReporter(
-      audioCapture: appState.audioCapture,
-      asrManager: appState.asrManager,
-      pipelineStateProvider: { [weak self] in
-        // PR7 of #763: pipeline phase resolves through LiveRecordingState.
-        self?.liveRecordingState?.pipelineState ?? .idle
-      },
-      onAudioDeviceEvent: { [weak self] in
-        self?.audioEnvironmentSnapshotter?.audioDeviceEventOccurred()
-      }
-    )
+    assertAttached(appLifecycleCoordinator, "appLifecycleCoordinator")
+    appLifecycleCoordinator?.runDidFinishLaunching()
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {
-    audioEnvironmentSnapshotter?.applicationBecameActive()
-
-    // Re-warm LLM backend when app comes to foreground.
-    guard let appState = self.appState else { return }
-    LLMNetworkSession.shared.preWarmModel(
-      provider: appState.settings.llmProvider,
-      model: appState.settings.llmModel,
-      keychainManager: appState.keychainManager
-    )
+    appLifecycleCoordinator?.runDidBecomeActive()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
-    // PR-B.2 of #763: both window-close observers are torn down by the
-    // coordinator now.
-    appWindowCoordinator?.tearDown()
-    appState?.setup.ollamaSetup.cleanup()
-    // PR10 of #763 — shared HotkeyService is owned by EnviousWisprApp as
-    // `@State`; AppDelegate holds a weak ref pushed via `attach(...)`.
-    hotkeyService?.stop()
-    LLMNetworkSession.shared.invalidate()
-
-    #if DEBUG
-      debugFaultEndpoint?.stop()
-      debugFaultEndpoint = nil
-    #endif
-
-    // Issue #574: tear down audio-event observers cleanly.
-    audioSystemEventReporter = nil
-    SentryBreadcrumb.audioEnvironmentProvider = nil
-    audioEnvironmentSnapshotter = nil
+    appLifecycleCoordinator?.runWillTerminate()
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     // Menu bar app — keep running when windows close.
     // User quits via "Quit EnviousWispr" in the status bar menu.
     return false
+  }
+
+  /// Loud tripwire for a wiring regression: a weak ref must never be nil when
+  /// a lifecycle callback fires (`attach(...)` runs synchronously in
+  /// `EnviousWisprApp.init()`). Debug builds crash so the mistake is caught
+  /// before any release ships; release builds emit a Sentry breadcrumb so a
+  /// future regression is diagnosable. The nil path is unreachable in a
+  /// correctly-wired build.
+  private func assertAttached<T: AnyObject>(_ ref: T?, _ name: String) {
+    #if DEBUG
+      if ref == nil {
+        assertionFailure(
+          "AppDelegate.\(name) was nil during a lifecycle callback — "
+            + "EnviousWisprApp.init() wiring failure.")
+      }
+    #endif
+    if ref == nil {
+      SentryBreadcrumb.add(
+        stage: "app_delegate", message: "lifecycle ref nil", data: ["ref": name])
+    }
   }
 }

--- a/Sources/EnviousWispr/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWispr/App/AppLifecycleCoordinator.swift
@@ -1,0 +1,254 @@
+import AppKit
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+
+// Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` are needed in release
+// builds because `AudioSystemEventReporter` (production telemetry) references
+// `AudioCaptureInterface` and `ASRManagerInterface` from those modules.
+
+#if DEBUG
+  import EnviousWisprPipeline
+#endif
+
+/// PR-B.4 of #763: App-owned home for the process-lifecycle sequence.
+///
+/// Coordinates the launch / foreground-activation / termination side effects
+/// that were previously inlined in `AppDelegate`'s `NSApplicationDelegate`
+/// callbacks. `EnviousWisprApp` owns this as `@State`; `AppDelegate` holds a
+/// weak ref and forwards its three lifecycle callbacks here. The three `run*`
+/// methods are verbatim relocations of the corresponding `AppDelegate`
+/// callback bodies — same launch order, same telemetry, same teardown.
+@MainActor
+final class AppLifecycleCoordinator {
+  // Owned process-lifetime objects: constructed in `runDidFinishLaunching`,
+  // torn down in `runWillTerminate`.
+  private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
+  private var audioSystemEventReporter: AudioSystemEventReporter?
+
+  #if DEBUG
+    /// V2 fault-injection control surface (issue #291). Started only when
+    /// `EW_FAULT_INJECTION=1` is set in the launching environment. Stopped in
+    /// `runWillTerminate`. Compiled out of release entirely.
+    private var debugFaultEndpoint: DebugFaultEndpoint?
+  #endif
+
+  // Injected dependencies — delegated to, never owned.
+  private let appState: AppState
+  private let dictationRuntime: DictationRuntime
+  private let dictationLifecycleCoordinator: DictationLifecycleCoordinator
+  private let liveRecordingState: LiveRecordingState
+  private let menuBarController: MenuBarController
+  private let appWindowCoordinator: AppWindowCoordinator
+  private let hotkeyService: HotkeyService
+
+  init(
+    appState: AppState,
+    dictationRuntime: DictationRuntime,
+    dictationLifecycleCoordinator: DictationLifecycleCoordinator,
+    liveRecordingState: LiveRecordingState,
+    menuBarController: MenuBarController,
+    appWindowCoordinator: AppWindowCoordinator,
+    hotkeyService: HotkeyService
+  ) {
+    self.appState = appState
+    self.dictationRuntime = dictationRuntime
+    self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
+    self.liveRecordingState = liveRecordingState
+    self.menuBarController = menuBarController
+    self.appWindowCoordinator = appWindowCoordinator
+    self.hotkeyService = hotkeyService
+    // Icon-refresh seam: the window coordinator's two onboarding-dismiss
+    // callsites route through this closure. Was wired in `AppDelegate.attach`
+    // before PR-B.4.
+    appWindowCoordinator.onOnboardingDismissed = { [weak menuBarController] in
+      menuBarController?.updateIcon()
+    }
+  }
+
+  func runDidFinishLaunching() {
+    // Hide dock icon on launch — we're a menu bar utility.
+    // If onboarding is needed, stay .regular so SwiftUI creates the main window
+    // hierarchy and ActionWirer can wire callbacks before opening the
+    // onboarding window.
+    if appState.settings.onboardingState == .completed {
+      NSApp.setActivationPolicy(.accessory)
+    }
+
+    // Issue #445: launch-time telemetry callback wiring. ASRManagerProxy/
+    // ASRManager fire this closure from inside `loadModelSilently()` so the
+    // launch-warming path (previously silent on success) becomes visible in
+    // PostHog.
+    ASRManagerProxy.launchPreloadReporter = { backend, result, durationMs in
+      Task { @MainActor in
+        TelemetryService.shared.launchModelPreloadCompleted(
+          backend: backend, result: result, durationMs: durationMs)
+      }
+    }
+    ASRManager.launchPreloadReporter = { backend, result, durationMs in
+      Task { @MainActor in
+        TelemetryService.shared.launchModelPreloadCompleted(
+          backend: backend, result: result, durationMs: durationMs)
+      }
+    }
+
+    // PR-B.2 of #763: the window-close observer lives on AppWindowCoordinator.
+    appWindowCoordinator.installOnLaunch()
+
+    // PR-B.3 of #763: the menu bar surface lives on `MenuBarController`.
+    menuBarController.installStatusItem()
+
+    // Update menu bar icon whenever pipeline state changes. The closure is
+    // composite — it also triggers the audio-environment snapshotter on
+    // `.recording`. PR-B.4 of #763: both the snapshotter and this closure now
+    // live in `AppLifecycleCoordinator`, so the closure is one coherent unit.
+    dictationLifecycleCoordinator.onPipelineStateChange = { [weak self] state in
+      guard let self else { return }
+      self.menuBarController.updateIcon()
+      // Issue #739: do NOT forward pipeline state to the update widget. The
+      // widget is bundle-version-driven only — visible whenever an update is
+      // pending, matching Claude Desktop / Slack / Cursor conventions.
+      if state == .recording {
+        self.audioEnvironmentSnapshotter?.recordingStarted()
+      }
+    }
+
+    // Start hotkeys now that the event loop is running.
+    // Carbon RegisterEventHotKey requires an active run loop for event delivery.
+    dictationRuntime.startHotkeyServiceIfEnabled()
+
+    if appState.settings.onboardingState == .completed {
+      let s = appState.settings
+      let hasKeys =
+        (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
+        || (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
+      TelemetryService.shared.settingsSnapshot(
+        asrBackend: s.selectedBackend.rawValue,
+        llmProvider: s.llmProvider.rawValue,
+        recordingMode: s.recordingMode.rawValue,
+        fillerRemoval: s.fillerRemovalEnabled,
+        customWordsCount: appState.customWordsCoordinator.customWords.count,
+        hasApiKeys: hasKeys,
+        noiseSuppression: s.noiseSuppression
+      )
+    }
+
+    // Run Apple Intelligence diagnostics via coordinator.
+    // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
+    let isFreshInstall = appState.settings.onboardingState != .completed
+    if isFreshInstall {
+      appState.aiAvailability.firstLaunchCheck()
+    } else {
+      Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
+    }
+
+    // Fire structured app.launched event — uses cached report (loaded from
+    // UserDefaults in coordinator init). No async wait needed.
+    let version =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+    let osVer = ProcessInfo.processInfo.operatingSystemVersion
+    let cachedReport = appState.aiAvailability.latestReport
+    TelemetryService.shared.appLaunched(
+      version: version,
+      build: build,
+      osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
+      hardware: cachedReport?.hardwareClass ?? "unknown",
+      isFreshInstall: isFreshInstall,
+      aiAvailable: cachedReport?.overallStatus == .available
+    )
+
+    // Check Accessibility permission on launch (query only — never auto-prompt).
+    appState.permissions.refreshOnLaunch()
+    menuBarController.updateIcon()  // Reflect accessibility warning state in icon.
+
+    // Begin smart polling if Accessibility is not yet granted.
+    appState.permissions.startMonitoring()
+
+    // Pre-warm LLM backend with a real inference request.
+    LLMNetworkSession.shared.preWarmModel(
+      provider: appState.settings.llmProvider,
+      model: appState.settings.llmModel,
+      keychainManager: appState.keychainManager
+    )
+
+    // Onboarding auto-open is handled by ActionWirer inside the main Window
+    // scene. No deferred dispatch required here.
+
+    #if DEBUG
+      // V2 fault-injection (issue #291). Only when explicitly opted in via env var.
+      if DebugFaultEndpoint.isRequested {
+        let endpoint = DebugFaultEndpoint(
+          audioProxy: appState.audioCapture as? AudioCaptureProxy,
+          asrProxy: appState.asrManager as? ASRManagerProxy,
+          parakeetPipeline: appState.pipeline,
+          whisperKitPipeline: appState.whisperKitPipeline,
+          activeBackend: { [weak self] in
+            self?.appState.settings.selectedBackend ?? .parakeet
+          }
+        )
+        endpoint.start()
+        debugFaultEndpoint = endpoint
+      }
+    #endif
+
+    audioEnvironmentSnapshotter = AudioEnvironmentSnapshotter(
+      routeProvider: { [weak self] in
+        self?.appState.audioCapture.currentAudioRoute
+      }
+    )
+    SentryBreadcrumb.audioEnvironmentProvider = { [weak self] in
+      self?.audioEnvironmentSnapshotter?.latestForError()
+    }
+
+    // Production telemetry: OS-level audio events (issue #574). Always on in
+    // release; ships to all users so we get cross-user data on what real
+    // devices/routes/connections users actually hit.
+    audioSystemEventReporter = AudioSystemEventReporter(
+      audioCapture: appState.audioCapture,
+      asrManager: appState.asrManager,
+      pipelineStateProvider: { [weak self] in
+        // PR7 of #763: pipeline phase resolves through LiveRecordingState.
+        self?.liveRecordingState.pipelineState ?? .idle
+      },
+      onAudioDeviceEvent: { [weak self] in
+        self?.audioEnvironmentSnapshotter?.audioDeviceEventOccurred()
+      }
+    )
+  }
+
+  func runDidBecomeActive() {
+    audioEnvironmentSnapshotter?.applicationBecameActive()
+
+    // Re-warm LLM backend when app comes to foreground.
+    LLMNetworkSession.shared.preWarmModel(
+      provider: appState.settings.llmProvider,
+      model: appState.settings.llmModel,
+      keychainManager: appState.keychainManager
+    )
+  }
+
+  func runWillTerminate() {
+    // PR-B.2 of #763: both window-close observers are torn down by the
+    // coordinator now.
+    appWindowCoordinator.tearDown()
+    appState.setup.ollamaSetup.cleanup()
+    // PR10 of #763 — shared HotkeyService is owned by EnviousWisprApp as
+    // `@State`; this coordinator holds an injected ref.
+    hotkeyService.stop()
+    LLMNetworkSession.shared.invalidate()
+
+    #if DEBUG
+      debugFaultEndpoint?.stop()
+      debugFaultEndpoint = nil
+    #endif
+
+    // Issue #574: tear down audio-event observers cleanly.
+    audioSystemEventReporter = nil
+    SentryBreadcrumb.audioEnvironmentProvider = nil
+    audioEnvironmentSnapshotter = nil
+  }
+}

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -43,6 +43,12 @@ struct EnviousWisprApp: App {
   /// `AppDelegate` holds a weak ref pushed via `attach(...)`. Not
   /// `.environment(...)`-injected — no SwiftUI view consumes the menu surface.
   @State private var menuBarController: MenuBarController
+  /// PR-B.4 of #763: App-owned home for the process-lifecycle sequence
+  /// (launch / foreground-activation / termination side effects). Strong owner
+  /// is this `@State`; `AppDelegate` holds a weak ref pushed via `attach(...)`
+  /// and forwards its three lifecycle callbacks here. Not
+  /// `.environment(...)`-injected — no SwiftUI view consumes it.
+  @State private var appLifecycleCoordinator: AppLifecycleCoordinator
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -226,6 +232,20 @@ struct EnviousWisprApp: App {
       )
     )
 
+    // PR-B.4 of #763: process-lifecycle home. Constructed last — it injects
+    // seven already-built dependencies and wires the onboarding-dismiss
+    // icon-refresh seam in its `init`. Holds the launch / become-active /
+    // terminate bodies that were inlined in `AppDelegate` before PR-B.4.
+    let appLifecycleCoordinator = AppLifecycleCoordinator(
+      appState: appState,
+      dictationRuntime: dictationRuntime,
+      dictationLifecycleCoordinator: dictationLifecycleCoordinator,
+      liveRecordingState: liveRecordingState,
+      menuBarController: menuBarController,
+      appWindowCoordinator: appWindowCoordinator,
+      hotkeyService: hotkeyService
+    )
+
     _appState = State(initialValue: appState)
     _navigationCoordinator = State(initialValue: navigationCoordinator)
     _diagnosticsCoordinator = State(initialValue: diagnosticsCoordinator)
@@ -240,23 +260,18 @@ struct EnviousWisprApp: App {
     _hotkeyService = State(initialValue: hotkeyService)
     _appWindowCoordinator = State(initialValue: appWindowCoordinator)
     _menuBarController = State(initialValue: menuBarController)
+    _appLifecycleCoordinator = State(initialValue: appLifecycleCoordinator)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires.
-    // PR10 of #763: also push `dictationRuntime` (so AppDelegate's menu-bar
-    // `toggleRecording` action and `applicationDidFinishLaunching`
-    // hotkey-start path resolve through the new façade) and `hotkeyService`
-    // (so `applicationWillTerminate` can stop the shared service without
-    // reaching through the deleted `appState.hotkeyService` path).
+    // PR-B.4 of #763: `AppDelegate` is now a thin AppKit adapter — it receives
+    // only `sparkleUpdateController` (for `applicationWillFinishLaunching`) and
+    // `appLifecycleCoordinator` (for the launch / become-active / terminate
+    // callbacks). All other dependencies are injected into
+    // `AppLifecycleCoordinator.init` instead.
     appDelegate.attach(
-      appState: appState,
       sparkleUpdateController: sparkleUpdateController,
-      liveRecordingState: liveRecordingState,
-      dictationLifecycleCoordinator: dictationLifecycleCoordinator,
-      dictationRuntime: dictationRuntime,
-      hotkeyService: hotkeyService,
-      appWindowCoordinator: appWindowCoordinator,
-      menuBarController: menuBarController
+      appLifecycleCoordinator: appLifecycleCoordinator
     )
 
     // Initialize observability (PostHog + Sentry) unconditionally at launch —

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+/// PR-B.4 of #763 — locks `AppDelegate` at its final shape: a thin AppKit
+/// adapter. PR-B extracted Sparkle (B.1), windows (B.2), the menu bar (B.3),
+/// and the process-lifecycle sequence (B.4) into App-owned homes. What remains
+/// is two weak refs, five forced `NSApplicationDelegate` callbacks, `attach`,
+/// and a private `assertAttached` tripwire.
+///
+/// The shape gate is an EXACT stored-property-name allowlist. This test parses
+/// every stored declaration in the class body (`let` and `var`, all access
+/// levels) and asserts the name set EQUALS the 2-name allowlist. Re-adding a
+/// dependency to `AppDelegate` fails the test — dependencies belong on the
+/// App-owned homes, not the adapter.
+@Suite struct AppDelegateCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/AppDelegate.swift"
+
+  private static let storedPropertyAllowlist: Set<String> = [
+    "sparkleUpdateController",
+    "appLifecycleCoordinator",
+  ]
+
+  @Test func storedPropertyNamesMatchAllowlist() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "AppDelegate", at: Self.sourcePath)
+    let names = storedPropertyNames(in: body)
+    let extras = names.subtracting(Self.storedPropertyAllowlist)
+    let missing = Self.storedPropertyAllowlist.subtracting(names)
+    #expect(
+      extras.isEmpty && missing.isEmpty,
+      """
+      AppDelegate stored-property set drifted from the PR-B.4 2-name \
+      allowlist. Unexpected: \(extras.sorted()). Missing: \(missing.sorted()). \
+      AppDelegate is a thin AppKit adapter — dependencies belong on the \
+      App-owned homes (EnviousWisprApp @State), not here.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "AppDelegate", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 6,
+      """
+      AppDelegate non-private method ceiling exceeded: \(count) > 6 \
+      non-private `func` declarations. PR-B.4 baseline: the five forced \
+      NSApplicationDelegate callbacks + `attach`. `assertAttached` is private \
+      and uncounted. New behavior belongs on AppLifecycleCoordinator.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 120,
+      """
+      AppDelegate line count exceeded: \(count) > 120 (hard cap, target 100). \
+      AppDelegate is a thin AppKit adapter — it must not grow.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    let allowed: Set<String> = ["AppKit", "EnviousWisprServices", "Foundation"]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      AppDelegate imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()). Feature-module imports belong on the \
+      App-owned homes that need them, not on the AppKit adapter.
+      """)
+  }
+
+  /// Guard against smuggling behavior into an extension that escapes the
+  /// in-class non-private method ceiling. `AppDelegate` must have no extension.
+  @Test func appDelegateHasNoExtensions() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let pattern = #"^[[:space:]]*extension[[:space:]]+AppDelegate\b[^\n]*"#
+    let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    let ns = source as NSString
+    let matches = regex.matches(in: source, range: NSRange(location: 0, length: ns.length))
+    #expect(
+      matches.isEmpty,
+      """
+      AppDelegate has \(matches.count) extension(s): \
+      \(matches.map { ns.substring(with: $0.range) }). Methods belong in the \
+      class body so the non-private method ceiling sees them.
+      """)
+  }
+
+  /// Issue #799 close criterion: the loud-guard tripwire. Both lifecycle entry
+  /// points that depend on a weak ref must call `assertAttached`, and the
+  /// helper must keep both arms — the `#if DEBUG` `assertionFailure` and the
+  /// release-build `SentryBreadcrumb`. Source-level check — booting AppKit or
+  /// firing `assertionFailure` in a unit test is not viable.
+  @Test func assertAttachedGuardsLifecycleEntryPoints() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    #expect(
+      source.contains("assertAttached(sparkleUpdateController,"),
+      "applicationWillFinishLaunching must guard its weak ref with assertAttached.")
+    #expect(
+      source.contains("assertAttached(appLifecycleCoordinator,"),
+      "applicationDidFinishLaunching must guard its weak ref with assertAttached.")
+    #expect(
+      source.contains("assertionFailure(") && source.contains("SentryBreadcrumb.add("),
+      """
+      assertAttached must keep both arms: a debug `assertionFailure` and a \
+      release-build `SentryBreadcrumb`. A wiring regression must be loud in \
+      debug and diagnosable in release.
+      """)
+  }
+}
+
+/// Extracts the names of top-level (brace-depth 0) `let`/`var` stored-property
+/// declarations in a class body. Includes all access levels and primitive
+/// types; excludes computed properties (declaration line ends with `{`).
+private func storedPropertyNames(in body: String) -> Set<String> {
+  let declPattern =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+    + #"(public|internal|private|fileprivate|package|open)?[[:space:]]*"#
+    + #"(weak[[:space:]]+)?(let|var)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+  guard let regex = try? NSRegularExpression(pattern: declPattern) else { return [] }
+
+  var depth = 0
+  var names: Set<String> = []
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      let isComputed =
+        s.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil
+      if !isComputed {
+        let ns = s as NSString
+        if let m = regex.firstMatch(
+          in: s, range: NSRange(location: 0, length: ns.length)),
+          m.numberOfRanges > 6, m.range(at: 6).location != NSNotFound
+        {
+          names.insert(ns.substring(with: m.range(at: 6)))
+        }
+      }
+    }
+    depth += opens - closes
+  }
+  return names
+}

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+
+/// PR-B.4 of #763 — locks `AppLifecycleCoordinator`'s initial shape so the
+/// extracted process-lifecycle home does not silently accrete domain state.
+///
+/// The shape gate is an EXACT stored-property-name allowlist, not a
+/// parser-visible count (the shared parser counts only non-primitive `let`s,
+/// which a count alone would under-report). This test parses every stored
+/// declaration in the class body (`let` and `var`, all access levels,
+/// primitives included) and asserts the name set EQUALS the 10-name allowlist.
+/// Adding an 11th field fails the test.
+///
+/// Bible §30 baseline: 10 stored — 3 owned `var` (`audioEnvironmentSnapshotter`,
+/// `audioSystemEventReporter`, `#if DEBUG debugFaultEndpoint`) + 7 injected
+/// `let` (`appState`, `dictationRuntime`, `dictationLifecycleCoordinator`,
+/// `liveRecordingState`, `menuBarController`, `appWindowCoordinator`,
+/// `hotkeyService`); non-private `func`s `runDidFinishLaunching`,
+/// `runDidBecomeActive`, `runWillTerminate` (`init` is not a `func`).
+@Suite struct AppLifecycleCoordinatorCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWispr/App/AppLifecycleCoordinator.swift"
+
+  private static let storedPropertyAllowlist: Set<String> = [
+    "audioEnvironmentSnapshotter",
+    "audioSystemEventReporter",
+    "debugFaultEndpoint",
+    "appState",
+    "dictationRuntime",
+    "dictationLifecycleCoordinator",
+    "liveRecordingState",
+    "menuBarController",
+    "appWindowCoordinator",
+    "hotkeyService",
+  ]
+
+  @Test func storedPropertyNamesMatchAllowlist() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "AppLifecycleCoordinator", at: Self.sourcePath)
+    let names = storedPropertyNames(in: body)
+    let extras = names.subtracting(Self.storedPropertyAllowlist)
+    let missing = Self.storedPropertyAllowlist.subtracting(names)
+    #expect(
+      extras.isEmpty && missing.isEmpty,
+      """
+      AppLifecycleCoordinator stored-property set drifted from the PR-B.4 \
+      10-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      \(missing.sorted()). Adding a stored property is god-object drift — \
+      raising the allowlist requires a Bible §30 entry. Removing one means \
+      this allowlist must shrink in the same PR.
+      """)
+  }
+
+  @Test func nonPrivateMethodCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "AppLifecycleCoordinator", at: Self.sourcePath)
+    let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    #expect(
+      count <= 4,
+      """
+      AppLifecycleCoordinator non-private method ceiling exceeded: \
+      \(count) > 4 non-private `func` declarations in the class body. \
+      PR-B.4 baseline: runDidFinishLaunching, runDidBecomeActive, \
+      runWillTerminate. The method cap is the primary anti-accretion gate — \
+      it blocks "and now this also fires at launch" helper growth.
+      """)
+  }
+
+  @Test func lineCount() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    #expect(
+      count <= 600,
+      """
+      AppLifecycleCoordinator line count exceeded: \(count) > 600 (soft \
+      trip-wire). File should stay focused on the process-lifecycle sequence.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+    let actual = RouterCeilingParser.imports(in: source)
+    // `RouterCeilingParser.imports` surfaces every anchored `import` line,
+    // including inside `#if DEBUG` — so `EnviousWisprPipeline` (imported only
+    // for `DebugFaultEndpoint` in debug builds) is on the allowlist.
+    let allowed: Set<String> = [
+      "AppKit", "EnviousWisprASR", "EnviousWisprAudio", "EnviousWisprCore",
+      "EnviousWisprLLM", "EnviousWisprPipeline", "EnviousWisprServices",
+      "Foundation",
+    ]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      AppLifecycleCoordinator imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()).
+      """)
+  }
+
+  /// Parser self-test: a fixture body with an 11th stored property must be
+  /// flagged. If this stops failing, the real gate above is untrustworthy.
+  @Test func parserCatchesExtraStoredProperty() {
+    let fixture = """
+        private var audioEnvironmentSnapshotter: AudioEnvironmentSnapshotter?
+        private let appState: AppState
+        private let hotkeyService: HotkeyService
+        private var smuggledExtraField: Int = 0
+      """
+    let names = storedPropertyNames(in: fixture)
+    #expect(
+      names.contains("smuggledExtraField"),
+      "Parser failed to detect a smuggled stored property — the gate cannot be trusted.")
+  }
+}
+
+/// Extracts the names of top-level (brace-depth 0) `let`/`var` stored-property
+/// declarations in a class body. Includes all access levels and primitive
+/// types; excludes computed properties (declaration line ends with `{`).
+private func storedPropertyNames(in body: String) -> Set<String> {
+  let declPattern =
+    #"^[[:space:]]*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?[[:space:]]+)*"#
+    + #"(public|internal|private|fileprivate|package|open)?[[:space:]]*"#
+    + #"(weak[[:space:]]+)?(let|var)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"#
+  guard let regex = try? NSRegularExpression(pattern: declPattern) else { return [] }
+
+  var depth = 0
+  var names: Set<String> = []
+  for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+    let opens = line.filter { $0 == "{" }.count
+    let closes = line.filter { $0 == "}" }.count
+    let depthForThisLine = depth - max(0, closes - opens)
+    if depthForThisLine == 0 {
+      let s = String(line)
+      let isComputed =
+        s.range(of: #"\{[[:space:]]*$"#, options: .regularExpression) != nil
+      if !isComputed {
+        let ns = s as NSString
+        if let m = regex.firstMatch(
+          in: s, range: NSRange(location: 0, length: ns.length)),
+          m.numberOfRanges > 6, m.range(at: 6).location != NSNotFound
+        {
+          names.insert(ns.substring(with: m.range(at: 6)))
+        }
+      }
+    }
+    depth += opens - closes
+  }
+  return names
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -65,13 +65,21 @@ import Testing
   ///   instance is constructed in `init()` with five menu-action closures and
   ///   threaded into `appDelegate.attach(...)`. Not `.environment(...)`-injected
   ///   — no SwiftUI view consumes the menu surface.
+  /// - 16 → 17 in PR-B.4 of epic #763 (2026-05-20, #799) for
+  ///   `AppLifecycleCoordinator`. Bible §30 entry: PR-B.4 lifts the
+  ///   process-lifecycle sequence (launch / become-active / terminate side
+  ///   effects, the three process-lifetime audio objects) off AppDelegate into
+  ///   a dedicated App-owned home. The `@State` instance is constructed last in
+  ///   `init()` from seven already-built dependencies and threaded into
+  ///   `appDelegate.attach(...)`. This is the final PR-B home — `AppDelegate`
+  ///   ends as a thin AppKit adapter. Not `.environment(...)`-injected.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 16,
+      count <= 17,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 16. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 17. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -114,14 +122,19 @@ import Testing
   /// `MenuBarController` construction (~22 lines: five menu-action closures),
   /// the `@State` declaration, and the `_menuBarController` assignment. The
   /// `attach(...)` arg count is unchanged (drops two, adds one).
+  /// Ratcheted 370→385 in PR-B.4 of epic #763 (2026-05-20, #799) to absorb
+  /// `AppLifecycleCoordinator` construction (the seven-dependency `init` call)
+  /// and its `@State` declaration + assignment, net of the `attach(...)` call
+  /// collapsing from eight arguments to two. Cap set by the deterministic rule
+  /// (post-change actual 375 + 10, rounded up to the nearest 5).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 370,
+      lineCount <= 385,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 370. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 385. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }


### PR DESCRIPTION
## Summary

Final child PR of sub-project PR-B (#780). Extracts the process-lifecycle sequence (launch / become-active / terminate) out of `AppDelegate` into a new App-owned home `AppLifecycleCoordinator`.

- `AppDelegate` shrinks 373 → 75 lines: a thin AppKit adapter with two weak refs, five forced `NSApplicationDelegate` callbacks, `attach(...)`, and a private `assertAttached` tripwire.
- The three `run*` methods on `AppLifecycleCoordinator` are verbatim relocations of the corresponding callback bodies — same launch order, same telemetry, same teardown.
- One deliberate non-identity change: `assertAttached` replaces the verbose nil-guard — release builds now emit a `SentryBreadcrumb` instead of an `AppLogger` line for a wiring-failure path that is unreachable in a correctly-wired build.
- Lands `AppLifecycleCoordinatorCeilingsTests` (10-name stored allowlist, ≤4 methods) and `AppDelegateCeilingsTests` (2-name stored allowlist, ≤6 methods, ≤120 lines, 0 extensions). Ratchets `EnviousWisprAppCeilingsTests` 16→17 stored, 370→385 line.

Closes PR-B meta-tracker #780. Issue #799.

Plan: greenlit via council (GPT + Gemini) + Codex grounded review (3 rounds → PROCEED-AS-PLANNED). Codex code-diff review: CLEAN.

## Test plan

- [x] `swift build -c release` exits 0
- [x] `scripts/swift-test.sh` — 1125 tests pass; new ceiling suites (19 tests across 4 suites) pass
- [x] Codex code-diff review — CLEAN, identity-preservation + retain-cycle handling verified
- [x] Live UAT (debug build): launch sequence runs; Parakeet menu dictation full heart path (correct transcription); backend switch via Settings UI; clean termination, no orphan process
- [ ] Founder hands-on sweep: hotkey dictation, onboarding wipe + relaunch, Sparkle dialog, accessibility revoke/grant, mic swap, no-duplicate-telemetry check (PostHog), initial menu-bar icon state
