### PR TITLE
refactor(appstate): hoist subsystem construction to EnviousWisprApp; AppState receive-only (PR-C.1 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppEnvironmentKeys.swift
+++ b/Sources/EnviousWispr/App/AppEnvironmentKeys.swift
@@ -1,0 +1,43 @@
+import EnviousWisprASR
+import EnviousWisprLLM
+import SwiftUI
+
+/// PR-C.1 of #763 — custom SwiftUI environment keys for the two view-facing
+/// homes that cannot use the object-based `.environment(_:)` modifier:
+///
+/// - `asrManager` is an `any ASRManagerInterface` existential; the protocol is
+///   not `Observable`-constrained, so the object-based modifier does not apply.
+/// - `KeychainManager` is a plain `Sendable` service, not `@Observable`.
+///
+/// The seven `@Observable` homes (settings, permissions, customWordsCoordinator,
+/// setup, audioDeviceList, aiAvailability, llmDiscovery) use the object-based
+/// `.environment(_:)` modifier directly and need no key here.
+///
+/// Values are optional with a `nil` default: `EnviousWisprApp` always injects a
+/// real instance, so consuming views (migrated in PR-C.2 / PR-C.3) read a
+/// non-nil value at runtime. The optionality exists only to satisfy
+/// `EnvironmentKey`'s `defaultValue` requirement.
+
+private struct ASRManagerEnvironmentKey: EnvironmentKey {
+  // Computed (not a stored `static let`): `any ASRManagerInterface` is not
+  // `Sendable`, so a stored static of this type trips Swift 6's
+  // `#MutableGlobalVariable` concurrency check. A computed property returning
+  // `nil` has no stored global state and is concurrency-safe.
+  static var defaultValue: (any ASRManagerInterface)? { nil }
+}
+
+private struct KeychainManagerEnvironmentKey: EnvironmentKey {
+  static let defaultValue: KeychainManager? = nil
+}
+
+extension EnvironmentValues {
+  var asrManager: (any ASRManagerInterface)? {
+    get { self[ASRManagerEnvironmentKey.self] }
+    set { self[ASRManagerEnvironmentKey.self] = newValue }
+  }
+
+  var keychainManager: KeychainManager? {
+    get { self[KeychainManagerEnvironmentKey.self] }
+    set { self[KeychainManagerEnvironmentKey.self] = newValue }
+  }
+}

--- a/Sources/EnviousWispr/App/AppState.swift
+++ b/Sources/EnviousWispr/App/AppState.swift
@@ -7,343 +7,122 @@ import EnviousWisprServices
 import EnviousWisprStorage
 import SwiftUI
 
-/// Root observable state for the entire application.
+/// Root observable state for the application.
 ///
-/// PR10 of #763 — recording-control surface (`toggleRecording`,
-/// `cancelRecording`, `resetActivePipeline`, `startHotkeyServiceIfEnabled`,
-/// `hotkeyService` collaborator, the `lazy var heartControlRecovery`, the
-/// `var lastUserStopRequest` post-condition-guard timestamp, the
-/// `dictationLifecycleCoordinator` weak ref + setter, and the hotkey
-/// callback wiring block) moved to `DictationRuntime` and its three
-/// new private collaborators (`HotkeyController` / `RecordingStarter` /
-/// `RecordingFinalizer`). AppState's init now takes `hotkeyService` so
-/// the shared instance still threads into `PipelineSettingsSync`.
-/// `var isRecordingLocked` stays here as a vestigial setter target
-/// through PR10 (read+written via PR9's `RecordingLockedAccess` struct
-/// passed into Starter+Finalizer+DLC); PR11 absorbs it with the host.
-/// `extension AppState: DictationActivityProviding` also stays through
-/// PR10 (PR11 sunsets it with the host).
+/// PR-C.1 of #763 — AppState is now **receive-only**. Construction of every
+/// subsystem and all init-time wiring moved to `EnviousWisprApp.init()` (the
+/// composition root). AppState's init only stores the references it is handed;
+/// it constructs nothing and wires nothing. It stays `@Environment`-injected so
+/// the not-yet-migrated views keep working unchanged. PR-C.2 / PR-C.3 migrate
+/// those views off `@Environment(AppState.self)`; PR-C.4 deletes this file.
+///
+/// The `let`/`var` split of the stored properties is unchanged from pre-PR-C.1
+/// on purpose: `AppStateCeilingsTests` counts only `let` collaborators and must
+/// stay green until PR-C.4 removes it. `var settings`, the four `attach`-set
+/// outlets, and `var isRecordingLocked` stay `var`.
 @MainActor
 @Observable
 final class AppState {
-  // Settings
-  var settings = SettingsManager()
-
-  // Sub-systems
-  let permissions = PermissionsService()
+  var settings: SettingsManager
+  let permissions: PermissionsService
   let audioCapture: any AudioCaptureInterface
   let asrManager: any ASRManagerInterface
-  let keychainManager = KeychainManager()
-  let recordingOverlay = RecordingOverlayPanel()
-  // Phase F (#501) — setup-orchestration cluster moved out of AppState.
-  // Holds ollamaSetup, whisperKitSetup, and the WhisperKit preload-observation
-  // task. Constructed in init() after asrManager and whisperKitPipeline exist
-  // (it needs both to drive the preload observer).
+  let keychainManager: KeychainManager
+  let recordingOverlay: RecordingOverlayPanel
   let setup: SetupCoordinator
-  let audioDeviceList = AudioDeviceList()
-  let captureTelemetry = CaptureTelemetryState()
-
-  // Pipelines — initialized after sub-systems
+  let audioDeviceList: AudioDeviceList
+  let captureTelemetry: CaptureTelemetryState
   let pipeline: TranscriptionPipeline
   let whisperKitPipeline: WhisperKitPipeline
 
-  // PR9 of #763 — pipeline state-change side effects (overlay, hotkey
-  // arbitration, telemetry, chip lifecycle, terminal settings sync) moved to
-  // `DictationLifecycleCoordinator` under DictationRuntime.
-  //
-  // PR10 of #763 — start / stop / cancel / hotkey callback wiring all moved
-  // to `DictationRuntime` and its three new private collaborators
-  // (`HotkeyController` / `RecordingStarter` / `RecordingFinalizer`).
-  // `hotkeyService` no longer lives on AppState; the App owns the shared
-  // instance as `@State` and threads it into all consumers.
-
   /// Standalone service for re-polishing saved transcripts from the detail view.
-  /// Completely decoupled from pipeline state machines.
   let polishService: TranscriptPolishService
 
   /// Forwards settings changes to pipelines and subsystems.
   let settingsSync: PipelineSettingsSync
 
   /// True when recording is in hands-free (locked) mode via double-press.
-  /// Read by the overlay to switch to the expanded lips visual.
-  ///
-  /// PR10 of #763 — the writers (Starter, Finalizer, the hotkey-onLocked
-  /// path) moved to `DictationRuntime`. This var stays as a vestigial
-  /// setter target through PR10, accessed via PR9's `RecordingLockedAccess`
-  /// get/set struct passed into DLC + Starter + Finalizer. PR11 absorbs
-  /// this var with the AppState host.
+  /// Read by the overlay. Written through PR9's `RecordingLockedAccess` get/set
+  /// struct. PR-C.3 of #763 rehomes this onto `LiveRecordingState`.
   var isRecordingLocked: Bool = false
 
-  /// PR4 of #763 (#252 fold-in): the chip presenter is set via setter
-  /// injection by AppDelegate after both AppState and the presenter exist.
-  /// PR10 moved the cancel-path chip-clear call site into `RecordingFinalizer`;
-  /// AppState no longer dispatches chip lifecycle. PR11 deletes AppState
-  /// (and this reference along with it).
-  private(set) var languageSuggestionPresenter: LanguageSuggestionPresenter?
+  // Feature #8: custom word management.
+  let customWordsCoordinator: CustomWordsCoordinator
 
-  /// Setter for `languageSuggestionPresenter`. Called once by AppDelegate
-  /// after both AppState and the presenter exist (presenter needs
-  /// `recordingOverlay` for its showOverlay closure; AppState constructs the
-  /// overlay; so the wiring runs post-init in AppDelegate).
+  /// Broadcasts custom-words changes to all registered consumers.
+  let customWordsPropagator: CustomWordsPropagator
+
+  // Model discovery.
+  let llmDiscovery: LLMModelDiscoveryCoordinator
+
+  // Apple Intelligence availability.
+  let aiAvailability: AIAvailabilityCoordinator
+
+  /// PR4 of #763 — chip presenter, setter-injected by `EnviousWisprApp` after
+  /// both AppState and the presenter exist.
+  private(set) var languageSuggestionPresenter: LanguageSuggestionPresenter?
   func attachLanguageSuggestionPresenter(_ presenter: LanguageSuggestionPresenter) {
     self.languageSuggestionPresenter = presenter
   }
 
-  /// PR7 of #763 — sunset PR9. App-owned home for live dictation facts
-  /// (pipelineState, audioLevel, currentTranscript). Setter-injected `var`
-  /// so the `AppStateCeilingsTests` collaborator parser (which counts only
-  /// `let`) does not see it. Migration-period plumbing: AppState held the
-  /// equivalent getters pre-PR7; PR9's `DictationLifecycleCoordinator`
-  /// absorbs the push sites and this outlet evaporates.
+  /// PR7 of #763 — App-owned home for live dictation facts. Setter-injected.
   private(set) var liveRecordingState: LiveRecordingState?
   func attachLiveRecordingState(_ state: LiveRecordingState) {
     self.liveRecordingState = state
   }
 
-  /// PR7 of #763 — sunset PR9. App-owned home for post-recording polish
-  /// error state. PR9's `DictationLifecycleCoordinator` owns the state-change
-  /// push sites; PR10 moved the start-path resets into `RecordingStarter`.
-  /// AppState no longer reads or writes this directly.
+  /// PR7 of #763 — App-owned home for post-recording polish error state.
   private(set) var lastRecordingResult: LastRecordingResult?
   func attachLastRecordingResult(_ result: LastRecordingResult) {
     self.lastRecordingResult = result
   }
 
-  /// PR7 of #763 — sunset PR11. App-owned home for backend display labels
-  /// (modelLabel, llmLabel, statusText). Setter-injected so AppDelegate's
-  /// menu reads can resolve through this outlet during the migration;
-  /// once AppDelegate shrinks per PR-B and AppState is deleted in PR11,
-  /// this outlet evaporates with the host.
+  /// PR7 of #763 — App-owned home for backend display labels. Setter-injected.
   private(set) var backendMetadata: BackendMetadata?
   func attachBackendMetadata(_ metadata: BackendMetadata) {
     self.backendMetadata = metadata
   }
 
-  // Feature #8: custom word management — delegated to coordinator
-  let customWordsCoordinator = CustomWordsCoordinator()
-
-  /// Broadcasts custom-words changes to all registered consumers (pipelines'
-  /// word-correction + polish steps, plus the re-polish service). Initialized
-  /// at property declaration (no ctor dependencies); seeded with
-  /// `customWordsCoordinator.customWords` in `init` before consumer
-  /// registrations.
-  let customWordsPropagator = CustomWordsPropagator()
-
-  // Model discovery — delegated to coordinator
-  let llmDiscovery: LLMModelDiscoveryCoordinator
-
-  // Apple Intelligence availability — dedicated coordinator (replaces KeyValidationState proxy)
-  let aiAvailability = AIAvailabilityCoordinator()
-
-  /// PR9 of #763 — `transcriptStore` is constructed by the composition root
-  /// (`EnviousWisprApp.init`) and injected.
-  ///
-  /// PR10 of #763 — `hotkeyService` is constructed by the composition root
-  /// as `@State` so it can be shared with `HotkeyController` (callback
-  /// wiring), `DictationLifecycleCoordinator` (per-pipeline cancel-hotkey
-  /// register/unregister), `PipelineSettingsSync` (live key/modifier/mode
-  /// updates), and `AppDelegate.attach(...)` (termination `.stop()`).
-  /// AppState passes the shared instance straight through to PSS without
-  /// holding a reference itself.
-  init(transcriptStore: TranscriptStore, hotkeyService: HotkeyService) {
-    // XPC audio service — default ON (Step 7). Audio capture runs in a separate XPC
-    // service process for crash isolation. Escape hatch: `defaults write ... useXPCAudioService -bool false`
-    // Read directly from UserDefaults because `settings` is not yet available (stored
-    // properties must all be initialized before `self` is accessible).
-    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern
-    // so existing installs (no key written) get the new default.
-    let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
-    if useXPC {
-      audioCapture = AudioCaptureProxy()
-    } else {
-      audioCapture = AudioCaptureManager()
-    }
-
-    // Phase 5: XPC ASR service — default ON (Stage F). ASR inference runs in a separate
-    // XPC service process for memory isolation. Escape hatch: `defaults write ... useXPCASRService -bool false`
-    // NOTE: .bool(forKey:) returns false for absent keys — use object() ?? true pattern.
-    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
-    if useXPCASR {
-      asrManager = ASRManagerProxy()
-    } else {
-      asrManager = ASRManager()
-    }
-
-    llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
-
-    // Phase 0 (#640) — single shared paste-completion registry. Constructed
-    // first so both pipelines and the polish service receive the same
-    // instance. NOT promoted to a top-level `let` collaborator (would breach
-    // the AppState concrete-collaborator ceiling at 19); the polish service
-    // exposes it as `polishService.pasteCompletionRegistry` for Phase 7
-    // (#629) auto-learn subscription.
-    polishService = TranscriptPolishService(
-      keychainManager: keychainManager,
-      transcriptStore: transcriptStore
-    )
-
-    // Both pipeline properties must be initialized before `self` can be used.
-    // WhisperKitBackend default is large-v3-turbo; reconfigured from settings below.
-    pipeline = TranscriptionPipeline(
-      audioCapture: audioCapture,
-      asrManager: asrManager,
-      transcriptStore: transcriptStore,
-      keychainManager: keychainManager,
-      captureTelemetry: captureTelemetry,
-      pasteCompletionRegistry: polishService.pasteCompletionRegistry
-    )
-    // W6: wire language-flip telemetry into the detector via a closure so
-    // `EnviousWisprASR` (which cannot import PostHog) stays vendor-contained.
-    // The detector fires this inline from an actor; we hop to MainActor to
-    // call `TelemetryService` (which is @MainActor isolated).
-    // The chip handler is wired AFTER init completes (see setPassiveChipHandler
-    // call below) because it needs to capture self, and Swift does not allow
-    // that before all stored properties are initialized.
-    let languageDetector = LanguageDetector(
-      onLanguageFlip: { @Sendable event in
-        Task { @MainActor in
-          TelemetryService.shared.trackLanguageFlip(
-            fromLang: event.fromLang,
-            toLang: event.toLang,
-            confidenceBoth: event.confidenceBoth
-          )
-        }
-      }
-    )
-    whisperKitPipeline = WhisperKitPipeline(
-      audioCapture: audioCapture,
-      backend: WhisperKitBackend(),
-      transcriptStore: transcriptStore,
-      keychainManager: keychainManager,
-      languageDetector: languageDetector,
-      captureTelemetry: captureTelemetry,
-      pasteCompletionRegistry: polishService.pasteCompletionRegistry
-    )
-
-    // Phase F (#501) — construct SetupCoordinator after asrManager + whisperKitPipeline
-    // exist (it needs both — asrManager for activeBackendType reads, the pipeline
-    // closure for prepareBackendSilently()). The capture is [weak whisperKitPipeline]
-    // so the coordinator does not retain the pipeline.
-    setup = SetupCoordinator(
-      asrManager: asrManager,
-      preloadAction: { [weak whisperKitPipeline] in
-        await whisperKitPipeline?.prepareBackendSilently()
-      }
-    )
-
-    // Initialize settingsSync and apply initial settings to all targets
-    settingsSync = PipelineSettingsSync(
-      pipeline: pipeline,
-      whisperKitPipeline: whisperKitPipeline,
-      polishService: polishService,
-      audioCapture: audioCapture,
-      asrManager: asrManager,
-      hotkeyService: hotkeyService,
-      whisperKitSetup: setup.whisperKitSetup
-    )
-    settingsSync.applyInitialSettings(settings)
-
-    recordingOverlay.setGrantHandler { [weak self] in
-      _ = self?.permissions.requestAccessibilityAccess()
-    }
-    recordingOverlay.setAccessibilityWarningDismissedProvider { [weak self] in
-      self?.permissions.accessibilityWarningDismissed ?? false
-    }
-
-    // Wire dictation activity provider (after all stored properties initialized)
-    polishService.setDictationActivity(self)
-
-    // Wire the passive-chip handler on the LanguageDetector actor now that
-    // self is fully constructed. The handler hops to MainActor and forwards
-    // the trigger to LanguageSuggestionPresenter (set by AppDelegate via
-    // attachLanguageSuggestionPresenter). DEBUG-only one-shot warning if the
-    // presenter is nil when an event arrives (catches test-harness misuse
-    // and refactor regressions; impossible in production AppDelegate flow).
-    Task { [weak self] in
-      await languageDetector.setPassiveChipHandler { @Sendable (trigger: PassiveChipTrigger) in
-        Task { @MainActor in
-          guard let self = self else { return }
-          ChipWiringDiagnostics.warnIfPresenterMissing(self.languageSuggestionPresenter)
-          self.languageSuggestionPresenter?.bufferTrigger(trigger)
-        }
-      }
-    }
-
-    // PR8 of #763 — heart-path event-routing callbacks (seven `audioCapture.on*`
-    // closures + `asrManager.onServiceInterrupted` + AVAudioEngineConfigurationChange
-    // observer) moved to `DictationRuntime` and its three private routers
-    // (`AudioEventRouter`, `ASREventRouter`, `WedgeRecoveryRouter`).
-    // PR9 absorbed the resolver helpers + warning Task into the new lifecycle
-    // home; PR10 absorbed the hotkey callback wiring + start/stop/cancel.
-
-    settingsSync.onNeedsPreloadObservation = { [weak setup] in
-      setup?.startPreloadObservation()
-    }
-
-    // Wire custom-words propagator. The exact ordering (seed → register all
-    // consumers → install onWordsChanged) lives in `wireCustomWords` so
-    // tests can drive the same path with spy consumers + a real
-    // `CustomWordsCoordinator`. Phase D (#496) replaces the prior 5-way
-    // fanout in AppState plus 5 mirror sites in `PipelineSettingsSync`.
-    wireCustomWords(
-      propagator: customWordsPropagator,
-      initialWords: customWordsCoordinator.customWords,
-      correctorConsumers: [
-        pipeline.wordCorrection,
-        whisperKitPipeline.wordCorrection,
-      ],
-      polishConsumers: [
-        pipeline.llmPolish,
-        whisperKitPipeline.llmPolish,
-        polishService.llmPolishStep,
-      ],
-      coordinator: customWordsCoordinator
-    )
-
-    // AppLogger initial seed lives in PipelineSettingsSync.applyInitialSettings
-    // (called above) — single owner for settings-driven side effects.
-    // See #728.
-
-    // Restore persisted backend selection synchronously (no race with first record).
-    // setInitialBackendType is safe at startup: nothing loaded, no unload needed.
-    asrManager.setInitialBackendType(settings.selectedBackend)
-    SentryBreadcrumb.updateASRBackend(
-      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
-
-    // Wire settings change handler
-    settings.onChange = { [weak self] key in
-      guard let self else { return }
-      self.settingsSync.handleSettingChanged(key, settings: self.settings)
-    }
-
-    // PR9 of #763 — pipeline state-change closures moved to
-    // `DictationLifecycleCoordinator.install()`, called once by the
-    // composition root (`EnviousWisprApp.init`) after the coordinator is
-    // constructed.
-
-    // PR10 of #763 — hotkey callback wiring + start/stop/cancel paths moved
-    // to `DictationRuntime` and its three new private collaborators
-    // (`HotkeyController` / `RecordingStarter` / `RecordingFinalizer`).
-    // DR.init builds the recording subsystem and calls
-    // `hotkeyController.install()` internally as the last init step.
-
-    // Pre-load the selected backend's model in the background to eliminate cold-start delay.
-    // Parakeet: direct silent load (model files already downloaded during onboarding).
-    // WhisperKit: observation-based (waits for setupState to become .ready first).
-    if settings.selectedBackend == .parakeet {
-      Task { [weak self] in
-        await self?.asrManager.loadModelSilently()
-      }
-    }
-    Task { [weak self] in
-      await self?.setup.whisperKitSetup.detectState()
-      self?.setup.startPreloadObservation()
-    }
+  /// Receive-only initializer (PR-C.1 of #763). Every subsystem is constructed
+  /// and wired by `EnviousWisprApp.init()`; AppState stores the references and
+  /// does nothing else. No construction, no wiring, no `Task`, no side effects.
+  init(
+    settings: SettingsManager,
+    permissions: PermissionsService,
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    keychainManager: KeychainManager,
+    recordingOverlay: RecordingOverlayPanel,
+    setup: SetupCoordinator,
+    audioDeviceList: AudioDeviceList,
+    captureTelemetry: CaptureTelemetryState,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    polishService: TranscriptPolishService,
+    settingsSync: PipelineSettingsSync,
+    customWordsCoordinator: CustomWordsCoordinator,
+    customWordsPropagator: CustomWordsPropagator,
+    llmDiscovery: LLMModelDiscoveryCoordinator,
+    aiAvailability: AIAvailabilityCoordinator
+  ) {
+    self.settings = settings
+    self.permissions = permissions
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.keychainManager = keychainManager
+    self.recordingOverlay = recordingOverlay
+    self.setup = setup
+    self.audioDeviceList = audioDeviceList
+    self.captureTelemetry = captureTelemetry
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.polishService = polishService
+    self.settingsSync = settingsSync
+    self.customWordsCoordinator = customWordsCoordinator
+    self.customWordsPropagator = customWordsPropagator
+    self.llmDiscovery = llmDiscovery
+    self.aiAvailability = aiAvailability
   }
-
-  // Phase 5 B.1 validated 2026-03-16: batch round-trip 51-60ms across XPC.
-  // Cold model load: 13,966ms. 3 warm back-to-back runs stable.
-  // Test function in git history.
 }
 
 // MARK: - DictationActivityProviding

--- a/Sources/EnviousWispr/App/CustomWordsPropagator.swift
+++ b/Sources/EnviousWispr/App/CustomWordsPropagator.swift
@@ -144,8 +144,15 @@ func wireCustomWords(
   for consumer in polishConsumers {
     propagator.register(consumer)
   }
-  let onChange: ([CustomWord]) -> Void = { [weak propagator] words in
-    guard let propagator else { return }
+  // PR-C.1 of #763: the closure captures `propagator` STRONGLY. Pre-PR-C.1
+  // this was `[weak propagator]` because AppState held the propagator as a
+  // stored `let`. With construction moved to `EnviousWisprApp.init()` the
+  // propagator would otherwise have no strong owner once AppState is deleted
+  // (PR-C.4) — `CustomWordsCoordinator` only stores this closure. Strong
+  // capture anchors the propagator's lifetime to the coordinator (App-owned
+  // `@State`). No retain cycle: the propagator holds only weak consumer
+  // boxes and never references the coordinator.
+  let onChange: ([CustomWord]) -> Void = { words in
     let next = LanePartitioner.split(words, generation: propagator.corrector.generation &+ 1)
     propagator.update(corrector: next.corrector, polish: next.polish)
   }

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -1,4 +1,8 @@
+import EnviousWisprASR
+import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
 import EnviousWisprServices
 import EnviousWisprStorage
 import SwiftUI
@@ -14,65 +18,221 @@ struct EnviousWisprApp: App {
   @State private var diagnosticsCoordinator: DiagnosticsCoordinator
   @State private var languageSuggestionPresenter: LanguageSuggestionPresenter
   @State private var updateCoordinatorHolder: UpdateCoordinatorHolder
-  /// PR-B.1 of #763 — App-owned Sparkle integration. Constructed in `init()`
-  /// from `updateCoordinatorHolder` so `startUpdater()` can publish the
-  /// coordinator into the env carrier synchronously during
-  /// `applicationWillFinishLaunching` (Issue #739 env-capture invariant).
   @State private var sparkleUpdateController: SparkleUpdateController
   @State private var transcriptWorkflowCoordinator: TranscriptWorkflowCoordinator
   @State private var liveRecordingState: LiveRecordingState
   @State private var lastRecordingResult: LastRecordingResult
   @State private var backendMetadata: BackendMetadata
   @State private var dictationRuntime: DictationRuntime
-  /// PR10 of #763: the App owns the shared `HotkeyService` so the single
-  /// instance can be threaded into `HotkeyController` (wires callbacks),
-  /// `PipelineSettingsSync` (live key/modifier/mode updates),
-  /// `DictationLifecycleCoordinator` (per-pipeline-state register/unregister
-  /// of the cancel hotkey), and `AppDelegate.attach(...)` (termination
-  /// `.stop()`). A single owner of the service is required because all
-  /// three consumers mutate it; multiple instances would silently lose
-  /// settings changes.
   @State private var hotkeyService: HotkeyService
-  /// PR-B.2 of #763: App-owned home for window lifecycle. Strong owner is this
-  /// `@State`; `AppDelegate` holds a weak ref. Injected into both Window
-  /// scenes via `.environment(...)` so `DiagnosticsSettingsView` reaches it
-  /// through `@Environment` instead of an `NSApp.delegate` downcast.
   @State private var appWindowCoordinator: AppWindowCoordinator
-  /// PR-B.3 of #763: App-owned home for the menu bar surface (status item,
-  /// dropdown menu, animated icon). Strong owner is this `@State`;
-  /// `AppDelegate` holds a weak ref pushed via `attach(...)`. Not
-  /// `.environment(...)`-injected — no SwiftUI view consumes the menu surface.
   @State private var menuBarController: MenuBarController
-  /// PR-B.4 of #763: App-owned home for the process-lifecycle sequence
-  /// (launch / foreground-activation / termination side effects). Strong owner
-  /// is this `@State`; `AppDelegate` holds a weak ref pushed via `attach(...)`
-  /// and forwards its three lifecycle callbacks here. Not
-  /// `.environment(...)`-injected — no SwiftUI view consumes it.
   @State private var appLifecycleCoordinator: AppLifecycleCoordinator
+
+  // PR-C.1 of #763: the nine view-facing subsystems that AppState used to own
+  // are now App-owned `@State` homes, injected into both Window scenes'
+  // environment alongside `appState`. Views still read `@Environment(AppState.self)`
+  // in PR-C.1; PR-C.2 / PR-C.3 migrate them onto these homes directly.
+  @State private var settings: SettingsManager
+  @State private var permissions: PermissionsService
+  @State private var asrManager: any ASRManagerInterface
+  @State private var customWordsCoordinator: CustomWordsCoordinator
+  @State private var setup: SetupCoordinator
+  @State private var audioDeviceList: AudioDeviceList
+  @State private var aiAvailability: AIAvailabilityCoordinator
+  @State private var keychainManager: KeychainManager
+  @State private var llmDiscovery: LLMModelDiscoveryCoordinator
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
 
   init() {
-    // Construct App-owned homes in dependency order. Closure-capture targets
-    // (overlay) must exist before the closures are built; AppState's chip
-    // handlers must be wired exactly once.
+    // ===== PR-C.1 of #763: subsystem construction (relocated from AppState.init) =====
+    // `EnviousWisprApp` is the composition root. Every subsystem is constructed
+    // here and handed to a receive-only `AppState`. Construction order is
+    // load-bearing: `polishService` before the pipelines (they read its
+    // `pasteCompletionRegistry`); `settingsSync` after both pipelines + `setup`.
+
+    let settings = SettingsManager()
+    let permissions = PermissionsService()
+    let keychainManager = KeychainManager()
+    let recordingOverlay = RecordingOverlayPanel()
+    let audioDeviceList = AudioDeviceList()
+    let captureTelemetry = CaptureTelemetryState()
+    let customWordsCoordinator = CustomWordsCoordinator()
+    let customWordsPropagator = CustomWordsPropagator()
+    let aiAvailability = AIAvailabilityCoordinator()
+
+    // XPC audio service — default ON. Audio capture runs in a separate XPC
+    // service process for crash isolation. Read directly from UserDefaults
+    // (the `object(forKey:) ?? true` pattern so existing installs with no key
+    // written get the new default). Escape hatch:
+    // `defaults write ... useXPCAudioService -bool false`.
+    let useXPC = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
+    let audioCapture: any AudioCaptureInterface =
+      useXPC ? AudioCaptureProxy() : AudioCaptureManager()
+
+    // XPC ASR service — default ON. ASR inference runs in a separate XPC
+    // service process for memory isolation. Escape hatch:
+    // `defaults write ... useXPCASRService -bool false`.
+    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
+    let asrManager: any ASRManagerInterface =
+      useXPCASR ? ASRManagerProxy() : ASRManager()
+
+    let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
+
     let transcriptStore = TranscriptStore()
     let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
-    // PR10 of #763 — shared `HotkeyService` constructed here as a local
-    // let so it can be threaded into AppState.init (for PSS), DLC.init,
-    // DR.init (which threads it into HotkeyController), and AppDelegate.attach
-    // (for termination). Assigned to `_hotkeyService = State(initialValue:)`
-    // at the end of init alongside the other @State homes.
+
+    // Phase 0 (#640) — single shared paste-completion registry. `polishService`
+    // is constructed before the pipelines so both receive the same instance.
+    let polishService = TranscriptPolishService(
+      keychainManager: keychainManager,
+      transcriptStore: transcriptStore
+    )
+
+    let pipeline = TranscriptionPipeline(
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      captureTelemetry: captureTelemetry,
+      pasteCompletionRegistry: polishService.pasteCompletionRegistry
+    )
+
+    // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
+    // stays vendor-contained. The detector fires this from an actor; hop to
+    // MainActor to call the @MainActor-isolated `TelemetryService`.
+    let languageDetector = LanguageDetector(
+      onLanguageFlip: { @Sendable event in
+        Task { @MainActor in
+          TelemetryService.shared.trackLanguageFlip(
+            fromLang: event.fromLang,
+            toLang: event.toLang,
+            confidenceBoth: event.confidenceBoth
+          )
+        }
+      }
+    )
+    let whisperKitPipeline = WhisperKitPipeline(
+      audioCapture: audioCapture,
+      backend: WhisperKitBackend(),
+      transcriptStore: transcriptStore,
+      keychainManager: keychainManager,
+      languageDetector: languageDetector,
+      captureTelemetry: captureTelemetry,
+      pasteCompletionRegistry: polishService.pasteCompletionRegistry
+    )
+
+    // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit
+    // preload closure. `[weak whisperKitPipeline]` so it does not retain it.
+    let setup = SetupCoordinator(
+      asrManager: asrManager,
+      preloadAction: { [weak whisperKitPipeline] in
+        await whisperKitPipeline?.prepareBackendSilently()
+      }
+    )
+
+    // PR10 of #763 — shared `HotkeyService`. One owner so the single instance
+    // threads into `HotkeyController`, `PipelineSettingsSync`,
+    // `DictationLifecycleCoordinator`, and `AppDelegate` termination.
     let hotkeyService = HotkeyService()
-    let appState = AppState(transcriptStore: transcriptStore, hotkeyService: hotkeyService)
+
+    let settingsSync = PipelineSettingsSync(
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: hotkeyService,
+      whisperKitSetup: setup.whisperKitSetup
+    )
+    settingsSync.applyInitialSettings(settings)
+
+    recordingOverlay.setGrantHandler { [weak permissions] in
+      _ = permissions?.requestAccessibilityAccess()
+    }
+    recordingOverlay.setAccessibilityWarningDismissedProvider { [weak permissions] in
+      permissions?.accessibilityWarningDismissed ?? false
+    }
+
+    // Custom-words propagator wiring (seed → register consumers → install
+    // `onWordsChanged`). Phase D (#496). PR-C.1: `wireCustomWords` now
+    // strong-captures the propagator so its lifetime survives AppState deletion
+    // in PR-C.4.
+    wireCustomWords(
+      propagator: customWordsPropagator,
+      initialWords: customWordsCoordinator.customWords,
+      correctorConsumers: [
+        pipeline.wordCorrection,
+        whisperKitPipeline.wordCorrection,
+      ],
+      polishConsumers: [
+        pipeline.llmPolish,
+        whisperKitPipeline.llmPolish,
+        polishService.llmPolishStep,
+      ],
+      coordinator: customWordsCoordinator
+    )
+
+    settingsSync.onNeedsPreloadObservation = { [weak setup] in
+      setup?.startPreloadObservation()
+    }
+
+    // Restore persisted backend selection synchronously (no race with first record).
+    asrManager.setInitialBackendType(settings.selectedBackend)
+    SentryBreadcrumb.updateASRBackend(
+      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+
+    settings.onChange = { [weak settingsSync, weak settings] key in
+      guard let settingsSync, let settings else { return }
+      settingsSync.handleSettingChanged(key, settings: settings)
+    }
+
+    // Pre-load the selected backend's model in the background to eliminate
+    // cold-start delay. Parakeet: direct silent load. WhisperKit:
+    // observation-based (waits for setupState to become .ready first).
+    if settings.selectedBackend == .parakeet {
+      Task { [weak asrManager] in
+        await asrManager?.loadModelSilently()
+      }
+    }
+    Task { [weak setup] in
+      await setup?.whisperKitSetup.detectState()
+      setup?.startPreloadObservation()
+    }
+
+    // ===== Receive-only AppState (PR-C.1 of #763) =====
+    let appState = AppState(
+      settings: settings,
+      permissions: permissions,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      keychainManager: keychainManager,
+      recordingOverlay: recordingOverlay,
+      setup: setup,
+      audioDeviceList: audioDeviceList,
+      captureTelemetry: captureTelemetry,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      polishService: polishService,
+      settingsSync: settingsSync,
+      customWordsCoordinator: customWordsCoordinator,
+      customWordsPropagator: customWordsPropagator,
+      llmDiscovery: llmDiscovery,
+      aiAvailability: aiAvailability
+    )
+    // PR-C.1: AppState still conforms to `DictationActivityProviding`.
+    // PR-C.3 rewires this provider to `LiveRecordingState`.
+    polishService.setDictationActivity(appState)
+
     let navigationCoordinator = NavigationCoordinator()
     let diagnosticsCoordinator = DiagnosticsCoordinator()
 
     // PR4 of #763 construction-order constraint preserved: LanguageSuggestionPresenter
-    // captures `appState.recordingOverlay` through narrow closures. Build
-    // overlay reference first, then presenter, then attach to AppState.
-    let overlay = appState.recordingOverlay
+    // captures `recordingOverlay` through narrow closures. Build presenter,
+    // then attach to AppState.
+    let overlay = recordingOverlay
     let languageSuggestionPresenter = LanguageSuggestionPresenter(
       showOverlay: { [weak overlay] intent in overlay?.show(intent: intent) },
       readCurrentIntent: { [weak overlay] in overlay?.currentIntent ?? .hidden },
@@ -80,25 +240,37 @@ struct EnviousWisprApp: App {
       // "Recording complete" AX announcement (PR4 Codex code-diff r5 [P3]).
       hideOverlay: { [weak overlay] in overlay?.hide() }
     )
-    // Setter injection: appState now holds a reference to the presenter for
-    // dispatching from its chip-handler closure and pipeline state-change closures.
+    // Setter injection: appState holds a reference to the presenter for the
+    // not-yet-migrated views and pipeline state-change closures.
     appState.attachLanguageSuggestionPresenter(languageSuggestionPresenter)
+
+    // PR-C.1 of #763: passive-chip handler relocated from `AppState.init`.
+    // Wires the `LanguageDetector` actor's callback to the presenter now that
+    // it exists. Previously wired inside `AppState.init` capturing `self`
+    // weakly; the presenter is now captured directly (App-lifetime `@State`).
+    Task {
+      await languageDetector.setPassiveChipHandler {
+        @Sendable (trigger: PassiveChipTrigger) in
+        Task { @MainActor in
+          languageSuggestionPresenter.bufferTrigger(trigger)
+        }
+      }
+    }
+
     // Wire RecordingOverlayPanel chip handler closures into the presenter.
-    appState.recordingOverlay.setPassiveChipHandlers(
-      onLock: { [weak appState, presenter = languageSuggestionPresenter] in
-        if let lang = presenter.accept(), let appState = appState {
+    recordingOverlay.setPassiveChipHandlers(
+      onLock: { [weak settings, presenter = languageSuggestionPresenter] in
+        if let lang = presenter.accept(), let settings = settings {
           // Capture prior mode for telemetry before mutating settings.
-          let priorMode = appState.settings.languageMode
+          let priorMode = settings.languageMode
           let fromLang: String
           switch priorMode {
           case .auto: fromLang = "auto"
           case .locked(let prev): fromLang = prev
           }
-          appState.settings.languageMode = .locked(lang)
-          // PR4 Codex code-diff r6 [P2]: chip-driven locks must emit the same
-          // language.manual_lock_used event as Settings-driven locks so the
-          // chip CTA is visible in analytics. "after_bad_detect" is the
-          // reserved reason for this surface (TelemetryService.swift:483).
+          settings.languageMode = .locked(lang)
+          // PR4 Codex code-diff r6 [P2]: chip-driven locks emit the same
+          // language.manual_lock_used event as Settings-driven locks.
           TelemetryService.shared.trackManualLockUsed(
             fromLang: fromLang, toLang: lang, reason: "after_bad_detect")
         }
@@ -117,64 +289,56 @@ struct EnviousWisprApp: App {
 
     let transcriptWorkflowCoordinator = TranscriptWorkflowCoordinator(
       transcriptCoordinator: transcriptCoordinator,
-      polishService: appState.polishService
+      polishService: polishService
     )
 
     let liveRecordingState = LiveRecordingState(
-      pipeline: appState.pipeline,
-      whisperKitPipeline: appState.whisperKitPipeline,
-      audioCapture: appState.audioCapture,
-      asrManager: appState.asrManager
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      audioCapture: audioCapture,
+      asrManager: asrManager
     )
     let lastRecordingResult = LastRecordingResult()
     let backendMetadata = BackendMetadata(
-      settings: appState.settings,
-      asrManager: appState.asrManager,
-      llmDiscovery: appState.llmDiscovery
+      settings: settings,
+      asrManager: asrManager,
+      llmDiscovery: llmDiscovery
     )
     appState.attachLiveRecordingState(liveRecordingState)
     appState.attachLastRecordingResult(lastRecordingResult)
     appState.attachBackendMetadata(backendMetadata)
 
     // PR9 of #763: construct the lifecycle home BEFORE DictationRuntime.
-    // PR10 of #763: the shared `hotkeyService` is now threaded in
-    // explicitly from the App-owned local let, not from `appState.hotkeyService`
-    // (which no longer exists).
     let recordingLockedAccess = DictationLifecycleCoordinator.RecordingLockedAccess(
       get: { [weak appState] in appState?.isRecordingLocked ?? false },
       set: { [weak appState] locked in appState?.isRecordingLocked = locked }
     )
     let dictationLifecycleCoordinator = DictationLifecycleCoordinator(
-      pipeline: appState.pipeline,
-      whisperKitPipeline: appState.whisperKitPipeline,
-      recordingOverlay: appState.recordingOverlay,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      recordingOverlay: recordingOverlay,
       hotkeyService: hotkeyService,
-      settingsSync: appState.settingsSync,
-      audioCapture: appState.audioCapture,
+      settingsSync: settingsSync,
+      audioCapture: audioCapture,
       transcriptCoordinator: transcriptCoordinator,
-      settings: appState.settings,
+      settings: settings,
       lastRecordingResult: lastRecordingResult,
       languageSuggestionPresenter: languageSuggestionPresenter,
       recordingLockedAccess: recordingLockedAccess
     )
     dictationLifecycleCoordinator.install()
 
-    // PR8 of #763: construct heart-path event-routing home. Routers install
-    // their `audioCapture.on*` / `asrManager.onServiceInterrupted` slots +
-    // the `AVAudioEngineConfigurationChange` observer at init.
-    // PR10 of #763: also constructs `HotkeyController` / `RecordingStarter` /
-    // `RecordingFinalizer` internally and calls `hotkeyController.install()`
-    // as the last init step. EnviousWisprApp.init does NOT construct the
-    // recording subsystem directly — DR is the composition root for it.
+    // PR8 of #763: heart-path event-routing home. PR10: also constructs
+    // HotkeyController / RecordingStarter / RecordingFinalizer internally.
     let dictationRuntime = DictationRuntime(
-      audioCapture: appState.audioCapture,
-      asrManager: appState.asrManager,
-      pipeline: appState.pipeline,
-      whisperKitPipeline: appState.whisperKitPipeline,
-      captureTelemetry: appState.captureTelemetry,
-      settings: appState.settings,
-      permissions: appState.permissions,
-      recordingOverlay: appState.recordingOverlay,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      captureTelemetry: captureTelemetry,
+      settings: settings,
+      permissions: permissions,
+      recordingOverlay: recordingOverlay,
       hotkeyService: hotkeyService,
       lastRecordingResult: lastRecordingResult,
       languageSuggestionPresenter: languageSuggestionPresenter,
@@ -191,32 +355,24 @@ struct EnviousWisprApp: App {
       }
     )
 
-    // PR-B.2 of #763: window-lifecycle home. The two closures encode today's
-    // two distinct onboarding guards exactly (`canOpenOnboarding` folds the
-    // stacked `guard let appState` + `!= .completed`; `isOnboardingComplete`
-    // is the close-observer abort gate). Both capture `appState` weakly so the
-    // coordinator carries no `AppState` import or stored reference.
+    // PR-B.2 of #763: window-lifecycle home.
     let appWindowCoordinator = AppWindowCoordinator(
-      canOpenOnboarding: { [weak appState] in
-        guard let appState else { return false }
-        return appState.settings.onboardingState != .completed
+      canOpenOnboarding: { [weak settings] in
+        guard let settings else { return false }
+        return settings.onboardingState != .completed
       },
-      isOnboardingComplete: { [weak appState] in
-        appState?.settings.onboardingState == .completed
+      isOnboardingComplete: { [weak settings] in
+        settings?.onboardingState == .completed
       }
     )
 
-    // PR-B.3 of #763: menu bar surface home. The five menu-action closures
-    // compose the previously inline `@objc` AppDelegate action bodies. The
-    // controller reads display facts through narrow PR11-survivor refs
-    // (`liveRecordingState`, `backendMetadata`, `sparkleUpdateController`,
-    // `appState.settings`, `appState.permissions`) — no AppState reference.
+    // PR-B.3 of #763: menu bar surface home.
     let menuBarController = MenuBarController(
       liveRecordingState: liveRecordingState,
       backendMetadata: backendMetadata,
       sparkleUpdateController: sparkleUpdateController,
-      settings: appState.settings,
-      permissions: appState.permissions,
+      settings: settings,
+      permissions: permissions,
       actions: MenuBarActions(
         continueOnboarding: { appWindowCoordinator.openOnboardingWindow() },
         openSettings: {
@@ -232,10 +388,7 @@ struct EnviousWisprApp: App {
       )
     )
 
-    // PR-B.4 of #763: process-lifecycle home. Constructed last — it injects
-    // seven already-built dependencies and wires the onboarding-dismiss
-    // icon-refresh seam in its `init`. Holds the launch / become-active /
-    // terminate bodies that were inlined in `AppDelegate` before PR-B.4.
+    // PR-B.4 of #763: process-lifecycle home. Constructed last.
     let appLifecycleCoordinator = AppLifecycleCoordinator(
       appState: appState,
       dictationRuntime: dictationRuntime,
@@ -262,21 +415,25 @@ struct EnviousWisprApp: App {
     _menuBarController = State(initialValue: menuBarController)
     _appLifecycleCoordinator = State(initialValue: appLifecycleCoordinator)
 
+    // PR-C.1 of #763: the nine view-facing homes.
+    _settings = State(initialValue: settings)
+    _permissions = State(initialValue: permissions)
+    _asrManager = State(initialValue: asrManager)
+    _customWordsCoordinator = State(initialValue: customWordsCoordinator)
+    _setup = State(initialValue: setup)
+    _audioDeviceList = State(initialValue: audioDeviceList)
+    _aiAvailability = State(initialValue: aiAvailability)
+    _keychainManager = State(initialValue: keychainManager)
+    _llmDiscovery = State(initialValue: llmDiscovery)
+
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires.
-    // PR-B.4 of #763: `AppDelegate` is now a thin AppKit adapter — it receives
-    // only `sparkleUpdateController` (for `applicationWillFinishLaunching`) and
-    // `appLifecycleCoordinator` (for the launch / become-active / terminate
-    // callbacks). All other dependencies are injected into
-    // `AppLifecycleCoordinator.init` instead.
     appDelegate.attach(
       sparkleUpdateController: sparkleUpdateController,
       appLifecycleCoordinator: appLifecycleCoordinator
     )
 
-    // Initialize observability (PostHog + Sentry) unconditionally at launch —
-    // captures install/open/update lifecycle events, startup crashes, and the
-    // full onboarding funnel. Anonymous from first launch.
+    // Initialize observability (PostHog + Sentry) unconditionally at launch.
     ObservabilityBootstrap.initialize()
   }
 
@@ -295,6 +452,16 @@ struct EnviousWisprApp: App {
         .environment(backendMetadata)
         .environment(dictationRuntime)
         .environment(appWindowCoordinator)
+        // PR-C.1 of #763: nine view-facing homes injected alongside `appState`.
+        .environment(settings)
+        .environment(permissions)
+        .environment(customWordsCoordinator)
+        .environment(setup)
+        .environment(audioDeviceList)
+        .environment(aiAvailability)
+        .environment(llmDiscovery)
+        .environment(\.asrManager, asrManager)
+        .environment(\.keychainManager, keychainManager)
         .background(
           ActionWirer(
             appState: appState,
@@ -316,6 +483,16 @@ struct EnviousWisprApp: App {
       .environment(languageSuggestionPresenter)
       .environment(dictationRuntime)
       .environment(appWindowCoordinator)
+      // PR-C.1 of #763: nine view-facing homes injected alongside `appState`.
+      .environment(settings)
+      .environment(permissions)
+      .environment(customWordsCoordinator)
+      .environment(setup)
+      .environment(audioDeviceList)
+      .environment(aiAvailability)
+      .environment(llmDiscovery)
+      .environment(\.asrManager, asrManager)
+      .environment(\.keychainManager, keychainManager)
     }
     .windowResizability(.contentSize)
     .defaultSize(width: 500, height: 550)
@@ -349,15 +526,10 @@ private struct ActionWirer: View {
         appWindowCoordinator.dismissOnboardingAction = { [dismissWindow] in
           dismissWindow(id: "onboarding")
         }
-        // PR-B.2 of #763: drain any queued onboarding-open request FIRST. On a
-        // normal fresh-install launch nothing was queued (no caller runs before
-        // this task), so `replayed` is false and the auto-open below fires
-        // exactly once — identical to today. Draining first prevents a
-        // double-open if a queued request exists.
+        // PR-B.2 of #763: drain any queued onboarding-open request FIRST.
         let replayed = appWindowCoordinator.consumePendingOpenOnboarding()
         // Auto-open onboarding if needed (first launch), only if nothing was
-        // already replayed. ActionWirer runs inside the main Window scene which
-        // is always created, so the callbacks are wired before this point.
+        // already replayed.
         if !replayed, appState.settings.onboardingState != .completed {
           appWindowCoordinator.openOnboardingWindow()
         }

--- a/Tests/EnviousWisprTests/Architecture/AppStateReceiveOnlyTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateReceiveOnlyTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+/// PR-C.1 of #763 — guards that `AppState` stays **receive-only**.
+///
+/// PR-C.1 moved all subsystem construction and every init-time wiring step out
+/// of `AppState.init()` into `EnviousWisprApp.init()` (the composition root).
+/// AppState's initializer must remain pure assignment: every statement is
+/// `self.<name> = <name>`. This test fails if a future change reintroduces
+/// construction (a `SomeType(...)` call), wiring (`.setX(...)`, `wireX(...)`,
+/// closure assignment), or a `Task` into the body — the regression that would
+/// re-grow AppState back toward a god object during the PR-C migration window.
+///
+/// Replaced by `AppStateFreezeTests` in PR-C.4, when `AppState.swift` is deleted.
+@Suite struct AppStateReceiveOnlyTests {
+
+  @Test func appStateInitIsPureAssignment() throws {
+    let url = URL(fileURLWithPath: "Sources/EnviousWispr/App/AppState.swift")
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let body = try Self.initBody(in: source)
+
+    let offending =
+      body
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { line in
+        guard !line.isEmpty, !line.hasPrefix("//") else { return false }
+        // The only allowed statement shape is `self.<ident> = <ident>`.
+        return line.range(
+          of: #"^self\.[A-Za-z_][A-Za-z0-9_]* = [A-Za-z_][A-Za-z0-9_]*$"#,
+          options: .regularExpression) == nil
+      }
+
+    #expect(
+      offending.isEmpty,
+      """
+      AppState.init must be pure assignment (receive-only — PR-C.1 of #763). \
+      Construction and wiring belong in EnviousWisprApp.init(). \
+      Non-assignment statements found:
+      \(offending.joined(separator: "\n"))
+      """)
+  }
+
+  /// Extract the body of `init(...) { ... }` — the text between the `{` that
+  /// opens the init body (the first `{` after the balanced parameter list) and
+  /// its matching `}`.
+  private static func initBody(in source: String) throws -> String {
+    guard let initRange = source.range(of: "  init(") else {
+      Issue.record("AppState `init(` not found at expected shape")
+      throw POSIXError(.ENOENT)
+    }
+    var idx = initRange.upperBound
+    var parenDepth = 1
+    while idx < source.endIndex, parenDepth > 0 {
+      if source[idx] == "(" { parenDepth += 1 }
+      if source[idx] == ")" { parenDepth -= 1 }
+      idx = source.index(after: idx)
+    }
+    guard let openBrace = source[idx...].firstIndex(of: "{") else {
+      Issue.record("AppState init body opening brace not found")
+      throw POSIXError(.ENOENT)
+    }
+    var braceDepth = 0
+    var j = openBrace
+    while j < source.endIndex {
+      if source[j] == "{" { braceDepth += 1 }
+      if source[j] == "}" {
+        braceDepth -= 1
+        if braceDepth == 0 {
+          return String(source[source.index(after: openBrace)..<j])
+        }
+      }
+      j = source.index(after: j)
+    }
+    Issue.record("AppState init body has unbalanced braces")
+    throw POSIXError(.EILSEQ)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -73,13 +73,21 @@ import Testing
   ///   `init()` from seven already-built dependencies and threaded into
   ///   `appDelegate.attach(...)`. This is the final PR-B home — `AppDelegate`
   ///   ends as a thin AppKit adapter. Not `.environment(...)`-injected.
+  /// - 17 → 26 in PR-C.1 of epic #763 (2026-05-20, #813). Bible §30 entry:
+  ///   PR-C.1 hoists the nine view-facing subsystems AppState used to own
+  ///   (`settings`, `permissions`, `asrManager`, `customWordsCoordinator`,
+  ///   `setup`, `audioDeviceList`, `aiAvailability`, `keychainManager`,
+  ///   `llmDiscovery`) into App-owned `@State` homes, injected into both Window
+  ///   scenes. `appState` itself stays (receive-only) until PR-C.4 deletes it,
+  ///   which lowers this ceiling back to 25 (lower-is-free). The seven
+  ///   construction-only subsystems stay `init()` locals and are not counted.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 17,
+      count <= 26,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 17. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 26. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -127,35 +135,47 @@ import Testing
   /// and its `@State` declaration + assignment, net of the `attach(...)` call
   /// collapsing from eight arguments to two. Cap set by the deterministic rule
   /// (post-change actual 375 + 10, rounded up to the nearest 5).
+  /// Ratcheted 385→560 in PR-C.1 of epic #763 (2026-05-20, #813) to absorb the
+  /// subsystem construction + init-time wiring relocated from `AppState.init()`
+  /// (the composition root now constructs all 17 subsystems), the nine
+  /// view-facing `@State` declarations + assignments, and the eighteen
+  /// `.environment(...)` injections across the two Window scenes. Cap set by
+  /// the deterministic rule (post-change actual 546 + 10, rounded up to the
+  /// nearest 5). Line count is a soft 5x backstop — the stored-property and
+  /// import ceilings are the primary entanglement signals.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 385,
+      lineCount <= 560,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 385. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 560. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }
 
-  /// Allowed-imports ceiling. The composition root must NOT depend on lower
-  /// modules like EnviousWisprPipeline / EnviousWisprAudio / EnviousWisprASR /
-  /// EnviousWisprLLM directly — that would couple SwiftUI mounting to engine
-  /// implementation details. AppDelegate already carries those imports.
+  /// Allowed-imports ceiling.
   ///
   /// PR9 of #763 added EnviousWisprStorage to construct `TranscriptStore`
-  /// directly in the composition root (hoisted out of `AppState.init` so the
-  /// composition root can thread the same `TranscriptCoordinator` instance
-  /// to both the lifecycle home and the transcript workflow coordinator).
-  /// `TranscriptStore` is a small, dependency-free persistence wrapper — not
-  /// an engine internal — so allowing it on the composition root is
-  /// consistent with the rule's intent.
+  /// directly in the composition root.
+  ///
+  /// PR-C.1 of #763 (#813) widened the allowlist to the full engine-module set
+  /// (`EnviousWisprASR`, `EnviousWisprAudio`, `EnviousWisprLLM`,
+  /// `EnviousWisprPipeline`). This is the deliberate consequence of making
+  /// `EnviousWisprApp` the construction root: it now builds `AudioCaptureProxy`,
+  /// `ASRManagerProxy`, both pipelines, `TranscriptPolishService`,
+  /// `LLMModelDiscoveryCoordinator`, etc. — the construction that used to live
+  /// in `AppState.init()`. A composition root importing the modules it
+  /// composes is correct; the anti-coupling intent is satisfied by the
+  /// zero-non-private-method ceiling, which keeps the App struct construction-
+  /// only with no behavior.
   @Test func envWisprAppImportsCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let allowed: Set<String> = [
       "SwiftUI", "EnviousWisprCore", "EnviousWisprServices", "EnviousWisprStorage",
+      "EnviousWisprASR", "EnviousWisprAudio", "EnviousWisprLLM", "EnviousWisprPipeline",
     ]
     let actual = parseImports(in: source)
     let unexpected = actual.subtracting(allowed)


### PR DESCRIPTION
PR-C.1 of 4 in the PR-C sub-bible (epic #763, AppState deletion). Meta-tracker #777.

## Summary
- Moves construction of all 17 subsystems + every init-time wiring step out of `AppState.init()` into `EnviousWisprApp.init()`, the SwiftUI composition root. `AppState` is now **receive-only**: pure-assignment init, constructs and wires nothing. It stays `@Environment`-injected so the not-yet-migrated views keep working unchanged (PR-C.2 / PR-C.3 migrate them; PR-C.4 deletes the file).
- Nine view-facing homes (`settings`, `permissions`, `asrManager`, `customWordsCoordinator`, `setup`, `audioDeviceList`, `aiAvailability`, `keychainManager`, `llmDiscovery`) become App-owned `@State`, injected into both Window scenes alongside `appState`.
- **Bug fix (Codex grounded review):** `wireCustomWords` now strong-captures the propagator. Pre-PR-C.1 it was `[weak propagator]` because AppState held it; with construction hoisted the propagator's lifetime is anchored to `CustomWordsCoordinator` (App-owned `@State`). Without this, custom-words fan-out would silently die after init.
- `AppEnvironmentKeys.swift` (new): custom EnvironmentKeys for the two homes that cannot use the object-based `.environment()` modifier (`asrManager` existential, `keychainManager` plain `Sendable`).
- `AppStateReceiveOnlyTests.swift` (new): asserts `AppState.init` stays pure assignment.
- `EnviousWisprAppCeilingsTests`: stored-property ceiling 17 → 26, line-count 385 → 560, import allowlist widened to the four engine modules. Bible §30 ratchet entries inline.

No behavior change: same instances, same wiring, same load-bearing construction order (`polishService` before pipelines).

## Validation
- `swift build` (debug + release): clean.
- `scripts/swift-test.sh`: 1126 tests pass.
- Codex code-diff review: PROCEED, zero findings — confirmed construction-order preservation, the propagator strong-capture fix is cycle-free, the chip-handler relocation sound, the environment keys correct.
- Founder runtime UAT: rewired-startup app launches; dictation verified end-to-end on both Parakeet and WhisperKit; custom words propagate correctly (verifies the propagator lifetime fix live).

Closes #813.
