### PR TITLE
refactor(appstate): migrate Settings view cluster off @Environment(AppState.self) (PR-C.2 of #763)

### DIFF
--- a/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AIPolishSettingsView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprServices
 import OSLog
 import Security
 import SwiftUI
@@ -135,33 +136,41 @@ enum AIPolishModelClassifier {
 
 /// LLM provider configuration, API keys, Ollama wizard, and prompt editing.
 struct AIPolishSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(SetupCoordinator.self) private var setup
+  @Environment(AIAvailabilityCoordinator.self) private var aiAvailability
+  @Environment(LLMModelDiscoveryCoordinator.self) private var llmDiscovery
+  @Environment(\.keychainManager) private var keychainManagerEnv
+
+  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
+  /// environment (see `AppEnvironmentKeys.swift`).
+  private var keychainManager: KeychainManager { keychainManagerEnv! }
 
   @State private var openAIKey: String = ""
   @State private var geminiKey: String = ""
   @State private var validationStatus: String = ""
 
   private var isCloudProvider: Bool {
-    appState.settings.llmProvider == .openAI || appState.settings.llmProvider == .gemini
+    settings.llmProvider == .openAI || settings.llmProvider == .gemini
   }
 
   private var isReasoningModel: Bool {
-    appState.settings.llmProvider.supportsReasoning(model: appState.settings.llmModel)
+    settings.llmProvider.supportsReasoning(model: settings.llmModel)
   }
 
   private var showModelSection: Bool {
-    appState.settings.llmProvider != .none && appState.settings.llmProvider != .appleIntelligence
+    settings.llmProvider != .none && settings.llmProvider != .appleIntelligence
   }
 
   private var ollamaShowsManageModels: Bool {
-    switch appState.setup.ollamaSetup.setupState {
+    switch setup.ollamaSetup.setupState {
     case .ready, .pullingModel, .runningNoModels: return true
     default: return false
     }
   }
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       // ── Section 1: LLM Provider ───────────────────────────────
@@ -169,7 +178,7 @@ struct AIPolishSettingsView: View {
         header: "LLM Provider",
         content: {
           BrandedRow {
-            Picker("LLM Provider", selection: $state.settings.llmProvider) {
+            Picker("LLM Provider", selection: $settings.llmProvider) {
               Text("Off").tag(LLMProvider.none)
               Text("OpenAI").tag(LLMProvider.openAI)
               Text("Google Gemini").tag(LLMProvider.gemini)
@@ -178,7 +187,7 @@ struct AIPolishSettingsView: View {
             }
           }
 
-          if appState.settings.llmProvider == .none {
+          if settings.llmProvider == .none {
             BrandedRow {
               Text("Turn on AI polish to automatically fix grammar, punctuation, and formatting.")
                 .font(.stHelper)
@@ -195,14 +204,14 @@ struct AIPolishSettingsView: View {
           }
 
           // Ollama wizard
-          if appState.settings.llmProvider == .ollama {
+          if settings.llmProvider == .ollama {
             BrandedRow {
               ollamaSetupContent
             }
           }
 
           // Apple Intelligence status
-          if appState.settings.llmProvider == .appleIntelligence {
+          if settings.llmProvider == .appleIntelligence {
             BrandedRow(showDivider: false) {
               appleIntelligenceStatus
             }
@@ -210,13 +219,13 @@ struct AIPolishSettingsView: View {
         },
         footer: {
           if isCloudProvider {
-            if appState.settings.llmProvider == .openAI {
+            if settings.llmProvider == .openAI {
               Link(
                 "Get your free API key at platform.openai.com",
                 destination: URL(string: "https://platform.openai.com/api-keys")!
               )
               .font(.stHelper)
-            } else if appState.settings.llmProvider == .gemini {
+            } else if settings.llmProvider == .gemini {
               Link(
                 "Get your free API key at aistudio.google.com",
                 destination: URL(string: "https://aistudio.google.com/apikey")!
@@ -231,33 +240,33 @@ struct AIPolishSettingsView: View {
         BrandedSection(header: "Model") {
           BrandedRow(showDivider: false) {
             HStack {
-              Picker("Model", selection: $state.settings.llmModel) {
-                if appState.llmDiscovery.discoveredModels.isEmpty
-                  && !appState.llmDiscovery.isDiscoveringModels
+              Picker("Model", selection: $settings.llmModel) {
+                if llmDiscovery.discoveredModels.isEmpty
+                  && !llmDiscovery.isDiscoveringModels
                 {
                   Text(
-                    appState.settings.llmModel.isEmpty
-                      ? (appState.settings.llmProvider == .ollama
+                    settings.llmModel.isEmpty
+                      ? (settings.llmProvider == .ollama
                         ? "No models found"
                         : "Save API key to discover models")
-                      : appState.settings.llmModel
+                      : settings.llmModel
                   )
-                  .tag(appState.settings.llmModel)
+                  .tag(settings.llmModel)
                 }
 
                 modelPickerSections
               }
 
-              if appState.settings.llmProvider == .ollama {
+              if settings.llmProvider == .ollama {
                 ollamaWarmupIndicator
-              } else if appState.llmDiscovery.isDiscoveringModels {
+              } else if llmDiscovery.isDiscoveringModels {
                 ProgressView()
                   .controlSize(.small)
               } else {
                 Button {
                   Task {
-                    await appState.llmDiscovery.validateKeyAndDiscoverModels(
-                      provider: appState.settings.llmProvider, settings: appState.settings)
+                    await llmDiscovery.validateKeyAndDiscoverModels(
+                      provider: settings.llmProvider, settings: settings)
                   }
                 } label: {
                   Image(systemName: "arrow.clockwise")
@@ -282,7 +291,7 @@ struct AIPolishSettingsView: View {
       }
 
       // Manage Models for Ollama (always expanded)
-      if appState.settings.llmProvider == .ollama,
+      if settings.llmProvider == .ollama,
         ollamaShowsManageModels
       {
         BrandedSection(header: "Manage Models") {
@@ -296,9 +305,8 @@ struct AIPolishSettingsView: View {
       if isReasoningModel {
         BrandedSection(header: "Advanced") {
           BrandedRow(showDivider: false) {
-            @Bindable var state2 = appState
             VStack(alignment: .leading, spacing: 4) {
-              Toggle("Deep reasoning", isOn: $state2.settings.useExtendedThinking)
+              Toggle("Deep reasoning", isOn: $settings.useExtendedThinking)
                 .toggleStyle(BrandedToggleStyle())
               Text("Takes longer but handles complex formatting instructions better.")
                 .font(.stHelper)
@@ -311,32 +319,32 @@ struct AIPolishSettingsView: View {
       }
     }
     .onAppear {
-      openAIKey = (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) ?? ""
-      geminiKey = (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) ?? ""
-      if appState.settings.llmProvider == .ollama {
-        appState.llmDiscovery.loadCachedModels(for: .ollama)
+      openAIKey = (try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)) ?? ""
+      geminiKey = (try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)) ?? ""
+      if settings.llmProvider == .ollama {
+        llmDiscovery.loadCachedModels(for: .ollama)
         Task {
-          await appState.setup.ollamaSetup.detectState()
-          if case .ready = appState.setup.ollamaSetup.setupState {
-            await appState.llmDiscovery.validateKeyAndDiscoverModels(
-              provider: .ollama, settings: appState.settings)
+          await setup.ollamaSetup.detectState()
+          if case .ready = setup.ollamaSetup.setupState {
+            await llmDiscovery.validateKeyAndDiscoverModels(
+              provider: .ollama, settings: settings)
           }
         }
-      } else if appState.settings.llmProvider == .appleIntelligence {
-        Task { await appState.aiAvailability.checkAvailability(trigger: "settings_open") }
-      } else if appState.settings.llmProvider != .none {
-        appState.llmDiscovery.loadCachedModels(for: appState.settings.llmProvider)
+      } else if settings.llmProvider == .appleIntelligence {
+        Task { await aiAvailability.checkAvailability(trigger: "settings_open") }
+      } else if settings.llmProvider != .none {
+        llmDiscovery.loadCachedModels(for: settings.llmProvider)
       }
     }
-    .onChange(of: appState.settings.llmProvider) { _, newProvider in
-      appState.llmDiscovery.reset()
+    .onChange(of: settings.llmProvider) { _, newProvider in
+      llmDiscovery.reset()
       // Model canonicalization handled by SettingsManager.llmProvider didSet.
       // Discovery will refine the model async if needed.
 
       // Clean up Ollama state when switching away
       if newProvider != .ollama {
-        appState.setup.ollamaSetup.cancelPull()
-        appState.setup.ollamaSetup.resetWarmup()
+        setup.ollamaSetup.cancelPull()
+        setup.ollamaSetup.resetWarmup()
       }
 
       switch newProvider {
@@ -345,39 +353,39 @@ struct AIPolishSettingsView: View {
       case .ollama:
         // detectState() will set setupState, which triggers the onChange handler
         // for discovery + warm-up. Don't duplicate that work here.
-        Task { await appState.setup.ollamaSetup.detectState() }
+        Task { await setup.ollamaSetup.detectState() }
       case .appleIntelligence:
-        Task { await appState.aiAvailability.checkAvailability(trigger: "provider_switch") }
+        Task { await aiAvailability.checkAvailability(trigger: "provider_switch") }
       default:
-        appState.llmDiscovery.loadCachedModels(for: newProvider)
+        llmDiscovery.loadCachedModels(for: newProvider)
         Task {
-          await appState.llmDiscovery.validateKeyAndDiscoverModels(
-            provider: newProvider, settings: appState.settings)
+          await llmDiscovery.validateKeyAndDiscoverModels(
+            provider: newProvider, settings: settings)
         }
       }
     }
-    .onChange(of: appState.setup.ollamaSetup.setupState) { _, newState in
-      if case .ready = newState, appState.settings.llmProvider == .ollama {
+    .onChange(of: setup.ollamaSetup.setupState) { _, newState in
+      if case .ready = newState, settings.llmProvider == .ollama {
         Task {
-          await appState.llmDiscovery.validateKeyAndDiscoverModels(
-            provider: .ollama, settings: appState.settings)
+          await llmDiscovery.validateKeyAndDiscoverModels(
+            provider: .ollama, settings: settings)
         }
         // Warm up the selected model when Ollama becomes ready
-        if !appState.settings.llmModel.isEmpty {
-          appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+        if !settings.llmModel.isEmpty {
+          setup.ollamaSetup.warmUpModel(settings.llmModel)
         }
-      } else if appState.settings.llmProvider == .ollama {
+      } else if settings.llmProvider == .ollama {
         // Reset warmup when Ollama leaves .ready (server died, etc.)
-        appState.setup.ollamaSetup.resetWarmup()
+        setup.ollamaSetup.resetWarmup()
       }
     }
-    .onChange(of: appState.settings.llmModel) { _, newModel in
+    .onChange(of: settings.llmModel) { _, newModel in
       // Warm up when user switches Ollama model
-      if appState.settings.llmProvider == .ollama,
-        case .ready = appState.setup.ollamaSetup.setupState,
+      if settings.llmProvider == .ollama,
+        case .ready = setup.ollamaSetup.setupState,
         !newModel.isEmpty
       {
-        appState.setup.ollamaSetup.warmUpModel(newModel)
+        setup.ollamaSetup.warmUpModel(newModel)
       }
     }
   }
@@ -386,7 +394,7 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var apiKeyRow: some View {
-    let isOpenAI = appState.settings.llmProvider == .openAI
+    let isOpenAI = settings.llmProvider == .openAI
     VStack(alignment: .leading, spacing: 6) {
       Text(isOpenAI ? "OpenAI API Key" : "Google Gemini API Key")
         .font(.stHelper)
@@ -414,14 +422,14 @@ struct AIPolishSettingsView: View {
           if isOpenAI {
             guard saveKey(key: openAIKey, keychainId: KeychainManager.openAIKeyID) else { return }
             Task {
-              await appState.llmDiscovery.validateKeyAndDiscoverModels(
-                provider: .openAI, settings: appState.settings)
+              await llmDiscovery.validateKeyAndDiscoverModels(
+                provider: .openAI, settings: settings)
             }
           } else {
             guard saveKey(key: geminiKey, keychainId: KeychainManager.geminiKeyID) else { return }
             Task {
-              await appState.llmDiscovery.validateKeyAndDiscoverModels(
-                provider: .gemini, settings: appState.settings)
+              await llmDiscovery.validateKeyAndDiscoverModels(
+                provider: .gemini, settings: settings)
             }
           }
         }
@@ -437,7 +445,7 @@ struct AIPolishSettingsView: View {
             guard clearKey(keychainId: KeychainManager.geminiKeyID) else { return }
             geminiKey = ""
           }
-          appState.llmDiscovery.reset()
+          llmDiscovery.reset()
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
@@ -462,7 +470,7 @@ struct AIPolishSettingsView: View {
         .font(.caption)
         .foregroundStyle(.stError)
     } else {
-      switch appState.llmDiscovery.keyValidationState {
+      switch llmDiscovery.keyValidationState {
       case .idle:
         if !validationStatus.isEmpty {
           Text(validationStatus)
@@ -503,7 +511,7 @@ struct AIPolishSettingsView: View {
   /// Locked rows are disabled so a user can't pick something the API will reject.
   @ViewBuilder
   private var modelPickerSections: some View {
-    let discovered = appState.llmDiscovery.discoveredModels
+    let discovered = llmDiscovery.discoveredModels
     let recommended = discovered.filter {
       $0.isAvailable && AIPolishModelClassifier.isRecommendedForCleanup($0.id)
     }
@@ -543,12 +551,12 @@ struct AIPolishSettingsView: View {
   // MARK: - Cloud Provider Explainer (#617)
 
   private var cloudProviderExplainerHeader: String {
-    appState.settings.llmProvider == .openAI ? "Why use OpenAI" : "Why use Gemini"
+    settings.llmProvider == .openAI ? "Why use OpenAI" : "Why use Gemini"
   }
 
   @ViewBuilder
   private var cloudProviderExplainer: some View {
-    if appState.settings.llmProvider == .openAI {
+    if settings.llmProvider == .openAI {
       VStack(alignment: .leading, spacing: 10) {
         Text(
           "Apple Intelligence cleans up short dictation well. OpenAI is a step up for longer recordings, lists, and code. You bring your own API key, you only pay OpenAI for what you use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to OpenAI under your API account."
@@ -580,7 +588,7 @@ struct AIPolishSettingsView: View {
         )
         .font(.stHelper)
       }
-    } else if appState.settings.llmProvider == .gemini {
+    } else if settings.llmProvider == .gemini {
       VStack(alignment: .leading, spacing: 10) {
         Text(
           "Apple Intelligence cleans up short dictation well. Gemini is a step up for longer recordings, lists, and code. You bring your own API key, the free tier is generous for personal use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to Google under your Gemini API account."
@@ -616,7 +624,7 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var ollamaSetupContent: some View {
-    switch appState.setup.ollamaSetup.setupState {
+    switch setup.ollamaSetup.setupState {
     case .detecting:
       HStack {
         ProgressView()
@@ -662,7 +670,7 @@ struct AIPolishSettingsView: View {
 
         HStack {
           Button("Start Ollama") {
-            appState.setup.ollamaSetup.startServer()
+            setup.ollamaSetup.startServer()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -684,8 +692,8 @@ struct AIPolishSettingsView: View {
           .foregroundStyle(Color.stTextTertiary)
 
         HStack {
-          Button("Download \(appState.settings.ollamaModel)") {
-            appState.setup.ollamaSetup.pullModel(appState.settings.ollamaModel)
+          Button("Download \(settings.ollamaModel)") {
+            setup.ollamaSetup.pullModel(settings.ollamaModel)
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -718,7 +726,7 @@ struct AIPolishSettingsView: View {
               .foregroundStyle(Color.stTextTertiary)
           }
           Button("Cancel") {
-            appState.setup.ollamaSetup.cancelPull()
+            setup.ollamaSetup.cancelPull()
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -751,10 +759,10 @@ struct AIPolishSettingsView: View {
 
         Button("Try Again") {
           Task {
-            await appState.setup.ollamaSetup.detectState()
-            if case .ready = appState.setup.ollamaSetup.setupState {
-              await appState.llmDiscovery.validateKeyAndDiscoverModels(
-                provider: .ollama, settings: appState.settings)
+            await setup.ollamaSetup.detectState()
+            if case .ready = setup.ollamaSetup.setupState {
+              await llmDiscovery.validateKeyAndDiscoverModels(
+                provider: .ollama, settings: settings)
             }
           }
         }
@@ -777,17 +785,17 @@ struct AIPolishSettingsView: View {
       Spacer()
       aiStatusLabel
       Button {
-        appState.aiAvailability.debouncedCheck()
+        aiAvailability.debouncedCheck()
       } label: {
         Image(systemName: "arrow.clockwise")
       }
       .buttonStyle(.borderless)
-      .disabled(appState.aiAvailability.isChecking)
+      .disabled(aiAvailability.isChecking)
       .help("Check Apple Intelligence availability")
     }
 
     // "Why?" detail text
-    if let report = appState.aiAvailability.latestReport,
+    if let report = aiAvailability.latestReport,
       report.overallStatus != .available
     {
       Text(report.userVisibleMessage)
@@ -800,7 +808,7 @@ struct AIPolishSettingsView: View {
       // `isDebugModeEnabled` runtime check) so a release binary inheriting a
       // persisted-true flag from a prior dev session cannot reach
       // `aiDebugSection`.
-      if appState.settings.isDebugModeEnabled, let report = appState.aiAvailability.latestReport {
+      if settings.isDebugModeEnabled, let report = aiAvailability.latestReport {
         aiDebugSection(report: report)
       }
     #endif
@@ -808,9 +816,9 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var aiStatusLabel: some View {
-    if appState.aiAvailability.isChecking {
+    if aiAvailability.isChecking {
       ProgressView().controlSize(.small)
-    } else if let report = appState.aiAvailability.latestReport {
+    } else if let report = aiAvailability.latestReport {
       switch report.overallStatus {
       case .available:
         Label("Available", systemImage: "checkmark.circle.fill")
@@ -865,7 +873,7 @@ struct AIPolishSettingsView: View {
           .foregroundStyle(Color.stTextTertiary)
 
           Button("Copy Diagnostics") {
-            appState.aiAvailability.copyDiagnosticsToClipboard()
+            aiAvailability.copyDiagnosticsToClipboard()
           }
           .font(.caption)
           .buttonStyle(.borderless)
@@ -906,9 +914,9 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var ollamaModelCatalogView: some View {
-    let catalog = appState.setup.ollamaSetup.dynamicCatalog
+    let catalog = setup.ollamaSetup.dynamicCatalog
     let isPulling: Bool = {
-      if case .pullingModel = appState.setup.ollamaSetup.setupState { return true }
+      if case .pullingModel = setup.ollamaSetup.setupState { return true }
       return false
     }()
 
@@ -933,15 +941,15 @@ struct AIPolishSettingsView: View {
 
           Spacer()
 
-          if appState.setup.ollamaSetup.currentPullingModel == entry.name {
+          if setup.ollamaSetup.currentPullingModel == entry.name {
             // Active pull for THIS row: show progress + Cancel.
             HStack(spacing: 8) {
-              Text("Downloading… \(Int(appState.setup.ollamaSetup.pullProgress * 100))%")
+              Text("Downloading… \(Int(setup.ollamaSetup.pullProgress * 100))%")
                 .font(.caption)
                 .foregroundStyle(Color.secondary)
                 .monospacedDigit()
               Button {
-                appState.setup.ollamaSetup.cancelPull()
+                setup.ollamaSetup.cancelPull()
               } label: {
                 Text("Cancel")
                   .foregroundStyle(.stError)
@@ -951,7 +959,7 @@ struct AIPolishSettingsView: View {
             }
           } else if entry.isDownloaded {
             Button {
-              appState.setup.ollamaSetup.deleteModel(name: entry.name)
+              setup.ollamaSetup.deleteModel(name: entry.name)
             } label: {
               Text("Delete")
                 .foregroundStyle(.stError)
@@ -961,7 +969,7 @@ struct AIPolishSettingsView: View {
             .disabled(isPulling)
           } else {
             Button {
-              appState.setup.ollamaSetup.pullModel(entry.name)
+              setup.ollamaSetup.pullModel(entry.name)
             } label: {
               Text("Download")
             }
@@ -985,7 +993,7 @@ struct AIPolishSettingsView: View {
   @discardableResult
   private func saveKey(key: String, keychainId: String) -> Bool {
     do {
-      try appState.keychainManager.store(key: keychainId, value: key)
+      try keychainManager.store(key: keychainId, value: key)
       validationStatus = "Saved!"
       Task {
         try? await Task.sleep(for: .seconds(2))
@@ -1014,7 +1022,7 @@ struct AIPolishSettingsView: View {
   @discardableResult
   private func clearKey(keychainId: String) -> Bool {
     do {
-      try appState.keychainManager.delete(key: keychainId)
+      try keychainManager.delete(key: keychainId)
       validationStatus = ""
       return true
     } catch {
@@ -1052,10 +1060,10 @@ struct AIPolishSettingsView: View {
   private func ollamaRefreshButton() -> some View {
     Button {
       Task {
-        await appState.setup.ollamaSetup.detectState()
-        if case .ready = appState.setup.ollamaSetup.setupState {
-          await appState.llmDiscovery.validateKeyAndDiscoverModels(
-            provider: .ollama, settings: appState.settings)
+        await setup.ollamaSetup.detectState()
+        if case .ready = setup.ollamaSetup.setupState {
+          await llmDiscovery.validateKeyAndDiscoverModels(
+            provider: .ollama, settings: settings)
         }
       }
     } label: {
@@ -1069,8 +1077,8 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var ollamaWarmupIndicator: some View {
-    let currentModel = OllamaSetupService.canonicalModelName(appState.settings.llmModel)
-    switch appState.setup.ollamaSetup.warmupState {
+    let currentModel = OllamaSetupService.canonicalModelName(settings.llmModel)
+    switch setup.ollamaSetup.warmupState {
     case .warming(let model) where model == currentModel:
       ProgressView()
         .controlSize(.small)
@@ -1081,7 +1089,7 @@ struct AIPolishSettingsView: View {
         .help("Model is ready")
     case .failed(let model) where model == currentModel:
       Button {
-        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+        setup.ollamaSetup.warmUpModel(settings.llmModel)
       } label: {
         Image(systemName: "exclamationmark.triangle")
           .foregroundStyle(.stWarning)
@@ -1090,8 +1098,8 @@ struct AIPolishSettingsView: View {
       .help("Couldn't prepare model. Click to retry.")
     default:
       Button {
-        guard !appState.settings.llmModel.isEmpty else { return }
-        appState.setup.ollamaSetup.warmUpModel(appState.settings.llmModel)
+        guard !settings.llmModel.isEmpty else { return }
+        setup.ollamaSetup.warmUpModel(settings.llmModel)
       } label: {
         Image(systemName: "arrow.clockwise")
       }

--- a/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/AudioSettingsView.swift
@@ -1,26 +1,28 @@
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Audio input device selection and noise processing settings.
 struct AudioSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(AudioDeviceList.self) private var audioDeviceList
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       BrandedSection(header: "Input Device") {
         BrandedRow {
-          Picker("Input Device", selection: $state.settings.preferredInputDeviceIDOverride) {
+          Picker("Input Device", selection: $settings.preferredInputDeviceIDOverride) {
             Text("Auto").tag("")
-            ForEach(appState.audioDeviceList.availableInputDevices) { device in
+            ForEach(audioDeviceList.availableInputDevices) { device in
               Text(device.name).tag(device.uid)
             }
           }
         }
         BrandedRow(showDivider: false) {
-          if appState.settings.preferredInputDeviceIDOverride.isEmpty,
+          if settings.preferredInputDeviceIDOverride.isEmpty,
             let outputID = AudioDeviceEnumerator.defaultOutputDeviceID(),
             AudioDeviceEnumerator.isBluetoothDevice(outputID)
           {
@@ -43,7 +45,7 @@ struct AudioSettingsView: View {
 
       BrandedSection(header: "Microphone Readiness") {
         BrandedRow {
-          Picker("Keep microphone ready", selection: $state.settings.warmEnginePolicy) {
+          Picker("Keep microphone ready", selection: $settings.warmEnginePolicy) {
             Text("Off").tag(WarmEnginePolicy.off)
             Text("10 seconds").tag(WarmEnginePolicy.seconds10)
             Text("30 seconds").tag(WarmEnginePolicy.seconds30)
@@ -58,7 +60,7 @@ struct AudioSettingsView: View {
             )
             .font(.stHelper)
             .foregroundStyle(.stTextTertiary)
-            if state.settings.warmEnginePolicy == .always {
+            if settings.warmEnginePolicy == .always {
               Text(
                 "Always keeps the microphone engine active. The macOS microphone indicator may remain visible and power usage may increase."
               )

--- a/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ClipboardSettingsView.swift
@@ -1,22 +1,23 @@
+import EnviousWisprServices
 import SwiftUI
 
 /// Clipboard behavior settings.
 struct ClipboardSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       BrandedSection(header: "Clipboard") {
         BrandedRow {
-          Toggle("Auto-copy to clipboard", isOn: $state.settings.autoCopyToClipboard)
+          Toggle("Auto-copy to clipboard", isOn: $settings.autoCopyToClipboard)
             .toggleStyle(BrandedToggleStyle())
         }
         BrandedRow(showDivider: false) {
           VStack(alignment: .leading, spacing: 4) {
             Toggle(
-              "Restore clipboard after paste", isOn: $state.settings.restoreClipboardAfterPaste
+              "Restore clipboard after paste", isOn: $settings.restoreClipboardAfterPaste
             )
             .toggleStyle(BrandedToggleStyle())
             Text("Saves and restores whatever was on your clipboard before pasting the transcript.")

--- a/Sources/EnviousWispr/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWispr/Views/Settings/CustomTermsSection.swift
@@ -5,13 +5,13 @@ import SwiftUI
 /// Reads `frequencyUsed` from Phase 3a/b for "used N times" subtitle (omitted
 /// when frequency is 0 to avoid the "0 times" looks-like-a-bug case). Bible §10.2.
 struct CustomTermsSection: View {
-  @Environment(AppState.self) private var appState
+  @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var searchQuery: String = ""
   @State private var currentPage: Int = 0
   @State private var editingWord: CustomWord?
 
   private var allWords: [CustomWord] {
-    appState.customWordsCoordinator.customWords
+    customWordsCoordinator.customWords
   }
 
   private var filteredWords: [CustomWord] {
@@ -116,12 +116,12 @@ struct CustomTermsSection: View {
     .sheet(item: $editingWord) { word in
       CustomWordEditSheet(
         word: word,
-        wordSuggestionService: appState.customWordsCoordinator.suggestionService,
+        wordSuggestionService: customWordsCoordinator.suggestionService,
         onSave: { updated in
-          appState.customWordsCoordinator.update(updated)
+          customWordsCoordinator.update(updated)
         },
         onDelete: {
-          appState.customWordsCoordinator.remove(id: word.id)
+          customWordsCoordinator.remove(id: word.id)
         }
       )
     }

--- a/Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/DiagnosticsSettingsView.swift
@@ -1,8 +1,11 @@
+import EnviousWisprASR
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 struct DiagnosticsSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(\.asrManager) private var asrManagerEnv
   @Environment(DiagnosticsCoordinator.self) private var diagnostics
   // PR7 of #763: live phase resolves through LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState
@@ -10,24 +13,28 @@ struct DiagnosticsSettingsView: View {
   // through the environment instead of an `NSApp.delegate` downcast.
   @Environment(AppWindowCoordinator.self) private var appWindowCoordinator
 
+  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
+  /// environment (see `AppEnvironmentKeys.swift`).
+  private var asrManager: any ASRManagerInterface { asrManagerEnv! }
+
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       // ── Debug Mode ────────────────────────────────────────────────────
       BrandedSection(header: "Debug Mode") {
         BrandedRow {
           VStack(alignment: .leading, spacing: 4) {
-            Toggle("Enable debug mode", isOn: $state.settings.isDebugModeEnabled)
+            Toggle("Enable debug mode", isOn: $settings.isDebugModeEnabled)
               .toggleStyle(BrandedToggleStyle())
             Text("Persists across relaunches. Toggle with Cmd+Shift+D from anywhere.")
               .font(.stHelper)
               .foregroundStyle(.stTextTertiary)
           }
         }
-        if appState.settings.isDebugModeEnabled {
+        if settings.isDebugModeEnabled {
           BrandedRow {
-            Picker("Log Level", selection: $state.settings.debugLogLevel) {
+            Picker("Log Level", selection: $settings.debugLogLevel) {
               ForEach(DebugLogLevel.allCases, id: \.self) { level in
                 Text(level.displayName).tag(level)
               }
@@ -36,7 +43,7 @@ struct DiagnosticsSettingsView: View {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 4) {
               Button("Restart Onboarding…") {
-                appState.settings.onboardingState = .notStarted
+                settings.onboardingState = .notStarted
                 appWindowCoordinator.openOnboardingWindow()
               }
               .disabled(liveRecordingState.pipelineState != .idle)
@@ -118,11 +125,11 @@ struct DiagnosticsSettingsView: View {
           BrandedRow {
             HStack {
               Button("Run ASR Benchmark") {
-                Task { await diagnostics.benchmark.run(using: appState.asrManager) }
+                Task { await diagnostics.benchmark.run(using: asrManager) }
               }
               Button("Run Pipeline Benchmark") {
                 Task {
-                  await diagnostics.benchmark.runPipelineBenchmark(using: appState.asrManager)
+                  await diagnostics.benchmark.runPipelineBenchmark(using: asrManager)
                 }
               }
             }
@@ -193,8 +200,8 @@ struct DiagnosticsSettingsView: View {
           HStack {
             Text("Model status:")
             Spacer()
-            Text(appState.asrManager.isModelLoaded ? "Loaded" : "Unloaded")
-              .foregroundStyle(appState.asrManager.isModelLoaded ? .stSuccess : .secondary)
+            Text(asrManager.isModelLoaded ? "Loaded" : "Unloaded")
+              .foregroundStyle(asrManager.isModelLoaded ? .stSuccess : .secondary)
           }
         }
       }

--- a/Sources/EnviousWispr/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWispr/Views/Settings/LanguageLockSheet.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// dismisses. The sheet is a settings detail, never an interrupt: nothing
 /// here blocks dictation.
 struct LanguageLockSheet: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
   @Environment(\.dismiss) private var dismiss
 
   @State private var searchText: String = ""
@@ -195,7 +195,7 @@ struct LanguageLockSheet: View {
     // W6 telemetry: record the mode transition before we mutate settings so
     // we can read the prior value for `from_lang`.
     let fromLang: String
-    switch appState.settings.languageMode {
+    switch settings.languageMode {
     case .auto:
       fromLang = "auto"
     case .locked(let prior):
@@ -206,13 +206,13 @@ struct LanguageLockSheet: View {
     // "after_bad_detect" path is reserved for the passive-chip CTA (future
     // hook) so we do not mis-label a Settings-driven change.
     let reason: String
-    if case .auto = appState.settings.languageMode {
+    if case .auto = settings.languageMode {
       reason = "first_time"
     } else {
       reason = "preference"
     }
 
-    appState.settings.languageMode = .locked(entry.code)
+    settings.languageMode = .locked(entry.code)
     TelemetryService.shared.trackManualLockUsed(
       fromLang: fromLang,
       toLang: entry.code,
@@ -222,7 +222,7 @@ struct LanguageLockSheet: View {
   }
 
   private func isCurrentLock(_ code: String) -> Bool {
-    if case .locked(let current) = appState.settings.languageMode {
+    if case .locked(let current) = settings.languageMode {
       return current == code
     }
     return false

--- a/Sources/EnviousWispr/Views/Settings/MemorySettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/MemorySettingsView.swift
@@ -1,23 +1,24 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Model memory management settings.
 struct MemorySettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       BrandedSection(header: "Memory") {
         BrandedRow {
-          Picker("Unload model after", selection: $state.settings.modelUnloadPolicy) {
+          Picker("Unload model after", selection: $settings.modelUnloadPolicy) {
             ForEach(ModelUnloadPolicy.allCases, id: \.self) { policy in
               Text(policy.displayName).tag(policy)
             }
           }
         }
-        if appState.settings.modelUnloadPolicy != .never {
+        if settings.modelUnloadPolicy != .never {
           BrandedRow {
             Text(
               "The ASR model will be unloaded from RAM after the selected idle period. The next recording will reload it (~2-5 s)."
@@ -26,7 +27,7 @@ struct MemorySettingsView: View {
             .foregroundStyle(.stTextTertiary)
           }
         }
-        if appState.settings.modelUnloadPolicy == .immediately {
+        if settings.modelUnloadPolicy == .immediately {
           BrandedRow(showDivider: false) {
             Text(
               "Model is freed after every transcription. Expect a reload delay on each recording."

--- a/Sources/EnviousWispr/Views/Settings/PermissionsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/PermissionsSettingsView.swift
@@ -1,21 +1,22 @@
+import EnviousWisprServices
 import SwiftUI
 
 /// Microphone and Accessibility permission status.
 struct PermissionsSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(PermissionsService.self) private var permissions
 
   var body: some View {
     SettingsContentView {
       BrandedSection(header: "Microphone") {
         BrandedRow(showDivider: false) {
           BrandedStatusRow(
-            isGranted: appState.permissions.hasMicrophonePermission,
+            isGranted: permissions.hasMicrophonePermission,
             grantedText: "Microphone access granted",
             deniedText: "Microphone access denied",
             actionLabel: "Request Access",
             action: {
               Task {
-                _ = await appState.permissions.requestMicrophoneAccess()
+                _ = await permissions.requestMicrophoneAccess()
               }
             }
           )
@@ -25,13 +26,13 @@ struct PermissionsSettingsView: View {
       BrandedSection(header: "Accessibility") {
         BrandedRow(showDivider: false) {
           BrandedStatusRow(
-            isGranted: appState.permissions.hasAccessibilityPermission,
+            isGranted: permissions.hasAccessibilityPermission,
             grantedText: "Accessibility access granted",
             deniedText: "Accessibility access required for paste",
             helperText: "After rebuilding the app you may need to re-grant this permission.",
             actionLabel: "Open System Settings",
             action: {
-              _ = appState.permissions.requestAccessibilityAccess()
+              _ = permissions.requestAccessibilityAccess()
             }
           )
         }

--- a/Sources/EnviousWispr/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SettingsView.swift
@@ -1,9 +1,10 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Unified single-window view: History + all settings tabs in one sidebar.
 struct UnifiedWindowView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
   @Environment(NavigationCoordinator.self) private var navigationCoordinator
   @Environment(UpdateCoordinatorHolder.self) private var updateCoordinatorHolder
   @State private var selectedSection: SettingsSection = .history
@@ -16,7 +17,7 @@ struct UnifiedWindowView: View {
             Section(group.rawValue) {
               ForEach(group.sections) { section in
                 if section == .whatsNew {
-                  WhatsNewSidebarRow(isUnread: appState.settings.hasUnreadWhatsNew)
+                  WhatsNewSidebarRow(isUnread: settings.hasUnreadWhatsNew)
                     .tag(section)
                 } else {
                   Label(section.label, systemImage: section.icon)

--- a/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/ShortcutsSettingsView.swift
@@ -3,17 +3,17 @@ import SwiftUI
 
 /// Global hotkey configuration.
 struct ShortcutsSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       BrandedSection(header: "Transcribe Shortcut") {
         BrandedRow {
           HotkeyRecorderView(
-            keyCode: $state.settings.toggleKeyCode,
-            modifiers: $state.settings.toggleModifiers,
+            keyCode: $settings.toggleKeyCode,
+            modifiers: $settings.toggleModifiers,
             defaultKeyCode: ModifierKeyCodes.rightOption,
             defaultModifiers: [],
             label: "Shortcut"
@@ -22,18 +22,18 @@ struct ShortcutsSettingsView: View {
         BrandedRow {
           VStack(alignment: .leading, spacing: 4) {
             Toggle(
-              appState.settings.isPushToTalk ? "Push to Talk" : "Toggle",
-              isOn: $state.settings.isPushToTalk
+              settings.isPushToTalk ? "Push to Talk" : "Toggle",
+              isOn: $settings.isPushToTalk
             )
             .toggleStyle(BrandedToggleStyle())
             Text(
-              appState.settings.isPushToTalk
+              settings.isPushToTalk
                 ? "Hold the hotkey to record, release to stop."
                 : "Press the hotkey to start recording, press again to stop."
             )
             .font(.stHelper)
             .foregroundStyle(.stTextTertiary)
-            if appState.settings.isPushToTalk {
+            if settings.isPushToTalk {
               Text("Double-press to go hands-free. Triple-press to cancel.")
                 .font(.stHelper)
                 .foregroundStyle(.stTextTertiary.opacity(0.72))
@@ -42,8 +42,8 @@ struct ShortcutsSettingsView: View {
         }
         BrandedRow {
           HotkeyRecorderView(
-            keyCode: $state.settings.cancelKeyCode,
-            modifiers: $state.settings.cancelModifiers,
+            keyCode: $settings.cancelKeyCode,
+            modifiers: $settings.cancelModifiers,
             defaultKeyCode: 53,
             defaultModifiers: [],
             label: "Cancel recording"

--- a/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/SpeechEngineSettingsView.swift
@@ -1,15 +1,17 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Transcription engine, multi-language options, recording environment, and cleanup settings.
 struct SpeechEngineSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(SetupCoordinator.self) private var setup
   @Environment(LanguageSuggestionPresenter.self) private var languageSuggestionPresenter
 
   @State private var showLanguageLockSheet: Bool = false
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       // ── Section 1: Transcription Engine ──────────────────────────────
@@ -20,12 +22,12 @@ struct SpeechEngineSettingsView: View {
               ("Fast (English)", ASRBackendType.parakeet),
               ("Multi-Language", ASRBackendType.whisperKit),
             ],
-            selection: $state.settings.selectedBackend
+            selection: $settings.selectedBackend
           )
         }
         BrandedRow(showDivider: false) {
           Text(
-            appState.settings.selectedBackend == .parakeet
+            settings.selectedBackend == .parakeet
               ? "Powered by Parakeet — fast English transcription with built-in punctuation."
               : "Powered by WhisperKit — broader language support with optimized quality defaults."
           )
@@ -35,7 +37,7 @@ struct SpeechEngineSettingsView: View {
       }
 
       // ── Section 2: WhisperKit Model Setup (conditional) ───────────────
-      if appState.settings.selectedBackend == .whisperKit {
+      if settings.selectedBackend == .whisperKit {
         BrandedSection(header: "Model Setup") {
           BrandedRow(showDivider: false) {
             whisperKitSetupContent
@@ -44,8 +46,8 @@ struct SpeechEngineSettingsView: View {
       }
 
       // ── Section 3: Language Selection (only when model is ready) ──
-      if appState.settings.selectedBackend == .whisperKit,
-        case .ready = appState.setup.whisperKitSetup.setupState
+      if settings.selectedBackend == .whisperKit,
+        case .ready = setup.whisperKitSetup.setupState
       {
         BrandedSection(header: "Language") {
           BrandedRow {
@@ -53,9 +55,9 @@ struct SpeechEngineSettingsView: View {
               Toggle(
                 "Auto-detect language",
                 isOn: Binding(
-                  get: { isAutoLanguage(appState.settings.languageMode) },
+                  get: { isAutoLanguage(settings.languageMode) },
                   set: { newValue in
-                    state.settings.languageMode =
+                    settings.languageMode =
                       newValue
                       ? .auto
                       : .locked(currentOrDefaultLockCode())
@@ -71,7 +73,7 @@ struct SpeechEngineSettingsView: View {
             }
           }
 
-          if case .locked(let code) = appState.settings.languageMode {
+          if case .locked(let code) = settings.languageMode {
             BrandedRow(showDivider: false) {
               HStack(spacing: 10) {
                 let entry = LanguageCatalog.entry(for: code)
@@ -124,21 +126,21 @@ struct SpeechEngineSettingsView: View {
         BrandedRow {
           EnvironmentPresetCards(
             selection: Binding(
-              get: { appState.settings.environmentPreset },
-              set: { state.settings.environmentPreset = $0 }
+              get: { settings.environmentPreset },
+              set: { settings.environmentPreset = $0 }
             ))
         }
         BrandedRow {
           VStack(alignment: .leading, spacing: 4) {
-            Toggle("Stop recording on silence", isOn: $state.settings.vadAutoStop)
+            Toggle("Stop recording on silence", isOn: $settings.vadAutoStop)
               .toggleStyle(BrandedToggleStyle())
           }
         }
-        if appState.settings.vadAutoStop {
+        if settings.vadAutoStop {
           BrandedRow {
             VStack(alignment: .leading, spacing: 4) {
               BrandedSlider(
-                "Pause duration", value: $state.settings.vadSilenceTimeout, in: 0.5...3.0,
+                "Pause duration", value: $settings.vadSilenceTimeout, in: 0.5...3.0,
                 step: 0.25, low: "0.5s", high: "3.0s", format: "%.1fs")
               Text("How long to wait after you stop speaking before ending the recording.")
                 .font(.stHelper)
@@ -151,11 +153,11 @@ struct SpeechEngineSettingsView: View {
       }
 
       // ── Section 4: Transcription Mode ────────────────────────────────
-      if appState.settings.selectedBackend == .parakeet {
+      if settings.selectedBackend == .parakeet {
         BrandedSection(header: "Transcription Mode") {
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 4) {
-              Toggle("Live transcription", isOn: $state.settings.useStreamingASR)
+              Toggle("Live transcription", isOn: $settings.useStreamingASR)
                 .toggleStyle(BrandedToggleStyle())
               Text(
                 "Transcribes while you speak for faster results. Turn off for cleaner text on longer recordings."
@@ -174,7 +176,7 @@ struct SpeechEngineSettingsView: View {
         BrandedRow(showDivider: true) {
           VStack(alignment: .leading, spacing: 4) {
             Toggle(
-              "Remove filler words (um, uh, hmm...)", isOn: $state.settings.fillerRemovalEnabled
+              "Remove filler words (um, uh, hmm...)", isOn: $settings.fillerRemovalEnabled
             )
             .toggleStyle(BrandedToggleStyle())
             Text("Strips common filler words from transcriptions.")
@@ -186,7 +188,7 @@ struct SpeechEngineSettingsView: View {
           VStack(alignment: .leading, spacing: 4) {
             Toggle(
               "Convert spoken emoji (e.g. \"thumbs up emoji\" → 👍)",
-              isOn: $state.settings.emojiFormatterEnabled
+              isOn: $settings.emojiFormatterEnabled
             )
             .toggleStyle(BrandedToggleStyle())
             Text("Say \"<phrase> emoji\" to get the glyph. Bare words never convert.")
@@ -197,18 +199,17 @@ struct SpeechEngineSettingsView: View {
       }
     }
     .onAppear {
-      if appState.settings.selectedBackend == .whisperKit {
-        Task { await appState.setup.whisperKitSetup.detectState() }
+      if settings.selectedBackend == .whisperKit {
+        Task { await setup.whisperKitSetup.detectState() }
       }
     }
-    .onChange(of: appState.settings.selectedBackend) { _, newBackend in
+    .onChange(of: settings.selectedBackend) { _, newBackend in
       if newBackend == .whisperKit {
-        Task { await appState.setup.whisperKitSetup.detectState() }
+        Task { await setup.whisperKitSetup.detectState() }
       }
     }
     .sheet(isPresented: $showLanguageLockSheet) {
       LanguageLockSheet()
-        .environment(appState)
     }
   }
 
@@ -225,10 +226,10 @@ struct SpeechEngineSettingsView: View {
   /// to lock to. Preserve the prior locked code if we have one (comes from
   /// the W2 migration of `whisperKitLanguage`), otherwise default to English.
   private func currentOrDefaultLockCode() -> String {
-    if case .locked(let code) = appState.settings.languageMode {
+    if case .locked(let code) = settings.languageMode {
       return code
     }
-    let migrated = appState.settings.whisperKitLanguage
+    let migrated = settings.whisperKitLanguage
     if LanguageTypes.isSupported(migrated) {
       return migrated
     }
@@ -239,7 +240,7 @@ struct SpeechEngineSettingsView: View {
 
   @ViewBuilder
   private var whisperKitSetupContent: some View {
-    switch appState.setup.whisperKitSetup.setupState {
+    switch setup.whisperKitSetup.setupState {
     case .checking:
       HStack {
         ProgressView()
@@ -261,7 +262,7 @@ struct SpeechEngineSettingsView: View {
 
         HStack {
           Button("Download WhisperKit Model") {
-            appState.setup.whisperKitSetup.downloadModel()
+            setup.whisperKitSetup.downloadModel()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
@@ -290,7 +291,7 @@ struct SpeechEngineSettingsView: View {
               .foregroundStyle(.stTextTertiary)
           }
           Button("Cancel") {
-            appState.setup.whisperKitSetup.cancelDownload()
+            setup.whisperKitSetup.cancelDownload()
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -317,7 +318,7 @@ struct SpeechEngineSettingsView: View {
           .fixedSize(horizontal: false, vertical: true)
 
         Button("Try Again") {
-          Task { await appState.setup.whisperKitSetup.detectState() }
+          Task { await setup.whisperKitSetup.detectState() }
         }
         .controlSize(.small)
       }
@@ -334,7 +335,7 @@ struct SpeechEngineSettingsView: View {
   @ViewBuilder
   private var whisperKitRefreshButton: some View {
     Button {
-      Task { await appState.setup.whisperKitSetup.forceDetectState() }
+      Task { await setup.whisperKitSetup.forceDetectState() }
     } label: {
       Image(systemName: "arrow.clockwise")
     }

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewSettingsView.swift
@@ -1,7 +1,8 @@
+import EnviousWisprServices
 import SwiftUI
 
 struct WhatsNewSettingsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
 
   var body: some View {
     SettingsContentView {
@@ -47,7 +48,7 @@ struct WhatsNewSettingsView: View {
       }
     }
     .onAppear {
-      appState.settings.markWhatsNewSeen()
+      settings.markWhatsNewSeen()
     }
   }
 }

--- a/Sources/EnviousWispr/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWispr/Views/Settings/YourWordsView.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Phase 4 (#634) — Your Words settings tab. Replaces the monolithic
@@ -10,11 +11,12 @@ import SwiftUI
 /// - VocabPacksSection: empty state until Phase 5.
 /// - CustomTermsSection: search + pagination + Edit per term.
 struct YourWordsView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var addingNewTerm = false
 
   var body: some View {
-    @Bindable var state = appState
+    @Bindable var settings = settings
 
     SettingsContentView {
       // Header
@@ -45,7 +47,7 @@ struct YourWordsView: View {
       BrandedSection {
         BrandedRow(showDivider: false) {
           VStack(alignment: .leading, spacing: 4) {
-            Toggle("Enable custom words", isOn: $state.settings.wordCorrectionEnabled)
+            Toggle("Enable custom words", isOn: $settings.wordCorrectionEnabled)
               .toggleStyle(BrandedToggleStyle())
             Text(
               "Automatically fix words the speech engine gets wrong using your custom list below."
@@ -63,13 +65,13 @@ struct YourWordsView: View {
     .sheet(isPresented: $addingNewTerm) {
       CustomWordEditSheet(
         word: CustomWord(canonical: ""),
-        wordSuggestionService: appState.customWordsCoordinator.suggestionService
+        wordSuggestionService: customWordsCoordinator.suggestionService
       ) { newWord in
         let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)
         guard !trimmedCanonical.isEmpty else { return nil }
         var wordToSave = newWord
         wordToSave.canonical = trimmedCanonical
-        if let error = appState.customWordsCoordinator.add(wordToSave) {
+        if let error = customWordsCoordinator.add(wordToSave) {
           return error
         }
         return nil

--- a/Tests/EnviousWisprTests/Architecture/SettingsViewsNoAppStateTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SettingsViewsNoAppStateTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+/// PR-C.2 of #763 — guards that no Settings view reaches for the god object.
+///
+/// PR-C.2 re-pointed every view under `Views/Settings/` from
+/// `@Environment(AppState.self)` onto the specific home it needs (the settings
+/// store, permissions service, custom-words coordinator, etc.). This test fails
+/// if a future Settings view reintroduces the `@Environment(AppState.self)`
+/// dependency — the coupling pattern epic #763 exists to delete.
+///
+/// Scope is intentionally narrow: the Main/Onboarding view cluster migrates in
+/// PR-C.3 and the repo-wide freeze test lands in PR-C.4.
+@Suite struct SettingsViewsNoAppStateTests {
+
+  @Test func noSettingsViewInjectsAppState() throws {
+    let directory = URL(fileURLWithPath: "Sources/EnviousWispr/Views/Settings")
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directory, includingPropertiesForKeys: nil
+    )
+    .filter { $0.pathExtension == "swift" }
+
+    #expect(!files.isEmpty, "No Swift files found under Views/Settings — wrong path?")
+
+    var offending: [String] = []
+    for file in files {
+      let source = try String(contentsOf: file, encoding: .utf8)
+      if source.contains("@Environment(AppState.self)") {
+        offending.append(file.lastPathComponent)
+      }
+    }
+
+    #expect(
+      offending.isEmpty,
+      """
+      Settings views must inject the specific home they need, not AppState \
+      (PR-C.2 of #763). Files still using @Environment(AppState.self):
+      \(offending.joined(separator: "\n"))
+      """)
+  }
+}


### PR DESCRIPTION
## Summary

PR-C.2 of the AppState deletion epic (#763). Closes #814.

Re-points the 13 views under `Views/Settings/` from `@Environment(AppState.self)` onto the specific homes each one needs — all already injected at the App scene level by PR-C.1:

- `SettingsManager`, `PermissionsService` (from `EnviousWisprServices`)
- `CustomWordsCoordinator`, `SetupCoordinator`, `AudioDeviceList`, `AIAvailabilityCoordinator`, `LLMModelDiscoveryCoordinator` (app module)
- `\.asrManager`, `\.keychainManager` environment keys (force-unwrapped via a documented accessor — `EnviousWisprApp` always injects a real instance)

Also drops the now-redundant explicit `.environment(appState)` re-injection on the `LanguageLockSheet` presentation (the sheet inherits `SettingsManager` from the Window scene).

`AppState` stays receive-only and still `@Environment`-injected for the not-yet-migrated Main/Onboarding views (PR-C.3).

**Plan correction:** the sub-bible §6 consumer matrix listed `YourWordsView` as needing only `customWordsCoordinator`; it also reads `settings.wordCorrectionEnabled`, so it gets both homes.

## Test plan

- [x] `swift build -c release` — clean
- [x] `scripts/swift-test.sh` — 1127 tests pass (includes the new `SettingsViewsNoAppStateTests` grep guard)
- [x] Codex code-diff review — clean, no actionable bugs
- [x] Live UAT (debug build): all 13 Settings screens render without crash; Multi-Language → Lock-language sheet renders + closes; custom-word add/delete both succeed; app process never crashed
- [x] No file under `Views/Settings/` references `@Environment(AppState.self)`
