### PR TITLE
refactor(appstate): migrate Main/Onboarding views + non-view consumers off AppState (PR-C.3 of #763)

### DIFF
--- a/Sources/EnviousWispr/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWispr/App/AppLifecycleCoordinator.swift
@@ -3,16 +3,16 @@ import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprPipeline
 import EnviousWisprServices
 import Foundation
 
 // Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` are needed in release
 // builds because `AudioSystemEventReporter` (production telemetry) references
 // `AudioCaptureInterface` and `ASRManagerInterface` from those modules.
-
-#if DEBUG
-  import EnviousWisprPipeline
-#endif
+// PR-C.3 of #763: `EnviousWisprPipeline` is now an unconditional import — the
+// `TranscriptionPipeline` / `WhisperKitPipeline` homes are stored properties
+// (still read only by `DebugFaultEndpoint` in debug builds).
 
 /// PR-B.4 of #763: App-owned home for the process-lifecycle sequence.
 ///
@@ -37,7 +37,18 @@ final class AppLifecycleCoordinator {
   #endif
 
   // Injected dependencies — delegated to, never owned.
-  private let appState: AppState
+  // PR-C.3 of #763: the single `appState` reference is replaced by the 10
+  // specific homes the launch/become-active/terminate bodies actually read.
+  private let settings: SettingsManager
+  private let permissions: PermissionsService
+  private let keychainManager: KeychainManager
+  private let customWordsCoordinator: CustomWordsCoordinator
+  private let aiAvailability: AIAvailabilityCoordinator
+  private let audioCapture: any AudioCaptureInterface
+  private let asrManager: any ASRManagerInterface
+  private let pipeline: TranscriptionPipeline
+  private let whisperKitPipeline: WhisperKitPipeline
+  private let setup: SetupCoordinator
   private let dictationRuntime: DictationRuntime
   private let dictationLifecycleCoordinator: DictationLifecycleCoordinator
   private let liveRecordingState: LiveRecordingState
@@ -46,7 +57,16 @@ final class AppLifecycleCoordinator {
   private let hotkeyService: HotkeyService
 
   init(
-    appState: AppState,
+    settings: SettingsManager,
+    permissions: PermissionsService,
+    keychainManager: KeychainManager,
+    customWordsCoordinator: CustomWordsCoordinator,
+    aiAvailability: AIAvailabilityCoordinator,
+    audioCapture: any AudioCaptureInterface,
+    asrManager: any ASRManagerInterface,
+    pipeline: TranscriptionPipeline,
+    whisperKitPipeline: WhisperKitPipeline,
+    setup: SetupCoordinator,
     dictationRuntime: DictationRuntime,
     dictationLifecycleCoordinator: DictationLifecycleCoordinator,
     liveRecordingState: LiveRecordingState,
@@ -54,7 +74,16 @@ final class AppLifecycleCoordinator {
     appWindowCoordinator: AppWindowCoordinator,
     hotkeyService: HotkeyService
   ) {
-    self.appState = appState
+    self.settings = settings
+    self.permissions = permissions
+    self.keychainManager = keychainManager
+    self.customWordsCoordinator = customWordsCoordinator
+    self.aiAvailability = aiAvailability
+    self.audioCapture = audioCapture
+    self.asrManager = asrManager
+    self.pipeline = pipeline
+    self.whisperKitPipeline = whisperKitPipeline
+    self.setup = setup
     self.dictationRuntime = dictationRuntime
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
     self.liveRecordingState = liveRecordingState
@@ -74,7 +103,7 @@ final class AppLifecycleCoordinator {
     // If onboarding is needed, stay .regular so SwiftUI creates the main window
     // hierarchy and ActionWirer can wire callbacks before opening the
     // onboarding window.
-    if appState.settings.onboardingState == .completed {
+    if settings.onboardingState == .completed {
       NSApp.setActivationPolicy(.accessory)
     }
 
@@ -120,17 +149,17 @@ final class AppLifecycleCoordinator {
     // Carbon RegisterEventHotKey requires an active run loop for event delivery.
     dictationRuntime.startHotkeyServiceIfEnabled()
 
-    if appState.settings.onboardingState == .completed {
-      let s = appState.settings
+    if settings.onboardingState == .completed {
+      let s = settings
       let hasKeys =
-        (try? appState.keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
-        || (try? appState.keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
+        (try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
+        || (try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
       TelemetryService.shared.settingsSnapshot(
         asrBackend: s.selectedBackend.rawValue,
         llmProvider: s.llmProvider.rawValue,
         recordingMode: s.recordingMode.rawValue,
         fillerRemoval: s.fillerRemovalEnabled,
-        customWordsCount: appState.customWordsCoordinator.customWords.count,
+        customWordsCount: customWordsCoordinator.customWords.count,
         hasApiKeys: hasKeys,
         noiseSuppression: s.noiseSuppression
       )
@@ -138,11 +167,11 @@ final class AppLifecycleCoordinator {
 
     // Run Apple Intelligence diagnostics via coordinator.
     // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
-    let isFreshInstall = appState.settings.onboardingState != .completed
+    let isFreshInstall = settings.onboardingState != .completed
     if isFreshInstall {
-      appState.aiAvailability.firstLaunchCheck()
+      aiAvailability.firstLaunchCheck()
     } else {
-      Task { await appState.aiAvailability.checkAvailability(trigger: "app_launch") }
+      Task { await aiAvailability.checkAvailability(trigger: "app_launch") }
     }
 
     // Fire structured app.launched event — uses cached report (loaded from
@@ -151,7 +180,7 @@ final class AppLifecycleCoordinator {
       Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
     let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
     let osVer = ProcessInfo.processInfo.operatingSystemVersion
-    let cachedReport = appState.aiAvailability.latestReport
+    let cachedReport = aiAvailability.latestReport
     TelemetryService.shared.appLaunched(
       version: version,
       build: build,
@@ -162,17 +191,17 @@ final class AppLifecycleCoordinator {
     )
 
     // Check Accessibility permission on launch (query only — never auto-prompt).
-    appState.permissions.refreshOnLaunch()
+    permissions.refreshOnLaunch()
     menuBarController.updateIcon()  // Reflect accessibility warning state in icon.
 
     // Begin smart polling if Accessibility is not yet granted.
-    appState.permissions.startMonitoring()
+    permissions.startMonitoring()
 
     // Pre-warm LLM backend with a real inference request.
     LLMNetworkSession.shared.preWarmModel(
-      provider: appState.settings.llmProvider,
-      model: appState.settings.llmModel,
-      keychainManager: appState.keychainManager
+      provider: settings.llmProvider,
+      model: settings.llmModel,
+      keychainManager: keychainManager
     )
 
     // Onboarding auto-open is handled by ActionWirer inside the main Window
@@ -182,12 +211,12 @@ final class AppLifecycleCoordinator {
       // V2 fault-injection (issue #291). Only when explicitly opted in via env var.
       if DebugFaultEndpoint.isRequested {
         let endpoint = DebugFaultEndpoint(
-          audioProxy: appState.audioCapture as? AudioCaptureProxy,
-          asrProxy: appState.asrManager as? ASRManagerProxy,
-          parakeetPipeline: appState.pipeline,
-          whisperKitPipeline: appState.whisperKitPipeline,
+          audioProxy: audioCapture as? AudioCaptureProxy,
+          asrProxy: asrManager as? ASRManagerProxy,
+          parakeetPipeline: pipeline,
+          whisperKitPipeline: whisperKitPipeline,
           activeBackend: { [weak self] in
-            self?.appState.settings.selectedBackend ?? .parakeet
+            self?.settings.selectedBackend ?? .parakeet
           }
         )
         endpoint.start()
@@ -197,7 +226,7 @@ final class AppLifecycleCoordinator {
 
     audioEnvironmentSnapshotter = AudioEnvironmentSnapshotter(
       routeProvider: { [weak self] in
-        self?.appState.audioCapture.currentAudioRoute
+        self?.audioCapture.currentAudioRoute
       }
     )
     SentryBreadcrumb.audioEnvironmentProvider = { [weak self] in
@@ -208,8 +237,8 @@ final class AppLifecycleCoordinator {
     // release; ships to all users so we get cross-user data on what real
     // devices/routes/connections users actually hit.
     audioSystemEventReporter = AudioSystemEventReporter(
-      audioCapture: appState.audioCapture,
-      asrManager: appState.asrManager,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
       pipelineStateProvider: { [weak self] in
         // PR7 of #763: pipeline phase resolves through LiveRecordingState.
         self?.liveRecordingState.pipelineState ?? .idle
@@ -225,9 +254,9 @@ final class AppLifecycleCoordinator {
 
     // Re-warm LLM backend when app comes to foreground.
     LLMNetworkSession.shared.preWarmModel(
-      provider: appState.settings.llmProvider,
-      model: appState.settings.llmModel,
-      keychainManager: appState.keychainManager
+      provider: settings.llmProvider,
+      model: settings.llmModel,
+      keychainManager: keychainManager
     )
   }
 
@@ -235,7 +264,7 @@ final class AppLifecycleCoordinator {
     // PR-B.2 of #763: both window-close observers are torn down by the
     // coordinator now.
     appWindowCoordinator.tearDown()
-    appState.setup.ollamaSetup.cleanup()
+    setup.ollamaSetup.cleanup()
     // PR10 of #763 — shared HotkeyService is owned by EnviousWisprApp as
     // `@State`; this coordinator holds an injected ref.
     hotkeyService.stop()

--- a/Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -27,9 +27,9 @@ final class DictationLifecycleCoordinator {
   // Ceiling 11 (raised from parent migration plan's 10; see
   // `DictationLifecycleCoordinatorCeilingsTests` Bible-changelog comment).
   // The 11th slot is `recordingLockedAccess`, a get/set closure-pair struct
-  // that lets the coordinator read AND write AppState's `isRecordingLocked`
-  // without storing an AppState reference. PR10 absorbs `isRecordingLocked`
-  // ownership into the recording-state homes and ratchets this back down.
+  // that lets the coordinator read AND write the hands-free `isRecordingLocked`
+  // flag without storing a reference to its owner. PR-C.3 of #763 rehomed that
+  // flag onto `LiveRecordingState` (the closures retarget at the call site).
 
   let pipeline: TranscriptionPipeline  // 1
   let whisperKitPipeline: WhisperKitPipeline  // 2
@@ -43,9 +43,9 @@ final class DictationLifecycleCoordinator {
   let languageSuggestionPresenter: LanguageSuggestionPresenter?  // 10
   let recordingLockedAccess: RecordingLockedAccess  // 11
 
-  /// Bidirectional accessor for `AppState.isRecordingLocked`. PR9 keeps the
-  /// stored property on AppState (PR10 absorbs it into the recording-state
-  /// homes). The state-change closure both READS the lock state (to pass into
+  /// Bidirectional accessor for the hands-free `isRecordingLocked` flag (rehomed
+  /// onto `LiveRecordingState` in PR-C.3 of #763). The state-change closure both
+  /// READS the lock state (to pass into
   /// `recordingOverlay.show(...)` so hands-free visuals render correctly) AND
   /// WRITES it (to clear hands-free on any transition out of `.recording`).
   /// Packaging the pair as one struct keeps the cap at 11.

--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -31,8 +31,8 @@ struct EnviousWisprApp: App {
 
   // PR-C.1 of #763: the nine view-facing subsystems that AppState used to own
   // are now App-owned `@State` homes, injected into both Window scenes'
-  // environment alongside `appState`. Views still read `@Environment(AppState.self)`
-  // in PR-C.1; PR-C.2 / PR-C.3 migrate them onto these homes directly.
+  // environment. As of PR-C.3 every Settings / Main / Onboarding view reads
+  // these homes directly; `appState` is receive-only and deleted in PR-C.4.
   @State private var settings: SettingsManager
   @State private var permissions: PermissionsService
   @State private var asrManager: any ASRManagerInterface
@@ -42,6 +42,11 @@ struct EnviousWisprApp: App {
   @State private var aiAvailability: AIAvailabilityCoordinator
   @State private var keychainManager: KeychainManager
   @State private var llmDiscovery: LLMModelDiscoveryCoordinator
+
+  // PR-C.3 of #763: the re-polish service is now App-owned. It was an
+  // `init()` local handed to `AppState`; with views and consumers migrated
+  // off `AppState`, the composition root holds the canonical reference.
+  @State private var polishService: TranscriptPolishService
 
   @State private var isOnboardingPresented: Bool =
     !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -222,9 +227,6 @@ struct EnviousWisprApp: App {
       llmDiscovery: llmDiscovery,
       aiAvailability: aiAvailability
     )
-    // PR-C.1: AppState still conforms to `DictationActivityProviding`.
-    // PR-C.3 rewires this provider to `LiveRecordingState`.
-    polishService.setDictationActivity(appState)
 
     let navigationCoordinator = NavigationCoordinator()
     let diagnosticsCoordinator = DiagnosticsCoordinator()
@@ -308,10 +310,16 @@ struct EnviousWisprApp: App {
     appState.attachLastRecordingResult(lastRecordingResult)
     appState.attachBackendMetadata(backendMetadata)
 
+    // PR-C.3 of #763: `LiveRecordingState` provides `DictationActivityProviding`
+    // (replaces `AppState`'s conformance). `polishService` blocks a re-polish
+    // while live dictation is in flight. Wired after `liveRecordingState` exists.
+    polishService.setDictationActivity(liveRecordingState)
+
     // PR9 of #763: construct the lifecycle home BEFORE DictationRuntime.
+    // PR-C.3: the hands-free lock flag is rehomed onto `LiveRecordingState`.
     let recordingLockedAccess = DictationLifecycleCoordinator.RecordingLockedAccess(
-      get: { [weak appState] in appState?.isRecordingLocked ?? false },
-      set: { [weak appState] locked in appState?.isRecordingLocked = locked }
+      get: { liveRecordingState.isRecordingLocked },
+      set: { locked in liveRecordingState.isRecordingLocked = locked }
     )
     let dictationLifecycleCoordinator = DictationLifecycleCoordinator(
       pipeline: pipeline,
@@ -389,8 +397,18 @@ struct EnviousWisprApp: App {
     )
 
     // PR-B.4 of #763: process-lifecycle home. Constructed last.
+    // PR-C.3 of #763: receives the 10 specific homes it reads, not `AppState`.
     let appLifecycleCoordinator = AppLifecycleCoordinator(
-      appState: appState,
+      settings: settings,
+      permissions: permissions,
+      keychainManager: keychainManager,
+      customWordsCoordinator: customWordsCoordinator,
+      aiAvailability: aiAvailability,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      pipeline: pipeline,
+      whisperKitPipeline: whisperKitPipeline,
+      setup: setup,
       dictationRuntime: dictationRuntime,
       dictationLifecycleCoordinator: dictationLifecycleCoordinator,
       liveRecordingState: liveRecordingState,
@@ -425,6 +443,9 @@ struct EnviousWisprApp: App {
     _aiAvailability = State(initialValue: aiAvailability)
     _keychainManager = State(initialValue: keychainManager)
     _llmDiscovery = State(initialValue: llmDiscovery)
+
+    // PR-C.3 of #763: App-owned re-polish service.
+    _polishService = State(initialValue: polishService)
 
     // PR-A: push App-owned homes into AppDelegate before any
     // NSApplicationDelegate callback fires.
@@ -464,7 +485,7 @@ struct EnviousWisprApp: App {
         .environment(\.keychainManager, keychainManager)
         .background(
           ActionWirer(
-            appState: appState,
+            settings: settings,
             appWindowCoordinator: appWindowCoordinator,
             menuBarController: menuBarController,
             isOnboardingPresented: $isOnboardingPresented
@@ -502,8 +523,9 @@ struct EnviousWisprApp: App {
 /// Hidden view that wires SwiftUI environment actions into App-owned homes.
 /// Must live inside a SwiftUI view hierarchy to access @Environment.
 private struct ActionWirer: View {
-  /// PR-A: App-owned AppState passed in directly.
-  let appState: AppState
+  /// PR-C.3 of #763: the onboarding-auto-open gate reads `onboardingState`
+  /// off the settings store directly, not via `AppState`.
+  let settings: SettingsManager
   /// PR-B.2 of #763: the three SwiftUI window bridges are wired onto the
   /// coordinator now, not AppDelegate.
   let appWindowCoordinator: AppWindowCoordinator
@@ -530,7 +552,7 @@ private struct ActionWirer: View {
         let replayed = appWindowCoordinator.consumePendingOpenOnboarding()
         // Auto-open onboarding if needed (first launch), only if nothing was
         // already replayed.
-        if !replayed, appState.settings.onboardingState != .completed {
+        if !replayed, settings.onboardingState != .completed {
           appWindowCoordinator.openOnboardingWindow()
         }
       }

--- a/Sources/EnviousWispr/App/LiveRecordingState.swift
+++ b/Sources/EnviousWispr/App/LiveRecordingState.swift
@@ -35,6 +35,11 @@ final class LiveRecordingState {
   let audioCapture: any AudioCaptureInterface
   let asrManager: any ASRManagerInterface
 
+  /// True when recording is in hands-free (locked) mode via double-press.
+  /// Read by the overlay, written through PR9's `RecordingLockedAccess` get/set
+  /// seam. PR-C.3 of #763 rehomed this off `AppState`.
+  var isRecordingLocked: Bool = false
+
   init(
     pipeline: TranscriptionPipeline,
     whisperKitPipeline: WhisperKitPipeline,
@@ -73,5 +78,17 @@ final class LiveRecordingState {
       return whisperKitPipeline.currentTranscript
     }
     return pipeline.currentTranscript
+  }
+}
+
+// MARK: - DictationActivityProviding
+
+/// PR-C.3 of #763: `LiveRecordingState` provides the dictation-activity signal
+/// (replaces `AppState`'s conformance). It already owns both pipelines.
+extension LiveRecordingState: DictationActivityProviding {
+  /// True when either pipeline is recording, transcribing, or polishing. Used
+  /// by `TranscriptPolishService` to block a re-polish during live dictation.
+  var isDictationActive: Bool {
+    pipeline.state.isActive || whisperKitPipeline.state.isActive
   }
 }

--- a/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
+++ b/Sources/EnviousWispr/Views/Components/AccessibilityWarningBanner.swift
@@ -1,3 +1,4 @@
+import EnviousWisprServices
 import SwiftUI
 
 /// Compact amber banner shown when Accessibility permission is missing.
@@ -5,7 +6,7 @@ import SwiftUI
 /// Displayed above the history split view. Provides a "Fix Now" shortcut to the
 /// Permissions settings tab and a "Dismiss" button to hide it for the session.
 struct AccessibilityWarningBanner: View {
-  @Environment(AppState.self) private var appState
+  @Environment(PermissionsService.self) private var permissions
   @Environment(NavigationCoordinator.self) private var navigationCoordinator
 
   var body: some View {
@@ -28,7 +29,7 @@ struct AccessibilityWarningBanner: View {
       .controlSize(.small)
 
       Button("Dismiss") {
-        appState.permissions.dismissAccessibilityWarning()
+        permissions.dismissAccessibilityWarning()
       }
       .buttonStyle(.plain)
       .foregroundStyle(.secondary)

--- a/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
+++ b/Sources/EnviousWispr/Views/Main/HistoryContentView.swift
@@ -1,9 +1,10 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Inner content for the History tab: transcript list (left) + detail/status (right).
 struct HistoryContentView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(PermissionsService.self) private var permissions
   @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
   // PR7 of #763: live-recording fallback transcript comes from LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState
@@ -23,7 +24,7 @@ struct HistoryContentView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      if appState.permissions.shouldShowAccessibilityWarning {
+      if permissions.shouldShowAccessibilityWarning {
         AccessibilityWarningBanner()
       }
 

--- a/Sources/EnviousWispr/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWispr/Views/Main/MainWindowView.swift
@@ -1,9 +1,11 @@
+import EnviousWisprASR
 import EnviousWisprCore
+import EnviousWisprServices
 import SwiftUI
 
 /// Status view when no transcript is active — handles all pipeline states.
 struct StatusView: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
   // PR7 of #763: live phase, audio level, model label, polish error all
   // resolve through the three new homes.
   @Environment(LiveRecordingState.self) private var liveRecordingState
@@ -12,8 +14,13 @@ struct StatusView: View {
   // PR10 of #763: recording-control surface (toggle, cancel, reset,
   // hotkey description) moved off AppState onto DictationRuntime façade.
   @Environment(DictationRuntime.self) private var dictationRuntime
+  @Environment(\.asrManager) private var asrManagerEnv
   @State private var elapsed: TimeInterval = 0
   @State private var recordingStart: Date?
+
+  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
+  /// environment (see `AppEnvironmentKeys.swift`).
+  private var asrManager: any ASRManagerInterface { asrManagerEnv! }
 
   var body: some View {
     VStack(spacing: 16) {
@@ -24,7 +31,7 @@ struct StatusView: View {
         } description: {
           VStack(spacing: 4) {
             Text("Press the record button to start dictating.")
-            if appState.settings.hotkeyEnabled {
+            if settings.hotkeyEnabled {
               Text("Hotkey: \(dictationRuntime.hotkeyDescription)")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
@@ -76,7 +83,7 @@ struct StatusView: View {
               .frame(width: 240, height: 6)
               .accessibilityHidden(true)
 
-            if appState.settings.vadAutoStop {
+            if settings.vadAutoStop {
               Text("VAD: Active")
                 .font(.caption2)
                 .foregroundStyle(.stSuccess)
@@ -124,7 +131,7 @@ struct StatusView: View {
             .controlSize(.large)
           Text("Transcribing...")
             .font(.title2)
-          if !appState.asrManager.isModelLoaded {
+          if !asrManager.isModelLoaded {
             Text("This may take a moment on first run while the model loads.")
               .font(.caption)
               .foregroundStyle(.secondary)
@@ -271,7 +278,6 @@ struct AudioLevelBar: View {
 
 /// Pipeline status badge in toolbar — hidden when idle/complete/error, minimal during active states.
 struct StatusBadge: View {
-  @Environment(AppState.self) private var appState
   // PR7 of #763: live phase resolves through LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState
 

--- a/Sources/EnviousWispr/Views/Main/SidebarStatsHeader.swift
+++ b/Sources/EnviousWispr/Views/Main/SidebarStatsHeader.swift
@@ -1,13 +1,18 @@
+import EnviousWisprASR
 import EnviousWisprCore
 import SwiftUI
 
 /// Stats header shown above the transcript list in the sidebar.
 struct SidebarStatsHeader: View {
-  @Environment(AppState.self) private var appState
   @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
   // PR7 of #763: live phase + display labels resolve through the three new homes.
   @Environment(LiveRecordingState.self) private var liveRecordingState
   @Environment(BackendMetadata.self) private var backendMetadata
+  @Environment(\.asrManager) private var asrManagerEnv
+
+  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
+  /// environment (see `AppEnvironmentKeys.swift`).
+  private var asrManager: any ASRManagerInterface { asrManagerEnv! }
 
   private var isRecording: Bool {
     liveRecordingState.pipelineState == .recording
@@ -42,7 +47,7 @@ struct SidebarStatsHeader: View {
         modelName: backendMetadata.modelLabel,
         statusText: backendMetadata.statusText(for: liveRecordingState.pipelineState),
         isRecording: isRecording,
-        isLoaded: appState.asrManager.isModelLoaded,
+        isLoaded: asrManager.isModelLoaded,
         hasError: {
           if case .error = liveRecordingState.pipelineState { return true }
           return false

--- a/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWispr/Views/Main/TranscriptDetailView.swift
@@ -5,7 +5,8 @@ import SwiftUI
 /// Detail view for a single transcript with toolbar actions.
 struct TranscriptDetailView: View {
   let transcript: Transcript
-  @Environment(AppState.self) private var appState
+  @Environment(PermissionsService.self) private var permissions
+  @Environment(SettingsManager.self) private var settings
   @Environment(NavigationCoordinator.self) private var navigationCoordinator
   @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
 
@@ -22,7 +23,7 @@ struct TranscriptDetailView: View {
         .help("Copy to clipboard")
 
         Button {
-          if appState.permissions.accessibilityGranted {
+          if permissions.accessibilityGranted {
             PasteService.copyToClipboard(transcript.displayText)
             NSApp.hide(nil)
             Task {
@@ -36,13 +37,13 @@ struct TranscriptDetailView: View {
           Label("Paste", systemImage: "arrow.right.doc.on.clipboard")
         }
         .controlSize(.small)
-        .disabled(!appState.permissions.accessibilityGranted)
+        .disabled(!permissions.accessibilityGranted)
         .help(
-          appState.permissions.accessibilityGranted
+          permissions.accessibilityGranted
             ? "Paste into active app"
             : "Accessibility permission required for paste")
 
-        if transcript.polishedText == nil && appState.settings.llmProvider != .none {
+        if transcript.polishedText == nil && settings.llmProvider != .none {
           Button {
             Task { await transcriptWorkflowCoordinator.polishTranscript(transcript) }
           } label: {

--- a/Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWispr/Views/Main/TranscriptHistoryView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 /// Sidebar list of past transcripts with stats header and search.
 struct TranscriptHistoryView: View {
-  @Environment(AppState.self) private var appState
   @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
   // PR7 of #763: live phase resolves through LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState

--- a/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWispr/Views/Onboarding/OnboardingV2View.swift
@@ -276,10 +276,16 @@ struct OnboardingV2View: View {
     removal: .opacity
   )
 
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(PermissionsService.self) private var permissions
+  @Environment(\.asrManager) private var asrManagerEnv
   var onComplete: () -> Void
 
   @State private var viewModel = OnboardingV2ViewModel()
+
+  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
+  /// environment (see `AppEnvironmentKeys.swift`).
+  private var asrManager: any ASRManagerInterface { asrManagerEnv! }
 
   var body: some View {
     ZStack {
@@ -292,7 +298,7 @@ struct OnboardingV2View: View {
           .transition(Self.screenTransition)
       case .ready:
         ReadyScreenV2(onComplete: {
-          viewModel.finishOnboarding(settings: appState.settings)
+          viewModel.finishOnboarding(settings: settings)
           onComplete()
         })
         .transition(Self.screenTransition)
@@ -312,12 +318,12 @@ struct OnboardingV2View: View {
         viewModel.downloadError == nil,
         case .pending = viewModel.checklistStatuses[0]
       else { return }
-      await viewModel.startSetup(asrManager: appState.asrManager, settings: appState.settings)
+      await viewModel.startSetup(asrManager: asrManager, settings: settings)
     }
   }
 
   private func recoverFromPersistedState() {
-    switch appState.settings.onboardingState {
+    switch settings.onboardingState {
     case .notStarted:
       viewModel.currentScreen = .welcome
     case .settingUp:
@@ -326,9 +332,9 @@ struct OnboardingV2View: View {
     case .needsPermissions:
       viewModel.currentScreen = .settingUp
       viewModel.checklistStatuses = [.completed, .completed, .completed]
-      appState.permissions.refreshAccessibilityStatus()
-      viewModel.micGranted = appState.permissions.hasMicrophonePermission
-      viewModel.accessibilityGranted = appState.permissions.accessibilityGranted
+      permissions.refreshAccessibilityStatus()
+      viewModel.micGranted = permissions.hasMicrophonePermission
+      viewModel.accessibilityGranted = permissions.accessibilityGranted
       if viewModel.micGranted && viewModel.accessibilityGranted {
         viewModel.currentScreen = .ready
       } else {
@@ -640,7 +646,8 @@ private struct ChecklistItemRow: View {
 
 private struct PermissionsPhaseView: View {
   var viewModel: OnboardingV2ViewModel
-  @Environment(AppState.self) private var appState
+  @Environment(PermissionsService.self) private var permissions
+  @Environment(SettingsManager.self) private var settings
 
   var body: some View {
     VStack(spacing: 0) {
@@ -667,7 +674,7 @@ private struct PermissionsPhaseView: View {
           subtitle: "To hear your voice for transcription.",
           isGranted: viewModel.micGranted,
           onGrant: {
-            Task { await viewModel.requestMicPermission(permissions: appState.permissions) }
+            Task { await viewModel.requestMicPermission(permissions: permissions) }
           }
         )
 
@@ -676,7 +683,7 @@ private struct PermissionsPhaseView: View {
           title: "Accessibility",
           subtitle: "To paste your transcribed text into any app.",
           isGranted: viewModel.accessibilityGranted,
-          onGrant: { viewModel.openAccessibilitySettings(permissions: appState.permissions) }
+          onGrant: { viewModel.openAccessibilitySettings(permissions: permissions) }
         )
 
         // #735: trust-builder banner. "Accessibility" is the scariest-sounding
@@ -749,11 +756,11 @@ private struct PermissionsPhaseView: View {
       }
     }
     .onAppear {
-      appState.permissions.refreshAccessibilityStatus()
-      viewModel.micGranted = appState.permissions.hasMicrophonePermission
-      viewModel.accessibilityGranted = appState.permissions.accessibilityGranted
+      permissions.refreshAccessibilityStatus()
+      viewModel.micGranted = permissions.hasMicrophonePermission
+      viewModel.accessibilityGranted = permissions.accessibilityGranted
       if viewModel.accessibilityGranted {
-        appState.settings.autoCopyToClipboard = true
+        settings.autoCopyToClipboard = true
       }
     }
     .task { await pollPermissions() }
@@ -770,15 +777,15 @@ private struct PermissionsPhaseView: View {
 
       elapsed += 2
 
-      appState.permissions.refreshAccessibilityStatus()
-      if appState.permissions.accessibilityGranted && !viewModel.accessibilityGranted {
+      permissions.refreshAccessibilityStatus()
+      if permissions.accessibilityGranted && !viewModel.accessibilityGranted {
         viewModel.accessibilityGranted = true
-        appState.settings.autoCopyToClipboard = true
+        settings.autoCopyToClipboard = true
         TelemetryService.shared.onboardingStepCompleted(
           step: "accessibility_permission", result: "granted")
       }
 
-      if appState.permissions.hasMicrophonePermission && !viewModel.micGranted {
+      if permissions.hasMicrophonePermission && !viewModel.micGranted {
         viewModel.micGranted = true
         TelemetryService.shared.onboardingStepCompleted(step: "mic_permission", result: "granted")
       }
@@ -845,11 +852,12 @@ private struct PermissionRow: View {
 // MARK: - Screen 3: Ready
 
 private struct ReadyScreenV2: View {
-  @Environment(AppState.self) private var appState
+  @Environment(SettingsManager.self) private var settings
+  @Environment(PermissionsService.self) private var permissions
   let onComplete: () -> Void
 
   var body: some View {
-    @Bindable var bindableAppState = appState
+    @Bindable var settings = settings
     VStack(spacing: 0) {
       // Bigger lips + radial glow for a celebratory feel
       ZStack {
@@ -880,12 +888,12 @@ private struct ReadyScreenV2: View {
 
       // Interactive keycap — tap to record, shows result inline
       KeycapHotkeyView(
-        keyCode: $bindableAppState.settings.toggleKeyCode,
-        modifiers: $bindableAppState.settings.toggleModifiers
+        keyCode: $settings.toggleKeyCode,
+        modifiers: $settings.toggleModifiers
       )
       .padding(.bottom, 20)
 
-      if !appState.permissions.accessibilityGranted {
+      if !permissions.accessibilityGranted {
         HStack(spacing: 10) {
           Image(systemName: "lightbulb.fill")
             .foregroundStyle(Color.obWarning)
@@ -943,7 +951,7 @@ private struct ReadyScreenV2: View {
         }
       }
     }
-    .animation(.easeInOut(duration: 0.35), value: appState.permissions.accessibilityGranted)
+    .animation(.easeInOut(duration: 0.35), value: permissions.accessibilityGranted)
   }
 }
 

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -8,15 +8,22 @@ import Testing
 /// parser-visible count (the shared parser counts only non-primitive `let`s,
 /// which a count alone would under-report). This test parses every stored
 /// declaration in the class body (`let` and `var`, all access levels,
-/// primitives included) and asserts the name set EQUALS the 10-name allowlist.
-/// Adding an 11th field fails the test.
+/// primitives included) and asserts the name set EQUALS the allowlist.
+/// Adding an unlisted field fails the test.
 ///
-/// Bible §30 baseline: 10 stored — 3 owned `var` (`audioEnvironmentSnapshotter`,
-/// `audioSystemEventReporter`, `#if DEBUG debugFaultEndpoint`) + 7 injected
-/// `let` (`appState`, `dictationRuntime`, `dictationLifecycleCoordinator`,
-/// `liveRecordingState`, `menuBarController`, `appWindowCoordinator`,
-/// `hotkeyService`); non-private `func`s `runDidFinishLaunching`,
-/// `runDidBecomeActive`, `runWillTerminate` (`init` is not a `func`).
+/// Bible §30 baseline (PR-B.4): 10 stored — 3 owned `var` + 7 injected `let`
+/// including the single `appState`.
+///
+/// Bible §30 entry (PR-C.3 of #763, 2026-05-20, #815): the single `appState`
+/// reference is replaced by the 10 specific homes the launch / become-active /
+/// terminate bodies actually read (`settings`, `permissions`, `keychainManager`,
+/// `customWordsCoordinator`, `aiAvailability`, `audioCapture`, `asrManager`,
+/// `pipeline`, `whisperKitPipeline`, `setup`). This is de-coupling, not
+/// god-object accretion: the coordinator trades one wide god-reference for ten
+/// narrow ones, reads nothing new, and its non-private method count is
+/// unchanged at 3. Allowlist count rises 10 → 19 (3 owned `var` + 16 injected
+/// `let`); non-private `func`s `runDidFinishLaunching`, `runDidBecomeActive`,
+/// `runWillTerminate` unchanged (`init` is not a `func`).
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWispr/App/AppLifecycleCoordinator.swift"
@@ -25,7 +32,16 @@ import Testing
     "audioEnvironmentSnapshotter",
     "audioSystemEventReporter",
     "debugFaultEndpoint",
-    "appState",
+    "settings",
+    "permissions",
+    "keychainManager",
+    "customWordsCoordinator",
+    "aiAvailability",
+    "audioCapture",
+    "asrManager",
+    "pipeline",
+    "whisperKitPipeline",
+    "setup",
     "dictationRuntime",
     "dictationLifecycleCoordinator",
     "liveRecordingState",
@@ -43,8 +59,8 @@ import Testing
     #expect(
       extras.isEmpty && missing.isEmpty,
       """
-      AppLifecycleCoordinator stored-property set drifted from the PR-B.4 \
-      10-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      AppLifecycleCoordinator stored-property set drifted from the \
+      19-name allowlist. Unexpected: \(extras.sorted()). Missing: \
       \(missing.sorted()). Adding a stored property is god-object drift — \
       raising the allowlist requires a Bible §30 entry. Removing one means \
       this allowlist must shrink in the same PR.

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -78,16 +78,20 @@ import Testing
   ///   (`settings`, `permissions`, `asrManager`, `customWordsCoordinator`,
   ///   `setup`, `audioDeviceList`, `aiAvailability`, `keychainManager`,
   ///   `llmDiscovery`) into App-owned `@State` homes, injected into both Window
-  ///   scenes. `appState` itself stays (receive-only) until PR-C.4 deletes it,
-  ///   which lowers this ceiling back to 25 (lower-is-free). The seven
-  ///   construction-only subsystems stay `init()` locals and are not counted.
+  ///   scenes. The seven construction-only subsystems stay `init()` locals and
+  ///   are not counted.
+  /// - 26 → 27 in PR-C.3 of epic #763 (2026-05-20, #815). Bible §30 entry:
+  ///   PR-C.3 rehomes `polishService` (the re-polish service) onto an App-owned
+  ///   `@State`; it was an `init()` local handed to `AppState`. `appState`
+  ///   itself stays (receive-only) until PR-C.4 deletes it, which lowers this
+  ///   ceiling back to 26 (lower-is-free).
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 26,
+      count <= 27,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 26. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 27. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -143,14 +147,19 @@ import Testing
   /// the deterministic rule (post-change actual 546 + 10, rounded up to the
   /// nearest 5). Line count is a soft 5x backstop — the stored-property and
   /// import ceilings are the primary entanglement signals.
+  /// Ratcheted 560→580 in PR-C.3 of epic #763 (2026-05-20, #815) to absorb the
+  /// `polishService` `@State` declaration + assignment and the
+  /// `AppLifecycleCoordinator` init call expanding from one `appState:` argument
+  /// to ten specific-home arguments. Cap set by the deterministic rule
+  /// (post-change actual 569 + 10, rounded up to the nearest 5).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 560,
+      lineCount <= 580,
       """
-      EnviousWisprApp line count exceeded: \(lineCount) > 560. \
+      EnviousWisprApp line count exceeded: \(lineCount) > 580. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/LiveRecordingStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/LiveRecordingStateCeilingsTests.swift
@@ -8,12 +8,18 @@ import Testing
 /// - 0 non-private `func` methods (three computed properties: `pipelineState`,
 ///   `audioLevel`, `currentTranscript`; computed properties are NOT counted
 ///   by `CeilingsTestSupport.countNonPrivateMethods`)
-/// - ≤90 lines
+/// - ≤100 lines
 /// - imports ⊆ {EnviousWisprASR, EnviousWisprAudio, EnviousWisprCore, EnviousWisprPipeline, Observation}
 ///
 /// Ceiling-raise note: stored-property count was raised from 3 to 4 before
 /// PR7 was written, after grep verification showed the four current AppState
 /// dependencies. Bible §30 entry filed.
+///
+/// Bible §30 entry (PR-C.3 of #763, 2026-05-20, #815): line ceiling 90 → 100.
+/// PR-C.3 adds the `isRecordingLocked` hands-free flag (rehomed off `AppState`)
+/// and the `DictationActivityProviding` conformance extension (also off
+/// `AppState`). The stored-property count is unchanged (the flag is a primitive
+/// `var`, not counted) and no `func` is added (`isDictationActive` is computed).
 ///
 /// Lowering any cap is free; raising requires a Bible §30 changelog entry.
 @Suite struct LiveRecordingStateCeilingsTests {
@@ -61,9 +67,9 @@ import Testing
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let count = CeilingsTestSupport.lineCount(in: source)
     #expect(
-      count <= 90,
+      count <= 100,
       """
-      LiveRecordingState line count exceeded: \(count) > 90. \
+      LiveRecordingState line count exceeded: \(count) > 100. \
       Ratchet down if implementation came in lower; raise only via Bible §30.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/MainOnboardingViewsNoAppStateTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/MainOnboardingViewsNoAppStateTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+/// PR-C.3 of #763 — guards that no Main, Onboarding, or shared-Component view
+/// reaches for the god object.
+///
+/// PR-C.3 re-pointed every view under `Views/Main/`, `Views/Onboarding/`, and
+/// `Views/Components/` from `@Environment(AppState.self)` onto the specific
+/// home it needs (settings store, permissions service, the `\.asrManager`
+/// environment key). This test fails if a future view in those folders
+/// reintroduces the `@Environment(AppState.self)` dependency — the coupling
+/// pattern epic #763 exists to delete.
+///
+/// Companion to `SettingsViewsNoAppStateTests` (PR-C.2, `Views/Settings/`).
+/// The repo-wide freeze test lands in PR-C.4 with the deletion of
+/// `AppState.swift`.
+@Suite struct MainOnboardingViewsNoAppStateTests {
+
+  private static let directories = [
+    "Sources/EnviousWispr/Views/Main",
+    "Sources/EnviousWispr/Views/Onboarding",
+    "Sources/EnviousWispr/Views/Components",
+  ]
+
+  @Test func noMainOnboardingViewInjectsAppState() throws {
+    var scanned = 0
+    var offending: [String] = []
+
+    for path in Self.directories {
+      let directory = URL(fileURLWithPath: path)
+      let files = try FileManager.default.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: nil
+      )
+      .filter { $0.pathExtension == "swift" }
+
+      for file in files {
+        scanned += 1
+        let source = try String(contentsOf: file, encoding: .utf8)
+        if source.contains("@Environment(AppState.self)") {
+          offending.append(file.lastPathComponent)
+        }
+      }
+    }
+
+    #expect(
+      scanned > 0, "No Swift files found under the Main/Onboarding/Components folders — wrong path?"
+    )
+
+    #expect(
+      offending.isEmpty,
+      """
+      Main / Onboarding / Components views must inject the specific home they \
+      need, not AppState (PR-C.3 of #763). Files still using \
+      @Environment(AppState.self):
+      \(offending.joined(separator: "\n"))
+      """)
+  }
+}


### PR DESCRIPTION
## Summary

PR-C.3 of the AppState deletion epic (#763), third child of the PR-C sub-bible. Closes #815.

- **9 Main / Onboarding / Components view structs** re-pointed from `@Environment(AppState.self)` onto the specific homes they need (`PermissionsService`, `SettingsManager`, the `\.asrManager` environment key). `TranscriptHistoryView` and `StatusBadge` had vestigial declared-but-unused `AppState` env lines — removed.
- **`AppLifecycleCoordinator`** now receives the 10 specific homes its launch / become-active / terminate bodies read, instead of the single `appState` god-reference. De-coupling, not accretion: one wide reference traded for ten narrow ones, no new reads, method count unchanged.
- **`polishService`** rehomed to an App-owned `@State`. `polishService.setDictationActivity(...)` retargeted from `AppState` to `LiveRecordingState`, which gains the `DictationActivityProviding` conformance and the `isRecordingLocked` hands-free flag (both off `AppState`).
- **`ActionWirer`** takes `settings` directly.
- New `MainOnboardingViewsNoAppStateTests` guard blocks any Main/Onboarding/Components view from re-introducing `@Environment(AppState.self)`.

After this PR no view references `AppState`. It stays receive-only and `@Environment`-injected for one more PR; **PR-C.4 deletes the file** (its 27→26 ceiling step-down depends on `appState` surviving C.3 — confirmed by Codex grounded review).

Ceilings (Bible §30 entries in the ceiling-test doc comments): `EnviousWisprApp` stored 26→27 (`polishService`), line 560→580; `AppLifecycleCoordinator` allowlist 10→19 names; `LiveRecordingState` line 90→100.

## Validation

- `swift build -c release` + `swift build -c debug`: clean.
- Full suite: 1128 tests pass (all 24 architecture/ceiling/guard suites green).
- Codex code-diff review: clean — no P0/P1 (one P2 stale comment, fixed).
- Live UAT on a debug build: both-backend dictation (Parakeet + WhisperKit) PASS; all 10 Settings tabs + History render without crash (10/10); Main window / History / detail views render correctly.

## Test plan

- [ ] CI `build-check` green
- [ ] Founder UAT per #777's script: re-polish a saved transcript, fresh-onboarding flow, window close/reopen
