### PR TITLE
chore(release): bump version to 2.0.3

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.0.3</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.2</string>
+	<string>2.0.3</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWispr/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,45 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.0.3
+
+    Entry(
+      id: "spoken-emoji",
+      icon: "face.smiling",
+      title: "Speak an emoji",
+      description:
+        "Say the emoji's name followed by the word \"emoji\" while you dictate, like \"smiley face emoji\" or \"thumbs up emoji\", and EnviousWispr drops the glyph right in.",
+      category: .newFeatures,
+      version: "2.0.3"
+    ),
+    Entry(
+      id: "smart-language-detection",
+      icon: "globe",
+      title: "Smarter language detection",
+      description:
+        "On the Multi-Language speech engine, EnviousWispr now notices when you keep dictating in the same non-English language and offers to lock it in. A fixed language makes transcription both faster and more accurate.",
+      category: .newFeatures,
+      version: "2.0.3"
+    ),
+    Entry(
+      id: "newer-ai-polish-models",
+      icon: "sparkles",
+      title: "Newer AI Polish models",
+      description:
+        "AI Polish now works with the latest models. We recommend Gemini 3.5 Flash, or OpenAI 5.4 mini or nano, for the best balance of speed and quality.",
+      category: .smarterAIPolish,
+      version: "2.0.3"
+    ),
+    Entry(
+      id: "steadier-under-the-hood",
+      icon: "wrench.and.screwdriver",
+      title: "A steadier app under the hood",
+      description:
+        "We continued a major rebuild of how the app manages itself internally. You won't see it directly, but it makes EnviousWispr more stable and quicker for us to improve.",
+      category: .fasterAndMoreReliable,
+      version: "2.0.3"
+    ),
+
     // MARK: - v2.0.2
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.0.2"
+  public static let currentContentVersion = "2.0.3"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.0.3 with What's New entries for user-visible changes shipped since v2.0.2.

- Spoken emoji conversion (say "smiley face emoji")
- Smart language detection on the Multi-Language speech engine (#252)
- Newer AI Polish models
- AppState-deletion internal rebuild (#763)

`currentContentVersion`, `Info.plist` `CFBundleShortVersionString`/`CFBundleVersion` all set to 2.0.3.

## Test plan

- [x] swift build -c release --arch arm64 — passed locally (96.7s)
- [x] scripts/swift-test.sh --no-run — test target compiles clean (60.8s)
- [x] Codex code-diff review — CLEAN
- [ ] build-check CI passes on this PR
- [ ] Tag v2.0.3 after merge triggers release pipeline
