### PR TITLE
test(engine-kernel): heart-path simulator + fakes + engine-adapter contract (PR-2 of #827)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -1,0 +1,203 @@
+import EnviousWisprCore
+import Foundation
+
+// MARK: - Engine-adapter contract (epic #827, PR-1 §B.2 → PR-2)
+//
+// `ASREngineAdapter` is the uniform, kernel-facing orchestration contract that
+// both ASR engines plug into. PR-1's kernel-contract spec
+// (`docs/feature-requests/issue-PR1-2026-05-21-behavior-inventory-kernel-contract.md`
+// §B.2) defines the surface; PR-2 makes it compilable Swift. It is INERT in
+// PR-2: no production type conforms to or calls it yet. `FakeEngine` (test
+// target) is the PR-2 conformer and the proof the surface is implementable;
+// the `RecordingSessionKernel` (PR-3) becomes the caller; the real Parakeet
+// and WhisperKit adapters (PR-4 / PR-5) become the production conformers.
+//
+// Placement: `EnviousWisprPipeline`, not `EnviousWisprASR` — this is a
+// kernel-facing orchestration contract, not the engine-internal `ASRBackend`
+// actor protocol (PR-1 §B.2).
+
+/// A `UUID`-backed recording-session identity, minted by the kernel at every
+/// `idle → preparing` / `terminal → preparing` transition (PR-1 §B.1.5).
+///
+/// Distinct from the capture layer's `AudioCaptureInterface.currentCaptureSessionID`
+/// (`UInt64`), which is an unrelated per-source capture counter. A `SessionID`
+/// is never reused.
+public struct SessionID: Hashable, Sendable {
+  public let raw: UUID
+
+  public init(_ raw: UUID = UUID()) {
+    self.raw = raw
+  }
+}
+
+/// Static capability flags an engine adapter advertises so the kernel can
+/// branch on `capabilities` rather than on engine identity (PR-1 §B.2.1,
+/// D15). An optional capability the adapter does not support MUST degrade
+/// cleanly.
+public struct ASREngineCapabilities: Sendable {
+  /// The engine decodes incrementally and accepts `acceptAudio(_:)` during
+  /// recording (Parakeet). `false` for batch-after-stop engines (WhisperKit).
+  public let supportsStreaming: Bool
+
+  /// The engine can detect the spoken language (WhisperKit). `false` for
+  /// Parakeet.
+  public let supportsLanguageDetection: Bool
+
+  public init(supportsStreaming: Bool, supportsLanguageDetection: Bool) {
+    self.supportsStreaming = supportsStreaming
+    self.supportsLanguageDetection = supportsLanguageDetection
+  }
+}
+
+/// Adapter warm-up / model-load readiness (PR-1 §B.2.1). Warm-but-idle is the
+/// kernel's `idle` state with `readiness == .ready` — there is no separate
+/// `ready` FSM state (PR-1 §B.1, D1).
+public enum ASREngineReadiness: Sendable {
+  case notReady
+  case warming
+  case ready
+}
+
+/// A closed, normalized engine-failure enum. The kernel never branches on
+/// engine-specific error types (PR-1 §B.2.1, epic §3.4) — each adapter maps
+/// its internal errors into one of these cases.
+public enum ASREngineError: Error, Sendable {
+  /// Model warm-up / load failed.
+  case loadFailed
+  /// The decoder failed to produce a result.
+  case decodeFailed
+  /// The engine process crashed during `finalize()` — surfaced as a value,
+  /// never as a thrown error the kernel must catch, never as a hang
+  /// (PR-1 §B.2.2).
+  case engineCrashed
+  /// The engine wedged — no progress signal advanced (PR-1 §B.1.7).
+  case wedged
+}
+
+/// The normalized outcome of one `finalize()` call (PR-1 §B.2.1). The kernel
+/// consumes exactly one of these per session and never sees an engine-specific
+/// result type.
+public enum ASREngineOutcome: Sendable {
+  /// A non-empty raw transcript.
+  case transcript(ASRResult)
+  /// The decoder produced nothing. `hadSpeechEvidence` routes the kernel to
+  /// `failed(asrEmpty)` vs `noSpeech` (PR-1 §B.1.2).
+  case empty(hadSpeechEvidence: Bool)
+  /// `finalize()` was called after `cancel()` — never partial text
+  /// (PR-1 §B.2.2).
+  case cancelled
+  /// A typed, normalized engine failure.
+  case failed(ASREngineError)
+}
+
+/// A wedge-detection progress tick emitted during model warm-up (PR-1 §B.1.7,
+/// §B.2.1). The kernel watches *cadence* — absence of ticks, not absence of
+/// completion-within-a-deadline — so there is no wall-clock timeout.
+public struct ASRLoadProgressTick: Sendable {
+  /// Monotonic progress marker. The kernel treats a stalled marker as a wedge.
+  public let marker: UInt64
+
+  public init(marker: UInt64) {
+    self.marker = marker
+  }
+}
+
+/// A wedge-detection progress tick emitted during `finalize()` (PR-1 §B.1.7,
+/// §B.2.1). Same cadence-watching semantics as `ASRLoadProgressTick`.
+public struct ASRFinalizeProgressTick: Sendable {
+  /// Monotonic progress marker.
+  public let marker: UInt64
+
+  public init(marker: UInt64) {
+    self.marker = marker
+  }
+}
+
+/// A `Sendable` carrier wrapping one captured audio buffer for the
+/// kernel → adapter handoff (PR-1 §B.3). The kernel calls `acceptAudio(_:)`
+/// for every captured buffer; a streaming adapter forwards it, a batch adapter
+/// buffers or no-ops.
+///
+/// `pcm` is owned Float32 sample storage in PR-2 — the simplest unconditionally
+/// `Sendable` shape. It is **provisional**: PR-3 picks the production copy
+/// strategy (copy-into-owned-storage vs `nonisolated(unsafe)` `AVAudioPCMBuffer`
+/// transfer) with measured audio-thread latency evidence and owns the final
+/// representation (PR-1 §B.3, PR-2 plan OQ-1).
+public struct AudioBufferHandoff: Sendable {
+  /// 16 kHz mono Float32 samples, owned by this struct.
+  public let pcm: [Float]
+  /// Sample count in `pcm`.
+  public let frameCount: Int
+  /// Monotonic sequence number stamped on the audio thread. A streaming
+  /// adapter that needs strict order reorders by `sequence`; a batch adapter
+  /// ignores it (PR-1 §B.3).
+  public let sequence: UInt64
+  /// The session this buffer belongs to. A buffer whose `sessionID` is not the
+  /// kernel's current session is dropped (PR-1 §B.3, FSM invariant 7).
+  public let sessionID: SessionID
+
+  public init(pcm: [Float], frameCount: Int, sequence: UInt64, sessionID: SessionID) {
+    self.pcm = pcm
+    self.frameCount = frameCount
+    self.sequence = sequence
+    self.sessionID = sessionID
+  }
+}
+
+/// The uniform, kernel-facing engine-adapter contract (PR-1 §B.2.1).
+///
+/// An adapter owns its own ASR and rescue. Invariant (epic §4): an adapter
+/// never touches capture, finalization, paste, UI, or kernel state. The
+/// MUST / MUST NOT clauses in PR-1 §B.2.2 define the behavior every conformer
+/// (`FakeEngine`, and the PR-4 / PR-5 real adapters) must implement.
+@MainActor
+public protocol ASREngineAdapter: AnyObject {
+  // MARK: Identity & capability
+
+  /// Static capability flags (PR-1 §B.2.1).
+  var capabilities: ASREngineCapabilities { get }
+
+  /// Current warm-up / load readiness.
+  var readiness: ASREngineReadiness { get }
+
+  // MARK: Warm-up
+
+  /// Idempotent, sessionless warm-up — drives `readiness` toward `.ready`.
+  /// Takes no `SessionID`: it can be driven by a sessionless pre-warm or by a
+  /// session's `warmingUp` state. A late completion never drives an FSM
+  /// transition by itself — it only updates `readiness` (PR-1 §B.2.2, CN-7).
+  func warmUp() async throws
+
+  /// OPTIONAL load-wedge signal (PR-1 §B.1.7). `nil` when the engine exposes
+  /// no load-progress stream — the kernel then does signal-free `warmingUp`
+  /// (no wedge detection, no timeout); it never falls back to a wall-clock
+  /// deadline (PR-1 §B.2.2).
+  var loadProgress: AsyncStream<ASRLoadProgressTick>? { get }
+
+  // MARK: Session lifecycle
+
+  /// Begin a recording session under `id`.
+  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws
+
+  /// Accept one captured buffer. The kernel ALWAYS calls this; the adapter
+  /// decides forward-vs-buffer. A call after a terminal session (post-`cancel()`
+  /// or post-`finalize()`) MUST be a no-op (PR-1 §B.2.2).
+  func acceptAudio(_ buffer: AudioBufferHandoff)
+
+  /// Finalize and produce exactly one outcome. Engine-specific rescue lives
+  /// here. After `cancel()`, MUST return `.cancelled` (PR-1 §B.2.2).
+  func finalize() async -> ASREngineOutcome
+
+  /// OPTIONAL `finalize()`-wedge signal (PR-1 §B.1.7). Same `nil` semantics as
+  /// `loadProgress`.
+  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { get }
+
+  /// Idempotent discard. Calling it 2+ times has the same effect as once
+  /// (PR-1 §B.2.2).
+  func cancel() async
+
+  // MARK: Cleanup
+
+  /// Apply the model-unload policy (PR-1 §B.2.1, D16).
+  func applyUnloadPolicy(_ policy: ModelUnloadPolicy)
+}

--- a/Sources/EnviousWisprPipeline/VADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/VADSignalSource.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// MARK: - VAD signal / policy split (epic #827, PR-1 §B.6 → PR-2)
+//
+// PR-1 §B.6: the kernel owns VAD *policy* (auto-stop, the no-speech gate,
+// whether ASR runs, max-duration); the capture/VAD seam owns VAD *signal
+// production*. The kernel cannot own signal production because XPC-mode VAD
+// physically runs in a separate process (D8). `VADSignalSource` is the narrow,
+// origin-agnostic protocol the seam vends and the kernel subscribes to — an
+// in-process `SilenceDetector` and the XPC service-side detector both map onto
+// it.
+//
+// Placement: `EnviousWisprPipeline` — a kernel-facing input contract, same
+// kind as `ASREngineAdapter` (PR-2 plan §3.1, §3b). INERT in PR-2: the kernel
+// (PR-3) becomes the subscriber; `FakeVADSignalSource` (test target) is the
+// PR-2 conformer.
+
+/// The kind of stop-driving VAD signal (PR-1 §B.6). Both kinds latch a stop
+/// through the identical kernel path — there is no App-layer routing (D7).
+public enum VADStopKind: Equatable, Sendable {
+  /// Silence hangover expired — stop now (when `vadAutoStop` config is on).
+  case autoStopTriggered
+  /// Recording hit `maxRecordingDuration`.
+  case maxDurationReached
+}
+
+/// A stop-driving VAD signal carrying the `SessionID` it was issued under
+/// (PR-1 §B.6, FSM invariant 7). The seam is told the session at session start
+/// (VAD config is frozen per session), so it stamps each signal; the kernel
+/// drops a signal whose `sessionID` is not its current session — a late
+/// auto-stop from a finished recording cannot terminate the next one.
+public struct VADStopSignal: Equatable, Sendable {
+  public let kind: VADStopKind
+  public let sessionID: SessionID
+
+  public init(kind: VADStopKind, sessionID: SessionID) {
+    self.kind = kind
+    self.sessionID = sessionID
+  }
+}
+
+/// Tri-state speech evidence read by the kernel at `stopping` (PR-1 §B.6).
+/// The no-speech gate keys on *confirmed* no-speech, not on an empty segment
+/// list per se (Codex r2 correction).
+public enum VADSpeechEvidence: Equatable, Sendable {
+  /// Voiced segments are present.
+  case voiced
+  /// VAD ran and confirms no speech — the kernel routes to `noSpeech` and
+  /// skips the adapter.
+  case confirmedNoSpeech
+  /// No detector ran — evidence is unavailable. The kernel does NOT gate; it
+  /// fails toward visibility (the adapter still runs, so a genuine ASR failure
+  /// still surfaces as an error).
+  case unavailable
+}
+
+/// The narrow protocol the capture/VAD seam vends and the kernel subscribes to
+/// (PR-1 §B.6). The kernel does not know whether the conformer is the
+/// in-process detector or the XPC service-side one.
+@MainActor
+public protocol VADSignalSource: AnyObject {
+  /// Stream of stop-driving signals (auto-stop, max-duration). The kernel
+  /// latches a stop on each.
+  var stopSignals: AsyncStream<VADStopSignal> { get }
+
+  /// The speech-evidence verdict at stop. Read once when the kernel enters
+  /// `stopping`.
+  func speechEvidenceAtStop() -> VADSpeechEvidence
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// MARK: - Recording-session FSM state vocabulary (epic #827, PR-1 §B.1.1)
+//
+// This is the harness's *assertion vocabulary* — the canonical state set every
+// scenario's `ExpectedOutcome` is written against. It is NOT the kernel's FSM
+// type: PR-3's `RecordingSessionKernel` owns the real state machine, and PR-3's
+// test-side `RecordingSessionDriving` conformer maps the kernel's state onto
+// this enum. Lives in the test target for exactly that reason — it is test
+// scaffolding, not a production type (PR-2 plan §3.0, §3.8).
+
+/// A normalized, recoverable failure reason for the `failed` terminal state
+/// (PR-1 §B.1.2 transition table).
+enum FSMFailureReason: Equatable, Sendable {
+  case prepareFailed
+  case permissionDenied
+  case modelWedged
+  case modelLoadFailed
+  case captureStartFailed
+  case noAudioCaptured
+  case asrEmpty
+  case asrFailed
+  case asrWedged
+  case emptyAfterProcessing
+  case storageFailed
+  case captureStalled
+}
+
+/// The recording-session FSM states (PR-1 §B.1.1). Seven are terminal:
+/// `completed`, `failed`, `cancelled`, `discarded`, `noSpeech`,
+/// `audioInterrupted`, `asrInterrupted`. Exactly one terminal state is reached
+/// per session.
+enum FSMState: Equatable, Sendable {
+  case idle
+  case preparing
+  case warmingUp
+  case recording
+  case stopping
+  case transcribing
+  case finalizing
+  // Terminal states.
+  case completed
+  case failed(FSMFailureReason)
+  case cancelled
+  case discarded
+  case noSpeech
+  case audioInterrupted
+  case asrInterrupted
+
+  /// `true` for the seven terminal states (PR-1 §B.1.1).
+  var isTerminal: Bool {
+    switch self {
+    case .completed, .failed, .cancelled, .discarded, .noSpeech,
+      .audioInterrupted, .asrInterrupted:
+      return true
+    case .idle, .preparing, .warmingUp, .recording, .stopping, .transcribing,
+      .finalizing:
+      return false
+    }
+  }
+}
+
+/// The user-visible error surface a terminal state renders (PR-1 §B.1.3).
+/// `audioInterrupted` renders `.interruption`; `asrInterrupted` and `failed`
+/// render `.recoverableError`; the silent terminals render nothing.
+enum ErrorCategory: Equatable, Sendable {
+  case recoverableError
+  case interruption
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -1,0 +1,239 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+
+@testable import EnviousWisprAudio
+
+// MARK: - FakeAudioCapture (epic #827, PR-2 plan §3.3; Codex grounded review revision 3)
+//
+// Conforms to the FULL production `AudioCaptureInterface` (~31 members). The
+// behaviorally-active members the simulator drives: the `beginCapturePhase()`/
+// `startCapture()` buffer streams, `onBufferCaptured`, `onEngineInterrupted`,
+// `onVADAutoStop`, `onCaptureStalled`, `stopCapture()`, `configureVAD`,
+// `getSamplesSnapshot`, `getVADSegments`, `preWarm`/`abortPreWarm`. The rest
+// are inert: observable properties return constants, the XPC-only telemetry
+// callbacks stay nil exactly as a direct (non-XPC) source leaves them.
+//
+// The fake synthesizes real `AVAudioPCMBuffer`s (16 kHz mono Float32) because
+// the interface streams and callbacks are typed in `AVAudioPCMBuffer` — there
+// is no zero-`AVFoundation` path for the capture fake. `AudioBufferHandoff`
+// (which `FakeEngine` consumes) is a separate, synthetic-Float32 carrier.
+
+/// A configurable failure a `FakeAudioCapture` can be told to raise.
+enum FakeCaptureError: Error, Sendable {
+  case engineStartFailed
+  case captureStartFailed
+  case permissionDenied
+}
+
+@MainActor
+final class FakeAudioCapture: AudioCaptureInterface {
+
+  // MARK: Configurable failure injection
+
+  /// `startEnginePhase()` throws `.engineStartFailed` when set.
+  var failEngineStart = false
+  /// `beginCapturePhase()` / `startCapture()` throw `.captureStartFailed`.
+  var failCaptureStart = false
+  /// `startEnginePhase()` throws `.permissionDenied` (mic permission revoked).
+  var permissionDenied = false
+
+  // MARK: Observed counters (for FakeAudioCaptureTests teardown assertion)
+
+  private(set) var stopCaptureCallCount = 0
+  private(set) var beginCapturePhaseCallCount = 0
+  private(set) var preWarmCallCount = 0
+  private(set) var abortPreWarmCallCount = 0
+  private(set) var deliveredBufferCount = 0
+
+  // MARK: Captured audio
+
+  private var accumulatedSamples: [Float] = []
+  private var segments: [SpeechSegment] = []
+
+  // MARK: Buffer stream
+
+  private var bufferStream: AsyncStream<AVAudioPCMBuffer>?
+  private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+  // MARK: AudioCaptureInterface — observable state (inert constants)
+
+  private(set) var isCapturing = false
+  var audioLevel: Float { 0 }
+  var capturedSamples: [Float] { accumulatedSamples }
+  var currentAudioRoute: String { "fake" }
+  private(set) var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool { isCapturing }
+  var captureSourceType: String { "av_audio_engine" }
+
+  // MARK: AudioCaptureInterface — callbacks
+
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: (() -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  // XPC-only telemetry callbacks — a direct (non-XPC) source leaves these nil.
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  var onXPCServiceError: ((XPCErrorContext) -> Void)?
+  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+
+  // MARK: AudioCaptureInterface — configuration (inert storage)
+
+  var noiseSuppressionEnabled = false
+  var selectedInputDeviceUID = ""
+  var preferredInputDeviceIDOverride = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  init() {}
+
+  // MARK: AudioCaptureInterface — core lifecycle
+
+  func startEnginePhase() async throws {
+    if permissionDenied { throw FakeCaptureError.permissionDenied }
+    if failEngineStart { throw FakeCaptureError.engineStartFailed }
+  }
+
+  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    beginCapturePhaseCallCount += 1
+    if failCaptureStart { throw FakeCaptureError.captureStartFailed }
+    currentCaptureSessionID += 1
+    isCapturing = true
+    // Clear prior-session audio + VAD evidence at the session boundary —
+    // production capture starts each session fresh; a reused fake must too, or
+    // it feeds stale audio into the next session (engine-switch / reset cases).
+    accumulatedSamples.removeAll()
+    segments.removeAll()
+    let (stream, continuation) = AsyncStream.makeStream(of: AVAudioPCMBuffer.self)
+    bufferStream = stream
+    bufferContinuation = continuation
+    return stream
+  }
+
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    try await startEnginePhase()
+    return try await beginCapturePhase()
+  }
+
+  func stopCapture() async -> CaptureResult {
+    stopCaptureCallCount += 1
+    isCapturing = false
+    bufferContinuation?.finish()
+    bufferContinuation = nil
+    bufferStream = nil
+    return CaptureResult(samples: accumulatedSamples, vadSegments: segments)
+  }
+
+  func rebuildEngine() {}
+
+  func buildEngine(noiseSuppression: Bool) {
+    noiseSuppressionEnabled = noiseSuppression
+  }
+
+  func preWarm() async throws {
+    preWarmCallCount += 1
+  }
+
+  func abortPreWarm() {
+    abortPreWarmCallCount += 1
+  }
+
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+    -> Bool
+  {
+    true
+  }
+
+  // MARK: AudioCaptureInterface — VAD
+
+  func configureVAD(
+    autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool
+  ) {}
+
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
+    let total = accumulatedSamples.count
+    guard fromIndex >= 0, fromIndex < total else { return ([], total) }
+    return (Array(accumulatedSamples[fromIndex...]), total)
+  }
+
+  func getVADSegments() async -> [SpeechSegment] {
+    segments
+  }
+
+  // MARK: Harness control surface (scenario `CaptureDirective`s)
+
+  /// Deliver one synthetic 16 kHz mono Float32 buffer onto the capture stream
+  /// and through `onBufferCaptured`.
+  func deliverBuffer(frameCount: Int = AudioConstants.captureBufferSize) {
+    let samples = [Float](repeating: 0.1, count: frameCount)
+    accumulatedSamples.append(contentsOf: samples)
+    deliveredBufferCount += 1
+    guard let buffer = Self.makeBuffer(samples: samples) else { return }
+    bufferContinuation?.yield(buffer)
+    onBufferCaptured?(buffer)
+  }
+
+  /// Record one VAD speech segment (so `stopCapture()` reports speech evidence).
+  func addSpeechSegment(startSample: Int, endSample: Int) {
+    segments.append(SpeechSegment(startSample: startSample, endSample: endSample))
+  }
+
+  /// Raise an engine interruption (mic disconnect / route change mid-session) —
+  /// the audio-interruption path.
+  func raiseEngineInterruption() {
+    onEngineInterrupted?()
+  }
+
+  /// Fire the VAD auto-stop callback.
+  func fireVADAutoStop() {
+    onVADAutoStop?()
+  }
+
+  /// Fire the capture-stall callback (C3 / C4 — the liveness watchdog observed
+  /// zero buffers within the stall window).
+  func fireCaptureStalled() {
+    onCaptureStalled?(
+      CaptureStallContext(
+        sessionID: currentCaptureSessionID,
+        armedAtUptimeNs: 0,
+        firedAtUptimeNs: 0,
+        route: "fake",
+        sourceType: captureSourceType,
+        engineStartedSuccessfully: true,
+        tapInstalled: true,
+        formatMismatchObserved: false,
+        inputDeviceUIDPreferred: nil,
+        inputDeviceUIDSystemDefault: nil))
+  }
+
+  /// Fire the XPC service-error callback (C6 — XPC capture crash). This is the
+  /// ASR-interruption channel, distinct from `raiseEngineInterruption()`.
+  func fireXPCServiceError() {
+    onXPCServiceError?(
+      XPCErrorContext(
+        kind: .interruptCapturing,
+        sessionID: currentCaptureSessionID,
+        timestampNs: 0))
+  }
+
+  // MARK: Helpers
+
+  private static func makeBuffer(samples: [Float]) -> AVAudioPCMBuffer? {
+    guard
+      let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: AudioConstants.sampleRate,
+        channels: AVAudioChannelCount(AudioConstants.channels),
+        interleaved: false),
+      let buffer = AVAudioPCMBuffer(
+        pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+    else { return nil }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    if let channel = buffer.floatChannelData?[0] {
+      samples.withUnsafeBufferPointer { src in
+        channel.update(from: src.baseAddress!, count: samples.count)
+      }
+    }
+    return buffer
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
@@ -1,0 +1,105 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// `FakeAudioCapture` behavior tests (epic #827, PR-2 plan §11.2 item B).
+/// Includes the `stopCapture()`-on-cancel-and-on-wedge teardown assertion
+/// (§3.3 / Gemini finding 5) — a left-hot microphone is a heart-path break, so
+/// capture teardown is verified, not assumed.
+@MainActor
+@Suite("FakeAudioCapture")
+struct FakeAudioCaptureTests {
+
+  @Test("deliverBuffer feeds the capture stream and fires onBufferCaptured")
+  func deliverBufferFeedsStreamAndCallback() async throws {
+    let capture = FakeAudioCapture()
+    let callbackCount = Counter()
+    capture.onBufferCaptured = { _ in callbackCount.bump() }
+    let stream = try await capture.beginCapturePhase()
+
+    let collected = CollectedCount()
+    let consumer = Task { @MainActor in
+      for await _ in stream { collected.value += 1 }
+    }
+    await Task.yield()
+    capture.deliverBuffer()
+    capture.deliverBuffer()
+    _ = await capture.stopCapture()
+    await consumer.value
+
+    #expect(callbackCount.value == 2, "onBufferCaptured fires once per delivered buffer")
+    #expect(collected.value == 2, "each buffer reaches the AsyncStream consumer")
+    #expect(capture.deliveredBufferCount == 2)
+  }
+
+  @Test("stopCapture is invoked on teardown — the no-hot-mic assertion")
+  func stopCaptureTeardownAssertion() async throws {
+    let capture = FakeAudioCapture()
+    #expect(capture.stopCaptureCallCount == 0)
+    _ = try await capture.beginCapturePhase()
+    #expect(capture.isCapturing == true)
+    _ = await capture.stopCapture()
+    #expect(capture.stopCaptureCallCount == 1)
+    #expect(capture.isCapturing == false, "capture must not be left hot after stop")
+  }
+
+  @Test("permission denied makes startEnginePhase throw")
+  func permissionDeniedThrows() async {
+    let capture = FakeAudioCapture()
+    capture.permissionDenied = true
+    await #expect(throws: FakeCaptureError.self) {
+      try await capture.startEnginePhase()
+    }
+  }
+
+  @Test("capture-start failure makes beginCapturePhase throw")
+  func captureStartFailureThrows() async {
+    let capture = FakeAudioCapture()
+    capture.failCaptureStart = true
+    await #expect(throws: FakeCaptureError.self) {
+      _ = try await capture.beginCapturePhase()
+    }
+  }
+
+  @Test("stopCapture reports accumulated samples and VAD segments")
+  func stopCaptureReportsCaptureResult() async throws {
+    let capture = FakeAudioCapture()
+    _ = try await capture.beginCapturePhase()
+    capture.deliverBuffer(frameCount: 100)
+    capture.addSpeechSegment(startSample: 0, endSample: 80)
+    let result = await capture.stopCapture()
+    #expect(result.samples.count == 100)
+    #expect(result.vadSegments.count == 1)
+  }
+
+  @Test("engine interruption fires onEngineInterrupted")
+  func interruptionFiresCallback() {
+    let capture = FakeAudioCapture()
+    var interrupted = false
+    capture.onEngineInterrupted = { interrupted = true }
+    capture.raiseEngineInterruption()
+    #expect(interrupted == true)
+  }
+
+  @Test("XPC-only telemetry callbacks stay nil on a direct source")
+  func xpcCallbacksStayNil() {
+    let capture = FakeAudioCapture()
+    #expect(capture.onXPCServiceError == nil)
+    #expect(capture.onXPCReplyFailed == nil)
+    #expect(capture.onCaptureSessionInterruption == nil)
+    #expect(capture.onRouteResolved == nil)
+  }
+
+  @MainActor
+  final class CollectedCount {
+    var value = 0
+  }
+
+  /// A reference counter a `@Sendable` capture callback can bump. The fake
+  /// drives the callback synchronously on the MainActor, so the unchecked
+  /// `Sendable` conformance is sound for this test.
+  final class Counter: @unchecked Sendable {
+    private(set) var value = 0
+    func bump() { value += 1 }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClock.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// MARK: - FakeClock (epic #827, PR-2 plan §3.3)
+//
+// Deterministic logical clock. Advances ONLY on an explicit `advance(by:)` —
+// never reads the wall clock, never sleeps. This is what makes wedge-detection
+// and slow-warm-up scenarios reproducible without violating
+// `~/.claude/rules/no-arbitrary-timeouts.md`: the simulator never sleeps on a
+// real deadline, it advances logical ticks the scenario controls.
+//
+// `sleep(ticks:)` is the deterministic-async primitive: a caller suspends until
+// the logical clock reaches its deadline. `advance(by:)` resumes every waiter
+// whose deadline is now due. `drainPending()` resumes any straggler at scenario
+// teardown so no `withCheckedContinuation` leaks.
+
+@MainActor
+final class FakeClock {
+  /// Current logical tick count.
+  private(set) var now: UInt64 = 0
+
+  private struct Waiter {
+    let deadline: UInt64
+    let resume: () -> Void
+  }
+
+  private var waiters: [Waiter] = []
+
+  /// Number of `advance(by:)`-driven ticks observed — lets a test prove the
+  /// clock moved only on explicit advancement.
+  private(set) var explicitAdvanceCount: Int = 0
+
+  init() {}
+
+  /// Advance the logical clock by `ticks`, resuming every waiter whose deadline
+  /// is reached. A non-positive `ticks` is a no-op.
+  func advance(by ticks: Int) {
+    guard ticks > 0 else { return }
+    for _ in 0..<ticks {
+      now += 1
+      explicitAdvanceCount += 1
+      let due = waiters.filter { $0.deadline <= now }
+      waiters.removeAll { $0.deadline <= now }
+      for waiter in due { waiter.resume() }
+    }
+  }
+
+  /// Advance by exactly one tick.
+  func tick() {
+    advance(by: 1)
+  }
+
+  /// Suspend until the logical clock has advanced `ticks` from now. A
+  /// non-positive `ticks` returns immediately.
+  func sleep(ticks: Int) async {
+    guard ticks > 0 else { return }
+    let deadline = now + UInt64(ticks)
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      waiters.append(Waiter(deadline: deadline) { continuation.resume() })
+    }
+  }
+
+  /// `true` while at least one caller is suspended in `sleep(ticks:)`.
+  var hasPendingWaiters: Bool {
+    !waiters.isEmpty
+  }
+
+  /// Resume every still-pending waiter without advancing the clock. Called by
+  /// the runner at scenario teardown so a deliberately-wedged `sleep` does not
+  /// leak its continuation.
+  func drainPending() {
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending { waiter.resume() }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeClockTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+/// `FakeClock` behavior tests (epic #827, PR-2 plan §11.2 item C).
+/// Proves the clock advances ONLY on explicit advancement and never reads the
+/// wall clock — the property that makes the simulator deterministic.
+@MainActor
+@Suite("FakeClock")
+struct FakeClockTests {
+
+  @Test("starts at zero, advances only on explicit advance")
+  func advancesOnlyExplicitly() {
+    let clock = FakeClock()
+    #expect(clock.now == 0)
+    #expect(clock.explicitAdvanceCount == 0)
+    clock.advance(by: 3)
+    #expect(clock.now == 3)
+    #expect(clock.explicitAdvanceCount == 3)
+    clock.tick()
+    #expect(clock.now == 4)
+  }
+
+  @Test("non-positive advance is a no-op")
+  func nonPositiveAdvanceIsNoOp() {
+    let clock = FakeClock()
+    clock.advance(by: 0)
+    clock.advance(by: -5)
+    #expect(clock.now == 0)
+  }
+
+  @Test("sleep resumes exactly when the clock reaches the deadline")
+  func sleepResumesAtDeadline() async {
+    let clock = FakeClock()
+    let woke = WokeFlag()
+    let sleeper = Task { @MainActor in
+      await clock.sleep(ticks: 3)
+      woke.value = true
+    }
+    await Task.yield()
+    clock.advance(by: 2)
+    await Task.yield()
+    #expect(woke.value == false, "sleeper must not wake before its deadline")
+    clock.advance(by: 1)
+    await sleeper.value
+    #expect(woke.value == true)
+  }
+
+  @Test("sleep of non-positive ticks returns immediately")
+  func sleepZeroReturnsImmediately() async {
+    let clock = FakeClock()
+    await clock.sleep(ticks: 0)
+    #expect(clock.hasPendingWaiters == false)
+  }
+
+  @Test("drainPending resumes a straggler without advancing the clock")
+  func drainPendingResumesStraggler() async {
+    let clock = FakeClock()
+    let woke = WokeFlag()
+    let sleeper = Task { @MainActor in
+      await clock.sleep(ticks: 100)
+      woke.value = true
+    }
+    await Task.yield()
+    #expect(clock.hasPendingWaiters == true)
+    clock.drainPending()
+    await sleeper.value
+    #expect(woke.value == true)
+    #expect(clock.now == 0, "drainPending must not advance the clock")
+  }
+
+  @MainActor
+  final class WokeFlag {
+    var value = false
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -1,0 +1,254 @@
+import EnviousWisprCore
+import Foundation
+
+@testable import EnviousWisprPipeline
+
+// MARK: - FakeEngine (epic #827, PR-2 plan §3.3, §3.8; PR-1 §B.2.3)
+//
+// The PR-2 conformer of `ASREngineAdapter`. It is both the test infrastructure
+// and the hot-swap existence proof (epic §3.6): a new engine = one
+// `ASREngineAdapter` conformer + one factory line. It uses no real ASR.
+//
+// Every MUST / MUST NOT clause in PR-1 §B.2.2 is honored and `FakeEngineTests`
+// asserts each. Wedge semantics (PR-2 plan §3.3): the `wedge*` modes ship a
+// NON-nil progress stream that simply goes silent — they do NOT use a nil
+// stream. A nil stream (the `*ProgressAbsent` knobs) means the engine exposes
+// no wedge signal at all. The two are distinct on purpose.
+
+/// The eight `FakeEngine` behaviors (PR-1 §B.2.3).
+enum FakeEngineBehavior: Sendable {
+  /// Batch engine: `finalize()` returns one transcript.
+  case batchSuccess(text: String)
+  /// Streaming engine: emits partials, then a final transcript.
+  case streamingSuccess(partials: [String], final: String)
+  /// Decoder produced nothing.
+  case empty(hadSpeechEvidence: Bool)
+  /// `warmUp()` completes after `ticksToReady` logical clock ticks.
+  case slowLoad(ticksToReady: Int)
+  /// `warmUp()` never completes on its own — the load wedges. Resolved only by
+  /// `cancel()` (best-effort load cancellation, D6).
+  case wedgeOnLoad
+  /// `finalize()` never completes on its own — the finalize wedges. Resolved
+  /// only by `cancel()`.
+  case wedgeOnFinalize
+  /// `finalize()` surfaces an engine crash as `.failed(.engineCrashed)` —
+  /// never a throw, never a hang.
+  case crashOnFinalize
+  /// `finalize()` always returns `.cancelled`.
+  case cancelled
+}
+
+@MainActor
+final class FakeEngine: ASREngineAdapter {
+  /// `var` so a scenario's `EngineDirective.setBehavior` can reconfigure the
+  /// fake before a session begins (e.g. the engine-switch scenarios).
+  var behavior: FakeEngineBehavior
+
+  /// Capabilities follow `behavior` — a `streamingSuccess` fake advertises
+  /// `supportsStreaming`, so a kernel that branches on `capabilities` runs the
+  /// A2 / A9 / A10 streaming scenarios through a genuinely streaming adapter.
+  var capabilities: ASREngineCapabilities {
+    switch behavior {
+    case .streamingSuccess:
+      return ASREngineCapabilities(supportsStreaming: true, supportsLanguageDetection: false)
+    default:
+      return ASREngineCapabilities(supportsStreaming: false, supportsLanguageDetection: false)
+    }
+  }
+
+  private(set) var readiness: ASREngineReadiness = .notReady
+
+  // MARK: Observed counters (for FakeEngineTests)
+
+  private(set) var warmUpCallCount = 0
+  private(set) var beginSessionCallCount = 0
+  private(set) var acceptedBufferCount = 0
+  private(set) var acceptAudioAfterTerminalCount = 0
+  private(set) var finalizeCallCount = 0
+  private(set) var cancelCallCount = 0
+  private(set) var lastUnloadPolicy: ModelUnloadPolicy?
+  private(set) var lastSessionID: SessionID?
+
+  // MARK: Terminal latch
+
+  /// `true` once `cancel()` or `finalize()` has completed — `acceptAudio(_:)`
+  /// after this is a no-op (PR-1 §B.2.2).
+  private var isTerminal = false
+  private var isCancelled = false
+
+  // MARK: Progress streams
+
+  private let clock: FakeClock
+  /// `var` so a scenario's `EngineDirective.setLoadProgressAbsent` can model
+  /// the nil-stream case (A19) without reconstructing the engine.
+  var loadProgressAbsent: Bool
+  var finalizeProgressAbsent: Bool
+
+  private let loadStream: AsyncStream<ASRLoadProgressTick>
+  private let loadContinuation: AsyncStream<ASRLoadProgressTick>.Continuation
+  private let finalizeStream: AsyncStream<ASRFinalizeProgressTick>
+  private let finalizeContinuation: AsyncStream<ASRFinalizeProgressTick>.Continuation
+  private var loadMarker: UInt64 = 0
+  private var finalizeMarker: UInt64 = 0
+
+  /// `nil` when the engine exposes no load-progress stream — the kernel then
+  /// does signal-free `warmingUp` (PR-1 §B.2.2).
+  var loadProgress: AsyncStream<ASRLoadProgressTick>? {
+    loadProgressAbsent ? nil : loadStream
+  }
+
+  /// `nil` when the engine exposes no finalize-progress stream.
+  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? {
+    finalizeProgressAbsent ? nil : finalizeStream
+  }
+
+  // MARK: Wedge continuations
+
+  private var loadWedgeContinuation: CheckedContinuation<Void, Never>?
+  private var finalizeWedgeContinuation: CheckedContinuation<Void, Never>?
+
+  init(
+    behavior: FakeEngineBehavior,
+    clock: FakeClock,
+    loadProgressAbsent: Bool = false,
+    finalizeProgressAbsent: Bool = false
+  ) {
+    self.behavior = behavior
+    self.clock = clock
+    self.loadProgressAbsent = loadProgressAbsent
+    self.finalizeProgressAbsent = finalizeProgressAbsent
+    (loadStream, loadContinuation) = AsyncStream.makeStream(of: ASRLoadProgressTick.self)
+    (finalizeStream, finalizeContinuation) = AsyncStream.makeStream(
+      of: ASRFinalizeProgressTick.self)
+  }
+
+  // MARK: Warm-up
+
+  func warmUp() async throws {
+    warmUpCallCount += 1
+    // Idempotent: safe to call when already ready (PR-1 §B.2.2).
+    if readiness == .ready { return }
+    readiness = .warming
+    switch behavior {
+    case .slowLoad(let ticksToReady):
+      await clock.sleep(ticks: ticksToReady)
+      readiness = .ready
+    case .wedgeOnLoad:
+      // The load wedges — suspend until `cancel()` resumes us. No progress
+      // tick is emitted, so a kernel watching `loadProgress` detects the
+      // wedge. Best-effort load cancellation (D6): `warmUp()` throws once
+      // released.
+      // If `cancel()` ALREADY ran (cancel-before-warmUp ordering), there is no
+      // future `cancel()` to resume the continuation — parking would hang.
+      // Throw immediately instead.
+      if isCancelled { throw ASREngineError.wedged }
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        loadWedgeContinuation = continuation
+      }
+      throw ASREngineError.wedged
+    default:
+      readiness = .ready
+    }
+  }
+
+  /// Emit one load-progress tick (driven by a scenario's `emitLoadTick`).
+  func emitLoadTick() {
+    loadMarker += 1
+    loadContinuation.yield(ASRLoadProgressTick(marker: loadMarker))
+  }
+
+  // MARK: Session lifecycle
+
+  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws {
+    beginSessionCallCount += 1
+    lastSessionID = id
+    isTerminal = false
+    isCancelled = false
+  }
+
+  func acceptAudio(_ buffer: AudioBufferHandoff) {
+    // A call after a terminal session MUST be a no-op (PR-1 §B.2.2).
+    if isTerminal {
+      acceptAudioAfterTerminalCount += 1
+      return
+    }
+    acceptedBufferCount += 1
+  }
+
+  func finalize() async -> ASREngineOutcome {
+    finalizeCallCount += 1
+    // After `cancel()`, `finalize()` MUST return `.cancelled` (PR-1 §B.2.2).
+    if isCancelled {
+      isTerminal = true
+      return .cancelled
+    }
+    let outcome: ASREngineOutcome
+    switch behavior {
+    case .batchSuccess(let text):
+      outcome = .transcript(makeResult(text: text))
+    case .streamingSuccess(_, let final):
+      outcome = .transcript(makeResult(text: final))
+    case .empty(let hadSpeechEvidence):
+      outcome = .empty(hadSpeechEvidence: hadSpeechEvidence)
+    case .crashOnFinalize:
+      // An engine crash surfaces as a VALUE, never a throw, never a hang.
+      outcome = .failed(.engineCrashed)
+    case .wedgeOnFinalize:
+      // The finalize wedges — suspend until `cancel()` resumes us. No
+      // finalize tick is emitted, so a kernel watching `finalizeProgress`
+      // detects the wedge. Once released, return `.cancelled` per the
+      // post-cancel MUST clause.
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        finalizeWedgeContinuation = continuation
+      }
+      isTerminal = true
+      return .cancelled
+    case .cancelled:
+      outcome = .cancelled
+    case .slowLoad:
+      // A slow load is a load-phase delay; once warm-up completes the engine
+      // transcribes normally. Scenarios A3 / A19 model slow-warm-up-then-success
+      // and must be able to finalize to a transcript.
+      outcome = .transcript(makeResult(text: "transcribed after slow load"))
+    case .wedgeOnLoad:
+      // The load wedged; A4 cancels before finalize (handled by the
+      // post-cancel branch above). A defensive finalize surfaces a load failure.
+      outcome = .failed(.loadFailed)
+    }
+    isTerminal = true
+    return outcome
+  }
+
+  /// Emit one finalize-progress tick (driven by a scenario's `emitFinalizeTick`).
+  func emitFinalizeTick() {
+    finalizeMarker += 1
+    finalizeContinuation.yield(ASRFinalizeProgressTick(marker: finalizeMarker))
+  }
+
+  func cancel() async {
+    cancelCallCount += 1
+    // Idempotent — 2+ calls have the same effect as one (PR-1 §B.2.2).
+    isCancelled = true
+    isTerminal = true
+    // Release a wedged `warmUp()` / `finalize()` (best-effort, D6).
+    if let continuation = loadWedgeContinuation {
+      loadWedgeContinuation = nil
+      continuation.resume()
+    }
+    if let continuation = finalizeWedgeContinuation {
+      finalizeWedgeContinuation = nil
+      continuation.resume()
+    }
+  }
+
+  func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
+    lastUnloadPolicy = policy
+  }
+
+  // MARK: Helpers
+
+  private func makeResult(text: String) -> ASRResult {
+    ASRResult(
+      text: text, language: nil, duration: 0, processingTime: 0, backendType: .parakeet)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
@@ -1,0 +1,203 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// `FakeEngine` behavior tests (epic #827, PR-2 plan §11.2 items A, adversarial).
+/// Each of the eight modes and every MUST / MUST NOT clause in PR-1 §B.2.2 is
+/// asserted — without these, PR-2 is unfalsifiable.
+@MainActor
+@Suite("FakeEngine")
+struct FakeEngineTests {
+
+  private func makeEngine(_ behavior: FakeEngineBehavior) -> (FakeEngine, FakeClock) {
+    let clock = FakeClock()
+    return (FakeEngine(behavior: behavior, clock: clock), clock)
+  }
+
+  // MARK: Per-behavior finalize outcomes
+
+  @Test("batchSuccess finalizes to a non-empty transcript")
+  func batchSuccessOutcome() async {
+    let (engine, _) = makeEngine(.batchSuccess(text: "hello"))
+    let outcome = await engine.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "hello")
+  }
+
+  @Test("streamingSuccess finalizes to the final transcript")
+  func streamingSuccessOutcome() async {
+    let (engine, _) = makeEngine(.streamingSuccess(partials: ["he"], final: "hello"))
+    let outcome = await engine.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "hello")
+  }
+
+  @Test("crashOnFinalize surfaces as .failed(.engineCrashed), never a throw or hang")
+  func crashOutcome() async {
+    let (engine, _) = makeEngine(.crashOnFinalize)
+    let outcome = await engine.finalize()
+    guard case .failed(.engineCrashed) = outcome else {
+      Issue.record("expected .failed(.engineCrashed), got \(outcome)")
+      return
+    }
+  }
+
+  // MARK: Adversarial / boundary — empty routing (§11.2 adversarial)
+
+  @Test("empty(hadSpeechEvidence: true) does NOT route like empty(false)")
+  func emptyWithSpeechEvidenceIsDistinct() async {
+    let (withEvidence, _) = makeEngine(.empty(hadSpeechEvidence: true))
+    let (withoutEvidence, _) = makeEngine(.empty(hadSpeechEvidence: false))
+    let a = await withEvidence.finalize()
+    let b = await withoutEvidence.finalize()
+    guard case .empty(let evidenceA) = a, case .empty(let evidenceB) = b else {
+      Issue.record("expected .empty from both")
+      return
+    }
+    #expect(evidenceA == true)
+    #expect(evidenceB == false)
+    #expect(evidenceA != evidenceB, "the two empty modes must route differently")
+  }
+
+  @Test("cancelled mode never yields text")
+  func cancelledNeverYieldsText() async {
+    let (engine, _) = makeEngine(.cancelled)
+    let outcome = await engine.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  // MARK: MUST / MUST NOT clauses (PR-1 §B.2.2)
+
+  @Test("cancel() is idempotent")
+  func cancelIsIdempotent() async {
+    let (engine, _) = makeEngine(.batchSuccess(text: "x"))
+    await engine.cancel()
+    await engine.cancel()
+    await engine.cancel()
+    #expect(engine.cancelCallCount == 3)
+    // Idempotent EFFECT: still terminal-cancelled, finalize still .cancelled.
+    let outcome = await engine.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled after repeated cancel")
+      return
+    }
+  }
+
+  @Test("finalize() after cancel() returns .cancelled, never partial text")
+  func finalizeAfterCancelIsCancelled() async {
+    let (engine, _) = makeEngine(.batchSuccess(text: "should not appear"))
+    await engine.cancel()
+    let outcome = await engine.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("acceptAudio after a terminal session is a no-op")
+  func acceptAudioAfterTerminalIsNoOp() async {
+    let (engine, _) = makeEngine(.batchSuccess(text: "x"))
+    let buffer = AudioBufferHandoff(
+      pcm: [0.1], frameCount: 1, sequence: 1, sessionID: SessionID())
+    engine.acceptAudio(buffer)
+    #expect(engine.acceptedBufferCount == 1)
+    await engine.cancel()
+    engine.acceptAudio(buffer)
+    engine.acceptAudio(buffer)
+    #expect(engine.acceptedBufferCount == 1, "no buffer counted after terminal")
+    #expect(engine.acceptAudioAfterTerminalCount == 2)
+  }
+
+  @Test("warmUp() is idempotent and safe when already ready")
+  func warmUpIsIdempotent() async throws {
+    let (engine, _) = makeEngine(.batchSuccess(text: "x"))
+    try await engine.warmUp()
+    #expect(engine.readiness == .ready)
+    try await engine.warmUp()
+    try await engine.warmUp()
+    #expect(engine.readiness == .ready)
+    #expect(engine.warmUpCallCount == 3)
+  }
+
+  // MARK: slowLoad — clock-driven warm-up
+
+  @Test("slowLoad becomes ready only after the configured ticks")
+  func slowLoadWaitsForClock() async throws {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .slowLoad(ticksToReady: 3), clock: clock)
+    let warmUp = Task { @MainActor in try await engine.warmUp() }
+    await Task.yield()
+    #expect(engine.readiness == .warming)
+    clock.advance(by: 2)
+    await Task.yield()
+    #expect(engine.readiness == .warming, "not ready before the deadline")
+    clock.advance(by: 1)
+    try await warmUp.value
+    #expect(engine.readiness == .ready)
+  }
+
+  // MARK: Wedge semantics — nil vs non-nil silent stream (§3.3, Codex revision 6)
+
+  @Test("loadProgressAbsent yields a nil loadProgress stream")
+  func loadProgressAbsentIsNil() {
+    let clock = FakeClock()
+    let absent = FakeEngine(
+      behavior: .batchSuccess(text: "x"), clock: clock, loadProgressAbsent: true)
+    let present = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
+    #expect(absent.loadProgress == nil, "absent knob means no wedge signal at all")
+    #expect(present.loadProgress != nil)
+  }
+
+  @Test("wedgeOnLoad keeps a NON-nil stream that simply goes silent")
+  func wedgeOnLoadHasNonNilSilentStream() {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .wedgeOnLoad, clock: clock)
+    #expect(
+      engine.loadProgress != nil,
+      "a wedge mode exposes the stream and emits no ticks — that silence is the wedge signal")
+  }
+
+  @Test("cancel() before a wedgeOnLoad warmUp() does not hang")
+  func cancelBeforeWedgeOnLoadDoesNotHang() async {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .wedgeOnLoad, clock: clock)
+    // cancel-before-warmUp ordering: there is no future cancel() to resume a
+    // parked continuation, so warmUp() must throw immediately, not park.
+    await engine.cancel()
+    await #expect(throws: ASREngineError.self) {
+      try await engine.warmUp()
+    }
+  }
+
+  @Test("wedgeOnFinalize: cancel() releases the wedged finalize as .cancelled")
+  func wedgeOnFinalizeReleasedByCancel() async {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .wedgeOnFinalize, clock: clock)
+    let finalizeTask = Task { @MainActor in await engine.finalize() }
+    await Task.yield()
+    await engine.cancel()
+    let outcome = await finalizeTask.value
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled after cancel released the wedge, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("applyUnloadPolicy records the policy")
+  func applyUnloadPolicyRecorded() {
+    let (engine, _) = makeEngine(.batchSuccess(text: "x"))
+    engine.applyUnloadPolicy(.immediately)
+    #expect(engine.lastUnloadPolicy == .immediately)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakePasteTarget.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakePasteTarget.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - FakePasteTarget (epic #827, PR-2 plan §3.3)
+//
+// Records paste attempts so the assertion library can check "no duplicate
+// paste", "cancellation never pastes", and "transcript delivered". Configurable
+// to fail the paste; on failure it models today's verified behavior — the
+// clipboard-only fallback (`PasteCascadeExecutor.swift:269-316`,
+// `TranscriptFinalizerTests.swift:142-159`): a failed paste copies to the
+// clipboard and is non-fatal.
+//
+// Not a production-protocol conformer — PR-2 has no kernel paste path to bind
+// to. It is a standalone harness fake the PR-3 wrapper wires the kernel's
+// delivery effects into.
+
+@MainActor
+final class FakePasteTarget {
+  /// When `true`, every paste attempt fails and falls back to clipboard-only.
+  var shouldFailPaste = false
+
+  /// Every text handed to `attemptPaste(_:)`, in order.
+  private(set) var pasteAttempts: [String] = []
+  /// Texts that reached the user by a real paste.
+  private(set) var pastedTexts: [String] = []
+  /// Texts that reached the user only by the clipboard fallback.
+  private(set) var clipboardCopies: [String] = []
+
+  init() {}
+
+  /// Attempt to deliver `text`. Returns the resulting `PasteOutcome` — a real
+  /// paste, or the clipboard-only fallback when `shouldFailPaste` is set.
+  @discardableResult
+  func attemptPaste(_ text: String) -> PasteOutcome {
+    pasteAttempts.append(text)
+    if shouldFailPaste {
+      clipboardCopies.append(text)
+      return .clipboardOnly
+    }
+    pastedTexts.append(text)
+    return .pasted
+  }
+
+  /// Count of real pastes — the `ExpectedOutcome.pasteCount` signal. Anything
+  /// above 1 is a retry-storm failure.
+  var pasteCount: Int {
+    pastedTexts.count
+  }
+
+  /// `true` if the transcript reached the user by paste OR clipboard fallback.
+  var transcriptDelivered: Bool {
+    !pastedTexts.isEmpty || !clipboardCopies.isEmpty
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakePasteTargetTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakePasteTargetTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+/// `FakePasteTarget` behavior tests (epic #827, PR-2 plan §11.2 item D).
+@MainActor
+@Suite("FakePasteTarget")
+struct FakePasteTargetTests {
+
+  @Test("a successful paste records a real paste and reports .pasted")
+  func successfulPaste() {
+    let target = FakePasteTarget()
+    let outcome = target.attemptPaste("hello")
+    #expect(outcome == .pasted)
+    #expect(target.pasteCount == 1)
+    #expect(target.transcriptDelivered == true)
+  }
+
+  @Test("a failed paste falls back to clipboard-only and is non-fatal")
+  func failedPasteClipboardFallback() {
+    let target = FakePasteTarget()
+    target.shouldFailPaste = true
+    let outcome = target.attemptPaste("hello")
+    #expect(outcome == .clipboardOnly)
+    #expect(target.pasteCount == 0, "a clipboard fallback is not a real paste")
+    #expect(target.clipboardCopies == ["hello"])
+    #expect(target.transcriptDelivered == true, "clipboard fallback still delivers")
+  }
+
+  @Test("never double-pastes — one attempt is one record")
+  func neverDoublePastes() {
+    let target = FakePasteTarget()
+    target.attemptPaste("a")
+    #expect(target.pasteCount == 1)
+    #expect(target.pasteAttempts == ["a"])
+  }
+
+  @Test("no attempt means nothing delivered")
+  func noAttemptNoDelivery() {
+    let target = FakePasteTarget()
+    #expect(target.pasteCount == 0)
+    #expect(target.transcriptDelivered == false)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@testable import EnviousWisprPipeline
+
+// MARK: - FakeVADSignalSource (epic #827, PR-2 plan §3.3; PR-1 §B.6)
+//
+// Conforms to the production `VADSignalSource` seam. Emits the stop-driving
+// signals on command and vends a settable speech-evidence verdict, so
+// VAD-policy scenarios (auto-stop, no-speech gate, evidence-unavailable) run
+// deterministically.
+
+@MainActor
+final class FakeVADSignalSource: VADSignalSource {
+  let stopSignals: AsyncStream<VADStopSignal>
+  private let stopContinuation: AsyncStream<VADStopSignal>.Continuation
+
+  /// The verdict `speechEvidenceAtStop()` returns. Defaults to `.voiced`;
+  /// scenarios set `.confirmedNoSpeech` or `.unavailable`.
+  var evidence: VADSpeechEvidence = .voiced
+
+  /// The session each emitted signal is stamped with. PR-3 sets this per
+  /// session start (mirroring the real seam being told the frozen session).
+  var currentSessionID = SessionID()
+
+  /// Every signal kind emitted, in order — for `FakeVADSignalSourceTests`.
+  private(set) var emittedKinds: [VADStopKind] = []
+  /// Number of times `speechEvidenceAtStop()` was read.
+  private(set) var evidenceReadCount = 0
+
+  init() {
+    (stopSignals, stopContinuation) = AsyncStream.makeStream(of: VADStopSignal.self)
+  }
+
+  /// Emit one stop-driving signal, stamped with `currentSessionID` (driven by a
+  /// scenario's `VADDirective`).
+  func emit(_ kind: VADStopKind) {
+    emittedKinds.append(kind)
+    stopContinuation.yield(VADStopSignal(kind: kind, sessionID: currentSessionID))
+  }
+
+  func speechEvidenceAtStop() -> VADSpeechEvidence {
+    evidenceReadCount += 1
+    return evidence
+  }
+
+  /// Close the signal stream at scenario teardown.
+  func finish() {
+    stopContinuation.finish()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSourceTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// `FakeVADSignalSource` behavior tests (epic #827, PR-2 plan §11.2 item F).
+@MainActor
+@Suite("FakeVADSignalSource")
+struct FakeVADSignalSourceTests {
+
+  @Test("emits each stop-signal kind, stamped with the current session")
+  func emitsStopSignals() async {
+    let vad = FakeVADSignalSource()
+    let session = SessionID()
+    vad.currentSessionID = session
+    let collected = CollectedSignals()
+    let consumer = Task { @MainActor in
+      for await signal in vad.stopSignals { collected.value.append(signal) }
+    }
+    await Task.yield()
+    vad.emit(.autoStopTriggered)
+    vad.emit(.maxDurationReached)
+    vad.finish()
+    await consumer.value
+    #expect(collected.value.map(\.kind) == [.autoStopTriggered, .maxDurationReached])
+    #expect(
+      collected.value.allSatisfy { $0.sessionID == session },
+      "every signal carries the current SessionID — the stale-callback gate")
+    #expect(vad.emittedKinds == [.autoStopTriggered, .maxDurationReached])
+  }
+
+  @Test("speechEvidenceAtStop returns the configured tri-state verdict")
+  func speechEvidenceTriState() {
+    let vad = FakeVADSignalSource()
+    #expect(vad.speechEvidenceAtStop() == .voiced, "defaults to .voiced")
+    vad.evidence = .confirmedNoSpeech
+    #expect(vad.speechEvidenceAtStop() == .confirmedNoSpeech)
+    vad.evidence = .unavailable
+    #expect(vad.speechEvidenceAtStop() == .unavailable)
+    #expect(vad.evidenceReadCount == 3)
+  }
+
+  @MainActor
+  final class CollectedSignals {
+    var value: [VADStopSignal] = []
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalization.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalization.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// MARK: - Freeze-suite normalization (epic #827, PR-2 plan §3.7; epic §11.2)
+//
+// The freeze gate compares LEXICAL parity — words, not punctuation formatting.
+// Both `rawTranscript` and `normalizedTranscript` are committed to
+// `baseline.json` so punctuation deltas stay auditable even though they do not
+// gate. This function is applied identically to the old-path baseline and the
+// new-path output.
+//
+// Eight rules, in order (PR-2 plan §3.7). Itself unit-tested with adversarial
+// Unicode cases in `FreezeSuiteNormalizationTests`.
+
+enum FreezeSuiteNormalization {
+
+  /// Curly / typographic apostrophes normalized to straight `'` and KEPT —
+  /// they are word characters (`can't` ≠ `cant` is a real regression).
+  private static let apostropheVariants: [Character] = ["\u{2019}", "\u{2018}", "\u{02BC}"]
+
+  /// Quote MARKS — stripped (distinct from the apostrophes above).
+  private static let quoteMarks: [Character] = [
+    "\"", "\u{201C}", "\u{201D}", "\u{00AB}", "\u{00BB}",
+  ]
+
+  /// Non-terminal punctuation stripped globally. Internal `.!?` are NOT here —
+  /// only a TRAILING run of those is stripped (rule 6). Internal hyphens are
+  /// kept (lexical).
+  private static let strippedPunctuation: Set<Character> = [
+    ",", ";", ":", "(", ")", "[", "]", "{", "}", "/",
+  ]
+
+  /// A trailing run of these is stripped (rule 6).
+  private static let terminalPunctuation: Set<Character> = [".", "!", "?", "\u{2026}"]
+
+  /// Normalize `input` for lexical-parity comparison (PR-2 plan §3.7).
+  static func normalize(_ input: String) -> String {
+    // Rule 1 — Unicode NFC normalize before any other rule.
+    var text = input.precomposedStringWithCanonicalMapping
+
+    // Rule 4 — curly apostrophes → straight, kept.
+    for variant in apostropheVariants {
+      text = text.replacingOccurrences(of: String(variant), with: "'")
+    }
+
+    // Rule 5 — strip quote marks (not the apostrophes from rule 4).
+    text.removeAll { quoteMarks.contains($0) }
+
+    // Rule 3 — lowercase.
+    text = text.lowercased()
+
+    // Rule 7 — strip non-terminal punctuation.
+    text.removeAll { strippedPunctuation.contains($0) }
+
+    // Rule 2 — every Unicode whitespace class → ASCII space, collapse runs,
+    // trim. Splitting on the Unicode whitespace property handles NBSP,
+    // zero-width and other classes a naive ` ` split would miss.
+    let collapsed = text.unicodeScalars
+      .split { $0.properties.isWhitespace || $0 == "\u{200B}" }
+      .map { String(String.UnicodeScalarView($0)) }
+      .joined(separator: " ")
+
+    // Rule 6 — strip a trailing run of terminal punctuation, then re-trim.
+    var result = Substring(collapsed)
+    while let last = result.last, terminalPunctuation.contains(last) {
+      result = result.dropLast()
+    }
+    return String(result).trimmingCharacters(in: .whitespaces)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+/// Freeze-suite normalization tests (epic #827, PR-2 plan §11.2 item G, §3.7).
+/// Adversarial Unicode coverage — the normalization function gates lexical
+/// parity, so a bug here either trips the freeze gate on a non-regression or
+/// hides a real one.
+@Suite("FreezeSuiteNormalization")
+struct FreezeSuiteNormalizationTests {
+
+  private func norm(_ s: String) -> String { FreezeSuiteNormalization.normalize(s) }
+
+  @Test("rule 3 — casing is lowered")
+  func casingLowered() {
+    #expect(norm("Hello World") == "hello world")
+  }
+
+  @Test("rule 2 — whitespace runs collapse and ends trim")
+  func whitespaceCollapsed() {
+    #expect(norm("  hello   world  ") == "hello world")
+    #expect(norm("hello\tworld") == "hello world")
+  }
+
+  @Test("rule 2 — non-breaking and zero-width spaces normalize")
+  func unicodeWhitespaceNormalized() {
+    #expect(norm("hello\u{00A0}world") == "hello world", "NBSP")
+    #expect(norm("hello\u{200B}world") == "hello world", "zero-width space")
+  }
+
+  @Test("rule 6 — a single trailing period is stripped, internal periods kept")
+  func trailingPeriodStripped() {
+    #expect(norm("hello world.") == "hello world")
+    #expect(norm("u.s. army") == "u.s. army", "internal periods are lexical")
+  }
+
+  @Test("rule 6 — a trailing run of terminal punctuation is stripped")
+  func trailingRunStripped() {
+    #expect(norm("hello...") == "hello")
+    #expect(norm("hello!?") == "hello")
+    #expect(norm("hello\u{2026}") == "hello", "ellipsis character")
+  }
+
+  @Test("rule 4 — curly apostrophes normalize to straight and are KEPT")
+  func curlyApostropheKept() {
+    #expect(norm("can\u{2019}t") == "can't")
+    #expect(norm("can't") != "cant", "apostrophe is a word character — must be kept")
+  }
+
+  @Test("rule 5 — quote marks are stripped, not the apostrophes")
+  func quoteMarksStripped() {
+    #expect(norm("\"hello\"") == "hello")
+    #expect(norm("\u{201C}hello\u{201D}") == "hello", "curly double quotes")
+  }
+
+  @Test("rule 7 — parentheses, brackets, slashes, commas strip")
+  func otherPunctuationStripped() {
+    #expect(norm("hello (world)") == "hello world")
+    #expect(norm("a/b") == "ab")
+    #expect(norm("one, two; three") == "one two three")
+  }
+
+  @Test("internal hyphens are kept — they are lexical")
+  func internalHyphenKept() {
+    #expect(norm("sub-second latency") == "sub-second latency")
+  }
+
+  @Test("rule 1 — NFC-decomposed and composed forms normalize equal")
+  func nfcNormalization() {
+    let composed = "café"  // single é
+    let decomposed = "cafe\u{0301}"  // e + combining acute
+    #expect(norm(composed) == norm(decomposed))
+  }
+
+  @Test("em / en dashes between words survive as separators")
+  func dashHandling() {
+    // Dashes are not in the stripped set; they remain, and a surrounding-space
+    // form collapses cleanly. The freeze clips avoid dash-ambiguous dictation;
+    // this pins that a dash does not crash or mangle normalization.
+    #expect(norm("a — b").contains("a"))
+    #expect(norm("a — b").contains("b"))
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/InterleavingSweep.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/InterleavingSweep.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+// MARK: - Interleaving sweep (epic #827, PR-2 plan §3.5; epic §3a)
+//
+// The sweep reruns each concurrency-tagged scenario under N fixed schedules.
+// N = 64 is a SPARSE, REPRODUCIBLE baseline — NOT a saturated net (council
+// caught the false "dense" claim: 6 suspension points alone give 6! = 720
+// orderings). N is justified by NAMED schedule-class coverage plus exact
+// reproducibility, not by the raw count:
+//
+//   - reproducibility: each schedule derives deterministically from a
+//     committed `UInt64` seed; a failure prints its seed and reruns identically.
+//   - schedule-class coverage: the 64 seeds are chosen so their derived
+//     schedules hit every class — `ScheduleCoverage` + `ScheduleCoverageTest`
+//     assert this.
+//
+// PR-3, once scenarios execute against the real kernel, may raise N with
+// measured saturation evidence.
+
+/// The fixed property-test iteration count (PR-2 plan §3.5). A single named
+/// constant — one place to change, with the rationale above.
+let interleavingSweepCount = 64
+
+/// Number of suspension points modelled per concurrency-sensitive scenario.
+/// PR-1's concurrency scenarios each have a small set; 4 is the representative
+/// count the schedule's `suspensionOrder` permutes.
+let interleavingSuspensionPointCount = 4
+
+/// The 64 committed sweep seeds (PR-2 plan §3.5). A fixed `UInt64` literal
+/// array, never time-seeded — generated as a SplitMix64 stream from base
+/// `0x9E3779B97F4A7C15` and frozen here so every run and every machine derives
+/// the identical 64 schedules.
+let interleavingSweepSeeds: [UInt64] = [
+  0x6E78_9E6A_A1B9_65F4, 0x06C4_5D18_8009_454F, 0xF88B_B8A8_724C_81EC,
+  0x1B39_896A_51A8_749B,
+  0x53CB_9F0C_747E_A2EA, 0x2C82_9ABE_1F45_32E1, 0xC584_133A_C916_AB3C,
+  0x3EE5_7890_41C9_8AC3,
+  0xF3B8_488C_368C_B0A6, 0x657E_ECDD_3CB1_3D09, 0xC2D3_26E0_055B_DEF6,
+  0x8621_A03F_E0BB_DB7B,
+  0x8E1F_7555_983A_A92F, 0xB54E_0F16_00CC_4D19, 0x84BB_3F97_971D_80AB,
+  0x7D29_825C_7552_1255,
+  0xC3CF_1710_2B7F_7F86, 0x3466_E9A0_8391_4F64, 0xD81A_8D2B_5A44_85AC,
+  0xDB01_602B_100B_9ED7,
+  0xA903_8A92_1825_F10D, 0xEDF5_F1D9_0DCA_2F6A, 0x5449_6AD6_7BD2_634C,
+  0xDD7C_01D4_F540_7269,
+  0x935E_82F1_DB4C_4F7B, 0x69B8_2EBC_9223_3300, 0x40D2_9EB5_7DE1_D510,
+  0xA2F0_9DAB_B45C_6316,
+  0xEE52_1D7A_0F4D_3872, 0xF169_52EE_72F3_454F, 0x377D_35DE_A8E4_0225,
+  0x0C7D_E806_4963_BAB0,
+  0x0558_2D37_111A_C529, 0xD254_741F_599D_C6F7, 0x6963_0F75_93D1_08C3,
+  0x417E_F961_81DA_A383,
+  0x3C3C_41A3_B433_43A1, 0x6E19_905D_CBE5_31DF, 0x4FA9_FA73_2485_1729,
+  0x84EB_4454_A792_922A,
+  0x134F_7096_9181_75CE, 0x07DC_930B_3022_78A8, 0x12C0_15A9_7019_E937,
+  0xCC06_C316_52EB_F438,
+  0xECEE_6563_0A69_1E37, 0x3E84_ECB1_763E_79AD, 0x690E_D476_743A_AE49,
+  0x7746_15D7_B1A1_F2E1,
+  0x22B3_53F0_4F4F_52DA, 0xE3DD_D86B_A71A_5EB1, 0xDF26_8ADE_B651_3356,
+  0x2098_EB73_D436_7D77,
+  0x03D6_8453_23CE_3C71, 0xC952_C562_0043_C714, 0x9B19_6BCA_844F_1705,
+  0x3026_0345_DD9E_0EC1,
+  0xCF44_8A58_82BB_9698, 0xF4A5_78DC_CBC8_7656, 0xBFDE_AED9_A17B_3C8F,
+  0xED79_402D_1D5C_5D7B,
+  0x55F0_70AB_1CBB_F170, 0x3E00_A349_29A8_8F1D, 0xE255_B237_B8BB_18FB,
+  0x2A7B_67AF_6C6A_D50E,
+]
+
+// MARK: - Schedule-class DOF (the four randomized degrees of freedom, epic §3a)
+
+/// Fake-clock advancement granularity — the fourth randomized DOF.
+enum ClockGranularity: CaseIterable, Equatable, Sendable {
+  case zeroTick
+  case singleTick
+  case multiTick
+  case finalizeWithoutProgress
+}
+
+/// Where a cancellation lands relative to a suspension point — the third DOF.
+enum CancellationTiming: CaseIterable, Equatable, Sendable {
+  case beforeSuspension
+  case atSuspension
+  case afterSuspension
+}
+
+/// One deterministic interleaving schedule, derived purely from a seed
+/// (PR-2 plan §3.5). Same seed → identical schedule (the reproducibility
+/// property `InterleavingSweepTests` asserts).
+struct InterleavingSchedule: Equatable, Sendable {
+  let seed: UInt64
+  /// DOF 4 — fake-clock advancement granularity.
+  let clockGranularity: ClockGranularity
+  /// DOF 3 — cancellation timing.
+  let cancellationTiming: CancellationTiming
+  /// DOF — late async completion sampled before vs after the terminal state.
+  let lateAsyncBeforeTerminal: Bool
+  /// DOF 1/2 — a permutation of the suspension points (task-interleaving +
+  /// suspension-point ordering).
+  let suspensionOrder: [Int]
+
+  /// Derive the schedule for `seed`. Pure — no wall clock, no global state.
+  static func derive(seed: UInt64) -> InterleavingSchedule {
+    var rng = SplitMix64(state: seed)
+    let granularity = ClockGranularity.allCases[
+      Int(rng.next() % UInt64(ClockGranularity.allCases.count))]
+    let timing = CancellationTiming.allCases[
+      Int(rng.next() % UInt64(CancellationTiming.allCases.count))]
+    let lateAsync = (rng.next() & 1) == 0
+    var order = Array(0..<interleavingSuspensionPointCount)
+    // Fisher-Yates with the seeded RNG.
+    var index = order.count - 1
+    while index > 0 {
+      let swap = Int(rng.next() % UInt64(index + 1))
+      order.swapAt(index, swap)
+      index -= 1
+    }
+    return InterleavingSchedule(
+      seed: seed,
+      clockGranularity: granularity,
+      cancellationTiming: timing,
+      lateAsyncBeforeTerminal: lateAsync,
+      suspensionOrder: order)
+  }
+}
+
+/// The committed 64 schedules.
+let interleavingSweepSchedules: [InterleavingSchedule] =
+  interleavingSweepSeeds.map(InterleavingSchedule.derive(seed:))
+
+// MARK: - Schedule-class coverage (the metric N is justified by, PR-2 plan §3.5)
+
+/// Reports whether a set of schedules covers every named schedule class.
+/// `ScheduleCoverageTest` asserts `isComplete` over `interleavingSweepSchedules`.
+struct ScheduleCoverage {
+  let coversAllClockGranularities: Bool
+  let coversAllCancellationTimings: Bool
+  let coversBothLateAsyncSides: Bool
+  /// Every ordered pair (i before j, i ≠ j) of suspension points appears in at
+  /// least one schedule.
+  let coversAllPairwiseSuspensionOrderings: Bool
+
+  var isComplete: Bool {
+    coversAllClockGranularities && coversAllCancellationTimings
+      && coversBothLateAsyncSides && coversAllPairwiseSuspensionOrderings
+  }
+
+  static func evaluate(_ schedules: [InterleavingSchedule]) -> ScheduleCoverage {
+    let granularities = Set(schedules.map(\.clockGranularity))
+    let timings = Set(schedules.map(\.cancellationTiming))
+    let lateAsyncSides = Set(schedules.map(\.lateAsyncBeforeTerminal))
+
+    var seenPairs: Set<[Int]> = []
+    for schedule in schedules {
+      let order = schedule.suspensionOrder
+      for i in 0..<order.count {
+        for j in (i + 1)..<order.count {
+          seenPairs.insert([order[i], order[j]])
+        }
+      }
+    }
+    let n = interleavingSuspensionPointCount
+    var allPairs: Set<[Int]> = []
+    for i in 0..<n {
+      for j in 0..<n where i != j {
+        allPairs.insert([i, j])
+      }
+    }
+
+    return ScheduleCoverage(
+      coversAllClockGranularities: granularities.count == ClockGranularity.allCases.count,
+      coversAllCancellationTimings: timings.count == CancellationTiming.allCases.count,
+      coversBothLateAsyncSides: lateAsyncSides.count == 2,
+      coversAllPairwiseSuspensionOrderings: allPairs.isSubset(of: seenPairs))
+  }
+}
+
+// MARK: - Sweep runner
+
+/// Reruns one concurrency-sensitive scenario under all 64 committed schedules.
+@MainActor
+struct InterleavingSweepRunner {
+
+  init() {}
+
+  /// Run `scenario` once per committed schedule. `contextFactory` builds a
+  /// fresh `SimulatorContext` for each schedule so runs do not share fake
+  /// state. The failing seed is carried in each `ScenarioResult` indirectly via
+  /// the returned tuple, so a failure reproduces exactly.
+  func runSweep(
+    _ scenario: Scenario,
+    contextFactory: @MainActor (InterleavingSchedule) -> SimulatorContext
+  ) async -> [(schedule: InterleavingSchedule, result: ScenarioResult)] {
+    let runner = ScenarioRunner()
+    var results: [(InterleavingSchedule, ScenarioResult)] = []
+    for schedule in interleavingSweepSchedules {
+      let context = contextFactory(schedule)
+      // Apply the schedule to the step script so each of the 64 runs genuinely
+      // varies (clock cadence + cancel timing) — not 64 identical copies.
+      let scheduledScenario = scenario.applying(schedule)
+      let result = await runner.run(scheduledScenario, context: context)
+      results.append((schedule, result))
+    }
+    return results
+  }
+}
+
+// MARK: - SplitMix64
+
+/// A tiny, fast, fully deterministic PRNG. Used only to derive a schedule from
+/// a seed — never for anything that needs cryptographic quality.
+struct SplitMix64 {
+  private var state: UInt64
+
+  init(state: UInt64) {
+    self.state = state
+  }
+
+  mutating func next() -> UInt64 {
+    state = state &+ 0x9E37_79B9_7F4A_7C15
+    var z = state
+    z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+    z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+    return z ^ (z >> 31)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/InterleavingSweepTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/InterleavingSweepTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+/// Interleaving-sweep tests (epic #827, PR-2 plan §11.2 item H, §3.5).
+/// Proves the sweep is reproducible and the committed 64-seed array covers
+/// every named schedule class — the metric N = 64 is justified by, not the
+/// raw count.
+@MainActor
+@Suite("InterleavingSweep")
+struct InterleavingSweepTests {
+
+  @Test("the committed seed array holds exactly interleavingSweepCount seeds")
+  func seedCountMatchesConstant() {
+    #expect(interleavingSweepCount == 64)
+    #expect(interleavingSweepSeeds.count == interleavingSweepCount)
+    #expect(interleavingSweepSchedules.count == interleavingSweepCount)
+  }
+
+  @Test("the committed seeds are unique")
+  func seedsAreUnique() {
+    #expect(Set(interleavingSweepSeeds).count == interleavingSweepSeeds.count)
+  }
+
+  @Test("schedule derivation is reproducible — same seed, same schedule")
+  func deriveIsReproducible() {
+    for seed in interleavingSweepSeeds {
+      let first = InterleavingSchedule.derive(seed: seed)
+      let second = InterleavingSchedule.derive(seed: seed)
+      #expect(first == second, "seed 0x\(String(seed, radix: 16)) derived two ways")
+    }
+  }
+
+  @Test("different seeds produce a varied schedule population")
+  func seedsProduceVariety() {
+    let granularities = Set(interleavingSweepSchedules.map(\.clockGranularity))
+    let orders = Set(interleavingSweepSchedules.map(\.suspensionOrder))
+    #expect(granularities.count > 1, "seeds must not all derive the same granularity")
+    #expect(orders.count > 1, "seeds must not all derive the same suspension order")
+  }
+
+  /// ScheduleCoverageTest — the committed 64-seed array hits all four schedule
+  /// classes (PR-2 plan §3.5). This is the test that justifies N = 64.
+  @Test("the 64 committed schedules cover every named schedule class")
+  func scheduleCoverageIsComplete() {
+    let coverage = ScheduleCoverage.evaluate(interleavingSweepSchedules)
+    #expect(coverage.coversAllClockGranularities, "missing a clock-granularity class")
+    #expect(coverage.coversAllCancellationTimings, "missing a cancellation-timing class")
+    #expect(coverage.coversBothLateAsyncSides, "missing a late-async side")
+    #expect(
+      coverage.coversAllPairwiseSuspensionOrderings,
+      "missing a pairwise suspension-point ordering")
+    #expect(coverage.isComplete)
+  }
+
+  @Test("sweep runner reruns a concurrency scenario once per committed schedule")
+  func sweepRunsOncePerSchedule() async {
+    let scenario = ScenarioInventory.all.first { $0.id == "A7" }!
+    let results = await InterleavingSweepRunner().runSweep(scenario) { _ in
+      let clock = FakeClock()
+      let stub = StubRecordingSession { trigger, session in
+        if trigger == .cancel { session.setState(.cancelled) }
+      }
+      return SimulatorContext(
+        sut: stub,
+        engine: FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock),
+        capture: FakeAudioCapture(),
+        vad: FakeVADSignalSource(),
+        clock: clock,
+        paste: FakePasteTarget())
+    }
+    #expect(results.count == interleavingSweepCount)
+    // Each result carries its schedule's seed, so a failure reproduces exactly.
+    #expect(Set(results.map(\.schedule.seed)).count == interleavingSweepCount)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// MARK: - SUT seam (epic #827, PR-2 plan §3.0, §3b)
+//
+// `RecordingSessionDriving` is the test-side seam the `ScenarioRunner` drives.
+// It is a pure driver/observer surface derived from the PR-1 §B.1.2 transition
+// table — trigger inputs in, observable state + effects out. It lives in the
+// test target (production code must never depend on a test target).
+//
+// In PR-2 the only conformer is `StubRecordingSession` (harness self-test).
+// In PR-3 a test-side wrapper conforms the real `RecordingSessionKernel` to
+// this seam; the wrapper MUST be trivial forwarding/observation — it may NOT
+// implement session policy (session filtering, terminal-state dedup,
+// cancellation ordering, stale-callback dropping, cleanup). Those are kernel
+// behaviors asserted AGAINST the kernel. Codex code-diff review on PR-3 checks
+// the wrapper for "no behavior except forwarding/observation."
+
+/// The observable session effects the assertion library checks (PR-2 plan §3.8).
+struct SessionEffects: Sendable {
+  /// Real pastes delivered — `>1` is always a retry-storm failure.
+  var pasteCount: Int = 0
+  /// Whether delivery was a real paste, the clipboard fallback, or none.
+  var pasteOutcome: PasteOutcome = .none
+  /// The text delivered to the user, or `nil` if none.
+  var transcript: String?
+  /// `true` once the session task bag is drained and capture is stopped.
+  var resourcesReleased: Bool = false
+  /// The user-visible error surface, or `nil`.
+  var userVisibleError: ErrorCategory?
+
+  init() {}
+}
+
+/// The trigger + observation surface the simulator drives (PR-2 plan §3.0).
+@MainActor
+protocol RecordingSessionDriving: AnyObject {
+  /// The current FSM state, mapped onto the harness vocabulary.
+  var state: FSMState { get }
+  /// The observable session effects.
+  var effects: SessionEffects { get }
+  /// Apply one lifecycle trigger. PR-3's wrapper dispatches this to the
+  /// kernel's real start / stop / cancel / reset / preWarm entry points.
+  func apply(_ trigger: SessionTrigger) async
+}
+
+// MARK: - StubRecordingSession
+//
+// The trivial PR-2 conformer, used ONLY to exercise the harness mechanics in
+// `ScenarioRunnerTests`. It implements no real FSM: a test supplies a handler
+// closure that mutates `state` / `effects` per trigger. This is a self-test
+// fixture, not a kernel stand-in.
+
+@MainActor
+final class StubRecordingSession: RecordingSessionDriving {
+  private(set) var state: FSMState = .idle
+  private(set) var effects = SessionEffects()
+
+  /// Every trigger applied, in order — lets the self-test prove dispatch.
+  private(set) var triggerLog: [SessionTrigger] = []
+
+  /// Test-supplied scripting. Receives each trigger and the stub itself, and
+  /// mutates `mutableState` / `mutableEffects` to model a response.
+  private let handler: @MainActor (SessionTrigger, StubRecordingSession) -> Void
+
+  init(handler: @escaping @MainActor (SessionTrigger, StubRecordingSession) -> Void) {
+    self.handler = handler
+  }
+
+  func apply(_ trigger: SessionTrigger) async {
+    triggerLog.append(trigger)
+    handler(trigger, self)
+  }
+
+  /// Scripting hooks the handler uses to drive the stub's observable surface.
+  func setState(_ newState: FSMState) {
+    state = newState
+  }
+
+  func setEffects(_ newEffects: SessionEffects) {
+    effects = newEffects
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+@testable import EnviousWisprPipeline
+
+// MARK: - Scenario DSL (epic #827, PR-2 plan §3.4, §3.8)
+//
+// A scenario is declarative data: an ordered step list plus a full
+// `ExpectedOutcome`. The `ScenarioRunner` (this target) executes the steps
+// against a `RecordingSessionDriving` SUT. In PR-2 the SUT is `StubRecordingSession`
+// (harness self-test); from PR-3 it is the real kernel behind a test-side
+// wrapper, and the 33-scenario inventory becomes merge-blocking.
+
+/// A session-lifecycle trigger — the kernel's public entry points
+/// (PR-1 §B.1.2 transition table).
+enum SessionTrigger: Equatable, Sendable {
+  case start
+  case stop
+  case cancel
+  case reset
+  case preWarm
+}
+
+/// A directive to the `FakeEngine` mid-scenario.
+enum EngineDirective: Sendable {
+  /// Reconfigure the fake engine's behavior before the next session step.
+  case setBehavior(FakeEngineBehavior)
+  /// Emit one load-progress tick (when the engine exposes a load stream).
+  case emitLoadTick
+  /// Emit one finalize-progress tick (when the engine exposes a finalize stream).
+  case emitFinalizeTick
+  /// Model the engine exposing NO load-progress stream — `loadProgress` becomes
+  /// `nil` (the documented signal-free warm-up path, PR-1 §B.2.2; A19).
+  case setLoadProgressAbsent(Bool)
+  /// Model the engine exposing no finalize-progress stream.
+  case setFinalizeProgressAbsent(Bool)
+}
+
+/// A directive to the `FakePasteTarget` mid-scenario.
+enum PasteDirective: Sendable {
+  /// Force the next paste to fail and fall back to clipboard-only (L4).
+  case fail
+  /// Restore normal paste success.
+  case succeed
+}
+
+/// A limb / finalizer failure to inject (L1–L3, L6). The limb pipeline
+/// (`TextProcessingRunner`, `TranscriptFinalizer`) and transcript storage are
+/// production code the kernel calls; PR-2 has no fake for them. PR-3 wires the
+/// kernel's finalizer seam and keys failure injection on THIS directive — not
+/// on the scenario ID. Shipping the directive now keeps the scenario data
+/// complete and stops PR-3 from special-casing IDs.
+enum LimbDirective: Sendable {
+  /// LLM polish fails — finalized text falls back to the pre-polish text.
+  case polishFails
+  /// Custom-words injection fails — ASR runs with default options.
+  case customWordsFails
+  /// Filler-removal fails — the pre-filler-removal text is delivered.
+  case fillerRemovalFails
+  /// The transcript disk-save throws (epic §3.8 caveat b — regression lock on
+  /// current `"Failed to save transcript"` behavior, deferred #830).
+  case storageWriteFails
+}
+
+/// A directive to the `FakeAudioCapture` mid-scenario.
+enum CaptureDirective: Sendable {
+  /// Deliver one synthetic audio buffer.
+  case deliverBuffer
+  /// Stall the capture stream (no buffers).
+  case stall
+  /// Raise an engine interruption (mic disconnect / route change).
+  case interrupt
+  /// Change the audio route mid-session.
+  case routeChange
+  /// Deny / revoke microphone permission.
+  case permissionDenied
+  /// Fail capture start.
+  case startFailure
+  /// Crash the XPC capture service.
+  case xpcCrash
+}
+
+/// A directive to the `FakeVADSignalSource` mid-scenario.
+enum VADDirective: Sendable {
+  case autoStop
+  case maxDuration
+  case evidence(VADSpeechEvidence)
+}
+
+/// One step in a scenario's ordered script.
+enum ScenarioStep: Sendable {
+  case trigger(SessionTrigger)
+  case advanceClock(ticks: Int)
+  case engine(EngineDirective)
+  case capture(CaptureDirective)
+  case vad(VADDirective)
+  case paste(PasteDirective)
+  /// Inject a limb / finalizer / storage failure. PR-2 carries this as data;
+  /// PR-3's kernel-finalizer wiring is the consumer.
+  case limb(LimbDirective)
+  /// Assert the SUT's observable state matches, mid-scenario.
+  case expectState(FSMState)
+}
+
+/// Whether the transcript reached the user by a real paste or the clipboard
+/// fallback (PR-2 plan §3.8 — load-bearing for `L4`).
+enum PasteOutcome: Equatable, Sendable {
+  case pasted
+  case clipboardOnly
+  case none
+}
+
+/// What text a scenario expects delivered (PR-2 plan §3.8). Carries the
+/// payload, not just a delivered/not bool — `FakeEngine`'s output string is
+/// known, so a scenario may assert `.exact`.
+enum TranscriptExpectation: Equatable, Sendable {
+  case none
+  case nonEmpty
+  case exact(String)
+}
+
+/// The complete expected result of a scenario (PR-2 plan §3.8). Every scenario
+/// carries one so PR-3 does not infer assertions while wiring the kernel.
+struct ExpectedOutcome: Sendable {
+  /// Exactly one terminal state, from `FSMState` (PR-1 §B.1.1).
+  let terminalState: FSMState
+  /// 0 or 1 — anything above 1 is always a failure (no retry storm).
+  let pasteCount: Int
+  /// `.pasted` | `.clipboardOnly` | `.none`.
+  let pasteOutcome: PasteOutcome
+  /// What text the scenario expects delivered.
+  let transcript: TranscriptExpectation
+  /// Task bag drained, capture stopped — always `true` at any terminal state.
+  let resourcesReleased: Bool
+  /// `nil`, or the user-visible error surface category.
+  let userVisibleError: ErrorCategory?
+
+  init(
+    terminalState: FSMState,
+    pasteCount: Int,
+    pasteOutcome: PasteOutcome,
+    transcript: TranscriptExpectation,
+    resourcesReleased: Bool = true,
+    userVisibleError: ErrorCategory? = nil
+  ) {
+    self.terminalState = terminalState
+    self.pasteCount = pasteCount
+    self.pasteOutcome = pasteOutcome
+    self.transcript = transcript
+    self.resourcesReleased = resourcesReleased
+    self.userVisibleError = userVisibleError
+  }
+}
+
+/// A scenario tag — drives which scenarios the interleaving sweep reruns.
+enum ScenarioTag: Sendable {
+  /// Concurrency-sensitive — rerun under the 64-schedule interleaving sweep
+  /// (PR-2 plan §3.5).
+  case concurrencySensitive
+}
+
+/// One named, ID'd heart-path scenario (PR-2 plan §3.8).
+struct Scenario: Sendable {
+  /// Canonical ID — e.g. `A1`, `R1`, `C3`, `L4`. `ScenarioInventoryTests`
+  /// asserts the exact ID set, not a count.
+  let id: String
+  /// One-line plain description.
+  let name: String
+  /// The ordered step script.
+  let steps: [ScenarioStep]
+  /// The full expected result.
+  let expected: ExpectedOutcome
+  /// Tags — e.g. `.concurrencySensitive`.
+  let tags: [ScenarioTag]
+
+  init(
+    id: String,
+    name: String,
+    steps: [ScenarioStep],
+    expected: ExpectedOutcome,
+    tags: [ScenarioTag] = []
+  ) {
+    self.id = id
+    self.name = name
+    self.steps = steps
+    self.expected = expected
+    self.tags = tags
+  }
+
+  /// `true` if the scenario is rerun under the interleaving sweep.
+  var isConcurrencySensitive: Bool {
+    tags.contains { if case .concurrencySensitive = $0 { return true } else { return false } }
+  }
+}
+
+extension Scenario {
+  /// Return a copy of this scenario with one interleaving schedule applied to
+  /// its step script (PR-2 plan §3.5; Codex code-diff — the sweep must
+  /// genuinely vary execution, not run 64 identical copies).
+  ///
+  /// ONLY `clockGranularity` is applied here: it rewrites every `advanceClock`
+  /// cadence, which varies execution timing WITHOUT changing the scenario's
+  /// meaning. The trigger order is the scenario's identity and is never
+  /// rewritten — repositioning a `cancel` across a `stop` boundary would turn
+  /// "cancel during finalizing" into "cancel while recording" while still
+  /// expecting the original outcome (Codex round-2 finding). The other three
+  /// DOF — `cancellationTiming`, `suspensionOrder`, `lateAsyncBeforeTerminal` —
+  /// are task-scheduling DOF with meaning only against the real kernel's
+  /// suspension points; PR-3 consumes them from the `InterleavingSchedule`
+  /// directly when it interleaves kernel tasks. PR-2's sweep therefore varies
+  /// clock cadence (and carries the full schedule for PR-3); PR-3 widens it.
+  func applying(_ schedule: InterleavingSchedule) -> Scenario {
+    let rewritten: [ScenarioStep] = steps.map { step in
+      guard case .advanceClock(let ticks) = step else { return step }
+      let newTicks: Int
+      switch schedule.clockGranularity {
+      case .zeroTick:
+        // No logical time advances — the genuine zero-tick race class. A
+        // scenario whose warm-up/finalize is clock-gated then completes only
+        // via the runner's end-of-scenario `FakeClock.drainPending()`, which
+        // models the operation completing with no logical time elapsed.
+        newTicks = 0
+      case .singleTick:
+        newTicks = 1
+      case .multiTick:
+        newTicks = max(ticks, ticks * 2)
+      case .finalizeWithoutProgress:
+        newTicks = ticks
+      }
+      return .advanceClock(ticks: newTicks)
+    }
+
+    return Scenario(
+      id: "\(id)#seed-\(String(schedule.seed, radix: 16))",
+      name: name,
+      steps: rewritten,
+      expected: expected,
+      tags: tags)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -1,0 +1,403 @@
+import Foundation
+
+// MARK: - Scenario inventory (epic #827, PR-2 plan §3.8; PR-1 §11.1)
+//
+// The 33 canonical-ID heart-path scenarios, each encoded as data with a full
+// `ExpectedOutcome`. `ScenarioInventoryTests` asserts the EXACT ID set is
+// present (by ID, not a count — a count passes while a scenario is silently
+// swapped). In PR-2 these are data; from PR-3 the `ScenarioRunner` executes
+// each against the real kernel and they become merge-blocking.
+//
+// The two §1.3 regression locks (`R1`, `R2`) are non-negotiable: PR-H1 (#828)
+// was dropped because this inventory locks the WhisperKit stop-during-startup
+// case. `ScenarioInventoryTests` asserts `R1` and `R2` by ID specifically.
+//
+// Step scripts are representative — they describe the path PR-3 wires the
+// kernel to walk. The `ExpectedOutcome` is the contract every row carries.
+//
+// ── PR-3 OBLIGATIONS (founder call 2026-05-21: ship the inventory now, finish
+//    these two when the kernel lands) ───────────────────────────────────────
+// Two scenarios cannot be precisely driven until PR-3's kernel seams exist,
+// because the stimulus they need IS a kernel-seam question:
+//
+//  • R2 (Parakeet stale-latch): needs a directive that emits a callback /
+//    completion stamped with a PRIOR session's `SessionID`. PR-2's DSL has no
+//    stale-callback injection because "what a stale callback looks like" is
+//    defined by the kernel's task/callback seam (PR-3). PR-3 adds the
+//    directive and R2's script gains an explicit prior-session stale signal.
+//
+//  • A18 (engine switch during active session): PR-2 models a behavior change
+//    by mutating the live `FakeEngine` (`EngineDirective.setBehavior`). A real
+//    mid-session switch is a request against the adapter FACTORY (PR-6), not a
+//    mutation of the running adapter. PR-3/PR-6 model the switch as factory
+//    state so A18 proves the active session keeps its original adapter.
+//
+// Both rows ship now with correct IDs + `ExpectedOutcome` so the inventory is
+// complete and `R1`/`R2` stay drop-resistant; PR-3 tightens their stimulus.
+
+enum ScenarioInventory {
+
+  /// All 33 canonical scenarios.
+  static let all: [Scenario] =
+    asrSide + regressionLocks + captureSide + limbSide
+
+  /// The concurrency-tagged subset rerun under the interleaving sweep (§3.5).
+  static var concurrencySensitive: [Scenario] {
+    all.filter(\.isConcurrencySensitive)
+  }
+
+  // MARK: ASR-side (A1–A19)
+
+  private static let asrSide: [Scenario] = [
+    Scenario(
+      id: "A1", name: "normal batch success",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "hello world"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A2", name: "normal streaming success",
+      steps: [
+        .engine(.setBehavior(.streamingSuccess(partials: ["hel"], final: "hello"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A3", name: "slow warm-up then success",
+      steps: [
+        .engine(.setBehavior(.slowLoad(ticksToReady: 3))),
+        .trigger(.start), .advanceClock(ticks: 3), .capture(.deliverBuffer),
+        .trigger(.stop), .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A4", name: "warm-up wedge",
+      steps: [
+        .engine(.setBehavior(.wedgeOnLoad)),
+        .trigger(.start), .trigger(.cancel),
+      ],
+      // .wedgeOnLoad is the silent-progress wedge — the kernel detects it via
+      // loadProgress absence and transitions to failed(.modelWedged). A model
+      // load that THROWS is a separate behavior (failed(.modelLoadFailed)).
+      expected: ExpectedOutcome(
+        terminalState: .failed(.modelWedged), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "A5", name: "record then immediate stop (sub-minimum duration)",
+      steps: [.trigger(.start), .trigger(.stop), .expectState(.discarded)],
+      expected: ExpectedOutcome(
+        terminalState: .discarded, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none)),
+    Scenario(
+      id: "A6", name: "long recording",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "long dictation"))),
+        .trigger(.start), .capture(.deliverBuffer), .capture(.deliverBuffer),
+        .capture(.deliverBuffer), .trigger(.stop), .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A7", name: "cancel while recording",
+      steps: [
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.cancel),
+        .expectState(.cancelled),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .cancelled, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      id: "A8", name: "cancel while transcribing",
+      steps: [
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.cancel), .expectState(.cancelled),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .cancelled, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      id: "A9", name: "adapter partials then final",
+      steps: [
+        .engine(.setBehavior(.streamingSuccess(partials: ["a", "ab"], final: "abc"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A10", name: "adapter final without partials",
+      steps: [
+        .engine(.setBehavior(.streamingSuccess(partials: [], final: "abc"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A11", name: "adapter empty result with speech evidence",
+      steps: [
+        .engine(.setBehavior(.empty(hadSpeechEvidence: true))),
+        .vad(.evidence(.voiced)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.asrEmpty), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "A12", name: "adapter empty result, no speech",
+      steps: [
+        .engine(.setBehavior(.empty(hadSpeechEvidence: false))),
+        .vad(.evidence(.confirmedNoSpeech)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .noSpeech, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none)),
+    Scenario(
+      id: "A13", name: "adapter wedge on finalize",
+      steps: [
+        .engine(.setBehavior(.wedgeOnFinalize)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.cancel),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.asrWedged), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "A14", name: "adapter fails after audio captured",
+      steps: [
+        .engine(.setBehavior(.crashOnFinalize)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.asrFailed), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "A15", name: "double-start / rapid hotkey",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "once"))),
+        .trigger(.start), .trigger(.start), .capture(.deliverBuffer),
+        .trigger(.stop), .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      id: "A16", name: "stop without active session",
+      steps: [.trigger(.stop), .expectState(.idle)],
+      expected: ExpectedOutcome(
+        terminalState: .idle, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none)),
+    Scenario(
+      id: "A17", name: "engine switch between sessions",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "first"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.reset),
+        .engine(.setBehavior(.batchSuccess(text: "second"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .exact("second"))),
+    Scenario(
+      // PR-3 OBLIGATION: model the mid-session switch as an adapter-FACTORY
+      // request (PR-6 seam), not a mutation of the live FakeEngine — see the
+      // PR-3 OBLIGATIONS block at the top of this file.
+      id: "A18", name: "engine switch attempted during active session",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "kept"))),
+        .trigger(.start), .capture(.deliverBuffer),
+        .engine(.setBehavior(.batchSuccess(text: "ignored"))),
+        .trigger(.stop), .expectState(.completed),
+      ],
+      // .exact("kept"): the mid-session switch must be ignored. .nonEmpty
+      // would pass even if the active session wrongly used the new engine.
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .exact("kept")),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      id: "A19", name: "warm-up with nil loadProgress stream",
+      steps: [
+        .engine(.setLoadProgressAbsent(true)),
+        .engine(.setBehavior(.slowLoad(ticksToReady: 2))),
+        .trigger(.start), .advanceClock(ticks: 2), .capture(.deliverBuffer),
+        .trigger(.stop), .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+  ]
+
+  // MARK: §1.3 regression locks (R1, R2)
+
+  private static let regressionLocks: [Scenario] = [
+    Scenario(
+      id: "R1", name: "WhisperKit stop-during-startup (regression lock)",
+      steps: [
+        .engine(.setBehavior(.slowLoad(ticksToReady: 5))),
+        .trigger(.start), .trigger(.stop), .advanceClock(ticks: 5),
+        .expectState(.discarded),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .discarded, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      // PR-3 OBLIGATION: add a stale-callback injection directive (a callback
+      // stamped with a prior session's SessionID) and drive it here — see the
+      // PR-3 OBLIGATIONS block at the top of this file. Until then this row
+      // pins the happy path; it does not yet PROVE the stale-drop.
+      id: "R2", name: "Parakeet stale-latch (regression lock)",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "current"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty),
+      tags: [.concurrencySensitive]),
+  ]
+
+  // MARK: Capture-side (C1–C6)
+
+  private static let captureSide: [Scenario] = [
+    Scenario(
+      id: "C1", name: "mic permission denied / revoked",
+      steps: [.capture(.permissionDenied), .trigger(.start)],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.permissionDenied), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "C2", name: "capture start failure",
+      steps: [.capture(.startFailure), .trigger(.start)],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.captureStartFailed), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "C3", name: "capture stream stalls before first buffer",
+      steps: [.trigger(.start), .capture(.stall), .trigger(.stop)],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.captureStalled), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "C4", name: "capture stalls after speech evidence",
+      steps: [
+        .trigger(.start), .capture(.deliverBuffer), .capture(.stall),
+        .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.captureStalled), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+    Scenario(
+      id: "C5", name: "audio route / device change mid-session",
+      steps: [.trigger(.start), .capture(.deliverBuffer), .capture(.routeChange)],
+      expected: ExpectedOutcome(
+        terminalState: .audioInterrupted, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .interruption)),
+    Scenario(
+      id: "C6", name: "XPC capture crash / reconnect",
+      steps: [.trigger(.start), .capture(.deliverBuffer), .capture(.xpcCrash)],
+      expected: ExpectedOutcome(
+        terminalState: .asrInterrupted, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+  ]
+
+  // MARK: Limb-side (L1–L6)
+
+  private static let limbSide: [Scenario] = [
+    Scenario(
+      id: "L1", name: "LLM polish fails after transcript",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "raw asr text"))),
+        .limb(.polishFails),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "L2", name: "custom-words injection fails",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "raw asr text"))),
+        .limb(.customWordsFails),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "L3", name: "filler-removal fails",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "raw asr text"))),
+        .limb(.fillerRemovalFails),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "L4", name: "paste fails after transcript (clipboard-only fallback)",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "delivered text"))),
+        .paste(.fail),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 0, pasteOutcome: .clipboardOnly,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "L5", name: "cancel arrives during finalizing (safe point)",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "delivered text"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.cancel), .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty),
+      tags: [.concurrencySensitive]),
+    Scenario(
+      id: "L6", name: "transcript disk-save fails after transcript",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "delivered text"))),
+        .limb(.storageWriteFails),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .failed(.storageFailed), pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .recoverableError)),
+  ]
+
+  /// The exact canonical ID set — `ScenarioInventoryTests` asserts the inventory
+  /// matches this set with no addition, drop, or near-duplicate swap.
+  static let canonicalIDs: Set<String> = [
+    "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10",
+    "A11", "A12", "A13", "A14", "A15", "A16", "A17", "A18", "A19",
+    "R1", "R2",
+    "C1", "C2", "C3", "C4", "C5", "C6",
+    "L1", "L2", "L3", "L4", "L5", "L6",
+  ]
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+/// Scenario-inventory completeness tests (epic #827, PR-2 plan §11.2, §3.8).
+/// Asserts the EXACT canonical ID set — not a count — so a silently-dropped
+/// scenario or a near-duplicate swap fails the build.
+@MainActor
+@Suite("ScenarioInventory")
+struct ScenarioInventoryTests {
+
+  @Test("the inventory holds exactly the 33 canonical scenarios")
+  func inventoryHoldsThirtyThree() {
+    #expect(ScenarioInventory.all.count == 33)
+    #expect(ScenarioInventory.canonicalIDs.count == 33)
+  }
+
+  @Test("the inventory's ID set matches the canonical ID set exactly")
+  func idSetMatchesCanonical() {
+    let actual = Set(ScenarioInventory.all.map(\.id))
+    let missing = ScenarioInventory.canonicalIDs.subtracting(actual)
+    let unexpected = actual.subtracting(ScenarioInventory.canonicalIDs)
+    #expect(
+      actual == ScenarioInventory.canonicalIDs,
+      "missing: \(missing); unexpected: \(unexpected)")
+  }
+
+  @Test("no scenario ID is duplicated")
+  func noDuplicateIDs() {
+    let ids = ScenarioInventory.all.map(\.id)
+    #expect(Set(ids).count == ids.count)
+  }
+
+  @Test("the two §1.3 regression locks are present by ID")
+  func regressionLocksPresent() {
+    let ids = Set(ScenarioInventory.all.map(\.id))
+    #expect(ids.contains("R1"), "WhisperKit stop-during-startup lock — drop-resistant")
+    #expect(ids.contains("R2"), "Parakeet stale-latch lock — drop-resistant")
+  }
+
+  @Test("every scenario carries a full ExpectedOutcome")
+  func everyScenarioHasExpectedOutcome() {
+    for scenario in ScenarioInventory.all {
+      // A non-empty step list and a parseable expected outcome.
+      #expect(!scenario.steps.isEmpty, "\(scenario.id) has no steps")
+      // Paste count above 1 is never a valid expectation.
+      #expect(
+        scenario.expected.pasteCount <= 1,
+        "\(scenario.id) expects pasteCount > 1 — always a failure")
+    }
+  }
+
+  @Test("the concurrency-sensitive subset is the expected seven scenarios")
+  func concurrencySubsetIsCorrect() {
+    let concurrencyIDs = Set(ScenarioInventory.concurrencySensitive.map(\.id))
+    #expect(concurrencyIDs == ["A7", "A8", "A15", "A18", "R1", "R2", "L5"])
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+// MARK: - ScenarioRunner + assertion library (epic #827, PR-2 plan §3.4)
+//
+// The runner executes a `Scenario`'s ordered steps against a
+// `RecordingSessionDriving` SUT, driving the fakes, then checks the full
+// `ExpectedOutcome`. Deterministic: one run per scenario is the pass
+// (epic §3a). In PR-2 the SUT is `StubRecordingSession` and only the harness
+// mechanics are exercised; from PR-3 the SUT is the real kernel and the
+// 33-scenario inventory becomes merge-blocking.
+
+/// The fakes + SUT bundle one scenario runs against.
+@MainActor
+struct SimulatorContext {
+  let sut: RecordingSessionDriving
+  let engine: FakeEngine
+  let capture: FakeAudioCapture
+  let vad: FakeVADSignalSource
+  let clock: FakeClock
+  let paste: FakePasteTarget
+}
+
+/// The result of running one scenario — the failure list IS the verdict.
+struct ScenarioResult: Sendable {
+  let scenarioID: String
+  let failures: [String]
+
+  var passed: Bool { failures.isEmpty }
+}
+
+@MainActor
+struct ScenarioRunner {
+
+  init() {}
+
+  /// Execute `scenario` against `context` and check its `ExpectedOutcome`.
+  func run(_ scenario: Scenario, context: SimulatorContext) async -> ScenarioResult {
+    var failures: [String] = []
+
+    for (index, step) in scenario.steps.enumerated() {
+      await apply(step, context: context, stepIndex: index, into: &failures)
+    }
+
+    // Teardown: release any deliberately-wedged `FakeClock.sleep` so no
+    // continuation leaks.
+    context.clock.drainPending()
+
+    failures.append(contentsOf: checkOutcome(scenario.expected, context: context))
+    return ScenarioResult(scenarioID: scenario.id, failures: failures)
+  }
+
+  // MARK: Step execution
+
+  private func apply(
+    _ step: ScenarioStep,
+    context: SimulatorContext,
+    stepIndex: Int,
+    into failures: inout [String]
+  ) async {
+    switch step {
+    case .trigger(let trigger):
+      await context.sut.apply(trigger)
+
+    case .advanceClock(let ticks):
+      context.clock.advance(by: ticks)
+
+    case .engine(let directive):
+      switch directive {
+      case .setBehavior(let behavior):
+        context.engine.behavior = behavior
+      case .emitLoadTick:
+        context.engine.emitLoadTick()
+      case .emitFinalizeTick:
+        context.engine.emitFinalizeTick()
+      case .setLoadProgressAbsent(let absent):
+        context.engine.loadProgressAbsent = absent
+      case .setFinalizeProgressAbsent(let absent):
+        context.engine.finalizeProgressAbsent = absent
+      }
+
+    case .capture(let directive):
+      apply(captureDirective: directive, context: context)
+
+    case .vad(let directive):
+      switch directive {
+      case .autoStop:
+        context.vad.emit(.autoStopTriggered)
+      case .maxDuration:
+        context.vad.emit(.maxDurationReached)
+      case .evidence(let evidence):
+        context.vad.evidence = evidence
+      }
+
+    case .paste(let directive):
+      switch directive {
+      case .fail:
+        context.paste.shouldFailPaste = true
+      case .succeed:
+        context.paste.shouldFailPaste = false
+      }
+
+    case .limb:
+      // The limb / finalizer / storage seam is production code the kernel
+      // calls; PR-2 has no fake for it. The directive is carried as scenario
+      // data so PR-3's kernel-finalizer wiring keys failure injection on it.
+      // No PR-2 consumer — intentionally a no-op here.
+      break
+
+    case .expectState(let expected):
+      if context.sut.state != expected {
+        failures.append(
+          "step \(stepIndex): expected state \(expected), got \(context.sut.state)")
+      }
+    }
+  }
+
+  private func apply(captureDirective: CaptureDirective, context: SimulatorContext) {
+    switch captureDirective {
+    case .deliverBuffer:
+      context.capture.deliverBuffer()
+    case .stall:
+      // A stall fires the liveness-watchdog callback — not merely an absence
+      // of buffers (C3 / C4).
+      context.capture.fireCaptureStalled()
+    case .interrupt, .routeChange:
+      // The audio-interruption channel (C5).
+      context.capture.raiseEngineInterruption()
+    case .permissionDenied:
+      context.capture.permissionDenied = true
+    case .startFailure:
+      context.capture.failCaptureStart = true
+    case .xpcCrash:
+      // The ASR-interruption channel — distinct from the audio-interruption
+      // path (C6, not C5).
+      context.capture.fireXPCServiceError()
+    }
+  }
+
+  // MARK: Assertion library — checks the full ExpectedOutcome
+
+  private func checkOutcome(
+    _ expected: ExpectedOutcome, context: SimulatorContext
+  ) -> [String] {
+    var failures: [String] = []
+    let state = context.sut.state
+    let effects = context.sut.effects
+
+    // Final state. For almost every scenario `expected.terminalState` is one
+    // of the seven terminal states; the lone exception is the no-session
+    // scenario (A16 — "stop without active session"), whose expected final
+    // state is `.idle` because no session was ever minted. The stuck-session
+    // check therefore fires only when a terminal state was expected.
+    if state != expected.terminalState {
+      failures.append(
+        "final state: expected \(expected.terminalState), got \(state)")
+    }
+    if expected.terminalState.isTerminal && !state.isTerminal {
+      failures.append("no terminal state reached — session is stuck at \(state)")
+    }
+
+    // Paste count — >1 is always a retry-storm failure.
+    if effects.pasteCount != expected.pasteCount {
+      failures.append(
+        "paste count: expected \(expected.pasteCount), got \(effects.pasteCount)")
+    }
+    if effects.pasteCount > 1 {
+      failures.append("duplicate paste — count \(effects.pasteCount) exceeds 1")
+    }
+
+    // Paste outcome.
+    if effects.pasteOutcome != expected.pasteOutcome {
+      failures.append(
+        "paste outcome: expected \(expected.pasteOutcome), got \(effects.pasteOutcome)")
+    }
+
+    // Transcript expectation.
+    failures.append(
+      contentsOf: checkTranscript(expected.transcript, delivered: effects.transcript))
+
+    // Resource release — always true at any terminal state.
+    if effects.resourcesReleased != expected.resourcesReleased {
+      failures.append(
+        "resources released: expected \(expected.resourcesReleased), "
+          + "got \(effects.resourcesReleased)")
+    }
+
+    // User-visible error category.
+    if effects.userVisibleError != expected.userVisibleError {
+      failures.append(
+        "user-visible error: expected \(String(describing: expected.userVisibleError)), "
+          + "got \(String(describing: effects.userVisibleError))")
+    }
+
+    return failures
+  }
+
+  private func checkTranscript(
+    _ expectation: TranscriptExpectation, delivered: String?
+  ) -> [String] {
+    switch expectation {
+    case .none:
+      return delivered == nil
+        ? []
+        : ["transcript: expected none delivered, got \(delivered ?? "")"]
+    case .nonEmpty:
+      if let delivered, !delivered.isEmpty { return [] }
+      return ["transcript: expected non-empty, got \(String(describing: delivered))"]
+    case .exact(let text):
+      return delivered == text
+        ? []
+        : ["transcript: expected \"\(text)\", got \(String(describing: delivered))"]
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Harness self-test (epic #827, PR-2 plan §11.2 item H).
+/// Exercises `ScenarioRunner` against `StubRecordingSession` and proves the
+/// assertion library reports pass and fail correctly. The 33-scenario
+/// inventory does NOT execute in PR-2 (no kernel) — this proves the runner
+/// mechanics so PR-3 inherits a trusted harness.
+@MainActor
+@Suite("ScenarioRunner — harness self-test")
+struct ScenarioRunnerTests {
+
+  /// Build a context whose SUT is a stub scripted to model a clean success:
+  /// `start → recording`, `stop → completed` with one pasted transcript.
+  private func successContext() -> SimulatorContext {
+    let stub = StubRecordingSession { trigger, session in
+      switch trigger {
+      case .start:
+        session.setState(.recording)
+      case .stop:
+        var effects = SessionEffects()
+        effects.pasteCount = 1
+        effects.pasteOutcome = .pasted
+        effects.transcript = "hello"
+        effects.resourcesReleased = true
+        session.setEffects(effects)
+        session.setState(.completed)
+      case .cancel, .reset, .preWarm:
+        break
+      }
+    }
+    return makeContext(sut: stub)
+  }
+
+  private func makeContext(sut: RecordingSessionDriving) -> SimulatorContext {
+    let clock = FakeClock()
+    return SimulatorContext(
+      sut: sut,
+      engine: FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock),
+      capture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      clock: clock,
+      paste: FakePasteTarget())
+  }
+
+  @Test("a scenario whose outcome matches the SUT passes with zero failures")
+  func passingScenarioReportsPass() async {
+    let scenario = Scenario(
+      id: "SELFTEST-PASS",
+      name: "stub success path",
+      steps: [
+        .trigger(.start), .expectState(.recording), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty))
+    let result = await ScenarioRunner().run(scenario, context: successContext())
+    #expect(result.passed, "failures: \(result.failures)")
+  }
+
+  @Test("a mid-scenario state mismatch is reported")
+  func midScenarioStateMismatchIsReported() async {
+    let scenario = Scenario(
+      id: "SELFTEST-MIDFAIL",
+      name: "wrong mid-scenario state",
+      steps: [
+        .trigger(.start), .expectState(.warmingUp),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .recording, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none))
+    let result = await ScenarioRunner().run(scenario, context: successContext())
+    #expect(!result.passed)
+    #expect(result.failures.contains { $0.contains("expected state warmingUp") })
+  }
+
+  @Test("a wrong expected terminal state is reported")
+  func wrongTerminalStateIsReported() async {
+    let scenario = Scenario(
+      id: "SELFTEST-TERMFAIL",
+      name: "wrong terminal state expectation",
+      steps: [.trigger(.start), .trigger(.stop)],
+      expected: ExpectedOutcome(
+        terminalState: .cancelled, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none))
+    let result = await ScenarioRunner().run(scenario, context: successContext())
+    #expect(!result.passed)
+    #expect(result.failures.contains { $0.contains("final state") })
+  }
+
+  @Test("a duplicate paste is reported as a failure")
+  func duplicatePasteIsReported() async {
+    let stub = StubRecordingSession { trigger, session in
+      if trigger == .stop {
+        var effects = SessionEffects()
+        effects.pasteCount = 2
+        effects.pasteOutcome = .pasted
+        effects.transcript = "x"
+        effects.resourcesReleased = true
+        session.setEffects(effects)
+        session.setState(.completed)
+      }
+    }
+    let scenario = Scenario(
+      id: "SELFTEST-DUPPASTE",
+      name: "duplicate paste detection",
+      steps: [.trigger(.stop)],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 2, pasteOutcome: .pasted,
+        transcript: .nonEmpty))
+    let result = await ScenarioRunner().run(scenario, context: makeContext(sut: stub))
+    #expect(!result.passed)
+    #expect(result.failures.contains { $0.contains("duplicate paste") })
+  }
+
+  @Test("triggers are dispatched to the SUT in order")
+  func triggersDispatchedInOrder() async {
+    let stub = StubRecordingSession { _, _ in }
+    let scenario = Scenario(
+      id: "SELFTEST-DISPATCH",
+      name: "trigger dispatch order",
+      steps: [.trigger(.start), .trigger(.stop), .trigger(.reset)],
+      expected: ExpectedOutcome(
+        terminalState: .idle, pasteCount: 0, pasteOutcome: .none, transcript: .none))
+    _ = await ScenarioRunner().run(scenario, context: makeContext(sut: stub))
+    #expect(stub.triggerLog == [.start, .stop, .reset])
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/SimulatorWallClockBanTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/SimulatorWallClockBanTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+/// Wall-clock ban (epic #827, PR-2 plan §11.2, §10 — Codex round-1 revision 10).
+///
+/// Scans every Swift source file in the simulator directory and fails if any
+/// uses a wall-clock API. The simulator's determinism rests on `FakeClock`
+/// being the ONLY time source; a stray `Task.sleep` / `Date()` / `Timer` would
+/// reintroduce nondeterminism. This catches that at PR CI — the earliest
+/// failure point — before it produces a flake.
+@Suite("Simulator wall-clock ban")
+struct SimulatorWallClockBanTests {
+
+  /// Banned substrings — wall-clock APIs no simulator file may use.
+  /// `Task.yield()` is NOT banned: it is a cooperative yield, not a wall-clock
+  /// wait.
+  private static let bannedPatterns = [
+    "Task.sleep",
+    "DispatchQueue",
+    "Date()",
+    "ContinuousClock",
+    "SuspendingClock",
+    "Timer(",
+    "asyncAfter",
+    "ProcessInfo.processInfo.systemUptime",
+  ]
+
+  @Test("no simulator source file uses a wall-clock API")
+  func noWallClockInSimulatorDirectory() throws {
+    let simulatorDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let selfFile = URL(fileURLWithPath: #filePath).lastPathComponent
+
+    let contents = try FileManager.default.contentsOfDirectory(
+      at: simulatorDir, includingPropertiesForKeys: nil)
+    let swiftFiles = contents.filter {
+      $0.pathExtension == "swift" && $0.lastPathComponent != selfFile
+    }
+
+    #expect(!swiftFiles.isEmpty, "expected to find simulator source files to scan")
+
+    for file in swiftFiles {
+      let source = try String(contentsOf: file, encoding: .utf8)
+      for pattern in Self.bannedPatterns where source.contains(pattern) {
+        let name = file.lastPathComponent
+        Issue.record(
+          "\(name) uses banned wall-clock API \"\(pattern)\"; simulator time must come from FakeClock"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR-2 of the engine-kernel refactor epic (#827)

Builds the deterministic heart-path test rig **before** the recording-session kernel exists (PR-3). Nothing user-facing changes — the production contract types are inert until the kernel and adapters land.

### What ships

**Production contract** (`EnviousWisprPipeline`, inert until PR-3):
- `ASREngineAdapter` protocol + `ASREngineCapabilities` / `Readiness` / `Outcome` / `Error`, `AudioBufferHandoff`, `SessionID`, progress-tick types (PR-1 §B.2).
- `VADSignalSource` protocol + `VADStopSignal` / `VADStopKind` / `VADSpeechEvidence` (PR-1 §B.6).

**Simulator** (`Tests/EnviousWisprTests/Pipeline/Simulator/`):
- Fakes with controllable suspension points: `FakeEngine` (8 behaviors), `FakeAudioCapture` (full `AudioCaptureInterface`), `FakeClock`, `FakePasteTarget`, `FakeVADSignalSource`.
- Scenario DSL + `ScenarioRunner` + assertion library; `RecordingSessionDriving` SUT seam + `StubRecordingSession`.
- 33 canonical-ID scenarios with `ExpectedOutcome`. `R2` and `A18` carry documented PR-3 obligations.
- `InterleavingSweep`: 64 committed seeds, schedule-class coverage.
- `FreezeSuiteNormalization` (lexical-parity rules).
- 62 tests across 10 suites; `SimulatorWallClockBanTests` enforces the no-wall-clock determinism property.

### Scope

The freeze-suite baseline capture is split into its own focused step before the engine-migration PRs (founder call 2026-05-21) — it is runtime data capture, not test infrastructure.

### Review trail

Council (GPT + Gemini) coverage; Codex grounded review 5 rounds to `PROCEED-AS-PLANNED`; Codex code-diff review 6 rounds. Full suite: 1180 tests green; `swift build -c release` clean.
