### PR TITLE
test(engine-kernel): PR-2 review fixes — drain order + recursive wall-clock scan (#827)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -41,11 +41,17 @@ struct ScenarioRunner {
       await apply(step, context: context, stepIndex: index, into: &failures)
     }
 
-    // Teardown: release any deliberately-wedged `FakeClock.sleep` so no
-    // continuation leaks.
+    // Assert the outcome the scenario's STEPS produced — BEFORE teardown.
+    // `drainPending()` force-completes any parked `FakeClock.sleep` (e.g. a
+    // slow-load warm-up that a zero-tick schedule never advanced), which would
+    // mutate the SUT state/effects this check verifies. Draining first would
+    // turn a genuinely-wedged end state into a false pass. Check, then drain.
+    failures.append(contentsOf: checkOutcome(scenario.expected, context: context))
+
+    // Teardown: now release any still-parked `FakeClock.sleep` so no
+    // continuation leaks. This runs after the outcome is already recorded.
     context.clock.drainPending()
 
-    failures.append(contentsOf: checkOutcome(scenario.expected, context: context))
     return ScenarioResult(scenarioID: scenario.id, failures: failures)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/SimulatorWallClockBanTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/SimulatorWallClockBanTests.swift
@@ -30,10 +30,15 @@ struct SimulatorWallClockBanTests {
     let simulatorDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     let selfFile = URL(fileURLWithPath: #filePath).lastPathComponent
 
-    let contents = try FileManager.default.contentsOfDirectory(
+    // Recursive enumeration — a non-recursive `contentsOfDirectory` would miss
+    // wall-clock APIs in any future nested subfolder under Simulator/.
+    let enumerator = FileManager.default.enumerator(
       at: simulatorDir, includingPropertiesForKeys: nil)
-    let swiftFiles = contents.filter {
-      $0.pathExtension == "swift" && $0.lastPathComponent != selfFile
+    var swiftFiles: [URL] = []
+    while let url = enumerator?.nextObject() as? URL {
+      if url.pathExtension == "swift" && url.lastPathComponent != selfFile {
+        swiftFiles.append(url)
+      }
     }
 
     #expect(!swiftFiles.isEmpty, "expected to find simulator source files to scan")


### PR DESCRIPTION
Follow-up to PR #833 — addresses the two Codex review findings that landed after #833 auto-merged.

### [P1] Assert scenario outcome before draining clock sleepers
`ScenarioRunner.run` called `FakeClock.drainPending()` before `checkOutcome`. `drainPending()` force-completes parked `FakeClock.sleep` waiters (e.g. a slow-load warm-up a zero-tick schedule never advanced) — running it first lets teardown mutate the SUT state/effects the scenario verifies, turning a genuinely-wedged end state into a false pass. Now: check the outcome first, then drain for continuation cleanup.

### [P2] Scan simulator sources recursively for wall-clock APIs
`SimulatorWallClockBanTests` used `contentsOfDirectory` (non-recursive) — a future nested subfolder under `Simulator/` would let a `Task.sleep` / `Date` / `Timer` slip past the determinism guard. Switched to a recursive `FileManager.enumerator`.

Codex code-diff review: clean. Simulator suite: 62 tests green.
