### PR TITLE
feat(engine-kernel): PR-4a — Parakeet kernel-migration infrastructure (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import EnviousWisprCore
 import Foundation
 
@@ -113,23 +114,28 @@ public struct ASRFinalizeProgressTick: Sendable {
   }
 }
 
-/// A `Sendable` carrier wrapping one captured audio buffer for the
-/// kernel → adapter handoff (PR-1 §B.3). The kernel calls `acceptAudio(_:)`
-/// for every captured buffer; a streaming adapter forwards it, a batch adapter
-/// buffers or no-ops.
+/// A carrier wrapping one captured audio buffer for the kernel → adapter
+/// handoff (PR-1 §B.3). The kernel calls `acceptAudio(_:)` for every captured
+/// buffer; a streaming adapter forwards it, a batch adapter buffers or no-ops.
 ///
-/// `pcm` is owned Float32 sample storage — the simplest unconditionally
-/// `Sendable` shape. PR-3 consumes this shape unchanged: its kernel is
-/// production-unwired, with no real audio thread to measure against, so it
-/// reuses the shipped per-buffer `Task { @MainActor }` hand-off pattern
-/// (PR-3 plan §3.4). The production PCM-representation decision
-/// (copy-into-owned-storage vs `nonisolated(unsafe)` `AVAudioPCMBuffer`
-/// transfer) belongs to PR-4 — the first PR with a real audio thread feeding
-/// the kernel (PR-1 §B.3 erratum 2026-05-21).
-public struct AudioBufferHandoff: Sendable {
-  /// 16 kHz mono Float32 samples, owned by this struct.
-  public let pcm: [Float]
-  /// Sample count in `pcm`.
+/// 2026-05-22 erratum (PR-4, plan §3.4). PR-1 §B.3 and the PR-3 plan deferred
+/// the production PCM-representation decision to PR-4 — the first PR with a
+/// real audio thread feeding the kernel. PR-4 resolves it: the carrier holds
+/// the `AVAudioPCMBuffer` directly (PR-1 §B.3 option b), not an owned `[Float]`
+/// copy. The production Parakeet adapter feeds streaming ASR through
+/// `ASRManagerInterface.feedAudio(_:)`, which takes an `AVAudioPCMBuffer`; an
+/// owned-`[Float]` carrier would force a buffer reconstruction the shipped
+/// streaming path (`TranscriptionPipeline.swift:483`) never does.
+///
+/// `@unchecked Sendable`: `AVAudioPCMBuffer` is not `Sendable`, but the buffer
+/// is created on the audio thread, wrapped here exactly once, and handed to
+/// `@MainActor` exactly once — never touched from two threads. This is the
+/// shipped `nonisolated(unsafe)` cross-actor-buffer transfer discipline
+/// (`swift-patterns.md`).
+public struct AudioBufferHandoff: @unchecked Sendable {
+  /// 16 kHz mono Float32 capture buffer.
+  public let buffer: AVAudioPCMBuffer
+  /// Frame count in `buffer` (`buffer.frameLength`).
   public let frameCount: Int
   /// Monotonic sequence number stamped on the audio thread. A streaming
   /// adapter that needs strict order reorders by `sequence`; a batch adapter
@@ -139,8 +145,10 @@ public struct AudioBufferHandoff: Sendable {
   /// kernel's current session is dropped (PR-1 §B.3, FSM invariant 7).
   public let sessionID: SessionID
 
-  public init(pcm: [Float], frameCount: Int, sequence: UInt64, sessionID: SessionID) {
-    self.pcm = pcm
+  public init(
+    buffer: AVAudioPCMBuffer, frameCount: Int, sequence: UInt64, sessionID: SessionID
+  ) {
+    self.buffer = buffer
     self.frameCount = frameCount
     self.sequence = sequence
     self.sessionID = sessionID
@@ -198,6 +206,16 @@ public protocol ASREngineAdapter: AnyObject {
   /// Idempotent discard. Calling it 2+ times has the same effect as once
   /// (PR-1 §B.2.2).
   func cancel() async
+
+  // MARK: Engine interruption
+
+  /// Fires when the engine's own backend dies mid-recording — distinct from a
+  /// crash surfaced through `finalize()` as `.failed(.engineCrashed)`
+  /// (PR-1 §B.2.2 covered only the `finalize()`-time crash; a mid-recording
+  /// crash was a gap, PR-4 plan §3.2). The kernel sets this during session
+  /// setup and routes it to the `asrInterrupted` terminal. An adapter whose
+  /// engine has no mid-recording crash signal leaves it nil.
+  var onEngineInterrupted: (@MainActor () -> Void)? { get set }
 
   // MARK: Cleanup
 

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -187,8 +187,13 @@ public protocol ASREngineAdapter: AnyObject {
 
   // MARK: Session lifecycle
 
-  /// Begin a recording session under `id`.
-  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws
+  /// Begin a recording session under `id`. `streaming` carries the kernel's
+  /// per-session orchestration decision — `config.useStreamingASR` ANDed with
+  /// this adapter's static `capabilities.supportsStreaming` (PR-4 plan §3.4).
+  /// The kernel owns the policy; the adapter obeys. `false` means batch-decode
+  /// after stop: the adapter MUST NOT open a live stream. An adapter MAY still
+  /// fall back to batch from `true` if its own runtime backend check fails.
+  func beginSession(_ id: SessionID, options: TranscriptionOptions, streaming: Bool) async throws
 
   /// Accept one captured buffer. The kernel ALWAYS calls this; the adapter
   /// decides forward-vs-buffer. A call after a terminal session (post-`cancel()`

--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -1,0 +1,92 @@
+import EnviousWisprAudio
+import Foundation
+
+// MARK: - CaptureVADSignalSource (epic #827, PR-4 §3.5)
+//
+// The production `VADSignalSource` conformer (PR-1 §B.6). No production
+// conformer existed before PR-4 — only the test `FakeVADSignalSource`.
+//
+// The kernel owns VAD *policy* (auto-stop, the no-speech gate, max-duration);
+// the capture/VAD seam owns VAD *signal production*. This source is the seam:
+// a thin event aggregator that unifies the two VAD signal origins into the one
+// normalized `stopSignals` stream the kernel subscribes to —
+//   - the XPC service-side detector, surfaced through
+//     `AudioCaptureInterface.onVADAutoStop` (this source is its single owner);
+//   - the in-process `SilenceDetector` auto-stop, delivered through
+//     `noteAutoStopTriggered()` by the VAD-loop wiring;
+//   - the max-duration stop, delivered through `noteMaxDurationReached()`.
+//
+// It does NOT host the in-process VAD loop — that loop is a wiring concern
+// (PR-4b). This source only aggregates and stamps signals.
+//
+// PR-4a ships this production-unwired: no App-layer caller binds it yet.
+
+/// Vends the kernel's `VADSignalSource` by bridging the in-process and XPC VAD
+/// signal origins (PR-1 §B.6, D7/D8).
+@MainActor
+final class CaptureVADSignalSource: VADSignalSource {
+
+  private let signalStream: AsyncStream<VADStopSignal>
+  private let signalContinuation: AsyncStream<VADStopSignal>.Continuation
+
+  /// The session each emitted signal is stamped with. The seam is told the
+  /// frozen session at session start (PR-1 §B.6 — VAD config is per-session);
+  /// the kernel drops a signal whose `sessionID` is not its current session.
+  private var currentSessionID = SessionID()
+
+  /// Computes the tri-state speech verdict at `stopping`. Defaults to
+  /// `.unavailable` (no detector) — the kernel then does not gate (PR-1 §B.6).
+  private var evidenceProvider: @MainActor () -> VADSpeechEvidence
+
+  init(
+    evidenceProvider: @escaping @MainActor () -> VADSpeechEvidence = { .unavailable }
+  ) {
+    (signalStream, signalContinuation) = AsyncStream.makeStream(of: VADStopSignal.self)
+    self.evidenceProvider = evidenceProvider
+  }
+
+  // MARK: VADSignalSource
+
+  var stopSignals: AsyncStream<VADStopSignal> { signalStream }
+
+  func speechEvidenceAtStop() -> VADSpeechEvidence { evidenceProvider() }
+
+  // MARK: Session wiring
+
+  /// Update the session stamp — the wiring calls this at session start so
+  /// every subsequent signal carries the live `SessionID` (PR-1 §B.6).
+  func setCurrentSessionID(_ id: SessionID) {
+    currentSessionID = id
+  }
+
+  /// Replace the speech-evidence provider for the session — the wiring sets it
+  /// from the in-process `SilenceDetector.speechSegments` or the XPC
+  /// `captureResult.vadSegments` (PR-4 §3.5).
+  func setEvidenceProvider(_ provider: @escaping @MainActor () -> VADSpeechEvidence) {
+    evidenceProvider = provider
+  }
+
+  /// Claim sole ownership of `AudioCaptureInterface.onVADAutoStop` (PR-4 §3.5).
+  /// The XPC service-side detector fires this callback; the kernel no longer
+  /// binds it directly (`bindCaptureCallbacks` dropped that wiring).
+  func bind(audioCapture: any AudioCaptureInterface) {
+    audioCapture.onVADAutoStop = { [weak self] in
+      self?.noteAutoStopTriggered()
+    }
+  }
+
+  // MARK: Signal inputs
+
+  /// Record a silence-hangover auto-stop — from the XPC `onVADAutoStop`
+  /// callback or the in-process VAD loop. Stamped with the current session.
+  func noteAutoStopTriggered() {
+    signalContinuation.yield(
+      VADStopSignal(kind: .autoStopTriggered, sessionID: currentSessionID))
+  }
+
+  /// Record a max-duration stop. Stamped with the current session.
+  func noteMaxDurationReached() {
+    signalContinuation.yield(
+      VADStopSignal(kind: .maxDurationReached, sessionID: currentSessionID))
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -41,6 +41,12 @@ final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
   private let outcome: KernelFinalizationOutcome
   private let steps: LimbSteps
 
+  /// The per-session context the wiring's closures read (PR-4 §3.3 — "captured
+  /// by the driver and threaded into the wiring"). PR-4a holds it; PR-4b's
+  /// `handle(.toggleRecording)` is the writer — it records the frozen config
+  /// and the frontmost app / focused element at recording start.
+  private let context: KernelSessionContext
+
   /// External-error surface (PR-4 §3.7). `kernel.cancel()` alone maps to a
   /// `.hidden` overlay, so the driver owns the error state pushed in from
   /// outside (`setExternalError`). Cleared on the next start / reset.
@@ -60,11 +66,13 @@ final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
     kernel: RecordingSessionKernel,
     observer: KernelHeartPathTelemetryObserver,
     outcome: KernelFinalizationOutcome,
+    context: KernelSessionContext,
     steps: LimbSteps
   ) {
     self.kernel = kernel
     self.observer = observer
     self.outcome = outcome
+    self.context = context
     self.steps = steps
     self.lastFiredState = Self.pipelineState(for: kernel.state, externalError: nil)
   }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1,0 +1,292 @@
+import EnviousWisprCore
+import Foundation
+
+// MARK: - KernelDictationDriver (epic #827, PR-4 §3.1)
+//
+// Adapts `RecordingSessionKernel` to the `DictationPipeline` surface the App
+// layer consumes. The App calls the active engine through `DictationPipeline`
+// and reads `state` / `overlayIntent` / `currentTranscript` / `lastPolishError`
+// / the four limb-step accessors / `onStateChange` / DEBUG `forceCancelNow()`
+// off the concrete pipeline type. The kernel exposes none of that — it has
+// synchronous triggers and its own `RecordingSessionState` vocabulary.
+//
+// The driver translates: `PipelineEvent` -> kernel triggers, `RecordingSessionState`
+// -> `PipelineState` / `OverlayIntent`. It is a permanent translation layer
+// until PR-9 deletes `DictationPipeline`; it carries real behavior (event
+// translation, state mapping, the limb-step home, the external-error surface)
+// and is NOT a forwarding shim — the old `TranscriptionPipeline` path is gone.
+//
+// PR-4a ships this production-unwired: no App-layer caller constructs it.
+// PR-4b re-points the 13 App files at this type.
+
+/// The four text-processing limb steps the App configures and the kernel's
+/// `processText` closure runs. Created once, shared by the driver (which
+/// exposes the accessors) and `KernelFinalizationWiring` (whose `processText`
+/// consumes them).
+@MainActor
+struct LimbSteps {
+  let wordCorrection: WordCorrectionStep
+  let fillerRemoval: FillerRemovalStep
+  let emojiFormatter: EmojiFormatterStep
+  let llmPolish: LLMPolishStep
+}
+
+/// Wraps `RecordingSessionKernel` as a `DictationPipeline` for the App layer.
+@MainActor
+@Observable
+final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
+
+  private let kernel: RecordingSessionKernel
+  private let observer: KernelHeartPathTelemetryObserver
+  private let outcome: KernelFinalizationOutcome
+  private let steps: LimbSteps
+
+  /// External-error surface (PR-4 §3.7). `kernel.cancel()` alone maps to a
+  /// `.hidden` overlay, so the driver owns the error state pushed in from
+  /// outside (`setExternalError`). Cleared on the next start / reset.
+  private var lastExternalError: String?
+
+  /// Fired by the kernel-state observer whenever the mapped `PipelineState`
+  /// changes. The App's `DictationLifecycleCoordinator` is the consumer.
+  @ObservationIgnored
+  var onStateChange: ((PipelineState) -> Void)?
+
+  /// The last mapped state `onStateChange` fired for — so a re-armed
+  /// observation that fires without a mapped-state change stays quiet.
+  @ObservationIgnored
+  private var lastFiredState: PipelineState
+
+  init(
+    kernel: RecordingSessionKernel,
+    observer: KernelHeartPathTelemetryObserver,
+    outcome: KernelFinalizationOutcome,
+    steps: LimbSteps
+  ) {
+    self.kernel = kernel
+    self.observer = observer
+    self.outcome = outcome
+    self.steps = steps
+    self.lastFiredState = Self.pipelineState(for: kernel.state, externalError: nil)
+  }
+
+  /// Begin observing the kernel for `onStateChange` fan-out.
+  func start() {
+    observeKernelState()
+  }
+
+  // MARK: Limb-step accessors (read by `PipelineSettingsSync` + custom-words)
+
+  var wordCorrection: WordCorrectionStep { steps.wordCorrection }
+  var fillerRemoval: FillerRemovalStep { steps.fillerRemoval }
+  var emojiFormatter: EmojiFormatterStep { steps.emojiFormatter }
+  var llmPolish: LLMPolishStep { steps.llmPolish }
+
+  // MARK: Caller-visible signals
+
+  /// The kernel's `RecordingSessionState` mapped to the legacy `PipelineState`.
+  var state: PipelineState {
+    Self.pipelineState(for: kernel.state, externalError: lastExternalError)
+  }
+
+  /// The transcript the `store` closure built for the last completed session.
+  var currentTranscript: Transcript? { outcome.transcript }
+
+  /// The polish error from the last session, or `nil`.
+  var lastPolishError: String? { outcome.polishError }
+
+  // MARK: DictationPipeline
+
+  var overlayIntent: OverlayIntent {
+    if let lastExternalError {
+      return .error(message: lastExternalError)
+    }
+    switch kernel.state {
+    case .idle, .completed, .cancelled, .discarded, .noSpeech:
+      return .hidden
+    case .preparing, .warmingUp:
+      return .processing(label: "Preparing dictation...")
+    case .recording:
+      // The real level is supplied by `AudioCaptureManager` downstream — the
+      // pipeline returns 0 here, exactly as `TranscriptionPipeline` did.
+      return .recording(audioLevel: 0)
+    case .stopping, .transcribing:
+      return .processing(label: "Transcribing...")
+    case .finalizing:
+      switch kernel.finalizingSubStatus {
+      case .transcribing:
+        return .processing(label: "Transcribing...")
+      case .polishing:
+        return .processing(label: "Polishing...")
+      }
+    case .failed(let reason):
+      return .error(message: Self.failureMessage(reason))
+    case .audioInterrupted:
+      return .interruption(message: InterruptionMessages.micDisconnected)
+    case .asrInterrupted:
+      return .error(message: Self.asrInterruptedMessage)
+    }
+  }
+
+  func handle(event: PipelineEvent) async throws {
+    switch event {
+    case .preWarm:
+      kernel.preWarm()
+    case .toggleRecording(let config):
+      switch kernel.state {
+      case .idle, .completed, .failed, .cancelled, .discarded, .noSpeech,
+        .audioInterrupted, .asrInterrupted:
+        // Start: clear the prior session's surfaces, then mint a new session.
+        lastExternalError = nil
+        outcome.transcript = nil
+        outcome.polishError = nil
+        kernel.start(config: config)
+      case .recording:
+        kernel.requestStop()
+      case .preparing, .warmingUp, .stopping, .transcribing, .finalizing:
+        // Mid-session — don't interrupt processing (PR-1 §B.1.2).
+        break
+      }
+    case .requestStop:
+      kernel.requestStop()
+    case .cancelRecording:
+      kernel.cancel()
+    case .reset:
+      lastExternalError = nil
+      kernel.reset()
+    }
+  }
+
+  /// Dumb external-error sink (PR-4 §3.7). Cancels the kernel session and
+  /// holds the message so `state` / `overlayIntent` surface `.error` until the
+  /// next start / reset clears it.
+  func setExternalError(_ message: String) {
+    kernel.cancel()
+    outcome.transcript = nil
+    lastExternalError = message
+  }
+
+  /// Intentional no-op (PR-4 §3.7). The kernel's `SessionID` structurally
+  /// replaces the stall-recovery token (D11) — there is nothing to clear.
+  func clearPendingStallRecovery() {}
+
+  // MARK: HeartPathTelemetryTarget — forwards to the observer (PR-4 §3.9)
+
+  func handleCaptureStall(_ ctx: CaptureStallContext) {
+    observer.handleCaptureStall(ctx)
+  }
+
+  func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
+    observer.handleXPCReplyFailed(ctx)
+  }
+
+  func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
+    observer.handleCaptureSessionInterruption(ctx)
+  }
+
+  // MARK: DEBUG
+
+  #if DEBUG
+    /// Drives the kernel's cancel unwind — the kernel-era equivalent of
+    /// `TranscriptionPipeline.forceCancelNow()`. Callable from `DebugFaultEndpoint`.
+    package func forceCancelNow() async {
+      kernel.cancel()
+    }
+  #endif
+
+  // MARK: Kernel-state observation
+
+  /// Arm `withObservationTracking` on `kernel.state`; the `onChange` closure
+  /// hops to `@MainActor` before re-reading state and re-arming (PR-4 §3.7,
+  /// Gemini concurrency premise — the explicit hop is the safe pattern).
+  private func observeKernelState() {
+    withObservationTracking {
+      _ = kernel.state
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.fireStateChangeIfNeeded()
+        self.observeKernelState()
+      }
+    }
+  }
+
+  private func fireStateChangeIfNeeded() {
+    let mapped = state
+    guard mapped != lastFiredState else { return }
+    lastFiredState = mapped
+    onStateChange?(mapped)
+  }
+
+  // MARK: State mapping — total, mechanical (PR-4 §3.7)
+
+  /// Map a kernel state to the legacy `PipelineState`. Total over all 14 kernel
+  /// states. `state.isActive` is `true` for every active kernel state, which
+  /// the `PipelineSettingsSync` backend-switch guard depends on (§3.13).
+  static func pipelineState(
+    for state: RecordingSessionState, externalError: String?
+  ) -> PipelineState {
+    if let externalError {
+      return .error(externalError)
+    }
+    switch state {
+    case .idle, .cancelled, .discarded, .noSpeech:
+      return .idle
+    case .preparing, .warmingUp:
+      return .loadingModel
+    case .recording:
+      return .recording
+    case .stopping, .transcribing:
+      return .transcribing
+    case .finalizing:
+      return .polishing
+    case .completed:
+      return .complete
+    case .failed(let reason):
+      return .error(failureMessage(reason))
+    case .audioInterrupted:
+      return .error(InterruptionMessages.micDisconnected)
+    case .asrInterrupted:
+      return .error(asrInterruptedMessage)
+    }
+  }
+
+  /// Mirrors the shipped `TranscriptionPipeline` string verbatim (em-dash
+  /// included) — PR-4 parity; the em-dash cleanup is a separate content change.
+  static let asrInterruptedMessage = "Transcription service crashed — please try again"
+
+  /// User-facing message for a `failed` terminal. The plan does not enumerate
+  /// this map; each message mirrors today's `TranscriptionPipeline` string for
+  /// the equivalent failure verbatim (parity — PR-4's bar is "user feels
+  /// nothing change"), or a sensible message where the kernel splits a reason
+  /// today's pipeline did not name distinctly. The `captureStalled` em-dash is
+  /// preserved to match the shipped string byte-for-byte; fixing it is a
+  /// separate content-lane change, out of PR-4 scope.
+  static func failureMessage(_ reason: RecordingFailureReason) -> String {
+    switch reason {
+    case .prepareFailed:
+      return "Couldn't start dictation. Please try again."
+    case .permissionDenied:
+      return "Microphone permission denied."
+    case .modelWedged:
+      return ModelLoadWatchdog.userMessage
+    case .modelLoadFailed:
+      return "Model load failed."
+    case .captureStartFailed:
+      return "Recording failed."
+    case .noAudioCaptured:
+      return "No audio captured"
+    case .asrEmpty:
+      return "Couldn't catch that -- try again"
+    case .asrFailed:
+      return "Transcription failed."
+    case .asrWedged:
+      return "Transcription stalled. Please try again."
+    case .emptyAfterProcessing:
+      return "No speech detected. Your clipboard is unchanged. Try again."
+    case .storageFailed:
+      return "Failed to save transcript"
+    case .captureStalled:
+      return "No audio detected — try again."
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -2,7 +2,6 @@ import AppKit
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
-import EnviousWisprStorage
 import Foundation
 
 // MARK: - KernelFinalizationWiring (epic #827, PR-4 §3.3, §3.6)
@@ -95,14 +94,18 @@ struct KernelFinalizationWiring {
   let currentTick: @MainActor () -> UInt64
   let sleepTicks: @MainActor (Int) async -> Void
 
+  /// `save` and `deliverPaste` are closure seams over `TranscriptStore.save`
+  /// and `PasteCascadeExecutor.deliver` — the same test-seam shape
+  /// `TranscriptFinalizer` exposes. The App wraps the concrete types; tests
+  /// pass fakes without touching disk or the AX paste APIs.
   init(
     outcome: KernelFinalizationOutcome,
     context: KernelSessionContext,
     adapter: ParakeetEngineAdapter,
     steps: LimbSteps,
     textProcessingRunner: TextProcessingRunner,
-    transcriptStore: TranscriptStore,
-    pasteExecutor: PasteCascadeExecutor,
+    save: @escaping @MainActor (Transcript) throws -> Void,
+    deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult,
     pasteCompletionRegistry: PasteCompletionRegistry?
   ) {
     // processText — run the limb chain, write the polish side-channel, return
@@ -149,7 +152,7 @@ struct KernelFinalizationWiring {
         backendType: .parakeet,
         llmProvider: outcome.llmProvider,
         llmModel: outcome.llmModel)
-      try transcriptStore.save(transcript)
+      try save(transcript)
       outcome.transcript = transcript
     }
 
@@ -161,7 +164,7 @@ struct KernelFinalizationWiring {
       let config = context.config
       if config?.autoPasteToActiveApp == true {
         let pasteText = PasteService.appendTrailingSpace(text)
-        let result = await pasteExecutor.deliver(
+        let result = await deliverPaste(
           PasteDeliveryRequest(
             text: pasteText,
             targetApp: context.targetApp,

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -1,0 +1,195 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+
+// MARK: - KernelFinalizationWiring (epic #827, PR-4 §3.3, §3.6)
+//
+// Assembles the kernel's post-ASR seams. `RecordingSessionKernel` takes its
+// finalization as three narrow closures (`processText` / `store` / `deliver`)
+// plus a logical clock (`currentTick` / `sleepTicks`). This helper builds them
+// from the real text-processing / storage / paste types — the documented,
+// single-unit-reviewable home for the run -> store -> deliver wiring, so the
+// App's kernel construction site does not grow a 40-line closure literal.
+//
+// `TranscriptFinalizer.swift` is NOT edited: PR-4 wires the kernel's three
+// closures to the three sub-types `TranscriptFinalizer` already composes
+// (`TextProcessingRunner` / `TranscriptStore` / `PasteCascadeExecutor`).
+// `TranscriptFinalizer` stays live for WhisperKit until PR-5/PR-9.
+//
+// PR-4a ships this production-unwired: no App-layer caller constructs it.
+
+/// The polish/storage side-channel (PR-4 §3.3). The kernel's three closures
+/// thread only a `String`; this reference carries the raw / polished split and
+/// the polish metadata the `store` closure and the driver need. `@Observable`
+/// so a driver reading `transcript` / `polishError` from it tracks changes.
+@MainActor
+@Observable
+final class KernelFinalizationOutcome {
+  /// The `Transcript` the `store` closure built and saved — the driver reads
+  /// this as `currentTranscript`.
+  var transcript: Transcript?
+  /// The polish-step error, or `nil` — the driver reads this as `lastPolishError`.
+  var polishError: String?
+  /// Raw ASR text (pre-polish) — `store` uses it for `Transcript.text`.
+  var rawText: String?
+  /// Polished text, or `nil` — `store` uses it for `Transcript.polishedText`.
+  var polishedText: String?
+  /// Polish provider / model identity for `Transcript`.
+  var llmProvider: String?
+  var llmModel: String?
+  /// Polish metadata + timing — carried for the PR-4b `ExecutionMetrics`
+  /// assembly (§8 polish-latency capture).
+  var polishMetadata: PolishMetadata?
+  var pipelineFellBackToRaw = false
+  var polishDurationSeconds: Double = 0
+
+  init() {}
+}
+
+/// Per-session inputs the finalization closures need but the kernel's narrow
+/// closure signatures do not thread (PR-4 §3.3 — "captured by the driver and
+/// threaded into the wiring"). A mutable holder shared by the driver (the
+/// writer — PR-4b populates it in `handle(.toggleRecording)`) and the wiring
+/// closures (the readers).
+@MainActor
+final class KernelSessionContext {
+  /// The frozen per-recording config — VAD, decode language, paste prefs.
+  var config: DictationSessionConfig?
+  /// The frontmost app captured at recording start, re-activated before paste.
+  var targetApp: NSRunningApplication?
+  /// The focused text element captured at recording start.
+  var targetElement: AXUIElement?
+
+  init() {}
+}
+
+/// Builds the kernel's `processText` / `store` / `deliver` closures + logical
+/// clock from the real finalization types.
+@MainActor
+struct KernelFinalizationWiring {
+
+  // MARK: Wedge-detection tuning (PR-4 §3.6)
+
+  /// Logical-tick granularity. Parakeet load-progress ticks arrive far slower
+  /// than 100 ms apart, so a healthy load refreshes the wedge watcher well
+  /// within every window.
+  static let tickDurationSeconds: Double = 0.1
+
+  /// Wedge window in ticks: `10 x 100 ms = 1.0 s`. Above `LoadProgressWatcher`'s
+  /// 0.8 s silence floor (`LoadProgressWatcher.swift:41`) with a 200 ms margin —
+  /// the kernel's cadence detector cannot false-positive a wedge sooner than
+  /// today's shipped detector is even allowed to (no arbitrary timeout; both
+  /// values are precedent-derived).
+  static let wedgeStallTicks: Int = 10
+
+  // MARK: Assembled seams
+
+  let processText:
+    @MainActor (_ raw: String, _ onPolishStarted: @escaping @MainActor () -> Void)
+      async throws -> String
+  let store: @MainActor (_ text: String) async throws -> Void
+  let deliver: @MainActor (_ text: String) async -> KernelDeliveryOutcome
+  let currentTick: @MainActor () -> UInt64
+  let sleepTicks: @MainActor (Int) async -> Void
+
+  init(
+    outcome: KernelFinalizationOutcome,
+    context: KernelSessionContext,
+    adapter: ParakeetEngineAdapter,
+    steps: LimbSteps,
+    textProcessingRunner: TextProcessingRunner,
+    transcriptStore: TranscriptStore,
+    pasteExecutor: PasteCascadeExecutor,
+    pasteCompletionRegistry: PasteCompletionRegistry?
+  ) {
+    // processText — run the limb chain, write the polish side-channel, return
+    // the final display text. `onPolishStarted` is wired into
+    // `LLMPolishStep.onWillProcess` so the limb emits and the kernel observes
+    // (D18 closed for Parakeet — PR-4 §3.8).
+    processText = { raw, onPolishStarted in
+      steps.llmPolish.onWillProcess = { onPolishStarted() }
+      let language: String? = {
+        if case .locked(let code) = context.config?.languageMode { return code }
+        return nil
+      }()
+      let start = CFAbsoluteTimeGetCurrent()
+      let result = try await textProcessingRunner.run(
+        rawText: raw,
+        language: language,
+        targetAppName: context.targetApp?.localizedName,
+        steps: [
+          steps.wordCorrection, steps.fillerRemoval, steps.emojiFormatter, steps.llmPolish,
+        ])
+      let ctx = result.context
+      outcome.rawText = ctx.text
+      outcome.polishedText = ctx.polishedText
+      outcome.llmProvider = ctx.llmProvider
+      outcome.llmModel = ctx.llmModel
+      outcome.polishMetadata = ctx.polishMetadata
+      outcome.pipelineFellBackToRaw = ctx.pipelineFellBackToRaw
+      outcome.polishError = result.polishError
+      outcome.polishDurationSeconds = CFAbsoluteTimeGetCurrent() - start
+      return ctx.polishedText ?? ctx.text
+    }
+
+    // store — build the Transcript exactly as TranscriptFinalizer.swift:129
+    // (raw / polished from the side-channel, ASR metadata from the adapter),
+    // persist it, and hand it to the driver via the side-channel. A throw
+    // propagates so the kernel routes `failed(storageFailed)` (PR-4 §3.3).
+    store = { text in
+      let transcript = Transcript(
+        text: outcome.rawText ?? text,
+        polishedText: outcome.polishedText,
+        language: adapter.lastResult?.language,
+        duration: adapter.lastResult?.duration ?? 0,
+        processingTime: adapter.lastResult?.processingTime ?? 0,
+        backendType: .parakeet,
+        llmProvider: outcome.llmProvider,
+        llmModel: outcome.llmModel)
+      try transcriptStore.save(transcript)
+      outcome.transcript = transcript
+    }
+
+    // deliver — run the paste cascade or clipboard copy per the session's
+    // paste prefs, map `PasteDeliveryResult` -> `KernelDeliveryOutcome`, emit
+    // the paste-completion event only on a real delivered paste
+    // (TranscriptFinalizer.swift:163).
+    deliver = { text in
+      let config = context.config
+      if config?.autoPasteToActiveApp == true {
+        let pasteText = PasteService.appendTrailingSpace(text)
+        let result = await pasteExecutor.deliver(
+          PasteDeliveryRequest(
+            text: pasteText,
+            targetApp: context.targetApp,
+            targetElement: context.targetElement,
+            restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false))
+        if case .delivered = result.outcome {
+          pasteCompletionRegistry?.emit(
+            PasteCompletionEvent(
+              pastedText: pasteText,
+              destinationBundleID: context.targetApp?.bundleIdentifier))
+          return .pasted
+        }
+        return .clipboardOnly
+      }
+      if config?.autoCopyToClipboard == true {
+        PasteService.copyToClipboard(text)
+      }
+      return .clipboardOnly
+    }
+
+    // Logical clock — production values for the kernel's wedge detection
+    // (PR-4 §3.6). `currentTick` quantizes `systemUptime` to 100 ms ticks
+    // (precedent: `LoadProgressWatcher.currentTime`).
+    currentTick = {
+      UInt64(ProcessInfo.processInfo.systemUptime / Self.tickDurationSeconds)
+    }
+    sleepTicks = { ticks in
+      try? await Task.sleep(for: .seconds(Double(ticks) * Self.tickDurationSeconds))
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -1,0 +1,177 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+// MARK: - KernelHeartPathTelemetryObserver (epic #827, PR-4 §3.9)
+//
+// Heart-path telemetry for the kernel path. It is a dedicated observer, NOT
+// folded into `KernelDictationDriver` (council placement challenge accepted):
+// the driver owns App-protocol translation; telemetry is a separate concern,
+// and folding it in would tie telemetry to UI-derived state — distinct
+// terminals (`completed` / `cancelled` / `discarded` / `noSpeech`) all map to
+// the `.hidden` overlay, so a UI-keyed observer would miss them.
+//
+// This observer watches RAW `kernel.state` transitions, so no terminal is
+// missed. It also owns the two capture-layer diagnostic callbacks the kernel
+// does not consume for control flow (`onCaptureSessionInterruption`,
+// `onXPCReplyFailed`). The capture-stall signal — which the kernel DOES
+// consume for control flow — reaches the observer through the kernel's
+// `captureStallTelemetry` fan-out seam (PR-4 §3.9).
+//
+// PR-4a ships this production-unwired: no App-layer caller constructs it. The
+// lifecycle-event sink is injected — PR-4b supplies the production sink
+// (Sentry breadcrumbs / PostHog) and the §11.2 event matrix verifies every
+// PR-1 §B.7 event empirically.
+
+/// A heart-path lifecycle event derived from a raw kernel state transition
+/// (PR-1 §B.7). The observer produces these; the injected sink renders them
+/// to the telemetry backends.
+enum KernelLifecycleEvent: Equatable, Sendable {
+  /// The session committed to `recording` — PR-1 §B.7 `dictation.invoked` +
+  /// the recording-started breadcrumb.
+  case recordingCommitted
+  /// The session entered `transcribing` — the `asr` "Transcription started"
+  /// breadcrumb.
+  case transcriptionStarted
+  /// The session reached `completed` — the `pipeline` "Pipeline complete"
+  /// breadcrumb.
+  case pipelineCompleted
+  /// The session reached a `failed` terminal — a per-reason `captureError`.
+  /// `model.load_wedged` is the `.modelWedged` case.
+  case failed(RecordingFailureReason)
+  /// The session reached `audioInterrupted` — a microphone-disconnect event.
+  case audioInterrupted
+  /// The session reached `asrInterrupted` — the `captureError(xpcServiceError)`.
+  case asrInterrupted
+  /// The session reached `discarded` — PR-1 §B.7.4, carrying the abort reason.
+  case discarded(DiscardReason)
+  /// The session reached `noSpeech` — the VAD no-speech outcome.
+  case noSpeech
+  /// The session reached `cancelled` — a user-cancelled recording.
+  case cancelled
+}
+
+/// Observes raw `RecordingSessionKernel` state and emits the PR-1 §B.7
+/// heart-path telemetry events.
+@MainActor
+final class KernelHeartPathTelemetryObserver {
+
+  private let kernel: RecordingSessionKernel
+  private let audioCapture: any AudioCaptureInterface
+  private let emitter: HeartPathTelemetryEmitter
+  private let emitLifecycleEvent: @MainActor (KernelLifecycleEvent) -> Void
+
+  /// The last kernel state the observer emitted for — so a re-armed
+  /// observation that fires without a state change emits nothing.
+  private var lastObservedState: RecordingSessionState
+
+  init(
+    kernel: RecordingSessionKernel,
+    audioCapture: any AudioCaptureInterface,
+    emitter: HeartPathTelemetryEmitter = HeartPathTelemetryEmitter(
+      backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+    emitLifecycleEvent: @escaping @MainActor (KernelLifecycleEvent) -> Void
+  ) {
+    self.kernel = kernel
+    self.audioCapture = audioCapture
+    self.emitter = emitter
+    self.emitLifecycleEvent = emitLifecycleEvent
+    self.lastObservedState = kernel.state
+  }
+
+  /// Begin observing. Wires the two capture-diagnostic callbacks the kernel
+  /// does not consume, and arms raw-state observation.
+  func start() {
+    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
+      self?.handleCaptureSessionInterruption(ctx)
+    }
+    audioCapture.onXPCReplyFailed = { [weak self] ctx in
+      self?.handleXPCReplyFailed(ctx)
+    }
+    observeKernelState()
+  }
+
+  // MARK: Capture-diagnostic callbacks (the kernel does not consume these)
+  //
+  // These three method names match `HeartPathTelemetryTarget`; the
+  // App-facing `KernelDictationDriver` conforms to that protocol and forwards
+  // its three methods here. The observer is the single telemetry brain.
+
+  /// Capture-stall telemetry. Reached through the kernel's `captureStallTelemetry`
+  /// fan-out seam (PR-4 §3.9) and through the driver's `HeartPathTelemetryTarget`
+  /// conformance. `HeartPathTelemetryEmitter` dedups per session, so a
+  /// double-call is harmless.
+  func handleCaptureStall(_ ctx: CaptureStallContext) {
+    emitter.stallFired(ctx: ctx, isActivelyCapturing: audioCapture.isActivelyCapturing)
+  }
+
+  func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {
+    emitter.xpcReplyFailed(ctx: ctx)
+  }
+
+  func handleCaptureSessionInterruption(_ ctx: CaptureSessionInterruptionContext) {
+    emitter.captureSessionInterrupted(ctx: ctx)
+  }
+
+  // MARK: Raw-state observation
+
+  /// Arm `withObservationTracking` on `kernel.state`. The `onChange` closure
+  /// runs synchronously on whatever context mutated the property; it hops to
+  /// `@MainActor` before re-reading state and re-arming (PR-4 §3.7, Gemini
+  /// concurrency premise — the explicit hop is the safe pattern even though
+  /// the kernel is `@MainActor`).
+  private func observeKernelState() {
+    withObservationTracking {
+      _ = kernel.state
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.handleStateChange()
+        self.observeKernelState()
+      }
+    }
+  }
+
+  /// Emit the lifecycle event for the current kernel state, if it changed.
+  private func handleStateChange() {
+    let state = kernel.state
+    guard state != lastObservedState else { return }
+    lastObservedState = state
+    guard let event = Self.lifecycleEvent(for: state, discardReason: kernel.discardReason)
+    else { return }
+    emitLifecycleEvent(event)
+  }
+
+  /// Map a kernel state to its lifecycle event. States with no §B.7 event
+  /// (`idle` / `preparing` / `warmingUp` / `stopping` / `finalizing`) map to
+  /// `nil` — observing raw state still guarantees no terminal is missed.
+  static func lifecycleEvent(
+    for state: RecordingSessionState, discardReason: DiscardReason?
+  ) -> KernelLifecycleEvent? {
+    switch state {
+    case .recording:
+      return .recordingCommitted
+    case .transcribing:
+      return .transcriptionStarted
+    case .completed:
+      return .pipelineCompleted
+    case .failed(let reason):
+      return .failed(reason)
+    case .audioInterrupted:
+      return .audioInterrupted
+    case .asrInterrupted:
+      return .asrInterrupted
+    case .discarded:
+      // The reason is a sibling observable set before the `→ discarded`
+      // transition (PR-4 §3.8a); default defensively if somehow absent.
+      return .discarded(discardReason ?? .releasedBeforeRecording)
+    case .noSpeech:
+      return .noSpeech
+    case .cancelled:
+      return .cancelled
+    case .idle, .preparing, .warmingUp, .stopping, .finalizing:
+      return nil
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -160,6 +160,12 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     feedsCompleted = 0
     retainedPCM.removeAll(keepingCapacity: true)
 
+    // Cancel any pending model-unload timer a prior session armed via
+    // `applyUnloadPolicy` — otherwise it can fire mid-recording and unload the
+    // model under the live session. Mirrors `TranscriptionPipeline.swift:359`,
+    // which cancels the idle timer at every session start.
+    asrManager.cancelIdleTimer()
+
     if streaming, await asrManager.activeBackendSupportsStreaming {
       do {
         try await asrManager.startStreaming(options: options)

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -46,6 +46,14 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// `true` while `warmUp()` has a `loadModel()` in flight — feeds `readiness`.
   private var isLoadInFlight = false
 
+  /// Streaming-feed drain counters. `acceptAudio(_:)` dispatches each
+  /// `feedAudio` on its own task; `finalize()` waits for every dispatched feed
+  /// to complete before `finalizeStreaming()`, so a non-empty streaming result
+  /// is never finalized missing the tail buffers. Mirrors the shipped
+  /// `TranscriptionPipeline` streaming drain (`TranscriptionPipeline.swift:675`).
+  private var feedsDispatched = 0
+  private var feedsCompleted = 0
+
   // MARK: Batch-rescue PCM retention (§3.2a)
 
   /// The whole session's 16 kHz mono Float32 samples, accumulated from every
@@ -146,6 +154,8 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     isCancelled = false
     streamingActive = false
     lastResult = nil
+    feedsDispatched = 0
+    feedsCompleted = 0
     retainedPCM.removeAll(keepingCapacity: true)
 
     if await asrManager.activeBackendSupportsStreaming {
@@ -170,8 +180,11 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // Mirror the shipped per-buffer hand-off (`TranscriptionPipeline.swift:481`):
     // each buffer is fed on its own `@MainActor` task. The buffer is already
     // MainActor-confined here, so capturing it carries no cross-actor transfer.
+    // `feedsDispatched` / `feedsCompleted` let `finalize()` drain the queue.
     let pcmBuffer = buffer.buffer
+    feedsDispatched += 1
     Task { @MainActor [weak self] in
+      defer { self?.feedsCompleted += 1 }
       try? await self?.asrManager.feedAudio(pcmBuffer)
     }
   }
@@ -187,6 +200,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     }
     let outcome: ASREngineOutcome
     if streamingActive {
+      await drainStreamingFeeds()
       outcome = await finalizeStreamingWithRescue()
     } else {
       outcome = await finalizeBatch()
@@ -224,6 +238,22 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
     asrManager.noteTranscriptionComplete(policy: policy)
+  }
+
+  // MARK: Streaming drain
+
+  /// Wait for every dispatched `feedAudio` task to complete before
+  /// `finalizeStreaming()` — so a non-empty streaming result is never
+  /// finalized missing tail buffers still queued behind `acceptAudio`
+  /// (`TranscriptionPipeline.swift:675` — "losing ~250-500ms of trailing
+  /// audio"). The signal is `feedsCompleted` catching `feedsDispatched`; the
+  /// 500 ms bound is the shipped drain deadline, a safety net against a feed
+  /// task that never completes (`TranscriptionPipeline.swift:680`).
+  private func drainStreamingFeeds() async {
+    let deadline = ContinuousClock.now + .milliseconds(500)
+    while feedsCompleted < feedsDispatched, ContinuousClock.now < deadline {
+      await Task.yield()
+    }
   }
 
   // MARK: Rescue

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -182,10 +182,19 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // MainActor-confined here, so capturing it carries no cross-actor transfer.
     // `feedsDispatched` / `feedsCompleted` let `finalize()` drain the queue.
     let pcmBuffer = buffer.buffer
+    let handoffSession = buffer.sessionID
     feedsDispatched += 1
     Task { @MainActor [weak self] in
-      defer { self?.feedsCompleted += 1 }
-      try? await self?.asrManager.feedAudio(pcmBuffer)
+      guard let self else { return }
+      defer { self.feedsCompleted += 1 }
+      // Re-check on the `@MainActor` hop: a `cancel()` or a new `beginSession()`
+      // between dispatch and now must not feed this buffer into a fresh
+      // streaming session (Codex r2 — stale-feed race). The shipped pipeline
+      // re-checks `streamingASRActive` / `state` inside the same hop
+      // (`TranscriptionPipeline.swift:486`).
+      guard self.sessionID == handoffSession, self.streamingActive, !self.isTerminal
+      else { return }
+      try? await self.asrManager.feedAudio(pcmBuffer)
     }
   }
 
@@ -198,12 +207,20 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       retainedPCM.removeAll()
       return .cancelled
     }
+    let session = sessionID
     let outcome: ASREngineOutcome
     if streamingActive {
       await drainStreamingFeeds()
       outcome = await finalizeStreamingWithRescue()
     } else {
       outcome = await finalizeBatch()
+    }
+    // A `cancel()` + new `beginSession()` during the ASR await must not let
+    // this stale finalize clobber the fresh session's `lastResult` / retained
+    // PCM / terminal flag (Codex r2 — stale-finalize race). The kernel's own
+    // `finalize(_:)` wrapper drops the stale return value separately.
+    guard sessionID == session, !isCancelled else {
+      return isCancelled ? .cancelled : outcome
     }
     if case .transcript(let result) = outcome {
       lastResult = result

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -144,10 +144,12 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   // MARK: ASREngineAdapter — session lifecycle
 
-  /// Begin a session. Starts streaming when the backend supports it; on a
-  /// streaming-setup failure it degrades to batch-after-stop — today's
-  /// `streamingSetupSucceeded` fallback (`TranscriptionPipeline.swift:458`).
-  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws {
+  /// Begin a session. Opens a live stream only when the kernel asked for one
+  /// (`streaming`) AND the backend supports it; on a streaming-setup failure it
+  /// degrades to batch-after-stop — today's `streamingSetupSucceeded` fallback
+  /// (`TranscriptionPipeline.swift:458`). `streaming == false` (the user
+  /// disabled live transcription) means batch decode after stop only.
+  func beginSession(_ id: SessionID, options: TranscriptionOptions, streaming: Bool) async throws {
     sessionID = id
     decodeOptions = options
     isTerminal = false
@@ -158,7 +160,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     feedsCompleted = 0
     retainedPCM.removeAll(keepingCapacity: true)
 
-    if await asrManager.activeBackendSupportsStreaming {
+    if streaming, await asrManager.activeBackendSupportsStreaming {
       do {
         try await asrManager.startStreaming(options: options)
         streamingActive = true

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -1,0 +1,273 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+
+// MARK: - ParakeetEngineAdapter (epic #827, PR-4 §3.2)
+//
+// The production `ASREngineAdapter` conformer for the Parakeet engine. It wraps
+// `any ASRManagerInterface` — Parakeet's model lives in the XPC ASR service
+// (PR-1 §B.2 names `ASRManagerInterface`, not a raw `ASRBackend`).
+//
+// Scope (epic §4): an adapter owns its own ASR and rescue and NOTHING else — no
+// capture, no finalization, no paste, no UI, no FSM, no kernel state. This
+// adapter owns Parakeet transcription, the streaming-finalize-then-batch rescue
+// (D14, today `TranscriptionPipeline.transcribeWithStreamingRescue`), and the
+// full-session PCM the batch rescue needs (§3.2a). It holds legitimate
+// engine-session bookkeeping (a streaming-active flag, the retained PCM, an
+// in-flight-load flag, a terminal / cancelled flag) — session bookkeeping is
+// explicitly NOT FSM state (Codex finding 46, §3.11 adapter-shape check).
+//
+// PR-4a ships this production-unwired: no App-layer caller constructs it yet.
+// PR-4b wires it behind the Parakeet branch and deletes `TranscriptionPipeline`.
+
+/// Wraps Parakeet's `ASRManagerInterface` as a kernel-facing `ASREngineAdapter`.
+@MainActor
+final class ParakeetEngineAdapter: ASREngineAdapter {
+
+  // MARK: Injected dependency
+
+  private let asrManager: any ASRManagerInterface
+
+  // MARK: Engine-session bookkeeping (NOT FSM state — §3.11)
+
+  /// The session `beginSession(_:)` opened, or `nil` between sessions.
+  private var sessionID: SessionID?
+  /// Decode options bound at `beginSession(_:)`, reused by the batch rescue.
+  private var decodeOptions: TranscriptionOptions = .default
+  /// `true` between a successful `startStreaming(...)` and `finalize()` /
+  /// `cancel()`. `false` means this session decodes batch-after-stop.
+  private var streamingActive = false
+  /// `true` once `finalize()` or `cancel()` has completed — `acceptAudio(_:)`
+  /// after this is a no-op (PR-1 §B.2.2).
+  private var isTerminal = false
+  /// `true` once `cancel()` ran — `finalize()` then returns `.cancelled`.
+  private var isCancelled = false
+  /// `true` while `warmUp()` has a `loadModel()` in flight — feeds `readiness`.
+  private var isLoadInFlight = false
+
+  // MARK: Batch-rescue PCM retention (§3.2a)
+
+  /// The whole session's 16 kHz mono Float32 samples, accumulated from every
+  /// `acceptAudio(_:)`. The streaming-finalize-then-batch rescue needs the
+  /// complete audio; streaming feeds buffers piecemeal and `ASRManagerInterface`
+  /// does not retain them. Cleared on `cancel()` and on `finalize()` return —
+  /// no accumulation outlives its session.
+  private var retainedPCM: [Float] = []
+
+  /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
+  /// (300 s x 16 kHz = 4.8 M `Float` = ~19 MB). On reaching the cap the
+  /// accumulation stops growing; recording auto-stops on max-duration anyway.
+  private static let retainedPCMCap = Int(
+    TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
+
+  // MARK: Load-progress stream
+
+  private let loadStream: AsyncStream<ASRLoadProgressTick>
+  private let loadContinuation: AsyncStream<ASRLoadProgressTick>.Continuation
+  private var loadMarker: UInt64 = 0
+
+  // MARK: ASREngineAdapter — engine interruption
+
+  /// Set by the kernel during session setup; the kernel routes it to the
+  /// `asrInterrupted` terminal. Bridged from `ASRManagerInterface.onServiceInterrupted`
+  /// — the mid-recording ASR-service crash signal (PR-4 §3.2, Codex RR1).
+  var onEngineInterrupted: (@MainActor () -> Void)?
+
+  // MARK: Init
+
+  init(asrManager: any ASRManagerInterface) {
+    self.asrManager = asrManager
+    (loadStream, loadContinuation) = AsyncStream.makeStream(of: ASRLoadProgressTick.self)
+    // Bridge the ASR-service-crash signal. `onServiceInterrupted` is a distinct
+    // XPC layer from the audio-capture `onXPCServiceError` the kernel binds
+    // separately (PR-4 §3.2).
+    asrManager.onServiceInterrupted = { [weak self] in
+      self?.onEngineInterrupted?()
+    }
+  }
+
+  // MARK: ASREngineAdapter — identity & capability
+
+  /// Parakeet decodes incrementally and detects no language (D2, D15). Static —
+  /// the kernel branches on `capabilities`, never on engine identity.
+  var capabilities: ASREngineCapabilities {
+    ASREngineCapabilities(supportsStreaming: true, supportsLanguageDetection: false)
+  }
+
+  var readiness: ASREngineReadiness {
+    if asrManager.isModelLoaded { return .ready }
+    return isLoadInFlight ? .warming : .notReady
+  }
+
+  // MARK: ASREngineAdapter — warm-up
+
+  /// Idempotent, sessionless warm-up. Wires `loadProgressTickReporter` for the
+  /// duration of the `loadModel()` call so the kernel's signal-based load-wedge
+  /// detection (D5) sees progress ticks; clears it after the load resolves.
+  func warmUp() async throws {
+    if asrManager.isModelLoaded { return }
+    isLoadInFlight = true
+    asrManager.loadProgressTickReporter = { [weak self] _, _ in
+      self?.emitLoadTick()
+    }
+    defer {
+      asrManager.loadProgressTickReporter = nil
+      isLoadInFlight = false
+    }
+    try await asrManager.loadModel()
+  }
+
+  /// Parakeet always exposes a load-progress stream (D5) — non-nil, so the
+  /// kernel runs signal-based warm-up wedge detection.
+  var loadProgress: AsyncStream<ASRLoadProgressTick>? { loadStream }
+
+  private func emitLoadTick() {
+    loadMarker += 1
+    loadContinuation.yield(ASRLoadProgressTick(marker: loadMarker))
+  }
+
+  // MARK: ASREngineAdapter — session lifecycle
+
+  /// Begin a session. Starts streaming when the backend supports it; on a
+  /// streaming-setup failure it degrades to batch-after-stop — today's
+  /// `streamingSetupSucceeded` fallback (`TranscriptionPipeline.swift:458`).
+  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws {
+    sessionID = id
+    decodeOptions = options
+    isTerminal = false
+    isCancelled = false
+    streamingActive = false
+    retainedPCM.removeAll(keepingCapacity: true)
+
+    if await asrManager.activeBackendSupportsStreaming {
+      do {
+        try await asrManager.startStreaming(options: options)
+        streamingActive = true
+      } catch {
+        // Streaming setup failed — fall back to batch decode after stop. Not a
+        // session failure; the batch rescue over `retainedPCM` covers it.
+        streamingActive = false
+      }
+    }
+  }
+
+  /// Accept one captured buffer. Feeds streaming ASR (when streaming) and
+  /// always appends to `retainedPCM` for the batch rescue (§3.2a). A call after
+  /// a terminal session is a no-op (PR-1 §B.2.2).
+  func acceptAudio(_ buffer: AudioBufferHandoff) {
+    guard !isTerminal else { return }
+    appendRetainedPCM(from: buffer.buffer)
+    guard streamingActive else { return }
+    // Mirror the shipped per-buffer hand-off (`TranscriptionPipeline.swift:481`):
+    // each buffer is fed on its own `@MainActor` task. The buffer is already
+    // MainActor-confined here, so capturing it carries no cross-actor transfer.
+    let pcmBuffer = buffer.buffer
+    Task { @MainActor [weak self] in
+      try? await self?.asrManager.feedAudio(pcmBuffer)
+    }
+  }
+
+  /// Finalize: one normalized outcome. Streaming runs the
+  /// streaming-finalize-then-batch rescue (D14); batch-mode runs batch decode
+  /// over the retained PCM. After `cancel()`, returns `.cancelled` (PR-1 §B.2.2).
+  func finalize() async -> ASREngineOutcome {
+    if isCancelled {
+      isTerminal = true
+      retainedPCM.removeAll()
+      return .cancelled
+    }
+    let outcome: ASREngineOutcome
+    if streamingActive {
+      outcome = await finalizeStreamingWithRescue()
+    } else {
+      outcome = await finalizeBatch()
+    }
+    isTerminal = true
+    streamingActive = false
+    retainedPCM.removeAll()
+    return outcome
+  }
+
+  /// Parakeet's streaming-finalize returns in milliseconds — no finalize-wedge
+  /// signal (§B.1.7 `finalizeProgress == nil` = signal-free `transcribing`).
+  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
+
+  /// Idempotent discard. Cancels streaming and any wedged in-flight model load,
+  /// clears the retained PCM. `cancelInFlightLoad()` is what unblocks the
+  /// kernel's load-wedge recovery (issue #445); the kernel routes its
+  /// `detectLoadWedge` recovery through this same `cancel()`.
+  func cancel() async {
+    isCancelled = true
+    isTerminal = true
+    retainedPCM.removeAll()
+    if streamingActive {
+      streamingActive = false
+      await asrManager.cancelStreaming()
+    }
+    asrManager.cancelInFlightLoad()
+  }
+
+  // MARK: ASREngineAdapter — cleanup
+
+  func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
+    asrManager.noteTranscriptionComplete(policy: policy)
+  }
+
+  // MARK: Rescue
+
+  /// Streaming finalize, then batch rescue if streaming returned empty or
+  /// failed. Mirrors `TranscriptionPipeline.transcribeWithStreamingRescue`.
+  /// The kernel runs the VAD no-speech gate before `finalize()`, so reaching
+  /// here means speech evidence was voiced or unavailable — the rescue always
+  /// attempts batch when streaming yields nothing.
+  private func finalizeStreamingWithRescue() async -> ASREngineOutcome {
+    do {
+      let result = try await asrManager.finalizeStreaming()
+      if !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return .transcript(result)
+      }
+      // Streaming returned empty — fall through to the batch rescue.
+    } catch is CancellationError {
+      return .cancelled
+    } catch {
+      // Streaming finalize failed — fall through to the batch rescue.
+    }
+    return await finalizeBatch()
+  }
+
+  /// Batch decode over the retained session PCM (§3.2a).
+  private func finalizeBatch() async -> ASREngineOutcome {
+    guard !retainedPCM.isEmpty else { return .empty(hadSpeechEvidence: true) }
+    do {
+      let result = try await asrManager.transcribe(
+        audioSamples: retainedPCM, options: decodeOptions)
+      if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        // Past the kernel's VAD no-speech gate, an empty decode is a real ASR
+        // failure — `hadSpeechEvidence: true` routes the kernel to
+        // `failed(asrEmpty)` (PR-1 §B.1.2), matching today's "Couldn't catch
+        // that" path.
+        return .empty(hadSpeechEvidence: true)
+      }
+      return .transcript(result)
+    } catch is CancellationError {
+      return .cancelled
+    } catch {
+      return .failed(.decodeFailed)
+    }
+  }
+
+  // MARK: PCM retention
+
+  /// Extract the buffer's Float32 samples and append to `retainedPCM`, bounded
+  /// by `retainedPCMCap`. Runs on `@MainActor` (the audio thread did only the
+  /// wrap + hop — `architecture-rules.md` audio-thread discipline).
+  private func appendRetainedPCM(from buffer: AVAudioPCMBuffer) {
+    guard retainedPCM.count < Self.retainedPCMCap else { return }
+    let count = Int(buffer.frameLength)
+    guard count > 0, let channel = buffer.floatChannelData?[0] else { return }
+    let remaining = Self.retainedPCMCap - retainedPCM.count
+    let take = min(count, remaining)
+    retainedPCM.append(contentsOf: UnsafeBufferPointer(start: channel, count: take))
+  }
+}

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -55,6 +55,13 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// no accumulation outlives its session.
   private var retainedPCM: [Float] = []
 
+  /// The `ASRResult` of the last successful `finalize()`, or `nil`. The kernel
+  /// threads only `result.text` to its `runFinalizing` closures, so the
+  /// finalization wiring reads the result's metadata (`language`, `duration`,
+  /// `processingTime`) from here to build the `Transcript` (PR-4 §3.3).
+  /// Cleared on `beginSession()` and `cancel()`.
+  private(set) var lastResult: ASRResult?
+
   /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
   /// (300 s x 16 kHz = 4.8 M `Float` = ~19 MB). On reaching the cap the
   /// accumulation stops growing; recording auto-stops on max-duration anyway.
@@ -138,6 +145,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     isTerminal = false
     isCancelled = false
     streamingActive = false
+    lastResult = nil
     retainedPCM.removeAll(keepingCapacity: true)
 
     if await asrManager.activeBackendSupportsStreaming {
@@ -183,6 +191,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     } else {
       outcome = await finalizeBatch()
     }
+    if case .transcript(let result) = outcome {
+      lastResult = result
+    }
     isTerminal = true
     streamingActive = false
     retainedPCM.removeAll()
@@ -200,6 +211,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   func cancel() async {
     isCancelled = true
     isTerminal = true
+    lastResult = nil
     retainedPCM.removeAll()
     if streamingActive {
       streamingActive = false

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -46,13 +46,16 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// `true` while `warmUp()` has a `loadModel()` in flight — feeds `readiness`.
   private var isLoadInFlight = false
 
-  /// Streaming-feed drain counters. `acceptAudio(_:)` dispatches each
-  /// `feedAudio` on its own task; `finalize()` waits for every dispatched feed
-  /// to complete before `finalizeStreaming()`, so a non-empty streaming result
-  /// is never finalized missing the tail buffers. Mirrors the shipped
-  /// `TranscriptionPipeline` streaming drain (`TranscriptionPipeline.swift:675`).
-  private var feedsDispatched = 0
-  private var feedsCompleted = 0
+  /// In-flight streaming-feed tasks. `acceptAudio(_:)` dispatches each
+  /// `feedAudio` on its own task and appends the handle here; `finalize()`
+  /// awaits every handle before `finalizeStreaming()`, so a non-empty streaming
+  /// result is never finalized missing the tail buffers. Awaiting the actual
+  /// task is the completion signal — no wall-clock deadline. A `ContinuousClock`
+  /// deadline raced the `@MainActor` scheduler: under contention it fired before
+  /// queued feed tasks ran, dropping tail audio (Codex PR-4a r4, reproduced as a
+  /// `finalizeDrainsStreamingFeeds` flake). Each task `try?`-awaits `feedAudio`,
+  /// so it always completes — on success or a thrown XPC error — never hangs.
+  private var feedTasks: [Task<Void, Never>] = []
 
   // MARK: Batch-rescue PCM retention (§3.2a)
 
@@ -156,8 +159,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     isCancelled = false
     streamingActive = false
     lastResult = nil
-    feedsDispatched = 0
-    feedsCompleted = 0
+    feedTasks.removeAll()
     retainedPCM.removeAll(keepingCapacity: true)
 
     // Cancel any pending model-unload timer a prior session armed via
@@ -188,13 +190,11 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // Mirror the shipped per-buffer hand-off (`TranscriptionPipeline.swift:481`):
     // each buffer is fed on its own `@MainActor` task. The buffer is already
     // MainActor-confined here, so capturing it carries no cross-actor transfer.
-    // `feedsDispatched` / `feedsCompleted` let `finalize()` drain the queue.
+    // The task handle is retained in `feedTasks` so `finalize()` can await it.
     let pcmBuffer = buffer.buffer
     let handoffSession = buffer.sessionID
-    feedsDispatched += 1
-    Task { @MainActor [weak self] in
+    let task = Task { @MainActor [weak self] in
       guard let self else { return }
-      defer { self.feedsCompleted += 1 }
       // Re-check on the `@MainActor` hop: a `cancel()` or a new `beginSession()`
       // between dispatch and now must not feed this buffer into a fresh
       // streaming session (Codex r2 — stale-feed race). The shipped pipeline
@@ -204,6 +204,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       else { return }
       try? await self.asrManager.feedAudio(pcmBuffer)
     }
+    feedTasks.append(task)
   }
 
   /// Finalize: one normalized outcome. Streaming runs the
@@ -252,6 +253,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     isTerminal = true
     lastResult = nil
     retainedPCM.removeAll()
+    // Drop feed-task handles — the tasks see `isTerminal` and skip; `finalize()`
+    // after `cancel()` short-circuits to `.cancelled` and never drains.
+    feedTasks.removeAll()
     if streamingActive {
       streamingActive = false
       await asrManager.cancelStreaming()
@@ -267,18 +271,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   // MARK: Streaming drain
 
-  /// Wait for every dispatched `feedAudio` task to complete before
-  /// `finalizeStreaming()` — so a non-empty streaming result is never
-  /// finalized missing tail buffers still queued behind `acceptAudio`
-  /// (`TranscriptionPipeline.swift:675` — "losing ~250-500ms of trailing
-  /// audio"). The signal is `feedsCompleted` catching `feedsDispatched`; the
-  /// 500 ms bound is the shipped drain deadline, a safety net against a feed
-  /// task that never completes (`TranscriptionPipeline.swift:680`).
+  /// Await every dispatched `feedAudio` task before `finalizeStreaming()` — so
+  /// a non-empty streaming result is never finalized missing tail buffers still
+  /// queued behind `acceptAudio` (`TranscriptionPipeline.swift:675` — "losing
+  /// ~250-500ms of trailing audio"). Awaiting the task handles is the actual
+  /// completion signal; no wall-clock deadline (`no-arbitrary-timeouts.md`) —
+  /// the prior `ContinuousClock` deadline raced the scheduler and flaked.
+  /// Iterates a value snapshot and does NOT clear `feedTasks` — only
+  /// `beginSession()` / `cancel()` clear it, so a session that begins during
+  /// this drain's `await` cannot have its fresh feed handles dropped here.
   private func drainStreamingFeeds() async {
-    let deadline = ContinuousClock.now + .milliseconds(500)
-    while feedsCompleted < feedsDispatched, ContinuousClock.now < deadline {
-      await Task.yield()
-    }
+    for task in feedTasks { await task.value }
   }
 
   // MARK: Rescue

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -504,9 +504,14 @@ final class RecordingSessionKernel {
     guard isCurrent(sid) else { return }
 
     // Begin the adapter session. Decode options derive from the frozen
-    // session config's language mode (PR-4 plan §3.3a).
+    // session config's language mode (PR-4 plan §3.3a). The kernel owns the
+    // streaming-vs-batch policy: the user's `useStreamingASR` setting ANDed
+    // with the adapter's static streaming capability (PR-4 plan §3.4). A
+    // non-streaming engine (PR-5 WhisperKit) is never asked to stream.
+    let shouldStream = config.useStreamingASR && adapter.capabilities.supportsStreaming
     do {
-      try await adapter.beginSession(sid, options: makeTranscriptionOptions(config))
+      try await adapter.beginSession(
+        sid, options: makeTranscriptionOptions(config), streaming: shouldStream)
     } catch {
       guard isCurrent(sid) else { return }
       audioCapture.onBufferCaptured = nil

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -134,7 +134,8 @@ final class RecordingSessionKernel {
   /// and signals polish-start via its callback; `store` persists; `deliver`
   /// pastes. PR-4 wires these to a real `TranscriptFinalizer` call site.
   private let processText:
-    @MainActor (_ raw: String, _ onPolishStarted: @MainActor () -> Void) async throws -> String
+    @MainActor (_ raw: String, _ onPolishStarted: @escaping @MainActor () -> Void)
+      async throws -> String
   private let store: @MainActor (_ text: String) async throws -> Void
   private let deliver: @MainActor (_ text: String) async -> KernelDeliveryOutcome
 
@@ -291,7 +292,7 @@ final class RecordingSessionKernel {
     currentTick: @escaping @MainActor () -> UInt64,
     sleepTicks: @escaping @MainActor (Int) async -> Void,
     processText: @escaping @MainActor (
-      _ raw: String, _ onPolishStarted: @MainActor () -> Void
+      _ raw: String, _ onPolishStarted: @escaping @MainActor () -> Void
     ) async throws -> String,
     store: @escaping @MainActor (_ text: String) async throws -> Void,
     deliver: @escaping @MainActor (_ text: String) async -> KernelDeliveryOutcome,

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -89,6 +89,19 @@ public enum KernelErrorCategory: Equatable, Sendable {
   case interruption
 }
 
+/// Why a session reached the `discarded` terminal — surfaced for the
+/// PR-1 §B.7.4 telemetry event (PR-4 plan §3.8a). A sibling observable to
+/// `state`, the same shape as `deliveredTranscript`; the `discarded` FSM case
+/// stays plain (no state-enum payload).
+public enum DiscardReason: Equatable, Sendable {
+  /// Stop latched before the session ever reached `recording` — PTT released
+  /// during prepare / warm-up. No transcribable audio.
+  case releasedBeforeRecording
+  /// Recording reached `recording` but handed off zero buffers — a
+  /// sub-minimum-duration accidental tap.
+  case tooShort
+}
+
 /// A typed limb-seam failure the kernel maps to a `failed` terminal reason
 /// (PR-3 plan §14a). The `processText` / `store` seams throw these.
 public enum KernelLimbError: Error, Sendable {
@@ -133,6 +146,17 @@ final class RecordingSessionKernel {
   /// the simulator's logical-tick time base — not a wall-clock deadline.
   private let wedgeStallTicks: Int
 
+  // MARK: Telemetry fan-out
+
+  /// Capture-stall telemetry fan-out (PR-4 plan §3.9). When the capture layer
+  /// reports a stall the kernel — besides routing `failed(.captureStalled)`
+  /// for control flow — hands the raw `CaptureStallContext` to this seam so a
+  /// telemetry observer receives the diagnostic payload the terminal state
+  /// cannot carry. A dumb fan-out: the kernel never reads it back, and it
+  /// keeps the kernel telemetry-infra-agnostic (the closure is a seam, like
+  /// `processText` / `store` / `deliver`). A no-op in the simulator.
+  private let captureStallTelemetry: @MainActor (CaptureStallContext) -> Void
+
   // MARK: Observable surface
 
   /// The current FSM state. Callers observe; they never mutate it.
@@ -148,6 +172,11 @@ final class RecordingSessionKernel {
 
   /// The text delivered to the user, or `nil` if none.
   private(set) var deliveredTranscript: String?
+
+  /// Why the session was `discarded`, or `nil` if it did not reach `discarded`
+  /// (PR-4 plan §3.8a). Set immediately before the `→ discarded` transition so
+  /// a state observer reads the correct reason.
+  private(set) var discardReason: DiscardReason?
 
   /// How delivery happened, or `nil` if nothing was delivered.
   private(set) var deliveryOutcome: KernelDeliveryOutcome?
@@ -183,6 +212,17 @@ final class RecordingSessionKernel {
   }
 
   // MARK: Session-scoped mutable state
+
+  /// The per-recording config bound at `start(config:)` (PR-4 plan §3.3a). The
+  /// forward path reads it for VAD configuration and decode options; a
+  /// terminal reads `modelUnloadPolicy`. `nil` before the first session.
+  private var sessionConfig: DictationSessionConfig?
+
+  /// `true` once `adapter.beginSession()` succeeded this session. Distinct from
+  /// `adapterSessionActive` (which `finalize()` clears) — this stays true for
+  /// the whole session so a terminal applies the model-unload policy exactly
+  /// once for any session that ran the adapter (PR-4 plan §3.2, Codex RR4).
+  private var adapterDidBeginSession = false
 
   /// The session task bag, keyed by `SessionID` (PR-1 §B.1.6). Reaching a
   /// terminal state cancels and clears it — nonblocking (PR-3 plan §3.1a).
@@ -255,7 +295,8 @@ final class RecordingSessionKernel {
     ) async throws -> String,
     store: @escaping @MainActor (_ text: String) async throws -> Void,
     deliver: @escaping @MainActor (_ text: String) async -> KernelDeliveryOutcome,
-    wedgeStallTicks: Int = 2
+    wedgeStallTicks: Int = 2,
+    captureStallTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in }
   ) {
     self.adapter = adapter
     self.audioCapture = audioCapture
@@ -266,14 +307,16 @@ final class RecordingSessionKernel {
     self.store = store
     self.deliver = deliver
     self.wedgeStallTicks = wedgeStallTicks
+    self.captureStallTelemetry = captureStallTelemetry
   }
 
   // MARK: Driver entry points (PR-1 §A.2 trigger vocabulary)
 
   /// Start a new recording session. Legal from `idle` or any terminal state;
   /// ignored while a session is active (PR-1 §B.1.2 — "don't interrupt
-  /// processing").
-  func start() {
+  /// processing"). `config` freezes per-recording settings (VAD, decode
+  /// language, model-unload policy) for this session (PR-4 plan §3.3a).
+  func start(config: DictationSessionConfig) {
     guard state == .idle || state.isTerminal else {
       log("start ignored — session active at \(state)")
       return
@@ -281,6 +324,7 @@ final class RecordingSessionKernel {
     let sid = SessionID()
     currentSessionID = sid
     resetSessionState()
+    sessionConfig = config
     transition(to: .preparing)
     spawn(sid) { [weak self] in
       await self?.runForwardPath(sid)
@@ -369,15 +413,26 @@ final class RecordingSessionKernel {
   // MARK: Forward path
 
   private func runForwardPath(_ sid: SessionID) async {
-    // Preparing: configure VAD, bind capture callbacks, derive options.
+    guard let config = sessionConfig else {
+      // `start(config:)` always sets `sessionConfig` before spawning this —
+      // this guard is defensive only and cannot fire in practice.
+      finishTerminal(.failed(.prepareFailed), sid: sid)
+      return
+    }
+    // Preparing: configure VAD from the frozen session config, bind capture
+    // callbacks, derive decode options (PR-4 plan §3.3a).
     audioCapture.configureVAD(
-      autoStop: true, silenceTimeout: 0, sensitivity: 0, energyGate: false)
+      autoStop: config.vadAutoStop,
+      silenceTimeout: config.vadSilenceTimeout,
+      sensitivity: config.vadSensitivity,
+      energyGate: config.vadEnergyGate)
     bindCaptureCallbacks(sid)
     subscribeVADSignals(sid)
 
     guard isCurrent(sid) else { return }
     if stopLatched {
       // PTT released before `recording` — no transcribable audio (PR-1 §B.1.2).
+      discardReason = .releasedBeforeRecording
       finishTerminal(.discarded, sid: sid)
       return
     }
@@ -404,6 +459,7 @@ final class RecordingSessionKernel {
         finishTerminal(.cancelled, sid: sid)
         return
       case .stopped:
+        discardReason = .releasedBeforeRecording
         finishTerminal(.discarded, sid: sid)
         return
       }
@@ -421,6 +477,7 @@ final class RecordingSessionKernel {
     // The capture engine is up — every terminal from here must stop capture.
     captureLifecycle = .active
     if stopLatched {
+      discardReason = .releasedBeforeRecording
       finishTerminal(.discarded, sid: sid)
       return
     }
@@ -445,9 +502,10 @@ final class RecordingSessionKernel {
     }
     guard isCurrent(sid) else { return }
 
-    // Begin the adapter session.
+    // Begin the adapter session. Decode options derive from the frozen
+    // session config's language mode (PR-4 plan §3.3a).
     do {
-      try await adapter.beginSession(sid, options: TranscriptionOptions.default)
+      try await adapter.beginSession(sid, options: makeTranscriptionOptions(config))
     } catch {
       guard isCurrent(sid) else { return }
       audioCapture.onBufferCaptured = nil
@@ -458,11 +516,15 @@ final class RecordingSessionKernel {
     // The adapter now holds an open session — a terminal before `finalize()`
     // must discard it via `adapter.cancel()` (`finishTerminal` does this).
     adapterSessionActive = true
+    // The adapter ran a session this run — the terminal applies the
+    // model-unload policy exactly once (PR-4 plan §3.2).
+    adapterDidBeginSession = true
     // Final latch check before `recording` — a stop / cancel that arrived
     // while `beginCapturePhase()` / `beginSession()` was suspended set only
     // `stopLatched` / `cancelRequested` (the FSM was still `warmingUp`); it
     // must be consumed here, not lost on the way into `recording` (Codex P1).
     if stopLatched {
+      discardReason = .releasedBeforeRecording
       finishTerminal(.discarded, sid: sid)
       return
     }
@@ -517,6 +579,7 @@ final class RecordingSessionKernel {
     // Sub-minimum-duration proxy: zero buffers handed off ⇒ discarded
     // (PR-1 §B.1.2 `recording → discarded`).
     if bufferCountThisSession == 0 {
+      discardReason = .tooShort
       finishTerminal(.discarded, sid: sid)
       return
     }
@@ -716,18 +779,29 @@ final class RecordingSessionKernel {
 
   // MARK: Capture callbacks + buffer handoff
 
+  /// Bind the recording-exit callbacks for this session — the capture-layer
+  /// signals and the adapter's mid-recording engine-crash signal (PR-4 plan
+  /// §3.2). VAD auto-stop is NOT bound here: it flows through `vad.stopSignals`
+  /// only, with `CaptureVADSignalSource` the single owner of
+  /// `AudioCaptureInterface.onVADAutoStop` (PR-4 plan §3.5).
   private func bindCaptureCallbacks(_ sid: SessionID) {
     audioCapture.onEngineInterrupted = { [weak self] in
       self?.deliverRecordingExitIfCurrent(.audioInterruption, sid: sid)
     }
-    audioCapture.onCaptureStalled = { [weak self] _ in
-      self?.deliverRecordingExitIfCurrent(.captureStall, sid: sid)
+    audioCapture.onCaptureStalled = { [weak self] ctx in
+      guard let self else { return }
+      // Fan the raw context to telemetry (PR-4 plan §3.9), then route the
+      // control-flow exit. The exit only latches; ordering is immaterial.
+      self.captureStallTelemetry(ctx)
+      self.deliverRecordingExitIfCurrent(.captureStall, sid: sid)
     }
     audioCapture.onXPCServiceError = { [weak self] _ in
       self?.deliverRecordingExitIfCurrent(.asrInterruption, sid: sid)
     }
-    audioCapture.onVADAutoStop = { [weak self] in
-      self?.deliverRecordingExitIfCurrent(.vadAutoStop, sid: sid)
+    // The adapter's own backend crashing mid-recording (distinct XPC layer
+    // from `onXPCServiceError`'s audio-capture service) — PR-4 plan §3.2.
+    adapter.onEngineInterrupted = { [weak self] in
+      self?.deliverRecordingExitIfCurrent(.asrInterruption, sid: sid)
     }
   }
 
@@ -735,26 +809,26 @@ final class RecordingSessionKernel {
   /// `Task { @MainActor }` per-buffer hop pattern). The audio-thread closure
   /// does the minimum — wrap + hop; the `@MainActor` side gates on
   /// `SessionID` + FSM state, then forwards to the adapter.
+  ///
+  /// PR-4 plan §3.4: the carrier holds the `AVAudioPCMBuffer` directly. The
+  /// audio thread transfers it via `nonisolated(unsafe)` — the buffer is
+  /// created on the audio thread, wrapped once, and read only on `@MainActor`,
+  /// never from two threads (the shipped pattern, `TranscriptionPipeline.swift:483`).
   private func makeBufferCallback(_ sid: SessionID) -> (@Sendable (AVAudioPCMBuffer) -> Void) {
     return { [weak self] buffer in
-      let pcm = Self.extractSamples(buffer)
+      nonisolated(unsafe) let safeBuffer = buffer
       let frameCount = Int(buffer.frameLength)
       Task { @MainActor [weak self] in
         guard let self, self.isCurrent(sid), self.state == .recording else { return }
         self.bufferSequence += 1
         let handoff = AudioBufferHandoff(
-          pcm: pcm, frameCount: frameCount, sequence: self.bufferSequence, sessionID: sid)
+          buffer: safeBuffer, frameCount: frameCount,
+          sequence: self.bufferSequence, sessionID: sid)
         self.adapter.acceptAudio(handoff)
         self.bufferCountThisSession += 1
         self.bump()
       }
     }
-  }
-
-  private nonisolated static func extractSamples(_ buffer: AVAudioPCMBuffer) -> [Float] {
-    let count = Int(buffer.frameLength)
-    guard count > 0, let channel = buffer.floatChannelData?[0] else { return [] }
-    return Array(UnsafeBufferPointer(start: channel, count: count))
   }
 
   // MARK: VAD subscription
@@ -913,7 +987,9 @@ final class RecordingSessionKernel {
     audioCapture.onEngineInterrupted = nil
     audioCapture.onCaptureStalled = nil
     audioCapture.onXPCServiceError = nil
-    audioCapture.onVADAutoStop = nil
+    // `onVADAutoStop` is NOT cleared here — the kernel never owns it
+    // (`CaptureVADSignalSource` is the single owner, PR-4 plan §3.5).
+    adapter.onEngineInterrupted = nil
     drainTaskBag()
 
     // Discard the adapter's open session — the only discard hook is
@@ -922,6 +998,14 @@ final class RecordingSessionKernel {
     if adapterSessionActive {
       adapterSessionActive = false
       detachedAdapterCancel()
+    }
+
+    // Apply the model-unload policy once for any session that ran the adapter
+    // (PR-4 plan §3.2) — the kernel-era equivalent of today's
+    // post-transcription `noteTranscriptionComplete(policy:)`.
+    if adapterDidBeginSession {
+      adapterDidBeginSession = false
+      adapter.applyUnloadPolicy(sessionConfig?.modelUnloadPolicy ?? .never)
     }
 
     // Stop the capture engine. `resourcesReleased` flips true only once the
@@ -999,6 +1083,7 @@ final class RecordingSessionKernel {
     bufferSequence = 0
     captureLifecycle = .notStarted
     adapterSessionActive = false
+    adapterDidBeginSession = false
     loadTickCount = 0
     finalizeTickCount = 0
     lastLoadTickAt = 0
@@ -1009,8 +1094,24 @@ final class RecordingSessionKernel {
     finalizingSubStatus = .transcribing
     deliveredTranscript = nil
     deliveryOutcome = nil
+    discardReason = nil
     pasteCount = 0
     forbiddenTransitionRejected = false
+  }
+
+  /// Derive decode options from the frozen session config's language mode
+  /// (PR-4 plan §3.3a — mirrors `TranscriptionPipeline.applySessionConfig`).
+  private func makeTranscriptionOptions(_ config: DictationSessionConfig)
+    -> TranscriptionOptions
+  {
+    var options = TranscriptionOptions()
+    switch config.languageMode {
+    case .auto:
+      options.language = nil
+    case .locked(let code):
+      options.language = code
+    }
+    return options
   }
 
   private func classifyCaptureStartError(_ error: Error) -> RecordingFailureReason {

--- a/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+// MARK: - AdapterShapeTests (epic #827, PR-4 §3.11)
+//
+// The lightweight precursor to PR-9's permanent kernel-ownership freeze test.
+// An `ASREngineAdapter` owns its own ASR and rescue and NOTHING else (epic §4):
+// it must never grow a second orchestration brain. This suite scans the
+// adapter source for tokens that signal a recording-session FSM leaking into
+// the adapter — `RecordingSessionState`, `transition(`, kernel trigger method
+// DEFINITIONS, FSM-style `state =` mutation.
+//
+// It does NOT ban legitimate engine-session bookkeeping (a streaming-active
+// flag, the retained PCM buffer, an in-flight-load flag, a terminal flag) —
+// those are required to satisfy the `ASREngineAdapter` MUST / MUST NOT clauses
+// (Codex finding 46). The positive / adversarial / negative-control tests
+// below pin that boundary.
+
+@Suite struct AdapterShapeTests {
+
+  /// A token that, present in an adapter source file, signals a second
+  /// orchestration brain. Each pattern is a whole-token regex.
+  private static let fsmTokenPatterns: [String] = [
+    #"\bRecordingSessionState\b"#,  // the kernel's FSM state enum
+    #"\btransition\("#,  // an FSM transition call
+    #"func\s+requestStop\b"#,  // a kernel trigger method, DEFINED in the adapter
+    #"func\s+cancelRecording\b"#,  // a kernel trigger method, DEFINED in the adapter
+    #"\bstate\s*="#,  // FSM-style mutation of a property named `state`
+  ]
+
+  private static let adapterRelativePath =
+    "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift"
+
+  // MARK: Positive — the real adapter passes
+
+  @Test("the production ParakeetEngineAdapter carries no FSM tokens")
+  func realAdapterIsClean() throws {
+    let url = repoRoot().appending(path: Self.adapterRelativePath)
+    let source = try String(contentsOf: url, encoding: .utf8)
+    let violations = Self.scan(source)
+    #expect(
+      violations.isEmpty,
+      """
+      ParakeetEngineAdapter.swift carries orchestration-FSM tokens:
+      \(violations.joined(separator: "\n"))
+      An adapter owns ASR + rescue only — the kernel owns the recording-session
+      FSM (epic §4, PR-4 §3.11).
+      """)
+  }
+
+  // MARK: Adversarial — an adapter with FSM tokens fails
+
+  @Test("an adapter source with a transition call is flagged")
+  func adversarialTransitionCall() {
+    let source = """
+      @MainActor final class RogueAdapter: ASREngineAdapter {
+        private var state: RecordingSessionState = .idle
+        func finalize() async -> ASREngineOutcome {
+          transition(to: .completed)
+          return .cancelled
+        }
+      }
+      """
+    let violations = Self.scan(source)
+    #expect(!violations.isEmpty, "RecordingSessionState + transition( + state = must be flagged")
+  }
+
+  @Test("an adapter that defines a kernel trigger method is flagged")
+  func adversarialTriggerDefinition() {
+    let source = """
+      @MainActor final class RogueAdapter: ASREngineAdapter {
+        func requestStop() { }
+      }
+      """
+    #expect(!Self.scan(source).isEmpty, "a defined kernel trigger method must be flagged")
+  }
+
+  // MARK: Negative control — legitimate session bookkeeping passes
+
+  @Test("an adapter with legitimate engine-session bookkeeping is not flagged")
+  func negativeControlBookkeepingPasses() {
+    let source = """
+      @MainActor final class CleanAdapter: ASREngineAdapter {
+        private var streamingActive = false
+        private var isTerminal = false
+        private var isCancelled = false
+        private var isLoadInFlight = false
+        private var retainedPCM: [Float] = []
+        func cancel() async {
+          isCancelled = true
+          isTerminal = true
+          retainedPCM.removeAll()
+        }
+      }
+      """
+    #expect(
+      Self.scan(source).isEmpty,
+      "session bookkeeping flags / buffers are allowed — only FSM tokens are banned")
+  }
+
+  // MARK: Scanner
+
+  /// Return `"line N: text"` for every line carrying an FSM token.
+  static func scan(_ source: String) -> [String] {
+    let regexes = fsmTokenPatterns.compactMap { try? NSRegularExpression(pattern: $0) }
+    var violations: [String] = []
+    for (idx, line) in source.split(
+      separator: "\n", omittingEmptySubsequences: false
+    ).enumerated() {
+      let text = String(line)
+      let ns = text as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      for regex in regexes where regex.firstMatch(in: text, range: range) != nil {
+        violations.append("line \(idx + 1): \(text.trimmingCharacters(in: .whitespaces))")
+        break
+      }
+    }
+    return violations
+  }
+
+  /// Repo root, anchored off `#filePath` — this file lives at
+  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
+  private func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
@@ -1,0 +1,80 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - CaptureVADSignalSourceTests (epic #827, PR-4 §11.4)
+//
+// Unit coverage for `CaptureVADSignalSource` — signal bridging, the
+// `speechEvidenceAtStop()` tri-state, and `SessionID` stamping.
+
+@MainActor
+@Suite struct CaptureVADSignalSourceTests {
+
+  @Test("noteAutoStopTriggered yields an autoStop signal stamped with the current session")
+  func autoStopBridging() async {
+    let source = CaptureVADSignalSource()
+    let sid = SessionID()
+    source.setCurrentSessionID(sid)
+    var iterator = source.stopSignals.makeAsyncIterator()
+    source.noteAutoStopTriggered()
+    let signal = await iterator.next()
+    #expect(signal == VADStopSignal(kind: .autoStopTriggered, sessionID: sid))
+  }
+
+  @Test("noteMaxDurationReached yields a maxDuration signal")
+  func maxDurationBridging() async {
+    let source = CaptureVADSignalSource()
+    let sid = SessionID()
+    source.setCurrentSessionID(sid)
+    var iterator = source.stopSignals.makeAsyncIterator()
+    source.noteMaxDurationReached()
+    let signal = await iterator.next()
+    #expect(signal == VADStopSignal(kind: .maxDurationReached, sessionID: sid))
+  }
+
+  @Test("bind claims onVADAutoStop — the XPC callback drives a stop signal")
+  func bindOwnsXPCCallback() async {
+    let source = CaptureVADSignalSource()
+    let capture = FakeAudioCapture()
+    let sid = SessionID()
+    source.setCurrentSessionID(sid)
+    source.bind(audioCapture: capture)
+    var iterator = source.stopSignals.makeAsyncIterator()
+    capture.fireVADAutoStop()  // the XPC service-side detector fires
+    let signal = await iterator.next()
+    #expect(signal == VADStopSignal(kind: .autoStopTriggered, sessionID: sid))
+  }
+
+  @Test("each signal carries the session current at emit time")
+  func sessionStamping() async {
+    let source = CaptureVADSignalSource()
+    let first = SessionID()
+    let second = SessionID()
+    var iterator = source.stopSignals.makeAsyncIterator()
+
+    source.setCurrentSessionID(first)
+    source.noteAutoStopTriggered()
+    source.setCurrentSessionID(second)
+    source.noteAutoStopTriggered()
+
+    let a = await iterator.next()
+    let b = await iterator.next()
+    #expect(a?.sessionID == first)
+    #expect(b?.sessionID == second, "a re-stamped session is reflected in later signals")
+  }
+
+  @Test("speechEvidenceAtStop returns the configured tri-state")
+  func evidenceTriState() {
+    let source = CaptureVADSignalSource()
+    // Default — no detector ran.
+    #expect(source.speechEvidenceAtStop() == .unavailable)
+
+    source.setEvidenceProvider { .voiced }
+    #expect(source.speechEvidenceAtStop() == .voiced)
+
+    source.setEvidenceProvider { .confirmedNoSpeech }
+    #expect(source.speechEvidenceAtStop() == .confirmedNoSpeech)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -1,0 +1,171 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelDictationDriverTests (epic #827, PR-4 §11.4)
+//
+// Unit coverage for `KernelDictationDriver` — the state / overlay maps, the
+// PipelineEvent dispatch, the external-error surface, and the no-op contracts.
+
+@MainActor
+@Suite struct KernelDictationDriverTests {
+
+  // MARK: RecordingSessionState -> PipelineState map (pure, total)
+
+  @Test("the state map is total and isActive holds for every active kernel state")
+  func stateMapIsTotal() {
+    func mapped(_ s: RecordingSessionState) -> PipelineState {
+      KernelDictationDriver.pipelineState(for: s, externalError: nil)
+    }
+    // Idle-class terminals collapse to idle (silent — no error surface).
+    #expect(mapped(.idle) == .idle)
+    #expect(mapped(.cancelled) == .idle)
+    #expect(mapped(.discarded) == .idle)
+    #expect(mapped(.noSpeech) == .idle)
+    // Active states — every one must report `isActive` so the backend-switch
+    // guard (`PipelineSettingsSync`, §3.13) sees the kernel session as active.
+    for s: RecordingSessionState in [
+      .preparing, .warmingUp, .recording, .stopping, .transcribing, .finalizing,
+    ] {
+      #expect(mapped(s).isActive, "\(s) must map to an active PipelineState")
+    }
+    #expect(mapped(.recording) == .recording)
+    #expect(mapped(.completed) == .complete)
+    // Error-surface terminals.
+    if case .error = mapped(.failed(.asrEmpty)) {
+    } else {
+      Issue.record("failed should map to .error")
+    }
+    if case .error = mapped(.audioInterrupted) {
+    } else {
+      Issue.record("audioInterrupted should map to .error")
+    }
+    if case .error = mapped(.asrInterrupted) {
+    } else {
+      Issue.record("asrInterrupted should map to .error")
+    }
+  }
+
+  @Test("an external error overrides the mapped state")
+  func externalErrorOverridesState() {
+    #expect(
+      KernelDictationDriver.pipelineState(for: .idle, externalError: "boom") == .error("boom"))
+    #expect(
+      KernelDictationDriver.pipelineState(for: .recording, externalError: "boom")
+        == .error("boom"))
+  }
+
+  @Test("failureMessage mirrors the shipped strings for the equivalent failures")
+  func failureMessages() {
+    #expect(KernelDictationDriver.failureMessage(.asrEmpty) == "Couldn't catch that -- try again")
+    #expect(KernelDictationDriver.failureMessage(.noAudioCaptured) == "No audio captured")
+    #expect(KernelDictationDriver.failureMessage(.storageFailed) == "Failed to save transcript")
+    #expect(
+      KernelDictationDriver.failureMessage(.emptyAfterProcessing)
+        == "No speech detected. Your clipboard is unchanged. Try again.")
+  }
+
+  // MARK: handle(event:) -> kernel triggers
+
+  @Test("handle(.toggleRecording) from idle starts a kernel session")
+  func toggleRecordingStarts() async throws {
+    let h = makeDriver()
+    try await h.driver.handle(event: .toggleRecording(.testDefault()))
+    await drainUntil { h.kernel.state == .recording }
+    #expect(h.kernel.state == .recording)
+    #expect(h.driver.state == .recording)
+  }
+
+  @Test("handle(.toggleRecording) while recording requests a stop")
+  func toggleRecordingWhileActiveStops() async throws {
+    let h = makeDriver()
+    try await h.driver.handle(event: .toggleRecording(.testDefault()))
+    await drainUntil { h.kernel.state == .recording }
+    try await h.driver.handle(event: .toggleRecording(.testDefault()))
+    await drainUntil { h.kernel.state.isTerminal }
+    #expect(h.kernel.state.isTerminal, "the second toggle drove the session to a terminal")
+  }
+
+  // MARK: External-error surface
+
+  @Test("setExternalError surfaces .error on state and overlay")
+  func setExternalErrorSurfaces() {
+    let h = makeDriver()
+    h.driver.setExternalError("device unplugged")
+    #expect(h.driver.state == .error("device unplugged"))
+    #expect(h.driver.overlayIntent == .error(message: "device unplugged"))
+  }
+
+  @Test("a new start clears the external error")
+  func startClearsExternalError() async throws {
+    let h = makeDriver()
+    h.driver.setExternalError("device unplugged")
+    try await h.driver.handle(event: .toggleRecording(.testDefault()))
+    await drainUntil { h.kernel.state == .recording }
+    #expect(h.driver.state != .error("device unplugged"))
+  }
+
+  @Test("clearPendingStallRecovery is an inert no-op")
+  func clearPendingStallRecoveryIsNoOp() {
+    let h = makeDriver()
+    let before = h.driver.state
+    h.driver.clearPendingStallRecovery()
+    #expect(h.driver.state == before)
+  }
+
+  // MARK: currentTranscript / lastPolishError side-channel
+
+  @Test("currentTranscript and lastPolishError read the finalization side-channel")
+  func sideChannelReads() {
+    let h = makeDriver()
+    #expect(h.driver.currentTranscript == nil)
+    h.outcome.transcript = Transcript(text: "hello world")
+    h.outcome.polishError = "polish timed out"
+    #expect(h.driver.currentTranscript?.text == "hello world")
+    #expect(h.driver.lastPolishError == "polish timed out")
+  }
+
+  // MARK: Helpers
+
+  private struct Harness {
+    let driver: KernelDictationDriver
+    let kernel: RecordingSessionKernel
+    let outcome: KernelFinalizationOutcome
+  }
+
+  private func makeDriver() -> Harness {
+    let kernel = RecordingSessionKernel(
+      adapter: FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock()),
+      audioCapture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 },
+      sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _ in },
+      deliver: { _ in .pasted })
+    let observer = KernelHeartPathTelemetryObserver(
+      kernel: kernel, audioCapture: FakeAudioCapture(), emitLifecycleEvent: { _ in })
+    let outcome = KernelFinalizationOutcome()
+    let steps = LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()))
+    let driver = KernelDictationDriver(
+      kernel: kernel, observer: observer, outcome: outcome,
+      context: KernelSessionContext(), steps: steps)
+    driver.start()
+    return Harness(driver: driver, kernel: kernel, outcome: outcome)
+  }
+
+  private func drainUntil(_ condition: @MainActor () -> Bool) async {
+    for _ in 0..<2000 {
+      if condition() { return }
+      await Task.yield()
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -1,0 +1,169 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelFinalizationWiringTests (epic #827, PR-4 §11.4)
+//
+// Unit coverage for `KernelFinalizationWiring` — the processText / store /
+// deliver closures and the wedge-tuning constants. `save` / `deliverPaste`
+// are fake closures so the suite touches neither disk nor the AX paste APIs.
+
+@MainActor
+@Suite struct KernelFinalizationWiringTests {
+
+  // MARK: Wedge tuning (PR-4 §3.6)
+
+  @Test("wedge tuning is precedent-derived: 10 ticks x 100ms = a 1.0s window")
+  func wedgeTuning() {
+    #expect(KernelFinalizationWiring.wedgeStallTicks == 10)
+    #expect(KernelFinalizationWiring.tickDurationSeconds == 0.1)
+    // 1.0 s window >= LoadProgressWatcher's 0.8 s silence floor.
+    let windowSeconds =
+      Double(KernelFinalizationWiring.wedgeStallTicks)
+      * KernelFinalizationWiring.tickDurationSeconds
+    #expect(windowSeconds >= 0.8)
+  }
+
+  @Test("the logical clock advances and sleepTicks returns")
+  func clock() async {
+    let wiring = makeWiring()
+    let first = wiring.currentTick()
+    #expect(first == wiring.currentTick() || wiring.currentTick() >= first)
+    await wiring.sleepTicks(0)  // a zero-tick sleep returns promptly
+  }
+
+  // MARK: processText
+
+  @Test("processText runs the limb chain and writes the polish side-channel")
+  func processTextWritesSideChannel() async throws {
+    let outcome = KernelFinalizationOutcome()
+    let wiring = makeWiring(outcome: outcome)
+    let result = try await wiring.processText("hello there") {}
+    #expect(!result.isEmpty)
+    #expect(outcome.rawText != nil, "the raw ASR text is recorded for the store closure")
+  }
+
+  @Test("processText wires onPolishStarted into LLMPolishStep.onWillProcess")
+  func processTextWiresPolishSignal() async throws {
+    let steps = makeSteps()
+    let wiring = makeWiring(steps: steps)
+    let signal = SignalFlag()
+    _ = try await wiring.processText("hello") { signal.fired = true }
+    // The closure is now installed on the polish step — the limb emits, the
+    // kernel observes (D18 closed, PR-4 §3.8).
+    steps.llmPolish.onWillProcess?()
+    #expect(signal.fired)
+  }
+
+  // MARK: store
+
+  @Test("store builds the Transcript from the side-channel and persists it")
+  func storeBuildsAndSaves() async throws {
+    let outcome = KernelFinalizationOutcome()
+    outcome.rawText = "raw asr text"
+    outcome.polishedText = "polished text"
+    outcome.llmProvider = "openai"
+    outcome.llmModel = "gpt-4o-mini"
+    let saved = SavedTranscriptBox()
+    let wiring = makeWiring(outcome: outcome, save: { saved.transcript = $0 })
+
+    try await wiring.store("polished text")
+
+    #expect(saved.transcript?.text == "raw asr text")
+    #expect(saved.transcript?.polishedText == "polished text")
+    #expect(saved.transcript?.backendType == .parakeet)
+    #expect(saved.transcript?.llmProvider == "openai")
+    #expect(outcome.transcript?.text == "raw asr text", "the driver reads the transcript here")
+  }
+
+  @Test("store rethrows a storage failure so the kernel routes failed(storageFailed)")
+  func storeRethrows() async {
+    let wiring = makeWiring(save: { _ in throw WiringTestError.storage })
+    await #expect(throws: WiringTestError.self) {
+      try await wiring.store("text")
+    }
+  }
+
+  // MARK: deliver
+
+  @Test("deliver pastes when auto-paste is on and the cascade delivered")
+  func deliverPastes() async {
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true)
+    let wiring = makeWiring(context: context, deliverPaste: { _ in Self.deliveredResult })
+    let outcome = await wiring.deliver("hello")
+    #expect(outcome == .pasted)
+  }
+
+  @Test("deliver reports clipboardOnly when the cascade fell back")
+  func deliverClipboardFallback() async {
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true)
+    let wiring = makeWiring(context: context, deliverPaste: { _ in Self.clipboardResult })
+    let outcome = await wiring.deliver("hello")
+    #expect(outcome == .clipboardOnly)
+  }
+
+  @Test("deliver reports clipboardOnly for a copy-to-clipboard-only session")
+  func deliverCopyOnly() async {
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoCopyToClipboard: true, autoPasteToActiveApp: false)
+    let wiring = makeWiring(context: context, deliverPaste: { _ in Self.deliveredResult })
+    let outcome = await wiring.deliver("hello")
+    #expect(outcome == .clipboardOnly, "no auto-paste => never .pasted")
+  }
+
+  // MARK: Helpers
+
+  private static let deliveredResult = PasteDeliveryResult(
+    tier: .cgEvent, durationMs: 5,
+    outcome: .delivered(tier: .cgEvent, durationMs: 5))
+
+  private static let clipboardResult = PasteDeliveryResult(
+    tier: .clipboardOnly, durationMs: 1,
+    outcome: .clipboardOnlyAccessibilityDenied(targetBundleID: nil))
+
+  private func makeSteps() -> LimbSteps {
+    LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()))
+  }
+
+  private func makeWiring(
+    outcome: KernelFinalizationOutcome = KernelFinalizationOutcome(),
+    context: KernelSessionContext = KernelSessionContext(),
+    steps: LimbSteps? = nil,
+    save: @escaping @MainActor (Transcript) throws -> Void = { _ in },
+    deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult = {
+      _ in Self.deliveredResult
+    }
+  ) -> KernelFinalizationWiring {
+    KernelFinalizationWiring(
+      outcome: outcome,
+      context: context,
+      adapter: ParakeetEngineAdapter(asrManager: StubParakeetASRManager()),
+      steps: steps ?? makeSteps(),
+      textProcessingRunner: TextProcessingRunner(),
+      save: save,
+      deliverPaste: deliverPaste,
+      pasteCompletionRegistry: nil)
+  }
+}
+
+private enum WiringTestError: Error { case storage }
+
+@MainActor
+private final class SignalFlag {
+  var fired = false
+}
+
+@MainActor
+private final class SavedTranscriptBox {
+  var transcript: Transcript?
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -1,0 +1,195 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelHeartPathTelemetryObserverTests (epic #827, PR-4 §11.4)
+//
+// Unit coverage for `KernelHeartPathTelemetryObserver` — the lifecycle-event
+// map, the raw-state observation wiring (every terminal emits despite mapping
+// to a `.hidden` overlay), and the `onCaptureStalled` fan-out.
+//
+// `#if DEBUG`-gated: the observation tests drive the kernel through
+// `testForceTransition`, a `#if DEBUG`-only hook. `build-check` never compiles
+// the test target in release, but the gate keeps a release-config test build
+// honest (PR #838 / `gotchas-release.md`).
+
+#if DEBUG
+
+@MainActor
+@Suite struct KernelHeartPathTelemetryObserverTests {
+
+  // MARK: lifecycleEvent map — pure
+
+  @Test("every terminal state maps to a lifecycle event, including .hidden-overlay terminals")
+  func everyTerminalMapsToAnEvent() {
+    // completed / cancelled / discarded / noSpeech all render a `.hidden`
+    // overlay — a UI-keyed observer would miss them. The observer keys on raw
+    // state, so each still produces an event.
+    #expect(event(.completed) == .pipelineCompleted)
+    #expect(event(.cancelled) == .cancelled)
+    #expect(event(.noSpeech) == .noSpeech)
+    #expect(event(.audioInterrupted) == .audioInterrupted)
+    #expect(event(.asrInterrupted) == .asrInterrupted)
+    #expect(event(.failed(.asrEmpty)) == .failed(.asrEmpty))
+  }
+
+  @Test("the discarded event carries the abort reason")
+  func discardedCarriesReason() {
+    #expect(
+      KernelHeartPathTelemetryObserver.lifecycleEvent(
+        for: .discarded, discardReason: .tooShort) == .discarded(.tooShort))
+    #expect(
+      KernelHeartPathTelemetryObserver.lifecycleEvent(
+        for: .discarded, discardReason: .releasedBeforeRecording)
+        == .discarded(.releasedBeforeRecording))
+  }
+
+  @Test("non-event states map to nil")
+  func nonEventStatesMapToNil() {
+    for state: RecordingSessionState in [.idle, .preparing, .warmingUp, .stopping, .finalizing] {
+      #expect(
+        KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil) == nil)
+    }
+  }
+
+  // MARK: Raw-state observation wiring
+
+  @Test("the observer emits lifecycle events as the kernel transitions")
+  func emitsOnTransition() async {
+    let recorder = EventRecorder()
+    let kernel = makeKernel()
+    let observer = makeObserver(kernel: kernel, recorder: recorder)
+    observer.start()
+
+    // Force a legal happy-path sequence — the observer keys on raw `state`.
+    kernel.testForceTransition(to: .preparing)
+    await drain()
+    kernel.testForceTransition(to: .recording)
+    await drain()
+    kernel.testForceTransition(to: .stopping)
+    await drain()
+    kernel.testForceTransition(to: .transcribing)
+    await drain()
+    kernel.testForceTransition(to: .finalizing)
+    await drain()
+    kernel.testForceTransition(to: .completed)
+    await drain()
+
+    #expect(recorder.events == [.recordingCommitted, .transcriptionStarted, .pipelineCompleted])
+  }
+
+  @Test("a cancelled terminal emits even though it renders a hidden overlay")
+  func cancelledTerminalEmits() async {
+    let recorder = EventRecorder()
+    let kernel = makeKernel()
+    let observer = makeObserver(kernel: kernel, recorder: recorder)
+    observer.start()
+
+    kernel.testForceTransition(to: .preparing)
+    await drain()
+    kernel.testForceTransition(to: .cancelled)
+    await drain()
+
+    #expect(recorder.events == [.cancelled])
+  }
+
+  // MARK: onCaptureStalled fan-out
+
+  @Test("a capture stall fans out to the observer's telemetry emitter")
+  func captureStallFanout() async {
+    // The kernel-side control flow (stall -> failed(captureStalled)) is covered
+    // by the simulator's capture-stall scenario; this test pins the new PR-4
+    // fan-out: the kernel's captureStallTelemetry seam reaches the observer.
+    let stallRecorder = StallRecorder()
+    let emitter = HeartPathTelemetryEmitter(
+      backend: .parakeet,
+      captureTelemetry: CaptureTelemetryState(),
+      captureError: { error, _, _, _ in stallRecorder.note(error) },
+      addBreadcrumb: { _, _, _ in })
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    let capture = FakeAudioCapture()
+    let observerHolder = ObserverHolder()
+    let kernel = RecordingSessionKernel(
+      adapter: engine,
+      audioCapture: capture,
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 },
+      sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _ in },
+      deliver: { _ in .pasted },
+      captureStallTelemetry: { ctx in observerHolder.observer?.handleCaptureStall(ctx) })
+    let observer = KernelHeartPathTelemetryObserver(
+      kernel: kernel, audioCapture: capture, emitter: emitter, emitLifecycleEvent: { _ in })
+    observerHolder.observer = observer
+    observer.start()
+
+    kernel.start(config: .testDefault())
+    await drainUntil { kernel.state == .recording }
+
+    capture.fireCaptureStalled()
+    await drain()
+
+    #expect(stallRecorder.count == 1, "the capture-stall context reached the observer's emitter")
+  }
+
+  // MARK: Helpers
+
+  private func event(_ state: RecordingSessionState) -> KernelLifecycleEvent? {
+    KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil)
+  }
+
+  private func makeKernel() -> RecordingSessionKernel {
+    RecordingSessionKernel(
+      adapter: FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock()),
+      audioCapture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 },
+      sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _ in },
+      deliver: { _ in .pasted })
+  }
+
+  private func makeObserver(
+    kernel: RecordingSessionKernel, recorder: EventRecorder
+  ) -> KernelHeartPathTelemetryObserver {
+    KernelHeartPathTelemetryObserver(
+      kernel: kernel,
+      audioCapture: FakeAudioCapture(),
+      emitLifecycleEvent: { recorder.events.append($0) })
+  }
+
+  private func drain() async {
+    for _ in 0..<100 { await Task.yield() }
+  }
+
+  private func drainUntil(_ condition: @MainActor () -> Bool) async {
+    for _ in 0..<2000 {
+      if condition() { return }
+      await Task.yield()
+    }
+  }
+}
+
+@MainActor
+private final class EventRecorder {
+  var events: [KernelLifecycleEvent] = []
+}
+
+@MainActor
+private final class StallRecorder {
+  private(set) var count = 0
+  func note(_ error: any Error) { count += 1 }
+}
+
+@MainActor
+private final class ObserverHolder {
+  weak var observer: KernelHeartPathTelemetryObserver?
+}
+
+#endif  // DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -1,0 +1,323 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - ParakeetEngineAdapterTests (epic #827, PR-4 §11.4)
+//
+// Unit coverage for `ParakeetEngineAdapter` — the production `ASREngineAdapter`
+// Parakeet conformer. Drives a configurable `StubParakeetASRManager`; the PR-1 §B.2.2
+// MUST / MUST NOT clauses get adversarial coverage.
+
+@MainActor
+@Suite struct ParakeetEngineAdapterTests {
+
+  // MARK: Capabilities + readiness
+
+  @Test("capabilities: Parakeet streams, detects no language")
+  func capabilities() {
+    let adapter = ParakeetEngineAdapter(asrManager: StubParakeetASRManager())
+    #expect(adapter.capabilities.supportsStreaming)
+    #expect(!adapter.capabilities.supportsLanguageDetection)
+  }
+
+  @Test("readiness reflects the ASR manager's load state")
+  func readiness() {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    #expect(adapter.readiness == .notReady)
+    manager.isModelLoaded = true
+    #expect(adapter.readiness == .ready)
+  }
+
+  // MARK: warmUp
+
+  @Test("warmUp() loads the model when not loaded")
+  func warmUpLoads() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.warmUp()
+    #expect(manager.loadModelCount == 1)
+  }
+
+  @Test("warmUp() is idempotent — a no-op when already loaded")
+  func warmUpIdempotent() async throws {
+    let manager = StubParakeetASRManager()
+    manager.isModelLoaded = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.warmUp()
+    #expect(manager.loadModelCount == 0)
+  }
+
+  // MARK: Streaming finalize + batch rescue (§3.2a)
+
+  @Test("finalize: streaming success returns the streaming transcript")
+  func streamingSuccess() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("streamed text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    let outcome = await adapter.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "streamed text")
+    #expect(manager.transcribeCount == 0, "no batch rescue when streaming succeeds")
+  }
+
+  @Test("finalize: streaming empty + speech evidence runs the batch rescue over retained PCM")
+  func streamingEmptyTriggersBatchRescue() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("")  // streaming returns empty
+    manager.transcribeResult = makeResult("rescued text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.1, 0.2, 0.3])
+    feed(adapter, samples: [0.4, 0.5])
+    let outcome = await adapter.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "rescued text")
+    #expect(manager.transcribeCount == 1, "the batch rescue ran")
+    #expect(
+      manager.lastTranscribeSamples == [0.1, 0.2, 0.3, 0.4, 0.5],
+      "the batch rescue decoded the retained session PCM")
+  }
+
+  @Test("finalize: streaming-finalize throwing falls back to the batch rescue")
+  func streamingThrowTriggersBatchRescue() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingThrows = true
+    manager.transcribeResult = makeResult("rescued after throw")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.7])
+    let outcome = await adapter.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "rescued after throw")
+  }
+
+  @Test("finalize: streaming + batch both empty returns .empty(hadSpeechEvidence: true)")
+  func bothEmpty() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("")
+    manager.transcribeResult = makeResult("")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.1])
+    let outcome = await adapter.finalize()
+    guard case .empty(let hadSpeechEvidence) = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(hadSpeechEvidence, "past the kernel's VAD gate, an empty decode is a real ASR failure")
+  }
+
+  // MARK: Retained-PCM lifecycle
+
+  @Test("retained PCM is cleared on finalize()")
+  func pcmClearedOnFinalize() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("")
+    manager.transcribeResult = makeResult("x")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.1, 0.2])
+    _ = await adapter.finalize()
+    // A fresh session must not see the prior session's PCM. Streaming empty +
+    // a no-op batch over zero retained samples => .empty.
+    manager.transcribeCount = 0
+    manager.lastTranscribeSamples = []
+    try await adapter.beginSession(SessionID(), options: .default)
+    let outcome = await adapter.finalize()
+    guard case .empty = outcome else {
+      Issue.record("expected .empty over cleared PCM, got \(outcome)")
+      return
+    }
+    #expect(manager.transcribeCount == 0, "no retained PCM => no batch decode")
+  }
+
+  @Test("retained PCM is cleared on cancel()")
+  func pcmClearedOnCancel() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.1, 0.2])
+    await adapter.cancel()
+    manager.transcribeResult = makeResult("")
+    manager.finalizeStreamingResult = makeResult("")
+    // After cancel, finalize() must short-circuit to .cancelled regardless.
+    let outcome = await adapter.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  // MARK: MUST / MUST NOT clauses (PR-1 §B.2.2)
+
+  @Test("acceptAudio after a terminal session is a no-op")
+  func acceptAudioAfterTerminalIsNoOp() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("done")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    _ = await adapter.finalize()
+    let before = manager.feedAudioCount
+    feed(adapter, samples: [0.9])  // post-terminal — must be ignored
+    #expect(manager.feedAudioCount == before, "no audio fed after a terminal session")
+  }
+
+  @Test("finalize() after cancel() returns .cancelled (never partial text)")
+  func finalizeAfterCancel() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("would-be text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    await adapter.cancel()
+    let outcome = await adapter.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("cancel() is idempotent")
+  func cancelIdempotent() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    await adapter.cancel()
+    await adapter.cancel()
+    await adapter.cancel()
+    // Three cancels behave as one — the adapter stays terminal-cancelled.
+    let outcome = await adapter.finalize()
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("applyUnloadPolicy forwards the policy to the ASR manager")
+  func applyUnloadPolicy() {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    adapter.applyUnloadPolicy(.fiveMinutes)
+    #expect(manager.lastUnloadPolicy == .fiveMinutes)
+  }
+
+  @Test("a mid-recording ASR-service crash drives onEngineInterrupted")
+  func engineInterruptedBridge() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    var fired = false
+    adapter.onEngineInterrupted = { fired = true }
+    manager.onServiceInterrupted?()
+    #expect(fired, "ASRManagerInterface.onServiceInterrupted bridges to onEngineInterrupted")
+  }
+
+  // MARK: Helpers
+
+  private func feed(_ adapter: ParakeetEngineAdapter, samples: [Float]) {
+    guard let buffer = FakeAudioCapture.makeBuffer(samples: samples) else {
+      Issue.record("failed to synthesize a test buffer")
+      return
+    }
+    adapter.acceptAudio(
+      AudioBufferHandoff(
+        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: SessionID()))
+  }
+
+  private func makeResult(_ text: String) -> ASRResult {
+    ASRResult(
+      text: text, language: "en", duration: 1, processingTime: 0.1, backendType: .parakeet)
+  }
+}
+
+// MARK: - StubParakeetASRManager
+
+/// Configurable `ASRManagerInterface` stub for `ParakeetEngineAdapterTests`.
+@MainActor
+final class StubParakeetASRManager: ASRManagerInterface {
+  var activeBackendType: ASRBackendType = .parakeet
+  var isModelLoaded = false
+  var isStreaming = false
+  var downloadProgress: Double = 0
+  var downloadPhase = "idle"
+  var downloadDetail = ""
+  var onServiceInterrupted: (() -> Void)?
+  var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
+
+  // Configurable behavior
+  var supportsStreaming = true
+  var startStreamingThrows = false
+  var finalizeStreamingThrows = false
+  var finalizeStreamingResult = ASRResult(
+    text: "default", language: "en", duration: 1, processingTime: 0, backendType: .parakeet)
+  var transcribeResult = ASRResult(
+    text: "default-batch", language: "en", duration: 1, processingTime: 0,
+    backendType: .parakeet)
+  var transcribeThrows = false
+
+  // Observed counters
+  var loadModelCount = 0
+  var startStreamingCount = 0
+  var feedAudioCount = 0
+  var finalizeStreamingCount = 0
+  var cancelStreamingCount = 0
+  var transcribeCount = 0
+  var cancelInFlightLoadCount = 0
+  var lastUnloadPolicy: ModelUnloadPolicy?
+  var lastTranscribeSamples: [Float] = []
+
+  func loadModel() async throws {
+    loadModelCount += 1
+    isModelLoaded = true
+  }
+  func loadModelSilently() async {}
+  func unloadModel() async {}
+  func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
+  func switchBackend(to type: ASRBackendType) async { activeBackendType = type }
+
+  var activeBackendSupportsStreaming: Bool { get async { supportsStreaming } }
+
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
+    transcribeCount += 1
+    lastTranscribeSamples = audioSamples
+    if transcribeThrows { throw FakeASRError.decode }
+    return transcribeResult
+  }
+
+  func startStreaming(options: TranscriptionOptions) async throws {
+    startStreamingCount += 1
+    if startStreamingThrows { throw FakeASRError.streamingSetup }
+    isStreaming = true
+  }
+
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws { feedAudioCount += 1 }
+
+  func finalizeStreaming() async throws -> ASRResult {
+    finalizeStreamingCount += 1
+    if finalizeStreamingThrows { throw FakeASRError.decode }
+    return finalizeStreamingResult
+  }
+
+  func cancelStreaming() async {
+    cancelStreamingCount += 1
+    isStreaming = false
+  }
+  func noteTranscriptionComplete(policy: ModelUnloadPolicy) { lastUnloadPolicy = policy }
+  func cancelIdleTimer() {}
+  func cancelInFlightLoad() { cancelInFlightLoadCount += 1 }
+
+  enum FakeASRError: Error { case streamingSetup, decode }
+}

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -289,6 +289,18 @@ import Testing
     }
   }
 
+  @Test("beginSession cancels a pending model-unload timer from a prior session")
+  func beginSessionCancelsIdleTimer() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    // A prior session armed a delayed unload.
+    adapter.applyUnloadPolicy(.fiveMinutes)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+    #expect(
+      manager.cancelIdleTimerCount == 1,
+      "beginSession cancels the idle timer so no unload fires mid-session")
+  }
+
   @Test("applyUnloadPolicy forwards the policy to the ASR manager")
   func applyUnloadPolicy() {
     let manager = StubParakeetASRManager()
@@ -367,6 +379,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
   var cancelStreamingCount = 0
   var transcribeCount = 0
   var cancelInFlightLoadCount = 0
+  var cancelIdleTimerCount = 0
   var lastUnloadPolicy: ModelUnloadPolicy?
   var lastTranscribeSamples: [Float] = []
 
@@ -415,7 +428,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
     isStreaming = false
   }
   func noteTranscriptionComplete(policy: ModelUnloadPolicy) { lastUnloadPolicy = policy }
-  func cancelIdleTimer() {}
+  func cancelIdleTimer() { cancelIdleTimerCount += 1 }
   func cancelInFlightLoad() { cancelInFlightLoadCount += 1 }
 
   enum FakeASRError: Error { case streamingSetup, decode }

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -163,6 +163,21 @@ import Testing
     }
   }
 
+  @Test("finalize drains in-flight streaming feeds before finalizeStreaming")
+  func finalizeDrainsStreamingFeeds() async throws {
+    let manager = StubParakeetASRManager()
+    manager.slowFeed = true  // feedAudio tasks are still in flight at finalize
+    manager.finalizeStreamingResult = makeResult("streamed text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default)
+    feed(adapter, samples: [0.1])
+    feed(adapter, samples: [0.2])
+    _ = await adapter.finalize()
+    #expect(
+      manager.feedAudioCount == 2,
+      "finalize() waited for every dispatched feed — no tail buffer dropped")
+  }
+
   // MARK: MUST / MUST NOT clauses (PR-1 §B.2.2)
 
   @Test("acceptAudio after a terminal session is a no-op")
@@ -267,6 +282,9 @@ final class StubParakeetASRManager: ASRManagerInterface {
     text: "default-batch", language: "en", duration: 1, processingTime: 0,
     backendType: .parakeet)
   var transcribeThrows = false
+  /// When set, `feedAudio` yields many times before completing — models a
+  /// streaming feed still in flight when `finalize()` is called.
+  var slowFeed = false
 
   // Observed counters
   var loadModelCount = 0
@@ -303,7 +321,12 @@ final class StubParakeetASRManager: ASRManagerInterface {
     isStreaming = true
   }
 
-  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws { feedAudioCount += 1 }
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {
+    if slowFeed {
+      for _ in 0..<100 { await Task.yield() }
+    }
+    feedAudioCount += 1
+  }
 
   func finalizeStreaming() async throws -> ASRResult {
     finalizeStreamingCount += 1

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -75,9 +75,10 @@ import Testing
     manager.finalizeStreamingResult = makeResult("")  // streaming returns empty
     manager.transcribeResult = makeResult("rescued text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.1, 0.2, 0.3])
-    feed(adapter, samples: [0.4, 0.5])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1, 0.2, 0.3], session: sid)
+    feed(adapter, samples: [0.4, 0.5], session: sid)
     let outcome = await adapter.finalize()
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
@@ -96,8 +97,9 @@ import Testing
     manager.finalizeStreamingThrows = true
     manager.transcribeResult = makeResult("rescued after throw")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.7])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.7], session: sid)
     let outcome = await adapter.finalize()
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
@@ -112,8 +114,9 @@ import Testing
     manager.finalizeStreamingResult = makeResult("")
     manager.transcribeResult = makeResult("")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.1])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1], session: sid)
     let outcome = await adapter.finalize()
     guard case .empty(let hadSpeechEvidence) = outcome else {
       Issue.record("expected .empty, got \(outcome)")
@@ -130,8 +133,9 @@ import Testing
     manager.finalizeStreamingResult = makeResult("")
     manager.transcribeResult = makeResult("x")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.1, 0.2])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
     _ = await adapter.finalize()
     // A fresh session must not see the prior session's PCM. Streaming empty +
     // a no-op batch over zero retained samples => .empty.
@@ -150,8 +154,9 @@ import Testing
   func pcmClearedOnCancel() async throws {
     let manager = StubParakeetASRManager()
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.1, 0.2])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
     await adapter.cancel()
     manager.transcribeResult = makeResult("")
     manager.finalizeStreamingResult = makeResult("")
@@ -169,13 +174,51 @@ import Testing
     manager.slowFeed = true  // feedAudio tasks are still in flight at finalize
     manager.finalizeStreamingResult = makeResult("streamed text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
-    feed(adapter, samples: [0.1])
-    feed(adapter, samples: [0.2])
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1], session: sid)
+    feed(adapter, samples: [0.2], session: sid)
     _ = await adapter.finalize()
     #expect(
       manager.feedAudioCount == 2,
       "finalize() waited for every dispatched feed — no tail buffer dropped")
+  }
+
+  // MARK: Stale-async session guards (Codex r2)
+
+  @Test("a feed queued before a cancel is not fed into the terminated session")
+  func staleFeedGuardOnCancel() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
+    feed(adapter, samples: [0.1], session: sid)  // dispatches a feed task
+    // cancel()'s synchronous prefix sets isTerminal/streamingActive before it
+    // suspends, so the queued feed task runs after and sees the terminated
+    // session.
+    await adapter.cancel()
+    for _ in 0..<50 { await Task.yield() }
+    #expect(manager.feedAudioCount == 0, "the queued feed saw the terminated session and skipped")
+  }
+
+  @Test("a stale finalize does not clobber a session that began during its await")
+  func staleFinalizeGuard() async throws {
+    let manager = StubParakeetASRManager()
+    manager.slowFinalizeStreaming = true
+    manager.finalizeStreamingResult = makeResult("session A text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default)
+    feed(adapter, samples: [0.1], session: sidA)
+    // finalize() for session A suspends inside the slow finalizeStreaming.
+    async let outcomeA = adapter.finalize()
+    for _ in 0..<10 { await Task.yield() }
+    // Session B begins while A's finalize is still suspended.
+    try await adapter.beginSession(SessionID(), options: .default)
+    _ = await outcomeA
+    #expect(
+      adapter.lastResult == nil,
+      "the stale finalize skipped its post-await mutations — session B's state is intact")
   }
 
   // MARK: MUST / MUST NOT clauses (PR-1 §B.2.2)
@@ -185,10 +228,11 @@ import Testing
     let manager = StubParakeetASRManager()
     manager.finalizeStreamingResult = makeResult("done")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default)
     _ = await adapter.finalize()
     let before = manager.feedAudioCount
-    feed(adapter, samples: [0.9])  // post-terminal — must be ignored
+    feed(adapter, samples: [0.9], session: sid)  // post-terminal — must be ignored
     #expect(manager.feedAudioCount == before, "no audio fed after a terminal session")
   }
 
@@ -242,14 +286,17 @@ import Testing
 
   // MARK: Helpers
 
-  private func feed(_ adapter: ParakeetEngineAdapter, samples: [Float]) {
+  /// Feed one synthetic buffer stamped with `session` — the kernel always
+  /// hands the adapter buffers stamped with the begun session, and the
+  /// adapter's streaming-feed guard drops a mismatched stamp.
+  private func feed(_ adapter: ParakeetEngineAdapter, samples: [Float], session: SessionID) {
     guard let buffer = FakeAudioCapture.makeBuffer(samples: samples) else {
       Issue.record("failed to synthesize a test buffer")
       return
     }
     adapter.acceptAudio(
       AudioBufferHandoff(
-        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: SessionID()))
+        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: session))
   }
 
   private func makeResult(_ text: String) -> ASRResult {
@@ -285,6 +332,9 @@ final class StubParakeetASRManager: ASRManagerInterface {
   /// When set, `feedAudio` yields many times before completing — models a
   /// streaming feed still in flight when `finalize()` is called.
   var slowFeed = false
+  /// When set, `finalizeStreaming` yields many times before returning — models
+  /// a finalize suspended in ASR while a new session begins.
+  var slowFinalizeStreaming = false
 
   // Observed counters
   var loadModelCount = 0
@@ -330,6 +380,9 @@ final class StubParakeetASRManager: ASRManagerInterface {
 
   func finalizeStreaming() async throws -> ASRResult {
     finalizeStreamingCount += 1
+    if slowFinalizeStreaming {
+      for _ in 0..<200 { await Task.yield() }
+    }
     if finalizeStreamingThrows { throw FakeASRError.decode }
     return finalizeStreamingResult
   }

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -59,7 +59,7 @@ import Testing
     let manager = StubParakeetASRManager()
     manager.finalizeStreamingResult = makeResult("streamed text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     let outcome = await adapter.finalize()
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
@@ -76,7 +76,7 @@ import Testing
     manager.transcribeResult = makeResult("rescued text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1, 0.2, 0.3], session: sid)
     feed(adapter, samples: [0.4, 0.5], session: sid)
     let outcome = await adapter.finalize()
@@ -98,7 +98,7 @@ import Testing
     manager.transcribeResult = makeResult("rescued after throw")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.7], session: sid)
     let outcome = await adapter.finalize()
     guard case .transcript(let result) = outcome else {
@@ -115,7 +115,7 @@ import Testing
     manager.transcribeResult = makeResult("")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)
     let outcome = await adapter.finalize()
     guard case .empty(let hadSpeechEvidence) = outcome else {
@@ -123,6 +123,29 @@ import Testing
       return
     }
     #expect(hadSpeechEvidence, "past the kernel's VAD gate, an empty decode is a real ASR failure")
+  }
+
+  @Test("beginSession(streaming: false) opens no live stream — batch decode after stop")
+  func batchModeSkipsStreaming() async throws {
+    let manager = StubParakeetASRManager()
+    manager.transcribeResult = makeResult("batch decoded")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    // The user disabled live transcription — the kernel passes streaming: false.
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
+    #expect(manager.startStreamingCount == 0, "streaming disabled — no live stream opened")
+    let outcome = await adapter.finalize()
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "batch decoded")
+    #expect(manager.finalizeStreamingCount == 0, "no streaming finalize when streaming was off")
+    #expect(manager.transcribeCount == 1, "the batch rescue decoded the retained PCM")
+    #expect(
+      manager.lastTranscribeSamples == [0.1, 0.2],
+      "the batch decode ran over the retained session PCM")
   }
 
   // MARK: Retained-PCM lifecycle
@@ -134,14 +157,14 @@ import Testing
     manager.transcribeResult = makeResult("x")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1, 0.2], session: sid)
     _ = await adapter.finalize()
     // A fresh session must not see the prior session's PCM. Streaming empty +
     // a no-op batch over zero retained samples => .empty.
     manager.transcribeCount = 0
     manager.lastTranscribeSamples = []
-    try await adapter.beginSession(SessionID(), options: .default)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     let outcome = await adapter.finalize()
     guard case .empty = outcome else {
       Issue.record("expected .empty over cleared PCM, got \(outcome)")
@@ -155,7 +178,7 @@ import Testing
     let manager = StubParakeetASRManager()
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1, 0.2], session: sid)
     await adapter.cancel()
     manager.transcribeResult = makeResult("")
@@ -175,7 +198,7 @@ import Testing
     manager.finalizeStreamingResult = makeResult("streamed text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)
     feed(adapter, samples: [0.2], session: sid)
     _ = await adapter.finalize()
@@ -191,7 +214,7 @@ import Testing
     let manager = StubParakeetASRManager()
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)  // dispatches a feed task
     // cancel()'s synchronous prefix sets isTerminal/streamingActive before it
     // suspends, so the queued feed task runs after and sees the terminated
@@ -208,13 +231,13 @@ import Testing
     manager.finalizeStreamingResult = makeResult("session A text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sidA = SessionID()
-    try await adapter.beginSession(sidA, options: .default)
+    try await adapter.beginSession(sidA, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sidA)
     // finalize() for session A suspends inside the slow finalizeStreaming.
     async let outcomeA = adapter.finalize()
     for _ in 0..<10 { await Task.yield() }
     // Session B begins while A's finalize is still suspended.
-    try await adapter.beginSession(SessionID(), options: .default)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     _ = await outcomeA
     #expect(
       adapter.lastResult == nil,
@@ -229,7 +252,7 @@ import Testing
     manager.finalizeStreamingResult = makeResult("done")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default)
+    try await adapter.beginSession(sid, options: .default, streaming: true)
     _ = await adapter.finalize()
     let before = manager.feedAudioCount
     feed(adapter, samples: [0.9], session: sid)  // post-terminal — must be ignored
@@ -241,7 +264,7 @@ import Testing
     let manager = StubParakeetASRManager()
     manager.finalizeStreamingResult = makeResult("would-be text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     await adapter.cancel()
     let outcome = await adapter.finalize()
     guard case .cancelled = outcome else {
@@ -254,7 +277,7 @@ import Testing
   func cancelIdempotent() async throws {
     let manager = StubParakeetASRManager()
     let adapter = ParakeetEngineAdapter(asrManager: manager)
-    try await adapter.beginSession(SessionID(), options: .default)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     await adapter.cancel()
     await adapter.cancel()
     await adapter.cancel()

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -218,7 +218,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   // MARK: Helpers
 
-  private static func makeBuffer(samples: [Float]) -> AVAudioPCMBuffer? {
+  /// Synthesize one 16 kHz mono Float32 `AVAudioPCMBuffer` from samples.
+  /// `internal` so other test fixtures (`FakeEngineTests`,
+  /// `ParakeetEngineAdapterTests`) build `AudioBufferHandoff`s without
+  /// reimplementing buffer construction.
+  static func makeBuffer(samples: [Float]) -> AVAudioPCMBuffer? {
     guard
       let format = AVAudioFormat(
         commonFormat: .pcmFormatFloat32,

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -80,6 +80,9 @@ final class FakeEngine: ASREngineAdapter {
   private(set) var cancelCallCount = 0
   private(set) var lastUnloadPolicy: ModelUnloadPolicy?
   private(set) var lastSessionID: SessionID?
+  /// The `streaming` flag the kernel passed on the last `beginSession()` —
+  /// lets a scenario assert the kernel's streaming-policy decision (PR-4 §3.4).
+  private(set) var lastStreamingRequested: Bool?
   /// Count of mid-session engine-switch requests (A18). The request models a
   /// factory-preference change (PR-6 owns the factory); it does NOT mutate
   /// this engine's `behavior`, so the active session keeps its transcript.
@@ -183,9 +186,12 @@ final class FakeEngine: ASREngineAdapter {
 
   // MARK: Session lifecycle
 
-  func beginSession(_ id: SessionID, options: TranscriptionOptions) async throws {
+  func beginSession(
+    _ id: SessionID, options: TranscriptionOptions, streaming: Bool
+  ) async throws {
     beginSessionCallCount += 1
     lastSessionID = id
+    lastStreamingRequested = streaming
     isTerminal = false
     isCancelled = false
   }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -65,6 +65,11 @@ final class FakeEngine: ASREngineAdapter {
 
   private(set) var readiness: ASREngineReadiness = .notReady
 
+  /// Mid-recording engine-crash callback (PR-4 §3.2). The kernel sets this
+  /// during session setup; `fireEngineInterrupted()` lets a scenario simulate
+  /// an ASR-service crash while recording.
+  var onEngineInterrupted: (@MainActor () -> Void)?
+
   // MARK: Observed counters (for FakeEngineTests)
 
   private(set) var warmUpCallCount = 0
@@ -274,6 +279,12 @@ final class FakeEngine: ASREngineAdapter {
 
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
     lastUnloadPolicy = policy
+  }
+
+  /// Simulate a mid-recording engine crash — drives the kernel's
+  /// `asrInterrupted` terminal (PR-4 §3.2).
+  func fireEngineInterrupted() {
+    onEngineInterrupted?()
   }
 
   // MARK: Helpers

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
@@ -106,10 +106,11 @@ struct FakeEngineTests {
   }
 
   @Test("acceptAudio after a terminal session is a no-op")
-  func acceptAudioAfterTerminalIsNoOp() async {
+  func acceptAudioAfterTerminalIsNoOp() async throws {
     let (engine, _) = makeEngine(.batchSuccess(text: "x"))
+    let pcm = try #require(FakeAudioCapture.makeBuffer(samples: [0.1]))
     let buffer = AudioBufferHandoff(
-      pcm: [0.1], frameCount: 1, sequence: 1, sessionID: SessionID())
+      buffer: pcm, frameCount: 1, sequence: 1, sessionID: SessionID())
     engine.acceptAudio(buffer)
     #expect(engine.acceptedBufferCount == 1)
     await engine.cancel()

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -1,4 +1,5 @@
 import EnviousWisprAudio
+import EnviousWisprCore
 import Foundation
 
 @testable import EnviousWisprPipeline
@@ -193,7 +194,10 @@ final class KernelRecordingSession: RecordingSessionDriving {
   func apply(_ trigger: SessionTrigger) async {
     switch trigger {
     case .start:
-      kernel.start()
+      // PR-4 §3.3a: the kernel's `start` now takes a `DictationSessionConfig`.
+      // The simulator passes the test default — `FakeAudioCapture.configureVAD`
+      // is inert, so no scenario behavior changes.
+      kernel.start(config: .testDefault())
       // The seam is told the frozen session at session start (PR-1 §B.6):
       // sync the fake VAD's stamp to the kernel's freshly minted SessionID.
       vad.currentSessionID = kernel.currentSessionID


### PR DESCRIPTION
## PR-4a — new tested infrastructure for the Parakeet kernel migration (#827)

First of three rungs for PR-4 of the engine-kernel epic. Ships the new internal machinery to migrate Parakeet onto `RecordingSessionKernel`. **Not App-wired** — `TranscriptionPipeline` stays live and injected; no App-layer caller constructs the new types yet. PR-4.5 hardens the kernel; PR-4b does the App migration.

### What lands
- **`ParakeetEngineAdapter`** — the production `ASREngineAdapter` Parakeet conformer: streaming-finalize-then-batch rescue, full-session PCM retention, mid-recording engine-crash signal.
- **`KernelDictationDriver`** — adapts the kernel to the `DictationPipeline` surface (state mapping, limb-step home, external-error surface).
- **`KernelFinalizationWiring`** — assembles the kernel's `processText` / `store` / `deliver` closures + logical clock.
- **`CaptureVADSignalSource`** — the production `VADSignalSource` event aggregator.
- **`KernelHeartPathTelemetryObserver`** — observes raw kernel state, emits the §B.7 telemetry.
- **Scoped kernel edits** — `start(config:)`, `discardReason`, the `AudioBufferHandoff` `AVAudioPCMBuffer` carrier change, `onEngineInterrupted` subscription, `applyUnloadPolicy` at terminal, `beginSession(streaming:)` (kernel owns the streaming-vs-batch policy).
- New unit suites for all five types + the adapter-shape check.

### Code-diff review — Codex rounds 1–5
- r1: tail-audio drain bug — fixed.
- r2: two stale-async session races — fixed.
- r3: streaming-policy ownership + `cancelIdleTimer()` at session start — fixed; two driver-internal items deferred.
- r4: re-flagged the drain; initially mis-dismissed.
- r5: confirmed the drain was a real flake — `finalizeDrainsStreamingFeeds` failed ~1/3 under load. **Fixed**: the drain now awaits the actual feed `Task` handles, no wall-clock deadline (`no-arbitrary-timeouts`). Combined kernel/adapter suite green 5/5 under load.

### Disposition of r5's two remaining findings — both routed to PR-4.5
`KernelDictationDriver` not populating `KernelSessionContext` and `setExternalError` not firing `onStateChange` are both driver-internal, latent until the driver is App-wired, and the same class as the conductor-seam-hardening findings. They are findings #6 and #9 in the PR-4.5 plan (`docs/feature-requests/issue-827-2026-05-22-conductor-seam-hardening.md`), not PR-4a scope.

### Validation
Release build + test build clean. Kernel / adapter / simulator suites (33-scenario inventory + 64-schedule sweep + FSM invariants + the new unit suites) green 5/5 under concurrent load. Full test suite deferred to CI `build-check` (local run skipped to avoid contending with a long-running local model-eval job). No Live UAT — nothing user-facing is wired (PR-4 plan §14 OQ-4).

PR-4a of #827. Does not close the epic.
