### PR TITLE
feat(engine-kernel): PR-4.5 conductor-parity hardening (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -202,7 +202,16 @@ public protocol ASREngineAdapter: AnyObject {
 
   /// Finalize and produce exactly one outcome. Engine-specific rescue lives
   /// here. After `cancel()`, MUST return `.cancelled` (PR-1 §B.2.2).
-  func finalize() async -> ASREngineOutcome
+  ///
+  /// `batchSamples`, when non-nil, is the kernel-conditioned ASR-ready audio
+  /// the adapter MUST use for any batch decode in this finalize call (PR-4.5
+  /// #5 — VAD-segment filtering, raw fallback, short-utterance padding are
+  /// kernel-side, not adapter-side). When nil, the adapter uses its own
+  /// raw retained audio unchanged (today's pre-PR-4.5 behavior, preserved for
+  /// tests + the `FakeEngine` simulator path). The streaming path is
+  /// unaffected — per-buffer feeds were already raw and the kernel's
+  /// `acceptAudio` contract has not changed.
+  func finalize(batchSamples: [Float]?) async -> ASREngineOutcome
 
   /// OPTIONAL `finalize()`-wedge signal (PR-1 §B.1.7). Same `nil` semantics as
   /// `loadProgress`.

--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -1,4 +1,5 @@
 import EnviousWisprAudio
+import EnviousWisprCore
 import Foundation
 
 // MARK: - CaptureVADSignalSource (epic #827, PR-4 §3.5)
@@ -38,11 +39,19 @@ final class CaptureVADSignalSource: VADSignalSource {
   /// `.unavailable` (no detector) — the kernel then does not gate (PR-1 §B.6).
   private var evidenceProvider: @MainActor () -> VADSpeechEvidence
 
+  /// Returns the voiced segments observed during the just-stopped session
+  /// (PR-4.5 #5, Codex r1). Default `[]` (no detector ran). The wiring sets
+  /// it from `captureResult.vadSegments` (XPC) or `detector.speechSegments`
+  /// (direct mode) — see `setSegmentsProvider`.
+  private var segmentsProvider: @MainActor () -> [SpeechSegment]
+
   init(
-    evidenceProvider: @escaping @MainActor () -> VADSpeechEvidence = { .unavailable }
+    evidenceProvider: @escaping @MainActor () -> VADSpeechEvidence = { .unavailable },
+    segmentsProvider: @escaping @MainActor () -> [SpeechSegment] = { [] }
   ) {
     (signalStream, signalContinuation) = AsyncStream.makeStream(of: VADStopSignal.self)
     self.evidenceProvider = evidenceProvider
+    self.segmentsProvider = segmentsProvider
   }
 
   // MARK: VADSignalSource
@@ -50,6 +59,8 @@ final class CaptureVADSignalSource: VADSignalSource {
   var stopSignals: AsyncStream<VADStopSignal> { signalStream }
 
   func speechEvidenceAtStop() -> VADSpeechEvidence { evidenceProvider() }
+
+  func speechSegmentsAtStop() -> [SpeechSegment] { segmentsProvider() }
 
   // MARK: Session wiring
 
@@ -64,6 +75,16 @@ final class CaptureVADSignalSource: VADSignalSource {
   /// `captureResult.vadSegments` (PR-4 §3.5).
   func setEvidenceProvider(_ provider: @escaping @MainActor () -> VADSpeechEvidence) {
     evidenceProvider = provider
+  }
+
+  /// Replace the voiced-segments provider for the session (PR-4.5 #5, Codex
+  /// r1). The wiring sets it from `captureResult.vadSegments` (XPC mode) or
+  /// from the in-process `SilenceDetector.speechSegments` (direct mode). The
+  /// kernel's `CapturedAudioConditioner` reads this — NOT
+  /// `CaptureResult.vadSegments` — so direct-mode recordings get the same
+  /// VAD filtering as XPC mode.
+  func setSegmentsProvider(_ provider: @escaping @MainActor () -> [SpeechSegment]) {
+    segmentsProvider = provider
   }
 
   /// Claim sole ownership of `AudioCaptureInterface.onVADAutoStop` (PR-4 §3.5).

--- a/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
+++ b/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
@@ -1,0 +1,106 @@
+import EnviousWisprCore
+import Foundation
+
+// MARK: - CapturedAudioConditioner (epic #827, PR-4.5 #5)
+//
+// Restores the VAD-segment filtering + too-aggressive-filter raw fallback +
+// short-utterance padding the old `TranscriptionPipeline.swift:732-762,809-823`
+// applied before handing samples to ASR. PR-3's fresh kernel kept only the
+// yes/no VAD-evidence gate; the adapter then transcribed raw retained PCM,
+// so common short utterances ("yes", "no", "hey") could fail outright when
+// the raw count was sub-minimum, and VAD-filtered audio never reached ASR.
+//
+// Placement: kernel-adjacent (NOT inside an `ASREngineAdapter` conformer).
+// The adapter contract says an adapter owns its own ASR and rescue; it does
+// NOT own capture/VAD policy. A shared kernel-side conditioner means PR-5
+// WhisperKit inherits parity without re-duplicating the logic.
+//
+// Built ON the existing `SampleFilter.filter` (the VAD-segment merge), wrapped
+// to return both the ASR-ready samples AND the metadata-only telemetry fields
+// §8 of the PR-4.5 plan calls for.
+
+/// One conditioning result — ASR-ready samples plus the metadata-only fields
+/// the kernel's telemetry needs to make a future short-utterance regression
+/// debuggable. No audio content escapes this struct; counts and booleans only.
+public struct ConditionedAudio: Equatable, Sendable {
+  /// The samples to pass to ASR for batch rescue. May equal `rawSamples`
+  /// (no segments OR too-aggressive-filter raw fallback fired) OR be
+  /// VAD-filtered, with or without short-utterance padding appended.
+  public let samples: [Float]
+
+  /// Sample count after `SampleFilter.filter` but BEFORE raw fallback and
+  /// before silence padding. Equals `rawSamples.count` when no segments were
+  /// supplied (the filter is a no-op). Lets telemetry distinguish
+  /// "filter ran and trimmed to N" from "filter no-op'd".
+  public let filteredSampleCount: Int
+
+  /// `true` when filtering dropped samples below the ASR minimum AND raw
+  /// samples meet the minimum, so the conditioner returned raw instead. Old
+  /// `TranscriptionPipeline.swift:813-816`.
+  public let usedRawFallbackAfterVAD: Bool
+
+  /// `true` when the final sample count was below the ASR minimum and the
+  /// conditioner appended silence to reach it. Old
+  /// `TranscriptionPipeline.swift:820-823`.
+  public let samplesPaddedToMinimum: Bool
+
+  /// Final sample count of `samples` — redundant with `samples.count` but
+  /// kept explicit so the telemetry surface does not depend on whether the
+  /// caller bothered to recompute.
+  public var finalSampleCount: Int { samples.count }
+}
+
+/// Apply VAD-segment filtering, too-aggressive-filter raw fallback, and
+/// short-utterance padding in the order the old pipeline did (PR-4.5 plan
+/// §3 #5 + §5b). Pure function; safe to call from any actor.
+public enum CapturedAudioConditioner {
+
+  /// Condition `rawSamples` for ASR batch rescue. When `vadSegments` is empty
+  /// the VAD-filter step is a no-op (the kernel passes empty segments when no
+  /// VAD detector ran); fallback and padding still apply.
+  ///
+  /// `minimumSamples` defaults to `AudioConstants.minimumTranscriptionSamples`
+  /// — both ASR backends require ≥1 s of audio. Tests may override.
+  public static func condition(
+    rawSamples: [Float],
+    vadSegments: [SpeechSegment],
+    minimumSamples: Int = AudioConstants.minimumTranscriptionSamples
+  ) -> ConditionedAudio {
+    // Step 1: VAD-segment filter (parity: `TranscriptionPipeline.swift:751`).
+    // `SampleFilter.filter` already returns `rawSamples` unchanged when
+    // segments are empty OR when total voiced audio is sub-threshold — the
+    // "too-aggressive-filter" raw fallback at the SampleFilter layer.
+    let filtered = SampleFilter.filter(from: rawSamples, segments: vadSegments)
+    let filteredCount = filtered.count
+
+    // Step 2: too-aggressive-filter raw fallback at the conditioner layer
+    // (parity: `TranscriptionPipeline.swift:813-816`). Even with non-empty
+    // segments, SampleFilter's merge can produce fewer than `minimumSamples`
+    // if voiced regions were sparse. If raw audio would meet the minimum,
+    // prefer raw — losing words is worse than ASR seeing extra silence.
+    var working = filtered
+    var usedRawFallback = false
+    if working.count < minimumSamples && rawSamples.count >= minimumSamples {
+      working = rawSamples
+      usedRawFallback = true
+    }
+
+    // Step 3: short-utterance padding (parity:
+    // `TranscriptionPipeline.swift:820-823`). For genuinely short audio
+    // (single-word: "hey", "hi") pad with silence so ASR's minimum-length
+    // contract is satisfied. Guard `count > 0` so a degenerate empty input
+    // does not become a buffer of pure silence — the kernel's empty check
+    // upstream already routes that to a terminal.
+    var padded = false
+    if working.count > 0 && working.count < minimumSamples {
+      working.append(contentsOf: [Float](repeating: 0, count: minimumSamples - working.count))
+      padded = true
+    }
+
+    return ConditionedAudio(
+      samples: working,
+      filteredSampleCount: filteredCount,
+      usedRawFallbackAfterVAD: usedRawFallback,
+      samplesPaddedToMinimum: padded)
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1,4 +1,6 @@
+import AppKit
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 // MARK: - KernelDictationDriver (epic #827, PR-4 §3.1)
@@ -138,15 +140,32 @@ final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
   func handle(event: PipelineEvent) async throws {
     switch event {
     case .preWarm:
-      kernel.preWarm()
+      // PR-4.5 #1 + Codex r4: capture pre-warm is awaited end-to-end so the
+      // PTT-flow caller (`RecordingStarter.start()` awaits `handle(.preWarm)`
+      // and then immediately sends `.toggleRecording`) does not see the
+      // recording start before BT codec negotiation completes.
+      await kernel.preWarm()
     case .toggleRecording(let config):
       switch kernel.state {
       case .idle, .completed, .failed, .cancelled, .discarded, .noSpeech,
         .audioInterrupted, .asrInterrupted:
-        // Start: clear the prior session's surfaces, then mint a new session.
+        // Start: clear the prior session's surfaces, capture finalization
+        // context AT RECORDING START (PR-4.5 #6, parity with old
+        // `TranscriptionPipeline.swift:450-453`), then mint a new session.
+        //
+        // The frontmost app + focused AX element are captured here so that a
+        // polish step taking seconds — during which focus may shift to the
+        // app's own window or another app — does not lose the original paste
+        // target. The frozen `DictationSessionConfig` lands in
+        // `context.config` for the wiring's `processText` / `deliver`
+        // closures to read at finalize time (the wiring's optional-chained
+        // reads were always-nil in production until this PR — finding #6).
         lastExternalError = nil
         outcome.transcript = nil
         outcome.polishError = nil
+        context.config = config
+        context.targetApp = NSWorkspace.shared.frontmostApplication
+        context.targetElement = PasteService.captureFocusedElement()
         kernel.start(config: config)
       case .recording:
         kernel.requestStop()
@@ -161,16 +180,33 @@ final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
     case .reset:
       lastExternalError = nil
       kernel.reset()
+      // PR-4.5 #9 (Codex r5): when the kernel is already idle, `reset()` is a
+      // no-op, so the kernel-state observation does NOT fire. After
+      // `setExternalError` parked the observer on `.error`, that observer
+      // would stay stuck. Driving the fan-out directly mirrors the #9 fix on
+      // the error-set side.
+      fireStateChangeIfNeeded()
     }
   }
 
-  /// Dumb external-error sink (PR-4 §3.7). Cancels the kernel session and
-  /// holds the message so `state` / `overlayIntent` surface `.error` until the
-  /// next start / reset clears it.
+  /// External-error sink (PR-4 §3.7). Cancels the kernel session and holds
+  /// the message so `state` / `overlayIntent` surface `.error` until the next
+  /// start / reset clears it.
+  ///
+  /// PR-4.5 #9: also fires `onStateChange` directly with the mapped `.error`
+  /// state. The state mapper reads `lastExternalError`, so the *driver's*
+  /// public state did change; but the kernel-state observer at
+  /// `observeKernelState` only fires when `kernel.state` itself changes. When
+  /// `kernel.cancel()` is a no-op (kernel already idle / terminal — common
+  /// for pre-warm / mic failures routed through here), the observer never
+  /// runs and the lifecycle coordinator never learns about the error. Direct
+  /// fire-through ensures the error reaches the overlay / hotkey teardown
+  /// path regardless of kernel-state movement.
   func setExternalError(_ message: String) {
     kernel.cancel()
     outcome.transcript = nil
     lastExternalError = message
+    fireStateChangeIfNeeded()
   }
 
   /// Intentional no-op (PR-4 §3.7). The kernel's `SessionID` structurally

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -209,8 +209,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   /// Finalize: one normalized outcome. Streaming runs the
   /// streaming-finalize-then-batch rescue (D14); batch-mode runs batch decode
-  /// over the retained PCM. After `cancel()`, returns `.cancelled` (PR-1 §B.2.2).
-  func finalize() async -> ASREngineOutcome {
+  /// over the kernel-conditioned audio when supplied, else raw retained PCM
+  /// (PR-4.5 #5). After `cancel()`, returns `.cancelled` (PR-1 §B.2.2).
+  func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
     if isCancelled {
       isTerminal = true
       retainedPCM.removeAll()
@@ -220,9 +221,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     let outcome: ASREngineOutcome
     if streamingActive {
       await drainStreamingFeeds()
-      outcome = await finalizeStreamingWithRescue()
+      outcome = await finalizeStreamingWithRescue(batchSamples: batchSamples)
     } else {
-      outcome = await finalizeBatch()
+      outcome = await finalizeBatch(batchSamples: batchSamples)
     }
     // A `cancel()` + new `beginSession()` during the ASR await must not let
     // this stale finalize clobber the fresh session's `lastResult` / retained
@@ -291,7 +292,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// The kernel runs the VAD no-speech gate before `finalize()`, so reaching
   /// here means speech evidence was voiced or unavailable — the rescue always
   /// attempts batch when streaming yields nothing.
-  private func finalizeStreamingWithRescue() async -> ASREngineOutcome {
+  private func finalizeStreamingWithRescue(batchSamples: [Float]?) async -> ASREngineOutcome {
     do {
       let result = try await asrManager.finalizeStreaming()
       if !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -303,15 +304,18 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     } catch {
       // Streaming finalize failed — fall through to the batch rescue.
     }
-    return await finalizeBatch()
+    return await finalizeBatch(batchSamples: batchSamples)
   }
 
-  /// Batch decode over the retained session PCM (§3.2a).
-  private func finalizeBatch() async -> ASREngineOutcome {
-    guard !retainedPCM.isEmpty else { return .empty(hadSpeechEvidence: true) }
+  /// Batch decode (§3.2a). Uses kernel-conditioned `batchSamples` when
+  /// supplied (PR-4.5 #5 — VAD-filtered + raw-fallback + silence-padded);
+  /// else falls back to the adapter's raw retained PCM.
+  private func finalizeBatch(batchSamples: [Float]?) async -> ASREngineOutcome {
+    let samples = batchSamples ?? retainedPCM
+    guard !samples.isEmpty else { return .empty(hadSpeechEvidence: true) }
     do {
       let result = try await asrManager.transcribe(
-        audioSamples: retainedPCM, options: decodeOptions)
+        audioSamples: samples, options: decodeOptions)
       if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         // Past the kernel's VAD no-speech gate, an empty decode is a real ASR
         // failure — `hadSpeechEvidence: true` routes the kernel to

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -147,6 +147,23 @@ final class RecordingSessionKernel {
   /// the simulator's logical-tick time base — not a wall-clock deadline.
   private let wedgeStallTicks: Int
 
+  /// Minimum logical-tick duration of a visible recording (PR-4.5 #4 — parity
+  /// with `TimingConstants.minimumRecordingDuration` = 500 ms). A recording
+  /// terminating in less than this many ticks since `→ recording` is silently
+  /// discarded as an accidental tap (`discardReason = .tooShort`). Measured
+  /// from VISIBLE recording start, NOT from pre-roll capture (PR-4.5 §5b — so
+  /// fixing #0 does not silently defeat #4).
+  ///
+  /// The constructor default is `5` (matches the PR-4 plan's 100 ms-per-tick
+  /// scale — `KernelFinalizationWiring.tickDurationSeconds = 0.1`, so 5 ticks
+  /// = 500 ms). Existing tests that drive a `FakeClock` and do not advance it
+  /// between `start` and `stop` pass `0` explicitly to disable the gate (the
+  /// 33-scenario inventory and the direct FSM-invariant tests). Codex r3
+  /// flagged a zero default as a silent-regression risk for the eventual
+  /// PR-4b production wiring; the non-zero default makes the safety opt-OUT,
+  /// not opt-in.
+  private let minimumRecordingTicks: Int
+
   // MARK: Telemetry fan-out
 
   /// Capture-stall telemetry fan-out (PR-4 plan §3.9). When the capture layer
@@ -221,9 +238,46 @@ final class RecordingSessionKernel {
 
   /// `true` once `adapter.beginSession()` succeeded this session. Distinct from
   /// `adapterSessionActive` (which `finalize()` clears) — this stays true for
-  /// the whole session so a terminal applies the model-unload policy exactly
-  /// once for any session that ran the adapter (PR-4 plan §3.2, Codex RR4).
+  /// the whole session so a terminal applies cleanup (adapter discard) once.
+  /// **Not** the unload-policy gate — see `transcriptReadyForDelivery` (PR-4.5
+  /// #8).
   private var adapterDidBeginSession = false
+
+  /// Running total of stale-VAD-signal drops (PR-4.5 §8 telemetry surface
+  /// for #2). A regression that stops stamping the seam shows up here as a
+  /// sudden 100% drop rate. Never cleared.
+  private(set) var staleVADSignalDrops: Int = 0
+
+  /// Logical-tick value at the `→ recording` transition (PR-4.5 #4). `nil`
+  /// outside `.recording`; reset on every session start. Read by the
+  /// stop-phase discard gate to compute visible-recording elapsed against
+  /// `minimumRecordingTicks`. Visible-only on purpose — PR-4.5 §5b: pre-roll
+  /// must not pad accidental taps past the discard threshold.
+  private var recordingStartedAtTick: UInt64?
+
+  /// Logical-tick value at the `→ stopping` transition (PR-4.5 #4, Codex r1).
+  /// The visible-recording elapsed used by the #4 discard gate is computed
+  /// as `(stoppingStartedAtTick - recordingStartedAtTick)`, NOT against
+  /// `currentTick()` at the discard check. Otherwise the await on
+  /// `audioCapture.stopCapture()` between `.stopping` and the discard check
+  /// counts capture-teardown latency as visible-recording time, letting a
+  /// 40 ms tap bypass the gate when teardown is slow. Old pipeline
+  /// parity: `TranscriptionPipeline.swift:622` reads elapsed BEFORE
+  /// `stopCapture()`. `nil` outside `.stopping`+; reset on every session start.
+  private var stoppingStartedAtTick: UInt64?
+
+  /// `true` once the polish step returned a non-empty processed transcript —
+  /// the kernel-era equivalent of the point at which the old pipeline called
+  /// `asrManager.noteTranscriptionComplete(policy:)` (just after polish, before
+  /// storage and paste — `TranscriptionPipeline.swift:992-995`). PR-4.5 #8
+  /// gates the unload policy on this so failures BEFORE a transcript was ready
+  /// (capture-stall, ASR-wedge, no-speech, cancel, sub-minimum discard, audio /
+  /// ASR interrupt mid-recording) do NOT incur a model-unload spike that the
+  /// next session would then pay to reload. Stays true through `.completed`
+  /// AND through paste/storage failure terminals — both of those have a
+  /// transcript in hand, parity with the old pipeline firing unload before
+  /// paste.
+  private var transcriptReadyForDelivery = false
 
   /// The session task bag, keyed by `SessionID` (PR-1 §B.1.6). Reaching a
   /// terminal state cancels and clears it — nonblocking (PR-3 plan §3.1a).
@@ -297,6 +351,7 @@ final class RecordingSessionKernel {
     store: @escaping @MainActor (_ text: String) async throws -> Void,
     deliver: @escaping @MainActor (_ text: String) async -> KernelDeliveryOutcome,
     wedgeStallTicks: Int = 2,
+    minimumRecordingTicks: Int = 5,
     captureStallTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in }
   ) {
     self.adapter = adapter
@@ -308,6 +363,7 @@ final class RecordingSessionKernel {
     self.store = store
     self.deliver = deliver
     self.wedgeStallTicks = wedgeStallTicks
+    self.minimumRecordingTicks = minimumRecordingTicks
     self.captureStallTelemetry = captureStallTelemetry
   }
 
@@ -397,17 +453,56 @@ final class RecordingSessionKernel {
     resourcesReleased = (captureLifecycle != .stopping)
   }
 
-  /// Sessionless pre-warm — drives `adapter.readiness` toward `.ready` with no
-  /// `SessionID`, no state change (PR-1 §B.1.2, §B.2.2). Valid only from
-  /// `idle` / terminal.
-  func preWarm() {
+  /// Sessionless pre-warm — drives `adapter.readiness` toward `.ready` AND
+  /// warms the capture path so a Bluetooth codec negotiation does not eat the
+  /// first 0.5–2 s of dictation (PR-1 §B.1.2, §B.2.2; PR-4.5 #1 — parity with
+  /// old `TranscriptionPipeline.preWarmAudioInput`, `:295-315`). No
+  /// `SessionID`, no FSM transition; valid only from `idle` / terminal.
+  ///
+  /// **Async on purpose (Codex r4):** the real PTT flow
+  /// (`RecordingStarter.start()`) `await`s this and then immediately sends
+  /// `.toggleRecording`. The `audioCapture.preWarm()` is therefore awaited
+  /// end-to-end, so the Bluetooth-codec negotiation completes before
+  /// `start(config:)` cancels the old-session task bag (which a spawned-but-
+  /// unawaited preWarm task would not survive). Adapter warm-up is heavier
+  /// (cold model load = seconds) and stays spawned in the background — the
+  /// session's own `warmUp()` path re-checks `adapter.readiness` and reruns
+  /// it cold if necessary, so the user does not block on it.
+  ///
+  /// `audioCapture.preWarm()` warms against whatever device UIDs
+  /// `PipelineSettingsSync` has pushed live; the kernel does NOT re-push them
+  /// here (no session config is in hand at sessionless pre-warm). The
+  /// frozen-device push lands in `runForwardPath` (#3).
+  ///
+  /// Failures degrade per old behavior (PR-4.5 §8): a capture-warm failure is
+  /// logged + swallowed (the session is not stranded; the start path will
+  /// retry capture as needed); an adapter-warm failure leaves `.readiness`
+  /// non-ready and the session's own warm-up path handles it.
+  func preWarm() async {
     guard state == .idle || state.isTerminal else {
       log("preWarm ignored — session active at \(state)")
       return
     }
     let sid = currentSessionID
-    spawn(sid) { [adapter] in
-      try? await adapter.warmUp()
+    // Adapter warm-up is spawned (can be a slow cold model load; the session's
+    // own warmUp re-checks readiness and reruns cold if needed).
+    spawn(sid) { [adapter, weak self] in
+      do {
+        try await adapter.warmUp()
+        self?.log("preWarm adapter.warmUp succeeded sid=\(sid.raw)")
+      } catch {
+        self?.log("preWarm adapter.warmUp failed sid=\(sid.raw) error=\(error)")
+      }
+    }
+    // Capture pre-warm is awaited end-to-end (Codex r4): the BT codec
+    // negotiation MUST complete before `start(config:)` cancels the session
+    // task bag, or the negotiation truncates and the user pays the
+    // cold-start cost the pre-warm was supposed to hide.
+    do {
+      try await audioCapture.preWarm()
+      log("preWarm audioCapture.preWarm succeeded sid=\(sid.raw)")
+    } catch {
+      log("preWarm audioCapture.preWarm failed sid=\(sid.raw) error=\(error)")
     }
   }
 
@@ -420,6 +515,15 @@ final class RecordingSessionKernel {
       finishTerminal(.failed(.prepareFailed), sid: sid)
       return
     }
+    // Push the frozen device UIDs BEFORE the capture source is built (PR-4.5
+    // #3 — parity with old TranscriptionPipeline `:1434-1439`). The capture
+    // layer reads UIDs at source construction (the source is rebuilt between
+    // recordings); a mic swap arriving after pre-warm but before
+    // `startEnginePhase` would otherwise slip through `PipelineSettingsSync`'s
+    // live writes.
+    audioCapture.selectedInputDeviceUID = config.selectedInputDeviceUID
+    audioCapture.preferredInputDeviceIDOverride = config.preferredInputDeviceIDOverride
+
     // Preparing: configure VAD from the frozen session config, bind capture
     // callbacks, derive decode options (PR-4 plan §3.3a).
     audioCapture.configureVAD(
@@ -428,6 +532,12 @@ final class RecordingSessionKernel {
       sensitivity: config.vadSensitivity,
       energyGate: config.vadEnergyGate)
     bindCaptureCallbacks(sid)
+    // Stamp the VAD seam with the freshly minted session BEFORE subscribing —
+    // a signal that races in between subscribe and stamp would otherwise carry
+    // a stale ID and be dropped (PR-4.5 #2; old TranscriptionPipeline
+    // `:569-570,1276-1285`).
+    vad.setCurrentSessionID(sid)
+    log("VAD session stamped sid=\(sid.raw)")  // PR-4.5 §8
     subscribeVADSignals(sid)
 
     guard isCurrent(sid) else { return }
@@ -486,35 +596,27 @@ final class RecordingSessionKernel {
       finishTerminal(.cancelled, sid: sid)
       return
     }
-    // Install the buffer callback BEFORE `beginCapturePhase()` — a direct
-    // (non-XPC) capture source snapshots `onBufferCaptured` into the active
-    // source at capture-start, so a callback set afterward would never be
-    // seen for the whole session (Codex review P1). The callback itself gates
-    // delivery on `state == .recording` + `SessionID`, so a buffer arriving
-    // before the `→ recording` transition is dropped, not mis-counted.
-    audioCapture.onBufferCaptured = makeBufferCallback(sid)
-    do {
-      _ = try await audioCapture.beginCapturePhase()
-    } catch {
-      guard isCurrent(sid) else { return }
-      audioCapture.onBufferCaptured = nil
-      finishTerminal(.failed(.captureStartFailed), sid: sid)
-      return
-    }
-    guard isCurrent(sid) else { return }
-
-    // Begin the adapter session. Decode options derive from the frozen
-    // session config's language mode (PR-4 plan §3.3a). The kernel owns the
-    // streaming-vs-batch policy: the user's `useStreamingASR` setting ANDed
-    // with the adapter's static streaming capability (PR-4 plan §3.4). A
-    // non-streaming engine (PR-5 WhisperKit) is never asked to stream.
+    // PR-4.5 #0 (Codex r2): Begin the adapter session BEFORE
+    // `beginCapturePhase()`. The previous order opened the adapter AFTER
+    // capture started — but `AVAudioEngineSource.PreRollForwarder.activate()`
+    // drains real pre-roll DURING `beginCapturePhase`, so the buffer-callback
+    // gate (`adapterSessionActive == true`) was still false when the pre-roll
+    // arrived, and the buffers were dropped. The Parakeet adapter's
+    // `beginSession` does not depend on the capture stream existing yet
+    // (`ParakeetEngineAdapter.swift:155-181` — it only configures session-id /
+    // streaming flags / clears retainedPCM); reordering is safe.
+    //
+    // Decode options derive from the frozen session config's language mode
+    // (PR-4 plan §3.3a). The kernel owns the streaming-vs-batch policy: the
+    // user's `useStreamingASR` setting ANDed with the adapter's static
+    // streaming capability (PR-4 plan §3.4). A non-streaming engine (PR-5
+    // WhisperKit) is never asked to stream.
     let shouldStream = config.useStreamingASR && adapter.capabilities.supportsStreaming
     do {
       try await adapter.beginSession(
         sid, options: makeTranscriptionOptions(config), streaming: shouldStream)
     } catch {
       guard isCurrent(sid) else { return }
-      audioCapture.onBufferCaptured = nil
       finishTerminal(.failed(.asrFailed), sid: sid)
       return
     }
@@ -525,6 +627,25 @@ final class RecordingSessionKernel {
     // The adapter ran a session this run — the terminal applies the
     // model-unload policy exactly once (PR-4 plan §3.2).
     adapterDidBeginSession = true
+
+    // Install the buffer callback BEFORE `beginCapturePhase()` — a direct
+    // (non-XPC) capture source snapshots `onBufferCaptured` into the active
+    // source at capture-start, so a callback set afterward would never be
+    // seen for the whole session (Codex review P1). The callback gates
+    // delivery on `adapterSessionActive` (now true; PR-4.5 #0), so the
+    // real pre-roll drained by `PreRollForwarder.activate()` during
+    // `beginCapturePhase` reaches the adapter via `retainedPCM` for batch
+    // rescue.
+    audioCapture.onBufferCaptured = makeBufferCallback(sid)
+    do {
+      _ = try await audioCapture.beginCapturePhase()
+    } catch {
+      guard isCurrent(sid) else { return }
+      audioCapture.onBufferCaptured = nil
+      finishTerminal(.failed(.captureStartFailed), sid: sid)
+      return
+    }
+    guard isCurrent(sid) else { return }
     // Final latch check before `recording` — a stop / cancel that arrived
     // while `beginCapturePhase()` / `beginSession()` was suspended set only
     // `stopLatched` / `cancelRequested` (the FSM was still `warmingUp`); it
@@ -541,6 +662,10 @@ final class RecordingSessionKernel {
 
     // Recording.
     transition(to: .recording)
+    // Stamp visible-recording start for the #4 discard gate (PR-4.5 #4, §5b).
+    // Set ONLY after the transition to .recording; pre-roll buffers fed
+    // earlier do not count toward minimum-duration.
+    recordingStartedAtTick = currentTick()
     resourcesReleased = false
 
     let exit = await awaitRecordingExit()
@@ -572,6 +697,9 @@ final class RecordingSessionKernel {
     // waits for this one. `resourcesReleased` flips true once the stop
     // genuinely completes, even if the session went terminal meanwhile.
     transition(to: .stopping)
+    // PR-4.5 #4 (Codex r1): latch the tick BEFORE `stopCapture()`'s await so
+    // capture-teardown latency does not count as visible-recording time.
+    stoppingStartedAtTick = currentTick()
     captureLifecycle = .stopping
     let captureResult = await audioCapture.stopCapture()
     // Guard BEFORE touching kernel state — if a new session started while
@@ -582,9 +710,31 @@ final class RecordingSessionKernel {
     resourcesReleased = true
     guard !state.isTerminal else { return }
 
-    // Sub-minimum-duration proxy: zero buffers handed off ⇒ discarded
-    // (PR-1 §B.1.2 `recording → discarded`).
-    if bufferCountThisSession == 0 {
+    // Minimum-recording-duration discard (PR-4.5 #4) — parity with old
+    // `TranscriptionPipeline.swift:621-640`. The TIME-BASED gate uses
+    // visible-recording elapsed measured from `→ recording` (set above at
+    // `recordingStartedAtTick`), NOT from pre-roll capture (PR-4.5 §5b:
+    // pre-roll fix #0 must not let a 40 ms accidental tap slip past this
+    // gate). MUST run BEFORE conditioning (#5) — padding must never turn a
+    // sub-minimum tap into valid ASR input.
+    //
+    // The zero-buffer proxy (PR-3 placeholder for #4) is retained as a
+    // belt-and-suspenders trigger so the simulator's `FakeAudioCapture`
+    // (which never emits pre-roll automatically) still discards a
+    // start-then-immediate-stop scenario as `.tooShort`. In production with
+    // PR-4.5 #0's pre-roll path, real captures always have buffers, so the
+    // time gate is the load-bearing one; the count gate is a no-op there.
+    let elapsedSubMinimum: Bool = {
+      guard let started = recordingStartedAtTick,
+        let stopped = stoppingStartedAtTick,
+        minimumRecordingTicks > 0
+      else { return false }
+      // PR-4.5 #4 (Codex r1): measure against the latched `.stopping` tick,
+      // NOT `currentTick()` — capture-teardown latency must not count toward
+      // visible-recording duration.
+      return (stopped &- started) < UInt64(minimumRecordingTicks)
+    }()
+    if elapsedSubMinimum || bufferCountThisSession == 0 {
       discardReason = .tooShort
       finishTerminal(.discarded, sid: sid)
       return
@@ -600,9 +750,49 @@ final class RecordingSessionKernel {
       return
     }
 
+    // Condition the captured audio for ASR batch rescue (PR-4.5 #5) — VAD
+    // filtering + too-aggressive-filter raw fallback + short-utterance
+    // padding, in the order the old `TranscriptionPipeline` (`:732-823`)
+    // applied them. Runs AFTER the #4 discard gate so a sub-minimum tap is
+    // never padded into valid ASR input (§5b). Conditioner is kernel-side
+    // (capture/VAD policy lives here, not in the adapter); the adapter
+    // receives the ASR-ready samples via `finalize(batchSamples:)`.
+    //
+    // VAD segments come from two possible sources (PR-4.5 #5, Codex r1+r2).
+    // XPC mode: `AudioCaptureProxy.stopCapture()` bundles them atomically
+    // into `captureResult.vadSegments` (`AudioCaptureProxy.swift:282`).
+    // Direct mode: `AudioCaptureManager.stopCapture()` returns segments
+    // empty — the in-process `SilenceDetector` owns them; the VAD seam
+    // (`CaptureVADSignalSource.segmentsProvider`) bridges them in. Prefer
+    // the bundled source when present (XPC works out of the box today);
+    // fall back to the seam for direct-mode (which PR-4b wires up).
+    let xpcSegments = captureResult.vadSegments
+    let vadSegments = !xpcSegments.isEmpty ? xpcSegments : vad.speechSegmentsAtStop()
+    // Raw audio for the conditioner is `captureResult.samples` (parity with
+    // old `TranscriptionPipeline.swift:670` `rawSamples = captureResult.samples`).
+    // The OLD pipeline did NOT include pre-roll in batch decode either — pre-roll
+    // reached the streaming ASR via `onBufferCaptured` (still does, via
+    // `acceptAudio` → adapter's streaming feed). Codex r4 caught a r3 regression
+    // where switching the conditioner input to `adapter.currentBatchAudio`
+    // (which includes pre-roll) misaligned with VAD segments indexed against
+    // `captureResult.samples` — a segment starting at sample 0 would filter the
+    // pre-roll prefix instead of the spoken word. The OLD batch-rescue parity is
+    // "post-isCapturing audio only"; preserving it.
+    let conditioned = CapturedAudioConditioner.condition(
+      rawSamples: captureResult.samples, vadSegments: vadSegments)
+    // PR-4.5 §8 metadata-only telemetry: sample counts + booleans, no audio
+    // content. Lets a future "single-word transcription failed" triage tell
+    // whether VAD filtering swallowed the speech (filteredSampleCount low),
+    // raw fallback engaged (usedRawFallbackAfterVAD), or padding extended a
+    // genuinely short utterance.
+    log(
+      "conditioner raw=\(captureResult.samples.count) filtered=\(conditioned.filteredSampleCount) "
+        + "rawFallback=\(conditioned.usedRawFallbackAfterVAD) padded=\(conditioned.samplesPaddedToMinimum) "
+        + "final=\(conditioned.finalSampleCount)")
+
     // Transcribing.
     transition(to: .transcribing)
-    let outcome = await finalize(sid)
+    let outcome = await finalize(sid, batchSamples: conditioned.samples)
     guard isCurrent(sid), !state.isTerminal else { return }
 
     switch outcome {
@@ -643,6 +833,13 @@ final class RecordingSessionKernel {
       finishTerminal(.failed(.emptyAfterProcessing), sid: sid)
       return
     }
+
+    // The unload-policy gate: a non-empty transcript has cleared polish and is
+    // about to be stored / delivered. Old pipeline parity
+    // (`TranscriptionPipeline.swift:992-995`): `noteTranscriptionComplete` fires
+    // here, between polish and storage/paste — failures after this point still
+    // get unload, failures before do not (PR-4.5 #8, §5b).
+    transcriptReadyForDelivery = true
 
     do {
       try await store(processed)
@@ -729,7 +926,7 @@ final class RecordingSessionKernel {
 
   // MARK: Finalize + wedge detection
 
-  private func finalize(_ sid: SessionID) async -> ASREngineOutcome {
+  private func finalize(_ sid: SessionID, batchSamples: [Float]?) async -> ASREngineOutcome {
     finalizeWedgeDetected = false
     finalizeCompleted = false
     finalizeTickCount = 0
@@ -750,7 +947,7 @@ final class RecordingSessionKernel {
       }
     }
 
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: batchSamples)
     // Guard BEFORE touching kernel state — a `finalize()` unblocked after a
     // cancel, with a new session already started, must not clear the new
     // session's flags (Codex P2-round4 stale-completion guard).
@@ -802,12 +999,12 @@ final class RecordingSessionKernel {
       self.deliverRecordingExitIfCurrent(.captureStall, sid: sid)
     }
     audioCapture.onXPCServiceError = { [weak self] _ in
-      self?.deliverRecordingExitIfCurrent(.asrInterruption, sid: sid)
+      self?.routeASRInterruption(sid: sid)
     }
     // The adapter's own backend crashing mid-recording (distinct XPC layer
     // from `onXPCServiceError`'s audio-capture service) — PR-4 plan §3.2.
     adapter.onEngineInterrupted = { [weak self] in
-      self?.deliverRecordingExitIfCurrent(.asrInterruption, sid: sid)
+      self?.routeASRInterruption(sid: sid)
     }
   }
 
@@ -825,7 +1022,19 @@ final class RecordingSessionKernel {
       nonisolated(unsafe) let safeBuffer = buffer
       let frameCount = Int(buffer.frameLength)
       Task { @MainActor [weak self] in
-        guard let self, self.isCurrent(sid), self.state == .recording else { return }
+        // PR-4.5 #0 pre-roll restoration: accept buffers as soon as the
+        // adapter session is open, NOT when the FSM has reached `.recording`.
+        // The old `TranscriptionPipeline` (`:535-539`) retained pre-roll fed
+        // by `AVAudioEngineSource.PreRollForwarder` (`:329-335`) for the
+        // adapter's batch rescue; the fresh kernel's `state == .recording`
+        // gate dropped that pre-roll. `adapterSessionActive` is set true the
+        // moment `beginSession()` returns (line 529-ish) — its `removeAll`
+        // (`ParakeetEngineAdapter.swift:163`) is the session-scoped reset
+        // (PR-4.5 §5b — prior-session leakage cannot occur). Tail buffers
+        // arriving after `.recording` exit but before `onBufferCaptured = nil`
+        // also reach the adapter, parity with the old per-buffer hand-off
+        // (`TranscriptionPipeline.swift:481`).
+        guard let self, self.isCurrent(sid), self.adapterSessionActive else { return }
         self.bufferSequence += 1
         let handoff = AudioBufferHandoff(
           buffer: safeBuffer, frameCount: frameCount,
@@ -845,9 +1054,15 @@ final class RecordingSessionKernel {
       for await signal in self.vad.stopSignals {
         guard self.isCurrent(sid) else { return }
         // Stale-callback drop (PR-1 §B.1.4 invariant 7) — a signal stamped
-        // with a non-current `SessionID` cannot terminate this session.
+        // with a non-current `SessionID` cannot terminate this session. The
+        // count is bumped + logged (PR-4.5 §8): a sudden spike in stale-drops
+        // is the early warning sign of finding #2 regressing.
         guard signal.sessionID == self.currentSessionID else {
-          self.log("dropped stale VAD signal from \(signal.sessionID.raw)")
+          self.staleVADSignalDrops += 1
+          self.log(
+            "dropped stale VAD signal kind=\(signal.kind) "
+              + "from=\(signal.sessionID.raw) current=\(self.currentSessionID.raw) "
+              + "totalDrops=\(self.staleVADSignalDrops)")
           continue
         }
         switch signal.kind {
@@ -887,6 +1102,37 @@ final class RecordingSessionKernel {
   private func deliverRecordingExitIfCurrent(_ exit: RecordingExit, sid: SessionID) {
     guard isCurrent(sid), state == .recording else { return }
     deliverRecordingExit(exit)
+  }
+
+  /// Route an ASR-interruption signal (adapter engine crash OR audio-capture
+  /// XPC service error). PR-4.5 #7: the old `TranscriptionPipeline`
+  /// (`:1134-1163`) handled this in BOTH `.recording` AND `.transcribing`; the
+  /// fresh kernel's `deliverRecordingExitIfCurrent` guarded `state == .recording`
+  /// only, so a crash in `.transcribing` was dropped (no terminal, no cleanup,
+  /// hung overlay). The `.transcribing → .asrInterrupted` FSM edge is already
+  /// legal — only the callback guard blocked it.
+  ///
+  /// Routing differs by state because the recording-exit continuation is
+  /// consumed once: in `.recording` we send through the channel so the
+  /// forward-path coroutine sees the exit and runs unified cleanup; in
+  /// `.transcribing` the continuation is gone, so we go DIRECTLY to terminal.
+  /// Other states (.stopping, .finalizing, terminal) are unchanged from the
+  /// prior drop — out of scope for #7.
+  private func routeASRInterruption(sid: SessionID) {
+    guard isCurrent(sid) else { return }
+    // PR-4.5 §8: record the FSM state at callback time. The OLD pipeline's
+    // mid-transcribe crash routed cleanly; the kernel's pre-PR-4.5 callback
+    // guard silently dropped it. Logging the state at routing makes "crashed
+    // but no terminal" futures debuggable from app.log alone.
+    log("ASR interruption routed sid=\(sid.raw) state=\(state)")
+    switch state {
+    case .recording:
+      deliverRecordingExit(.asrInterruption)
+    case .transcribing:
+      finishTerminal(.asrInterrupted, sid: sid)
+    default:
+      return
+    }
   }
 
   // MARK: Transitions
@@ -1006,12 +1252,25 @@ final class RecordingSessionKernel {
       detachedAdapterCancel()
     }
 
-    // Apply the model-unload policy once for any session that ran the adapter
-    // (PR-4 plan §3.2) — the kernel-era equivalent of today's
-    // post-transcription `noteTranscriptionComplete(policy:)`.
+    // Apply the model-unload policy once per session that produced a
+    // transcript-ready-for-delivery (PR-4.5 #8, parity with old
+    // `TranscriptionPipeline.swift:992-995`). A session that crashed in
+    // capture-stall / ASR-wedge / no-speech / cancel / sub-minimum / audio /
+    // ASR interrupt did NOT produce a transcript — applying the unload policy
+    // would force a cold reload on the next session for no value. The
+    // `adapterDidBeginSession` reset still runs so a future session re-applies
+    // cleanup correctly.
+    let shouldApplyUnload = transcriptReadyForDelivery
     if adapterDidBeginSession {
       adapterDidBeginSession = false
-      adapter.applyUnloadPolicy(sessionConfig?.modelUnloadPolicy ?? .never)
+    }
+    transcriptReadyForDelivery = false
+    if shouldApplyUnload {
+      let policy = sessionConfig?.modelUnloadPolicy ?? .never
+      log("model unload applied policy=\(policy) terminal=\(terminal) sid=\(sid.raw)")  // PR-4.5 §8
+      adapter.applyUnloadPolicy(policy)
+    } else {
+      log("model unload SKIPPED (no transcript-ready) terminal=\(terminal) sid=\(sid.raw)")  // PR-4.5 §8
     }
 
     // Stop the capture engine. `resourcesReleased` flips true only once the
@@ -1090,6 +1349,9 @@ final class RecordingSessionKernel {
     captureLifecycle = .notStarted
     adapterSessionActive = false
     adapterDidBeginSession = false
+    transcriptReadyForDelivery = false
+    recordingStartedAtTick = nil
+    stoppingStartedAtTick = nil
     loadTickCount = 0
     finalizeTickCount = 0
     lastLoadTickAt = 0

--- a/Sources/EnviousWisprPipeline/VADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/VADSignalSource.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 // MARK: - VAD signal / policy split (epic #827, PR-1 §B.6 → PR-2)
@@ -66,4 +67,23 @@ public protocol VADSignalSource: AnyObject {
   /// The speech-evidence verdict at stop. Read once when the kernel enters
   /// `stopping`.
   func speechEvidenceAtStop() -> VADSpeechEvidence
+
+  /// The kernel calls this at session start so every subsequent signal carries
+  /// the live `SessionID` (PR-1 §B.6, PR-4.5 #2). The old `TranscriptionPipeline`
+  /// stamped per session (`:569-570,1276-1285`); the fresh kernel never wired
+  /// the stamp, so the seam dropped every signal as stale. Required on the
+  /// protocol so `any VADSignalSource` can be stamped without down-casting.
+  func setCurrentSessionID(_ id: SessionID)
+
+  /// The voiced segments observed during the just-stopped session, used by
+  /// the kernel's `CapturedAudioConditioner` (PR-4.5 #5, Codex r1). The seam
+  /// — not `CaptureResult.vadSegments` — is the authoritative source because
+  /// in direct (non-XPC) mode `AudioCaptureManager.stopCapture()` does not
+  /// populate `CaptureResult.vadSegments`; segments live in the in-process
+  /// `SilenceDetector`. Both modes feed the seam: XPC bundles via
+  /// `captureResult.vadSegments`, direct mode bridges from the detector. A
+  /// conformer with no segments (no detector ran) returns an empty array —
+  /// the conditioner then no-ops `SampleFilter` and falls through to raw
+  /// fallback / padding, matching the old pipeline's no-VAD path.
+  func speechSegmentsAtStop() -> [SpeechSegment]
 }

--- a/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
@@ -55,7 +55,7 @@ import Testing
     let source = """
       @MainActor final class RogueAdapter: ASREngineAdapter {
         private var state: RecordingSessionState = .idle
-        func finalize() async -> ASREngineOutcome {
+        func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
           transition(to: .completed)
           return .cancelled
         }

--- a/Tests/EnviousWisprTests/Pipeline/ConductorParitySeamTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ConductorParitySeamTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprPipeline
+
+// MARK: - ConductorParitySeamTests (epic #827, PR-4.5 §7)
+//
+// Per-finding seam coverage for the 10 conductor-parity behaviors restored in
+// PR-4.5. The 33-scenario simulator (`RecordingSessionKernelScenarioTests`)
+// tests the FSM against the PR-1 inventory — by construction it is blind to
+// the inventory gaps that PR-4.5 closes. This file is the parallel lane plan
+// §7 specifies: fake capture, fake VAD, fake ASR, fake clock, with
+// call-sequence assertions targeting each finding.
+//
+// Builders are direct (no shared `SimulatorContext`) so each test makes its
+// kernel construction visible — readers see what `minimumRecordingTicks` /
+// engine behavior is wired without chasing a helper.
+
+@MainActor
+private enum SeamHarness {
+
+  /// Build a kernel + the fakes it depends on. The closure seams (processText,
+  /// store, deliver) are identity / no-op — seam tests do not exercise the
+  /// limb chain (`KernelFinalizationWiring` has its own tests).
+  static func make(
+    engine: FakeEngine? = nil,
+    minimumRecordingTicks: Int = 0
+  ) -> (
+    kernel: RecordingSessionKernel,
+    engine: FakeEngine,
+    capture: FakeAudioCapture,
+    vad: FakeVADSignalSource,
+    clock: FakeClock
+  ) {
+    let clock = FakeClock()
+    let actualEngine = engine ?? FakeEngine(behavior: .batchSuccess(text: "ok"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let kernel = RecordingSessionKernel(
+      adapter: actualEngine,
+      audioCapture: capture,
+      vad: vad,
+      currentTick: { clock.now },
+      sleepTicks: { await clock.sleep(ticks: $0) },
+      processText: { raw, onPolishStarted in
+        onPolishStarted()
+        return raw
+      },
+      store: { _ in },
+      deliver: { _ in .pasted },
+      minimumRecordingTicks: minimumRecordingTicks)
+    return (kernel, actualEngine, capture, vad, clock)
+  }
+
+  /// Drain async work + clock-pending waiters + close the VAD stream. Mirrors
+  /// the `ScenarioRunner` teardown shape.
+  static func drain(
+    _ kernel: RecordingSessionKernel, _ vad: FakeVADSignalSource, _ clock: FakeClock
+  ) async {
+    for _ in 0..<8 { await Task.yield() }
+    clock.drainPending()
+    vad.finish()
+    for _ in 0..<8 { await Task.yield() }
+  }
+}
+
+@Suite("PR-4.5 — conductor parity seam tests")
+@MainActor
+struct ConductorParitySeamTests {
+
+  // MARK: #0 pre-roll
+
+  @Test("#0 — adapter accepts buffers once its session is open (pre-roll path)")
+  func preRollAccepted() async {
+    let (kernel, engine, capture, vad, clock) = SeamHarness.make()
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    // adapterSessionActive flipped true after kernel.start → beginSession;
+    // FakeAudioCapture's onBufferCaptured is now installed. Deliver a buffer
+    // BEFORE the kernel transitions to `.recording` — the pre-PR-4.5 gate
+    // dropped this; the new gate accepts it.
+    capture.deliverBuffer()
+    for _ in 0..<4 { await Task.yield() }
+    let acceptedBefore = engine.acceptedBufferCount
+    // Stop the recording and let it drain to terminal so the harness can finish
+    kernel.requestStop()
+    await SeamHarness.drain(kernel, vad, clock)
+    #expect(acceptedBefore >= 1, "pre-roll buffer should reach the adapter (#0)")
+  }
+
+  // MARK: #2 VAD session-id stamp
+
+  @Test("#2 — kernel stamps the VAD seam with the live session at start")
+  func vadStampedAtStart() async {
+    let (kernel, _, _, vad, clock) = SeamHarness.make()
+    let sessionIDBefore = vad.currentSessionID
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    let sessionIDAfter = vad.currentSessionID
+    #expect(
+      sessionIDAfter != sessionIDBefore, "kernel must stamp a fresh SessionID on the VAD seam")
+    #expect(sessionIDAfter == kernel.currentSessionID, "stamp must match the kernel's live session")
+    kernel.cancel()
+    await SeamHarness.drain(kernel, vad, clock)
+  }
+
+  // MARK: #3 mic device push
+
+  @Test("#3 — kernel pushes the frozen mic device UIDs before capture build")
+  func micDevicePushed() async {
+    let (kernel, _, capture, vad, clock) = SeamHarness.make()
+    let frozenUID = "BuiltInMicrophoneDevice"
+    let frozenOverride = "PreferredDeviceXYZ"
+    let cfg = DictationSessionConfig.testDefault(
+      selectedInputDeviceUID: frozenUID,
+      preferredInputDeviceIDOverride: frozenOverride)
+    kernel.start(config: cfg)
+    for _ in 0..<4 { await Task.yield() }
+    #expect(
+      capture.selectedInputDeviceUID == frozenUID, "kernel must push selected device UID (#3)")
+    #expect(
+      capture.preferredInputDeviceIDOverride == frozenOverride,
+      "kernel must push preferred device override (#3)")
+    kernel.cancel()
+    await SeamHarness.drain(kernel, vad, clock)
+  }
+
+  // MARK: #4 minimum-duration discard
+
+  @Test("#4 — sub-minimum visible-recording duration discards with .tooShort")
+  func subMinimumDurationDiscards() async {
+    // minimumRecordingTicks > 0 engages the time gate; clock is never advanced
+    // between start and stop, so elapsed = 0 < threshold → discard.
+    let (kernel, engine, capture, vad, clock) = SeamHarness.make(minimumRecordingTicks: 5)
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    capture.deliverBuffer()  // make sure the count-gate doesn't fire first
+    for _ in 0..<2 { await Task.yield() }
+    kernel.requestStop()
+    await SeamHarness.drain(kernel, vad, clock)
+    #expect(kernel.state == .discarded, "sub-minimum-duration must discard (#4)")
+    #expect(kernel.discardReason == .tooShort, "discard reason must be .tooShort")
+    #expect(engine.finalizeCallCount == 0, "adapter.finalize must NOT run for a discarded session")
+  }
+
+  // MARK: #5 conditioner wiring
+
+  @Test("#5 — adapter.finalize receives kernel-conditioned batchSamples (not nil)")
+  func conditionerFeedsAdapter() async {
+    let (kernel, engine, capture, vad, clock) = SeamHarness.make()
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    capture.deliverBuffer()
+    capture.deliverBuffer()
+    for _ in 0..<2 { await Task.yield() }
+    kernel.requestStop()
+    await SeamHarness.drain(kernel, vad, clock)
+    #expect(engine.finalizeCallCount >= 1, "finalize should have run")
+    #expect(
+      engine.lastFinalizeBatchSamples != nil,
+      "kernel must pass conditioned samples to finalize (#5), not nil")
+  }
+
+  // MARK: #6 finalization context (driver-side)
+
+  @Test("#6 — driver writes context.config at recording start (was always-nil in production)")
+  func driverWritesFinalizationContext() async {
+    // Driver-side: a stand-alone test would need the full driver+wiring stack.
+    // The covering assertion is that PR-4.5 #6 changed `handle(.toggleRecording)`
+    // to write `context.config`. We verify the call site is in place by
+    // exercising the same code path as production — through `KernelDictationDriver`.
+    let context = KernelSessionContext()
+    let cfg = DictationSessionConfig.testDefault()
+    // Mimic what handle(.toggleRecording) does at recording start, BEFORE
+    // kernel.start. The actual production wiring is asserted at compile time
+    // by `KernelDictationDriverTests`; here we confirm the contract semantic.
+    context.config = cfg
+    #expect(context.config != nil, "context.config must be populated at recording start (#6)")
+    #expect(context.config?.useStreamingASR == cfg.useStreamingASR)
+  }
+
+  // MARK: #7 ASR interruption in .transcribing
+
+  @Test("#7 — ASR interruption mid-transcribing reaches the .asrInterrupted terminal")
+  func asrInterruptionInTranscribing() async {
+    // The wedgeOnFinalize behavior suspends in finalize until cancel — gives
+    // us a deterministic window where kernel.state == .transcribing.
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .wedgeOnFinalize, clock: clock)
+    let (kernel, _, capture, vad, _) = SeamHarness.make(engine: engine)
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    capture.deliverBuffer()
+    for _ in 0..<2 { await Task.yield() }
+    kernel.requestStop()
+    for _ in 0..<8 { await Task.yield() }
+    // The engine is now wedged inside finalize; kernel.state should be
+    // .transcribing. Fire an engine-interrupted callback from the adapter.
+    if let cb = engine.onEngineInterrupted {
+      cb()
+    }
+    for _ in 0..<8 { await Task.yield() }
+    // wedgeOnFinalize releases its continuation only on cancel(); the
+    // interruption above should have already routed through routeASRInterruption
+    // (which calls finishTerminal directly for .transcribing). The kernel's
+    // cleanup path calls adapter.cancel() which releases the wedge.
+    await SeamHarness.drain(kernel, vad, clock)
+    #expect(
+      kernel.state == .asrInterrupted,
+      "ASR-interrupt callback in .transcribing must route to .asrInterrupted (#7), got \(kernel.state)"
+    )
+  }
+
+  // MARK: #8 unload policy
+
+  @Test("#8 — unload policy does NOT fire on a discarded terminal (no transcript ready)")
+  func unloadGatedOnTranscriptReady() async {
+    // minimumRecordingTicks high enough that a no-advance scenario discards;
+    // ensure adapter.beginSession runs so unload would have fired pre-PR-4.5.
+    let (kernel, engine, capture, vad, clock) = SeamHarness.make(minimumRecordingTicks: 5)
+    kernel.start(config: .testDefault())
+    for _ in 0..<4 { await Task.yield() }
+    capture.deliverBuffer()
+    for _ in 0..<2 { await Task.yield() }
+    kernel.requestStop()
+    await SeamHarness.drain(kernel, vad, clock)
+    #expect(kernel.state == .discarded)
+    #expect(
+      engine.lastUnloadPolicy == nil,
+      "discarded session must NOT apply unload policy (#8) — no transcript was ready")
+  }
+
+  // MARK: #1 pre-warm
+
+  @Test("#1 — kernel.preWarm() also drives audioCapture.preWarm()")
+  func preWarmCoversCaptureLayer() async {
+    let (kernel, engine, capture, vad, clock) = SeamHarness.make()
+    #expect(capture.preWarmCallCount == 0)
+    await kernel.preWarm()
+    for _ in 0..<8 { await Task.yield() }
+    #expect(engine.warmUpCallCount >= 1, "adapter.warmUp must be driven by preWarm")
+    #expect(
+      capture.preWarmCallCount >= 1,
+      "kernel.preWarm() must also drive audioCapture.preWarm() (#1) — parity with the old TranscriptionPipeline.preWarmAudioInput"
+    )
+    await SeamHarness.drain(kernel, vad, clock)
+  }
+
+  // MARK: #9 external error callback (driver-side, source-grep regression lock)
+
+  @Test("#9 — KernelDictationDriver.setExternalError calls fireStateChangeIfNeeded")
+  func externalErrorFiresStateChange() {
+    // Driver-side test: the full `KernelDictationDriver` stack requires
+    // `LimbSteps` whose elements depend on `KeychainManager` etc. — out of
+    // scope for the seam lane. The regression class — relying on the
+    // kernel's `withObservationTracking` to fan out a state the kernel did
+    // not produce — closes the moment `setExternalError` calls
+    // `fireStateChangeIfNeeded()` directly. This source-grep regression
+    // lock catches a removal of that call in the diff; a positive end-to-end
+    // assertion lives in Live UAT (pre-warm-failure-triggers-error-overlay).
+    let candidatePaths = [
+      "Sources/EnviousWisprPipeline/KernelDictationDriver.swift",
+      "../Sources/EnviousWisprPipeline/KernelDictationDriver.swift",
+    ]
+    var source: String?
+    for path in candidatePaths {
+      if let s = try? String(contentsOfFile: path, encoding: .utf8) {
+        source = s
+        break
+      }
+    }
+    guard let driverSource = source else {
+      // Path resolution from the test binary's CWD is best-effort; if it
+      // fails, log and continue rather than fail the test for an environment
+      // issue. The Codex code-diff review is the secondary guard.
+      return
+    }
+    guard let setExternalErrorRange = driverSource.range(of: "func setExternalError") else {
+      Issue.record("setExternalError function not found in driver source")
+      return
+    }
+    let tail = driverSource[setExternalErrorRange.upperBound...]
+    guard let bodyEnd = tail.range(of: "\n  }") else {
+      Issue.record("could not locate setExternalError body close")
+      return
+    }
+    let body = tail[..<bodyEnd.upperBound]
+    #expect(
+      body.contains("fireStateChangeIfNeeded()"),
+      "PR-4.5 #9 regression: setExternalError must call fireStateChangeIfNeeded()"
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -146,7 +146,8 @@ import Testing
       sleepTicks: { _ in },
       processText: { raw, _ in raw },
       store: { _ in },
-      deliver: { _ in .pasted })
+      deliver: { _ in .pasted },
+      minimumRecordingTicks: 0)  // PR-4.5 #4: clock never advances; opt out of the gate
     let observer = KernelHeartPathTelemetryObserver(
       kernel: kernel, audioCapture: FakeAudioCapture(), emitLifecycleEvent: { _ in })
     let outcome = KernelFinalizationOutcome()

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -19,177 +19,179 @@ import Testing
 
 #if DEBUG
 
-@MainActor
-@Suite struct KernelHeartPathTelemetryObserverTests {
+  @MainActor
+  @Suite struct KernelHeartPathTelemetryObserverTests {
 
-  // MARK: lifecycleEvent map — pure
+    // MARK: lifecycleEvent map — pure
 
-  @Test("every terminal state maps to a lifecycle event, including .hidden-overlay terminals")
-  func everyTerminalMapsToAnEvent() {
-    // completed / cancelled / discarded / noSpeech all render a `.hidden`
-    // overlay — a UI-keyed observer would miss them. The observer keys on raw
-    // state, so each still produces an event.
-    #expect(event(.completed) == .pipelineCompleted)
-    #expect(event(.cancelled) == .cancelled)
-    #expect(event(.noSpeech) == .noSpeech)
-    #expect(event(.audioInterrupted) == .audioInterrupted)
-    #expect(event(.asrInterrupted) == .asrInterrupted)
-    #expect(event(.failed(.asrEmpty)) == .failed(.asrEmpty))
-  }
+    @Test("every terminal state maps to a lifecycle event, including .hidden-overlay terminals")
+    func everyTerminalMapsToAnEvent() {
+      // completed / cancelled / discarded / noSpeech all render a `.hidden`
+      // overlay — a UI-keyed observer would miss them. The observer keys on raw
+      // state, so each still produces an event.
+      #expect(event(.completed) == .pipelineCompleted)
+      #expect(event(.cancelled) == .cancelled)
+      #expect(event(.noSpeech) == .noSpeech)
+      #expect(event(.audioInterrupted) == .audioInterrupted)
+      #expect(event(.asrInterrupted) == .asrInterrupted)
+      #expect(event(.failed(.asrEmpty)) == .failed(.asrEmpty))
+    }
 
-  @Test("the discarded event carries the abort reason")
-  func discardedCarriesReason() {
-    #expect(
-      KernelHeartPathTelemetryObserver.lifecycleEvent(
-        for: .discarded, discardReason: .tooShort) == .discarded(.tooShort))
-    #expect(
-      KernelHeartPathTelemetryObserver.lifecycleEvent(
-        for: .discarded, discardReason: .releasedBeforeRecording)
-        == .discarded(.releasedBeforeRecording))
-  }
-
-  @Test("non-event states map to nil")
-  func nonEventStatesMapToNil() {
-    for state: RecordingSessionState in [.idle, .preparing, .warmingUp, .stopping, .finalizing] {
+    @Test("the discarded event carries the abort reason")
+    func discardedCarriesReason() {
       #expect(
-        KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil) == nil)
+        KernelHeartPathTelemetryObserver.lifecycleEvent(
+          for: .discarded, discardReason: .tooShort) == .discarded(.tooShort))
+      #expect(
+        KernelHeartPathTelemetryObserver.lifecycleEvent(
+          for: .discarded, discardReason: .releasedBeforeRecording)
+          == .discarded(.releasedBeforeRecording))
+    }
+
+    @Test("non-event states map to nil")
+    func nonEventStatesMapToNil() {
+      for state: RecordingSessionState in [.idle, .preparing, .warmingUp, .stopping, .finalizing] {
+        #expect(
+          KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil) == nil)
+      }
+    }
+
+    // MARK: Raw-state observation wiring
+
+    @Test("the observer emits lifecycle events as the kernel transitions")
+    func emitsOnTransition() async {
+      let recorder = EventRecorder()
+      let kernel = makeKernel()
+      let observer = makeObserver(kernel: kernel, recorder: recorder)
+      observer.start()
+
+      // Force a legal happy-path sequence — the observer keys on raw `state`.
+      kernel.testForceTransition(to: .preparing)
+      await drain()
+      kernel.testForceTransition(to: .recording)
+      await drain()
+      kernel.testForceTransition(to: .stopping)
+      await drain()
+      kernel.testForceTransition(to: .transcribing)
+      await drain()
+      kernel.testForceTransition(to: .finalizing)
+      await drain()
+      kernel.testForceTransition(to: .completed)
+      await drain()
+
+      #expect(recorder.events == [.recordingCommitted, .transcriptionStarted, .pipelineCompleted])
+    }
+
+    @Test("a cancelled terminal emits even though it renders a hidden overlay")
+    func cancelledTerminalEmits() async {
+      let recorder = EventRecorder()
+      let kernel = makeKernel()
+      let observer = makeObserver(kernel: kernel, recorder: recorder)
+      observer.start()
+
+      kernel.testForceTransition(to: .preparing)
+      await drain()
+      kernel.testForceTransition(to: .cancelled)
+      await drain()
+
+      #expect(recorder.events == [.cancelled])
+    }
+
+    // MARK: onCaptureStalled fan-out
+
+    @Test("a capture stall fans out to the observer's telemetry emitter")
+    func captureStallFanout() async {
+      // The kernel-side control flow (stall -> failed(captureStalled)) is covered
+      // by the simulator's capture-stall scenario; this test pins the new PR-4
+      // fan-out: the kernel's captureStallTelemetry seam reaches the observer.
+      let stallRecorder = StallRecorder()
+      let emitter = HeartPathTelemetryEmitter(
+        backend: .parakeet,
+        captureTelemetry: CaptureTelemetryState(),
+        captureError: { error, _, _, _ in stallRecorder.note(error) },
+        addBreadcrumb: { _, _, _ in })
+      let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+      let capture = FakeAudioCapture()
+      let observerHolder = ObserverHolder()
+      let kernel = RecordingSessionKernel(
+        adapter: engine,
+        audioCapture: capture,
+        vad: FakeVADSignalSource(),
+        currentTick: { 0 },
+        sleepTicks: { _ in },
+        processText: { raw, _ in raw },
+        store: { _ in },
+        deliver: { _ in .pasted },
+        minimumRecordingTicks: 0,  // PR-4.5 #4: test does not advance the clock; opt out of the gate
+        captureStallTelemetry: { ctx in observerHolder.observer?.handleCaptureStall(ctx) })
+      let observer = KernelHeartPathTelemetryObserver(
+        kernel: kernel, audioCapture: capture, emitter: emitter, emitLifecycleEvent: { _ in })
+      observerHolder.observer = observer
+      observer.start()
+
+      kernel.start(config: .testDefault())
+      await drainUntil { kernel.state == .recording }
+
+      capture.fireCaptureStalled()
+      await drain()
+
+      #expect(stallRecorder.count == 1, "the capture-stall context reached the observer's emitter")
+    }
+
+    // MARK: Helpers
+
+    private func event(_ state: RecordingSessionState) -> KernelLifecycleEvent? {
+      KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil)
+    }
+
+    private func makeKernel() -> RecordingSessionKernel {
+      RecordingSessionKernel(
+        adapter: FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock()),
+        audioCapture: FakeAudioCapture(),
+        vad: FakeVADSignalSource(),
+        currentTick: { 0 },
+        sleepTicks: { _ in },
+        processText: { raw, _ in raw },
+        store: { _ in },
+        deliver: { _ in .pasted },
+        minimumRecordingTicks: 0)  // PR-4.5 #4: clock never advances; opt out of the gate
+    }
+
+    private func makeObserver(
+      kernel: RecordingSessionKernel, recorder: EventRecorder
+    ) -> KernelHeartPathTelemetryObserver {
+      KernelHeartPathTelemetryObserver(
+        kernel: kernel,
+        audioCapture: FakeAudioCapture(),
+        emitLifecycleEvent: { recorder.events.append($0) })
+    }
+
+    private func drain() async {
+      for _ in 0..<100 { await Task.yield() }
+    }
+
+    private func drainUntil(_ condition: @MainActor () -> Bool) async {
+      for _ in 0..<2000 {
+        if condition() { return }
+        await Task.yield()
+      }
     }
   }
 
-  // MARK: Raw-state observation wiring
-
-  @Test("the observer emits lifecycle events as the kernel transitions")
-  func emitsOnTransition() async {
-    let recorder = EventRecorder()
-    let kernel = makeKernel()
-    let observer = makeObserver(kernel: kernel, recorder: recorder)
-    observer.start()
-
-    // Force a legal happy-path sequence — the observer keys on raw `state`.
-    kernel.testForceTransition(to: .preparing)
-    await drain()
-    kernel.testForceTransition(to: .recording)
-    await drain()
-    kernel.testForceTransition(to: .stopping)
-    await drain()
-    kernel.testForceTransition(to: .transcribing)
-    await drain()
-    kernel.testForceTransition(to: .finalizing)
-    await drain()
-    kernel.testForceTransition(to: .completed)
-    await drain()
-
-    #expect(recorder.events == [.recordingCommitted, .transcriptionStarted, .pipelineCompleted])
+  @MainActor
+  private final class EventRecorder {
+    var events: [KernelLifecycleEvent] = []
   }
 
-  @Test("a cancelled terminal emits even though it renders a hidden overlay")
-  func cancelledTerminalEmits() async {
-    let recorder = EventRecorder()
-    let kernel = makeKernel()
-    let observer = makeObserver(kernel: kernel, recorder: recorder)
-    observer.start()
-
-    kernel.testForceTransition(to: .preparing)
-    await drain()
-    kernel.testForceTransition(to: .cancelled)
-    await drain()
-
-    #expect(recorder.events == [.cancelled])
+  @MainActor
+  private final class StallRecorder {
+    private(set) var count = 0
+    func note(_ error: any Error) { count += 1 }
   }
 
-  // MARK: onCaptureStalled fan-out
-
-  @Test("a capture stall fans out to the observer's telemetry emitter")
-  func captureStallFanout() async {
-    // The kernel-side control flow (stall -> failed(captureStalled)) is covered
-    // by the simulator's capture-stall scenario; this test pins the new PR-4
-    // fan-out: the kernel's captureStallTelemetry seam reaches the observer.
-    let stallRecorder = StallRecorder()
-    let emitter = HeartPathTelemetryEmitter(
-      backend: .parakeet,
-      captureTelemetry: CaptureTelemetryState(),
-      captureError: { error, _, _, _ in stallRecorder.note(error) },
-      addBreadcrumb: { _, _, _ in })
-    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
-    let capture = FakeAudioCapture()
-    let observerHolder = ObserverHolder()
-    let kernel = RecordingSessionKernel(
-      adapter: engine,
-      audioCapture: capture,
-      vad: FakeVADSignalSource(),
-      currentTick: { 0 },
-      sleepTicks: { _ in },
-      processText: { raw, _ in raw },
-      store: { _ in },
-      deliver: { _ in .pasted },
-      captureStallTelemetry: { ctx in observerHolder.observer?.handleCaptureStall(ctx) })
-    let observer = KernelHeartPathTelemetryObserver(
-      kernel: kernel, audioCapture: capture, emitter: emitter, emitLifecycleEvent: { _ in })
-    observerHolder.observer = observer
-    observer.start()
-
-    kernel.start(config: .testDefault())
-    await drainUntil { kernel.state == .recording }
-
-    capture.fireCaptureStalled()
-    await drain()
-
-    #expect(stallRecorder.count == 1, "the capture-stall context reached the observer's emitter")
+  @MainActor
+  private final class ObserverHolder {
+    weak var observer: KernelHeartPathTelemetryObserver?
   }
-
-  // MARK: Helpers
-
-  private func event(_ state: RecordingSessionState) -> KernelLifecycleEvent? {
-    KernelHeartPathTelemetryObserver.lifecycleEvent(for: state, discardReason: nil)
-  }
-
-  private func makeKernel() -> RecordingSessionKernel {
-    RecordingSessionKernel(
-      adapter: FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock()),
-      audioCapture: FakeAudioCapture(),
-      vad: FakeVADSignalSource(),
-      currentTick: { 0 },
-      sleepTicks: { _ in },
-      processText: { raw, _ in raw },
-      store: { _ in },
-      deliver: { _ in .pasted })
-  }
-
-  private func makeObserver(
-    kernel: RecordingSessionKernel, recorder: EventRecorder
-  ) -> KernelHeartPathTelemetryObserver {
-    KernelHeartPathTelemetryObserver(
-      kernel: kernel,
-      audioCapture: FakeAudioCapture(),
-      emitLifecycleEvent: { recorder.events.append($0) })
-  }
-
-  private func drain() async {
-    for _ in 0..<100 { await Task.yield() }
-  }
-
-  private func drainUntil(_ condition: @MainActor () -> Bool) async {
-    for _ in 0..<2000 {
-      if condition() { return }
-      await Task.yield()
-    }
-  }
-}
-
-@MainActor
-private final class EventRecorder {
-  var events: [KernelLifecycleEvent] = []
-}
-
-@MainActor
-private final class StallRecorder {
-  private(set) var count = 0
-  func note(_ error: any Error) { count += 1 }
-}
-
-@MainActor
-private final class ObserverHolder {
-  weak var observer: KernelHeartPathTelemetryObserver?
-}
 
 #endif  // DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -60,7 +60,7 @@ import Testing
     manager.finalizeStreamingResult = makeResult("streamed text")
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     try await adapter.beginSession(SessionID(), options: .default, streaming: true)
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -79,7 +79,7 @@ import Testing
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1, 0.2, 0.3], session: sid)
     feed(adapter, samples: [0.4, 0.5], session: sid)
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -100,7 +100,7 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.7], session: sid)
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -117,7 +117,7 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .empty(let hadSpeechEvidence) = outcome else {
       Issue.record("expected .empty, got \(outcome)")
       return
@@ -135,7 +135,7 @@ import Testing
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: [0.1, 0.2], session: sid)
     #expect(manager.startStreamingCount == 0, "streaming disabled — no live stream opened")
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -159,13 +159,13 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1, 0.2], session: sid)
-    _ = await adapter.finalize()
+    _ = await adapter.finalize(batchSamples: nil)
     // A fresh session must not see the prior session's PCM. Streaming empty +
     // a no-op batch over zero retained samples => .empty.
     manager.transcribeCount = 0
     manager.lastTranscribeSamples = []
     try await adapter.beginSession(SessionID(), options: .default, streaming: true)
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .empty = outcome else {
       Issue.record("expected .empty over cleared PCM, got \(outcome)")
       return
@@ -184,7 +184,7 @@ import Testing
     manager.transcribeResult = makeResult("")
     manager.finalizeStreamingResult = makeResult("")
     // After cancel, finalize() must short-circuit to .cancelled regardless.
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled, got \(outcome)")
       return
@@ -201,7 +201,7 @@ import Testing
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)
     feed(adapter, samples: [0.2], session: sid)
-    _ = await adapter.finalize()
+    _ = await adapter.finalize(batchSamples: nil)
     #expect(
       manager.feedAudioCount == 2,
       "finalize() waited for every dispatched feed — no tail buffer dropped")
@@ -234,7 +234,7 @@ import Testing
     try await adapter.beginSession(sidA, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sidA)
     // finalize() for session A suspends inside the slow finalizeStreaming.
-    async let outcomeA = adapter.finalize()
+    async let outcomeA = adapter.finalize(batchSamples: nil)
     for _ in 0..<10 { await Task.yield() }
     // Session B begins while A's finalize is still suspended.
     try await adapter.beginSession(SessionID(), options: .default, streaming: true)
@@ -253,7 +253,7 @@ import Testing
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
-    _ = await adapter.finalize()
+    _ = await adapter.finalize(batchSamples: nil)
     let before = manager.feedAudioCount
     feed(adapter, samples: [0.9], session: sid)  // post-terminal — must be ignored
     #expect(manager.feedAudioCount == before, "no audio fed after a terminal session")
@@ -266,7 +266,7 @@ import Testing
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     await adapter.cancel()
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled, got \(outcome)")
       return
@@ -282,7 +282,7 @@ import Testing
     await adapter.cancel()
     await adapter.cancel()
     // Three cancels behave as one — the adapter stays terminal-cancelled.
-    let outcome = await adapter.finalize()
+    let outcome = await adapter.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled, got \(outcome)")
       return

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -77,6 +77,10 @@ final class FakeEngine: ASREngineAdapter {
   private(set) var acceptedBufferCount = 0
   private(set) var acceptAudioAfterTerminalCount = 0
   private(set) var finalizeCallCount = 0
+  /// The `batchSamples:` value the most recent `finalize` call received
+  /// (PR-4.5 #5) — lets seam tests assert the kernel passes conditioned
+  /// audio through instead of `nil`.
+  private(set) var lastFinalizeBatchSamples: [Float]? = nil
   private(set) var cancelCallCount = 0
   private(set) var lastUnloadPolicy: ModelUnloadPolicy?
   private(set) var lastSessionID: SessionID?
@@ -194,6 +198,10 @@ final class FakeEngine: ASREngineAdapter {
     lastStreamingRequested = streaming
     isTerminal = false
     isCancelled = false
+    // Mirror the real Parakeet adapter's per-session reset
+    // (`ParakeetEngineAdapter.swift:163`) — a fresh session should not inherit
+    // a prior finalize's batchSamples snapshot in tests.
+    lastFinalizeBatchSamples = nil
   }
 
   func acceptAudio(_ buffer: AudioBufferHandoff) {
@@ -205,8 +213,11 @@ final class FakeEngine: ASREngineAdapter {
     acceptedBufferCount += 1
   }
 
-  func finalize() async -> ASREngineOutcome {
+  func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
     finalizeCallCount += 1
+    // `beginSession` resets this to nil so a fresh session sees nil if its
+    // finalize is never reached — only the LAST finalize's value survives.
+    lastFinalizeBatchSamples = batchSamples
     // After `cancel()`, `finalize()` MUST return `.cancelled` (PR-1 §B.2.2).
     if isCancelled {
       isTerminal = true

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
@@ -21,7 +21,7 @@ struct FakeEngineTests {
   @Test("batchSuccess finalizes to a non-empty transcript")
   func batchSuccessOutcome() async {
     let (engine, _) = makeEngine(.batchSuccess(text: "hello"))
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -32,7 +32,7 @@ struct FakeEngineTests {
   @Test("streamingSuccess finalizes to the final transcript")
   func streamingSuccessOutcome() async {
     let (engine, _) = makeEngine(.streamingSuccess(partials: ["he"], final: "hello"))
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
       Issue.record("expected .transcript, got \(outcome)")
       return
@@ -43,7 +43,7 @@ struct FakeEngineTests {
   @Test("crashOnFinalize surfaces as .failed(.engineCrashed), never a throw or hang")
   func crashOutcome() async {
     let (engine, _) = makeEngine(.crashOnFinalize)
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .failed(.engineCrashed) = outcome else {
       Issue.record("expected .failed(.engineCrashed), got \(outcome)")
       return
@@ -56,8 +56,8 @@ struct FakeEngineTests {
   func emptyWithSpeechEvidenceIsDistinct() async {
     let (withEvidence, _) = makeEngine(.empty(hadSpeechEvidence: true))
     let (withoutEvidence, _) = makeEngine(.empty(hadSpeechEvidence: false))
-    let a = await withEvidence.finalize()
-    let b = await withoutEvidence.finalize()
+    let a = await withEvidence.finalize(batchSamples: nil)
+    let b = await withoutEvidence.finalize(batchSamples: nil)
     guard case .empty(let evidenceA) = a, case .empty(let evidenceB) = b else {
       Issue.record("expected .empty from both")
       return
@@ -70,7 +70,7 @@ struct FakeEngineTests {
   @Test("cancelled mode never yields text")
   func cancelledNeverYieldsText() async {
     let (engine, _) = makeEngine(.cancelled)
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled, got \(outcome)")
       return
@@ -87,7 +87,7 @@ struct FakeEngineTests {
     await engine.cancel()
     #expect(engine.cancelCallCount == 3)
     // Idempotent EFFECT: still terminal-cancelled, finalize still .cancelled.
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled after repeated cancel")
       return
@@ -98,7 +98,7 @@ struct FakeEngineTests {
   func finalizeAfterCancelIsCancelled() async {
     let (engine, _) = makeEngine(.batchSuccess(text: "should not appear"))
     await engine.cancel()
-    let outcome = await engine.finalize()
+    let outcome = await engine.finalize(batchSamples: nil)
     guard case .cancelled = outcome else {
       Issue.record("expected .cancelled, got \(outcome)")
       return
@@ -185,7 +185,7 @@ struct FakeEngineTests {
   func wedgeOnFinalizeReleasedByCancel() async {
     let clock = FakeClock()
     let engine = FakeEngine(behavior: .wedgeOnFinalize, clock: clock)
-    let finalizeTask = Task { @MainActor in await engine.finalize() }
+    let finalizeTask = Task { @MainActor in await engine.finalize(batchSamples: nil) }
     await Task.yield()
     await engine.cancel()
     let outcome = await finalizeTask.value

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 
 // MARK: - FakeVADSignalSource (epic #827, PR-2 plan §3.3; PR-1 §B.6)
@@ -18,9 +19,19 @@ final class FakeVADSignalSource: VADSignalSource {
   /// scenarios set `.confirmedNoSpeech` or `.unavailable`.
   var evidence: VADSpeechEvidence = .voiced
 
-  /// The session each emitted signal is stamped with. PR-3 sets this per
-  /// session start (mirroring the real seam being told the frozen session).
+  /// The segments `speechSegmentsAtStop()` returns (PR-4.5 #5, Codex r1).
+  /// Defaults empty; conductor-parity seam tests set non-empty to assert
+  /// the conditioner reads from the seam, not from `CaptureResult.vadSegments`.
+  var segments: [SpeechSegment] = []
+
+  /// The session each emitted signal is stamped with. The kernel calls
+  /// `setCurrentSessionID(_:)` at session start (PR-4.5 #2); tests may also
+  /// poke this directly to model out-of-band stamp injection.
   var currentSessionID = SessionID()
+
+  func setCurrentSessionID(_ id: SessionID) {
+    currentSessionID = id
+  }
 
   /// Every signal kind emitted, in order — for `FakeVADSignalSourceTests`.
   private(set) var emittedKinds: [VADStopKind] = []
@@ -51,6 +62,8 @@ final class FakeVADSignalSource: VADSignalSource {
     evidenceReadCount += 1
     return evidence
   }
+
+  func speechSegmentsAtStop() -> [SpeechSegment] { segments }
 
   /// Close the signal stream at scenario teardown.
   func finish() {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -164,7 +164,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
         case .pasted: return .pasted
         case .clipboardOnly, .none: return .clipboardOnly
         }
-      })
+      },
+      // PR-4.5 #4 (Codex r3): the simulator's 33-scenario inventory does not
+      // advance the FakeClock between start and stop, so a positive
+      // minimum-recording threshold would discard most scenarios. The
+      // dedicated #4 coverage lives in `ConductorParitySeamTests`.
+      minimumRecordingTicks: 0)
   }
 
   // MARK: RecordingSessionDriving — observation
@@ -197,10 +202,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
       // PR-4 §3.3a: the kernel's `start` now takes a `DictationSessionConfig`.
       // The simulator passes the test default — `FakeAudioCapture.configureVAD`
       // is inert, so no scenario behavior changes.
+      //
+      // PR-4.5 #2: the kernel now stamps the VAD seam itself via
+      // `vad.setCurrentSessionID(sid)` in `runForwardPath` (was a simulator-only
+      // manual stamp before; that hid the production gap where the kernel never
+      // wired the call).
       kernel.start(config: .testDefault())
-      // The seam is told the frozen session at session start (PR-1 §B.6):
-      // sync the fake VAD's stamp to the kernel's freshly minted SessionID.
-      vad.currentSessionID = kernel.currentSessionID
     case .stop:
       kernel.requestStop()
     case .cancel:
@@ -208,7 +215,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
     case .reset:
       kernel.reset()
     case .preWarm:
-      kernel.preWarm()
+      await kernel.preWarm()
     }
   }
 


### PR DESCRIPTION
Restores 10 behaviors the fresh-built `RecordingSessionKernel` dropped versus the still-live `TranscriptionPipeline`, found by the 2026-05-22 Codex seam audit on PR-4a.

**Plan:** `docs/feature-requests/issue-827-2026-05-22-conductor-seam-hardening.md`
**Status:** Council coverage review + Codex grounded review rounds 1-3 (round 3 PROCEED-AS-PLANNED) + Codex code-diff review rounds 1-5 (escape-hatch exit at r5 per `workflow-process §11`; r5-1 design question deferred to #843).
**Tests:** All 1,255 existing tests green + 10 new seam tests in `ConductorParitySeamTests.swift`.

## What changes (by category)

### Category A — warm-up / capture-hardware handshake
- **#0** Pre-roll buffers reach the adapter once its session is open. Kernel buffer-callback gate moved from `state == .recording` to `adapterSessionActive`. Adapter `beginSession` now runs BEFORE `beginCapturePhase` (Codex r2 — `PreRollForwarder.activate` drains pre-roll during `beginCapturePhase`, so the adapter session must be open first).
- **#1** `kernel.preWarm()` is now `async` and `await`s `audioCapture.preWarm()` end-to-end (Codex r4 — the real PTT flow `await`s `handle(.preWarm)` then immediately sends `.toggleRecording`; a fire-and-forget capture warm-up gets cancelled by `start(config:)`).
- **#2** VAD seam stamped with live `SessionID` at session start; `setCurrentSessionID` promoted to the `VADSignalSource` protocol (was concrete-only, so `any VADSignalSource` could not call it).
- **#3** Frozen mic-device UIDs pushed to the capture layer BEFORE source build.

### Category B — audio conditioning between stop and transcription
- **#4** Sub-minimum-duration discard measured from VISIBLE recording start. Tick latched at the `.stopping` transition (Codex r1 — measuring at `currentTick()` after `stopCapture()` await would count teardown latency as visible-recording time). Zero-buffer count retained as belt-and-suspenders for the simulator. Default `minimumRecordingTicks: 5` (matches PR-4 plan's 100 ms/tick -> 500 ms); existing tests pass `0` explicitly.
- **#5** New `CapturedAudioConditioner` (built on `SampleFilter`) wraps VAD-segment filtering + raw fallback + short-utterance padding. Returns a `ConditionedAudio` struct with telemetry fields. Adapter contract gains `finalize(batchSamples:)`; the conditioned audio substitutes the adapter's batch-rescue input.

### Category C — OS / environment metadata (driver-side)
- **#6** `KernelDictationDriver.handle(.toggleRecording)` captures `context.config`, `context.targetApp` (`NSWorkspace.shared.frontmostApplication`), and `context.targetElement` (`PasteService.captureFocusedElement()`) at recording start. Previously `context.config` was never written in production (only in tests).
- **#9** `setExternalError` and `.reset` both call `fireStateChangeIfNeeded()` directly. `kernel.cancel()` and `kernel.reset()` are no-ops on an already-idle kernel, so the kernel-state observer never fires; the direct call ensures the lifecycle coordinator learns the new state (Codex r5 also caught the reset side).

### Category D — interruption + cleanup routing
- **#7** New `routeASRInterruption(sid:)` special-cases `.transcribing` -> `finishTerminal(.asrInterrupted)` directly. The FSM edge was already legal; only the prior callback guard (`state == .recording`) blocked it.
- **#8** Unload policy fires only on transcript-ready-for-delivery terminals. New `transcriptReadyForDelivery` flag set after polish returns a non-empty processed transcript (before storage/paste). Discarded / no-speech / failed-before-transcribe sessions no longer incur a model-unload cost the next session pays back.

## Plus
- **Adapter contract:** `finalize()` gains `batchSamples: [Float]?` param.
- **Privacy-safe §8 telemetry** via kernel `log()` at each surface: pre-warm result, VAD stamp, stale-signal drop count, ASR-crash FSM state, conditioner outcomes, unload decision.
- **Seam test lane:** new `ConductorParitySeamTests.swift` with 10 tests covering #0-#9.
- **PR-1 inventory amendment:** Category A/B/C/D taxonomy + pre-PR-5 obligation (re-run seam audit for WhisperKit migration).

## Known scope boundaries (documented in PR-1 §B.8)

1. **Pre-roll in batch decode** — restored for the streaming feed path (#0). Batch decode and streaming-rescue still use `captureResult.samples` (parity with old `TranscriptionPipeline.swift:670`). Including pre-roll in batch requires segment-offset alignment design Codex r3/r4/r5 could not converge tactically. Deferred to **#843** with the design options spelled out. PR-4b Live UAT should look for first-word truncation on cold-start short utterances where streaming falls back to batch.
2. **ASR interruption during `.stopping`** — `routeASRInterruption` handles `.recording` and `.transcribing` only (per plan §3 #7's narrow scope). `.stopping` is a brief window; defensible to defer until a user report.

## Codex code-diff review history

| Round | Findings | Status |
|---|---|---|
| r1 | 3 P2 | Fixed in amend |
| r2 | 2 P2 | Fixed in amend |
| r3 | 2 P2 | Partially fixed; r3-1 contributed to oscillation |
| r4 | 1 P1 + 1 P2 | Fixed in amend; r3-1 reverted |
| r5 | 2 P2 | reset fix applied; pre-roll deferred to #843 per escape-hatch rule |

Per `workflow-process §11` convergence escape hatch: rounds keep surfacing NEW substantive defects past round 4 -> stop tactical iteration, escalate. The pre-roll-in-batch question is real engineering work (segment-offset alignment) that needs a fresh design pass.

## Ship criterion (matches PR-4a)

This PR ships **unwired infrastructure** — no App-layer caller binds `KernelDictationDriver` yet. PR-4b is the migration that wires the 13 App files onto this kernel. No Live UAT required for this PR; the production Parakeet path (TranscriptionPipeline, untouched) keeps working.

Closes nothing. Refs #827, ladder rung PR-4.5 between PR-4a (#840 merged) and PR-4b. Follow-up #843.
