### PR TITLE
fix(security): adopt Data Protection keychain + explicit accessibility (#845)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ scripts/*
 !scripts/validation-status.sh
 !scripts/lid-perf-bench.sh
 !scripts/lid-perf-bench.py
+# UAT helpers (per-PR Swift CLIs invoked during Live UAT, e.g. issue #845 keychain verifier)
+!scripts/uat/
+!scripts/uat/**
 # Polish eval harness — PUBLIC tracked files only (see .claude/knowledge/polish-eval.md for scope rules)
 !scripts/eval/
 scripts/eval/*

--- a/Sources/EnviousWispr/Resources/EnviousWispr.entitlements
+++ b/Sources/EnviousWispr/Resources/EnviousWispr.entitlements
@@ -6,5 +6,21 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <!--
+      Issue #845: data-protection keychain access for OpenAI/Gemini API key
+      storage. Non-sandboxed Developer-ID-signed macOS apps need an explicit
+      keychain-access-groups entitlement to use SecItem* with
+      kSecUseDataProtectionKeychain: true (Apple TN3137). Sandboxed apps get
+      the equivalent application-identifier auto-derived; we don't, so we
+      declare it. The "9UT54V24XG" prefix is the EnviousLabs team ID, present
+      on both "Developer ID Application: Saurabh Vaish (9UT54V24XG)" and
+      "Developer ID Application: ENVIOUS LABS LLC (9UT54V24XG)" certs used by
+      the release pipeline. The first entry is the default access group used
+      by SecItemAdd when no explicit kSecAttrAccessGroup is set.
+    -->
+    <key>keychain-access-groups</key>
+    <array>
+        <string>9UT54V24XG.com.enviouswispr.app</string>
+    </array>
 </dict>
 </plist>

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -299,6 +299,9 @@ struct FileLegacyKeyStore: LegacyKeyFileStorage {
 }
 
 struct SecurityKeychainItemStore: KeychainItemStorage {
+  private static let logger = Logger(
+    subsystem: "com.enviouswispr.app", category: "Keychain")
+
   func store(service: String, account: String, value: String) throws {
     guard let data = value.data(using: .utf8) else {
       throw KeyStoreError.storeFailed(-1)
@@ -313,6 +316,7 @@ struct SecurityKeychainItemStore: KeychainItemStorage {
     case errSecItemNotFound:
       var addQuery = query
       addQuery[kSecValueData as String] = data
+      addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
       let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
       guard addStatus == errSecSuccess else {
         throw KeyStoreError.storeFailed(addStatus)
@@ -345,6 +349,25 @@ struct SecurityKeychainItemStore: KeychainItemStorage {
     guard status == errSecSuccess || status == errSecItemNotFound else {
       throw KeyStoreError.deleteFailed(status)
     }
+    // Issue #845: best-effort cleanup of any v2.0.2 / v2.0.3 orphan that
+    // lives in the legacy file-based macOS keychain. The query omits
+    // kSecUseDataProtectionKeychain so it targets the legacy backend. We
+    // swallow non-not-found errors here because the primary (DP) delete
+    // already succeeded; throwing now would surface a confusing error for
+    // an orphan the production code never reads. errSecItemNotFound is the
+    // common case (no orphan) and is success.
+    let legacyQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+    ]
+    let legacyStatus = SecItemDelete(legacyQuery as CFDictionary)
+    if legacyStatus != errSecSuccess && legacyStatus != errSecItemNotFound {
+      Self.logger.error(
+        "Legacy-keychain orphan cleanup failed account=\(account, privacy: .public) status=\(legacyStatus, privacy: .public)"
+      )
+    }
   }
 
   private func baseQuery(service: String, account: String) -> [String: Any] {
@@ -353,6 +376,7 @@ struct SecurityKeychainItemStore: KeychainItemStorage {
       kSecAttrService as String: service,
       kSecAttrAccount as String: account,
       kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
     ]
   }
 }

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -32,7 +32,44 @@ struct KeychainManagerTests {
         atPath: dir.appendingPathComponent(KeychainManager.openAIKeyID).path))
   }
 
-  @Test("Security Keychain store can round-trip with a unique test service")
+  /// Probe the Data Protection keychain to decide whether tests that hit real
+  /// `SecItem*` APIs can run. Bare `swift test` produces an unsigned test
+  /// binary; macOS returns `errSecMissingEntitlement` (-34018) for DP-scoped
+  /// queries without a signed entitlement. These tests are then conditionally
+  /// disabled in CI and local `swift test`, and exercised only in signed
+  /// release-config Live UAT against the shipped `.app`.
+  ///
+  /// Probe is intentionally lazy and cached for the suite lifetime to avoid
+  /// repeatedly trying SecItemAdd during test discovery.
+  static let hasDataProtectionKeychainEntitlement: Bool = {
+    let probeService = "com.enviouswispr.tests.dp-probe.\(UUID().uuidString)"
+    let addQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: probeService,
+      kSecAttrAccount as String: "probe",
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+      kSecValueData as String: Data([0]),
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    ]
+    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+    // Clean up the probe item regardless of outcome.
+    let deleteQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: probeService,
+      kSecAttrAccount as String: "probe",
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+    ]
+    _ = SecItemDelete(deleteQuery as CFDictionary)
+    return addStatus == errSecSuccess
+  }()
+
+  @Test(
+    "Security Keychain store can round-trip with a unique test service",
+    .enabled(
+      if: KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Data Protection keychain requires signed entitlement; verified in Live UAT against shipped .app"
+    ))
   func securityKeychainRoundTrip() throws {
     let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
     let store = SecurityKeychainItemStore()
@@ -50,6 +87,195 @@ struct KeychainManagerTests {
       _ = try store.retrieve(service: service, account: KeychainManager.openAIKeyID)
     }
   }
+
+  // MARK: - Issue #845 — Data Protection Keychain + explicit accessibility
+
+  @Test(
+    "DP-backend write is invisible to a legacy-scoped read",
+    .enabled(
+      if: KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Data Protection keychain requires signed entitlement; verified in Live UAT against shipped .app"
+    ),
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/845",
+      "Data-protection keychain + explicit accessibility per TN3137"))
+  func securityKeychainBackendIsolationWriteDPReadLegacyMisses() throws {
+    let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
+    let store = SecurityKeychainItemStore()
+    defer {
+      try? store.delete(service: service, account: KeychainManager.openAIKeyID)
+      // Belt-and-suspenders: also wipe any leftover legacy item from the raw query.
+      _ = SecItemDelete(
+        Self.legacyQuery(service: service, account: KeychainManager.openAIKeyID) as CFDictionary)
+    }
+
+    try store.store(
+      service: service, account: KeychainManager.openAIKeyID, value: "dp-only-value")
+
+    // Reading via SecurityKeychainItemStore (DP-scoped) must hit.
+    #expect(
+      try store.retrieve(service: service, account: KeychainManager.openAIKeyID)
+        == "dp-only-value")
+
+    // Reading via a raw legacy-scoped query MUST miss — the item is in DP, not legacy.
+    var legacyReadQuery = Self.legacyQuery(
+      service: service, account: KeychainManager.openAIKeyID)
+    legacyReadQuery[kSecReturnData as String] = kCFBooleanTrue
+    legacyReadQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(legacyReadQuery as CFDictionary, &result)
+    #expect(status == errSecItemNotFound)
+  }
+
+  @Test(
+    "Legacy-backend item is invisible to a DP-scoped retrieve",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/845",
+      "Data-protection keychain + explicit accessibility per TN3137"))
+  func securityKeychainBackendIsolationWriteLegacyReadDPMisses() throws {
+    let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
+    let store = SecurityKeychainItemStore()
+    defer {
+      try? store.delete(service: service, account: KeychainManager.openAIKeyID)
+      _ = SecItemDelete(
+        Self.legacyQuery(service: service, account: KeychainManager.openAIKeyID) as CFDictionary)
+    }
+
+    // Seed a legacy-backend item directly.
+    guard let data = "legacy-only-value".data(using: .utf8) else {
+      Issue.record("UTF-8 encoding failed")
+      return
+    }
+    var legacyAddQuery = Self.legacyQuery(
+      service: service, account: KeychainManager.openAIKeyID)
+    legacyAddQuery[kSecValueData as String] = data
+    let addStatus = SecItemAdd(legacyAddQuery as CFDictionary, nil)
+    #expect(addStatus == errSecSuccess)
+
+    // Production code (DP-scoped retrieve) MUST NOT see the legacy item.
+    #expect(throws: KeyStoreError.self) {
+      _ = try store.retrieve(service: service, account: KeychainManager.openAIKeyID)
+    }
+  }
+
+  @Test(
+    "Stored item has explicit kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly",
+    .enabled(
+      if: KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Data Protection keychain requires signed entitlement; verified in Live UAT against shipped .app"
+    ),
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/845",
+      "Data-protection keychain + explicit accessibility per TN3137"))
+  func securityKeychainStoredItemHasExplicitAccessibility() throws {
+    let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
+    let store = SecurityKeychainItemStore()
+    defer { try? store.delete(service: service, account: KeychainManager.openAIKeyID) }
+
+    try store.store(
+      service: service, account: KeychainManager.openAIKeyID, value: "access-attr-test")
+
+    // Re-read via the DP-scoped query and ask for the attributes dictionary.
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: KeychainManager.openAIKeyID,
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+      kSecReturnAttributes as String: kCFBooleanTrue as Any,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    #expect(status == errSecSuccess)
+
+    let attrs = try #require(result as? [String: Any])
+    let accessible = try #require(attrs[kSecAttrAccessible as String] as? String)
+    #expect(accessible == (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String))
+    _ = query  // silence unused warning on local var rebinding form
+  }
+
+  @Test(
+    "Delete wipes both DP item and any legacy-backend orphan",
+    .enabled(
+      if: KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Data Protection keychain requires signed entitlement; verified in Live UAT against shipped .app"
+    ),
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/845",
+      "Data-protection keychain + explicit accessibility per TN3137"))
+  func securityKeychainDeleteCleansLegacyOrphan() throws {
+    let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
+    let store = SecurityKeychainItemStore()
+    defer {
+      try? store.delete(service: service, account: KeychainManager.openAIKeyID)
+      _ = SecItemDelete(
+        Self.legacyQuery(service: service, account: KeychainManager.openAIKeyID) as CFDictionary)
+    }
+
+    // Seed both backends: a legacy orphan (simulating v2.0.2 / v2.0.3 leftover)
+    // and a DP item (simulating the user's re-pasted key on the fixed build).
+    guard let legacyData = "legacy-orphan".data(using: .utf8) else {
+      Issue.record("UTF-8 encoding failed")
+      return
+    }
+    var legacyAddQuery = Self.legacyQuery(
+      service: service, account: KeychainManager.openAIKeyID)
+    legacyAddQuery[kSecValueData as String] = legacyData
+    #expect(SecItemAdd(legacyAddQuery as CFDictionary, nil) == errSecSuccess)
+
+    try store.store(
+      service: service, account: KeychainManager.openAIKeyID, value: "dp-current")
+
+    // User-initiated clear MUST wipe both backends.
+    try store.delete(service: service, account: KeychainManager.openAIKeyID)
+
+    // DP backend empty.
+    #expect(throws: KeyStoreError.self) {
+      _ = try store.retrieve(service: service, account: KeychainManager.openAIKeyID)
+    }
+
+    // Legacy backend ALSO empty — the N5 cleanup ran.
+    var legacyReadQuery = Self.legacyQuery(
+      service: service, account: KeychainManager.openAIKeyID)
+    legacyReadQuery[kSecReturnData as String] = kCFBooleanTrue
+    legacyReadQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+    var legacyResult: CFTypeRef?
+    let legacyReadStatus = SecItemCopyMatching(legacyReadQuery as CFDictionary, &legacyResult)
+    #expect(legacyReadStatus == errSecItemNotFound)
+  }
+
+  @Test(
+    "Delete on missing item is success across both backends",
+    .enabled(
+      if: KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Data Protection keychain requires signed entitlement; verified in Live UAT against shipped .app"
+    ),
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/845",
+      "Data-protection keychain + explicit accessibility per TN3137"))
+  func securityKeychainDeleteIsIdempotentWhenNothingExists() throws {
+    let service = "com.enviouswispr.tests.api-keys.\(UUID().uuidString)"
+    let store = SecurityKeychainItemStore()
+
+    // No items in either backend. delete() must succeed (errSecItemNotFound on
+    // both is treated as success).
+    try store.delete(service: service, account: KeychainManager.openAIKeyID)
+  }
+
+  /// Builds a legacy-backend SecItem query (omits kSecUseDataProtectionKeychain
+  /// so the call targets the legacy file-based macOS keychain, matching what
+  /// EW v2.0.2 / v2.0.3 wrote before #845 adopted the DP backend).
+  private static func legacyQuery(service: String, account: String) -> [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+    ]
+  }
+
+  // MARK: - Pre-#845 tests follow
 
   @Test("release retrieve migrates legacy file when Keychain item is missing")
   func releaseRetrieveMigratesLegacyFile() throws {

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -32,12 +32,37 @@ struct KeychainManagerTests {
         atPath: dir.appendingPathComponent(KeychainManager.openAIKeyID).path))
   }
 
+  /// Probe the legacy file-based macOS keychain to decide whether tests that
+  /// hit real `SecItem*` APIs (even without the DP attribute) can run. Some
+  /// hardened CI environments refuse all `SecItemAdd` calls from an unsigned
+  /// binary; this probe makes that condition explicit and skippable instead of
+  /// surfacing as a test failure during `SecItemAdd` of a test fixture item.
+  static let hasLegacyKeychainAccess: Bool = {
+    let probeService = "com.enviouswispr.tests.legacy-probe.\(UUID().uuidString)"
+    let addQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: probeService,
+      kSecAttrAccount as String: "probe",
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+      kSecValueData as String: Data([0]),
+    ]
+    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+    let deleteQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: probeService,
+      kSecAttrAccount as String: "probe",
+    ]
+    _ = SecItemDelete(deleteQuery as CFDictionary)
+    return addStatus == errSecSuccess
+  }()
+
   /// Probe the Data Protection keychain to decide whether tests that hit real
-  /// `SecItem*` APIs can run. Bare `swift test` produces an unsigned test
-  /// binary; macOS returns `errSecMissingEntitlement` (-34018) for DP-scoped
-  /// queries without a signed entitlement. These tests are then conditionally
-  /// disabled in CI and local `swift test`, and exercised only in signed
-  /// release-config Live UAT against the shipped `.app`.
+  /// `SecItem*` APIs with `kSecUseDataProtectionKeychain: true` can run. Bare
+  /// `swift test` produces an unsigned test binary; macOS returns
+  /// `errSecMissingEntitlement` (-34018) for DP-scoped queries without a
+  /// signed entitlement. These tests are then conditionally disabled in CI and
+  /// local `swift test`, and exercised only in signed release-config Live UAT
+  /// against the shipped `.app`.
   ///
   /// Probe is intentionally lazy and cached for the suite lifetime to avoid
   /// repeatedly trying SecItemAdd during test discovery.
@@ -129,6 +154,11 @@ struct KeychainManagerTests {
 
   @Test(
     "Legacy-backend item is invisible to a DP-scoped retrieve",
+    .enabled(
+      if: KeychainManagerTests.hasLegacyKeychainAccess
+        && KeychainManagerTests.hasDataProtectionKeychainEntitlement,
+      "Requires both legacy and DP keychain access; verified in Live UAT against shipped .app"
+    ),
     .bug(
       "https://github.com/saurabhav88/EnviousWispr/issues/845",
       "Data-protection keychain + explicit accessibility per TN3137"))

--- a/scripts/uat/keychain-verify.swift
+++ b/scripts/uat/keychain-verify.swift
@@ -1,0 +1,111 @@
+#!/usr/bin/env swift
+
+// keychain-verify.swift — Issue #845 UAT helper.
+//
+// Probes both the macOS Data Protection keychain (DP-scoped query) AND the
+// legacy file-based macOS keychain (legacy-scoped query) for EnviousWispr's
+// customer API key items. Reports which backend currently holds each item.
+//
+// Why a Swift CLI and not the `security` shell tool: per Apple TN3137
+// ("On Mac keychains"), the `security` tool is primarily file-keychain
+// focused and does not reliably distinguish DP-keychain items from
+// legacy-keychain items. A direct SecItemCopyMatching call with explicit
+// `kSecUseDataProtectionKeychain` is the only reliable probe.
+//
+// Usage (interactive, founder-driven):
+//   swift scripts/uat/keychain-verify.swift                  # check both keys
+//   swift scripts/uat/keychain-verify.swift openai-api-key   # check just one
+//
+// Output is JSON for easy capture into .validation/runs/<id>/keychain-verify-*.json.
+
+import Foundation
+import Security
+
+let productionService = "com.enviouswispr.app.api-keys"
+let defaultAccounts = ["openai-api-key", "gemini-api-key"]
+
+struct AccountResult: Encodable {
+  let account: String
+  let dpBackend: String
+  let legacyBackend: String
+  let interpretation: String
+}
+
+struct Output: Encodable {
+  let service: String
+  let timestamp: String
+  let results: [AccountResult]
+}
+
+func statusString(_ status: OSStatus) -> String {
+  switch status {
+  case errSecSuccess: return "errSecSuccess"
+  case errSecItemNotFound: return "errSecItemNotFound"
+  case errSecMissingEntitlement: return "errSecMissingEntitlement"
+  case errSecAuthFailed: return "errSecAuthFailed"
+  case errSecInteractionNotAllowed: return "errSecInteractionNotAllowed"
+  default: return "OSStatus(\(status))"
+  }
+}
+
+func probe(service: String, account: String, dataProtection: Bool) -> OSStatus {
+  var query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrService as String: service,
+    kSecAttrAccount as String: account,
+    kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+    kSecMatchLimit as String: kSecMatchLimitOne,
+  ]
+  if dataProtection {
+    query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
+  }
+  var result: CFTypeRef?
+  return SecItemCopyMatching(query as CFDictionary, &result)
+}
+
+func interpret(dpStatus: OSStatus, legacyStatus: OSStatus) -> String {
+  switch (dpStatus, legacyStatus) {
+  case (errSecSuccess, errSecItemNotFound):
+    return "OK: key lives only in Data Protection keychain (post-#845 state, no orphan)"
+  case (errSecSuccess, errSecSuccess):
+    return
+      "OK with orphan: key in DP backend (production reads this), legacy backend also has an item (v2.0.2/v2.0.3 orphan); cleaned next time user clears the key in Settings"
+  case (errSecItemNotFound, errSecSuccess):
+    return
+      "PRE-FIX or PRE-PASTE: key only in legacy backend; production code (post-#845) will NOT see it. Either this is a v2.0.2/v2.0.3 install that has not been upgraded, OR the user has not re-pasted on the fixed build yet."
+  case (errSecItemNotFound, errSecItemNotFound):
+    return "EMPTY: no key in either backend. Fresh install or fully cleared."
+  case (errSecMissingEntitlement, _), (_, errSecMissingEntitlement):
+    return
+      "ENTITLEMENT MISSING: this Swift CLI cannot read the keychain — run it via a signed wrapper or from inside a signed app context. Try running against a signed EnviousWispr.app instead of via raw `swift scripts/uat/...`."
+  default:
+    return "UNEXPECTED: dp=\(statusString(dpStatus)) legacy=\(statusString(legacyStatus))"
+  }
+}
+
+let args = CommandLine.arguments.dropFirst()
+let accountsToCheck = args.isEmpty ? defaultAccounts : Array(args)
+
+var results: [AccountResult] = []
+for account in accountsToCheck {
+  let dpStatus = probe(service: productionService, account: account, dataProtection: true)
+  let legacyStatus = probe(service: productionService, account: account, dataProtection: false)
+  results.append(
+    AccountResult(
+      account: account,
+      dpBackend: statusString(dpStatus),
+      legacyBackend: statusString(legacyStatus),
+      interpretation: interpret(dpStatus: dpStatus, legacyStatus: legacyStatus)
+    ))
+}
+
+let output = Output(
+  service: productionService,
+  timestamp: ISO8601DateFormatter().string(from: Date()),
+  results: results
+)
+
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+let data = try encoder.encode(output)
+print(String(data: data, encoding: .utf8)!)


### PR DESCRIPTION
## Summary

Closes #845. Adopts the macOS Data Protection keychain (Apple TN3137) and sets the access policy attribute explicitly in code instead of relying on the silent default.

- `SecurityKeychainItemStore.baseQuery()` now sets `kSecUseDataProtectionKeychain: true` on every `SecItem*` call.
- `store()` add-branch now sets `kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` on `SecItemAdd`.
- `delete()` now issues a second best-effort `SecItemDelete` with a legacy-scoped query so user-initiated clears wipe any v2.0.2 / v2.0.3 orphan in addition to the DP item. Closes the clear-then-rollback resurrection failure mode.

## Scope decision (founder call mid-planning)

No automated legacy → DP migration. ~100 lines of production Swift + 10 migration-specific tests + two race-tolerance shapes + rollback-symmetry analysis was disproportionate to the user impact (~100 affected users at most, one Settings tap each to re-paste their key). Plan and review trail show the migration scope considered, designed, and dropped: `docs/feature-requests/issue-845-2026-05-24-keychain-data-protection.md` (gitignored locally; grounded review at `docs/audits/2026-05-24-issue-845-grounded-review-r{1,3,4}.txt`).

## Release notes copy (apply at next release)

Single paragraph to add to the next release's `docs/whats-new/v<X.Y.Z>.md` and the GitHub Release body:

> **Heads-up for AI Polish users.** This update changes where EnviousWispr stores your OpenAI and Gemini API keys (moving to Apple's modern keychain for better security and future Touch ID support). After updating you will need to open AI Polish settings and paste your API key once more. Your transcription still works exactly as before; only the AI polish step needs the key.

## Follow-up

#848 — pre-existing `keychain-not-mainactor` rule violation. Explicitly out of scope here; ~8 call sites would need to convert to `async`.

## Test plan

- [x] `scripts/swift-test.sh` passes (1260 tests; 5 honest skips with `.enabled(if: hasDataProtectionKeychainEntitlement)` — unsigned `swift test` binary cannot exercise the DP keychain per Apple TN3137, so these are validated in signed-release Live UAT).
- [x] `swift build -c release` exits 0.
- [x] Dev bundle launches without crash (smoke only — dev bundle ID is `com.enviouswispr.app.dev` which is not in the production `productionKeychainBundleIDs` allowlist, so the dev runtime uses the file backend and does NOT exercise the new DP code path at runtime).
- [x] `scripts/uat/keychain-verify.swift` compiles and runs against an empty keychain (sanity).
- [x] Codex code-diff review pass (see below or `.codex/` artifacts).
- [ ] **Live UAT on signed release.** Genuine DP-keychain behavior validation will come from the next signed release pipeline. Plan §11.1 specifies the verification: log assertion (`LLM polish requested:` + `LLM polish complete:`), filler-token removal in clipboard, and `scripts/uat/keychain-verify.swift` confirming DP-backend hit.
