### PR TITLE
refactor(engine-kernel): PR-4b.1 — callback ownership cleanup (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -13,10 +13,15 @@ import Foundation
 // the `.hidden` overlay, so a UI-keyed observer would miss them.
 //
 // This observer watches RAW `kernel.state` transitions, so no terminal is
-// missed. It also owns the two capture-layer diagnostic callbacks the kernel
-// does not consume for control flow (`onCaptureSessionInterruption`,
-// `onXPCReplyFailed`). The capture-stall signal — which the kernel DOES
-// consume for control flow — reaches the observer through the kernel's
+// missed. PR-4b.1: the observer no longer claims the shared
+// `AudioCaptureInterface` callbacks (`onCaptureSessionInterruption`,
+// `onXPCReplyFailed`). Those are single-owner; the App-side routers stay as
+// sole subscribers. The driver's `HeartPathTelemetryTarget` conformance
+// already forwards into the observer's `handleCaptureSessionInterruption(_:)`
+// and `handleXPCReplyFailed(_:)` methods via `WedgeRecoveryRouter`'s
+// `resolveActiveTelemetryTarget()` (PR-4b.4 wires the App router's Parakeet
+// branch). The capture-stall signal — which the kernel DOES consume for
+// control flow — reaches the observer through the kernel's
 // `captureStallTelemetry` fan-out seam (PR-4 §3.9).
 //
 // PR-4a ships this production-unwired: no App-layer caller constructs it. The
@@ -80,18 +85,6 @@ final class KernelHeartPathTelemetryObserver {
     self.lastObservedState = kernel.state
   }
 
-  /// Begin observing. Wires the two capture-diagnostic callbacks the kernel
-  /// does not consume, and arms raw-state observation.
-  func start() {
-    audioCapture.onCaptureSessionInterruption = { [weak self] ctx in
-      self?.handleCaptureSessionInterruption(ctx)
-    }
-    audioCapture.onXPCReplyFailed = { [weak self] ctx in
-      self?.handleXPCReplyFailed(ctx)
-    }
-    observeKernelState()
-  }
-
   // MARK: Capture-diagnostic callbacks (the kernel does not consume these)
   //
   // These three method names match `HeartPathTelemetryTarget`; the
@@ -120,8 +113,10 @@ final class KernelHeartPathTelemetryObserver {
   /// runs synchronously on whatever context mutated the property; it hops to
   /// `@MainActor` before re-reading state and re-arming (PR-4 §3.7, Gemini
   /// concurrency premise — the explicit hop is the safe pattern even though
-  /// the kernel is `@MainActor`).
-  private func observeKernelState() {
+  /// the kernel is `@MainActor`). PR-4b.1 widened access from `private` to
+  /// internal so the factory (PR-4b.2) can call it directly post-construction
+  /// in place of the deleted `start()` method.
+  func observeKernelState() {
     withObservationTracking {
       _ = kernel.state
     } onChange: { [weak self] in

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -982,30 +982,79 @@ final class RecordingSessionKernel {
 
   // MARK: Capture callbacks + buffer handoff
 
-  /// Bind the recording-exit callbacks for this session — the capture-layer
-  /// signals and the adapter's mid-recording engine-crash signal (PR-4 plan
-  /// §3.2). VAD auto-stop is NOT bound here: it flows through `vad.stopSignals`
+  /// Bind the adapter's mid-recording engine-crash signal (PR-4 plan §3.2).
+  ///
+  /// PR-4b.1: the three shared `AudioCaptureInterface` callbacks
+  /// (`onEngineInterrupted`, `onCaptureStalled`, `onXPCServiceError`) are no
+  /// longer claimed here. `AudioCaptureInterface` callbacks are single-owner;
+  /// the App-side `AudioEventRouter` + `WedgeRecoveryRouter` stay as the sole
+  /// subscribers and forward into the kernel through the driver's
+  /// `externalEngineInterrupted` / `externalASRInterrupted` /
+  /// `externalCaptureStalled` entry methods (wired in PR-4b.4). The adapter's
+  /// own engine-interruption callback STAYS — the adapter is internal to the
+  /// kernel boundary, not a shared resource.
+  ///
+  /// VAD auto-stop is NOT bound here: it flows through `vad.stopSignals`
   /// only, with `CaptureVADSignalSource` the single owner of
   /// `AudioCaptureInterface.onVADAutoStop` (PR-4 plan §3.5).
   private func bindCaptureCallbacks(_ sid: SessionID) {
-    audioCapture.onEngineInterrupted = { [weak self] in
-      self?.deliverRecordingExitIfCurrent(.audioInterruption, sid: sid)
-    }
-    audioCapture.onCaptureStalled = { [weak self] ctx in
-      guard let self else { return }
-      // Fan the raw context to telemetry (PR-4 plan §3.9), then route the
-      // control-flow exit. The exit only latches; ordering is immaterial.
-      self.captureStallTelemetry(ctx)
-      self.deliverRecordingExitIfCurrent(.captureStall, sid: sid)
-    }
-    audioCapture.onXPCServiceError = { [weak self] _ in
-      self?.routeASRInterruption(sid: sid)
-    }
     // The adapter's own backend crashing mid-recording (distinct XPC layer
     // from `onXPCServiceError`'s audio-capture service) — PR-4 plan §3.2.
     adapter.onEngineInterrupted = { [weak self] in
       self?.routeASRInterruption(sid: sid)
     }
+  }
+
+  // MARK: External entry points (PR-4b.1)
+  //
+  // PR-4b.1 removed the kernel's direct subscriptions to the shared
+  // `AudioCaptureInterface` callbacks (`onEngineInterrupted`, `onCaptureStalled`,
+  // `onXPCServiceError`). The App-side routers stay as sole subscribers; the
+  // driver (`KernelDictationDriver` — same module) forwards the calls into
+  // these internal entry methods. PR-4b.4 wires the App routers' Parakeet
+  // branches.
+  //
+  // Each method is idempotent — early-return when the kernel is in a terminal
+  // state via the existing `RecordingSessionState.isTerminal` (`:60`). The
+  // seven terminal states (`completed`, `cancelled`, `discarded`, `noSpeech`,
+  // `failed`, `audioInterrupted`, `asrInterrupted`) return true; `.idle` does
+  // NOT. Between sessions the kernel sits at `.idle`, which is non-terminal
+  // but also non-recording — the no-op at `.idle` is delivered by
+  // `deliverRecordingExitIfCurrent`'s `state == .recording` guard (`:1103`),
+  // not by `!state.isTerminal`. `routeASRInterruption` similarly switches on
+  // state and falls through to `default: return` for non-recording /
+  // non-transcribing states.
+
+  /// Route an external audio-interruption (BT disconnect, mic route change)
+  /// into the FSM. Replaces the removed direct subscription to
+  /// `audioCapture.onEngineInterrupted`. Idempotent: a second call after a
+  /// terminal short-circuits via `!state.isTerminal`.
+  func externalEngineInterrupted() {
+    guard !state.isTerminal else { return }
+    deliverRecordingExitIfCurrent(.audioInterruption, sid: currentSessionID)
+  }
+
+  /// Route an external ASR-XPC interruption (audio-capture XPC service error,
+  /// equivalent in shape to the adapter's own engine-crash) into the FSM.
+  /// Mirror of the internal `routeASRInterruption(sid:)` path the removed
+  /// `onXPCServiceError` subscription used to invoke.
+  func externalASRInterrupted() {
+    guard !state.isTerminal else { return }
+    routeASRInterruption(sid: currentSessionID)
+  }
+
+  /// Route an external capture-stall into the FSM. Replaces the removed
+  /// `audioCapture.onCaptureStalled` subscription. The driver fans the
+  /// `CaptureStallContext` to the telemetry observer separately (PR-4b.4);
+  /// this method only routes the FSM transition. The context's `sessionID`
+  /// is a `UInt64` capture counter (different domain from the kernel's UUID
+  /// `SessionID`), so the guard is on kernel terminal state, not ID
+  /// equality — the App-side `WedgeRecoveryRouter` already filters by
+  /// capture session via its own `isCurrentSession(ctx.sessionID)` check.
+  func externalCaptureStalled(_ ctx: CaptureStallContext) {
+    _ = ctx
+    guard !state.isTerminal else { return }
+    deliverRecordingExitIfCurrent(.captureStall, sid: currentSessionID)
   }
 
   /// The buffer-handoff callback (PR-3 plan §3.4 — reuses the shipped
@@ -1236,11 +1285,12 @@ final class RecordingSessionKernel {
     guard isCurrent(sid) else { return }
     guard transition(to: terminal) else { return }
     audioCapture.onBufferCaptured = nil
-    audioCapture.onEngineInterrupted = nil
-    audioCapture.onCaptureStalled = nil
-    audioCapture.onXPCServiceError = nil
-    // `onVADAutoStop` is NOT cleared here — the kernel never owns it
-    // (`CaptureVADSignalSource` is the single owner, PR-4 plan §3.5).
+    // PR-4b.1: `onEngineInterrupted`, `onCaptureStalled`, and `onXPCServiceError`
+    // are no longer owned by the kernel — the App-side routers stay as sole
+    // subscribers, so the kernel must not nil-clear them on session terminal
+    // (doing so would steal them from the App router for the lifetime of the
+    // app). `onVADAutoStop` is similarly NOT cleared here — `CaptureVADSignalSource`
+    // is the single owner (PR-4 plan §3.5).
     adapter.onEngineInterrupted = nil
     drainTaskBag()
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -63,7 +63,7 @@ import Testing
       let recorder = EventRecorder()
       let kernel = makeKernel()
       let observer = makeObserver(kernel: kernel, recorder: recorder)
-      observer.start()
+      observer.observeKernelState()
 
       // Force a legal happy-path sequence — the observer keys on raw `state`.
       kernel.testForceTransition(to: .preparing)
@@ -87,7 +87,7 @@ import Testing
       let recorder = EventRecorder()
       let kernel = makeKernel()
       let observer = makeObserver(kernel: kernel, recorder: recorder)
-      observer.start()
+      observer.observeKernelState()
 
       kernel.testForceTransition(to: .preparing)
       await drain()
@@ -99,40 +99,30 @@ import Testing
 
     // MARK: onCaptureStalled fan-out
 
-    @Test("a capture stall fans out to the observer's telemetry emitter")
+    @Test("a capture stall handled by the observer reaches its telemetry emitter")
     func captureStallFanout() async {
-      // The kernel-side control flow (stall -> failed(captureStalled)) is covered
-      // by the simulator's capture-stall scenario; this test pins the new PR-4
-      // fan-out: the kernel's captureStallTelemetry seam reaches the observer.
+      // PR-4b.1: the kernel no longer subscribes to `audioCapture.onCaptureStalled`,
+      // so the previous end-to-end path (capture callback → kernel
+      // `captureStallTelemetry` seam → observer) is unsubscribed. PR-4b.4 wires
+      // the driver to fan out a stall to BOTH `observer.handleCaptureStall(_:)`
+      // AND `kernel.externalCaptureStalled(_:)` from a single App router
+      // subscription. This test now pins the observer-emitter half of that
+      // fan-out: a direct `handleCaptureStall` invocation reaches the emitter.
+      // The kernel-side control flow (stall → failed(captureStalled)) is
+      // covered by the simulator's capture-stall scenario via the new
+      // `externalCaptureStalled` entry.
       let stallRecorder = StallRecorder()
       let emitter = HeartPathTelemetryEmitter(
         backend: .parakeet,
         captureTelemetry: CaptureTelemetryState(),
         captureError: { error, _, _, _ in stallRecorder.note(error) },
         addBreadcrumb: { _, _, _ in })
-      let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
       let capture = FakeAudioCapture()
-      let observerHolder = ObserverHolder()
-      let kernel = RecordingSessionKernel(
-        adapter: engine,
-        audioCapture: capture,
-        vad: FakeVADSignalSource(),
-        currentTick: { 0 },
-        sleepTicks: { _ in },
-        processText: { raw, _ in raw },
-        store: { _ in },
-        deliver: { _ in .pasted },
-        minimumRecordingTicks: 0,  // PR-4.5 #4: test does not advance the clock; opt out of the gate
-        captureStallTelemetry: { ctx in observerHolder.observer?.handleCaptureStall(ctx) })
+      let kernel = makeKernel()
       let observer = KernelHeartPathTelemetryObserver(
         kernel: kernel, audioCapture: capture, emitter: emitter, emitLifecycleEvent: { _ in })
-      observerHolder.observer = observer
-      observer.start()
 
-      kernel.start(config: .testDefault())
-      await drainUntil { kernel.state == .recording }
-
-      capture.fireCaptureStalled()
+      observer.handleCaptureStall(capture.makeStallContext())
       await drain()
 
       #expect(stallRecorder.count == 1, "the capture-stall context reached the observer's emitter")
@@ -169,13 +159,6 @@ import Testing
     private func drain() async {
       for _ in 0..<100 { await Task.yield() }
     }
-
-    private func drainUntil(_ condition: @MainActor () -> Bool) async {
-      for _ in 0..<2000 {
-        if condition() { return }
-        await Task.yield()
-      }
-    }
   }
 
   @MainActor
@@ -187,11 +170,6 @@ import Testing
   private final class StallRecorder {
     private(set) var count = 0
     func note(_ error: any Error) { count += 1 }
-  }
-
-  @MainActor
-  private final class ObserverHolder {
-    weak var observer: KernelHeartPathTelemetryObserver?
   }
 
 #endif  // DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
@@ -1,0 +1,236 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - RecordingSessionKernel — external entry methods (epic #827, PR-4b.1)
+//
+// PR-4b.1 removed the kernel's direct subscriptions to the shared
+// `AudioCaptureInterface` callbacks (`onEngineInterrupted`, `onCaptureStalled`,
+// `onXPCServiceError`). The App-side routers stay as sole subscribers; the
+// driver (PR-4b.2) forwards their signals into the kernel's three new
+// internal entry methods. These tests pin the contract for each entry:
+//
+//   1. routes the correct FSM transition while the kernel is in `.recording`
+//   2. is idempotent — a second call after the first reached terminal no-ops
+//   3. is a no-op when the kernel is at `.idle` (between sessions)
+//   4. is a no-op when the kernel is in any terminal state
+//   5. covers a back-to-back double-fire — one entry wins, the other no-ops
+//   6. tolerates a `CaptureStallContext` whose `sessionID` is a `UInt64`
+//      capture counter from a different domain than the kernel's UUID
+//      `SessionID` (the guard is on kernel terminal state, not ID equality)
+//
+// `#if DEBUG`-gated like the FSM-invariant suite — these tests reuse the
+// `KernelRecordingSession` simulator wrapper, which uses `testForceTransition`
+// in places and depends on the `#if DEBUG`-only test hooks already gated on
+// `RecordingSessionKernel`.
+
+#if DEBUG
+
+  @MainActor
+  @Suite("RecordingSessionKernel — external entry methods (PR-4b.1)")
+  struct RecordingSessionKernelExternalInterruptionTests {
+
+    private func makeWrapper() -> (SimulatorContext, KernelRecordingSession) {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+      let capture = FakeAudioCapture()
+      let vad = FakeVADSignalSource()
+      let paste = FakePasteTarget()
+      let wrapper = KernelRecordingSession(
+        engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+      let context = SimulatorContext(
+        sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+      return (context, wrapper)
+    }
+
+    private func startToRecording(_ wrapper: KernelRecordingSession) async {
+      await wrapper.apply(.start)
+      await wrapper.drainReadyWork()
+    }
+
+    // MARK: 1. Routing — each entry produces the right terminal
+
+    @Test("externalEngineInterrupted routes to the audio-interrupted terminal")
+    func engineInterruptedRoutes() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      #expect(kernel.state == .recording)
+
+      kernel.externalEngineInterrupted()
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .audioInterrupted)
+    }
+
+    @Test("externalASRInterrupted routes to the ASR-interrupted terminal")
+    func asrInterruptedRoutes() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      #expect(kernel.state == .recording)
+
+      kernel.externalASRInterrupted()
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .asrInterrupted)
+    }
+
+    @Test("externalCaptureStalled routes to the capture-stalled failed terminal")
+    func captureStalledRoutes() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      #expect(kernel.state == .recording)
+
+      kernel.externalCaptureStalled(context.capture.makeStallContext())
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .failed(.captureStalled))
+    }
+
+    // MARK: 2. Idempotency — a second call after terminal no-ops
+
+    @Test("a second externalEngineInterrupted after the first reached terminal is a no-op")
+    func engineInterruptedIdempotent() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      kernel.externalEngineInterrupted()
+      await wrapper.drainReadyWork()
+      let firstTerminal = kernel.state
+      #expect(firstTerminal == .audioInterrupted)
+
+      kernel.externalEngineInterrupted()
+      await wrapper.drainReadyWork()
+      #expect(kernel.state == firstTerminal)
+    }
+
+    @Test("a second externalASRInterrupted after the first reached terminal is a no-op")
+    func asrInterruptedIdempotent() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      kernel.externalASRInterrupted()
+      await wrapper.drainReadyWork()
+      let firstTerminal = kernel.state
+      #expect(firstTerminal == .asrInterrupted)
+
+      kernel.externalASRInterrupted()
+      await wrapper.drainReadyWork()
+      #expect(kernel.state == firstTerminal)
+    }
+
+    @Test("a second externalCaptureStalled after the first reached terminal is a no-op")
+    func captureStalledIdempotent() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      kernel.externalCaptureStalled(context.capture.makeStallContext())
+      await wrapper.drainReadyWork()
+      let firstTerminal = kernel.state
+      #expect(firstTerminal == .failed(.captureStalled))
+
+      kernel.externalCaptureStalled(context.capture.makeStallContext())
+      await wrapper.drainReadyWork()
+      #expect(kernel.state == firstTerminal)
+    }
+
+    // MARK: 3. Idle no-op — non-terminal but non-recording
+
+    @Test("each external entry is a no-op at .idle (non-terminal, non-recording)")
+    func idleNoOp() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+      #expect(kernel.state == .idle)
+
+      kernel.externalEngineInterrupted()
+      kernel.externalASRInterrupted()
+      kernel.externalCaptureStalled(context.capture.makeStallContext())
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .idle)
+    }
+
+    // MARK: 4. Terminal no-op — every terminal short-circuits the guard
+
+    @Test("each external entry is a no-op once the kernel is in a terminal state")
+    func terminalNoOp() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      await wrapper.apply(.cancel)  // → cancelled
+      await wrapper.drainReadyWork()
+      #expect(kernel.state == .cancelled)
+
+      kernel.externalEngineInterrupted()
+      kernel.externalASRInterrupted()
+      kernel.externalCaptureStalled(context.capture.makeStallContext())
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .cancelled)
+    }
+
+    // MARK: 5. Double-fire — one entry wins, the other no-ops
+
+    @Test("an engine interruption followed by an ASR interruption lands a single terminal")
+    func doubleFireOneWins() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      kernel.externalEngineInterrupted()
+      // Second call lands BEFORE the first has settled — the FSM is still in
+      // `.recording` so the guard does not bite yet. The forward path picks
+      // up one exit signal; the second is overwritten in `pendingRecordingExit`
+      // OR silently discarded if a continuation already absorbed the first.
+      // After draining, exactly ONE terminal must hold.
+      kernel.externalASRInterrupted()
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state.isTerminal)
+      #expect(
+        kernel.state == .audioInterrupted || kernel.state == .asrInterrupted,
+        "exactly one of the two interruption terminals must win")
+    }
+
+    // MARK: 6. Capture-stall cross-domain sessionID
+
+    @Test("externalCaptureStalled tolerates an arbitrary UInt64 capture sessionID")
+    func captureStallCrossDomainSessionID() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+
+      // The capture-layer sessionID is a `UInt64` capture counter — a different
+      // domain than the kernel's UUID `SessionID`. The guard is on kernel
+      // terminal state, not ID equality.
+      let crossDomain = CaptureStallContext(
+        sessionID: UInt64.max,
+        armedAtUptimeNs: 0,
+        firedAtUptimeNs: 0,
+        route: "fake-cross-domain",
+        sourceType: "av_audio_engine",
+        engineStartedSuccessfully: true,
+        tapInstalled: true,
+        formatMismatchObserved: false,
+        inputDeviceUIDPreferred: nil,
+        inputDeviceUIDSystemDefault: nil)
+      kernel.externalCaptureStalled(crossDomain)
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .failed(.captureStalled))
+    }
+  }
+
+#endif  // DEBUG (RecordingSessionKernel external-entry tests — share the testForceTransition gating posture)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -192,18 +192,27 @@ final class FakeAudioCapture: AudioCaptureInterface {
   /// Fire the capture-stall callback (C3 / C4 — the liveness watchdog observed
   /// zero buffers within the stall window).
   func fireCaptureStalled() {
-    onCaptureStalled?(
-      CaptureStallContext(
-        sessionID: currentCaptureSessionID,
-        armedAtUptimeNs: 0,
-        firedAtUptimeNs: 0,
-        route: "fake",
-        sourceType: captureSourceType,
-        engineStartedSuccessfully: true,
-        tapInstalled: true,
-        formatMismatchObserved: false,
-        inputDeviceUIDPreferred: nil,
-        inputDeviceUIDSystemDefault: nil))
+    onCaptureStalled?(makeStallContext())
+  }
+
+  /// Construct a synthetic capture-stall context against the fake's current
+  /// session counter. Used by the simulator's `ScenarioRunner` to route a
+  /// stall directly into the kernel's `externalCaptureStalled(_:)` entry
+  /// method (PR-4b.1) — the kernel no longer subscribes to
+  /// `onCaptureStalled`, so the simulator drives the FSM transition through
+  /// the new entry instead of firing the callback.
+  func makeStallContext() -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: currentCaptureSessionID,
+      armedAtUptimeNs: 0,
+      firedAtUptimeNs: 0,
+      route: "fake",
+      sourceType: captureSourceType,
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil)
   }
 
   /// Fire the XPC service-error callback (C6 — XPC capture crash). This is the

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+@testable import EnviousWisprPipeline
+
 // MARK: - ScenarioRunner + assertion library (epic #827, PR-2 plan §3.4)
 //
 // The runner executes a `Scenario`'s ordered steps against a
@@ -134,16 +136,26 @@ struct ScenarioRunner {
   }
 
   private func apply(captureDirective: CaptureDirective, context: SimulatorContext) {
+    // PR-4b.1: the kernel no longer subscribes to `audioCapture.onEngineInterrupted`,
+    // `onCaptureStalled`, or `onXPCServiceError`. The simulator routes these
+    // signals through the kernel's new internal entry methods (
+    // `externalEngineInterrupted` / `externalASRInterrupted` /
+    // `externalCaptureStalled`) instead of firing the now-unsubscribed capture
+    // callbacks. The `StubRecordingSession` self-test never wired these
+    // directives (the stub has no kernel), so the kernel-cast falls through to
+    // a no-op there — same shape as before the migration.
+    let kernel = (context.sut as? KernelRecordingSession)?.testKernel
     switch captureDirective {
     case .deliverBuffer:
       context.capture.deliverBuffer()
     case .stall:
-      // A stall fires the liveness-watchdog callback — not merely an absence
-      // of buffers (C3 / C4).
-      context.capture.fireCaptureStalled()
+      // A stall fires the liveness-watchdog signal — not merely an absence
+      // of buffers (C3 / C4). Routed through the kernel's external entry to
+      // match the production path PR-4b.4 wires (App router → driver → kernel).
+      kernel?.externalCaptureStalled(context.capture.makeStallContext())
     case .interrupt, .routeChange:
       // The audio-interruption channel (C5).
-      context.capture.raiseEngineInterruption()
+      kernel?.externalEngineInterrupted()
     case .permissionDenied:
       context.capture.permissionDenied = true
     case .startFailure:
@@ -151,7 +163,7 @@ struct ScenarioRunner {
     case .xpcCrash:
       // The ASR-interruption channel — distinct from the audio-interruption
       // path (C6, not C5).
-      context.capture.fireXPCServiceError()
+      kernel?.externalASRInterrupted()
     }
   }
 


### PR DESCRIPTION
## Summary

PR-4b.1 of the engine-kernel refactor (#827). Pure structural cleanup that unblocks PR-4b.2's clean driver routing. **No App-layer change, no live behavior change** — the kernel stays unwired in production through this PR.

- Drops the kernel's three direct subscriptions to shared `AudioCaptureInterface` callbacks (`onEngineInterrupted` / `onCaptureStalled` / `onXPCServiceError`) plus their matching nil-clears on session terminal.
- Drops the observer's two direct subscriptions (`onCaptureSessionInterruption` / `onXPCReplyFailed`) and the now-trivial `start()` method; widens `observeKernelState()` from `private` to internal so PR-4b.2's factory can arm observation directly.
- Adds three internal entry methods on `RecordingSessionKernel` — `externalEngineInterrupted()`, `externalASRInterrupted()`, `externalCaptureStalled(_:)` — each idempotent via the existing `RecordingSessionState.isTerminal` guard. The driver (PR-4b.2) and the App-router cutover (PR-4b.4) wire production forwarding into these methods.
- Adapter-internal `adapter.onEngineInterrupted` stays — it is not a shared resource.

The latent bug this prevents: `AudioCaptureInterface` callbacks are single-owner; once PR-4b.4 wires the kernel live, the kernel's direct subscriptions would have stolen them from the App-side `AudioEventRouter` + `WedgeRecoveryRouter` for the session lifetime and then nil-cleared them on terminal, leaving WhisperKit deaf to BT disconnects on the next recording.

## Lane

- **Lane:** Code (`Sources/EnviousWisprPipeline/**`, `Tests/EnviousWisprTests/**`). Not mixed.
- **Tier:** MEDIUM (kernel-internal cleanup, no App migration, no driver-surface change).
- **User Rubric:** N/A — internal refactor.

## Validation

- `swift build` + `swift build -c release` clean.
- `scripts/swift-test.sh` — 1265 tests / 164 suites pass.
- New `RecordingSessionKernelExternalInterruptionTests.swift` (7 tests): routing per entry, idempotency, idle no-op, terminal no-op, double-fire combined scenario, capture-stall cross-domain `UInt64` sessionID.
- Existing kernel + observer tests migrated. The simulator's `ScenarioRunner` now routes capture-directive steps through `kernel.externalX()` instead of firing the (now-unsubscribed) `audioCapture` callbacks. `KernelHeartPathTelemetryObserverTests` switched `observer.start()` calls to `observer.observeKernelState()` and the capture-stall fan-out test now exercises the direct `handleCaptureStall(_:)` path.
- **Phase 3:** Code lane, all artifacts present at `.validation/runs/2026-05-25T04-02-10Z-863d0d7/`. Smoke (release build + bundle + launch) PASS. Live UAT against a debug bundle: `wispr_eyes.test_recording` PASS, pipeline TOTAL 1.649s. Codex code-diff review at medium reasoning flagged one P1 (\"keep capture exits wired into the kernel\") — that finding is the multi-PR ladder's intent: PR-4b.4 wires the App router's Parakeet branch to the new external entry methods. The kernel is still unwired in production (`EnviousWisprApp.swift:96` constructs `TranscriptionPipeline`), so the removal is structural-only and matches plan §1 / §5 (\"UNCHANGED across every E2E path\").
- Grep gates per plan §13: kernel callback assigns → empty; observer callback assigns → empty; `adapter.onEngineInterrupted` retained at line 1003 + 1294 nil-clear; no `Sources/EnviousWispr/` files modified.

## Plan

- `docs/feature-requests/issue-827-2026-05-24-pr4b1-callback-ownership.md` (gitignored, local).
- Council coverage review + Codex grounded review **r5 PROCEED-AS-PLANNED**.

## Sequencing

PR-4b ladder: 4b.1 (this) → 4b.2 (driver surface + factory) → 4b.4 (App cutover + `TranscriptionPipeline` deletion). PR-4b.3 (freeze-suite parity harness) is parallel-mergeable.

## Test plan

- [x] `swift build` + `swift build -c release` clean
- [x] `scripts/swift-test.sh` — 1265 tests pass
- [x] New external-interruption test file — 7 tests pass
- [x] Existing kernel + observer + scenario tests pass after migration
- [x] Phase 3 validate-pr.sh PASS
- [x] Live UAT (debug bundle, regression check) PASS
- [x] Codex code-diff review run; P1 fact-checked as multi-PR ladder intent
