### PR TITLE
fix(telemetry): suppress benign Sparkle terminal codes from update.install_failed

### DIFF
--- a/Sources/EnviousWispr/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWispr/App/SparkleUpdateController.swift
@@ -240,6 +240,24 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     return false
   }
 
+  /// Issue #846: classifier for whether an error from `didFinishUpdateCycleFor`
+  /// represents a real install failure (worth firing `update.install_failed`)
+  /// or one of Sparkle's three benign terminal outcomes. Pure function — no
+  /// instance state. Sparkle itself excludes these three codes from its own
+  /// logging (`SPUUpdater.m:797-800`).
+  ///
+  /// Domain guard: a non-Sparkle error happening to carry one of the numeric
+  /// codes (e.g. a CFNetwork error with code 1001) still emits. We only
+  /// suppress when Sparkle's own domain emits one of its known benign codes.
+  ///
+  /// `internal` (not `private`) so `@testable import EnviousWispr` tests can
+  /// call it without constructing a `SPUUpdater` (which Sparkle does not
+  /// expose for tests per `SPUUpdater.h:62-69`).
+  static func isReportableSparkleInstallFailure(_ error: NSError) -> Bool {
+    guard error.domain == "SUSparkleErrorDomain" else { return true }
+    return ![1001, 4007, 4008].contains(error.code)
+  }
+
   /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
   /// resolves service state, clears install-source.
   func updater(
@@ -268,12 +286,19 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
       source: source,
       errorCode: errorCode
     )
-    if error != nil {
+    // Issue #846: filter Sparkle's three benign terminal outcomes from
+    // update.install_failed. Sparkle itself excludes them from its own logging
+    // (SPUUpdater.m:797-800): SUNoUpdateError = 1001 (no update available),
+    // SUInstallationCanceledError = 4007 (user cancelled authorization),
+    // SUInstallationAuthorizeLaterError = 4008 (user chose install later).
+    // All three reach this callback via SPUUpdater.m:810-812. Non-Sparkle
+    // errors with the same numeric codes still emit (domain guard).
+    if let nsError = error as NSError?, Self.isReportableSparkleInstallFailure(nsError) {
       TelemetryService.shared.updateInstallFailed(
         version: version,
         isCritical: isCritical,
         source: source,
-        errorCode: errorCode ?? "unknown"
+        errorCode: "\(nsError.domain).\(nsError.code)"
       )
     }
     // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -76,9 +76,9 @@ struct SparkleUpdateControllerTests {
 
   // MARK: - Bundle-version-aware install-attempt evaluation
 
-  // The next two tests rely on the DEBUG-only `testEventHook` seam, so they
-  // compile only in debug. CI also builds tests in release; gating preserves
-  // both lanes.
+  // The tests below rely on the DEBUG-only `testEventHook` seam (and the
+  // `EventBox` Sendable storage), so they compile only in debug. CI also
+  // builds tests in release; gating preserves both lanes.
   #if DEBUG
 
     /// Sendable storage box for the testEventHook closure. The hook is
@@ -216,6 +216,71 @@ struct SparkleUpdateControllerTests {
         #expect(evt.stringProps.keys.sorted() == ["error_code", "source", "version"])
         #expect(evt.boolProps.keys.sorted() == ["is_critical"])
       }
+    }
+
+    // MARK: - #846: isReportableSparkleInstallFailure classifier (Layer A)
+    //
+    // Pure-function tests on the new classifier helper. Direct delegate
+    // testing of `didFinishUpdateCycleFor` is infeasible (SPUUpdater.init
+    // is unavailable per Sparkle/SPUUpdater.h:62-69), so we test the
+    // classifier as a function and trust the integration call site by
+    // inspection. The three benign Sparkle codes come from Sparkle's own
+    // logging filter at SPUUpdater.m:797-800.
+
+    @Test("Sparkle code 1001 (SUNoUpdateError) is suppressed")
+    func classifier_sparkle1001_isFalse() {
+      let error = NSError(domain: "SUSparkleErrorDomain", code: 1001)
+      #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == false)
+    }
+
+    @Test("Sparkle code 4007 (SUInstallationCanceledError) is suppressed")
+    func classifier_sparkle4007_isFalse() {
+      let error = NSError(domain: "SUSparkleErrorDomain", code: 4007)
+      #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == false)
+    }
+
+    @Test("Sparkle code 4008 (SUInstallationAuthorizeLaterError) is suppressed")
+    func classifier_sparkle4008_isFalse() {
+      let error = NSError(domain: "SUSparkleErrorDomain", code: 4008)
+      #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == false)
+    }
+
+    @Test("Sparkle code 4005 (SUInstallationError) is reported")
+    func classifier_sparkle4005_isTrue() {
+      let error = NSError(domain: "SUSparkleErrorDomain", code: 4005)
+      #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == true)
+    }
+
+    @Test("Non-Sparkle domain with code 1001 is reported (domain guard)")
+    func classifier_nonSparkleDomain1001_isTrue() {
+      let error = NSError(domain: "NSURLErrorDomain", code: 1001)
+      #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == true)
+    }
+
+    // MARK: - #846: telemetry-hook smoke (Layer B)
+
+    @Test("updateInstallFailed propagates error_code to testEventHook")
+    func installFailedPropagatesErrorCodeToHook() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateInstallFailed(
+        version: "v1",
+        isCritical: false,
+        source: "test",
+        errorCode: "SUSparkleErrorDomain.4005")
+
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let evt = captured.first(where: { $0.name == "update.install_failed" })
+      #expect(evt != nil, "update.install_failed event should be captured")
+      #expect(evt?.stringProps["error_code"] == "SUSparkleErrorDomain.4005")
     }
 
   #endif  // DEBUG


### PR DESCRIPTION
## Summary

- Sparkle's `didFinishUpdateCycleFor` fires for any cycle outcome — including `SUNoUpdateError` (1001), `SUInstallationCanceledError` (4007), and `SUInstallationAuthorizeLaterError` (4008). All three are benign terminal outcomes Sparkle itself excludes from its own logging (`SPUUpdater.m:797-800`), not install failures.
- Today we emit `update.install_failed` for all of them, inflating the PostHog failure metric by ~50% in last-7d production data (1001: 7 events / 4 users; 4007: 1 event / 1 user).
- Add a static classifier helper `isReportableSparkleInstallFailure(_:)` on `SparkleUpdateController` and gate `update.install_failed` emission on it. Domain guard ensures non-Sparkle errors carrying the same numeric codes still emit (e.g. CFNetwork code 1001).

Closes #846.

## Plan + audit trail

- Plan: `docs/feature-requests/issue-846-2026-05-25-update-install-failed-mislabel.md`
- Council coverage review: `docs/audits/2026-05-25-issue-846-council-{gpt,gemini}.md`
- Codex grounded review: 3 rounds, defect trajectory 5 → 3 → 0. Final verdict PROCEED-AS-PLANNED at `docs/audits/2026-05-25-issue-846-grounded-review-r3.txt`.
- Codex code-diff review: SHIP-WITH-NITS, no required revisions (`docs/audits/2026-05-25-issue-846-code-diff-review-v2.txt`).

## Test plan

- [x] `scripts/swift-test.sh` full suite — 1261 tests passed.
- [x] `swift build -c release` — exit 0.
- [x] Six new `@Test`s in `SparkleUpdateControllerTests` (five Layer A pure-function tests covering codes 1001/4007/4008/4005/non-Sparkle, plus one Layer B telemetry-hook smoke).
- [x] Live UAT heart-path safety check on debug bundle — recording state machine verified (menu → overlay → stop). Pipeline polish path tested separately; my code change is isolated to the Sparkle delegate (no overlap with recording/ASR/polish/paste).
- [ ] Post-merge: 7 days after release, query PostHog with prod filter + dogfooder exclusion for `update.install_failed` events where `error_code` ∈ {`SUSparkleErrorDomain.1001`, `SUSparkleErrorDomain.4007`, `SUSparkleErrorDomain.4008`} — expect zero.
