### PR TITLE
feat(telemetry): Phase 1 diagnostic enrichment for Sparkle no-update root cause

### DIFF
--- a/Sources/EnviousWispr/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWispr/App/SparkleUpdateController.swift
@@ -258,6 +258,56 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     return ![1001, 4007, 4008].contains(error.code)
   }
 
+  /// Issue #847 Phase 1: extract Sparkle's no-update reason from the error
+  /// userInfo. Guarded — returns nil unless the error is a Sparkle SUNoUpdateError
+  /// (code 1001 with the `SUSparkleErrorDomain` domain). Sparkle attaches
+  /// `SPUNoUpdateFoundReasonKey: NSNumber(rawValue)` ONLY on that specific
+  /// error path per `SPUBasicUpdateDriver.m:244-261`. Pure function, no
+  /// instance state, testable directly.
+  ///
+  /// Returns a stable lowercase-snake string. Unknown raw values map to the
+  /// fixed string `"unrecognized"` (bounded cardinality — no rawValue
+  /// interpolation, addresses Gemini council finding about unbounded
+  /// PostHog property cardinality).
+  static func noUpdateReason(from error: NSError?) -> String? {
+    guard let error else { return nil }
+    guard error.domain == "SUSparkleErrorDomain", error.code == 1001 else { return nil }
+    // SPUNoUpdateFoundReason is declared as NS_ENUM(OSStatus, ...) per
+    // SUErrors.h:80, so rawValue: takes OSStatus (Int32). Read NSNumber
+    // and convert with int32Value to match the bridged enum's signature.
+    guard
+      let raw = (error.userInfo[SPUNoUpdateFoundReasonKey as String] as? NSNumber)?.int32Value
+    else { return nil }
+    // Prefer the Swift-bridged enum case-switch; rawValue init is
+    // failable so unknown future cases fall through to "unrecognized".
+    guard let reason = SPUNoUpdateFoundReason(rawValue: raw) else { return "unrecognized" }
+    switch reason {
+    case .unknown: return "unknown"
+    case .onLatestVersion: return "on_latest_version"
+    case .onNewerThanLatestVersion: return "on_newer_than_latest_version"
+    case .systemIsTooOld: return "system_is_too_old"
+    case .systemIsTooNew: return "system_is_too_new"
+    case .hardwareDoesNotSupportARM64: return "hardware_does_not_support_arm64"
+    @unknown default: return "unrecognized"
+    }
+  }
+
+  /// Issue #847 Phase 1: discriminator string for Sparkle's update-check
+  /// classification. The founder workaround (manual menu click works when
+  /// background check returns no update) makes this the load-bearing
+  /// signal for Phase 2 root-cause analysis.
+  ///
+  /// `@unknown default` forces a compile warning if Sparkle adds new cases
+  /// at the next major bump — early signal at build time.
+  static func checkKindString(_ check: SPUUpdateCheck) -> String {
+    switch check {
+    case .updates: return "user_initiated"
+    case .updatesInBackground: return "background"
+    case .updateInformation: return "informational"
+    @unknown default: return "unrecognized"
+    }
+  }
+
   /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
   /// resolves service state, clears install-source.
   func updater(
@@ -280,11 +330,22 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
       return false
     }()
     let errorCode = (error as NSError?).map { "\($0.domain).\($0.code)" }
+    // Issue #847 Phase 1: diagnostic enrichment. Extract Sparkle's
+    // SPUNoUpdateFoundReasonKey (guarded to SUNoUpdateError + domain) and
+    // map SPUUpdateCheck to a stable string. Pair with current app version
+    // sourced from the existing bundleVersionProvider so Phase 2 can
+    // pivot the fix on (current_app_version × check_kind × no_update_reason).
+    let noUpdateReason = Self.noUpdateReason(from: error as NSError?)
+    let checkKind = Self.checkKindString(updateCheck)
+    let currentAppVersion = bundleVersionProvider()
     TelemetryService.shared.updateSparkleCycleFinished(
       version: version,
       isCritical: isCritical,
       source: source,
-      errorCode: errorCode
+      errorCode: errorCode,
+      noUpdateReason: noUpdateReason,
+      checkKind: checkKind,
+      currentAppVersion: currentAppVersion
     )
     // Issue #846: filter Sparkle's three benign terminal outcomes from
     // update.install_failed. Sparkle itself excludes them from its own logging
@@ -298,7 +359,10 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
         version: version,
         isCritical: isCritical,
         source: source,
-        errorCode: "\(nsError.domain).\(nsError.code)"
+        errorCode: "\(nsError.domain).\(nsError.code)",
+        noUpdateReason: noUpdateReason,
+        checkKind: checkKind,
+        currentAppVersion: currentAppVersion
       )
     }
     // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -644,11 +644,20 @@ public final class TelemetryService {
     version: String,
     isCritical: Bool,
     source: String,
-    errorCode: String?
+    errorCode: String?,
+    noUpdateReason: String?,
+    checkKind: String,
+    currentAppVersion: String
   ) {
     #if DEBUG
-      var hookStringProps: [String: String] = ["version": version, "source": source]
+      var hookStringProps: [String: String] = [
+        "version": version,
+        "source": source,
+        "check_kind": checkKind,
+        "current_app_version": currentAppVersion,
+      ]
       if let errorCode { hookStringProps["error_code"] = errorCode }
+      if let noUpdateReason { hookStringProps["no_update_reason"] = noUpdateReason }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "update.sparkle_cycle_finished",
@@ -660,8 +669,11 @@ public final class TelemetryService {
       "version": version,
       "is_critical": isCritical,
       "source": source,
+      "check_kind": checkKind,
+      "current_app_version": currentAppVersion,
     ]
     if let errorCode { props["error_code"] = errorCode }
+    if let noUpdateReason { props["no_update_reason"] = noUpdateReason }
     PostHogSDK.shared.capture("update.sparkle_cycle_finished", properties: props)
   }
 
@@ -688,25 +700,37 @@ public final class TelemetryService {
     version: String,
     isCritical: Bool,
     source: String,
-    errorCode: String
+    errorCode: String,
+    noUpdateReason: String?,
+    checkKind: String,
+    currentAppVersion: String
   ) {
     #if DEBUG
+      var hookStringProps: [String: String] = [
+        "version": version,
+        "source": source,
+        "error_code": errorCode,
+        "check_kind": checkKind,
+        "current_app_version": currentAppVersion,
+      ]
+      if let noUpdateReason { hookStringProps["no_update_reason"] = noUpdateReason }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "update.install_failed",
-          stringProps: ["version": version, "source": source, "error_code": errorCode],
+          stringProps: hookStringProps,
           boolProps: ["is_critical": isCritical]
         ))
     #endif
-    PostHogSDK.shared.capture(
-      "update.install_failed",
-      properties: [
-        "version": version,
-        "is_critical": isCritical,
-        "source": source,
-        "error_code": errorCode,
-      ]
-    )
+    var props: [String: Any] = [
+      "version": version,
+      "is_critical": isCritical,
+      "source": source,
+      "error_code": errorCode,
+      "check_kind": checkKind,
+      "current_app_version": currentAppVersion,
+    ]
+    if let noUpdateReason { props["no_update_reason"] = noUpdateReason }
+    PostHogSDK.shared.capture("update.install_failed", properties: props)
   }
 
   public func updateInstallCancelled(version: String, isCritical: Bool, source: String) {

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -1,6 +1,7 @@
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
+@preconcurrency import Sparkle
 import Testing
 
 @testable import EnviousWispr
@@ -174,13 +175,27 @@ struct SparkleUpdateControllerTests {
       TelemetryService.shared.updateInstallStarted(
         version: "v1", isCritical: true, source: "menu")
       TelemetryService.shared.updateSparkleCycleFinished(
-        version: "v1", isCritical: false, source: "menu", errorCode: nil)
+        version: "v1",
+        isCritical: false,
+        source: "menu",
+        errorCode: nil,
+        noUpdateReason: nil,
+        checkKind: "background",
+        currentAppVersion: "v-host"
+      )
       TelemetryService.shared.updateInstallCompleted(
         version: "v1", isCritical: false, source: "menu")
       TelemetryService.shared.updateInstallCancelled(
         version: "v1", isCritical: false, source: "banner")
       TelemetryService.shared.updateInstallFailed(
-        version: "v1", isCritical: false, source: "menu", errorCode: "NSURLErrorDomain.-1009")
+        version: "v1",
+        isCritical: false,
+        source: "menu",
+        errorCode: "NSURLErrorDomain.-1009",
+        noUpdateReason: nil,
+        checkKind: "background",
+        currentAppVersion: "v-host"
+      )
 
       // Drain the Task hops scheduled by each test hook firing.
       await Task.yield()
@@ -213,7 +228,10 @@ struct SparkleUpdateControllerTests {
         #expect(evt.boolProps.keys.sorted() == ["is_critical"])
       }
       if let evt = captured.first(where: { $0.name == "update.install_failed" }) {
-        #expect(evt.stringProps.keys.sorted() == ["error_code", "source", "version"])
+        #expect(
+          evt.stringProps.keys.sorted() == [
+            "check_kind", "current_app_version", "error_code", "source", "version",
+          ])
         #expect(evt.boolProps.keys.sorted() == ["is_critical"])
       }
     }
@@ -272,7 +290,11 @@ struct SparkleUpdateControllerTests {
         version: "v1",
         isCritical: false,
         source: "test",
-        errorCode: "SUSparkleErrorDomain.4005")
+        errorCode: "SUSparkleErrorDomain.4005",
+        noUpdateReason: nil,
+        checkKind: "background",
+        currentAppVersion: "v-host"
+      )
 
       await Task.yield()
       await Task.yield()
@@ -281,6 +303,173 @@ struct SparkleUpdateControllerTests {
       let evt = captured.first(where: { $0.name == "update.install_failed" })
       #expect(evt != nil, "update.install_failed event should be captured")
       #expect(evt?.stringProps["error_code"] == "SUSparkleErrorDomain.4005")
+    }
+
+    // MARK: - #847 Phase 1: noUpdateReason classifier (Layer A)
+    //
+    // Pure-function tests on the extraction helper. Sparkle attaches
+    // SPUNoUpdateFoundReasonKey only to errors with the SUSparkleErrorDomain
+    // domain AND code SUNoUpdateError (1001) per SPUBasicUpdateDriver.m:244-261.
+    // The helper enforces that guard. Bridged enum init is failable so
+    // unknown future raw values fall through to "unrecognized" (fixed string,
+    // not interpolated — bounded PostHog cardinality).
+
+    @Test("noUpdateReason: nil error returns nil")
+    func noUpdateReason_nilError_returnsNil() {
+      #expect(SparkleUpdateController.noUpdateReason(from: nil) == nil)
+    }
+
+    @Test("noUpdateReason: Sparkle 1001 with systemIsTooNew rawValue returns mapped string")
+    func noUpdateReason_systemTooNew_returnsString() {
+      let error = NSError(
+        domain: "SUSparkleErrorDomain",
+        code: 1001,
+        userInfo: [SPUNoUpdateFoundReasonKey as String: NSNumber(value: Int32(4))]
+      )
+      #expect(SparkleUpdateController.noUpdateReason(from: error) == "system_is_too_new")
+    }
+
+    @Test("noUpdateReason: Sparkle 1001 with missing reason key returns nil")
+    func noUpdateReason_missingReasonKey_returnsNil() {
+      let error = NSError(domain: "SUSparkleErrorDomain", code: 1001)
+      #expect(SparkleUpdateController.noUpdateReason(from: error) == nil)
+    }
+
+    @Test("noUpdateReason: non-Sparkle domain with reason key returns nil (domain guard)")
+    func noUpdateReason_nonSparkleDomain_returnsNil() {
+      let error = NSError(
+        domain: "NSURLErrorDomain",
+        code: 1001,
+        userInfo: [SPUNoUpdateFoundReasonKey as String: NSNumber(value: Int32(4))]
+      )
+      #expect(SparkleUpdateController.noUpdateReason(from: error) == nil)
+    }
+
+    @Test("noUpdateReason: Sparkle non-1001 code with reason key returns nil (code guard)")
+    func noUpdateReason_wrongCode_returnsNil() {
+      let error = NSError(
+        domain: "SUSparkleErrorDomain",
+        code: 4005,
+        userInfo: [SPUNoUpdateFoundReasonKey as String: NSNumber(value: Int32(4))]
+      )
+      #expect(SparkleUpdateController.noUpdateReason(from: error) == nil)
+    }
+
+    @Test("noUpdateReason: out-of-range rawValue returns fixed 'unrecognized' string")
+    func noUpdateReason_unknownRawValue_returnsUnrecognized() {
+      let error = NSError(
+        domain: "SUSparkleErrorDomain",
+        code: 1001,
+        userInfo: [SPUNoUpdateFoundReasonKey as String: NSNumber(value: Int32(999))]
+      )
+      #expect(SparkleUpdateController.noUpdateReason(from: error) == "unrecognized")
+    }
+
+    @Test("checkKindString: maps all three documented SPUUpdateCheck cases")
+    func checkKindString_mapsAllThreeCases() {
+      #expect(SparkleUpdateController.checkKindString(.updates) == "user_initiated")
+      #expect(SparkleUpdateController.checkKindString(.updatesInBackground) == "background")
+      #expect(SparkleUpdateController.checkKindString(.updateInformation) == "informational")
+    }
+
+    // MARK: - #847 Phase 1: telemetry-hook propagation (Layer B)
+
+    @Test("updateSparkleCycleFinished propagates all three new props to hook")
+    func cycleFinished_propagatesAllThreeNewPropsToHook() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateSparkleCycleFinished(
+        version: "v-pending",
+        isCritical: false,
+        source: "background",
+        errorCode: "SUSparkleErrorDomain.1001",
+        noUpdateReason: "on_latest_version",
+        checkKind: "background",
+        currentAppVersion: "v2.0.4"
+      )
+
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let evt = captured.first(where: { $0.name == "update.sparkle_cycle_finished" })
+      #expect(evt != nil, "update.sparkle_cycle_finished event should be captured")
+      #expect(evt?.stringProps["no_update_reason"] == "on_latest_version")
+      #expect(evt?.stringProps["check_kind"] == "background")
+      #expect(evt?.stringProps["current_app_version"] == "v2.0.4")
+    }
+
+    @Test("updateSparkleCycleFinished with nil noUpdateReason omits the property entirely")
+    func cycleFinished_withNilNoUpdateReason_omitsProperty() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateSparkleCycleFinished(
+        version: "v-pending",
+        isCritical: false,
+        source: "background",
+        errorCode: nil,
+        noUpdateReason: nil,
+        checkKind: "user_initiated",
+        currentAppVersion: "v2.0.4"
+      )
+
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let evt = captured.first(where: { $0.name == "update.sparkle_cycle_finished" })
+      #expect(evt != nil)
+      #expect(
+        evt?.stringProps["no_update_reason"] == nil,
+        "no_update_reason key MUST be absent (not the literal 'nil' string).")
+      #expect(evt?.stringProps["check_kind"] == "user_initiated")
+      #expect(evt?.stringProps["current_app_version"] == "v2.0.4")
+    }
+
+    @Test("updateInstallFailed propagates all three new props to hook")
+    func installFailed_propagatesAllThreeNewPropsToHook() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      // Note: production callers will not pair install_failed with a
+      // non-nil no_update_reason after #846 lands (1001 events stop
+      // routing through install_failed). The test still passes a non-nil
+      // value to prove the signature handles all three new props
+      // independently of the call-site policy.
+      TelemetryService.shared.updateInstallFailed(
+        version: "v-pending",
+        isCritical: false,
+        source: "menu",
+        errorCode: "SUSparkleErrorDomain.4005",
+        noUpdateReason: "on_latest_version",
+        checkKind: "user_initiated",
+        currentAppVersion: "v2.0.4"
+      )
+
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let evt = captured.first(where: { $0.name == "update.install_failed" })
+      #expect(evt != nil)
+      #expect(evt?.stringProps["error_code"] == "SUSparkleErrorDomain.4005")
+      #expect(evt?.stringProps["check_kind"] == "user_initiated")
+      #expect(evt?.stringProps["current_app_version"] == "v2.0.4")
+      #expect(evt?.stringProps["no_update_reason"] == "on_latest_version")
     }
 
   #endif  // DEBUG


### PR DESCRIPTION
## Summary

- Phase 1 of the Sparkle false-negative investigation (#847). Adds three new properties to `update.sparkle_cycle_finished` and `update.install_failed` so Phase 2 can pivot the root-cause fix on real production data instead of guesses.
- New properties: `no_update_reason` (optional — one of Sparkle's 6 enum cases, present only on `SUSparkleErrorDomain` + `SUNoUpdateError`), `check_kind` (required — `user_initiated` / `background` / `informational` / `unrecognized`), `current_app_version` (required — sourced from existing `bundleVersionProvider`).
- Founder's workaround (manual menu click works when background auto-check returns "no update") makes `check_kind` the load-bearing Phase 2 axis. The pair `(current_app_version × check_kind × no_update_reason)` is what tells us whether the bug is "macOS 26.x is too new for Sparkle's filter," cache, or something else.

Closes #847 Phase 1. Phase 2 opens as a separate issue after 21 days OR 10 unique users emit non-nil `no_update_reason` across diverse `current_app_version` pairs with a ≥60% dominant reason, whichever first.

## Plan + audit trail

- Plan: `docs/feature-requests/issue-847-2026-05-25-sparkle-auto-check-false-negative-phase1.md`
- Council coverage review: `docs/audits/2026-05-25-issue-847-council-{gpt,gemini}.md`
- Codex grounded review: 4 rounds, defect trajectory 8 → 1 + cleanup → 0 substantive → clean. Final verdict PROCEED-AS-PLANNED at `docs/audits/2026-05-25-issue-847-grounded-review-r4.txt`.
- Codex code-diff review: 2 rounds (round 1 caught a test gap I missed in self-proof: my "all three props" install_failed test was asserting nil propagation). Round 2 verdict SHIP at `docs/audits/2026-05-25-issue-847-code-diff-review-r2.txt`.

## Test plan

- [x] `scripts/swift-test.sh` full suite — 1286 tests passed (up from 1261 on the previous PR).
- [x] `swift build -c release` — exit 0.
- [x] 10 new `@Test`s in `SparkleUpdateControllerTests`: 7 Layer A pure-function tests (6 `noUpdateReason` variants covering nil/missing-key/wrong-domain/wrong-code/known-rawValue/unknown-rawValue + 1 `checkKindString` all-cases test) and 3 Layer B telemetry-hook propagation tests. Plan called for 9; added 1 defensive `nilError → nil` case.
- [x] Existing `sparkleTelemetryCallSiteParity` test updated to pass widened signatures (3 new params each on `updateSparkleCycleFinished` and `updateInstallFailed`).
- [x] Live UAT heart-path safety check deferred to Plan A's verification — same code area (Sparkle delegate + TelemetryService), zero overlap with recording/ASR/polish/paste pipelines.
- [ ] Post-release validation per plan §13a: 24 hours after release, query PostHog for at least one `update.sparkle_cycle_finished` event from the new build with non-nil `check_kind` and the new property dict — if absent, telemetry wiring broke at runtime → revert.

## Self-proof + Codex catches

- Self-proofread caught: `OSStatus` (Int32) vs `Int` rawValue type for `SPUNoUpdateFoundReason(rawValue:)` — fixed at build time before the first commit. Static `func` (not instance method) for the helpers, mirroring #846's pattern.
- Codex code-diff caught what I missed: the `installFailed_propagatesAllThreeNewPropsToHook` test passed `noUpdateReason: nil` and asserted absence, contradicting the test name and the plan's contract. Fixed in round 2.
