### PR TITLE
ci: SHA-pin 4 floating action refs in polish-eval-smoke.yml

### DIFF
--- a/.github/workflows/polish-eval-smoke.yml
+++ b/.github/workflows/polish-eval-smoke.yml
@@ -37,10 +37,10 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       SHA: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect polish paths
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             polish:
@@ -58,7 +58,7 @@ jobs:
         run: echo "Polish paths not touched; nothing to evaluate."
       - name: Setup Python
         if: steps.filter.outputs.polish == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
       - name: Stage API keys locally
@@ -116,7 +116,7 @@ jobs:
           esac
       - name: Upload full run artifacts
         if: always() && steps.filter.outputs.polish == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: polish-eval-pr
           path: benchmark-results/eval/runs/


### PR DESCRIPTION
## Summary
- Pins all 4 floating action refs in `polish-eval-smoke.yml` to exact commit SHAs
- Fixes the weekly CI Drift Check failing every Monday since 2026-04-20 (5 consecutive failures)
- SHAs match versions already pinned in all other workflow files — no behavior change

## Actions pinned
| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v6` | `de0fac2e...` (v6.0.2) |
| `dorny/paths-filter` | `@v4` | `fbd0ab8f...` (v4.0.1) |
| `actions/setup-python` | `@v6` | `a309ff8b...` (v6.2.0) |
| `actions/upload-artifact` | `@v7` | `043fb46d...` (v7.0.1) |

## Test plan
- [ ] CI Drift Check passes on next Monday run (or trigger `workflow_dispatch` manually to verify immediately)

council-skip: zero-blast-radius (single-value config constants)
