### PR TITLE
feat(audio): hang hardening — signal-based watchdogs on audio + ASR XPC await sites

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -283,18 +283,35 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
   public func startStreaming(options: TranscriptionOptions) async throws {
     let language = options.language ?? ""
+    try await withASRXPCOperationSignal(stage: "start_streaming") { operationID in
+      try await self.awaitStartStreamingReply(
+        operationID: operationID,
+        language: language,
+        enableTimestamps: options.enableTimestamps
+      )
+    }
+    isStreaming = true
+  }
+
+  private func awaitStartStreamingReply(
+    operationID: String,
+    language: String,
+    enableTimestamps: Bool
+  ) async throws {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
       let guard_ = OneShotContinuationASR(cont)
       serviceProxy { proxy in
-        proxy.startStreaming(language: language, enableTimestamps: options.enableTimestamps) {
-          nsError in
+        proxy.startStreaming(
+          operationID: operationID,
+          language: language,
+          enableTimestamps: enableTimestamps
+        ) { nsError in
           if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
         }
       } onProxyError: {
         guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
       }
     }
-    isStreaming = true
   }
 
   public func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {
@@ -465,6 +482,56 @@ public final class ASRManagerProxy: ASRManagerInterface {
       return
     }
     work(service)
+  }
+
+  private func withASRXPCOperationSignal<T: Sendable>(
+    stage: String,
+    _ work: @MainActor @escaping (String) async throws -> T
+  ) async throws -> T {
+    let operationID = UUID().uuidString
+    let signal = XPCOperationSignalWatcher(file: .asr, operationID: operationID)
+    signal.start()
+    nonisolated(unsafe) let unsafeWork = work
+    let operationTask = Task { @MainActor in
+      try await unsafeWork(operationID)
+    }
+    let outcome = await raceWithSignalWatcher(watcher: signal.progressWatcher) {
+      try await operationTask.value
+    }
+    let snapshot = signal.snapshot
+    signal.stop()
+
+    switch outcome {
+    case .completed(let value):
+      return value
+    case .threw(let error):
+      throw error
+    case .wedged:
+      operationTask.cancel()
+      handleASRXPCOperationWedge(stage: stage, operationID: operationID, snapshot: snapshot)
+      throw XPCOperationSignalWedgeError(
+        service: "ASR",
+        stage: stage,
+        observedPhase: snapshot.lastObservedPhase
+      )
+    }
+  }
+
+  private func handleASRXPCOperationWedge(
+    stage: String,
+    operationID: String,
+    snapshot: WatcherSnapshot
+  ) {
+    Task {
+      await AppLogger.shared.log(
+        "[ASRManagerProxy] signal watchdog fired stage=\(stage) operationID=\(operationID) phase=\(snapshot.lastObservedPhase) silenceMs=\(snapshot.silenceMs)",
+        level: .info, category: "XPC"
+      )
+    }
+    connection?.invalidate()
+    connection = nil
+    isStreaming = false
+    needsReinit = true
   }
 
   // MARK: - Nonisolated Handler Factories (Swift 6 isolation safety)

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -1,6 +1,10 @@
 import EnviousWisprCore
 import Foundation
 
+// FIXME(#827): founder/upstream action needed. The LID observer closure needs
+// within-window progress from WhisperKit before LanguageDetector can recover a
+// wedged language-detection await without a wall-clock timeout.
+
 // R2 (#360): no longer reaches `WhisperKit` directly. The non-Sendable
 // reference stays inside `WhisperKitBackend.observeLID`; this actor consumes
 // only the Sendable `LIDObservationBatch` shape.
@@ -186,6 +190,9 @@ public actor LanguageDetector {
     // and returns a Sendable batch. We map each batch variant to the matching
     // abstain reason — this preserves the per-failure-mode semantics from
     // the previous inline implementation.
+    // TODO(#827): watchdog needs a within-window progress signal from the
+    // observer owner (`WhisperKitBackend.observeLID`). This actor only sees the
+    // batch after all windows return.
     let batch = await observerFn()
     let multi: MultiWindowLID
     switch batch {

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -2,6 +2,10 @@ import EnviousWisprCore
 import Foundation
 @preconcurrency import WhisperKit
 
+// FIXME(#827): founder/upstream action needed. WhisperKit/CoreML must expose
+// model-load, LID-window, and decoder-step progress signals before this backend
+// can add real signal-based watchdog recovery without wall-clock timeouts.
+
 /// Hardcoded compute options optimized for Apple Silicon dictation.
 /// Audio encoder + text decoder → Neural Engine, mel spectrogram → GPU.
 private let dictationComputeOptions = ModelComputeOptions(
@@ -74,6 +78,8 @@ public actor WhisperKitBackend: ASRBackend {
       if let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) {
         modelPath = cached
       } else {
+        // TODO(#827): watchdog needs WhisperKit download progress wired into
+        // this fallback path if product keeps allowing first-record downloads.
         let folder = try await WhisperKit.download(variant: modelVariant, progressCallback: nil)
         modelPath = folder.path
       }
@@ -152,6 +158,9 @@ public actor WhisperKitBackend: ASRBackend {
       computeOptions: dictationComputeOptions,
       download: false
     )
+    // TODO(#827): watchdog needs CoreML/WhisperKit model-load progress or a
+    // service process-liveness signal owned upstream. Do not wrap this in a
+    // wall-clock timeout.
     let kit = try await WhisperKit(config)
     self.whisperKit = kit
     isReady = true
@@ -167,6 +176,9 @@ public actor WhisperKitBackend: ASRBackend {
     let startTime = CFAbsoluteTimeGetCurrent()
     let results: [TranscriptionResult]
     do {
+      // TODO(#827): watchdog needs a decoder-step or token/segment progress
+      // callback owned by WhisperKit; cancellation depends on this await
+      // returning.
       results = try await kit.transcribe(audioArray: paddedSamples, decodeOptions: decodeOptions)
     } catch {
       throw ASRError.transcriptionFailed(error.localizedDescription)
@@ -250,6 +262,8 @@ public actor WhisperKitBackend: ASRBackend {
       do {
         // WhisperKit API is `detectLangauge(audioArray:)` (original typo
         // preserved upstream — do not "fix" it).
+        // TODO(#827): watchdog needs a within-window LID progress callback
+        // owned by WhisperKit; cancellation is only checked between windows.
         result = try await kit.detectLangauge(audioArray: window)
       } catch is CancellationError {
         return .cancelled

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -2,6 +2,10 @@ import EnviousWisprCore
 import Foundation
 @preconcurrency import WhisperKit
 
+// FIXME(#827): founder/upstream action needed. WhisperKit must expose decoder
+// progress callbacks for incremental and tail transcribe calls before this
+// worker can add signal-based wedge recovery without wall-clock timeouts.
+
 package struct IncrementalResult: Sendable {
   package let text: String?
   package let samplesCovered: Int
@@ -138,6 +142,8 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
       // the remaining short fragment (e.g., "by Friday"). This was the root
       // cause of #216: tail decode returned empty despite speech being present.
 
+      // TODO(#827): watchdog needs WhisperKit decoder-step progress during tail
+      // decode; cancellation depends on this await returning.
       let results = try await whisperKit.transcribe(audioArray: paddedSamples, decodeOptions: opts)
       let tailText = results.map(\.text)
         .joined(separator: " ")
@@ -214,6 +220,9 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
         if isLongRecording {
           var opts = baseDecodingOptions
           opts.clipTimestamps = [lastClipSeconds]
+          // TODO(#827): watchdog needs decoder-step progress for clipped
+          // incremental decodes; accepted-byte counters only move after this
+          // await returns.
           let results = try await whisperKit.transcribe(
             audioArray: snapshot.samples, decodeOptions: opts
           )
@@ -233,6 +242,9 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
             lastResultSampleCount = snapshot.count
           }
         } else {
+          // TODO(#827): watchdog needs decoder-step progress for full-buffer
+          // incremental decodes; accepted-byte counters only move after this
+          // await returns.
           let results = try await whisperKit.transcribe(
             audioArray: snapshot.samples, decodeOptions: baseDecodingOptions
           )

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -71,6 +71,9 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
           self.parakeetBackend = backend
         case "whisperKit":
           let backend = WhisperKitBackend()
+          // TODO(#827): watchdog needs WhisperKit/CoreML model-load progress
+          // written to ProgressFile or XPCOperationSignalFile. Current upstream
+          // load has no progress callback.
           try await backend.prepare()
           self.whisperKitBackend = backend
         default:
@@ -179,9 +182,17 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
   // MARK: - Streaming
 
-  func startStreaming(language: String, enableTimestamps: Bool, reply: @escaping (NSError?) -> Void)
+  func startStreaming(
+    operationID: String,
+    language: String,
+    enableTimestamps: Bool,
+    reply: @escaping (NSError?) -> Void
+  )
   {
+    let signal = XPCOperationSignalFile.asr.makeEmitter(operationID: operationID)
+    signal.emit(stage: "asr.start_streaming.received")
     guard let parakeet = parakeetBackend else {
+      signal.emit(stage: "asr.start_streaming.failed", detail: "no_parakeet_model")
       reply(
         NSError(
           domain: "ASRService", code: -3,
@@ -191,14 +202,18 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
+      signal.emit(stage: "asr.start_streaming.main_actor")
       do {
         var options = TranscriptionOptions()
         options.language = language.isEmpty ? nil : language
         options.enableTimestamps = enableTimestamps
+        signal.emit(stage: "asr.start_streaming.backend_entered")
         try await parakeet.startStreaming(options: options)
+        signal.emit(stage: "asr.start_streaming.backend_completed")
         self.isStreamingActive = true
         safeReply(nil)
       } catch {
+        signal.emit(stage: "asr.start_streaming.failed", detail: error.localizedDescription)
         // XPC error sanitization boundary.
         safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -93,6 +93,7 @@ final class AVAudioEngineSource: AudioInputSource {
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onInterrupted: (() -> Void)?
+  var onLifecycleSignal: (@Sendable (String) -> Void)?
 
   // MARK: - Round-4 telemetry (issue #285) — capture liveness watchdog.
 
@@ -159,7 +160,10 @@ final class AVAudioEngineSource: AudioInputSource {
   // MARK: - Lifecycle
 
   func prepare() async throws {
-    guard !engine.isRunning else { return }
+    guard !engine.isRunning else {
+      onLifecycleSignal?("engine_prepare_already_running")
+      return
+    }
     let prepareStart = ContinuousClock.now
 
     activeTasks.removeAll()
@@ -173,6 +177,7 @@ final class AVAudioEngineSource: AudioInputSource {
     // Split-route check: when input != output device (e.g., built-in mic + BT headphones),
     // CoreAudio's AEC can't sync different hardware clocks. Disable VP in this case.
     let vpStart = ContinuousClock.now
+    onLifecycleSignal?("engine_voice_processing_entered")
     let inputDeviceID = AudioDeviceEnumerator.defaultInputDeviceID()
     let outputDeviceID = AudioDeviceEnumerator.defaultOutputDeviceID()
     let isSplitRoute =
@@ -199,11 +204,13 @@ final class AVAudioEngineSource: AudioInputSource {
     } else {
       try? engine.inputNode.setVoiceProcessingEnabled(false)
     }
+    onLifecycleSignal?("engine_voice_processing_completed")
     let vpMs = ms(ContinuousClock.now - vpStart)
 
     // Step 2: Resolve input device — smart selection when in Auto mode.
     // SAFETY: Skip setInputDevice() entirely when BT output is active.
     let deviceStart = ContinuousClock.now
+    onLifecycleSignal?("engine_input_device_entered")
     let btOutputActive: Bool
     if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
       btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
@@ -237,6 +244,7 @@ final class AVAudioEngineSource: AudioInputSource {
     }
     try setInputDevice(resolvedDeviceID)
     currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
+    onLifecycleSignal?("engine_input_device_completed")
     let deviceMs = ms(ContinuousClock.now - deviceStart)
 
     // Create the capture stop token for this session
@@ -262,7 +270,9 @@ final class AVAudioEngineSource: AudioInputSource {
 
     let engineStartTime = ContinuousClock.now
     btCrashLogger.info("Engine starting — stop token created, observer registered (queue: nil)")
+    onLifecycleSignal?("engine_start_entered")
     try engine.start()
+    onLifecycleSignal?("engine_start_completed")
     let engineMs = ms(ContinuousClock.now - engineStartTime)
     btCrashLogger.info("Engine started successfully")
 
@@ -271,6 +281,7 @@ final class AVAudioEngineSource: AudioInputSource {
     // The tap routes through a PreRollForwarder that buffers audio until
     // startCapture() activates live forwarding.
     let tapStart = ContinuousClock.now
+    onLifecycleSignal?("engine_preroll_tap_entered")
     let inputNode = engine.inputNode
     let inputFormat = inputNode.outputFormat(forBus: 0)
 
@@ -306,6 +317,7 @@ final class AVAudioEngineSource: AudioInputSource {
       tapLocal: tapLocalSeen
     )
     inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
+    onLifecycleSignal?("engine_preroll_tap_completed")
     let tapMs = ms(ContinuousClock.now - tapStart)
     let totalMs = ms(ContinuousClock.now - prepareStart)
     AudioCaptureManager.btRouteLog(

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -14,9 +14,9 @@ private final class CaptureLivenessFlag: Sendable {
   func reset() { _lock.withLock { $0 = false } }
 }
 
-/// One-shot await helper for AVCaptureSession lifecycle calls. The signal is a
-/// platform state notification (`DidStartRunning`, `DidStopRunning`,
-/// `RuntimeError`, or `WasInterrupted`) racing the blocking sessionQueue call.
+/// One-shot await helper for AVCaptureSession lifecycle calls. Start can use
+/// platform notifications as terminal signals. Stop uses notifications only as
+/// progress ticks; `stopRunning()` returning is the cleanup boundary.
 private final class SessionLifecycleSignal<T: Sendable>: @unchecked Sendable {
   private let lock = NSLock()
   private var continuation: CheckedContinuation<T, Never>?
@@ -43,6 +43,23 @@ private final class SessionLifecycleSignal<T: Sendable>: @unchecked Sendable {
     ) { [weak self] _ in
       onSignal?()
       self?.resume(returning: value)
+    }
+    lock.lock()
+    observers.append(observer)
+    lock.unlock()
+  }
+
+  func observeProgress(
+    name: Notification.Name,
+    object: Any?,
+    onSignal: @escaping @Sendable () -> Void
+  ) {
+    let observer = NotificationCenter.default.addObserver(
+      forName: name,
+      object: object,
+      queue: nil
+    ) { _ in
+      onSignal()
     }
     lock.lock()
     observers.append(observer)
@@ -372,18 +389,18 @@ final class AVCaptureSessionSource: AudioInputSource {
     let sessionQ = sessionQueue
     await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
       let signal = SessionLifecycleSignal(cont)
-      signal.observe(
-        name: .AVCaptureSessionDidStopRunning, object: captureSession, returning: ()
+      signal.observeProgress(
+        name: .AVCaptureSessionDidStopRunning, object: captureSession
       ) {
         lifecycleSignal?("capture_session_did_stop_running")
       }
-      signal.observe(
-        name: .AVCaptureSessionRuntimeError, object: captureSession, returning: ()
+      signal.observeProgress(
+        name: .AVCaptureSessionRuntimeError, object: captureSession
       ) {
         lifecycleSignal?("capture_session_runtime_error")
       }
-      signal.observe(
-        name: .AVCaptureSessionWasInterrupted, object: captureSession, returning: ()
+      signal.observeProgress(
+        name: .AVCaptureSessionWasInterrupted, object: captureSession
       ) {
         lifecycleSignal?("capture_session_was_interrupted")
       }

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -14,6 +14,56 @@ private final class CaptureLivenessFlag: Sendable {
   func reset() { _lock.withLock { $0 = false } }
 }
 
+/// One-shot await helper for AVCaptureSession lifecycle calls. The signal is a
+/// platform state notification (`DidStartRunning`, `DidStopRunning`,
+/// `RuntimeError`, or `WasInterrupted`) racing the blocking sessionQueue call.
+private final class SessionLifecycleSignal<T: Sendable>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<T, Never>?
+  private var observers: [NSObjectProtocol] = []
+
+  init(_ continuation: CheckedContinuation<T, Never>) {
+    self.continuation = continuation
+  }
+
+  func observe(name: Notification.Name, object: Any?, returning value: T) {
+    observe(name: name, object: object, returning: value, onSignal: nil)
+  }
+
+  func observe(
+    name: Notification.Name,
+    object: Any?,
+    returning value: T,
+    onSignal: (@Sendable () -> Void)?
+  ) {
+    let observer = NotificationCenter.default.addObserver(
+      forName: name,
+      object: object,
+      queue: nil
+    ) { [weak self] _ in
+      onSignal?()
+      self?.resume(returning: value)
+    }
+    lock.lock()
+    observers.append(observer)
+    lock.unlock()
+  }
+
+  func resume(returning value: T) {
+    lock.lock()
+    let cont = continuation
+    continuation = nil
+    let observersToRemove = observers
+    observers = []
+    lock.unlock()
+
+    for observer in observersToRemove {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    cont?.resume(returning: value)
+  }
+}
+
 /// AVCaptureSession-based audio capture source. Avoids BT A2DP→SCO codec switch by
 /// capturing from the built-in microphone via AVCaptureSession, which on macOS does NOT
 /// trigger Bluetooth audio route changes (AVAudioSession is API_UNAVAILABLE(macos)).
@@ -31,6 +81,7 @@ final class AVCaptureSessionSource: AudioInputSource {
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onInterrupted: (() -> Void)?
+  var onLifecycleSignal: (@Sendable (String) -> Void)?
 
   // MARK: - Round-4 telemetry (issue #285) — stall watchdog + interruption ctx.
 
@@ -82,15 +133,21 @@ final class AVCaptureSessionSource: AudioInputSource {
 
   func prepare() async throws {
     // Double-start protection
-    guard session == nil || session?.isRunning == false else { return }
+    guard session == nil || session?.isRunning == false else {
+      onLifecycleSignal?("capture_session_prepare_already_running")
+      return
+    }
 
     // Find the built-in microphone by transport type — NOT AVCaptureDevice.default(for: .audio)
     // which follows the system default and may return a BT device.
+    onLifecycleSignal?("capture_session_find_mic_entered")
     let builtInMic = findBuiltInMicrophone()
     guard let mic = builtInMic else {
       throw AudioError.noBuiltInMicrophoneFound
     }
+    onLifecycleSignal?("capture_session_find_mic_completed")
 
+    onLifecycleSignal?("capture_session_configure_entered")
     let captureSession = AVCaptureSession()
 
     let input = try AVCaptureDeviceInput(device: mic)
@@ -132,20 +189,19 @@ final class AVCaptureSessionSource: AudioInputSource {
     )
     self.delegate = preRollDelegate
     output.setSampleBufferDelegate(preRollDelegate, queue: callbackQueue)
+    onLifecycleSignal?("capture_session_configure_completed")
 
     // Register interruption observers
+    onLifecycleSignal?("capture_session_observers_entered")
     registerInterruptionObservers(for: captureSession)
+    onLifecycleSignal?("capture_session_observers_completed")
 
     // Start the session — this does NOT trigger BT route changes on macOS.
     // IMPORTANT: startRunning() is a blocking call that Apple says must not run on main thread.
     // Dispatch to background and await completion.
-    let sessionQ = sessionQueue
-    let started = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-      sessionQ.async {
-        captureSession.startRunning()
-        cont.resume(returning: captureSession.isRunning)
-      }
-    }
+    onLifecycleSignal?("capture_session_start_running_entered")
+    let started = await awaitStartRunning(captureSession, lifecycleSignal: onLifecycleSignal)
+    onLifecycleSignal?("capture_session_start_running_completed")
 
     guard started else {
       throw AudioError.formatCreationFailed(source: "AVCaptureSessionSource.prepare.start_running")
@@ -153,6 +209,36 @@ final class AVCaptureSessionSource: AudioInputSource {
 
     AudioCaptureManager.btRouteLog(
       "AVCaptureSessionSource: prepared with \(mic.localizedName) (uid=\(mic.uniqueID))")
+  }
+
+  private func awaitStartRunning(
+    _ captureSession: AVCaptureSession,
+    lifecycleSignal: (@Sendable (String) -> Void)?
+  ) async -> Bool {
+    let sessionQ = sessionQueue
+    return await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+      let signal = SessionLifecycleSignal(cont)
+      signal.observe(
+        name: .AVCaptureSessionDidStartRunning, object: captureSession, returning: true
+      ) {
+        lifecycleSignal?("capture_session_did_start_running")
+      }
+      signal.observe(
+        name: .AVCaptureSessionRuntimeError, object: captureSession, returning: false
+      ) {
+        lifecycleSignal?("capture_session_runtime_error")
+      }
+      signal.observe(
+        name: .AVCaptureSessionWasInterrupted, object: captureSession, returning: false
+      ) {
+        lifecycleSignal?("capture_session_was_interrupted")
+      }
+      sessionQ.async {
+        captureSession.startRunning()
+        lifecycleSignal?("capture_session_start_running_returned")
+        signal.resume(returning: captureSession.isRunning)
+      }
+    }
   }
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -261,13 +347,9 @@ final class AVCaptureSessionSource: AudioInputSource {
     // RULE: Do NOT touch delegate, callback queue, or continuation state until
     // stopRunning() has returned. No "cleanup optimization" before the session stops.
     if let captureSession = session {
-      let sessionQ = sessionQueue
-      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-        sessionQ.async {
-          captureSession.stopRunning()
-          cont.resume()
-        }
-      }
+      onLifecycleSignal?("capture_session_stop_running_entered")
+      await awaitStopRunning(captureSession, lifecycleSignal: onLifecycleSignal)
+      onLifecycleSignal?("capture_session_stop_running_completed")
     }
 
     // NOW safe to clear delegate — session is stopped, no more buffers arriving.
@@ -281,6 +363,36 @@ final class AVCaptureSessionSource: AudioInputSource {
 
     // Source does not own samples — manager accumulates via onSamples callback.
     return []
+  }
+
+  private func awaitStopRunning(
+    _ captureSession: AVCaptureSession,
+    lifecycleSignal: (@Sendable (String) -> Void)?
+  ) async {
+    let sessionQ = sessionQueue
+    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+      let signal = SessionLifecycleSignal(cont)
+      signal.observe(
+        name: .AVCaptureSessionDidStopRunning, object: captureSession, returning: ()
+      ) {
+        lifecycleSignal?("capture_session_did_stop_running")
+      }
+      signal.observe(
+        name: .AVCaptureSessionRuntimeError, object: captureSession, returning: ()
+      ) {
+        lifecycleSignal?("capture_session_runtime_error")
+      }
+      signal.observe(
+        name: .AVCaptureSessionWasInterrupted, object: captureSession, returning: ()
+      ) {
+        lifecycleSignal?("capture_session_was_interrupted")
+      }
+      sessionQ.async {
+        captureSession.stopRunning()
+        lifecycleSignal?("capture_session_stop_running_returned")
+        signal.resume(returning: ())
+      }
+    }
   }
 
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -37,6 +37,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// No-op for in-process capture — VAD runs in the pipeline's monitorVAD() loop instead.
   public var onVADAutoStop: (() -> Void)?
 
+  /// Optional fine-grained lifecycle signal used by the XPC service to publish
+  /// phase ticks while a proxy is waiting on a lifecycle reply.
+  public var onLifecycleSignal: (@Sendable (String) -> Void)? {
+    didSet {
+      activeSource?.onLifecycleSignal = onLifecycleSignal
+    }
+  }
+
   // MARK: - Round-4 telemetry callbacks (issue #285)
 
   /// Stall watchdog callback (forwarded to active source in Phase B implementation).
@@ -150,8 +158,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   public func startEnginePhase() async throws {
     // Re-evaluate route on every recording start — BT state may have changed.
+    onLifecycleSignal?("manager_resolve_source_entered")
     let source = resolveSource()
+    source.onLifecycleSignal = onLifecycleSignal
+    onLifecycleSignal?("manager_prepare_entered")
     try await source.prepare()
+    onLifecycleSignal?("manager_prepare_completed")
   }
 
   public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -215,7 +227,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       self.onCaptureSessionInterruption?(ctx)
     }
 
+    source.onLifecycleSignal = onLifecycleSignal
+    onLifecycleSignal?("manager_start_capture_entered")
     let stream = try await source.startCapture()
+    onLifecycleSignal?("manager_start_capture_completed")
     isCapturing = true
     // Mirror source identity so pipeline-layer Sentry extras still resolve
     // after stopCapture tears `activeSource` down synchronously.
@@ -254,7 +269,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // prepare() sees the engine is already running and skips startup.
     // This eliminates first-word clipping by ensuring the ring buffer has
     // audio from before the user pressed the key.
+    onLifecycleSignal?("manager_deactivate_capture_entered")
     source.deactivateCapture()
+    onLifecycleSignal?("manager_deactivate_capture_completed")
 
     // Keep activeSource alive — resolveSource() will reuse it if still running.
     // BT state changes are handled by resolveSource() re-evaluating the route.

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -285,7 +285,13 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
     var result = CaptureResult(samples: [])
     do {
-      result = try await withAudioXPCOperationSignal(stage: "stop_capture") { operationID in
+      // Cleanup must outlive forward-path task cancellation. `finishTerminal`
+      // cancels that task while stop may already be in flight; returning early
+      // would mark capture resources released before the service actually stops.
+      result = try await withAudioXPCOperationSignal(
+        stage: "stop_capture",
+        parentCancellationBehavior: .waitForResolution
+      ) { operationID in
         try await self.awaitStopCaptureReply(
           operationID: operationID,
           endingSession: endingSession
@@ -419,6 +425,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   private func withAudioXPCOperationSignal<T: Sendable>(
     stage: String,
+    parentCancellationBehavior: WatcherParentCancellationBehavior = .returnCancellation,
     _ work: @MainActor @escaping (String) async throws -> T
   ) async throws -> T {
     let operationID = UUID().uuidString
@@ -428,7 +435,10 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     let operationTask = Task { @MainActor in
       try await unsafeWork(operationID)
     }
-    let outcome = await raceWithSignalWatcher(watcher: signal.progressWatcher) {
+    let outcome = await raceWithSignalWatcher(
+      watcher: signal.progressWatcher,
+      parentCancellationBehavior: parentCancellationBehavior
+    ) {
       try await operationTask.value
     }
     let snapshot = signal.snapshot

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -153,10 +153,17 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
     ensureConnection()
     resendConfigIfNeeded()
+    try await withAudioXPCOperationSignal(stage: "start_engine") { operationID in
+      try await self.awaitStartEnginePhaseReply(operationID: operationID)
+    }
+  }
+
+  private func awaitStartEnginePhaseReply(operationID: String) async throws {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
       let guard_ = OneShotContinuation(cont)
       serviceProxy { proxy in
         proxy.startEnginePhase(
+          operationID: operationID,
           preferredDeviceUID: self.preferredInputDeviceIDOverride,
           selectedDeviceUID: self.selectedInputDeviceUID
         ) { nsError in
@@ -182,15 +189,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       self.bufferContinuation = continuation
     }
 
-    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-      let guard_ = OneShotContinuation(cont)
-      serviceProxy { proxy in
-        proxy.beginCapture { nsError in
-          if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
-        }
-      } onProxyError: {
-        guard_.resume(throwing: XPCTransportError.serviceUnreachable)
-      }
+    try await withAudioXPCOperationSignal(stage: "begin_capture") { operationID in
+      try await self.awaitBeginCaptureReply(operationID: operationID)
     }
 
     isCapturing = true
@@ -198,6 +198,19 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     hasReceivedBufferThisSession = false
     armCaptureStallWatchdog()
     return stream
+  }
+
+  private func awaitBeginCaptureReply(operationID: String) async throws {
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+      let guard_ = OneShotContinuation(cont)
+      serviceProxy { proxy in
+        proxy.beginCapture(operationID: operationID) { nsError in
+          if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
+        }
+      } onProxyError: {
+        guard_.resume(throwing: XPCTransportError.serviceUnreachable)
+      }
+    }
   }
 
   /// Arm the one-shot stall watchdog for the current `activeCaptureGeneration`.
@@ -272,21 +285,16 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
     var result = CaptureResult(samples: [])
     do {
-      result = try await withCheckedThrowingContinuation {
-        (cont: CheckedContinuation<CaptureResult, any Error>) in
-        let guard_ = OneShotContinuation(cont)
-        serviceProxy { proxy in
-          proxy.stopCapture { sampleData, vadData in
-            let samples = Self.dataToFloats(sampleData)
-            let segments = Self.decodeVADSegments(vadData)
-            guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
-          }
-        } onProxyError: { [weak self] in
-          self?.reportXPCReplyFailure(stage: "stop_capture", sessionID: endingSession)
-          guard_.resume(returning: CaptureResult(samples: []))
-        }
+      result = try await withAudioXPCOperationSignal(stage: "stop_capture") { operationID in
+        try await self.awaitStopCaptureReply(
+          operationID: operationID,
+          endingSession: endingSession
+        )
       }
     } catch {
+      if error is XPCOperationSignalWedgeError {
+        reportXPCReplyFailure(stage: "stop_capture_signal_watchdog", sessionID: endingSession)
+      }
       // XPC error — service crashed during stopCapture. Samples are lost.
       // The interruptionHandler fires independently and handles pipeline notification.
       // Do NOT call onEngineInterrupted here to avoid double-firing.
@@ -304,6 +312,26 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     bufferContinuation?.finish()
     bufferContinuation = nil
     return result
+  }
+
+  private func awaitStopCaptureReply(
+    operationID: String,
+    endingSession: UInt64
+  ) async throws -> CaptureResult {
+    try await withCheckedThrowingContinuation {
+      (cont: CheckedContinuation<CaptureResult, any Error>) in
+      let guard_ = OneShotContinuation(cont)
+      serviceProxy { proxy in
+        proxy.stopCapture(operationID: operationID) { sampleData, vadData in
+          let samples = Self.dataToFloats(sampleData)
+          let segments = Self.decodeVADSegments(vadData)
+          guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
+        }
+      } onProxyError: { [weak self] in
+        self?.reportXPCReplyFailure(stage: "stop_capture", sessionID: endingSession)
+        guard_.resume(returning: CaptureResult(samples: []))
+      }
+    }
   }
 
   public func rebuildEngine() {
@@ -336,18 +364,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     // Phase 1: start engine
     let enginePhaseStart = ContinuousClock.now
     do {
-      try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
-        let guard_ = OneShotContinuation(cont)
-        serviceProxy { proxy in
-          proxy.startEnginePhase(
-            preferredDeviceUID: self.preferredInputDeviceIDOverride,
-            selectedDeviceUID: self.selectedInputDeviceUID
-          ) { nsError in
-            if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
-          }
-        } onProxyError: {
-          guard_.resume(throwing: XPCTransportError.serviceUnreachable)
-        }
+      try await withAudioXPCOperationSignal(stage: "start_engine_prewarm") { operationID in
+        try await self.awaitStartEnginePhaseReply(operationID: operationID)
       }
     } catch {
       Task {
@@ -397,6 +415,55 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         cont.resume(returning: false)
       }
     }
+  }
+
+  private func withAudioXPCOperationSignal<T: Sendable>(
+    stage: String,
+    _ work: @MainActor @escaping (String) async throws -> T
+  ) async throws -> T {
+    let operationID = UUID().uuidString
+    let signal = XPCOperationSignalWatcher(file: .audio, operationID: operationID)
+    signal.start()
+    nonisolated(unsafe) let unsafeWork = work
+    let operationTask = Task { @MainActor in
+      try await unsafeWork(operationID)
+    }
+    let outcome = await raceWithSignalWatcher(watcher: signal.progressWatcher) {
+      try await operationTask.value
+    }
+    let snapshot = signal.snapshot
+    signal.stop()
+
+    switch outcome {
+    case .completed(let value):
+      return value
+    case .threw(let error):
+      throw error
+    case .wedged:
+      operationTask.cancel()
+      handleAudioXPCOperationWedge(stage: stage, operationID: operationID, snapshot: snapshot)
+      throw XPCOperationSignalWedgeError(
+        service: "Audio",
+        stage: stage,
+        observedPhase: snapshot.lastObservedPhase
+      )
+    }
+  }
+
+  private func handleAudioXPCOperationWedge(
+    stage: String,
+    operationID: String,
+    snapshot: WatcherSnapshot
+  ) {
+    Task {
+      await AppLogger.shared.log(
+        "[AudioCaptureProxy] signal watchdog fired stage=\(stage) operationID=\(operationID) phase=\(snapshot.lastObservedPhase) silenceMs=\(snapshot.silenceMs)",
+        level: .info, category: "XPC"
+      )
+    }
+    connection?.invalidate()
+    connection = nil
+    needsReinit = true
   }
 
   // MARK: - Config re-send after crash

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -16,6 +16,7 @@ protocol AudioInputSource: AnyObject {
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)? { get set }
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
   var onInterrupted: (() -> Void)? { get set }
+  var onLifecycleSignal: (@Sendable (String) -> Void)? { get set }
 
   /// Liveness-watchdog callback — fires once per capture session if zero
   /// buffers are delivered within `Constants.audioCaptureStallWindowMs` of

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -137,18 +137,30 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
   // MARK: - Lifecycle
 
   func startEnginePhase(
+    operationID: String,
     preferredDeviceUID: String,
     selectedDeviceUID: String,
     reply: @escaping (NSError?) -> Void
   ) {
+    let signal = XPCOperationSignalFile.audio.makeEmitter(operationID: operationID)
+    signal.emit(stage: "audio.start_engine.received")
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
+      signal.emit(stage: "audio.start_engine.main_actor")
+      let previousLifecycleSignal = captureManager.onLifecycleSignal
+      captureManager.onLifecycleSignal = { phase in
+        signal.emit(stage: "audio.start_engine.\(phase)")
+      }
+      defer { captureManager.onLifecycleSignal = previousLifecycleSignal }
       captureManager.preferredInputDeviceIDOverride = preferredDeviceUID
       captureManager.selectedInputDeviceUID = selectedDeviceUID
       do {
+        signal.emit(stage: "audio.start_engine.prepare_entered")
         try await captureManager.startEnginePhase()
+        signal.emit(stage: "audio.start_engine.prepare_completed")
         safeReply(nil)
       } catch {
+        signal.emit(stage: "audio.start_engine.failed", detail: error.localizedDescription)
         // XPC error sanitization boundary.
         safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
@@ -170,28 +182,51 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     }
   }
 
-  func beginCapture(reply: @escaping (NSError?) -> Void) {
+  func beginCapture(operationID: String, reply: @escaping (NSError?) -> Void) {
+    let signal = XPCOperationSignalFile.audio.makeEmitter(operationID: operationID)
+    signal.emit(stage: "audio.begin_capture.received")
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
+      signal.emit(stage: "audio.begin_capture.main_actor")
+      let previousLifecycleSignal = self.captureManager.onLifecycleSignal
+      self.captureManager.onLifecycleSignal = { phase in
+        signal.emit(stage: "audio.begin_capture.\(phase)")
+      }
+      defer { self.captureManager.onLifecycleSignal = previousLifecycleSignal }
       do {
+        signal.emit(stage: "audio.begin_capture.source_entered")
         _ = try await self.captureManager.beginCapturePhase()
+        signal.emit(stage: "audio.begin_capture.source_completed")
         self.startVADMonitoring()
+        signal.emit(stage: "audio.begin_capture.vad_started")
         safeReply(nil)
       } catch {
+        signal.emit(stage: "audio.begin_capture.failed", detail: error.localizedDescription)
         // XPC error sanitization boundary.
         safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
       }
     }
   }
 
-  func stopCapture(reply: @escaping (Data, Data) -> Void) {
+  func stopCapture(operationID: String, reply: @escaping (Data, Data) -> Void) {
+    let signal = XPCOperationSignalFile.audio.makeEmitter(operationID: operationID)
+    signal.emit(stage: "audio.stop_capture.received")
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
+      signal.emit(stage: "audio.stop_capture.main_actor")
+      let previousLifecycleSignal = self.captureManager.onLifecycleSignal
+      self.captureManager.onLifecycleSignal = { phase in
+        signal.emit(stage: "audio.stop_capture.\(phase)")
+      }
+      defer { self.captureManager.onLifecycleSignal = previousLifecycleSignal }
       self.cancelVADMonitoring()
+      signal.emit(stage: "audio.stop_capture.vad_cancelled")
 
       // Stop capture first: freezes the tap, returns all accumulated samples,
       // clears the internal buffer. No new samples can arrive after this.
+      signal.emit(stage: "audio.stop_capture.source_entered")
       let captureResult = await self.captureManager.stopCapture()
+      signal.emit(stage: "audio.stop_capture.source_completed")
 
       // Finalize VAD using the EXACT count of returned samples. This guarantees
       // segment endpoints align perfectly with the sample array the caller receives.
@@ -200,8 +235,10 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       // - The race window: samples arriving during await -> count drift -> tail trim
       var vadData = Data()
       if let detector = self.silenceDetector {
+        signal.emit(stage: "audio.stop_capture.vad_finalize_entered")
         await detector.finalizeSegments(totalSampleCount: captureResult.samples.count)
         let segments = await detector.speechSegments
+        signal.emit(stage: "audio.stop_capture.vad_finalize_completed")
         vadData = Data(capacity: segments.count * MemoryLayout<Int32>.size * 2)
         for seg in segments {
           var start = Int32(seg.startSample)
@@ -212,6 +249,7 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       }
 
       let sampleData = captureResult.samples.withUnsafeBytes { Data($0) }
+      signal.emit(stage: "audio.stop_capture.reply_ready")
       safeReply(sampleData, vadData)
     }
   }

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -46,7 +46,9 @@ import Foundation
   // MARK: - Streaming Transcription (Parakeet)
 
   /// Start a streaming ASR session.
-  func startStreaming(language: String, enableTimestamps: Bool, reply: @escaping (NSError?) -> Void)
+  func startStreaming(
+    operationID: String, language: String, enableTimestamps: Bool,
+    reply: @escaping (NSError?) -> Void)
 
   /// Feed an audio buffer to the streaming session. Fire-and-forget — no reply.
   /// Transport format: raw Float32 bytes, non-interleaved mono, 16kHz.

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -41,20 +41,21 @@ import Foundation
   /// Phase 1: start the audio engine, trigger BT codec switch, register config-change observer.
   /// Device UIDs are passed inline so the proxy doesn't need separate setter replay before this call.
   func startEnginePhase(
-    preferredDeviceUID: String, selectedDeviceUID: String, reply: @escaping (NSError?) -> Void)
+    operationID: String, preferredDeviceUID: String, selectedDeviceUID: String,
+    reply: @escaping (NSError?) -> Void)
 
   /// Poll engine format until stable after BT codec negotiation.
   func waitForFormatStabilization(
     maxWait: Double, pollInterval: Double, reply: @escaping (Bool) -> Void)
 
   /// Phase 2: install audio tap and begin capture. Buffers flow back via audioBufferCaptured callback.
-  func beginCapture(reply: @escaping (NSError?) -> Void)
+  func beginCapture(operationID: String, reply: @escaping (NSError?) -> Void)
 
   /// Stop capture and return accumulated samples + finalized VAD segments atomically.
   /// First Data = raw Float32 sample bytes. Second Data = packed [Int32 start, Int32 end] VAD segment pairs.
   /// VAD segments are finalized BEFORE the sample buffer is cleared, preventing the call-order bug
   /// where separate stopCapture/getVADSegments calls produced endSample=0 on open segments.
-  func stopCapture(reply: @escaping (Data, Data) -> Void)
+  func stopCapture(operationID: String, reply: @escaping (Data, Data) -> Void)
 
   /// Cancel a pre-warmed engine that never began capture.
   func abortPreWarm()

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -66,10 +66,11 @@ public final class LoadProgressWatcher {
   private var signalCount: Int = 0
   private var fired = false
   private var continuation: CheckedContinuation<Void, Never>?
-  /// Model-load progress keeps the original safer rule: require two observed
-  /// progress signals before ratio-based silence can fire. Discrete XPC
-  /// lifecycle operations set this false because their signal is an explicit
-  /// "entered a blocking state" transition, not a long download cadence.
+  /// Require two observed progress signals before ratio-based silence can fire.
+  /// This keeps the 800ms floor from becoming a standalone timeout after only
+  /// one lifecycle tick. XPC lifecycle operations keep this safer default:
+  /// cold `startRunning()`, `AVAudioEngine.start()`, and large stop replies can
+  /// legitimately stay quiet for longer than the floor before their next signal.
   private let requiresObservedGap: Bool
 
   /// Monotonic clock source. Production uses `ProcessInfo.processInfo.systemUptime`
@@ -273,10 +274,21 @@ public enum WatcherOutcome<T: Sendable>: Sendable {
   /// background. The function returns regardless; the caller's state machine
   /// must reset cleanly without depending on the work actually stopping.
   case wedged
-  /// Work threw before the watcher fired, OR the parent task that called
-  /// `raceWithSignalWatcher` was cancelled. Caller cancellation surfaces as
-  /// `CancellationError`.
+  /// Work threw before the watcher fired. With the default parent-cancellation
+  /// behavior, caller cancellation also surfaces here as `CancellationError`.
   case threw(Error)
+}
+
+/// Parent-task cancellation policy for `raceWithSignalWatcher`.
+public enum WatcherParentCancellationBehavior: Sendable {
+  /// Surface caller cancellation as `.threw(CancellationError())` and cancel
+  /// the raced work best-effort. This is the normal behavior for foreground
+  /// operations whose caller is no longer interested in the result.
+  case returnCancellation
+  /// Ignore parent-task cancellation and keep awaiting the real operation result
+  /// or the signal watcher. Cleanup awaits use this so a cancelled forward-path
+  /// task cannot mark resources released before the service actually stops.
+  case waitForResolution
 }
 
 /// At-most-once outcome delivery. First sender wins; subsequent senders are
@@ -312,13 +324,16 @@ private actor OutcomeBox<T: Sendable> {
 ///
 /// On wedge, the work task is `cancel()`ed (best-effort, cooperative).
 ///
-/// On parent-task cancellation, returns `.threw(CancellationError())`.
+/// On parent-task cancellation, returns `.threw(CancellationError())` by
+/// default. Cleanup callers can opt into `.waitForResolution` when returning
+/// before the real operation resolves would violate a release contract.
 ///
 /// Caller must call `watcher.start()` before invoking this and `watcher.stop()`
 /// after it returns (typically via `defer`). The race helper does NOT manage
 /// the watcher's lifecycle.
 public func raceWithSignalWatcher<T: Sendable>(
   watcher: LoadProgressWatcher,
+  parentCancellationBehavior: WatcherParentCancellationBehavior = .returnCancellation,
   _ work: @Sendable @escaping () async throws -> T
 ) async -> WatcherOutcome<T> {
   let box = OutcomeBox<T>()
@@ -350,8 +365,13 @@ public func raceWithSignalWatcher<T: Sendable>(
     }
     return result
   } onCancel: {
-    Task { await box.deliver(.threw(CancellationError())) }
-    workTask.cancel()
-    watcherTask.cancel()
+    switch parentCancellationBehavior {
+    case .returnCancellation:
+      Task { await box.deliver(.threw(CancellationError())) }
+      workTask.cancel()
+      watcherTask.cancel()
+    case .waitForResolution:
+      break
+    }
   }
 }

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -66,6 +66,11 @@ public final class LoadProgressWatcher {
   private var signalCount: Int = 0
   private var fired = false
   private var continuation: CheckedContinuation<Void, Never>?
+  /// Model-load progress keeps the original safer rule: require two observed
+  /// progress signals before ratio-based silence can fire. Discrete XPC
+  /// lifecycle operations set this false because their signal is an explicit
+  /// "entered a blocking state" transition, not a long download cadence.
+  private let requiresObservedGap: Bool
 
   /// Monotonic clock source. Production uses `ProcessInfo.processInfo.systemUptime`
   /// via the default; tests inject a `ManualClock` for deterministic timing.
@@ -77,9 +82,11 @@ public final class LoadProgressWatcher {
   public init(
     currentTime: @escaping @MainActor () -> TimeInterval = {
       ProcessInfo.processInfo.systemUptime
-    }
+    },
+    requiresObservedGap: Bool = true
   ) {
     self.currentTime = currentTime
+    self.requiresObservedGap = requiresObservedGap
   }
 
   /// Begin a new attempt. Resets all per-attempt state.
@@ -149,7 +156,18 @@ public final class LoadProgressWatcher {
     // non-goal; in practice the wedge symptom sits inside compile phase, after
     // many signals have accumulated, so this restriction does not lose coverage
     // for the targeted defect).
-    guard maxGapSeconds > 0 else { return }
+    guard maxGapSeconds > 0 else {
+      guard !requiresObservedGap else { return }
+      let silence = now - (lastSignalAt ?? attemptStartedAt)
+      if silence > floorSeconds {
+        fired = true
+        if let cont = continuation {
+          continuation = nil
+          cont.resume()
+        }
+      }
+      return
+    }
     let silence = now - (lastSignalAt ?? attemptStartedAt)
     let ratioThreshold = maxGapSeconds * abnormalRatio
     let threshold = max(floorSeconds, ratioThreshold)

--- a/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
+++ b/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
@@ -6,6 +6,12 @@ import Foundation
 /// service for progress while it is already waiting for that request's reply.
 /// This file mirrors `ProgressFile`: the service writes state-transition ticks
 /// to `/tmp`, and the host polls those ticks outside XPC.
+///
+/// The host watcher intentionally keeps `LoadProgressWatcher`'s observed-gap
+/// gate. A single service tick followed by 800ms of silence is not enough
+/// evidence of a wedge: cold AVFoundation/CoreAudio phases and large stop
+/// replies can be healthy while quiet. Once at least one inter-signal cadence
+/// exists, later silence still fires through the normal floor + 5x-gap rule.
 public final class XPCOperationSignalFile: Sendable {
   public static let audio = XPCOperationSignalFile(
     filePath: "/tmp/com.enviouswispr.audio-operation-signal")
@@ -103,7 +109,7 @@ public final class XPCOperationSignalWatcher {
   public init(file: XPCOperationSignalFile, operationID: String) {
     self.file = file
     self.operationID = operationID
-    self.progressWatcher = LoadProgressWatcher(requiresObservedGap: false)
+    self.progressWatcher = LoadProgressWatcher()
   }
 
   public func start() {

--- a/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
+++ b/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Cross-process operation progress for XPC calls whose reply may wedge.
+///
+/// XPC replies serialize behind the pending request, so a proxy cannot ask the
+/// service for progress while it is already waiting for that request's reply.
+/// This file mirrors `ProgressFile`: the service writes state-transition ticks
+/// to `/tmp`, and the host polls those ticks outside XPC.
+public final class XPCOperationSignalFile: Sendable {
+  public static let audio = XPCOperationSignalFile(
+    filePath: "/tmp/com.enviouswispr.audio-operation-signal")
+  public static let asr = XPCOperationSignalFile(
+    filePath: "/tmp/com.enviouswispr.asr-operation-signal")
+
+  private let filePath: String
+
+  private init(filePath: String) {
+    self.filePath = filePath
+  }
+
+  public func makeEmitter(operationID: String) -> XPCOperationSignalEmitter {
+    XPCOperationSignalEmitter(file: self, operationID: operationID)
+  }
+
+  public func write(_ state: XPCOperationSignalState) {
+    guard let data = try? PropertyListEncoder().encode(state) else { return }
+    do {
+      try data.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+    } catch {
+      // Signal write failure is non-fatal. The caller's XPC reply/error path
+      // remains the primary completion path.
+    }
+  }
+
+  public func read() -> XPCOperationSignalState? {
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else { return nil }
+    return try? PropertyListDecoder().decode(XPCOperationSignalState.self, from: data)
+  }
+
+  public func clear() {
+    try? FileManager.default.removeItem(atPath: filePath)
+  }
+}
+
+public struct XPCOperationSignalState: Codable, Sendable {
+  public let operationID: String
+  public let sequence: Int
+  public let stage: String
+  public let detail: String
+  public let uptimeNanoseconds: UInt64
+
+  public init(
+    operationID: String,
+    sequence: Int,
+    stage: String,
+    detail: String = "",
+    uptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
+  ) {
+    self.operationID = operationID
+    self.sequence = sequence
+    self.stage = stage
+    self.detail = detail
+    self.uptimeNanoseconds = uptimeNanoseconds
+  }
+}
+
+public final class XPCOperationSignalEmitter: @unchecked Sendable {
+  private let file: XPCOperationSignalFile
+  private let operationID: String
+  private let lock = NSLock()
+  private var sequence = 0
+
+  fileprivate init(file: XPCOperationSignalFile, operationID: String) {
+    self.file = file
+    self.operationID = operationID
+  }
+
+  public func emit(stage: String, detail: String = "") {
+    lock.lock()
+    sequence += 1
+    let next = sequence
+    lock.unlock()
+
+    file.write(
+      XPCOperationSignalState(
+        operationID: operationID,
+        sequence: next,
+        stage: stage,
+        detail: detail
+      )
+    )
+  }
+}
+
+@MainActor
+public final class XPCOperationSignalWatcher {
+  public let progressWatcher: LoadProgressWatcher
+
+  private let file: XPCOperationSignalFile
+  private let operationID: String
+  private var pollTimer: Timer?
+
+  public init(file: XPCOperationSignalFile, operationID: String) {
+    self.file = file
+    self.operationID = operationID
+    self.progressWatcher = LoadProgressWatcher(requiresObservedGap: false)
+  }
+
+  public func start() {
+    stopPollingOnly()
+    file.clear()
+    progressWatcher.start()
+    let timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.poll()
+      }
+    }
+    RunLoop.main.add(timer, forMode: .common)
+    pollTimer = timer
+  }
+
+  public func stop() {
+    stopPollingOnly()
+    progressWatcher.stop()
+    file.clear()
+  }
+
+  public var snapshot: WatcherSnapshot { progressWatcher.snapshot }
+
+  private func stopPollingOnly() {
+    pollTimer?.invalidate()
+    pollTimer = nil
+  }
+
+  private func poll() {
+    guard let state = file.read(), state.operationID == operationID else {
+      progressWatcher.observeTick(observedMtime: nil, observedPhase: "")
+      return
+    }
+
+    // Use the service-written monotonic sequence as the signal token. This avoids
+    // filesystem mtime precision hiding rapid state transitions.
+    let signalToken = Date(timeIntervalSince1970: Double(state.sequence))
+    progressWatcher.observeTick(observedMtime: signalToken, observedPhase: state.stage)
+  }
+}
+
+public struct XPCOperationSignalWedgeError: LocalizedError, Sendable {
+  public let service: String
+  public let stage: String
+  public let observedPhase: String
+
+  public init(service: String, stage: String, observedPhase: String) {
+    self.service = service
+    self.stage = stage
+    self.observedPhase = observedPhase
+  }
+
+  public var errorDescription: String? {
+    "\(service) XPC operation wedged during \(stage) after signal phase \(observedPhase)"
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -458,6 +458,11 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
   /// during the suspension cannot double-resume the continuation (which would
   /// crash). The latch is `@MainActor`-isolated; every re-arm path passes
   /// through it before any work.
+  ///
+  /// REVIEWED_OK(#827): the signal source is the kernel's observable terminal
+  /// state transition. A hang here means a lower-level kernel await failed to
+  /// produce its own transition signal; the driver has no separate recovery
+  /// action beyond observing the kernel state it adapts.
   private func awaitKernelTerminal() async {
     if Self.isTerminal(kernel.state) { return }
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -278,6 +278,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// ~250-500ms of trailing audio"). Awaiting the task handles is the actual
   /// completion signal; no wall-clock deadline (`no-arbitrary-timeouts.md`) —
   /// the prior `ContinuousClock` deadline raced the scheduler and flaked.
+  /// REVIEWED_OK(#827): production uses `ASRManagerProxy.feedAudio`, which is
+  /// XPC fire-and-forget and returns after dispatch. The task drain waits for
+  /// host-side dispatch completion, not for remote ASR processing.
   /// Iterates a value snapshot and does NOT clear `feedTasks` — only
   /// `beginSession()` / `cancel()` clear it, so a session that begins during
   /// this drain's `await` cannot have its fresh feed handles dropped here.

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -30,6 +30,10 @@ internal final class TextProcessingRunner {
   /// that decides per call whether to run the operation or throw
   /// `TimeoutError`. Specialized to `TextProcessingContext` because the
   /// runner only ever times out step operations of that return type.
+  ///
+  /// REVIEWED_OK(#827): this pre-existing guard is covered by the injected
+  /// executor tests and surfaces `TimeoutError` into the normal limb-failed
+  /// continuation path.
   typealias TimeoutExecutor = @MainActor (
     Double,
     @escaping @MainActor () async throws -> TextProcessingContext

--- a/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipeline.swift
@@ -7,6 +7,10 @@ import EnviousWisprServices
 import EnviousWisprStorage
 import Foundation
 
+// FIXME(#827): founder/upstream action needed. WhisperKit model load, LID, and
+// decoder awaits need vendor progress signals before this pipeline can add
+// signal-based recovery without wall-clock timeouts.
+
 // R2 (#360): the pipeline holds no WhisperKit-typed values after the
 // Approach C session protocol + LID-button refactor, so it no longer
 // imports the vendor module directly. The dependency is also dropped from
@@ -455,6 +459,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
       }
       prepareTask = task
       do {
+        // TODO(#827): watchdog needs CoreML/WhisperKit model-load progress from
+        // `WhisperKitBackend.prepare`; no local signal exists at this await.
         try await task.value
         prepareTask = nil
         guard state == .loadingModel else { return }  // cancelled during model load
@@ -769,6 +775,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
     // Snapshot `lidSamples` into an immutable binding so the @Sendable observer
     // closure does not capture the surrounding `var lidSamples` (would race).
     let observerSamples = lidSamples
+    // TODO(#827): watchdog needs within-window LID progress from WhisperKit.
+    // `LanguageDetector` only returns after the backend observer finishes.
     let lidResult = await languageDetector.detect(
       samples: lidSamples,
       voicedDuration: voicedDurationSec,
@@ -861,6 +869,9 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
 
       if let worker = incrementalWorker {
         let segments = await silenceDetector?.speechSegments ?? []
+        // TODO(#827): watchdog needs decoder-step progress from
+        // `WhisperKitIncrementalWorker.finalize`; worker counters update only
+        // after vendor transcribe returns.
         let result = await worker.finalize(finalSamples: rawSamples, speechSegments: segments)
         incrementalWorker = nil
         asrEmptyDiagnostics.incrementalAccepted = result.accepted
@@ -911,6 +922,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
             lidWindowCount: lidWindowCount,
             clipKind: clipKind
           )
+          // TODO(#827): watchdog needs WhisperKit decoder-step progress from
+          // `WhisperKitBackend.transcribe`.
           let batchResult = try await backend.transcribe(
             audioSamples: asrSamples, options: transcriptionOptions)
           let batchEnd = CFAbsoluteTimeGetCurrent()
@@ -946,6 +959,8 @@ public final class WhisperKitPipeline: DictationPipeline, HeartPathTelemetryTarg
           lidWindowCount: lidWindowCount,
           clipKind: clipKind
         )
+        // TODO(#827): watchdog needs WhisperKit decoder-step progress from
+        // `WhisperKitBackend.transcribe`.
         let batchResult = try await backend.transcribe(
           audioSamples: asrSamples, options: transcriptionOptions)
         asrEmptyDiagnostics.batchRescueAttempted = false

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -80,7 +80,7 @@ struct LoadProgressWatcherTests {
     watcher.stop()
   }
 
-  @Test("Single signal then long silence does NOT fire (no ratio data)")
+  @Test("Single signal then long silence does NOT fire (observed-gap gate protects XPC)")
   func singleSignalLongSilenceDoesNotFire() async {
     let clock = ManualClock()
     let watcher = LoadProgressWatcher(currentTime: { clock.now })
@@ -97,7 +97,10 @@ struct LoadProgressWatcherTests {
     let snap = watcher.snapshot
     #expect(snap.signalCountTotal == 1)
     #expect(snap.maxGapMs == 0)
-    #expect(!watcher.hasFired, "single signal with no observed gap must not fire")
+    #expect(
+      !watcher.hasFired,
+      "single XPC lifecycle tick with no observed gap must not become an 800ms timeout"
+    )
     watcher.stop()
   }
 
@@ -183,6 +186,30 @@ struct LoadProgressWatcherTests {
       #expect(value == 42)
     } else {
       Issue.record("Expected .completed(42), got \(outcome)")
+    }
+  }
+
+  @Test("raceWithSignalWatcher can wait through parent cancellation for cleanup awaits")
+  func raceWaitsThroughParentCancellationWhenRequested() async {
+    let watcher = LoadProgressWatcher()
+    watcher.start()
+    let task = Task { @MainActor in
+      await raceWithSignalWatcher(
+        watcher: watcher,
+        parentCancellationBehavior: .waitForResolution
+      ) {
+        try await Task.sleep(nanoseconds: 50_000_000)
+        return 42
+      }
+    }
+    await sleep(ms: 10)
+    task.cancel()
+    let outcome = await task.value
+    watcher.stop()
+    if case .completed(let value) = outcome {
+      #expect(value == 42)
+    } else {
+      Issue.record("Expected cleanup wait to complete after cancellation, got \(outcome)")
     }
   }
 


### PR DESCRIPTION
## Summary

Adds signal-based watchdogs to 5 cross-process audio and ASR XPC await sites that could hang indefinitely. The watchdogs detect wedges via a host-side ↔ service-side operation-signal file (`/tmp/com.enviouswispr.audio-operation-signal`) — the XPC service emits monotonic phase ticks as it processes each operation, and the host watcher fires `XPCOperationSignalWedgeError` if those ticks stop arriving with a healthy cadence.

Independent of #862 (kernel parity). Both PRs are pre-requisites for the PR-4b.4 cutover re-attempt.

## What's covered (signal-based watchdogs)

1. **`AudioCaptureProxy.startEnginePhase`** — start-engine reply await (PTT/overlay start path)
2. **`AudioCaptureProxy.beginCapturePhase`** — begin-capture reply await
3. **`AudioCaptureProxy.stopCapture`** — stop-capture reply await (cleanup blocks transcription if stuck)
4. **`ASRManagerProxy.startStreaming`** — ASR XPC start-streaming reply await
5. **`AVCaptureSessionSource.startRunning` / `stopRunning`** — wired AVCaptureSession lifecycle notifications as progress signals

**3 reviewed-OK (no change needed):**
- `ParakeetEngineAdapter.feedAudio` — XPC fire-and-forget, host dispatch completion only
- `KernelDictationDriver.awaitKernelTerminal` — observes kernel state, no separate hang concern
- `TextProcessingRunner` LLM call — existing timeout executor covers it

**3 deferred — need upstream API changes:**
- WhisperKit/CoreML model load (`WhisperKitBackend.prepare`)
- WhisperKit LID window progress
- WhisperKit decoder-step progress (transcribe, tail, incremental)

All deferred sites have `TODO(#827)` comments naming the missing signal. Tagged for future founder action.

## Hard constraint honored

**Zero wall-clock timeouts.** Every watchdog is signal-based per `~/.claude/rules/no-arbitrary-timeouts.md`. Signal source: XPC operation heartbeat file written by the service, polled by the host watcher (125ms polling, observed-gap gate). Wedge fires when ticks stop advancing AFTER initial observed cadence — not on a fixed timeout.

## Codex code-diff review fixes (this PR)

- Restored observed-gap gate (`LoadProgressWatcher()` default): previous `requiresObservedGap: false` caused false-positive fires on legitimately slow cold-path AVFoundation operations
- Added `WatcherParentCancellationBehavior` enum; `stopCapture` uses `.waitForResolution` so parent-task cancellation cannot mark resources released before XPC stop reply arrives
- `awaitStopRunning` made notification-progress-only: RuntimeError / WasInterrupted observers feed progress ticks but do NOT short-circuit the await; `stopRunning()` returning is the terminal

## Test plan

- [x] All 1343 unit tests pass (was 1342 + 1 new test for `.waitForResolution` cancellation behavior)
- [x] `swift build -c release` exits 0
- [x] `scripts/swift-test.sh` exits 0
- [x] Codex code-diff review iterated to clean (2 rounds — Round 1 found 3 P1/P2 issues addressed here)
- [x] Live UAT validated end-to-end with #862 merged: watchdogs sat idle during 7+ successful dictations (correct — nothing was wedged)

## Risk

- Tier: MEDIUM (audio + ASR XPC paths, heart-path adjacent)
- Heart-path: protects against hangs without changing happy-path latency (watchdogs only fire on wedge signal absence)
- Rollback: revert this PR — restores prior unguarded XPC awaits

## Related

- Epic #827 — engine-kernel refactor
- Pre-requisite for PR-4b.4 cutover re-attempt (with #862)
- Future: vendor-side WhisperKit progress APIs would unblock the 3 deferred sites