### PR TITLE
fix(tests): bump LimbFailureFallback polish deadline to 60s for slow CI

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
@@ -67,7 +67,12 @@ struct LimbFailureFallbackTests {
 private final class FailingPolishStep: TextProcessingStep {
   let name = "LLM Polish"
   let isEnabled: Bool
-  let maxDuration: Duration = .seconds(5)
+  // Generous timeout: the runner races `process()` against this deadline.
+  // On contended CI (Apple M1 Virtual, 3 cores), MainActor scheduling delay
+  // beat a 5s deadline on the post-merge run of a5a2eec, causing the timeout
+  // to surface before the deterministic throw. The test asserts behavior on
+  // the throw, not on the timeout — make the deadline unreachable in practice.
+  let maxDuration: Duration = .seconds(60)
   let errorSurfacePolicy: ErrorSurfacePolicy = .surface
   private let message: String
 


### PR DESCRIPTION
## Summary
- New test from PR #864 flaked on the post-merge `Main Post-Merge Check` run of `a5a2eec` (1 of 1345 tests).
- The runner races `process()` against the step's `maxDuration` (5s). On the contended Apple M1 Virtual / 3-core runner, MainActor scheduling delay let the timeout fire before the deterministic throw, surfacing `TimeoutError` instead of the test's expected error message.
- Fix: bump the test mock's `maxDuration` to 60s. The test asserts behavior on the throw, not on the timeout. The production polish step's own `maxDuration` is unaffected.

## Why this is zero-blast-radius
- 1 file, +6/-1 lines.
- Test-only constant change.
- No production code touched.
- No behavior change on local builds (the test passed pre-merge in PR #864's CI on the same machine class).

`council-skip: zero-blast-radius (test-only constant change)`

## Test plan
- [x] Local run: `scripts/swift-test.sh --filter "LimbFailureFallbackTests"` — both tests pass in 1ms.
- [ ] CI `build-check` green on this PR.
- [ ] Post-merge `Main Post-Merge Check` green on the merged commit.