### PR TITLE
refactor(engine-kernel): PR-5 Rung 1 — engine identity cleanup (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -31,6 +31,21 @@ public struct SessionID: Hashable, Sendable {
   }
 }
 
+/// Self-declared engine identity (epic #827, PR-5 Rung 1). Replaces the
+/// kernel- and factory-side hard-coded `.parakeet` literals: each
+/// `ASREngineAdapter` conformer declares its identity, and the kernel /
+/// factory read identity from `adapter.engineIdentity` rather than
+/// branching on engine type (epic §3.4).
+public struct ASREngineIdentity: Sendable {
+  public let backendType: ASRBackendType
+  public var rawValue: String { backendType.rawValue }
+  public var displayName: String { backendType.displayName }
+
+  public init(backendType: ASRBackendType) {
+    self.backendType = backendType
+  }
+}
+
 /// Static capability flags an engine adapter advertises so the kernel can
 /// branch on `capabilities` rather than on engine identity (PR-1 §B.2.1,
 /// D15). An optional capability the adapter does not support MUST degrade
@@ -170,6 +185,11 @@ public struct AudioBufferHandoff: @unchecked Sendable {
 @MainActor
 public protocol ASREngineAdapter: AnyObject {
   // MARK: Identity & capability
+
+  /// Self-declared engine identity. The kernel and factory read identity from
+  /// here rather than branching on engine type (epic §3.4: kernel never
+  /// branches on engine identity).
+  var engineIdentity: ASREngineIdentity { get }
 
   /// Static capability flags (PR-1 §B.2.1).
   var capabilities: ASREngineCapabilities { get }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -76,14 +76,6 @@ public enum KernelDictationDriverFactory {
       emojiFormatter: EmojiFormatterStep(),
       llmPolish: LLMPolishStep(keychainManager: inputs.keychainManager)
     )
-    limbSteps.llmPolish.backend = .parakeet
-    // PR-4b.4 of #827: a non-nil `onToken` callback is the discriminant that
-    // tells `GeminiConnector` to use `streamGenerateContent?alt=sse` instead
-    // of batch `generateContent`. The old Parakeet pipeline set this to a
-    // no-op closure for the same purpose; preserve that behavior so Gemini
-    // polish stays on the streaming endpoint post-cutover. Live token UI is
-    // a separate follow-up; this callback intentionally discards tokens.
-    limbSteps.llmPolish.onToken = { _ in }
 
     // 2. Shared mutable holders.
     let outcome = KernelFinalizationOutcome()
@@ -97,9 +89,22 @@ public enum KernelDictationDriverFactory {
     // 4. Parakeet adapter.
     let adapter = ParakeetEngineAdapter(asrManager: inputs.asrManager)
 
+    // 4a. Polish-step backend stamp — sourced from the adapter's self-declared
+    // identity so this site never hard-codes engine identity (PR-5 Rung 1).
+    // Late-assigned after step 4 because `LLMPolishStep` is class-typed and
+    // nothing between step 1 and here reads `llmPolish.backend`.
+    limbSteps.llmPolish.backend = adapter.engineIdentity.backendType
+    // PR-4b.4 of #827: a non-nil `onToken` callback is the discriminant that
+    // tells `GeminiConnector` to use `streamGenerateContent?alt=sse` instead
+    // of batch `generateContent`. The old Parakeet pipeline set this to a
+    // no-op closure for the same purpose; preserve that behavior so Gemini
+    // polish stays on the streaming endpoint post-cutover. Live token UI is
+    // a separate follow-up; this callback intentionally discards tokens.
+    limbSteps.llmPolish.onToken = { _ in }
+
     // 5. Telemetry emitter (factory-internal; App never sees it).
     let emitter = HeartPathTelemetryEmitter(
-      backend: .parakeet,
+      backend: adapter.engineIdentity.backendType,
       captureTelemetry: inputs.captureTelemetry
     )
 
@@ -159,7 +164,7 @@ public enum KernelDictationDriverFactory {
     //     `context.config`, `inputs.audioCapture.currentAudioRoute`, and
     //     `inputs.captureTelemetry`. Internal type; never appears in `Inputs`.
     let lifecycleSink = KernelLifecycleTelemetrySink(
-      backend: .parakeet,
+      backend: adapter.engineIdentity.backendType,
       audioCapture: inputs.audioCapture,
       context: context,
       outcome: outcome,

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -156,7 +156,7 @@ struct KernelFinalizationWiring {
         language: adapter.lastResult?.language,
         duration: adapter.lastResult?.duration ?? 0,
         processingTime: adapter.lastResult?.processingTime ?? 0,
-        backendType: .parakeet,
+        backendType: adapter.engineIdentity.backendType,
         llmProvider: outcome.llmProvider,
         llmModel: outcome.llmModel)
       try save(transcript)

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -106,8 +106,7 @@ final class KernelHeartPathTelemetryObserver {
   init(
     kernel: RecordingSessionKernel,
     audioCapture: any AudioCaptureInterface,
-    emitter: HeartPathTelemetryEmitter = HeartPathTelemetryEmitter(
-      backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+    emitter: HeartPathTelemetryEmitter,
     emitLifecycleEvent: @escaping @MainActor (KernelLifecycleEvent) -> Void
   ) {
     self.kernel = kernel

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -108,6 +108,12 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   // MARK: ASREngineAdapter — identity & capability
 
+  /// Self-declared identity. The kernel reads from here at every site that
+  /// previously hard-coded `.parakeet` (PR-5 Rung 1).
+  var engineIdentity: ASREngineIdentity {
+    ASREngineIdentity(backendType: .parakeet)
+  }
+
   /// Parakeet decodes incrementally and detects no language (D2, D15). Static —
   /// the kernel branches on `capabilities`, never on engine identity.
   var capabilities: ASREngineCapabilities {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -614,7 +614,7 @@ final class RecordingSessionKernel {
       let totalMs = Int((ContinuousClock.now - preWarmStart) / .milliseconds(1))
       Task {
         await AppLogger.shared.log(
-          "COLD-START [Parakeet] preWarmAudioInput total=\(totalMs)ms",
+          "COLD-START [\(adapter.engineIdentity.displayName)] preWarmAudioInput total=\(totalMs)ms",
           level: .info, category: "Pipeline"
         )
       }
@@ -1012,7 +1012,7 @@ final class RecordingSessionKernel {
       )
     }
     telemetryState.asrEmptyDiagnostics = ASREmptyResultDiagnostics(
-      backend: ASRBackendType.parakeet.rawValue,
+      backend: adapter.engineIdentity.rawValue,
       mode: isStreamingSession ? "streaming" : "batch",
       hasSpeechEvidence: speechEvidence != .confirmedNoSpeech,
       rawSampleCount: captureResult.samples.count,
@@ -1789,7 +1789,7 @@ final class RecordingSessionKernel {
   private func freezeRecordingSnapshot() {
     let start = recordingStartedAtDate ?? Date()
     telemetryState.recordingSnapshot = KernelRecordingSnapshotTelemetry(
-      backend: ASRBackendType.parakeet.rawValue,
+      backend: adapter.engineIdentity.rawValue,
       audioRoute: audioCapture.currentAudioRoute,
       wasStreaming: isStreamingSession,
       startTime: start,
@@ -1911,6 +1911,13 @@ final class RecordingSessionKernel {
     }
     func testGetRecordingSnapshot() -> KernelRecordingSnapshotTelemetry? {
       telemetryState.recordingSnapshot
+    }
+
+    /// PR-5 Rung 1: surface the natural `freezeRecordingSnapshot()` path so
+    /// the engine-identity propagation sentinel can prove `:1791-1792` reads
+    /// `adapter.engineIdentity.rawValue` rather than a hard-coded literal.
+    func testTriggerRecordingSnapshotFreeze() {
+      freezeRecordingSnapshot()
     }
 
     /// Test-only finalizing-sub-status setter. Lets unit tests flip the

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+
+// MARK: - EngineIdentityFreezeTests (epic #827, PR-5 Rung 1)
+//
+// Source-level guard that the four kernel-side production sites never
+// reintroduce a `.parakeet` engine-identity literal and (where they own an
+// adapter reference) continue to read identity via `adapter.engineIdentity`.
+// The runtime sentinel in `EngineIdentityPropagationTests` covers the
+// natural-flow plumbing; this freeze test catches a future refactor that
+// accidentally hard-codes the first engine again at the source level — a
+// `.parakeet` literal compiles fine and would pass type-checking.
+
+@Suite struct EngineIdentityFreezeTests {
+
+  /// Matches the `.parakeet` enum-case literal (leading dot, identifier
+  /// boundary trailing). Does NOT match `Parakeet` (capitalized engine name)
+  /// nor `ParakeetEngineAdapter` (the concrete type name).
+  private static let bannedIdentityLiteral = #"\.parakeet\b"#
+
+  /// Sites that must read identity from the adapter and must not carry the
+  /// banned literal.
+  private static let identityReaderSites = [
+    "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift",
+    "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift",
+    "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+  ]
+
+  /// The observer file no longer holds an emitter default — it must never
+  /// reintroduce the `.parakeet` literal that previously seeded the default
+  /// emitter; callers pass an explicit emitter constructed from
+  /// `adapter.engineIdentity.backendType`.
+  private static let identityFreeSites = [
+    "Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift"
+  ]
+
+  // MARK: Positive — production sites are clean
+
+  @Test("identity-reader sites contain at least one adapter.engineIdentity read")
+  func readerSitesUseAdapterIdentity() throws {
+    for relative in Self.identityReaderSites {
+      let source = try Self.readSource(relative)
+      #expect(
+        source.contains("adapter.engineIdentity"),
+        "\(relative) must read identity from `adapter.engineIdentity`")
+    }
+  }
+
+  @Test("identity-reader sites carry no `.parakeet` literal")
+  func readerSitesHaveNoLiteral() throws {
+    for relative in Self.identityReaderSites {
+      let violations = try Self.scanForLiteral(relative)
+      #expect(
+        violations.isEmpty,
+        """
+        \(relative) reintroduces `.parakeet` literal:
+        \(violations.joined(separator: "\n"))
+        Read identity from `adapter.engineIdentity` instead (epic §3.4, PR-5 Rung 1).
+        """)
+    }
+  }
+
+  @Test("identity-free sites carry no `.parakeet` literal")
+  func freeSitesHaveNoLiteral() throws {
+    for relative in Self.identityFreeSites {
+      let violations = try Self.scanForLiteral(relative)
+      #expect(
+        violations.isEmpty,
+        """
+        \(relative) reintroduces `.parakeet` literal:
+        \(violations.joined(separator: "\n"))
+        This file must not declare a hard-coded engine-identity default
+        (PR-5 Rung 1 — emitter is caller-supplied).
+        """)
+    }
+  }
+
+  // MARK: Adversarial — the scanner flags a regression
+
+  @Test("a source line with `.parakeet` is flagged")
+  func adversarialRegressionFlagged() {
+    let source = """
+      let snapshot = KernelRecordingSnapshotTelemetry(
+        backend: ASRBackendType.parakeet.rawValue,
+        audioRoute: route, wasStreaming: false,
+        startTime: Date(), durationMs: 0,
+        targetAppBundleID: nil)
+      """
+    let regex = try? NSRegularExpression(pattern: Self.bannedIdentityLiteral)
+    var matches: [String] = []
+    for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated()
+    {
+      let text = String(line)
+      let ns = text as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      if regex?.firstMatch(in: text, range: range) != nil {
+        matches.append("line \(idx + 1)")
+      }
+    }
+    #expect(!matches.isEmpty, "`.parakeet` literal must be flagged by the scanner")
+  }
+
+  // MARK: Negative control — `Parakeet` engine-name references are not flagged
+
+  @Test("`Parakeet`, `ParakeetEngineAdapter`, and `Parakeet v3` strings are not flagged")
+  func negativeControlEngineNamePasses() {
+    let source = """
+      // 4. Parakeet adapter.
+      let adapter = ParakeetEngineAdapter(asrManager: inputs.asrManager)
+      // Display name "Parakeet v3" sourced from adapter.engineIdentity.displayName.
+      """
+    let regex = try? NSRegularExpression(pattern: Self.bannedIdentityLiteral)
+    var matches: [String] = []
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+      let text = String(line)
+      let ns = text as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      if regex?.firstMatch(in: text, range: range) != nil {
+        matches.append(text)
+      }
+    }
+    #expect(matches.isEmpty, "capitalized `Parakeet` engine-name references must NOT be flagged")
+  }
+
+  // MARK: Helpers
+
+  private static func readSource(_ relative: String) throws -> String {
+    let url = repoRoot().appending(path: relative)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  private static func scanForLiteral(_ relative: String) throws -> [String] {
+    let source = try readSource(relative)
+    guard let regex = try? NSRegularExpression(pattern: bannedIdentityLiteral) else { return [] }
+    var violations: [String] = []
+    for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated()
+    {
+      let text = String(line)
+      let ns = text as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      if regex.firstMatch(in: text, range: range) != nil {
+        violations.append("  line \(idx + 1): \(text.trimmingCharacters(in: .whitespaces))")
+      }
+    }
+    return violations
+  }
+
+  /// Repo root, anchored off `#filePath` — this file lives at
+  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
+  private static func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/EngineIdentityPropagationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EngineIdentityPropagationTests.swift
@@ -1,0 +1,73 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - EngineIdentityPropagationTests (epic #827, PR-5 Rung 1)
+//
+// Sentinel coverage that the kernel's identity reads are sourced from
+// `adapter.engineIdentity`, not hard-coded `.parakeet` literals. The
+// architecture freeze test (`EngineIdentityFreezeTests`) covers the
+// source-level guard at every production site; this suite proves the runtime
+// plumbing for `:1791-1792` (`KernelRecordingSnapshotTelemetry.backend`) by
+// driving the natural `freezeRecordingSnapshot()` path with a `FakeEngine`
+// declaring an alternate identity.
+
+@MainActor
+@Suite struct EngineIdentityPropagationTests {
+
+  @Test(
+    "recording snapshot backend reads adapter.engineIdentity.rawValue"
+  )
+  func recordingSnapshotReadsAdapterIdentity() {
+    let telemetryState = KernelTelemetryState()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    engine.engineIdentity = ASREngineIdentity(backendType: .whisperKit)
+    let kernel = RecordingSessionKernel(
+      adapter: engine,
+      audioCapture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 },
+      sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _ in },
+      deliver: { _ in .pasted },
+      minimumRecordingTicks: 0,
+      telemetryState: telemetryState)
+
+    #if DEBUG
+      kernel.testTriggerRecordingSnapshotFreeze()
+      let snapshot = kernel.testGetRecordingSnapshot()
+      #expect(snapshot != nil, "freezeRecordingSnapshot should populate the snapshot")
+      #expect(
+        snapshot?.backend == "whisperKit",
+        "snapshot.backend must come from adapter.engineIdentity.rawValue, not a literal")
+    #endif
+  }
+
+  @Test(
+    "swapping the adapter's engineIdentity flows into the snapshot"
+  )
+  func snapshotReflectsAdapterIdentityChange() {
+    let telemetryState = KernelTelemetryState()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    // Default identity .parakeet — verify the snapshot reflects it.
+    let kernel = RecordingSessionKernel(
+      adapter: engine,
+      audioCapture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 },
+      sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _ in },
+      deliver: { _ in .pasted },
+      minimumRecordingTicks: 0,
+      telemetryState: telemetryState)
+
+    #if DEBUG
+      kernel.testTriggerRecordingSnapshotFreeze()
+      #expect(kernel.testGetRecordingSnapshot()?.backend == "parakeet")
+    #endif
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -56,6 +56,8 @@ import Testing
         minimumRecordingTicks: 0)
       let observer = KernelHeartPathTelemetryObserver(
         kernel: kernel, audioCapture: FakeAudioCapture(),
+        emitter: HeartPathTelemetryEmitter(
+          backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { _ in })
       let driver = KernelDictationDriver(
         kernel: kernel, observer: observer, outcome: outcome,

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
@@ -51,6 +51,8 @@ import Testing
         minimumRecordingTicks: 0)
       let observer = KernelHeartPathTelemetryObserver(
         kernel: kernel, audioCapture: FakeAudioCapture(),
+        emitter: HeartPathTelemetryEmitter(
+          backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { _ in })
       let driver = KernelDictationDriver(
         kernel: kernel, observer: observer, outcome: outcome,

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -288,7 +288,10 @@ import Testing
       deliver: { _ in .pasted },
       minimumRecordingTicks: 0)  // PR-4.5 #4: clock never advances; opt out of the gate
     let observer = KernelHeartPathTelemetryObserver(
-      kernel: kernel, audioCapture: FakeAudioCapture(), emitLifecycleEvent: { _ in })
+      kernel: kernel, audioCapture: FakeAudioCapture(),
+      emitter: HeartPathTelemetryEmitter(
+        backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+      emitLifecycleEvent: { _ in })
     let outcome = KernelFinalizationOutcome()
     let steps = LimbSteps(
       wordCorrection: WordCorrectionStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -245,6 +245,8 @@ import Testing
       KernelHeartPathTelemetryObserver(
         kernel: kernel,
         audioCapture: FakeAudioCapture(),
+        emitter: HeartPathTelemetryEmitter(
+          backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { recorder.events.append($0) })
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -15,6 +15,21 @@ import Testing
 @MainActor
 @Suite struct ParakeetEngineAdapterTests {
 
+  // MARK: Identity (PR-5 Rung 1)
+
+  @Test("engineIdentity: Parakeet declares .parakeet backend")
+  func engineIdentityBackend() {
+    let adapter = ParakeetEngineAdapter(asrManager: StubParakeetASRManager())
+    #expect(adapter.engineIdentity.backendType == .parakeet)
+    #expect(adapter.engineIdentity.rawValue == "parakeet")
+  }
+
+  @Test("engineIdentity: Parakeet displayName == Parakeet v3")
+  func engineIdentityDisplayName() {
+    let adapter = ParakeetEngineAdapter(asrManager: StubParakeetASRManager())
+    #expect(adapter.engineIdentity.displayName == "Parakeet v3")
+  }
+
   // MARK: Capabilities + readiness
 
   @Test("capabilities: Parakeet streams, detects no language")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -51,6 +51,12 @@ final class FakeEngine: ASREngineAdapter {
   /// fake before a session begins (e.g. the engine-switch scenarios).
   var behavior: FakeEngineBehavior
 
+  /// Self-declared identity (PR-5 Rung 1). Settable so the engine-identity
+  /// propagation sentinel test can construct a `FakeEngine` with `.whisperKit`
+  /// and assert the kernel reads it back; defaults to `.parakeet` so existing
+  /// scenarios assert byte-identical strings.
+  var engineIdentity: ASREngineIdentity = ASREngineIdentity(backendType: .parakeet)
+
   /// Capabilities follow `behavior` — a `streamingSuccess` fake advertises
   /// `supportsStreaming`, so a kernel that branches on `capabilities` runs the
   /// A2 / A9 / A10 streaming scenarios through a genuinely streaming adapter.


### PR DESCRIPTION
## Summary

First rung of PR-5 of the engine-kernel refactor epic. Adds one `engineIdentity` property to the `ASREngineAdapter` protocol so the kernel and factory stop hard-coding `.parakeet` literals; eight call sites now read identity from the adapter.

This is the prerequisite for Rungs 2A → 5 to wire a second engine adapter into the same factory + kernel without multiplying review surface or risking the wrong engine identity in telemetry / persistence.

## What changed

- **New contract** — `ASREngineIdentity` value type + required `engineIdentity` property on `ASREngineAdapter`.
- **Conformers** — `ParakeetEngineAdapter` declares `.parakeet`; `FakeEngine` declares `.parakeet` as default with a settable override for the sentinel test.
- **Read-site refactor** — 8 sites in `Sources/EnviousWisprPipeline/` (factory ×3, finalization wiring ×1, kernel ×3, observer default-arg drop ×1) now read from `adapter.engineIdentity`.
- **Factory step reorder** — `limbSteps.llmPolish.backend` moves from step 1 (line 79) to just after step 4 (line 98); grep-confirmed safe because `LLMPolishStep` is class-typed and nothing in between reads the field.
- **Observer default-arg drop** — `KernelHeartPathTelemetryObserver` no longer carries an `emitter:` default; four test callers updated to construct emitters explicitly.

## Wire-format

Byte-identical on the first engine: Sentry `data["backend"]`, PostHog `asr.completed.backend` / `dictation.completed.asr_backend`, persisted `Transcript.backendType` — all still `"parakeet"`.

One intentional change: `COLD-START [Parakeet]` → `COLD-START [Parakeet v3]`, sourced from the existing enum `displayName`. Single source of truth in the enum, accepted post-council. Rung 4.5's seam-audit prompt rewrite lands separately per the epic ladder.

## Test coverage

- **Runtime sentinel** (`EngineIdentityPropagationTests`) — `FakeEngine` with `.whisperKit` identity → kernel reads `"whisperKit"` from `freezeRecordingSnapshot()` via a new DEBUG-gated `testTriggerRecordingSnapshotFreeze()` seam. Proves `:1791-1792` reads adapter identity, not a literal.
- **Architecture freeze test** (`EngineIdentityFreezeTests`) — source-level guard that the four production files contain `adapter.engineIdentity` and zero `\.parakeet` matches; adversarial + negative-control tests pin the scanner boundary.
- **Adapter identity assertions** — `engineIdentity.backendType == .parakeet`, `displayName == "Parakeet v3"`.

All 1354 unit tests pass.

## Validation trail

- Plan: `docs/feature-requests/issue-827-2026-05-26-pr5-rung1-engine-identity.md`.
- Council coverage review: 1 round (GPT + Gemini).
- Grounded review (Codex): 4 rounds; terminal verdict PROCEED-AS-PLANNED.
- Code-diff review (Codex on this commit): CLEAN — no actionable defects.
- Live UAT: debug bundle from worktree, kernel reached `failed(asrEmpty)` cleanly without crash; both runtime identity reads (snapshot + asrEmptyDiagnostics) exercised. The new bundle contains the identity-interpolated COLD-START format string in place of the old `[Parakeet]` literal (verified via `strings` on the built binary). The COLD-START log line only fires on the PTT path (not the menu path test_recording uses), so the static freeze test is the line-617 guard.

## Test plan

- [x] `swift build` clean
- [x] `scripts/swift-test.sh` — 1354 tests, all green
- [x] Debug-bundle rebuild + relaunch from worktree
- [x] Live UAT: heart path runs through kernel without crash
- [x] Codex code-diff review CLEAN
- [ ] CI `build-check` green (post-merge verification)

## Related

- Epic: #827.
- Greenlit PR-5 shape: `/tmp/pr5-plan-r3.md`.
- Predecessor: PR-4b family (#864).