### PR TITLE
refactor(engine-kernel): PR-5 Rung 2A — adapter passive protocol surface (#827)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ Brand Assets/
 workers/weekly-digest/.wrangler/
 routine-session-logs/
 routine-session-logs-*/
+
+# Codex scratch artifacts (local-only review prompts/outputs)
+.codex/

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -269,6 +269,44 @@ public protocol ASREngineAdapter: AnyObject {
 
   /// Apply the model-unload policy (PR-1 §B.2.1, D16).
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy)
+
+  // MARK: Finalization metadata (PR-5 Rung 2A)
+
+  /// The last successful `finalize()` result, or `nil` between sessions.
+  /// The kernel's finalization wiring reads `result.{language, duration,
+  /// processingTime}` to build `Transcript`; without this on the protocol,
+  /// the wiring would have to know the concrete adapter type.
+  ///
+  /// MUST be `nil` between sessions: cleared at `beginSession()` and
+  /// `cancel()`, assigned only by a successful `finalize()` returning
+  /// `.transcript(...)`. Read-only on the protocol; each conformer owns the
+  /// storage.
+  var lastResult: ASRResult? { get }
+
+  // MARK: Optional engine hooks (PR-5 Rung 2A, passive surface)
+  //
+  // Each has a no-op default in the protocol extension below. Adapters whose
+  // engine has a meaningful implementation override; adapters without leave
+  // the default. The kernel does NOT call any of these in Rung 2A: that
+  // wiring lands in Rung 2B. They are declared now so the contract surface
+  // is closed before Rung 3 writes the second adapter.
+
+  /// Best-effort load from on-disk model cache only: no network, no full
+  /// in-memory model resolve. Default no-op. Adapters whose engine has a
+  /// meaningful cache-only preload path override.
+  func warmUpFromCache() async throws
+
+  /// Cancel any pending model-unload timer the engine had armed. Called by
+  /// the kernel (in Rung 2B+) when the user signals intent to record soon,
+  /// before `beginSession()`. Default no-op. Idempotent.
+  func cancelPendingUnload()
+
+  /// Receive the voiced-speech segments computed by the kernel's VAD at the
+  /// stop boundary. The adapter MAY use them to derive engine-specific
+  /// decode parameters (the second engine derives `clipTimestamps`). Default
+  /// no-op. The kernel calls this (in Rung 2B+) once per session, after VAD
+  /// finalize, before `finalize(batchSamples:)`.
+  func observeSpeechSegments(_ segments: [SpeechSegment])
 }
 
 extension ASREngineAdapter {
@@ -276,4 +314,10 @@ extension ASREngineAdapter {
   /// generic warmup label. Concrete adapters override when they observe
   /// real phase strings.
   public var lastObservedPhase: String { "warmup" }
+
+  // PR-5 Rung 2A: no-op defaults for the three optional hooks. Adapters
+  // with meaningful semantics override; the others inherit these.
+  public func warmUpFromCache() async throws {}
+  public func cancelPendingUnload() {}
+  public func observeSpeechSegments(_ segments: [SpeechSegment]) {}
 }

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -108,7 +108,7 @@ struct KernelFinalizationWiring {
   init(
     outcome: KernelFinalizationOutcome,
     context: KernelSessionContext,
-    adapter: ParakeetEngineAdapter,
+    adapter: any ASREngineAdapter,
     steps: LimbSteps,
     textProcessingRunner: TextProcessingRunner,
     save: @escaping @MainActor (Transcript) throws -> Void,

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -311,6 +311,18 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     asrManager.noteTranscriptionComplete(policy: policy)
   }
 
+  // MARK: ASREngineAdapter optional engine hooks (PR-5 Rung 2A)
+
+  /// Cancel any pending model-unload idle timer the prior session armed. The
+  /// existing `cancelIdleTimer()` call inside `beginSession()` above
+  /// (`:192`) covers today's flow where no kernel caller exists yet; this
+  /// override lifts that semantic to the protocol surface so Rung 2B can
+  /// wire the kernel to call the hook pre-`beginSession()`. Idempotent:
+  /// safe to call when no timer is armed.
+  func cancelPendingUnload() {
+    asrManager.cancelIdleTimer()
+  }
+
   // MARK: Streaming drain
 
   /// Await every dispatched `feedAudio` task before `finalizeStreaming()` — so

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -122,6 +122,82 @@ import Testing
     #expect(matches.isEmpty, "capitalized `Parakeet` engine-name references must NOT be flagged")
   }
 
+  // MARK: PR-5 Rung 2A KernelFinalizationWiring takes the protocol type
+
+  @Test(
+    "KernelFinalizationWiring.init(adapter:) takes any ASREngineAdapter, not the concrete type"
+  )
+  func kernelFinalizationWiringInitTakesProtocolType() throws {
+    let relative = "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift"
+    let source = try Self.readSource(relative)
+    #expect(
+      source.contains("any ASREngineAdapter"),
+      """
+      \(relative) must keep `any ASREngineAdapter` somewhere. Rung 2A retyped
+      the wiring's init parameter onto the protocol existential. Re-narrowing
+      to the concrete ParakeetEngineAdapter type would couple the wiring to
+      a single engine and block Rung 3.
+      """)
+    let bannedLiteral = "ParakeetEngineAdapter"
+    #expect(
+      !source.contains(bannedLiteral),
+      """
+      \(relative) reintroduces the literal `\(bannedLiteral)`. The wiring's
+      adapter parameter is `any ASREngineAdapter`; a type annotation, an
+      `as? ParakeetEngineAdapter`, or an `as! ParakeetEngineAdapter` downcast
+      would each re-couple the wiring to the concrete engine. Read through
+      the protocol surface instead (epic §3.4, PR-5 Rung 2A).
+      """)
+  }
+
+  // MARK: PR-5 Rung 2A no production caller for the optional adapter hooks
+
+  @Test(
+    "production code calls the three optional adapter hooks only at the allowlisted sites"
+  )
+  func noOptionalHookCallersInProduction() throws {
+    // Allowlist (PR-5 Rung 2A plan §3a). Rung 2A is the passive-surface
+    // rung: the kernel does NOT call any of these hooks yet. The protocol
+    // declares + extension-defaults them, and the Parakeet conformer
+    // overrides one (`cancelPendingUnload`). Any other production caller
+    // means Rung 2B (or later) leaked into Rung 2A.
+    let allowed: [String: Int] = [
+      "Sources/EnviousWisprPipeline/ASREngineAdapter.swift": 6,  // 3 decls + 3 ext defaults
+      "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift": 1,  // override decl
+    ]
+    let pattern = #"\b(warmUpFromCache|cancelPendingUnload|observeSpeechSegments)\("#
+    let regex = try NSRegularExpression(pattern: pattern)
+    let sourcesRoot = Self.repoRoot().appending(path: "Sources")
+    let enumerator = FileManager.default.enumerator(
+      at: sourcesRoot, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+    var offenders: [String] = []
+    while let url = enumerator?.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+      let ns = source as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      let count = regex.numberOfMatches(in: source, range: range)
+      guard count > 0 else { continue }
+      let relative = url.path.replacingOccurrences(
+        of: Self.repoRoot().path + "/", with: "")
+      let allowedCount = allowed[relative] ?? 0
+      if count > allowedCount {
+        offenders.append(
+          "  \(relative): \(count) call site(s), allowlisted \(allowedCount)")
+      }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      Unexpected production call site(s) for the optional adapter hooks
+      (PR-5 Rung 2A is the passive-surface rung, no kernel callers):
+      \(offenders.joined(separator: "\n"))
+      If this is Rung 2B+ wiring, update the allowlist in this freeze test in
+      the same PR.
+      """)
+  }
+
   // MARK: Helpers
 
   private static func readSource(_ relative: String) throws -> String {

--- a/Tests/EnviousWisprTests/Pipeline/FakeEngineLastResultLifecycleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FakeEngineLastResultLifecycleTests.swift
@@ -1,0 +1,67 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - FakeEngineLastResultLifecycleTests (epic #827, PR-5 Rung 2A)
+//
+// Enforces the §4 contract on the test simulator: `lastResult` is `nil`
+// after `beginSession()`, set after a successful `finalize()`, `nil` after
+// `cancel()`, and NOT set on `.empty(...)` / `.failed(...)` finalize
+// outcomes (no stale-success). The adversarial empty-finalize case is the
+// one a future Rung 3 conformer is most likely to get wrong.
+
+@MainActor
+@Suite struct FakeEngineLastResultLifecycleTests {
+
+  @Test("lastResult is nil after beginSession()")
+  func lastResultNilAfterBeginSession() async throws {
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    // Pre-seed a stale value as if a prior session had run.
+    engine.lastResult = ASRResult(
+      text: "stale", language: "en", duration: 0.5, processingTime: 0.1,
+      backendType: .parakeet)
+    try await engine.beginSession(SessionID(), options: .default, streaming: false)
+    #expect(engine.lastResult == nil)
+  }
+
+  @Test("lastResult is set after a successful .transcript finalize()")
+  func lastResultSetAfterSuccessfulFinalize() async throws {
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello world"), clock: FakeClock())
+    try await engine.beginSession(SessionID(), options: .default, streaming: false)
+    let outcome = await engine.finalize(batchSamples: nil)
+    guard case .transcript = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    let result = try #require(engine.lastResult)
+    #expect(result.text == "hello world")
+  }
+
+  @Test("lastResult is nil after cancel()")
+  func lastResultNilAfterCancel() async throws {
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    try await engine.beginSession(SessionID(), options: .default, streaming: false)
+    _ = await engine.finalize(batchSamples: nil)
+    #expect(engine.lastResult != nil, "successful finalize set lastResult")
+    await engine.cancel()
+    #expect(engine.lastResult == nil, "cancel() must clear lastResult")
+  }
+
+  @Test("lastResult is NOT set on .empty / non-transcript finalize outcomes")
+  func lastResultNotSetOnEmptyOrFailedFinalize() async throws {
+    let engine = FakeEngine(
+      behavior: .empty(hadSpeechEvidence: true), clock: FakeClock())
+    try await engine.beginSession(SessionID(), options: .default, streaming: false)
+    let outcome = await engine.finalize(batchSamples: nil)
+    guard case .empty = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(
+      engine.lastResult == nil,
+      "an .empty finalize must not write lastResult (no stale-success)")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringMetadataPropagationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringMetadataPropagationTests.swift
@@ -1,0 +1,67 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelFinalizationWiringMetadataPropagationTests (epic #827, PR-5 Rung 2A)
+//
+// Sentinel coverage for the protocol-typed `adapter.lastResult` read at
+// `KernelFinalizationWiring.swift:156-158`. Drives the production `store`
+// closure with a `FakeEngine` whose engine identity is `.whisperKit` and
+// whose `lastResult` is seeded with deterministic metadata. A future
+// refactor that re-narrows the `adapter:` parameter back to a concrete type
+// fails to compile here (FakeEngine is not `ParakeetEngineAdapter`); a
+// silent regression that bypassed the protocol getter would corrupt the
+// metadata reads asserted below.
+
+@MainActor
+@Suite struct KernelFinalizationWiringMetadataPropagationTests {
+
+  @Test("store closure reads ASR metadata + backend through the protocol existential")
+  func metadataReadsThroughProtocol() async throws {
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hi"), clock: FakeClock())
+    engine.engineIdentity = ASREngineIdentity(backendType: .whisperKit)
+    engine.lastResult = ASRResult(
+      text: "hi", language: "es", duration: 1.5, processingTime: 0.2,
+      backendType: .whisperKit)
+
+    let outcome = KernelFinalizationOutcome()
+    outcome.rawText = "hi"
+
+    let saved = SavedTranscriptBox()
+    let wiring = KernelFinalizationWiring(
+      outcome: outcome,
+      context: KernelSessionContext(),
+      adapter: engine,
+      steps: LimbSteps(
+        wordCorrection: WordCorrectionStep(),
+        fillerRemoval: FillerRemovalStep(),
+        emojiFormatter: EmojiFormatterStep(),
+        llmPolish: LLMPolishStep(keychainManager: KeychainManager())),
+      textProcessingRunner: TextProcessingRunner(),
+      save: { saved.transcript = $0 },
+      deliverPaste: { _ in
+        PasteDeliveryResult(
+          tier: .cgEvent, durationMs: 1,
+          outcome: .delivered(tier: .cgEvent, durationMs: 1))
+      },
+      pasteCompletionRegistry: nil)
+
+    try await wiring.store("hi")
+
+    let transcript = try #require(saved.transcript)
+    #expect(transcript.language == "es")
+    #expect(transcript.duration == 1.5)
+    #expect(transcript.processingTime == 0.2)
+    #expect(transcript.backendType == .whisperKit)
+    #expect(outcome.transcript?.language == "es")
+  }
+}
+
+@MainActor
+private final class SavedTranscriptBox {
+  var transcript: Transcript?
+}

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterLastResultLifecycleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterLastResultLifecycleTests.swift
@@ -1,0 +1,101 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - ParakeetEngineAdapterLastResultLifecycleTests (epic #827, PR-5 Rung 2A)
+//
+// Mirrors `FakeEngineLastResultLifecycleTests` against the production
+// Parakeet conformer using `StubParakeetASRManager` (declared at the bottom
+// of `ParakeetEngineAdapterTests.swift`). The adversarial empty-finalize
+// test exercises `finalizeBatch`'s `.empty(hadSpeechEvidence: true)` branch
+// at `ParakeetEngineAdapter.swift:455-460`, the conformer's most
+// regression-prone path.
+
+@MainActor
+@Suite struct ParakeetEngineAdapterLastResultLifecycleTests {
+
+  @Test("lastResult is nil after beginSession()")
+  func lastResultNilAfterBeginSession() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("first")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    feed(adapter, samples: [0.1], session: sid)
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastResult != nil, "successful finalize set lastResult")
+    // A fresh session must start with lastResult cleared.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+    #expect(adapter.lastResult == nil)
+  }
+
+  @Test("lastResult is set after a successful .transcript finalize()")
+  func lastResultSetAfterSuccessfulFinalize() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("streamed text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: true)
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    let result = try #require(adapter.lastResult)
+    #expect(result.text == "streamed text")
+    #expect(result.language == "en")
+  }
+
+  @Test("lastResult is nil after cancel()")
+  func lastResultNilAfterCancel() async throws {
+    let manager = StubParakeetASRManager()
+    manager.finalizeStreamingResult = makeResult("done")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastResult != nil, "successful finalize set lastResult")
+    await adapter.cancel()
+    #expect(adapter.lastResult == nil, "cancel() must clear lastResult")
+  }
+
+  @Test("lastResult is NOT set on .empty / non-transcript finalize outcomes")
+  func lastResultNotSetOnEmptyOrFailedFinalize() async throws {
+    // Batch mode with an empty transcribe result drives finalizeBatch's
+    // `.empty(hadSpeechEvidence: true)` branch (ParakeetEngineAdapter.swift:455-460).
+    let manager = StubParakeetASRManager()
+    manager.transcribeResult = makeResult("")  // empty -> .empty
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(
+      adapter.lastResult == nil,
+      "an .empty finalize must not write lastResult (no stale-success)")
+  }
+
+  // MARK: Helpers
+
+  private func feed(_ adapter: ParakeetEngineAdapter, samples: [Float], session: SessionID) {
+    guard let buffer = FakeAudioCapture.makeBuffer(samples: samples) else {
+      Issue.record("failed to synthesize a test buffer")
+      return
+    }
+    adapter.acceptAudio(
+      AudioBufferHandoff(
+        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: session))
+  }
+
+  private func makeResult(_ text: String) -> ASRResult {
+    ASRResult(
+      text: text, language: "en", duration: 1, processingTime: 0.1, backendType: .parakeet)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -98,6 +98,13 @@ final class FakeEngine: ASREngineAdapter {
   /// this engine's `behavior`, so the active session keeps its transcript.
   private(set) var midSessionSwitchRequestCount = 0
 
+  /// Last successful finalize() result (PR-5 Rung 2A). `var` (not
+  /// `private(set)`) so the metadata-propagation sentinel test can seed it
+  /// from another file; the simulator already exposes `var behavior` the
+  /// same way. Cleared in `beginSession()` and `cancel()`; assigned in
+  /// `finalize(...)` only on `.transcript(...)`.
+  var lastResult: ASRResult?
+
   /// Record a mid-session engine-switch request (A18, PR-3 plan §3.6). A
   /// no-op against the running adapter — proves the request was inert.
   func noteMidSessionSwitchRequest() {
@@ -208,6 +215,9 @@ final class FakeEngine: ASREngineAdapter {
     // (`ParakeetEngineAdapter.swift:163`) — a fresh session should not inherit
     // a prior finalize's batchSamples snapshot in tests.
     lastFinalizeBatchSamples = nil
+    // PR-5 Rung 2A: clear last finalize result so the new session starts
+    // with no stale metadata, matching the Parakeet conformer.
+    lastResult = nil
   }
 
   func acceptAudio(_ buffer: AudioBufferHandoff) {
@@ -275,6 +285,10 @@ final class FakeEngine: ASREngineAdapter {
       outcome = .failed(.loadFailed)
     }
     isTerminal = true
+    // PR-5 Rung 2A: honor the §4 contract, assigning only on .transcript(...).
+    if case .transcript(let result) = outcome {
+      lastResult = result
+    }
     return outcome
   }
 
@@ -289,6 +303,8 @@ final class FakeEngine: ASREngineAdapter {
     // Idempotent — 2+ calls have the same effect as one (PR-1 §B.2.2).
     isCancelled = true
     isTerminal = true
+    // PR-5 Rung 2A: cancellation invalidates any prior session's result.
+    lastResult = nil
     // Release a wedged `warmUp()` / `finalize()` (best-effort, D6).
     if let continuation = loadWedgeContinuation {
       loadWedgeContinuation = nil


### PR DESCRIPTION
## Summary

- Widens `ASREngineAdapter` with one MUST-conform property (`lastResult`) and three OPTIONAL hooks (`warmUpFromCache`, `cancelPendingUnload`, `observeSpeechSegments`) with no-op extension defaults so the second engine adapter (Rung 3) can plug into `KernelFinalizationWiring` without forking the wiring or branching by engine type.
- Retypes `KernelFinalizationWiring.init(adapter:)` from concrete `ParakeetEngineAdapter` to `any ASREngineAdapter`. Backend identity wire format (Sentry `data["backend"]`, PostHog `backend`, `Transcript.backendType`) preserved byte-identically — all sourced from `adapter.engineIdentity`.
- `ParakeetEngineAdapter` overrides `cancelPendingUnload()` to call its existing `asrManager.cancelIdleTimer()` (council finding — defaulting to no-op would make the seam a second-engine-only appendage). Kernel does NOT call any of the three optional hooks in this rung; Rung 2B wires the calls.

## Validation (5 layers)

- **Sentinel** `KernelFinalizationWiringMetadataPropagationTests.metadataReadsThroughProtocol` — drives the production `wiring.store` closure with `FakeEngine` carrying alternate identity + seeded metadata. A future regression that re-narrows the init parameter would fail to compile here.
- **Lifecycle (FakeEngine)** `FakeEngineLastResultLifecycleTests` — 4 @Tests enforcing the §4 contract (clear-on-begin, set-on-success, clear-on-cancel, no-stale-after-non-transcript).
- **Lifecycle (Parakeet)** `ParakeetEngineAdapterLastResultLifecycleTests` — 4 @Tests mirroring the simulator suite 1:1 against the production conformer using `StubParakeetASRManager`. Adversarial test routes through `finalizeBatch`'s `.empty(hadSpeechEvidence: true)` branch at `ParakeetEngineAdapter.swift:455-460`.
- **Architecture freeze** `EngineIdentityFreezeTests.kernelFinalizationWiringInitTakesProtocolType` — asserts `any ASREngineAdapter` present and `ParakeetEngineAdapter` literal absent in `KernelFinalizationWiring.swift` (catches both type annotations and `as?` / `as!` downcasts).
- **No-optional-caller freeze** `EngineIdentityFreezeTests.noOptionalHookCallersInProduction` — asserts only allowlisted sites (protocol decls + extension defaults + Parakeet override) match the three optional hooks in `Sources/`.

## Process digest

- Plan: `docs/feature-requests/issue-827-2026-05-26-pr5-rung2a-passive-protocol-surface.md` (lane: Code; Live UAT: Y; User Rubric: N/A — internal-only).
- Council coverage: GPT-5.5 + Gemini-3.1-pro (1 round). Gemini Premise 1 caught the Parakeet override gap; GPT split the byte-identical metadata overclaim and surfaced the no-caller freeze test.
- Codex grounded review: 4 rounds to PROCEED-AS-PLANNED (defect trajectory 4 → 4 → 1 → 0).
- Codex code-diff review: CLEAN on round 2 (round 1 flagged 14 em-dashes in new code per plan §13).

## Test plan

- [x] `swift build -c release` exit 0
- [x] `scripts/swift-test.sh` (1365 tests in 173 suites pass)
- [x] Live UAT on debug bundle:
  - [x] Parakeet English (heart path + metadata sanity + log shape + backend identity)
  - [x] WhisperKit English
  - [x] WhisperKit Spanish, French, German, Italian, Japanese (heart path intact)
- [x] CI `build-check` (green on merge)

Refs #827.