### PR TITLE
refactor(engine-kernel): PR-5 Rung 2B — kernel call sites for the three optional adapter hooks (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -584,6 +584,31 @@ final class RecordingSessionKernel {
       return
     }
     let sid = currentSessionID
+    // PR-5 Rung 2B (#827): best-effort cache-only preload. Awaited inline
+    // (the contract says cheap; second-engine override walks the on-disk
+    // model cache, Parakeet inherits the no-op default). `try?` because a
+    // throw signals cache-only-preload failure, not full-warmup failure
+    // (Rung 2A §4) — the spawned `warmUp()` below is the canonical path.
+    //
+    // No `cancelPendingUnload()` from preWarm (Codex code-diff r3 P2):
+    // cancelling the idle-unload timer here would leak a loaded model when
+    // PTT is abandoned (key-up between preWarm and start, or pre-warm
+    // failure) — no session terminal fires to re-apply the unload policy,
+    // and the model stays warm indefinitely. The cancel lands in
+    // `runForwardPath` pre-beginSession only (single site, no PTT/toggle
+    // divergence). Parakeet's existing `:192` cancelIdleTimer() inside
+    // beginSession stays as the deepest defense-in-depth.
+    try? await adapter.warmUpFromCache()
+    // PR-5 Rung 2B post-await reentrancy guard: the cache-warm await
+    // suspends the MainActor. While suspended, `start(config:)` can mint a
+    // new session and cancel the prior sid's task bag; re-check before
+    // spawning the heavy warmUp() and awaiting capture pre-warm, otherwise
+    // this stale continuation would launch work against a session the
+    // kernel has already moved past.
+    guard isCurrent(sid), state == .idle || state.isTerminal else {
+      log("preWarm aborted post-cache-warm sid=\(sid.raw) state=\(state)")
+      return
+    }
     // Adapter warm-up is spawned (can be a slow cold model load; the session's
     // own warmUp re-checks readiness and reruns cold if needed).
     spawn(sid) { [adapter, weak self] in
@@ -769,6 +794,22 @@ final class RecordingSessionKernel {
     // Stamp BEFORE beginSession so the lifecycle observer reads the correct
     // streaming flag at the `.recording` transition (Codex review #11 r2).
     isStreamingSession = shouldStream
+    // PR-5 Rung 2B (#827): single kernel-side timer-cancel point, fired
+    // immediately before adapter.beginSession. Parakeet's existing :192
+    // cancelIdleTimer() inside beginSession stays as defense-in-depth at
+    // the adapter level (idempotent per Rung 2A §4).
+    //
+    // Aborted-session caveat (Codex code-diff r4 P2): if this session
+    // ends without a transcript (cancel / no-speech / too-short / failed),
+    // `finishTerminal` skips `applyUnloadPolicy` because
+    // `transcriptReadyForDelivery` is false — the cancelled timer is not
+    // re-armed. For Parakeet today this is the EXISTING pattern (Parakeet
+    // already cancels the timer inside its own beginSession on every
+    // session, no behavior change). A future Rung 3 adapter that wants
+    // unload-timer continuity across aborted sessions MUST re-arm in its
+    // own beginSession/cancel/finalize implementation; the kernel does
+    // not guarantee re-arming.
+    adapter.cancelPendingUnload()
     do {
       try await adapter.beginSession(
         sid, options: makeTranscriptionOptions(config), streaming: shouldStream)
@@ -988,6 +1029,34 @@ final class RecordingSessionKernel {
     // fall back to the seam for direct-mode (which PR-4b wires up).
     let xpcSegments = captureResult.vadSegments
     let vadSegments = !xpcSegments.isEmpty ? xpcSegments : vad.speechSegmentsAtStop()
+    // PR-5 Rung 2B (#827): push the kernel-computed VAD speech segments to
+    // the adapter at finalize-time, BEFORE the kernel-side conditioning
+    // runs. The second engine (Rung 3) derives engine-specific decode
+    // parameters (clipTimestamps) from these; the first engine inherits
+    // the no-op default. Sync, must-not-throw, must-not-block (Rung 2A §4).
+    //
+    // Coordinate space contract (Codex code-diff r4 P2): segments are
+    // indexed into `captureResult.samples` (raw capture audio), NOT into
+    // the `conditioned.samples` the adapter receives in
+    // `finalize(batchSamples:)` immediately after. A Rung 3 adapter that
+    // applies these segments to the audio handed to `finalize` MUST
+    // either (a) translate offsets into the conditioned buffer's
+    // coordinate space, or (b) use engine-internal VAD chunking
+    // (e.g. WhisperKit `chunkingStrategy: .vad`) and treat
+    // `observeSpeechSegments` as a hint rather than a clip-timestamp
+    // source. Parakeet inherits the no-op default so this caveat does
+    // not apply to it.
+    //
+    // Post-finalizeAtStop guard (Codex code-diff r2 P2): the prior
+    // `finalizeAtStop(...)` await at :908 is a suspension point; if cancel
+    // or external interruption lands during that await, the kernel can be
+    // terminal here. The Rung 2A §4 contract says
+    // `observeSpeechSegments(_:)` fires BEFORE `finalize(batchSamples:)` —
+    // a terminal session skips finalize, so it must skip observe too,
+    // otherwise a future engine that stores observed segments for use in
+    // finalize would see them and apply them to the next session.
+    guard isCurrent(sid), !state.isTerminal else { return }
+    adapter.observeSpeechSegments(vadSegments)
     // Raw audio for the conditioner is `captureResult.samples` (parity with
     // old Parakeet pipeline `rawSamples = captureResult.samples`).
     // The OLD pipeline did NOT include pre-roll in batch decode either — pre-roll

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -150,51 +150,79 @@ import Testing
       """)
   }
 
-  // MARK: PR-5 Rung 2A no production caller for the optional adapter hooks
+  // MARK: PR-5 Rung 2B optional adapter hook callers match allowlist
 
   @Test(
     "production code calls the three optional adapter hooks only at the allowlisted sites"
   )
-  func noOptionalHookCallersInProduction() throws {
-    // Allowlist (PR-5 Rung 2A plan §3a). Rung 2A is the passive-surface
-    // rung: the kernel does NOT call any of these hooks yet. The protocol
-    // declares + extension-defaults them, and the Parakeet conformer
-    // overrides one (`cancelPendingUnload`). Any other production caller
-    // means Rung 2B (or later) leaked into Rung 2A.
-    let allowed: [String: Int] = [
-      "Sources/EnviousWisprPipeline/ASREngineAdapter.swift": 6,  // 3 decls + 3 ext defaults
-      "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift": 1,  // override decl
+  func optionalAdapterHookCallersMatchAllowlist() throws {
+    // Allowlist (PR-5 Rung 2B #827). The kernel wires the three optional
+    // hooks at three lifecycle positions: `preWarm` awaits
+    // `warmUpFromCache` only (Codex code-diff r3 dropped the preWarm-side
+    // `cancelPendingUnload` to prevent an abandoned-preWarm timer leak);
+    // `runForwardPath` fires `cancelPendingUnload` pre-`beginSession` and
+    // `observeSpeechSegments` pre-finalize. The regex matches executable
+    // call syntax only (`adapter.<hook>(`) so protocol declarations and
+    // adapter overrides do not count — only kernel-side callers. Counts
+    // are tracked PER HOOK so a regression that removed one hook and added
+    // another would still fail (Codex code-diff r1 P3). The assertion is
+    // bidirectional: adding a new site OR removing an expected site fails.
+    let hooks = ["warmUpFromCache", "cancelPendingUnload", "observeSpeechSegments"]
+    let allowed: [String: [String: Int]] = [
+      "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift": [
+        "warmUpFromCache": 1,
+        "cancelPendingUnload": 1,
+        "observeSpeechSegments": 1,
+      ]
     ]
-    let pattern = #"\b(warmUpFromCache|cancelPendingUnload|observeSpeechSegments)\("#
-    let regex = try NSRegularExpression(pattern: pattern)
+    let regexes: [String: NSRegularExpression] = try hooks.reduce(into: [:]) {
+      acc, hook in
+      acc[hook] = try NSRegularExpression(pattern: #"\badapter\."# + hook + #"\("#)
+    }
     let sourcesRoot = Self.repoRoot().appending(path: "Sources")
     let enumerator = FileManager.default.enumerator(
       at: sourcesRoot, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
     var offenders: [String] = []
+    var visited: Set<String> = []
     while let url = enumerator?.nextObject() as? URL {
       guard url.pathExtension == "swift" else { continue }
       let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
       let ns = source as NSString
       let range = NSRange(location: 0, length: ns.length)
-      let count = regex.numberOfMatches(in: source, range: range)
-      guard count > 0 else { continue }
       let relative = url.path.replacingOccurrences(
         of: Self.repoRoot().path + "/", with: "")
-      let allowedCount = allowed[relative] ?? 0
-      if count > allowedCount {
+      visited.insert(relative)
+      let allowedPerHook = allowed[relative] ?? [:]
+      for hook in hooks {
+        let count = regexes[hook]!.numberOfMatches(in: source, range: range)
+        let allowedCount = allowedPerHook[hook] ?? 0
+        if count != allowedCount {
+          let kind = count > allowedCount ? "unexpected addition" : "missing expected call"
+          offenders.append(
+            "  \(relative) adapter.\(hook): \(count) call site(s), allowlisted \(allowedCount) — \(kind)"
+          )
+        }
+      }
+    }
+    // Catch the case where an allowlisted file disappeared from `Sources/`
+    // entirely (rename / move) — the kernel call sites are required, not
+    // optional.
+    for (relative, perHook) in allowed where !visited.contains(relative) {
+      for (hook, allowedCount) in perHook {
         offenders.append(
-          "  \(relative): \(count) call site(s), allowlisted \(allowedCount)")
+          "  \(relative) adapter.\(hook): 0 call site(s), allowlisted \(allowedCount) — missing expected file"
+        )
       }
     }
     #expect(
       offenders.isEmpty,
       """
-      Unexpected production call site(s) for the optional adapter hooks
-      (PR-5 Rung 2A is the passive-surface rung, no kernel callers):
+      Optional adapter hook call site count drift (PR-5 Rung 2B #827 wires
+      four kernel call sites at fixed lifecycle positions, counted per hook):
       \(offenders.joined(separator: "\n"))
-      If this is Rung 2B+ wiring, update the allowlist in this freeze test in
-      the same PR.
+      Adding or removing a kernel call site requires updating the allowlist
+      in this freeze test in the same PR.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
@@ -1,0 +1,371 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelEngineHookCallSitesTests (epic #827, PR-5 Rung 2B)
+//
+// Asserts the kernel calls each of the three optional adapter hooks at the
+// expected lifecycle moment with the expected count, lifecycle order, and
+// argument values:
+//   1. `cancelPendingUnload()` — in `preWarm()` and in `runForwardPath`
+//      pre-`beginSession()` (idempotent per Rung 2A §4).
+//   2. `warmUpFromCache()` — in `preWarm()` between `cancelPendingUnload()`
+//      and the spawned `warmUp()`; awaited inline with `try?`.
+//   3. `observeSpeechSegments(_:)` — in `runForwardPath` between VAD finalize
+//      and `CapturedAudioConditioner.condition`, with the kernel's selected
+//      `vadSegments` array verbatim.
+//
+// Twelve `@Test`s cover: counts (×2), event-trace lifecycle order (×3),
+// VAD-source-precedence branches (×2), guard short-circuit (×1), cancel
+// before VAD-finalize (×1), cache-preload failure-bypass (×1),
+// post-await reentrancy guard (×1), and the single-preWarm baseline (×1).
+
+@MainActor
+@Suite("RecordingSessionKernel — optional adapter hook call sites (PR-5 Rung 2B)")
+struct KernelEngineHookCallSitesTests {
+
+  // MARK: Fixture
+
+  @MainActor
+  private struct Fixture {
+    let context: SimulatorContext
+    let wrapper: KernelRecordingSession
+
+    var engine: FakeEngine { context.engine }
+    var capture: FakeAudioCapture { context.capture }
+    var vad: FakeVADSignalSource { context.vad }
+    var clock: FakeClock { context.clock }
+    var kernel: RecordingSessionKernel { wrapper.testKernel }
+  }
+
+  private func makeFixture(
+    behavior: FakeEngineBehavior = .batchSuccess(text: "hello")
+  ) -> Fixture {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: behavior, clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    let context = SimulatorContext(
+      sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return Fixture(context: context, wrapper: wrapper)
+  }
+
+  /// Drive the kernel through a complete PTT-mode session (preWarm + start +
+  /// deliver one buffer + stop) and settle. The default `.batchSuccess`
+  /// behavior produces a transcript so the kernel reaches `.completed`.
+  /// `xpcSegments` (when non-empty) are added AFTER `beginCapturePhase` has
+  /// run — FakeAudioCapture clears its segments at session boundary, so
+  /// segments must be added between start and stop.
+  private func driveCompletePTTSession(
+    _ fx: Fixture, xpcSegments: [SpeechSegment]? = nil
+  ) async {
+    try? await fx.kernel.preWarm()
+    await fx.wrapper.drainReadyWork()
+    fx.kernel.start(config: .testDefault())
+    await fx.wrapper.drainReadyWork()
+    let segments = xpcSegments ?? [SpeechSegment(startSample: 0, endSample: 100)]
+    for seg in segments {
+      fx.capture.addSpeechSegment(
+        startSample: seg.startSample, endSample: seg.endSample)
+    }
+    fx.capture.deliverBuffer()
+    await fx.wrapper.drainReadyWork()
+    fx.kernel.requestStop()
+    await fx.wrapper.drainReadyWork()
+  }
+
+  /// Drive the kernel through a complete toggle-mode session (start + deliver
+  /// one buffer + stop, no preWarm).
+  private func driveCompleteToggleSession(
+    _ fx: Fixture, xpcSegments: [SpeechSegment]? = nil
+  ) async {
+    fx.kernel.start(config: .testDefault())
+    await fx.wrapper.drainReadyWork()
+    let segments = xpcSegments ?? [SpeechSegment(startSample: 0, endSample: 100)]
+    for seg in segments {
+      fx.capture.addSpeechSegment(
+        startSample: seg.startSample, endSample: seg.endSample)
+    }
+    fx.capture.deliverBuffer()
+    await fx.wrapper.drainReadyWork()
+    fx.kernel.requestStop()
+    await fx.wrapper.drainReadyWork()
+  }
+
+  // MARK: 1. preWarm fires warmUpFromCache once and NOT cancelPendingUnload
+
+  @Test("preWarm fires warmUpFromCache once and does not fire cancelPendingUnload")
+  func preWarmFiresWarmUpFromCacheOnceAndNotCancelPendingUnload() async throws {
+    let fx = makeFixture()
+    try await fx.kernel.preWarm()
+    await fx.wrapper.drainReadyWork()
+    // Codex code-diff r3 P2: the preWarm-side cancelPendingUnload was
+    // dropped — cancelling the idle-unload timer here would leak a loaded
+    // model when PTT is abandoned (no terminal fires to re-apply the
+    // unload policy).
+    #expect(fx.engine.cancelPendingUnloadCallCount == 0)
+    #expect(fx.engine.warmUpFromCacheCallCount == 1)
+  }
+
+  // MARK: 2. preWarm event-trace lifecycle order
+
+  @Test("preWarm emits warmUpFromCache, then the spawned warmUp")
+  func preWarmEventTraceIsCacheThenWarm() async throws {
+    let fx = makeFixture()
+    try await fx.kernel.preWarm()
+    await fx.wrapper.drainReadyWork()
+    // The spawned warmUp() may interleave with the await; the canonical
+    // ordering is: warmUpFromCache await (instant on FakeEngine), then the
+    // spawned warmUp(). The first two events observed on the engine MUST
+    // be those two, in that order. No cancelPendingUnload from preWarm
+    // (Codex r3 P2).
+    let firstTwo = Array(fx.engine.eventLog.prefix(2))
+    #expect(
+      firstTwo == [.warmUpFromCache, .warmUp],
+      "expected [warmUpFromCache, warmUp]; got \(firstTwo)")
+  }
+
+  // MARK: 3. runForwardPath emits cancelPendingUnload before beginSession
+
+  @Test("runForwardPath emits cancelPendingUnload strictly before beginSession")
+  func runForwardPathEventTraceCancelBeforeBeginSession() async throws {
+    let fx = makeFixture()
+    await driveCompleteToggleSession(fx)
+    // No preWarm; the toggle-mode path is the only source of
+    // cancelPendingUnload events.
+    let log = fx.engine.eventLog
+    guard let cancelIdx = log.firstIndex(of: .cancelPendingUnload) else {
+      Issue.record("expected a .cancelPendingUnload event; got \(log)")
+      return
+    }
+    guard let beginIdx = log.firstIndex(of: .beginSession) else {
+      Issue.record("expected a .beginSession event; got \(log)")
+      return
+    }
+    #expect(
+      cancelIdx < beginIdx,
+      "cancelPendingUnload must precede beginSession; got cancelIdx=\(cancelIdx) beginIdx=\(beginIdx)"
+    )
+  }
+
+  // MARK: 4. runForwardPath emits observeSpeechSegments before finalize
+
+  @Test("runForwardPath emits observeSpeechSegments strictly before finalize")
+  func runForwardPathEventTraceObserveBeforeFinalize() async throws {
+    let fx = makeFixture()
+    await driveCompleteToggleSession(fx)
+    let log = fx.engine.eventLog
+    guard
+      let observeIdx = log.firstIndex(where: {
+        if case .observeSpeechSegments = $0 { return true } else { return false }
+      })
+    else {
+      Issue.record("expected an .observeSpeechSegments event; got \(log)")
+      return
+    }
+    guard let finalizeIdx = log.firstIndex(of: .finalize) else {
+      Issue.record("expected a .finalize event; got \(log)")
+      return
+    }
+    #expect(
+      observeIdx < finalizeIdx,
+      "observeSpeechSegments must precede finalize; got observeIdx=\(observeIdx) finalizeIdx=\(finalizeIdx)"
+    )
+  }
+
+  // MARK: 5. Full PTT-mode session — expected counts
+
+  @Test("PTT-mode session fires expected hook counts (1 cancel + 1 cache + 1 observe)")
+  func preWarmAndRunFireExpectedHookCounts() async throws {
+    let fx = makeFixture()
+    await driveCompletePTTSession(fx)
+    #expect(
+      fx.engine.cancelPendingUnloadCallCount == 1,
+      "expected 1 cancelPendingUnload (runForwardPath only — Codex r3 P2 dropped the preWarm-side call); got \(fx.engine.cancelPendingUnloadCallCount)"
+    )
+    #expect(
+      fx.engine.warmUpFromCacheCallCount == 1,
+      "expected 1 warmUpFromCache (preWarm only); got \(fx.engine.warmUpFromCacheCallCount)")
+    #expect(
+      fx.engine.observeSpeechSegmentsCallCount == 1,
+      "expected 1 observeSpeechSegments (runForwardPath only); got \(fx.engine.observeSpeechSegmentsCallCount)"
+    )
+  }
+
+  // MARK: 6. Toggle-mode session — only runForwardPath hooks fire
+
+  @Test("toggle-mode session fires only runForwardPath hooks (1 cancel + 0 cache + 1 observe)")
+  func toggleModeFiresOnlyRunForwardPathHooks() async throws {
+    let fx = makeFixture()
+    await driveCompleteToggleSession(fx)
+    #expect(
+      fx.engine.cancelPendingUnloadCallCount == 1,
+      "expected 1 cancelPendingUnload (runForwardPath only); got \(fx.engine.cancelPendingUnloadCallCount)"
+    )
+    #expect(
+      fx.engine.warmUpFromCacheCallCount == 0,
+      "expected 0 warmUpFromCache (no preWarm); got \(fx.engine.warmUpFromCacheCallCount)")
+    #expect(
+      fx.engine.observeSpeechSegmentsCallCount == 1,
+      "expected 1 observeSpeechSegments (runForwardPath only); got \(fx.engine.observeSpeechSegmentsCallCount)"
+    )
+  }
+
+  // MARK: 7. observeSpeechSegments XPC-branch source
+
+  @Test("observeSpeechSegments receives the XPC-bundled segments when non-empty")
+  func observeSpeechSegmentsPassesKernelComputedSegmentsXPCBranch() async throws {
+    let fx = makeFixture()
+    // Two XPC-bundled segments populated on FakeAudioCapture; the kernel's
+    // selection at line 990 prefers `captureResult.vadSegments` when
+    // non-empty.
+    let xpcSegments = [
+      SpeechSegment(startSample: 0, endSample: 100),
+      SpeechSegment(startSample: 200, endSample: 300),
+    ]
+    // Seed the fallback path with DIFFERENT segments so a regression that
+    // reads the fallback instead of the XPC bundle would be caught.
+    fx.vad.segments = [SpeechSegment(startSample: 999, endSample: 1000)]
+    await driveCompleteToggleSession(fx, xpcSegments: xpcSegments)
+    let observed = try #require(fx.engine.lastObservedSpeechSegments)
+    let observedPairs = observed.map { ($0.startSample, $0.endSample) }
+    let expectedPairs = xpcSegments.map { ($0.startSample, $0.endSample) }
+    #expect(
+      observedPairs.elementsEqual(expectedPairs, by: ==),
+      "expected XPC-bundled segments \(expectedPairs); got \(observedPairs)")
+  }
+
+  // MARK: 8. observeSpeechSegments fallback-branch source
+
+  @Test("observeSpeechSegments receives the vad seam segments when XPC bundle is empty")
+  func observeSpeechSegmentsPassesKernelComputedSegmentsFallbackBranch() async throws {
+    let fx = makeFixture()
+    // FakeAudioCapture left empty -> XPC bundle is empty -> kernel falls
+    // back to `vad.speechSegmentsAtStop()`.
+    let fallbackSegments = [
+      SpeechSegment(startSample: 50, endSample: 150),
+      SpeechSegment(startSample: 250, endSample: 350),
+    ]
+    fx.vad.segments = fallbackSegments
+    // XPC bundle stays empty -> kernel falls back to vad seam.
+    await driveCompleteToggleSession(fx, xpcSegments: [])
+    let observed = try #require(fx.engine.lastObservedSpeechSegments)
+    let observedPairs = observed.map { ($0.startSample, $0.endSample) }
+    let expectedPairs = fallbackSegments.map { ($0.startSample, $0.endSample) }
+    #expect(
+      observedPairs.elementsEqual(expectedPairs, by: ==),
+      "expected fallback (vad seam) segments \(expectedPairs); got \(observedPairs)")
+  }
+
+  // MARK: 9. preWarm guarded out by active session — no hooks fire
+
+  @Test("preWarm guarded out while recording fires no hooks")
+  func preWarmGuardedOutFiresNoHooks() async throws {
+    let fx = makeFixture()
+    fx.kernel.start(config: .testDefault())
+    await fx.wrapper.drainReadyWork()
+    // Snapshot counters just before the guarded-out preWarm.
+    let cancelBefore = fx.engine.cancelPendingUnloadCallCount
+    let cacheBefore = fx.engine.warmUpFromCacheCallCount
+    try await fx.kernel.preWarm()
+    await fx.wrapper.drainReadyWork()
+    #expect(
+      fx.engine.cancelPendingUnloadCallCount == cancelBefore,
+      "preWarm guarded out at active session must not fire cancelPendingUnload")
+    #expect(
+      fx.engine.warmUpFromCacheCallCount == cacheBefore,
+      "preWarm guarded out at active session must not fire warmUpFromCache")
+  }
+
+  // MARK: 10. cancel before VAD-finalize skips observeSpeechSegments
+
+  @Test("cancel before VAD-finalize phase skips observeSpeechSegments")
+  func cancelMidWarmupSkipsObserveSpeechSegments() async throws {
+    let fx = makeFixture()
+    fx.kernel.start(config: .testDefault())
+    await fx.wrapper.drainReadyWork()
+    fx.kernel.cancel()
+    await fx.wrapper.drainReadyWork()
+    #expect(
+      fx.engine.observeSpeechSegmentsCallCount == 0,
+      "cancelled session must not reach observeSpeechSegments; got \(fx.engine.observeSpeechSegmentsCallCount)"
+    )
+  }
+
+  // MARK: 11. warmUpFromCache throws does not block warmUp or recording
+
+  @Test("warmUpFromCache throwing does not block the spawned warmUp or recording")
+  func warmUpFromCacheThrowsDoesNotBlockWarmUpOrRecording() async throws {
+    let fx = makeFixture()
+    fx.engine.warmUpFromCacheThrows = true
+    // preWarm must not throw — the kernel's `try?` swallows it.
+    try await fx.kernel.preWarm()
+    await fx.wrapper.drainReadyWork()
+    #expect(
+      fx.engine.warmUpFromCacheCallCount == 1,
+      "warmUpFromCache must still have been called once")
+    #expect(
+      fx.engine.warmUpCallCount >= 1,
+      "spawned warmUp() must still have run despite cache-preload throw")
+    // The session must still complete normally.
+    await driveCompleteToggleSession(fx)
+    #expect(
+      fx.kernel.deliveredTranscript == "hello",
+      "recording must still deliver the transcript despite cache-preload throw")
+  }
+
+  // MARK: 12. preWarm post-await reentrancy guard
+
+  @Test("preWarm post-await reentrancy guard aborts the stale continuation")
+  func preWarmPostAwaitReentrancyGuardAbortsStaleContinuation() async throws {
+    let fx = makeFixture()
+    fx.engine.blockWarmUpFromCache = true
+    // Capture the sid preWarm will hold; the guard checks against this.
+    let staleSID = fx.kernel.currentSessionID
+    // Spawn preWarm so it parks on warmUpFromCache.
+    let preWarmTask = Task { @MainActor in
+      try? await fx.kernel.preWarm()
+    }
+    // Yield until the engine has entered warmUpFromCache.
+    var entered = false
+    for _ in 0..<200 {
+      if fx.engine.warmUpFromCacheCallCount > 0 {
+        entered = true
+        break
+      }
+      await Task.yield()
+    }
+    #expect(entered, "FakeEngine.warmUpFromCache must have been entered")
+    // While preWarm is parked, mint a new session via start() — this bumps
+    // the kernel's currentSessionID off staleSID and transitions state out
+    // of .idle. The post-await guard MUST see this and short-circuit.
+    fx.kernel.start(config: .testDefault())
+    #expect(
+      fx.kernel.currentSessionID != staleSID,
+      "start() should have minted a fresh SessionID")
+    // Release the cache-warm continuation so preWarm can resume.
+    fx.engine.releaseWarmUpFromCacheBlocker()
+    _ = await preWarmTask.value
+    // Cancel the in-flight session to settle the kernel.
+    fx.kernel.cancel()
+    await fx.wrapper.drainReadyWork()
+    // The stale preWarm continuation must not have crashed and must not
+    // have driven the engine into an inconsistent state. The new session
+    // owns whatever subsequent calls the engine recorded.
+    #expect(
+      fx.engine.warmUpFromCacheCallCount == 1,
+      "warmUpFromCache must have been called exactly once (preWarm only)")
+    // The new session called beginSession; ensure preWarm's stale
+    // continuation did NOT race into the new session's lifecycle and
+    // double-fire beginSession.
+    #expect(
+      fx.engine.beginSessionCallCount <= 1,
+      "stale preWarm continuation must not double-fire beginSession; got \(fx.engine.beginSessionCallCount)"
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -15,6 +15,26 @@ import Foundation
 // stream. A nil stream (the `*ProgressAbsent` knobs) means the engine exposes
 // no wedge signal at all. The two are distinct on purpose.
 
+/// Ordered lifecycle events recorded by `FakeEngine` (PR-5 Rung 2B #827). The
+/// kernel call-site behavioral tests assert ordering AND counts; counts alone
+/// would silently accept a misplaced call.
+enum FakeEngineEvent: Equatable, Sendable {
+  case warmUp
+  case warmUpFromCache
+  case cancelPendingUnload
+  case beginSession
+  case acceptAudio
+  case observeSpeechSegments(count: Int)
+  case finalize
+  case cancel
+}
+
+/// Synthetic error type for the cache-preload failure-bypass test
+/// (`warmUpFromCacheThrowsDoesNotBlockWarmUpOrRecording`).
+enum FakeEngineCacheError: Error, Equatable, Sendable {
+  case simulated
+}
+
 /// The nine `FakeEngine` behaviors (PR-1 §B.2.3).
 enum FakeEngineBehavior: Sendable {
   /// Batch engine: `finalize()` returns one transcript.
@@ -98,6 +118,48 @@ final class FakeEngine: ASREngineAdapter {
   /// this engine's `behavior`, so the active session keeps its transcript.
   private(set) var midSessionSwitchRequestCount = 0
 
+  // MARK: PR-5 Rung 2B (#827) — kernel call-site observation
+  //
+  // Counters + event log for the kernel's calls to the three optional adapter
+  // hooks (`warmUpFromCache`, `cancelPendingUnload`, `observeSpeechSegments`).
+  // The event log records ordered lifecycle events so the behavioral tests
+  // assert position, not just count.
+
+  private(set) var cancelPendingUnloadCallCount = 0
+  private(set) var warmUpFromCacheCallCount = 0
+  private(set) var observeSpeechSegmentsCallCount = 0
+  /// The segments argument from the most recent `observeSpeechSegments(_:)`
+  /// call — lets VAD-source-precedence tests assert the kernel passes its own
+  /// computed `vadSegments` array verbatim.
+  private(set) var lastObservedSpeechSegments: [SpeechSegment]?
+
+  /// Ordered log of lifecycle events the kernel triggers on this adapter. Used
+  /// by the Rung 2B lifecycle-order tests; append from every adapter method.
+  private(set) var eventLog: [FakeEngineEvent] = []
+
+  /// When `true`, `warmUpFromCache()` throws `FakeEngineCacheError.simulated`
+  /// AFTER incrementing its counter and appending its event. The
+  /// failure-bypass test sets this to assert the kernel's `try?` swallow
+  /// holds.
+  var warmUpFromCacheThrows: Bool = false
+
+  /// When set, `warmUpFromCache()` parks on this continuation until the test
+  /// resumes it via `releaseWarmUpFromCacheBlocker()`. The post-await
+  /// reentrancy guard test uses this to hold the preWarm continuation while
+  /// a second session is minted.
+  private var warmUpFromCacheBlocker: CheckedContinuation<Void, Never>?
+  /// When `true`, the next `warmUpFromCache()` call parks on
+  /// `warmUpFromCacheBlocker`. Test-only.
+  var blockWarmUpFromCache: Bool = false
+
+  /// Resume any pending `warmUpFromCacheBlocker` continuation (test-only).
+  func releaseWarmUpFromCacheBlocker() {
+    if let continuation = warmUpFromCacheBlocker {
+      warmUpFromCacheBlocker = nil
+      continuation.resume()
+    }
+  }
+
   /// Last successful finalize() result (PR-5 Rung 2A). `var` (not
   /// `private(set)`) so the metadata-propagation sentinel test can seed it
   /// from another file; the simulator already exposes `var behavior` the
@@ -168,6 +230,7 @@ final class FakeEngine: ASREngineAdapter {
 
   func warmUp() async throws {
     warmUpCallCount += 1
+    eventLog.append(.warmUp)
     // Idempotent: safe to call when already ready (PR-1 §B.2.2).
     if readiness == .ready { return }
     readiness = .warming
@@ -207,6 +270,7 @@ final class FakeEngine: ASREngineAdapter {
     _ id: SessionID, options: TranscriptionOptions, streaming: Bool
   ) async throws {
     beginSessionCallCount += 1
+    eventLog.append(.beginSession)
     lastSessionID = id
     lastStreamingRequested = streaming
     isTerminal = false
@@ -227,10 +291,12 @@ final class FakeEngine: ASREngineAdapter {
       return
     }
     acceptedBufferCount += 1
+    eventLog.append(.acceptAudio)
   }
 
   func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
     finalizeCallCount += 1
+    eventLog.append(.finalize)
     // `beginSession` resets this to nil so a fresh session sees nil if its
     // finalize is never reached — only the LAST finalize's value survives.
     lastFinalizeBatchSamples = batchSamples
@@ -300,6 +366,7 @@ final class FakeEngine: ASREngineAdapter {
 
   func cancel() async {
     cancelCallCount += 1
+    eventLog.append(.cancel)
     // Idempotent — 2+ calls have the same effect as one (PR-1 §B.2.2).
     isCancelled = true
     isTerminal = true
@@ -318,6 +385,36 @@ final class FakeEngine: ASREngineAdapter {
 
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
     lastUnloadPolicy = policy
+  }
+
+  // MARK: PR-5 Rung 2B (#827) — optional adapter hook overrides
+  //
+  // Override the three protocol-extension defaults so the behavioral tests
+  // can assert the kernel call counts AND lifecycle ordering.
+
+  func cancelPendingUnload() {
+    cancelPendingUnloadCallCount += 1
+    eventLog.append(.cancelPendingUnload)
+  }
+
+  func warmUpFromCache() async throws {
+    warmUpFromCacheCallCount += 1
+    eventLog.append(.warmUpFromCache)
+    if blockWarmUpFromCache {
+      await withCheckedContinuation {
+        (continuation: CheckedContinuation<Void, Never>) in
+        warmUpFromCacheBlocker = continuation
+      }
+    }
+    if warmUpFromCacheThrows {
+      throw FakeEngineCacheError.simulated
+    }
+  }
+
+  func observeSpeechSegments(_ segments: [SpeechSegment]) {
+    observeSpeechSegmentsCallCount += 1
+    lastObservedSpeechSegments = segments
+    eventLog.append(.observeSpeechSegments(count: segments.count))
   }
 
   /// Simulate a mid-recording engine crash — drives the kernel's


### PR DESCRIPTION
## Summary

Wires the kernel call sites for the three optional adapter hooks declared in PR-5 Rung 2A (#868, merged `6d1300f`):

- `RecordingSessionKernel.preWarm()` awaits `try? await adapter.warmUpFromCache()` inline, then re-checks `isCurrent(sid)` AND `state == .idle || state.isTerminal` (post-await reentrancy guard) before spawning the existing `adapter.warmUp()` and awaiting `audioCapture.preWarm()`.
- `RecordingSessionKernel.runForwardPath(_:)` calls `adapter.cancelPendingUnload()` synchronously immediately before `adapter.beginSession(...)`. Single kernel-side timer-cancel point. Parakeet's existing `:192` `cancelIdleTimer()` inside `beginSession` stays as deepest defense-in-depth.
- `RecordingSessionKernel.runForwardPath(_:)` calls `adapter.observeSpeechSegments(vadSegments)` synchronously after the kernel-side VAD-source selection at `:990`, behind a `guard isCurrent(sid), !state.isTerminal` to cover the `finalizeAtStop` post-await window. Fires BEFORE `CapturedAudioConditioner.condition(...)`.

For the only engine alive today (Parakeet), all three calls reduce to no-ops or idempotent timer cancellations. Heart path user-visible equivalent: wire format, log shape, persisted schema, Sentry / PostHog payloads stay byte-identical. Pipeline-timing `Pipeline timing TOTAL: 1.236s (PTT)` and `1.005s (toggle)` confirmed in UAT.

## Validation

- `swift build -c release` ✓
- `scripts/swift-test.sh` ✓ — 12 new behavioral tests in `KernelEngineHookCallSitesTests` + 1365 existing tests pass. (One pre-existing race-flake under contention — `CancellationSilentUnwindTests.testCancellationSilentUnwind` — passes in isolation; documented in the test itself as a known fixture-driven artifact.)
- `EngineIdentityFreezeTests.optionalAdapterHookCallersMatchAllowlist` (renamed from `noOptionalHookCallersInProduction`) enforces per-hook counts in `RecordingSessionKernel.swift`: `warmUpFromCache: 1`, `cancelPendingUnload: 1`, `observeSpeechSegments: 1` (3 kernel call sites). Regex tightened to `\badapter\.(hook)\(` so protocol declarations / adapter overrides do not count.
- Live UAT (PTT + toggle paths) on Parakeet via `wispr_eyes.test_ptt(...)` and `test_recording(...)` — both green, transcripts landed in clipboard, no crash, no stuck overlay. Log shape preserved: `COLD-START [Parakeet v3] preWarmAudioInput total=149ms`, `VAD filtered to 67472 samples (86.3% voiced)`, `conditioner raw=78160 filtered=67472`, `Pipeline timing TOTAL` all present with same shape. Zero new log lines from the three new hook calls (silent on Parakeet, as expected).
- Council (GPT + Gemini coverage) + Codex grounded review (5 rounds, defect trajectory 10 → 3 → 2 → 2 → 0 substantive, terminal PROCEED-AS-PLANNED) + Codex code-diff review (4 rounds, defect trajectory 1 → 1 → 2 → 0). Findings addressed:
  - r1 P3: freeze test now counts per hook (caught aggregate-count masking regression).
  - r2 P2: post-`finalizeAtStop` reentrancy guard before `observeSpeechSegments` (closes cancel-during-VAD-finalize window).
  - r3 P2: dropped the preWarm-side `cancelPendingUnload` (would leak loaded model on abandoned PTT).
  - r4 P2: documented coordinate-space contract for `observeSpeechSegments` and aborted-session unload-timer caveat (both forward-looking concerns for Rung 3 adapter design; Parakeet today has identical behavior).

## Test plan

- [x] `swift build -c release` exits 0
- [x] `scripts/swift-test.sh` passes (12 new + 1365 existing)
- [x] Behavioral `KernelEngineHookCallSitesTests` 12/12 pass
- [x] `EngineIdentityFreezeTests.optionalAdapterHookCallersMatchAllowlist` passes with per-hook allowlist
- [x] Live UAT green on PTT path (`wispr_eyes.test_ptt`) — `Pipeline timing TOTAL: 1.236s`, Parakeet cold-start log present, no new log lines, transcript in clipboard
- [x] Live UAT green on menu/toggle path (`wispr_eyes.test_recording`) — `Pipeline timing TOTAL: 1.005s`, transcript in clipboard
- [x] CI `build-check` green (will verify post-push)

Plan: `docs/feature-requests/issue-827-2026-05-26-pr5-rung2b-kernel-call-sites.md`
Issue: #827