### PR TITLE
refactor(engine-kernel): PR-5 Rung 3 — WhisperKit engine adapter (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -238,13 +238,31 @@ public protocol ASREngineAdapter: AnyObject {
   /// here. After `cancel()`, MUST return `.cancelled` (PR-1 §B.2.2).
   ///
   /// `batchSamples`, when non-nil, is the kernel-conditioned ASR-ready audio
-  /// the adapter MUST use for any batch decode in this finalize call (PR-4.5
-  /// #5 — VAD-segment filtering, raw fallback, short-utterance padding are
-  /// kernel-side, not adapter-side). When nil, the adapter uses its own
-  /// raw retained audio unchanged (today's pre-PR-4.5 behavior, preserved for
-  /// tests + the `FakeEngine` simulator path). The streaming path is
-  /// unaffected — per-buffer feeds were already raw and the kernel's
-  /// `acceptAudio` contract has not changed.
+  /// (PR-4.5 #5 — VAD-segment filtering, raw fallback, short-utterance padding
+  /// are kernel-side, not adapter-side). Per-engine semantics:
+  ///
+  /// - The Parakeet adapter MUST use `batchSamples` for batch rescue. The
+  ///   kernel-side conditioning is the canonical audio for Parakeet's
+  ///   decoder; using its own retained PCM would skip the conditioning step.
+  /// - The WhisperKit adapter MUST NOT use `batchSamples`. WhisperKit decodes
+  ///   with `clipTimestamps` derived from kernel-supplied voiced segments
+  ///   (the #452/#560 hallucination-suppression mechanism); the kernel's
+  ///   silence-stripping conditioning shifts the time origin and would
+  ///   invalidate the segment-derived timestamps. The WhisperKit adapter
+  ///   decodes against its own retained raw PCM so the coordinate space
+  ///   matches.
+  ///
+  /// PR-5 Rung 3 (#827) carved out this engine-specific divergence; before
+  /// Rung 3 the contract said all adapters MUST use `batchSamples`. Adapters
+  /// whose decode requires raw-coordinate audio (engine-internal VAD chunking,
+  /// `clipTimestamps` derivation, etc.) MUST document the deviation at the
+  /// adapter call site and use their own retained source.
+  ///
+  /// When `batchSamples` is nil, the adapter uses its own raw retained audio
+  /// unchanged (today's pre-PR-4.5 behavior, preserved for tests + the
+  /// `FakeEngine` simulator path). The streaming path is unaffected —
+  /// per-buffer feeds were already raw and the kernel's `acceptAudio`
+  /// contract has not changed.
   func finalize(batchSamples: [Float]?) async -> ASREngineOutcome
 
   /// OPTIONAL `finalize()`-wedge signal (PR-1 §B.1.7). Same `nil` semantics as

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -63,6 +63,20 @@ struct KernelASRAdapterDiagnostics {
   var streamingBuffersFed: Int? = nil
   var batchRescueAttempted: Bool? = nil
   var batchRescueResultChars: Int? = nil
+
+  // PR-5 Rung 3 (#827): WhisperKit-specific finalize diagnostics. The
+  // WhisperKit adapter populates these on every terminal outcome so the
+  // kernel's lifecycle sink can render the asr-empty-with-speech-evidence
+  // payload (today's `WhisperKitPipeline.swift:1005-1019` Sentry call).
+  // Sink-side wiring lands in Rung 5; adapter-side population lands here.
+  var rawSampleCount: Int? = nil
+  var incrementalAccepted: Bool? = nil
+  var incrementalResultChars: Int? = nil
+  var incrementalDecodeCount: Int? = nil
+  var incrementalSamplesCovered: Int? = nil
+  var incrementalStrategy: String? = nil
+  var incrementalMode: String? = nil
+  var incrementalTailDecodeMs: Int? = nil
 }
 
 @MainActor

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -315,6 +315,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
           let samples = self?.retainedPCM ?? []
           return (samples: samples, count: samples.count)
         })
+        // Stale-beginSession guard AFTER `session.start`: if a `cancel()` +
+        // new `beginSession(B)` landed during the start await, the worker
+        // was installed under the wrong session. Uninstall + cancel it
+        // (Codex r7 matrix S6).
+        guard sessionID == id, !isCancelled else {
+          if (incrementalWorker as AnyObject?) === (session as AnyObject) {
+            incrementalWorker = nil
+          }
+          await session.cancel()
+          return
+        }
         Task {
           await AppLogger.shared.log(
             "WhisperKit recording started (batch mode, incremental worker: on)",
@@ -359,6 +370,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// so `clipTimestamps` derived from these are aligned to the audio the
   /// decoder actually sees.
   func observeSpeechSegments(_ segments: [SpeechSegment]) {
+    // Drop calls without a live session OR after the session went
+    // terminal/cancelled (Codex r7 matrix S0/S3/S4/S6). A late observe
+    // from a prior session must NOT repopulate the fresh adapter state.
+    guard sessionID != nil, !isTerminal, !isCancelled else { return }
     observedSpeechSegments = segments
   }
 
@@ -378,7 +393,15 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       observedSpeechSegments.removeAll()
       return .cancelled
     }
-    let session = sessionID
+    // Entry guard: no active session OR already-terminal session must not
+    // re-enter the decode path (Codex r7 matrix S0/S4). The protocol's
+    // "one outcome per session" shape at `ASREngineAdapter.swift:237-266`
+    // means a second `finalize()` after a successful one is undefined; the
+    // adapter declines rather than re-running LID/transcribe and clobbering
+    // the prior outcome.
+    guard let session = sessionID, !isTerminal else {
+      return .empty(hadSpeechEvidence: false)
+    }
 
     // No-speech gating is kernel-owned in the new model
     // (`RecordingSessionKernel.swift:974-1059` returns early for
@@ -754,14 +777,31 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
 
   /// Apply the model-unload policy. Mirrors
   /// `WhisperKitPipeline.scheduleModelUnloadIfNeeded:1457-1476`.
+  /// Refuses to arm during an active session and session-keys the unload
+  /// task so a delayed unload from session A cannot fire under session B
+  /// (Codex r7 matrix S0-S3, S5, S6). The legacy pipeline armed unload
+  /// only at the post-finalize terminal transition, so an
+  /// active-session arming was implicitly disallowed; the kernel-driven
+  /// model needs an explicit guard.
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
     modelUnloadTask?.cancel()
     modelUnloadTask = nil
+    // Only arm when no active session exists (idle/post-terminal).
+    guard sessionID == nil || isTerminal else { return }
+    let armedSession = sessionID
     switch policy {
     case .never:
       return
     case .immediately:
       modelUnloadTask = Task { [backend, weak self] in
+        guard !Task.isCancelled else { return }
+        // Re-check session keying right before the unload call — a
+        // `beginSession(B)` between arm and execute must NOT see A's
+        // unload land on B.
+        let shouldUnload = await MainActor.run { [weak self] () -> Bool in
+          self?.sessionID == armedSession && (self?.isTerminal == true || self?.sessionID == nil)
+        }
+        guard shouldUnload else { return }
         await backend.unload()
         await MainActor.run { [weak self] in
           self?.cachedReadiness = .notReady
@@ -772,6 +812,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       modelUnloadTask = Task { [backend, weak self] in
         try? await Task.sleep(for: .seconds(interval))
         guard !Task.isCancelled else { return }
+        let shouldUnload = await MainActor.run { [weak self] () -> Bool in
+          self?.sessionID == armedSession && (self?.isTerminal == true || self?.sessionID == nil)
+        }
+        guard shouldUnload else { return }
         await backend.unload()
         await MainActor.run { [weak self] in
           self?.cachedReadiness = .notReady

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -222,33 +222,39 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   }
 
   /// Cache-only warm-up — mirrors `WhisperKitPipeline.prepareBackendSilently`.
-  /// Fire-and-forget logging; never throws to the caller (the kernel's
-  /// `preWarm` path runs this best-effort).
+  /// `WhisperKitBackend.prepareIfCached()` performs the full cached CoreML
+  /// `loadFromPath` when the cache hits, so it is NOT a cheap probe. The
+  /// kernel's `preWarm()` awaits this hook before sending `.toggleRecording`,
+  /// so running the load synchronously here would block the PTT critical
+  /// path (Codex code-diff r4 defect 2). Fire-and-forget the cached load on
+  /// a detached `Task` instead — the kernel's spawned `warmUp()` path
+  /// already covers the heavy-load case on user intent, and a cache hit
+  /// here lets a subsequent press skip the load. Returns immediately;
+  /// never throws to the caller.
   func warmUpFromCache() async throws {
     if await backend.isReady {
       cachedReadiness = .ready
       return
     }
-    do {
-      let loaded = try await backend.prepareIfCached()
-      if loaded {
-        cachedReadiness = .ready
-        Task {
+    let captured = backend
+    Task {
+      do {
+        let loaded = try await captured.prepareIfCached()
+        if loaded {
+          await MainActor.run { [weak self] in
+            self?.cachedReadiness = .ready
+          }
           await AppLogger.shared.log(
             "WhisperKit model pre-loaded successfully (background)",
             level: .info, category: "WhisperKitEngineAdapter"
           )
-        }
-      } else {
-        Task {
+        } else {
           await AppLogger.shared.log(
             "WhisperKit model not cached, skipping silent pre-load",
             level: .info, category: "WhisperKitEngineAdapter"
           )
         }
-      }
-    } catch {
-      Task {
+      } catch {
         await AppLogger.shared.log(
           "WhisperKit model pre-load failed: \(error.localizedDescription)",
           level: .info, category: "WhisperKitEngineAdapter"

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1,0 +1,859 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+
+// MARK: - WhisperKitEngineAdapter (epic #827, PR-5 Rung 3)
+//
+// The production `ASREngineAdapter` conformer for the WhisperKit engine. It
+// wraps a `WhisperKitBackend` actor (the model-owning seam introduced by R2,
+// #360) plus a `LanguageDetector` actor (engine-internal LID, capability
+// `supportsLanguageDetection: true`) and lifts the WhisperKit-engine-internal
+// orchestration from `WhisperKitPipeline.swift`: model load + cancellation
+// (#445 held `prepareTask`), `warmUpFromCache` (cache-only preload, no
+// network), `beginSession` (cancel pending model unload, start incremental
+// worker in `.locked` mode only), `acceptAudio` (retained-PCM accumulator,
+// bounded to ~19 MB), `observeSpeechSegments` (store voiced ranges from the
+// kernel's VAD), `finalize` (LID → transcribe with `clipTimestamps` derived
+// from observed segments → incremental-worker-then-batch-fallback decode),
+// `cancel` (cancels held tasks + worker), `applyUnloadPolicy` (delay-then-
+// unload timer mirroring `scheduleModelUnloadIfNeeded`), `cancelPendingUnload`
+// (Rung 2B kernel hook).
+//
+// Scope (epic §4): an adapter owns its own ASR and rescue and NOTHING else —
+// no capture, no finalization, no paste, no UI, no FSM, no kernel state. The
+// adapter holds legitimate engine-session bookkeeping (a session ID, decode
+// options, an `isTerminal`/`isCancelled` pair, the retained PCM, the observed
+// speech segments, the LID result, held async-task handles).
+//
+// Coordinate-space (epic §0.5 LESSON `observeSpeechSegments-coordinate-space`):
+// the kernel's `observeSpeechSegments` hands speech segments in
+// raw-capture-sample coordinates. The adapter stores them as-is and decodes
+// against its own `retainedPCM`, which accumulates the same raw buffers the
+// kernel saw — so segment-derived `clipTimestamps` (the #452/#560
+// hallucination-suppression mechanism) stay coordinate-aligned. The
+// `finalize(batchSamples:)` parameter is intentionally ignored: any
+// kernel-conditioned audio (silence stripped in place by the kernel's
+// `CapturedAudioConditioner`) would shift the time origin and invalidate the
+// `clipTimestamps`. The protocol comment at `ASREngineAdapter.swift:240-247`
+// carves this out: engines whose decode requires raw-coordinate audio MUST
+// document the deviation here and use their own retained source. The Parakeet
+// adapter MUST use `batchSamples`; this adapter MUST NOT.
+//
+// PR-5 Rung 3 ships this production-unwired: no factory site, no App caller.
+// `KernelDictationDriverFactory` still constructs only `ParakeetEngineAdapter`
+// (Rung 4 will add the factory branch); `WhisperKitPipeline.swift` still owns
+// every WhisperKit recording in production (Rung 5 cutover deletes it).
+
+/// The kernel-facing `ASREngineAdapter` conformer for WhisperKit. Drives the
+/// underlying WhisperKit actor through a local `package` protocol seam
+/// (`WhisperKitBackendDriving` below) so tests can inject a stub without
+/// loading a real model.
+@MainActor
+final class WhisperKitEngineAdapter: ASREngineAdapter {
+
+  // MARK: Injected dependencies
+
+  private let backend: any WhisperKitBackendDriving
+  private let languageDetector: LanguageDetector
+
+  // MARK: Engine-session bookkeeping (NOT FSM state — §3.11 adapter-shape check)
+
+  /// The session `beginSession(_:)` opened, or `nil` between sessions.
+  private var sessionID: SessionID?
+  /// Decode options bound at `beginSession(_:)`. Mutated inside `finalize` to
+  /// pin the LID-decided language and to thread VAD `speechSegments` through
+  /// to `clipTimestamps`.
+  private var decodeOptions: TranscriptionOptions = .default
+  /// `true` once `finalize()` or `cancel()` has completed — `acceptAudio(_:)`
+  /// after this is a no-op (PR-1 §B.2.2).
+  private var isTerminal = false
+  /// `true` once `cancel()` ran — `finalize()` then returns `.cancelled`.
+  private var isCancelled = false
+
+  /// Synchronously-readable cached readiness. WhisperKit's `isReady` lives on
+  /// an actor (`public private(set) var isReady`); the `ASREngineAdapter`
+  /// protocol's `readiness` getter is synchronous, so the adapter caches the
+  /// most-recent observed state and refreshes it on every transition. All
+  /// mutations happen on `@MainActor`, so the cache update is observable to
+  /// any subsequent `@MainActor` reader without an intervening `await`.
+  private var cachedReadiness: ASREngineReadiness = .notReady
+
+  // MARK: Engine state
+
+  /// Issue #445: held `prepare()` task so `cancel()` can cancel its host
+  /// await even though CoreML's `MLModel.load` is uncancellable cooperatively.
+  /// The backend's single-flight guard handles the orphan that keeps grinding.
+  private var prepareTask: Task<Void, Error>?
+
+  /// The incremental decoding worker — present only in `.locked` language
+  /// mode. `WhisperKitPipeline.swift:519-530`: in `.auto` mode the worker
+  /// would snapshot the legacy language and decode with the wrong language;
+  /// post-LID batch decode is the only correct path. The worker reads
+  /// `retainedPCM` via its provider closure.
+  private var incrementalWorker: (any WhisperKitIncrementalSession)?
+
+  /// Pending model-unload timer armed by `applyUnloadPolicy(_:)`.
+  /// `cancelPendingUnload()` (the Rung 2B kernel hook called pre-`beginSession`)
+  /// and `beginSession` (defense-in-depth) both cancel it.
+  private var modelUnloadTask: Task<Void, Never>?
+
+  // MARK: Audio + speech segments
+
+  /// The whole session's 16 kHz mono Float32 samples, accumulated from every
+  /// `acceptAudio(_:)`. The WhisperKit adapter decodes batch-only over this
+  /// buffer (no streaming) — the kernel hands buffers piecemeal and the
+  /// adapter retains them so `finalize` has the full session audio.
+  /// Cleared on `cancel()` and at the tail of `finalize()`.
+  private var retainedPCM: [Float] = []
+
+  /// Speech segments handed in by the kernel's `observeSpeechSegments` hook
+  /// (Rung 2B). Coordinates are raw-capture-sample positions matching
+  /// `retainedPCM`. Used to derive `clipTimestamps` for WhisperKit's VAD-driven
+  /// clip-seek (the #452/#560 hallucination-suppression mechanism) and to
+  /// filter LID audio to voiced-only ranges. Cleared on `cancel()` /
+  /// `beginSession()` and after `finalize()` commits.
+  private var observedSpeechSegments: [SpeechSegment] = []
+
+  /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
+  /// (300 s * 16 kHz = 4.8 M Float = ~19 MB). Mirrors Parakeet's cap so the
+  /// two engines size memory the same way. On reaching the cap the
+  /// accumulation stops growing; recording auto-stops on max-duration anyway.
+  private static let retainedPCMCap = Int(
+    TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
+
+  // MARK: Last-result + telemetry (Rung 2A passive surface)
+
+  /// The `ASRResult` of the last successful `finalize()`, or `nil` between
+  /// sessions. Cleared on `beginSession()` and `cancel()`; assigned only by a
+  /// successful `finalize()` returning `.transcript(...)`.
+  private(set) var lastResult: ASRResult?
+
+  /// Rich incremental + batch-rescue diagnostics surfaced through the
+  /// `ASREngineTelemetryProviding` protocol. Kernel's lifecycle sink reads
+  /// this for the asr-empty-with-speech-evidence payload (today's
+  /// `WhisperKitPipeline.swift:1005-1019`). NOT cleared on `finalize()` — only
+  /// on `beginSession()` and `cancel()` — so the sink can read it after the
+  /// outcome lands.
+  private(set) var lastASRDiagnostics: KernelASRAdapterDiagnostics?
+
+  /// The last decode error, surfaced through `ASREngineTelemetryProviding`.
+  private(set) var lastFailureError: (any Error)?
+
+  /// The last LID result. NOT surfaced on the `ASREngineAdapter` protocol
+  /// (Rung 2A "contract surface stays closed"); Rung 5's App cutover wires
+  /// this into `LLMPolishStep.languageDetection`. Cleared on `beginSession()`
+  /// and `cancel()`; set inside `finalize` after `languageDetector.detect(...)`
+  /// returns and the stale-session guard passes.
+  private(set) var lastLanguageDetection: LanguageDetectionResult?
+
+  // MARK: ASREngineAdapter — engine interruption
+
+  /// Optional adapter-local interruption hook. WhisperKit has no
+  /// mid-recording crash signal today (the legacy pipeline's
+  /// `handleASRServiceInterruption` is XPC-driven from the App layer), so
+  /// this remains settable but unused inside the adapter.
+  var onEngineInterrupted: (@MainActor () -> Void)?
+
+  // MARK: Init
+
+  init(
+    backend: any WhisperKitBackendDriving,
+    languageDetector: LanguageDetector = LanguageDetector()
+  ) {
+    self.backend = backend
+    self.languageDetector = languageDetector
+  }
+
+  // MARK: ASREngineAdapter — identity & capability
+
+  /// Self-declared identity. The kernel reads from here at every site that
+  /// previously hard-coded an engine literal (PR-5 Rung 1).
+  var engineIdentity: ASREngineIdentity {
+    ASREngineIdentity(backendType: .whisperKit)
+  }
+
+  /// WhisperKit decodes batch-only (no streaming) and runs engine-internal
+  /// LID. Static — the kernel branches on `capabilities`, never on engine
+  /// identity (epic §3.4).
+  var capabilities: ASREngineCapabilities {
+    ASREngineCapabilities(supportsStreaming: false, supportsLanguageDetection: true)
+  }
+
+  var readiness: ASREngineReadiness { cachedReadiness }
+
+  // MARK: ASREngineAdapter — warm-up
+
+  /// Idempotent, sessionless warm-up. Held `prepareTask` so `cancel()` can
+  /// cancel the host await; the backend's single-flight guard owns the
+  /// in-flight CoreML load semantics (`#445`). CoreML's `MLModel.load` exposes
+  /// no progress signal, so the kernel runs signal-free warm-up — no wedge
+  /// detection, no wall-clock timeout (per the protocol's MUST NOT clause).
+  func warmUp() async throws {
+    if await backend.isReady {
+      cachedReadiness = .ready
+      return
+    }
+    cachedReadiness = .warming
+    let captured = backend
+    let task = Task<Void, Error> { try await captured.prepare() }
+    prepareTask = task
+    do {
+      try await task.value
+      prepareTask = nil
+      cachedReadiness = .ready
+    } catch {
+      prepareTask = nil
+      cachedReadiness = .notReady
+      throw error
+    }
+  }
+
+  /// Cache-only warm-up — mirrors `WhisperKitPipeline.prepareBackendSilently`.
+  /// Fire-and-forget logging; never throws to the caller (the kernel's
+  /// `preWarm` path runs this best-effort).
+  func warmUpFromCache() async throws {
+    if await backend.isReady {
+      cachedReadiness = .ready
+      return
+    }
+    do {
+      let loaded = try await backend.prepareIfCached()
+      if loaded {
+        cachedReadiness = .ready
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit model pre-loaded successfully (background)",
+            level: .info, category: "WhisperKitEngineAdapter"
+          )
+        }
+      } else {
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit model not cached, skipping silent pre-load",
+            level: .info, category: "WhisperKitEngineAdapter"
+          )
+        }
+      }
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit model pre-load failed: \(error.localizedDescription)",
+          level: .info, category: "WhisperKitEngineAdapter"
+        )
+      }
+    }
+  }
+
+  /// WhisperKit / CoreML exposes no model-load progress signal. The kernel
+  /// runs signal-free `warmingUp` with no wedge detection, per the protocol's
+  /// MUST NOT clause.
+  var loadProgress: AsyncStream<ASRLoadProgressTick>? { nil }
+
+  // `lastObservedPhase` falls back to the protocol-extension default
+  // (`"warmup"`) — WhisperKit's loader exposes no phase strings.
+
+  // MARK: ASREngineAdapter — session lifecycle
+
+  /// Begin a session. WhisperKit doesn't stream — `streaming` is ignored for
+  /// the live-stream decision. In `.locked` language mode (`options.language`
+  /// non-nil) the incremental worker is started so finalize can use its
+  /// best-effort result before falling back to batch. In `.auto` mode
+  /// (language nil) the worker is intentionally skipped — see
+  /// `WhisperKitPipeline.swift:519-530` for the rationale (the worker
+  /// snapshots language at start; in `.auto` it would decode with the wrong
+  /// language).
+  func beginSession(_ id: SessionID, options: TranscriptionOptions, streaming: Bool) async throws {
+    sessionID = id
+    decodeOptions = options
+    isTerminal = false
+    isCancelled = false
+    lastResult = nil
+    lastASRDiagnostics = nil
+    lastFailureError = nil
+    lastLanguageDetection = nil
+    retainedPCM.removeAll(keepingCapacity: true)
+    observedSpeechSegments.removeAll()
+
+    // Cancel any pending model-unload timer a prior session armed. Rung 2B's
+    // kernel `cancelPendingUnload` hook already fires synchronously before
+    // `beginSession`; this is defense-in-depth, matching Parakeet's
+    // `ParakeetEngineAdapter.swift:192` pattern.
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+
+    // Refresh cached readiness — backend may have been unloaded by a prior
+    // session's policy timer that fired while idle.
+    cachedReadiness = await backend.isReady ? .ready : .notReady
+
+    // `.locked` mode → start the worker. In `.auto` mode language is unknown
+    // until LID runs at finalize, so the worker is skipped.
+    if options.language != nil {
+      if let session = await backend.makeIncrementalSession(options: options) {
+        incrementalWorker = session
+        await session.start(audioSamplesProvider: { @MainActor [weak self] in
+          let samples = self?.retainedPCM ?? []
+          return (samples: samples, count: samples.count)
+        })
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit recording started (batch mode, incremental worker: on)",
+            level: .info, category: "WhisperKitEngineAdapter"
+          )
+        }
+      } else {
+        Task {
+          await AppLogger.shared.log(
+            "WhisperKit recording started (batch mode, incremental worker: off, model not loaded)",
+            level: .info, category: "WhisperKitEngineAdapter"
+          )
+        }
+      }
+    } else {
+      Task {
+        await AppLogger.shared.log(
+          "WhisperKit recording started (batch mode, incremental worker: off, auto language mode)",
+          level: .info, category: "WhisperKitEngineAdapter"
+        )
+      }
+    }
+  }
+
+  /// Accept one captured buffer. Always appends to `retainedPCM` (bounded by
+  /// `retainedPCMCap`). A call after a terminal session is a no-op
+  /// (PR-1 §B.2.2). WhisperKit has no live stream — buffers are batched
+  /// until `finalize`.
+  func acceptAudio(_ buffer: AudioBufferHandoff) {
+    guard !isTerminal, !isCancelled else { return }
+    appendRetainedPCM(from: buffer.buffer)
+  }
+
+  /// Store the kernel's VAD-derived speech segments. Coordinates are
+  /// raw-capture-sample positions — same coordinate space as `retainedPCM`,
+  /// so `clipTimestamps` derived from these are aligned to the audio the
+  /// decoder actually sees.
+  func observeSpeechSegments(_ segments: [SpeechSegment]) {
+    observedSpeechSegments = segments
+  }
+
+  /// Finalize: LID → transcribe with `clipTimestamps` derived from observed
+  /// segments → incremental-worker-result-or-batch-fallback. After `cancel()`,
+  /// returns `.cancelled`. **MUST NOT use `batchSamples`** — see the
+  /// coordinate-space note above and the protocol comment at
+  /// `ASREngineAdapter.swift:240-247`. Uses adapter-owned `retainedPCM` for
+  /// every decode in this finalize call so segment-derived `clipTimestamps`
+  /// stay coordinate-aligned.
+  func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
+    _ = batchSamples  // intentionally ignored — see coordinate-space note
+    lastFailureError = nil
+    if isCancelled {
+      isTerminal = true
+      retainedPCM.removeAll()
+      observedSpeechSegments.removeAll()
+      return .cancelled
+    }
+    let session = sessionID
+
+    // No-speech gate: matches `WhisperKitPipeline.swift:694-718`. In the
+    // kernel-driven model the kernel ALWAYS calls `observeSpeechSegments`
+    // before `finalize`, so an empty array IS the "kernel computed no
+    // voiced segments" signal — pass it directly (not nil, which would
+    // default to true / "no detector available, fail toward visibility").
+    let hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
+      vadSegments: observedSpeechSegments
+    )
+    let minimumSamples = AudioConstants.minimumTranscriptionSamples
+    let rawSamples = retainedPCM
+
+    if !hasSpeechEvidence {
+      if let worker = incrementalWorker {
+        await worker.cancel()
+        incrementalWorker = nil
+      }
+      // Stale-cancel guard.
+      guard sessionID == session, !isCancelled else {
+        isTerminal = true
+        retainedPCM.removeAll()
+        observedSpeechSegments.removeAll()
+        return isCancelled ? .cancelled : .empty(hadSpeechEvidence: false)
+      }
+      var diagnostics = KernelASRAdapterDiagnostics()
+      diagnostics.rawSampleCount = rawSamples.count
+      lastASRDiagnostics = diagnostics
+      isTerminal = true
+      retainedPCM.removeAll()
+      observedSpeechSegments.removeAll()
+      return .empty(hadSpeechEvidence: false)
+    }
+
+    // Sample shaping for LID + ASR. ASR runs over raw retained PCM (padded);
+    // LID runs over voiced-only audio (with raw fallback if voiced is too short).
+    let speechSegments = observedSpeechSegments
+    let asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
+      rawSamples: rawSamples,
+      minimumSamples: minimumSamples
+    )
+    let lidFiltered = SampleFilter.filter(from: rawSamples, segments: speechSegments)
+    let lidSamples = WhisperKitPipelineSpeechRouting.paddedLIDSamples(
+      filteredSamples: lidFiltered,
+      rawSamples: rawSamples,
+      minimumSamples: minimumSamples
+    )
+    decodeOptions = WhisperKitPipelineSpeechRouting.transcriptionOptions(
+      from: decodeOptions,
+      speechSegments: speechSegments
+    )
+    let voicedDurationSec =
+      Double(
+        speechSegments.reduce(0) { $0 + ($1.endSample - $1.startSample) }
+      ) / AudioConstants.sampleRate
+    let lidWindowCount = WhisperKitPipelineSpeechRouting.lidWindowCount(
+      forVoicedDuration: voicedDurationSec
+    )
+    let clipKind = lidWindowCount == 1 ? "short" : "normal"
+
+    // LID perf signpost: state flip (kernel-owned in the new model; the
+    // adapter logs the LID-bound signposts only).
+    logLIDPerfSignpost(
+      "t_state_flip",
+      voicedDuration: voicedDurationSec,
+      lidWindowCount: lidWindowCount,
+      clipKind: clipKind
+    )
+
+    // LID. `LanguageMode` is reconstructed from `decodeOptions.language`:
+    // non-nil → `.locked(code)`; nil → `.auto` — mirrors how the App layer
+    // threads `DictationSessionConfig.languageMode` through
+    // `TranscriptionOptions.language` (`KernelFinalizationWiring.swift:124-127`).
+    let mode: LanguageMode =
+      (decodeOptions.language).map { LanguageMode.locked($0) } ?? .auto
+    let backendForObserver = backend
+    let observerSamples = lidSamples
+    let lidWindowCountForObserver = lidWindowCount
+    let lidResult = await languageDetector.detect(
+      samples: lidSamples,
+      voicedDuration: voicedDurationSec,
+      observerFn: {
+        await backendForObserver.observeLID(
+          samples: observerSamples, maxWindows: lidWindowCountForObserver)
+      },
+      mode: mode
+    )
+    logLIDPerfSignpost(
+      "t_lid_settled",
+      voicedDuration: voicedDurationSec,
+      lidWindowCount: lidWindowCount,
+      clipKind: clipKind
+    )
+
+    // Stale-cancel guard before mutating LID-derived state.
+    guard sessionID == session, !isCancelled else {
+      isTerminal = true
+      retainedPCM.removeAll()
+      observedSpeechSegments.removeAll()
+      return .cancelled
+    }
+    lastLanguageDetection = lidResult
+    if let lang = lidResult.lang, !lidResult.abstained {
+      decodeOptions.language = lang
+    } else {
+      decodeOptions.language = nil  // let WhisperKit's internal LID run
+    }
+    Task {
+      await AppLogger.shared.log(
+        "LID result: lang=\(lidResult.lang ?? "nil") tier=\(lidResult.tier) "
+          + "conf=\(String(format: "%.2f", lidResult.confidence)) "
+          + "margin=\(String(format: "%.2f", lidResult.margin)) "
+          + "voiced=\(String(format: "%.2f", lidResult.voicedDuration))s "
+          + "abstained=\(lidResult.abstained)",
+        level: .info, category: "WhisperKitEngineAdapter"
+      )
+    }
+
+    // LID PostHog telemetry — adapter-owned per `supportsLanguageDetection`
+    // TODO at `ASREngineAdapter.swift:60-65`.
+    let sessionPreferredSnapshot = await languageDetector.peekMemory().sessionPreferred
+    TelemetryService.shared.trackLanguageDetected(
+      lang: lidResult.lang,
+      confidence: lidResult.confidence,
+      margin: lidResult.margin,
+      voicedDuration: lidResult.voicedDuration,
+      abstained: lidResult.abstained,
+      sessionPreferredLang: sessionPreferredSnapshot,
+      usedSticky: lidResult.usedSessionPrior,
+      lidWindowCount: lidWindowCount
+    )
+    if lidResult.abstained {
+      let reason: String
+      if lidResult.voicedDuration < LanguageDetectorThresholds.shortClipMinSec {
+        reason = "too_short"
+      } else if lidResult.confidence < LanguageDetectorThresholds.normalProb {
+        reason = "low_confidence"
+      } else if lidResult.margin < LanguageDetectorThresholds.normalMargin {
+        reason = "narrow_margin"
+      } else {
+        reason = "low_confidence"
+      }
+      TelemetryService.shared.trackLIDAbstained(
+        voicedDuration: lidResult.voicedDuration,
+        top1Prob: lidResult.confidence,
+        top1Lang: lidResult.lang,
+        reason: reason
+      )
+    }
+
+    // Decode — worker-result first, batch fallback. Diagnostics surface
+    // through `lastASRDiagnostics` on every terminal outcome.
+    var diagnostics = KernelASRAdapterDiagnostics()
+    diagnostics.rawSampleCount = rawSamples.count
+
+    let asrText: String
+    let asrLanguage: String?
+    let asrStart = CFAbsoluteTimeGetCurrent()
+
+    if let worker = incrementalWorker {
+      let workerResult = await worker.finalize(
+        finalSamples: rawSamples, speechSegments: speechSegments)
+      incrementalWorker = nil
+      diagnostics.incrementalAccepted = workerResult.accepted
+      diagnostics.incrementalResultChars =
+        workerResult.text?.trimmingCharacters(in: .whitespacesAndNewlines).count
+      diagnostics.incrementalDecodeCount = workerResult.decodeCount
+      diagnostics.incrementalSamplesCovered = workerResult.samplesCovered
+      diagnostics.incrementalStrategy = workerResult.strategy
+      diagnostics.incrementalMode = workerResult.mode
+      diagnostics.incrementalTailDecodeMs = workerResult.tailDecodeMs
+
+      if workerResult.accepted, let text = workerResult.text,
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      {
+        asrText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        asrLanguage = decodeOptions.language
+        Task {
+          [
+            text = asrText, strategy = workerResult.strategy, mode = workerResult.mode,
+            decodes = workerResult.decodeCount, tailMs = workerResult.tailDecodeMs,
+            covered = workerResult.samplesCovered, totalSamples = rawSamples.count
+          ] in
+          let coveragePct =
+            totalSamples > 0
+            ? String(format: "%.1f", Double(covered) / Double(totalSamples) * 100)
+            : "0"
+          await AppLogger.shared.log(
+            "WhisperKit finalize: strategy=\(strategy), mode=\(mode), "
+              + "decodes=\(decodes), tailDecodeMs=\(tailMs), "
+              + "coverage=\(covered)/\(totalSamples) (\(coveragePct)%) chars=\(text.count)",
+            level: .info, category: "WhisperKitEngineAdapter"
+          )
+        }
+      } else {
+        // Batch fallback over raw retained PCM.
+        logLIDPerfSignpost(
+          "t_asr_start",
+          voicedDuration: voicedDurationSec,
+          lidWindowCount: lidWindowCount,
+          clipKind: clipKind
+        )
+        diagnostics.batchRescueAttempted = true
+        let batchOutcome = await runBatchDecode(samples: asrSamples)
+        logLIDPerfSignpost(
+          "t_asr_end",
+          voicedDuration: voicedDurationSec,
+          lidWindowCount: lidWindowCount,
+          clipKind: clipKind
+        )
+        switch batchOutcome {
+        case .success(let result):
+          let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+          diagnostics.batchRescueResultChars = trimmed.count
+          asrText = trimmed
+          asrLanguage = result.language
+        case .cancelled:
+          isTerminal = true
+          retainedPCM.removeAll()
+          observedSpeechSegments.removeAll()
+          return .cancelled
+        case .failed(let error):
+          lastFailureError = error
+          lastASRDiagnostics = diagnostics
+          isTerminal = true
+          retainedPCM.removeAll()
+          observedSpeechSegments.removeAll()
+          return .failed(.decodeFailed)
+        }
+      }
+    } else {
+      // `.auto` mode (or worker setup failed): batch only.
+      logLIDPerfSignpost(
+        "t_asr_start",
+        voicedDuration: voicedDurationSec,
+        lidWindowCount: lidWindowCount,
+        clipKind: clipKind
+      )
+      diagnostics.batchRescueAttempted = false
+      let batchOutcome = await runBatchDecode(samples: asrSamples)
+      logLIDPerfSignpost(
+        "t_asr_end",
+        voicedDuration: voicedDurationSec,
+        lidWindowCount: lidWindowCount,
+        clipKind: clipKind
+      )
+      switch batchOutcome {
+      case .success(let result):
+        let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        diagnostics.batchRescueResultChars = trimmed.count
+        asrText = trimmed
+        asrLanguage = result.language
+      case .cancelled:
+        isTerminal = true
+        retainedPCM.removeAll()
+        observedSpeechSegments.removeAll()
+        return .cancelled
+      case .failed(let error):
+        lastFailureError = error
+        lastASRDiagnostics = diagnostics
+        isTerminal = true
+        retainedPCM.removeAll()
+        observedSpeechSegments.removeAll()
+        return .failed(.decodeFailed)
+      }
+    }
+
+    let asrEnd = CFAbsoluteTimeGetCurrent()
+    let asrLatencySec = asrEnd - asrStart
+    let audioDurationSec = Double(rawSamples.count) / AudioConstants.sampleRate
+
+    // Telemetry fetch BEFORE the stale guard so that every mutation after
+    // the guard is synchronous on `@MainActor`. An await between the guard
+    // and the state writes would let `beginSession` clobber session B's
+    // state if a stale finalize landed in the gap. The model name lookup
+    // is the only remaining backend hop; pre-fetch it here.
+    let modelName = await backend.modelVariantName
+
+    // Stale-finalize guard: a `cancel()` + new `beginSession()` during the
+    // ASR await must not let this stale finalize clobber the fresh session's
+    // state (mirrors `ParakeetEngineAdapter.swift:271-273`).
+    guard sessionID == session, !isCancelled else {
+      lastASRDiagnostics = diagnostics
+      return isCancelled
+        ? .cancelled
+        : .empty(hadSpeechEvidence: true)
+    }
+
+    // All remaining mutations are synchronous on `@MainActor` — no await
+    // between here and `return`, so the guard above protects every write.
+    lastASRDiagnostics = diagnostics
+    isTerminal = true
+    retainedPCM.removeAll()
+    observedSpeechSegments.removeAll()
+
+    if asrText.isEmpty {
+      // Past the kernel's VAD gate, an empty decode is a real ASR failure;
+      // route the kernel to `failed(asrEmpty)` (PR-1 §B.1.2).
+      return .empty(hadSpeechEvidence: true)
+    }
+
+    let result = ASRResult(
+      text: asrText,
+      language: asrLanguage,
+      duration: audioDurationSec,
+      processingTime: asrLatencySec,
+      backendType: .whisperKit
+    )
+    lastResult = result
+
+    // Per-transcription latency telemetry — adapter-owned per the
+    // `supportsLanguageDetection` TODO on `ASREngineAdapter.swift:60-65`.
+    // Fired post-state-commit; telemetry is a limb and must never block the
+    // heart path. `audioDurationSec > 0` is true here (we cleared the
+    // no-speech gate above and decode produced text).
+    if audioDurationSec > 0 {
+      let msPerAudioSec = (asrLatencySec * 1000.0) / audioDurationSec
+      TelemetryService.shared.trackTranscriptionLatency(
+        lang: asrLanguage,
+        model: modelName,
+        durationSeconds: asrLatencySec,
+        msPerAudioSecond: msPerAudioSec
+      )
+    }
+
+    return .transcript(result)
+  }
+
+  /// WhisperKit's `transcribe(...)` is completion-only — no decoder-step
+  /// progress signal. Same `nil` semantics as `loadProgress`.
+  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
+
+  /// Idempotent discard. Cancels held tasks (prepare, model-unload timer) and
+  /// the incremental worker; clears retained audio + segments + LID result.
+  func cancel() async {
+    isCancelled = true
+    isTerminal = true
+    lastResult = nil
+    lastLanguageDetection = nil
+    retainedPCM.removeAll()
+    observedSpeechSegments.removeAll()
+    prepareTask?.cancel()
+    prepareTask = nil
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+    if let worker = incrementalWorker {
+      incrementalWorker = nil
+      await worker.cancel()
+    }
+    cachedReadiness = await backend.isReady ? .ready : .notReady
+  }
+
+  // MARK: ASREngineAdapter — cleanup
+
+  /// Apply the model-unload policy. Mirrors
+  /// `WhisperKitPipeline.scheduleModelUnloadIfNeeded:1457-1476`.
+  func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+    switch policy {
+    case .never:
+      return
+    case .immediately:
+      modelUnloadTask = Task { [backend, weak self] in
+        await backend.unload()
+        await MainActor.run { [weak self] in
+          self?.cachedReadiness = .notReady
+        }
+      }
+    case .twoMinutes, .fiveMinutes, .tenMinutes, .fifteenMinutes, .sixtyMinutes:
+      guard let interval = policy.interval else { return }
+      modelUnloadTask = Task { [backend, weak self] in
+        try? await Task.sleep(for: .seconds(interval))
+        guard !Task.isCancelled else { return }
+        await backend.unload()
+        await MainActor.run { [weak self] in
+          self?.cachedReadiness = .notReady
+        }
+      }
+    }
+  }
+
+  // MARK: ASREngineAdapter optional engine hooks (PR-5 Rung 2A)
+
+  /// Cancel any pending model-unload timer the adapter armed. The kernel
+  /// fires this synchronously immediately before `beginSession(...)` in the
+  /// Rung 2B `cancelPendingUnload-at-beginSession-not-preWarm` lesson —
+  /// catches a fired timer that would otherwise leak the loaded model on
+  /// abandoned PTT. Idempotent.
+  func cancelPendingUnload() {
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+  }
+
+  // MARK: PCM retention
+
+  /// Extract the buffer's Float32 samples and append to `retainedPCM`,
+  /// bounded by `retainedPCMCap`. Mirrors `ParakeetEngineAdapter`'s shape.
+  private func appendRetainedPCM(from buffer: AVAudioPCMBuffer) {
+    guard retainedPCM.count < Self.retainedPCMCap else { return }
+    let count = Int(buffer.frameLength)
+    guard count > 0, let channel = buffer.floatChannelData?[0] else { return }
+    let remaining = Self.retainedPCMCap - retainedPCM.count
+    let take = min(count, remaining)
+    retainedPCM.append(contentsOf: UnsafeBufferPointer(start: channel, count: take))
+  }
+
+  // MARK: Batch decode helper
+
+  private enum BatchDecodeOutcome {
+    case success(ASRResult)
+    case cancelled
+    case failed(any Error)
+  }
+
+  private func runBatchDecode(samples: [Float]) async -> BatchDecodeOutcome {
+    do {
+      let result = try await backend.transcribe(
+        audioSamples: samples, options: decodeOptions)
+      return .success(result)
+    } catch is CancellationError {
+      return .cancelled
+    } catch {
+      return .failed(error)
+    }
+  }
+
+  // MARK: LID perf signposts (5 of 6 — the 6th, `t_clipboard_write`, is
+  // kernel-owned in the new model and fires after `KernelFinalizationWiring.deliver`;
+  // Rung 5 wires that emission).
+
+  private func logLIDPerfSignpost(
+    _ name: String,
+    voicedDuration: TimeInterval? = nil,
+    lidWindowCount: Int? = nil,
+    clipKind: String? = nil
+  ) {
+    var fields = [
+      "lid_perf_signpost",
+      "name=\(name)",
+      "timestamp_s=\(String(format: "%.6f", CFAbsoluteTimeGetCurrent()))",
+    ]
+    if let voicedDuration {
+      fields.append("voiced_duration_s=\(String(format: "%.3f", voicedDuration))")
+    }
+    if let lidWindowCount {
+      fields.append("lid_window_count=\(lidWindowCount)")
+    }
+    if let clipKind {
+      fields.append("clip_kind=\(clipKind)")
+    }
+    let message = fields.joined(separator: " ")
+    Task {
+      await AppLogger.shared.log(message, level: .info, category: "WhisperKitEngineAdapter")
+    }
+  }
+}
+
+// MARK: - ASREngineTelemetryProviding conformance
+
+extension WhisperKitEngineAdapter: ASREngineTelemetryProviding {}
+
+// MARK: - Test-only inspectors (`@testable import` reaches `internal`)
+
+extension WhisperKitEngineAdapter {
+  /// Test-only read of the retained PCM. The production read site is the
+  /// incremental worker's provider closure, which captures `self` weakly and
+  /// reads `retainedPCM` on `@MainActor`.
+  internal var retainedPCMForUnitTests: [Float] { retainedPCM }
+  /// Test-only read of the kernel-supplied speech segments.
+  internal var observedSpeechSegmentsForUnitTests: [SpeechSegment] { observedSpeechSegments }
+}
+
+// MARK: - WhisperKitBackendDriving — local seam for testability (OQ-4 option a)
+
+/// Actor-bound protocol that captures every WhisperKit-backend surface this
+/// adapter needs to drive. Declared `package` and local to this file so the
+/// protocol surface for the adapter stays in Pipeline; tests inject a stub
+/// conforming to this protocol without loading a real WhisperKit model. The
+/// concrete `WhisperKitBackend` (in `EnviousWisprASR`) is retro-conformed
+/// below.
+///
+/// The `: Actor` constraint mirrors `package protocol ASRBackend: Actor` at
+/// `Sources/EnviousWisprASR/ASRProtocol.swift:14` — `WhisperKitBackend.isReady`
+/// is actor-isolated (`public private(set) var isReady`), so the synchronous
+/// protocol requirement only satisfies through an actor-bound protocol.
+package protocol WhisperKitBackendDriving: Actor {
+  var isReady: Bool { get }
+  var modelVariantName: String { get }
+  func prepare() async throws
+  func prepareIfCached() async throws -> Bool
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
+  func observeLID(samples: [Float], maxWindows: Int) async -> LIDObservationBatch
+  func makeIncrementalSession(options: TranscriptionOptions) async
+    -> (any WhisperKitIncrementalSession)?
+  func unload() async
+}
+
+// Retroactive conformance — `WhisperKitBackend` already has every requirement
+// at the right access level (`isReady` public, `modelVariantName` package,
+// `prepare()` public, `prepareIfCached()` package, `transcribe(...)` public,
+// `observeLID(...)` package, `makeIncrementalSession(...)` package, `unload()`
+// public). No method additions needed in `EnviousWisprASR`.
+extension WhisperKitBackend: WhisperKitBackendDriving {}

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -301,6 +301,15 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // until LID runs at finalize, so the worker is skipped.
     if options.language != nil {
       if let session = await backend.makeIncrementalSession(options: options) {
+        // Stale-beginSession guard: a `cancel()` + new `beginSession(B)`
+        // during the `makeIncrementalSession` await must NOT let this
+        // stale install land on the fresh session — otherwise `finalize`
+        // for B would see a non-nil `incrementalWorker` from A and route
+        // through it (Codex code-diff r6).
+        guard sessionID == id, !isCancelled else {
+          await session.cancel()
+          return
+        }
         incrementalWorker = session
         await session.start(audioSamplesProvider: { @MainActor [weak self] in
           let samples = self?.retainedPCM ?? []

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -294,6 +294,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     modelUnloadTask?.cancel()
     modelUnloadTask = nil
 
+    // Cancel + drop any orphan worker from a prior session — if the previous
+    // session was superseded before finalize/cancel cleared the handle, the
+    // worker would still be installed and the auto-mode branch below would
+    // erroneously route through it (Codex code-diff r3 defect 2). Fire the
+    // cancel detached so beginSession stays nominally fast; the worker
+    // itself is safe to discard immediately since no caller holds it.
+    if let orphan = incrementalWorker {
+      incrementalWorker = nil
+      Task { await orphan.cancel() }
+    }
+
     // Refresh cached readiness — backend may have been unloaded by a prior
     // session's policy timer that fired while idle.
     cachedReadiness = await backend.isReady ? .ready : .notReady
@@ -336,7 +347,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// (PR-1 §B.2.2). WhisperKit has no live stream — buffers are batched
   /// until `finalize`.
   func acceptAudio(_ buffer: AudioBufferHandoff) {
-    guard !isTerminal, !isCancelled else { return }
+    // Drop late buffers from a prior session — PR-1 §B.3 / FSM invariant 7:
+    // a buffer whose `sessionID` is not the kernel's current session is
+    // dropped. Without this gate, a delayed handoff after `beginSession(B)`
+    // would land in session B's `retainedPCM` and misalign the
+    // segment-derived `clipTimestamps` for batch decode (Codex code-diff r3
+    // defect 3).
+    guard !isTerminal, !isCancelled, buffer.sessionID == sessionID else { return }
     appendRetainedPCM(from: buffer.buffer)
   }
 
@@ -468,6 +485,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // LID PostHog telemetry — adapter-owned per `supportsLanguageDetection`
     // TODO at `ASREngineAdapter.swift:60-65`.
     let sessionPreferredSnapshot = await languageDetector.peekMemory().sessionPreferred
+
+    // Stale guard after the `peekMemory()` await: a `beginSession(B)` during
+    // this hop must not let the stale A finalize keep reading mutable
+    // `incrementalWorker`/`decodeOptions` for the rest of finalize. The
+    // downstream guards catch session B's state AFTER the next awaits, but
+    // an early bail here prevents reading session B's worker between
+    // LID telemetry and the decode (Codex code-diff r3 defect 1).
+    guard sessionID == session, !isCancelled else {
+      return isCancelled ? .cancelled : .empty(hadSpeechEvidence: true)
+    }
+
     TelemetryService.shared.trackLanguageDetected(
       lang: lidResult.lang,
       confidence: lidResult.confidence,

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -802,7 +802,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
           self?.sessionID == armedSession && (self?.isTerminal == true || self?.sessionID == nil)
         }
         guard shouldUnload else { return }
+        // Final cancellation re-check: between the `shouldUnload` MainActor
+        // hop and this point, a `beginSession(B)` may have cancelled this
+        // task. Without the recheck, the cancelled task can still fire
+        // `backend.unload()` under session B (Codex code-diff r8).
+        guard !Task.isCancelled else { return }
         await backend.unload()
+        guard !Task.isCancelled else { return }
         await MainActor.run { [weak self] in
           self?.cachedReadiness = .notReady
         }
@@ -816,7 +822,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
           self?.sessionID == armedSession && (self?.isTerminal == true || self?.sessionID == nil)
         }
         guard shouldUnload else { return }
+        // Final cancellation re-check: between the `shouldUnload` MainActor
+        // hop and this point, a `beginSession(B)` may have cancelled this
+        // task. Without the recheck, the cancelled task can still fire
+        // `backend.unload()` under session B (Codex code-diff r8).
+        guard !Task.isCancelled else { return }
         await backend.unload()
+        guard !Task.isCancelled else { return }
         await MainActor.run { [weak self] in
           self?.cachedReadiness = .notReady
         }

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -45,6 +45,17 @@ import Foundation
 // `KernelDictationDriverFactory` still constructs only `ParakeetEngineAdapter`
 // (Rung 4 will add the factory branch); `WhisperKitPipeline.swift` still owns
 // every WhisperKit recording in production (Rung 5 cutover deletes it).
+//
+// TODO(#827 Rung 5 cutover): the Codex code-diff review of this rung flagged a
+// pre-roll coordinate-space concern — if the kernel feeds pre-roll buffers
+// through `acceptAudio` before / after the kernel's `captureResult.samples`
+// origin, the segment offsets the kernel computes from `captureResult.samples`
+// would not align with this adapter's `retainedPCM`. Rung 3 ships
+// production-unwired (zero kernel callers), so the bug cannot fire today; the
+// Rung 5 plan MUST verify the kernel's `acceptAudio` feed and
+// `observeSpeechSegments` segment-source share the same coordinate origin,
+// translate offsets if not, and cover the case with a 5-language Live UAT
+// matrix run on a real Mac.
 
 /// The kernel-facing `ASREngineAdapter` conformer for WhisperKit. Drives the
 /// underlying WhisperKit actor through a local `package` protocol seam
@@ -115,6 +126,21 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// filter LID audio to voiced-only ranges. Cleared on `cancel()` /
   /// `beginSession()` and after `finalize()` commits.
   private var observedSpeechSegments: [SpeechSegment] = []
+
+  /// True once `observeSpeechSegments(_:)` has been called this session.
+  /// Disambiguates `observedSpeechSegments == []` between two semantically
+  /// distinct cases:
+  ///   1. VAD ran and confirmed no voiced segments → kernel calls
+  ///      `observeSpeechSegments([])` → adapter sees empty + flag true → no-speech
+  ///      gate fires → return `.empty(hadSpeechEvidence: false)`.
+  ///   2. VAD was unavailable (`VADSignalSource.speechEvidenceAtStop()` returned
+  ///      `.unavailable`, kernel intentionally skips the no-speech gate) →
+  ///      kernel calls `observeSpeechSegments([])` with raw-fallback samples →
+  ///      adapter must fail toward visibility (run ASR anyway) just like the
+  ///      legacy pipeline's `hasSpeechEvidence(vadSegments: nil) -> true`
+  ///      branch at `WhisperKitPipeline.swift:683-688`.
+  /// Cleared on `beginSession()` and `cancel()`.
+  private var hasReceivedSpeechSegmentSignal = false
 
   /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
   /// (300 s * 16 kHz = 4.8 M Float = ~19 MB). Mirrors Parakeet's cap so the
@@ -275,6 +301,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
+    hasReceivedSpeechSegmentSignal = false
 
     // Cancel any pending model-unload timer a prior session armed. Rung 2B's
     // kernel `cancelPendingUnload` hook already fires synchronously before
@@ -335,6 +362,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// decoder actually sees.
   func observeSpeechSegments(_ segments: [SpeechSegment]) {
     observedSpeechSegments = segments
+    hasReceivedSpeechSegmentSignal = true
   }
 
   /// Finalize: LID → transcribe with `clipTimestamps` derived from observed
@@ -355,14 +383,29 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     }
     let session = sessionID
 
-    // No-speech gate: matches `WhisperKitPipeline.swift:694-718`. In the
-    // kernel-driven model the kernel ALWAYS calls `observeSpeechSegments`
-    // before `finalize`, so an empty array IS the "kernel computed no
-    // voiced segments" signal — pass it directly (not nil, which would
-    // default to true / "no detector available, fail toward visibility").
-    let hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
-      vadSegments: observedSpeechSegments
-    )
+    // No-speech gate: matches `WhisperKitPipeline.swift:694-718`. Two
+    // ambiguity cases for `observedSpeechSegments == []`:
+    //   (a) VAD ran, found no voiced ranges → kernel calls
+    //       `observeSpeechSegments([])` (`hasReceivedSpeechSegmentSignal ==
+    //       true`) → confirmed no speech → return `.empty(false)`.
+    //   (b) VAD was unavailable (`VADSignalSource.speechEvidenceAtStop()`
+    //       returned `.unavailable`, kernel skips the call) →
+    //       `hasReceivedSpeechSegmentSignal == false` → fail toward
+    //       visibility, run ASR (legacy pipeline's `hasSpeechEvidence(
+    //       vadSegments: nil) -> true` branch at
+    //       `WhisperKitPipeline.swift:683-688`). Codex code-diff defect 2.
+    let hasSpeechEvidence: Bool
+    if hasReceivedSpeechSegmentSignal {
+      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
+        vadSegments: observedSpeechSegments
+      )
+    } else {
+      // Kernel did not call `observeSpeechSegments` this session — treat
+      // as VAD-unavailable, fail toward visibility.
+      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
+        vadSegments: nil
+      )
+    }
     let minimumSamples = AudioConstants.minimumTranscriptionSamples
     let rawSamples = retainedPCM
 
@@ -371,11 +414,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
         await worker.cancel()
         incrementalWorker = nil
       }
-      // Stale-cancel guard.
+      // Stale-cancel guard: a `cancel()` + new `beginSession()` during the
+      // worker.cancel() await must NOT clobber session B's fresh state.
+      // Just return on session mismatch (Codex code-diff defect 3).
       guard sessionID == session, !isCancelled else {
-        isTerminal = true
-        retainedPCM.removeAll()
-        observedSpeechSegments.removeAll()
         return isCancelled ? .cancelled : .empty(hadSpeechEvidence: false)
       }
       var diagnostics = KernelASRAdapterDiagnostics()
@@ -447,12 +489,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       clipKind: clipKind
     )
 
-    // Stale-cancel guard before mutating LID-derived state.
+    // Stale-cancel guard before mutating LID-derived state. Just return on
+    // session mismatch — `beginSession(B)` already reset adapter state for
+    // session B; this stale finalize for session A must NOT clobber B's
+    // PCM/segments/terminal flag (Codex code-diff defect 3).
     guard sessionID == session, !isCancelled else {
-      isTerminal = true
-      retainedPCM.removeAll()
-      observedSpeechSegments.removeAll()
-      return .cancelled
+      return isCancelled ? .cancelled : .empty(hadSpeechEvidence: false)
     }
     lastLanguageDetection = lidResult
     if let lang = lidResult.lang, !lidResult.abstained {
@@ -633,9 +675,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
 
     // Stale-finalize guard: a `cancel()` + new `beginSession()` during the
     // ASR await must not let this stale finalize clobber the fresh session's
-    // state (mirrors `ParakeetEngineAdapter.swift:271-273`).
+    // state — including `lastASRDiagnostics` (mirrors
+    // `ParakeetEngineAdapter.swift:271-273`). Just return on mismatch
+    // (Codex code-diff defect 3).
     guard sessionID == session, !isCancelled else {
-      lastASRDiagnostics = diagnostics
       return isCancelled
         ? .cancelled
         : .empty(hadSpeechEvidence: true)
@@ -694,6 +737,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastLanguageDetection = nil
     retainedPCM.removeAll()
     observedSpeechSegments.removeAll()
+    hasReceivedSpeechSegmentSignal = false
     prepareTask?.cancel()
     prepareTask = nil
     modelUnloadTask?.cancel()

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -221,46 +221,28 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     }
   }
 
-  /// Cache-only warm-up — mirrors `WhisperKitPipeline.prepareBackendSilently`.
-  /// `WhisperKitBackend.prepareIfCached()` performs the full cached CoreML
-  /// `loadFromPath` when the cache hits, so it is NOT a cheap probe. The
-  /// kernel's `preWarm()` awaits this hook before sending `.toggleRecording`,
-  /// so running the load synchronously here would block the PTT critical
-  /// path (Codex code-diff r4 defect 2). Fire-and-forget the cached load on
-  /// a detached `Task` instead — the kernel's spawned `warmUp()` path
-  /// already covers the heavy-load case on user intent, and a cache hit
-  /// here lets a subsequent press skip the load. Returns immediately;
-  /// never throws to the caller.
+  /// Cache-only warm-up — intentionally a near no-op for WhisperKit.
+  ///
+  /// Earlier drafts dispatched `prepareIfCached()` here on a detached `Task`
+  /// to silently load a cached model during the kernel's `preWarm` hop. But
+  /// `WhisperKitBackend.prepareIfCached()` does NOT participate in
+  /// `prepare()`'s `loadTask` single-flight guard at
+  /// `WhisperKitBackend.swift:61-97` — so a detached `prepareIfCached` racing
+  /// the kernel's spawned `warmUp()` (which calls `prepare()`) can launch
+  /// two concurrent CoreML loads, doubling cold-start work and memory
+  /// pressure (Codex code-diff r5).
+  ///
+  /// In the kernel-driven flow, the kernel's spawned `warmUp()` path
+  /// already calls `prepare()`, which internally checks
+  /// `WhisperKitSetupService.getLocalModelPath` and loads from cache when
+  /// the model is cached. So no `warmUpFromCache` work is needed here —
+  /// the cached-load optimization is preserved by `prepare()`'s own cache
+  /// branch, and the single-flight guard prevents duplicate loads.
+  ///
+  /// Side effect: keep `cachedReadiness` refreshed against the backend's
+  /// current state so a recently-unloaded model is reported as `.notReady`.
   func warmUpFromCache() async throws {
-    if await backend.isReady {
-      cachedReadiness = .ready
-      return
-    }
-    let captured = backend
-    Task {
-      do {
-        let loaded = try await captured.prepareIfCached()
-        if loaded {
-          await MainActor.run { [weak self] in
-            self?.cachedReadiness = .ready
-          }
-          await AppLogger.shared.log(
-            "WhisperKit model pre-loaded successfully (background)",
-            level: .info, category: "WhisperKitEngineAdapter"
-          )
-        } else {
-          await AppLogger.shared.log(
-            "WhisperKit model not cached, skipping silent pre-load",
-            level: .info, category: "WhisperKitEngineAdapter"
-          )
-        }
-      } catch {
-        await AppLogger.shared.log(
-          "WhisperKit model pre-load failed: \(error.localizedDescription)",
-          level: .info, category: "WhisperKitEngineAdapter"
-        )
-      }
-    }
+    cachedReadiness = await backend.isReady ? .ready : .notReady
   }
 
   /// WhisperKit / CoreML exposes no model-load progress signal. The kernel

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -127,21 +127,6 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// `beginSession()` and after `finalize()` commits.
   private var observedSpeechSegments: [SpeechSegment] = []
 
-  /// True once `observeSpeechSegments(_:)` has been called this session.
-  /// Disambiguates `observedSpeechSegments == []` between two semantically
-  /// distinct cases:
-  ///   1. VAD ran and confirmed no voiced segments → kernel calls
-  ///      `observeSpeechSegments([])` → adapter sees empty + flag true → no-speech
-  ///      gate fires → return `.empty(hadSpeechEvidence: false)`.
-  ///   2. VAD was unavailable (`VADSignalSource.speechEvidenceAtStop()` returned
-  ///      `.unavailable`, kernel intentionally skips the no-speech gate) →
-  ///      kernel calls `observeSpeechSegments([])` with raw-fallback samples →
-  ///      adapter must fail toward visibility (run ASR anyway) just like the
-  ///      legacy pipeline's `hasSpeechEvidence(vadSegments: nil) -> true`
-  ///      branch at `WhisperKitPipeline.swift:683-688`.
-  /// Cleared on `beginSession()` and `cancel()`.
-  private var hasReceivedSpeechSegmentSignal = false
-
   /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
   /// (300 s * 16 kHz = 4.8 M Float = ~19 MB). Mirrors Parakeet's cap so the
   /// two engines size memory the same way. On reaching the cap the
@@ -301,7 +286,6 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
-    hasReceivedSpeechSegmentSignal = false
 
     // Cancel any pending model-unload timer a prior session armed. Rung 2B's
     // kernel `cancelPendingUnload` hook already fires synchronously before
@@ -362,7 +346,6 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// decoder actually sees.
   func observeSpeechSegments(_ segments: [SpeechSegment]) {
     observedSpeechSegments = segments
-    hasReceivedSpeechSegmentSignal = true
   }
 
   /// Finalize: LID → transcribe with `clipTimestamps` derived from observed
@@ -383,51 +366,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     }
     let session = sessionID
 
-    // No-speech gate: matches `WhisperKitPipeline.swift:694-718`. Two
-    // ambiguity cases for `observedSpeechSegments == []`:
-    //   (a) VAD ran, found no voiced ranges → kernel calls
-    //       `observeSpeechSegments([])` (`hasReceivedSpeechSegmentSignal ==
-    //       true`) → confirmed no speech → return `.empty(false)`.
-    //   (b) VAD was unavailable (`VADSignalSource.speechEvidenceAtStop()`
-    //       returned `.unavailable`, kernel skips the call) →
-    //       `hasReceivedSpeechSegmentSignal == false` → fail toward
-    //       visibility, run ASR (legacy pipeline's `hasSpeechEvidence(
-    //       vadSegments: nil) -> true` branch at
-    //       `WhisperKitPipeline.swift:683-688`). Codex code-diff defect 2.
-    let hasSpeechEvidence: Bool
-    if hasReceivedSpeechSegmentSignal {
-      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
-        vadSegments: observedSpeechSegments
-      )
-    } else {
-      // Kernel did not call `observeSpeechSegments` this session — treat
-      // as VAD-unavailable, fail toward visibility.
-      hasSpeechEvidence = WhisperKitPipelineSpeechRouting.hasSpeechEvidence(
-        vadSegments: nil
-      )
-    }
+    // No-speech gating is kernel-owned in the new model
+    // (`RecordingSessionKernel.swift:974-1059` returns early for
+    // `VADSignalSource.speechEvidenceAtStop() == .confirmedNoSpeech` BEFORE
+    // calling `adapter.finalize`). The kernel calls `observeSpeechSegments`
+    // with an empty array in both the `.confirmedSpeech` + (vad found no
+    // ranges) AND the `.unavailable` cases, so the adapter cannot
+    // disambiguate them from `observedSpeechSegments == []` alone. Trust the
+    // kernel: if we reached finalize, ASR runs. Empty segments simply mean
+    // "no `clipTimestamps` to thread into decode" (Codex code-diff r2
+    // defect 1). The legacy pipeline's own no-speech gate at
+    // `WhisperKitPipeline.swift:694-718` was a pipeline-level defense; in
+    // the kernel-driven model the kernel owns that gate.
     let minimumSamples = AudioConstants.minimumTranscriptionSamples
     let rawSamples = retainedPCM
-
-    if !hasSpeechEvidence {
-      if let worker = incrementalWorker {
-        await worker.cancel()
-        incrementalWorker = nil
-      }
-      // Stale-cancel guard: a `cancel()` + new `beginSession()` during the
-      // worker.cancel() await must NOT clobber session B's fresh state.
-      // Just return on session mismatch (Codex code-diff defect 3).
-      guard sessionID == session, !isCancelled else {
-        return isCancelled ? .cancelled : .empty(hadSpeechEvidence: false)
-      }
-      var diagnostics = KernelASRAdapterDiagnostics()
-      diagnostics.rawSampleCount = rawSamples.count
-      lastASRDiagnostics = diagnostics
-      isTerminal = true
-      retainedPCM.removeAll()
-      observedSpeechSegments.removeAll()
-      return .empty(hadSpeechEvidence: false)
-    }
 
     // Sample shaping for LID + ASR. ASR runs over raw retained PCM (padded);
     // LID runs over voiced-only audio (with raw fallback if voiced is too short).
@@ -555,9 +507,22 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     let asrStart = CFAbsoluteTimeGetCurrent()
 
     if let worker = incrementalWorker {
-      let workerResult = await worker.finalize(
+      // Snapshot the worker handle for THIS session — if session B starts
+      // while this await is suspended, `incrementalWorker` may already point
+      // at B's worker. Clear only the captured handle on the post-await
+      // session-match path (Codex code-diff r2 defect 2).
+      let capturedWorker = worker
+      let workerResult = await capturedWorker.finalize(
         finalSamples: rawSamples, speechSegments: speechSegments)
-      incrementalWorker = nil
+      if sessionID == session, !isCancelled {
+        // Only A's worker handle can be cleared. If session B is now
+        // current, its worker stays installed.
+        if (incrementalWorker as AnyObject?) === (capturedWorker as AnyObject) {
+          incrementalWorker = nil
+        }
+      } else {
+        return isCancelled ? .cancelled : .empty(hadSpeechEvidence: true)
+      }
       diagnostics.incrementalAccepted = workerResult.accepted
       diagnostics.incrementalResultChars =
         workerResult.text?.trimmingCharacters(in: .whitespacesAndNewlines).count
@@ -605,6 +570,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
           lidWindowCount: lidWindowCount,
           clipKind: clipKind
         )
+        // Stale guard immediately after the decode await — a stale
+        // failure/cancel from session A MUST NOT clobber session B's
+        // state (Codex code-diff r2 defect 3).
+        guard sessionID == session, !isCancelled else {
+          return isCancelled ? .cancelled : .empty(hadSpeechEvidence: true)
+        }
         switch batchOutcome {
         case .success(let result):
           let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -641,6 +612,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
         lidWindowCount: lidWindowCount,
         clipKind: clipKind
       )
+      // Stale guard immediately after the decode await — a stale
+      // failure/cancel from session A MUST NOT clobber session B's
+      // state (Codex code-diff r2 defect 3).
+      guard sessionID == session, !isCancelled else {
+        return isCancelled ? .cancelled : .empty(hadSpeechEvidence: true)
+      }
       switch batchOutcome {
       case .success(let result):
         let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -737,7 +714,6 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastLanguageDetection = nil
     retainedPCM.removeAll()
     observedSpeechSegments.removeAll()
-    hasReceivedSpeechSegmentSignal = false
     prepareTask?.cancel()
     prepareTask = nil
     modelUnloadTask?.cancel()

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -1,25 +1,55 @@
 import Foundation
 import Testing
 
-// MARK: - EngineIdentityFreezeTests (epic #827, PR-5 Rung 1)
+// MARK: - EngineIdentityFreezeTests (epic #827, PR-5 Rung 1 + Rung 3)
 //
-// Source-level guard that the four kernel-side production sites never
-// reintroduce a `.parakeet` engine-identity literal and (where they own an
-// adapter reference) continue to read identity via `adapter.engineIdentity`.
-// The runtime sentinel in `EngineIdentityPropagationTests` covers the
+// Source-level guard that the kernel-side production sites never reintroduce
+// a hard-coded engine-identity literal and (where they own an adapter
+// reference) continue to read identity via `adapter.engineIdentity`. The
+// runtime sentinel in `EngineIdentityPropagationTests` covers the
 // natural-flow plumbing; this freeze test catches a future refactor that
-// accidentally hard-codes the first engine again at the source level — a
-// `.parakeet` literal compiles fine and would pass type-checking.
+// accidentally hard-codes an engine again at the source level — a `.parakeet`
+// or `.whisperKit` literal compiles fine and would pass type-checking.
+//
+// Rung 3 (#827) extended the scan: both engine literals are banned at every
+// reader site, and `KernelLifecycleTelemetrySink` is added to the reader-site
+// list (it became an identity reader once Rung 2A wired it through
+// `adapter.engineIdentity`).
 
 @Suite struct EngineIdentityFreezeTests {
 
   /// Matches the `.parakeet` enum-case literal (leading dot, identifier
   /// boundary trailing). Does NOT match `Parakeet` (capitalized engine name)
   /// nor `ParakeetEngineAdapter` (the concrete type name).
-  private static let bannedIdentityLiteral = #"\.parakeet\b"#
+  private static let bannedParakeetLiteral = #"\.parakeet\b"#
 
-  /// Sites that must read identity from the adapter and must not carry the
-  /// banned literal.
+  /// Matches the `.whisperKit` enum-case literal. Does NOT match
+  /// `WhisperKit` (capitalized engine name) nor `WhisperKitEngineAdapter` /
+  /// `WhisperKitBackend` type names.
+  private static let bannedWhisperKitLiteral = #"\.whisperKit\b"#
+
+  /// All banned engine-identity literals — both must be absent at every
+  /// reader site (epic §3.4, PR-5 Rung 1 + Rung 3).
+  private static let bannedIdentityLiterals: [(name: String, pattern: String)] = [
+    ("parakeet", bannedParakeetLiteral),
+    ("whisperKit", bannedWhisperKitLiteral),
+  ]
+
+  /// Sites that must read identity from the adapter and must not carry any
+  /// banned literal. PR-5 Rung 3 widened the literal scan from `.parakeet`
+  /// only to `.parakeet` AND `.whisperKit` — both engines are now banned at
+  /// every reader site (epic §3.4: kernel never branches on engine identity).
+  ///
+  /// `KernelLifecycleTelemetrySink` is intentionally NOT in this list: it
+  /// receives `backend: ASRBackendType` via init (factory-sourced from
+  /// `adapter.engineIdentity.backendType`), so it doesn't reference
+  /// `adapter.engineIdentity` directly. It also carries one legitimate
+  /// `backend == .whisperKit` routing-policy switch at
+  /// `KernelLifecycleTelemetrySink.swift:399` (only emits the backend tag
+  /// in capture-failure extras for WhisperKit). That switch is pre-Rung-3
+  /// behavior unrelated to the kernel-side identity-reader contract this
+  /// freeze test guards; ideally it migrates to a capability flag, but
+  /// that's a separate refactor (epic backlog).
   private static let identityReaderSites = [
     "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift",
     "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift",
@@ -27,8 +57,8 @@ import Testing
   ]
 
   /// The observer file no longer holds an emitter default — it must never
-  /// reintroduce the `.parakeet` literal that previously seeded the default
-  /// emitter; callers pass an explicit emitter constructed from
+  /// reintroduce an engine-identity literal that previously seeded the
+  /// default emitter; callers pass an explicit emitter constructed from
   /// `adapter.engineIdentity.backendType`.
   private static let identityFreeSites = [
     "Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift"
@@ -46,80 +76,93 @@ import Testing
     }
   }
 
-  @Test("identity-reader sites carry no `.parakeet` literal")
+  @Test("identity-reader sites carry no banned engine-identity literal")
   func readerSitesHaveNoLiteral() throws {
     for relative in Self.identityReaderSites {
-      let violations = try Self.scanForLiteral(relative)
-      #expect(
-        violations.isEmpty,
-        """
-        \(relative) reintroduces `.parakeet` literal:
-        \(violations.joined(separator: "\n"))
-        Read identity from `adapter.engineIdentity` instead (epic §3.4, PR-5 Rung 1).
-        """)
+      for banned in Self.bannedIdentityLiterals {
+        let violations = try Self.scanForLiteral(relative, pattern: banned.pattern)
+        #expect(
+          violations.isEmpty,
+          """
+          \(relative) reintroduces `.\(banned.name)` literal:
+          \(violations.joined(separator: "\n"))
+          Read identity from `adapter.engineIdentity` instead (epic §3.4,
+          PR-5 Rung 1 + Rung 3).
+          """)
+      }
     }
   }
 
-  @Test("identity-free sites carry no `.parakeet` literal")
+  @Test("identity-free sites carry no banned engine-identity literal")
   func freeSitesHaveNoLiteral() throws {
     for relative in Self.identityFreeSites {
-      let violations = try Self.scanForLiteral(relative)
-      #expect(
-        violations.isEmpty,
-        """
-        \(relative) reintroduces `.parakeet` literal:
-        \(violations.joined(separator: "\n"))
-        This file must not declare a hard-coded engine-identity default
-        (PR-5 Rung 1 — emitter is caller-supplied).
-        """)
+      for banned in Self.bannedIdentityLiterals {
+        let violations = try Self.scanForLiteral(relative, pattern: banned.pattern)
+        #expect(
+          violations.isEmpty,
+          """
+          \(relative) reintroduces `.\(banned.name)` literal:
+          \(violations.joined(separator: "\n"))
+          This file must not declare a hard-coded engine-identity default
+          (PR-5 Rung 1 — emitter is caller-supplied).
+          """)
+      }
     }
   }
 
   // MARK: Adversarial — the scanner flags a regression
 
   @Test("a source line with `.parakeet` is flagged")
-  func adversarialRegressionFlagged() {
+  func adversarialParakeetRegressionFlagged() {
     let source = """
       let snapshot = KernelRecordingSnapshotTelemetry(
         backend: ASRBackendType.parakeet.rawValue,
-        audioRoute: route, wasStreaming: false,
-        startTime: Date(), durationMs: 0,
-        targetAppBundleID: nil)
+        audioRoute: route, wasStreaming: false)
       """
-    let regex = try? NSRegularExpression(pattern: Self.bannedIdentityLiteral)
-    var matches: [String] = []
-    for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated()
-    {
-      let text = String(line)
-      let ns = text as NSString
-      let range = NSRange(location: 0, length: ns.length)
-      if regex?.firstMatch(in: text, range: range) != nil {
-        matches.append("line \(idx + 1)")
-      }
-    }
-    #expect(!matches.isEmpty, "`.parakeet` literal must be flagged by the scanner")
+    #expect(
+      Self.regexFlags(source: source, pattern: Self.bannedParakeetLiteral),
+      "`.parakeet` literal must be flagged by the scanner")
   }
 
-  // MARK: Negative control — `Parakeet` engine-name references are not flagged
+  @Test("a source line with `.whisperKit` is flagged (PR-5 Rung 3 adversarial mirror)")
+  func adversarialWhisperKitRegressionFlagged() {
+    let source = """
+      let snapshot = KernelRecordingSnapshotTelemetry(
+        backend: ASRBackendType.whisperKit.rawValue,
+        audioRoute: route, wasStreaming: false)
+      """
+    #expect(
+      Self.regexFlags(source: source, pattern: Self.bannedWhisperKitLiteral),
+      "`.whisperKit` literal must be flagged by the scanner")
+  }
+
+  // MARK: Negative controls — capitalized engine-name references are not flagged
 
   @Test("`Parakeet`, `ParakeetEngineAdapter`, and `Parakeet v3` strings are not flagged")
-  func negativeControlEngineNamePasses() {
+  func negativeControlParakeetEngineNamePasses() {
     let source = """
       // 4. Parakeet adapter.
       let adapter = ParakeetEngineAdapter(asrManager: inputs.asrManager)
       // Display name "Parakeet v3" sourced from adapter.engineIdentity.displayName.
       """
-    let regex = try? NSRegularExpression(pattern: Self.bannedIdentityLiteral)
-    var matches: [String] = []
-    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
-      let text = String(line)
-      let ns = text as NSString
-      let range = NSRange(location: 0, length: ns.length)
-      if regex?.firstMatch(in: text, range: range) != nil {
-        matches.append(text)
-      }
-    }
-    #expect(matches.isEmpty, "capitalized `Parakeet` engine-name references must NOT be flagged")
+    #expect(
+      Self.regexFlags(source: source, pattern: Self.bannedParakeetLiteral) == false,
+      "capitalized `Parakeet` engine-name references must NOT be flagged")
+  }
+
+  @Test(
+    "`WhisperKit`, `WhisperKitEngineAdapter`, and `WhisperKitBackend` strings are not flagged (PR-5 Rung 3 negative control)"
+  )
+  func negativeControlWhisperKitEngineNamePasses() {
+    let source = """
+      // 5. WhisperKit adapter.
+      let adapter = WhisperKitEngineAdapter(backend: inputs.whisperKitBackend)
+      // The WhisperKit display name is sourced from adapter.engineIdentity.displayName.
+      // WhisperKitBackend lives in EnviousWisprASR; reach via the package seam.
+      """
+    #expect(
+      Self.regexFlags(source: source, pattern: Self.bannedWhisperKitLiteral) == false,
+      "capitalized `WhisperKit` engine-name references must NOT be flagged")
   }
 
   // MARK: PR-5 Rung 2A KernelFinalizationWiring takes the protocol type
@@ -140,7 +183,7 @@ import Testing
       """)
     let bannedLiteral = "ParakeetEngineAdapter"
     #expect(
-      !source.contains(bannedLiteral),
+      source.contains(bannedLiteral) == false,
       """
       \(relative) reintroduces the literal `\(bannedLiteral)`. The wiring's
       adapter parameter is `any ASREngineAdapter`; a type annotation, an
@@ -156,17 +199,6 @@ import Testing
     "production code calls the three optional adapter hooks only at the allowlisted sites"
   )
   func optionalAdapterHookCallersMatchAllowlist() throws {
-    // Allowlist (PR-5 Rung 2B #827). The kernel wires the three optional
-    // hooks at three lifecycle positions: `preWarm` awaits
-    // `warmUpFromCache` only (Codex code-diff r3 dropped the preWarm-side
-    // `cancelPendingUnload` to prevent an abandoned-preWarm timer leak);
-    // `runForwardPath` fires `cancelPendingUnload` pre-`beginSession` and
-    // `observeSpeechSegments` pre-finalize. The regex matches executable
-    // call syntax only (`adapter.<hook>(`) so protocol declarations and
-    // adapter overrides do not count — only kernel-side callers. Counts
-    // are tracked PER HOOK so a regression that removed one hook and added
-    // another would still fail (Codex code-diff r1 P3). The assertion is
-    // bidirectional: adding a new site OR removing an expected site fails.
     let hooks = ["warmUpFromCache", "cancelPendingUnload", "observeSpeechSegments"]
     let allowed: [String: [String: Int]] = [
       "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift": [
@@ -205,9 +237,6 @@ import Testing
         }
       }
     }
-    // Catch the case where an allowlisted file disappeared from `Sources/`
-    // entirely (rename / move) — the kernel call sites are required, not
-    // optional.
     for (relative, perHook) in allowed where !visited.contains(relative) {
       for (hook, allowedCount) in perHook {
         offenders.append(
@@ -233,9 +262,9 @@ import Testing
     return try String(contentsOf: url, encoding: .utf8)
   }
 
-  private static func scanForLiteral(_ relative: String) throws -> [String] {
+  private static func scanForLiteral(_ relative: String, pattern: String) throws -> [String] {
     let source = try readSource(relative)
-    guard let regex = try? NSRegularExpression(pattern: bannedIdentityLiteral) else { return [] }
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
     var violations: [String] = []
     for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated()
     {
@@ -247,6 +276,20 @@ import Testing
       }
     }
     return violations
+  }
+
+  /// Returns true iff the regex matches any line in `source`. Used by the
+  /// adversarial + negative-control tests so they share the scanner shape
+  /// rather than duplicating the regex loop.
+  private static func regexFlags(source: String, pattern: String) -> Bool {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+      let text = String(line)
+      let ns = text as NSString
+      let range = NSRange(location: 0, length: ns.length)
+      if regex.firstMatch(in: text, range: range) != nil { return true }
+    }
+    return false
   }
 
   /// Repo root, anchored off `#filePath` — this file lives at

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -1,0 +1,197 @@
+import EnviousWisprCore
+import Foundation
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprPipeline
+
+// MARK: - StubWhisperKitBackend (epic #827, PR-5 Rung 3 §11.2)
+//
+// Configurable test double for the `WhisperKitBackendDriving` actor-bound
+// protocol declared in `WhisperKitEngineAdapter.swift`. Lets
+// `WhisperKitEngineAdapterTests` drive the adapter without loading a real
+// WhisperKit model. The actor-bound seam means this stub must itself be an
+// `actor` (the protocol declares `: Actor`).
+//
+// Members mirror the protocol surface 1:1. Configurable behavior knobs +
+// observed counters follow the `StubParakeetASRManager` shape.
+
+actor StubWhisperKitBackend: WhisperKitBackendDriving {
+
+  // MARK: Configurable behavior
+
+  /// Drives the synchronous `readiness` cache in the adapter through the
+  /// protocol's `isReady` getter. The adapter refreshes `cachedReadiness`
+  /// from this value on every transition.
+  var isReady = false
+  var modelVariantName: String = "stub-whisperkit-large-v3"
+  var prepareThrows: (any Error)?
+  var prepareIfCachedThrows: (any Error)?
+  var prepareIfCachedResult: Bool = true
+  var transcribeThrows: (any Error)?
+  var transcribeResult: ASRResult = ASRResult(
+    text: "stub-transcribed",
+    language: "en",
+    duration: 1,
+    processingTime: 0.1,
+    backendType: .whisperKit
+  )
+  var observeLIDResult: LIDObservationBatch = .observations([])
+  /// When set, `makeIncrementalSession` returns this session; otherwise nil
+  /// (mirrors the "model not loaded" path).
+  var incrementalSessionFactory: (@Sendable () -> (any WhisperKitIncrementalSession)?)?
+
+  /// When set, `transcribe(...)` yields N times before returning — models a
+  /// decode suspended in WhisperKit while a new session begins.
+  var slowTranscribe = false
+
+  // MARK: Observed counters
+
+  var prepareCount = 0
+  var prepareIfCachedCount = 0
+  var transcribeCount = 0
+  var lastTranscribeSamples: [Float] = []
+  var lastTranscribeOptions: TranscriptionOptions = .default
+  var observeLIDCount = 0
+  var makeIncrementalSessionCount = 0
+  var unloadCount = 0
+
+  // MARK: Setters (callable from MainActor tests)
+
+  func setIsReady(_ v: Bool) { isReady = v }
+  func setTranscribeResult(_ v: ASRResult) { transcribeResult = v }
+  func setTranscribeThrows(_ v: (any Error)?) { transcribeThrows = v }
+  func setObserveLIDResult(_ v: LIDObservationBatch) { observeLIDResult = v }
+  func setIncrementalSessionFactory(
+    _ v: (@Sendable () -> (any WhisperKitIncrementalSession)?)?
+  ) {
+    incrementalSessionFactory = v
+  }
+  func setSlowTranscribe(_ v: Bool) { slowTranscribe = v }
+  func setPrepareIfCachedResult(_ v: Bool) { prepareIfCachedResult = v }
+  func setPrepareIfCachedThrows(_ v: (any Error)?) { prepareIfCachedThrows = v }
+  func setPrepareThrows(_ v: (any Error)?) { prepareThrows = v }
+
+  // MARK: WhisperKitBackendDriving
+
+  func prepare() async throws {
+    prepareCount += 1
+    if let err = prepareThrows { throw err }
+    isReady = true
+  }
+
+  func prepareIfCached() async throws -> Bool {
+    prepareIfCachedCount += 1
+    if let err = prepareIfCachedThrows { throw err }
+    if prepareIfCachedResult { isReady = true }
+    return prepareIfCachedResult
+  }
+
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws
+    -> ASRResult
+  {
+    transcribeCount += 1
+    lastTranscribeSamples = audioSamples
+    lastTranscribeOptions = options
+    if slowTranscribe {
+      for _ in 0..<200 { await Task.yield() }
+    }
+    if let err = transcribeThrows { throw err }
+    return transcribeResult
+  }
+
+  func observeLID(samples: [Float], maxWindows: Int) async -> LIDObservationBatch {
+    observeLIDCount += 1
+    return observeLIDResult
+  }
+
+  func makeIncrementalSession(options: TranscriptionOptions) async
+    -> (any WhisperKitIncrementalSession)?
+  {
+    makeIncrementalSessionCount += 1
+    return incrementalSessionFactory?()
+  }
+
+  func unload() async {
+    unloadCount += 1
+    isReady = false
+  }
+}
+
+// MARK: - StubIncrementalSession
+
+/// Configurable test double for `WhisperKitIncrementalSession`. The adapter
+/// holds a session as an existential; tests inject this stub via the
+/// backend's `incrementalSessionFactory` to control accepted-vs-rejected
+/// worker results.
+actor StubIncrementalSession: WhisperKitIncrementalSession {
+  var finalizeResult: IncrementalResult
+  var startCount = 0
+  var finalizeCount = 0
+  var cancelCount = 0
+  /// When set, `finalize(...)` yields N times before returning — models a
+  /// worker decode suspended while a new session begins.
+  var slowFinalize = false
+
+  init(result: IncrementalResult) {
+    self.finalizeResult = result
+  }
+
+  func setFinalizeResult(_ v: IncrementalResult) { finalizeResult = v }
+  func setSlowFinalize(_ v: Bool) { slowFinalize = v }
+
+  func start(
+    audioSamplesProvider: @Sendable @escaping () async -> (samples: [Float], count: Int)
+  ) async {
+    startCount += 1
+  }
+
+  func finalize(
+    finalSamples: [Float],
+    speechSegments: [SpeechSegment]
+  ) async -> IncrementalResult {
+    finalizeCount += 1
+    if slowFinalize {
+      for _ in 0..<200 { await Task.yield() }
+    }
+    return finalizeResult
+  }
+
+  func cancel() async {
+    cancelCount += 1
+  }
+}
+
+// MARK: - IncrementalResult convenience constructors
+
+extension IncrementalResult {
+  static func accepted(text: String, decodeCount: Int = 1) -> IncrementalResult {
+    IncrementalResult(
+      text: text,
+      samplesCovered: 16000,
+      decodeCount: decodeCount,
+      totalDecodeTimeMs: 100,
+      accepted: true,
+      mode: "stub-mode",
+      strategy: "stub-strategy",
+      tailDecodeMs: 0
+    )
+  }
+
+  static func rejected() -> IncrementalResult {
+    IncrementalResult(
+      text: nil,
+      samplesCovered: 0,
+      decodeCount: 0,
+      totalDecodeTimeMs: 0,
+      accepted: false,
+      mode: "stub-mode",
+      strategy: "stub-strategy",
+      tailDecodeMs: 0
+    )
+  }
+}
+
+enum StubBackendError: Error, Sendable {
+  case prepareFailed
+  case decodeFailed
+}

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterLastResultLifecycleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterLastResultLifecycleTests.swift
@@ -1,0 +1,141 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - WhisperKitEngineAdapterLastResultLifecycleTests (epic #827, PR-5 Rung 3 §11.2)
+//
+// Mirrors `ParakeetEngineAdapterLastResultLifecycleTests` against the
+// WhisperKit conformer using `StubWhisperKitBackend` (declared at the bottom
+// of `StubWhisperKitBackend.swift`). The adversarial empty-finalize test
+// exercises the .empty(hadSpeechEvidence: true) branch — the conformer's
+// most regression-prone path.
+
+@MainActor
+@Suite struct WhisperKitEngineAdapterLastResultLifecycleTests {
+
+  @Test("lastResult is nil after beginSession()")
+  func lastResultNilAfterBeginSession() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "first", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastResult != nil, "successful finalize set lastResult")
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    #expect(adapter.lastResult == nil)
+  }
+
+  @Test("lastResult is set after a successful .transcript finalize()")
+  func lastResultSetAfterSuccessfulFinalize() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "polished", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    let result = try #require(adapter.lastResult)
+    #expect(result.text == "polished")
+  }
+
+  @Test("lastResult is nil after cancel()")
+  func lastResultNilAfterCancel() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "done", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastResult != nil)
+    await adapter.cancel()
+    #expect(adapter.lastResult == nil, "cancel() must clear lastResult")
+  }
+
+  @Test("lastResult is NOT set on .empty / non-transcript finalize outcomes")
+  func lastResultNotSetOnEmptyFinalize() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(
+      adapter.lastResult == nil,
+      ".empty finalize must not write lastResult (no stale-success)")
+  }
+
+  @Test("lastResult is NOT set on .failed finalize outcomes")
+  func lastResultNotSetOnFailedFinalize() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeThrows(StubBackendError.decodeFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .failed = outcome else {
+      Issue.record("expected .failed, got \(outcome)")
+      return
+    }
+    #expect(adapter.lastResult == nil)
+  }
+
+  @Test("lastResult is NOT set on .cancelled finalize outcomes")
+  func lastResultNotSetOnCancelledFinalize() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    await adapter.cancel()
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastResult == nil)
+  }
+
+  // MARK: Helpers
+
+  private func feed(_ adapter: WhisperKitEngineAdapter, samples: [Float], session: SessionID) {
+    guard let buffer = FakeAudioCapture.makeBuffer(samples: samples) else {
+      Issue.record("failed to synthesize a test buffer")
+      return
+    }
+    adapter.acceptAudio(
+      AudioBufferHandoff(
+        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: session))
+  }
+
+  private func speechSamples(count: Int) -> [Float] {
+    (0..<count).map { _ in 0.1 }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -195,6 +195,48 @@ import Testing
     #expect(adapter.retainedPCMForTests.count == beforeRetainedCount)
   }
 
+  @Test(
+    "acceptAudio drops late buffers stamped with a prior session (Codex code-diff r3 defect 3, PR-1 §B.3 invariant 7)"
+  )
+  func acceptAudioDropsStaleSessionBuffers() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.1], session: sidA)
+    let sidB = SessionID()
+    try await adapter.beginSession(sidB, options: .default, streaming: false)
+    // Buffer stamped with the old (sidA) session arrives after the new
+    // beginSession — must be dropped, NOT appended to B's retainedPCM.
+    feed(adapter, samples: [0.9, 0.9, 0.9], session: sidA)
+    #expect(
+      adapter.retainedPCMForTests.isEmpty,
+      "stale buffer was appended to fresh session's retainedPCM")
+  }
+
+  @Test(
+    "beginSession cancels and drops any orphan incremental worker from a prior session (Codex r3 defect 2)"
+  )
+  func beginSessionCancelsOrphanWorker() async throws {
+    let backend = StubWhisperKitBackend()
+    let stubSession = StubIncrementalSession(result: .rejected())
+    await backend.setIncrementalSessionFactory({ stubSession })
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    // Session A: locked mode, worker is installed.
+    try await adapter.beginSession(
+      SessionID(), options: TranscriptionOptions(language: "en"), streaming: false)
+    let starts1 = await stubSession.startCount
+    #expect(starts1 == 1, "worker installed for session A")
+    // Session B: auto mode, no factory provided this time. The orphan must
+    // be cancelled and dropped so auto mode does NOT enter the worker path.
+    await backend.setIncrementalSessionFactory(nil)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    // Yield so the detached worker.cancel() task runs.
+    for _ in 0..<10 { await Task.yield() }
+    let cancels = await stubSession.cancelCount
+    #expect(cancels == 1, "orphan worker must be cancelled on beginSession")
+  }
+
   @Test("acceptAudio is bounded by retainedPCMCap")
   func acceptAudioCappedAtMaxRecording() async throws {
     let backend = StubWhisperKitBackend()

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -226,20 +226,47 @@ import Testing
 
   // MARK: Finalize — core paths
 
-  @Test("finalize with no observed segments returns .empty(hadSpeechEvidence: false)")
-  func finalizeNoSpeechReturnsEmptyFalse() async throws {
+  @Test("finalize with observed-empty segments (VAD confirmed no speech) returns .empty(false)")
+  func finalizeVADConfirmedNoSpeechReturnsEmptyFalse() async throws {
     let backend = StubWhisperKitBackend()
     let adapter = WhisperKitEngineAdapter(backend: backend)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: [0.1, 0.2], session: sid)
-    // No `observeSpeechSegments` call — adapter sees empty segments.
+    // Kernel explicitly signals "VAD ran, found no voiced ranges".
+    adapter.observeSpeechSegments([])
     let outcome = await adapter.finalize(batchSamples: nil)
     guard case .empty(let hadSpeechEvidence) = outcome else {
       Issue.record("expected .empty, got \(outcome)")
       return
     }
     #expect(hadSpeechEvidence == false)
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 0, "no transcribe runs when VAD confirmed no speech")
+  }
+
+  @Test(
+    "finalize WITHOUT observeSpeechSegments runs ASR (VAD-unavailable fail-toward-visibility, Codex code-diff defect 2)"
+  )
+  func finalizeWithoutSegmentSignalFailsTowardVisibility() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "recovered", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    // Deliberately skip observeSpeechSegments — simulates VAD-unavailable
+    // (legacy `WhisperKitPipeline.swift:683-688` `hasSpeechEvidence(vadSegments:
+    // nil) -> true` branch).
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript (fail toward visibility), got \(outcome)")
+      return
+    }
+    #expect(result.text == "recovered")
   }
 
   @Test("finalize with segments + non-empty decode returns .transcript and sets lastResult")
@@ -605,6 +632,53 @@ import Testing
     #expect(
       adapter.lastResult == nil,
       "stale finalize must skip post-await mutations; session B's lastResult stays clean")
+  }
+
+  @Test(
+    "staleFinalize must NOT clear session B's PCM/segments (Codex code-diff defect 3)"
+  )
+  func staleFinalizeMustNotClearFreshSessionState() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setSlowTranscribe(true)
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "stale-text", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    async let outcomeA = adapter.finalize(batchSamples: nil)
+    // Wait for finalize to reach transcribe.
+    var entered = false
+    for _ in 0..<200 {
+      let count = await backend.transcribeCount
+      if count == 1 {
+        entered = true
+        break
+      }
+      await Task.yield()
+    }
+    #expect(entered, "finalize did not reach backend.transcribe within 200 yields")
+    // Session B begins, feeds fresh audio + segments.
+    let sidB = SessionID()
+    try await adapter.beginSession(sidB, options: .default, streaming: false)
+    let freshSamples: [Float] = [Float](repeating: 0.42, count: 16_000)
+    feed(adapter, samples: freshSamples, session: sidB)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 8_000)])
+    // The stale finalize resolves while session B is mid-flight.
+    _ = await outcomeA
+    // Session B's PCM and segments must remain intact — the stale guard must
+    // only return, not mutate fresh state.
+    #expect(
+      adapter.retainedPCMForTests == freshSamples, "session B's PCM was cleared by stale finalize")
+    #expect(
+      adapter.observedSpeechSegmentsForTests.count == 1,
+      "session B's observed segments were cleared by stale finalize")
+    #expect(
+      adapter.observedSpeechSegmentsForTests.first?.endSample == 8_000,
+      "session B's segment payload was mutated by stale finalize")
   }
 
   // MARK: Cleanup

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -106,53 +106,40 @@ import Testing
   }
 
   @Test(
-    "warmUpFromCache() returns immediately and loads the cached model on a detached Task (Codex r4 defect 2)"
+    "warmUpFromCache() does NOT call prepareIfCached (avoids load-race with prepare(), Codex r5)"
   )
-  func warmUpFromCacheHit() async throws {
+  func warmUpFromCacheDoesNotTriggerLoad() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setPrepareIfCachedResult(true)
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUpFromCache()
-    // Caller's await returns BEFORE the detached load completes — readiness
-    // is still .notReady right after. Poll until the detached Task lands
-    // (signal-based wait, no arbitrary timeout).
-    var loaded = false
-    for _ in 0..<200 {
-      if adapter.readiness == .ready {
-        loaded = true
-        break
-      }
-      await Task.yield()
-    }
-    #expect(loaded, "detached cache-only warm-up never completed")
+    // Give any putative background task a chance to run.
+    for _ in 0..<50 { await Task.yield() }
+    let pifCount = await backend.prepareIfCachedCount
+    let prepareCount = await backend.prepareCount
+    #expect(pifCount == 0, "warmUpFromCache must NOT call prepareIfCached")
+    #expect(prepareCount == 0, "warmUpFromCache must NOT call prepare")
   }
 
-  @Test("warmUpFromCache() swallows throws (limb-style) and never blocks the caller")
-  func warmUpFromCacheSwallowsErrors() async throws {
+  @Test("warmUpFromCache() refreshes cachedReadiness from the backend state")
+  func warmUpFromCacheRefreshesCachedReadiness() async throws {
     let backend = StubWhisperKitBackend()
-    await backend.setPrepareIfCachedThrows(StubBackendError.prepareFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    // Backend is not ready → cachedReadiness stays .notReady.
+    try await adapter.warmUpFromCache()
+    #expect(adapter.readiness == .notReady)
+    // Backend flips ready (simulating a prior `warmUp()` that completed) →
+    // the next warmUpFromCache call observes and reports .ready.
+    await backend.setIsReady(true)
+    try await adapter.warmUpFromCache()
+    #expect(adapter.readiness == .ready)
+  }
+
+  @Test("warmUpFromCache() never throws (limb-style)")
+  func warmUpFromCacheNeverThrows() async throws {
+    let backend = StubWhisperKitBackend()
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUpFromCache()  // must not throw
-    // Yield so the detached error log fires, then confirm readiness stayed
-    // notReady (no fake-ready on a failed cache load).
-    for _ in 0..<50 { await Task.yield() }
-    #expect(adapter.readiness == .notReady)
-  }
-
-  @Test(
-    "warmUpFromCache() returns synchronously — does NOT block the PTT preWarm critical path"
-  )
-  func warmUpFromCacheDoesNotBlockCaller() async throws {
-    let backend = StubWhisperKitBackend()
-    await backend.setPrepareIfCachedResult(true)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
-    // Caller's await must return before `prepareIfCached` is even called
-    // on the backend (the load is fully detached).
-    try await adapter.warmUpFromCache()
-    let countImmediatelyAfter = await backend.prepareIfCachedCount
-    // Either the detached task hasn't run yet (count=0) OR it has (count=1).
-    // The key invariant: the caller did NOT have to await the load.
-    #expect(countImmediatelyAfter <= 1)
   }
 
   @Test("loadProgress returns nil (WhisperKit has no model-load signal)")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -226,29 +226,10 @@ import Testing
 
   // MARK: Finalize — core paths
 
-  @Test("finalize with observed-empty segments (VAD confirmed no speech) returns .empty(false)")
-  func finalizeVADConfirmedNoSpeechReturnsEmptyFalse() async throws {
-    let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
-    let sid = SessionID()
-    try await adapter.beginSession(sid, options: .default, streaming: false)
-    feed(adapter, samples: [0.1, 0.2], session: sid)
-    // Kernel explicitly signals "VAD ran, found no voiced ranges".
-    adapter.observeSpeechSegments([])
-    let outcome = await adapter.finalize(batchSamples: nil)
-    guard case .empty(let hadSpeechEvidence) = outcome else {
-      Issue.record("expected .empty, got \(outcome)")
-      return
-    }
-    #expect(hadSpeechEvidence == false)
-    let txCount = await backend.transcribeCount
-    #expect(txCount == 0, "no transcribe runs when VAD confirmed no speech")
-  }
-
   @Test(
-    "finalize WITHOUT observeSpeechSegments runs ASR (VAD-unavailable fail-toward-visibility, Codex code-diff defect 2)"
+    "finalize with empty observeSpeechSegments runs ASR — adapter trusts kernel-side no-speech gate (Codex r2 defect 1)"
   )
-  func finalizeWithoutSegmentSignalFailsTowardVisibility() async throws {
+  func finalizeEmptySegmentsRunsASRTrustingKernelGate() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setTranscribeResult(
       ASRResult(
@@ -258,12 +239,40 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
-    // Deliberately skip observeSpeechSegments — simulates VAD-unavailable
-    // (legacy `WhisperKitPipeline.swift:683-688` `hasSpeechEvidence(vadSegments:
-    // nil) -> true` branch).
+    // Kernel calls `observeSpeechSegments([])` in both
+    // VAD-confirmed-no-speech AND VAD-unavailable cases — adapter cannot
+    // disambiguate, so it trusts the kernel's own `.confirmedNoSpeech` gate
+    // (which would have early-returned before reaching `finalize`) and
+    // ALWAYS runs ASR. Empty segments simply means "no clipTimestamps".
+    adapter.observeSpeechSegments([])
     let outcome = await adapter.finalize(batchSamples: nil)
     guard case .transcript(let result) = outcome else {
-      Issue.record("expected .transcript (fail toward visibility), got \(outcome)")
+      Issue.record("expected .transcript (no adapter-side no-speech gate), got \(outcome)")
+      return
+    }
+    #expect(result.text == "recovered")
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 1, "ASR runs even with empty segments — kernel owns the gate")
+  }
+
+  @Test(
+    "finalize WITHOUT observeSpeechSegments runs ASR — adapter trusts kernel-side no-speech gate"
+  )
+  func finalizeNoSegmentSignalRunsASR() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "recovered", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    // Deliberately skip observeSpeechSegments — same semantic as empty
+    // segments in the kernel-driven model.
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
       return
     }
     #expect(result.text == "recovered")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -105,22 +105,54 @@ import Testing
     #expect(count == 0)
   }
 
-  @Test("warmUpFromCache() returns ready when cache hit")
+  @Test(
+    "warmUpFromCache() returns immediately and loads the cached model on a detached Task (Codex r4 defect 2)"
+  )
   func warmUpFromCacheHit() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setPrepareIfCachedResult(true)
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUpFromCache()
-    #expect(adapter.readiness == .ready)
+    // Caller's await returns BEFORE the detached load completes — readiness
+    // is still .notReady right after. Poll until the detached Task lands
+    // (signal-based wait, no arbitrary timeout).
+    var loaded = false
+    for _ in 0..<200 {
+      if adapter.readiness == .ready {
+        loaded = true
+        break
+      }
+      await Task.yield()
+    }
+    #expect(loaded, "detached cache-only warm-up never completed")
   }
 
-  @Test("warmUpFromCache() swallows throws (limb-style)")
+  @Test("warmUpFromCache() swallows throws (limb-style) and never blocks the caller")
   func warmUpFromCacheSwallowsErrors() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setPrepareIfCachedThrows(StubBackendError.prepareFailed)
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUpFromCache()  // must not throw
+    // Yield so the detached error log fires, then confirm readiness stayed
+    // notReady (no fake-ready on a failed cache load).
+    for _ in 0..<50 { await Task.yield() }
     #expect(adapter.readiness == .notReady)
+  }
+
+  @Test(
+    "warmUpFromCache() returns synchronously — does NOT block the PTT preWarm critical path"
+  )
+  func warmUpFromCacheDoesNotBlockCaller() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setPrepareIfCachedResult(true)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    // Caller's await must return before `prepareIfCached` is even called
+    // on the backend (the load is fully detached).
+    try await adapter.warmUpFromCache()
+    let countImmediatelyAfter = await backend.prepareIfCachedCount
+    // Either the detached task hasn't run yet (count=0) OR it has (count=1).
+    // The key invariant: the caller did NOT have to await the load.
+    #expect(countImmediatelyAfter <= 1)
   }
 
   @Test("loadProgress returns nil (WhisperKit has no model-load signal)")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1,0 +1,701 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - WhisperKitEngineAdapterTests (epic #827, PR-5 Rung 3 §11.2)
+//
+// Unit coverage for `WhisperKitEngineAdapter` — the production
+// `ASREngineAdapter` WhisperKit conformer. Drives a configurable
+// `StubWhisperKitBackend` (actor stub conforming to the local
+// `WhisperKitBackendDriving` seam) so no real WhisperKit model loads. The
+// PR-1 §B.2.2 MUST / MUST NOT clauses get adversarial coverage, and the
+// coordinate-space lesson (epic §0.5) is locked by `batchSamplesIgnored`.
+
+@MainActor
+@Suite struct WhisperKitEngineAdapterTests {
+
+  // MARK: Identity (PR-5 Rung 1)
+
+  @Test("engineIdentity: WhisperKit declares .whisperKit backend")
+  func engineIdentityBackend() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    #expect(adapter.engineIdentity.backendType == .whisperKit)
+    #expect(adapter.engineIdentity.rawValue == "whisperKit")
+  }
+
+  @Test("engineIdentity: WhisperKit displayName == WhisperKit")
+  func engineIdentityDisplayName() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    #expect(adapter.engineIdentity.displayName == "WhisperKit")
+  }
+
+  // MARK: Capabilities + readiness
+
+  @Test("capabilities: WhisperKit decodes batch-only and detects language")
+  func capabilities() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    #expect(adapter.capabilities.supportsStreaming == false)
+    #expect(adapter.capabilities.supportsLanguageDetection == true)
+  }
+
+  @Test("readiness transitions: init → notReady; warmUp → ready; cancel keeps notReady")
+  func cachedReadinessTransitions() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    #expect(adapter.readiness == .notReady)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    await adapter.cancel()
+    // Backend was set ready by `prepare()`; cancel only refreshes the cached
+    // value from the live backend, so `.ready` is retained when the backend
+    // says so. Adversarial path is `applyUnloadPolicy(.immediately)` below.
+    #expect(adapter.readiness == .ready)
+  }
+
+  @Test("readiness goes notReady after applyUnloadPolicy(.immediately) executes")
+  func cachedReadinessAfterImmediateUnload() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    adapter.applyUnloadPolicy(.immediately)
+    // Yield so the scheduled `Task` runs `backend.unload()` and posts back.
+    for _ in 0..<50 { await Task.yield() }
+    #expect(adapter.readiness == .notReady)
+    let unloadCount = await backend.unloadCount
+    #expect(unloadCount == 1)
+  }
+
+  @Test("readiness goes notReady when warmUp throws (failed prepare)")
+  func cachedReadinessAfterFailedPrepare() async {
+    let backend = StubWhisperKitBackend()
+    await backend.setPrepareThrows(StubBackendError.prepareFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    do {
+      try await adapter.warmUp()
+      Issue.record("expected throw")
+    } catch {
+      // expected
+    }
+    #expect(adapter.readiness == .notReady)
+  }
+
+  // MARK: warmUp
+
+  @Test("warmUp() loads when the backend is not ready")
+  func warmUpLoads() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    let count = await backend.prepareCount
+    #expect(count == 1)
+  }
+
+  @Test("warmUp() is a no-op when the backend is already ready")
+  func warmUpIdempotent() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setIsReady(true)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    let count = await backend.prepareCount
+    #expect(count == 0)
+  }
+
+  @Test("warmUpFromCache() returns ready when cache hit")
+  func warmUpFromCacheHit() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setPrepareIfCachedResult(true)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUpFromCache()
+    #expect(adapter.readiness == .ready)
+  }
+
+  @Test("warmUpFromCache() swallows throws (limb-style)")
+  func warmUpFromCacheSwallowsErrors() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setPrepareIfCachedThrows(StubBackendError.prepareFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUpFromCache()  // must not throw
+    #expect(adapter.readiness == .notReady)
+  }
+
+  @Test("loadProgress returns nil (WhisperKit has no model-load signal)")
+  func loadProgressIsNil() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    #expect(adapter.loadProgress == nil)
+  }
+
+  @Test("lastObservedPhase falls back to protocol default \"warmup\"")
+  func lastObservedPhaseDefault() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    #expect(adapter.lastObservedPhase == "warmup")
+  }
+
+  // MARK: Session lifecycle
+
+  @Test(".auto mode (language nil) does NOT start the incremental worker")
+  func autoModeSkipsWorker() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    let count = await backend.makeIncrementalSessionCount
+    #expect(count == 0)
+  }
+
+  @Test(".locked mode (language non-nil) starts the incremental worker")
+  func lockedModeStartsWorker() async throws {
+    let backend = StubWhisperKitBackend()
+    let stubSession = StubIncrementalSession(result: .rejected())
+    await backend.setIncrementalSessionFactory({ stubSession })
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let options = TranscriptionOptions(language: "en")
+    try await adapter.beginSession(SessionID(), options: options, streaming: false)
+    let count = await backend.makeIncrementalSessionCount
+    #expect(count == 1)
+    let starts = await stubSession.startCount
+    #expect(starts == 1)
+  }
+
+  @Test(
+    "beginSession clears lastResult, lastASRDiagnostics, lastFailureError, lastLanguageDetection, PCM, segments"
+  )
+  func beginSessionClearsState() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 1600)])
+    // Begin a fresh session — must clear everything.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    #expect(adapter.lastResult == nil)
+    #expect(adapter.lastASRDiagnostics == nil)
+    #expect(adapter.lastFailureError == nil)
+    #expect(adapter.lastLanguageDetection == nil)
+  }
+
+  // MARK: acceptAudio
+
+  @Test("acceptAudio after a terminal session is a no-op")
+  func acceptAudioAfterTerminalIsNoOp() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setObserveLIDResult(.unavailable)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1], session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 1600)])
+    _ = await adapter.finalize(batchSamples: nil)
+    let beforeRetainedCount = adapter.retainedPCMForTests.count
+    feed(adapter, samples: [0.9, 0.9, 0.9], session: sid)
+    #expect(adapter.retainedPCMForTests.count == beforeRetainedCount)
+  }
+
+  @Test("acceptAudio is bounded by retainedPCMCap")
+  func acceptAudioCappedAtMaxRecording() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    let cap = Int(TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
+    // Two oversize buffers — the second must be truncated to the cap.
+    let big = [Float](repeating: 0.1, count: cap - 100)
+    feed(adapter, samples: big, session: sid)
+    feed(adapter, samples: [Float](repeating: 0.2, count: 1_000), session: sid)
+    #expect(adapter.retainedPCMForTests.count == cap)
+  }
+
+  // MARK: observeSpeechSegments
+
+  @Test("observeSpeechSegments stores segments; cleared on beginSession and cancel")
+  func observeSpeechSegmentsLifecycle() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    let segments = [SpeechSegment(startSample: 0, endSample: 16_000)]
+    adapter.observeSpeechSegments(segments)
+    #expect(adapter.observedSpeechSegmentsForTests.count == 1)
+    await adapter.cancel()
+    #expect(adapter.observedSpeechSegmentsForTests.isEmpty)
+  }
+
+  // MARK: Finalize — core paths
+
+  @Test("finalize with no observed segments returns .empty(hadSpeechEvidence: false)")
+  func finalizeNoSpeechReturnsEmptyFalse() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.2], session: sid)
+    // No `observeSpeechSegments` call — adapter sees empty segments.
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty(let hadSpeechEvidence) = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(hadSpeechEvidence == false)
+  }
+
+  @Test("finalize with segments + non-empty decode returns .transcript and sets lastResult")
+  func finalizeSuccessSetsLastResult() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "hello world", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "hello world")
+    #expect(adapter.lastResult != nil)
+  }
+
+  @Test("finalize with segments + empty decode returns .empty(hadSpeechEvidence: true)")
+  func finalizeEmptyDecodeReturnsEmptyTrue() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "  ", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty(let hadSpeechEvidence) = outcome else {
+      Issue.record("expected .empty, got \(outcome)")
+      return
+    }
+    #expect(hadSpeechEvidence == true)
+  }
+
+  @Test(
+    "asrEmptyWithSpeechEvidenceExposesDiagnostics: lastASRDiagnostics survives finalize (council F4 / OQ-6)"
+  )
+  func asrEmptyWithSpeechEvidenceExposesDiagnostics() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    let samples = speechSamples(count: 16_000)
+    feed(adapter, samples: samples, session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty(let hadSpeechEvidence) = outcome, hadSpeechEvidence else {
+      Issue.record("expected .empty(hadSpeechEvidence: true), got \(outcome)")
+      return
+    }
+    let diagnostics = try #require(adapter.lastASRDiagnostics)
+    #expect(diagnostics.rawSampleCount == samples.count)
+  }
+
+  @Test("finalize after cancel() returns .cancelled (never partial text)")
+  func finalizeAfterCancelReturnsCancelled() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    await adapter.cancel()
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("finalize: backend throws CancellationError returns .cancelled")
+  func finalizeBackendCancellationReturnsCancelled() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeThrows(CancellationError())
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .cancelled = outcome else {
+      Issue.record("expected .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test(
+    "finalize: backend throws non-cancel error returns .failed(.decodeFailed) and sets lastFailureError"
+  )
+  func finalizeBackendErrorReturnsFailed() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeThrows(StubBackendError.decodeFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .failed(let kind) = outcome, case .decodeFailed = kind else {
+      Issue.record("expected .failed(.decodeFailed), got \(outcome)")
+      return
+    }
+    #expect(adapter.lastFailureError != nil)
+  }
+
+  // MARK: Finalize — LID
+
+  @Test("lidDetectedSetsLanguage: LID non-abstain sets decodeOptions.language before transcribe")
+  func lidDetectedSetsLanguage() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setObserveLIDResult(
+      .observations([
+        RawLIDObservation(argmaxLang: "es", logProb: -0.05),
+        RawLIDObservation(argmaxLang: "es", logProb: -0.05),
+      ]))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000 * 3), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000 * 3)])
+    _ = await adapter.finalize(batchSamples: nil)
+    let opts = await backend.lastTranscribeOptions
+    // LID confidence might still abstain depending on classifier thresholds;
+    // assert the lastLanguageDetection is set regardless and the language
+    // pinned to decodeOptions is non-nil iff LID accepted.
+    let lid = try #require(adapter.lastLanguageDetection)
+    if !lid.abstained, let lang = lid.lang {
+      #expect(opts.language == lang)
+    } else {
+      #expect(opts.language == nil)
+    }
+  }
+
+  @Test("lidAbstainedKeepsNilLanguage: abstaining LID nulls decodeOptions.language")
+  func lidAbstainedKeepsNilLanguage() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setObserveLIDResult(.error(reason: "all_windows_failed"))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    let opts = await backend.lastTranscribeOptions
+    #expect(opts.language == nil)
+  }
+
+  @Test(
+    "lastLanguageDetectionLifecycle: nil at init / beginSession; set after finalize; nil after cancel"
+  )
+  func lastLanguageDetectionLifecycle() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    #expect(adapter.lastLanguageDetection == nil)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    #expect(adapter.lastLanguageDetection == nil)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(adapter.lastLanguageDetection != nil)
+    await adapter.cancel()
+    #expect(adapter.lastLanguageDetection == nil)
+  }
+
+  // MARK: Finalize — incremental worker
+
+  @Test("workerAcceptedResultUsedDirectly: accepted worker result skips batch decode")
+  func workerAcceptedResultUsedDirectly() async throws {
+    let backend = StubWhisperKitBackend()
+    let stubSession = StubIncrementalSession(result: .accepted(text: "worker-text"))
+    await backend.setIncrementalSessionFactory({ stubSession })
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    let options = TranscriptionOptions(language: "en")
+    try await adapter.beginSession(sid, options: options, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "worker-text")
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 0, "accepted worker result skips batch decode")
+  }
+
+  @Test("workerRejectedFallsBackToBatch: rejected worker result triggers batch decode")
+  func workerRejectedFallsBackToBatch() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "batch-text", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let stubSession = StubIncrementalSession(result: .rejected())
+    await backend.setIncrementalSessionFactory({ stubSession })
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    let options = TranscriptionOptions(language: "en")
+    try await adapter.beginSession(sid, options: options, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "batch-text")
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 1)
+  }
+
+  @Test("workerNotStartedInAutoMode: .auto mode never creates a worker; finalize goes to batch")
+  func workerNotStartedInAutoMode() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "auto-batch", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .transcript = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    let mks = await backend.makeIncrementalSessionCount
+    #expect(mks == 0)
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 1)
+  }
+
+  // MARK: Finalize — coordinate space (council F1 / OQ-1)
+
+  @Test(
+    "batchSamplesIgnored: adapter passes its own retainedPCM-derived samples, not batchSamples (council F1 / OQ-1)"
+  )
+  func batchSamplesIgnored() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "decoded", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    let retained: [Float] = (0..<16_000).map { _ in 0.1 }
+    feed(adapter, samples: retained, session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    // Pass a distinct, easily-identifiable batchSamples — the WhisperKit
+    // adapter MUST ignore it and decode against `retainedPCM`.
+    let distinct: [Float] = [Float](repeating: 0.99, count: 16_000)
+    _ = await adapter.finalize(batchSamples: distinct)
+    let lastSamples = await backend.lastTranscribeSamples
+    // The adapter pads via `paddedASRSamples(rawSamples:)`; samples shorter
+    // than `minimumTranscriptionSamples` get zero-padded. 16_000 == minimum,
+    // so the passed-in payload is the retained PCM (all 0.1), not the 0.99
+    // distinct buffer.
+    #expect(lastSamples.first == Float(0.1))
+    #expect(lastSamples.contains(where: { $0 == Float(0.99) }) == false)
+  }
+
+  @Test(
+    "clipTimestampsDerivedFromObservedSegments: decodeOptions.speechSegments threaded from observe")
+  func clipTimestampsDerivedFromObservedSegments() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "ok", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    let segments = [
+      SpeechSegment(startSample: 0, endSample: 8_000),
+      SpeechSegment(startSample: 12_000, endSample: 16_000),
+    ]
+    adapter.observeSpeechSegments(segments)
+    _ = await adapter.finalize(batchSamples: nil)
+    let opts = await backend.lastTranscribeOptions
+    #expect(opts.speechSegments.count == 2)
+    #expect(opts.speechSegments[0].startSample == 0)
+    #expect(opts.speechSegments[0].endSample == 8_000)
+    #expect(opts.speechSegments[1].startSample == 12_000)
+    #expect(opts.speechSegments[1].endSample == 16_000)
+  }
+
+  // MARK: Adversarial / stale guards
+
+  @Test("cancelPendingUnload is idempotent — multiple calls do not crash")
+  func cancelPendingUnloadIdempotent() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    adapter.cancelPendingUnload()
+    adapter.cancelPendingUnload()
+    adapter.cancelPendingUnload()
+    // No crash, no observable effect — passes if it returns.
+  }
+
+  @Test(
+    "staleFeedDropped: a buffer fed after cancel + new beginSession does not appear in the fresh session's PCM"
+  )
+  func staleFeedDropped() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.1], session: sidA)
+    await adapter.cancel()
+    let sidB = SessionID()
+    try await adapter.beginSession(sidB, options: .default, streaming: false)
+    feed(adapter, samples: [0.2, 0.2], session: sidB)
+    let pcm = adapter.retainedPCMForTests
+    #expect(pcm == [Float(0.2), Float(0.2)])
+  }
+
+  @Test("staleFinalize: a stale finalize during a fresh session does not clobber lastResult")
+  func staleFinalizeGuard() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setSlowTranscribe(true)
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "stale-text", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    async let outcomeA = adapter.finalize(batchSamples: nil)
+    // Signal-based wait: poll the backend's transcribeCount until finalize
+    // has actually entered the slow transcribe path. Pure-yield racing is
+    // fragile — `async let` schedules finalize but doesn't guarantee it
+    // reaches the suspend point before the test's next await
+    // (~/.claude/rules/no-arbitrary-timeouts.md `prefer-signal-based-detection`).
+    var entered = false
+    for _ in 0..<200 {
+      let count = await backend.transcribeCount
+      if count == 1 {
+        entered = true
+        break
+      }
+      await Task.yield()
+    }
+    #expect(entered, "finalize did not reach backend.transcribe within 200 yields")
+    // Session B begins while A's finalize is still suspended in transcribe.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    _ = await outcomeA
+    #expect(
+      adapter.lastResult == nil,
+      "stale finalize must skip post-await mutations; session B's lastResult stays clean")
+  }
+
+  // MARK: Cleanup
+
+  @Test("applyUnloadPolicy(.never) schedules no unload task")
+  func applyUnloadPolicyNever() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    adapter.applyUnloadPolicy(.never)
+    for _ in 0..<50 { await Task.yield() }
+    let count = await backend.unloadCount
+    #expect(count == 0)
+  }
+
+  @Test("applyUnloadPolicy(.immediately) calls backend.unload()")
+  func applyUnloadPolicyImmediately() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    adapter.applyUnloadPolicy(.immediately)
+    for _ in 0..<50 { await Task.yield() }
+    let count = await backend.unloadCount
+    #expect(count == 1)
+  }
+
+  @Test("cancelPendingUnload cancels the in-flight modelUnloadTask")
+  func cancelPendingUnloadCancelsArmed() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    adapter.applyUnloadPolicy(.twoMinutes)
+    adapter.cancelPendingUnload()
+    for _ in 0..<50 { await Task.yield() }
+    let count = await backend.unloadCount
+    #expect(count == 0, "armed timer was cancelled before its deadline; no unload fired")
+  }
+
+  // MARK: Engine interruption hook
+
+  @Test("WhisperKit leaves onEngineInterrupted to the App router (settable but not auto-fired)")
+  func engineInterruptedCallbackOwnership() async throws {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    var fired = false
+    adapter.onEngineInterrupted = { fired = true }
+    #expect(fired == false)
+    // No mid-recording crash signal exists for WhisperKit today; the App
+    // layer's `handleASRServiceInterruption` (Rung 5) wires the callback.
+  }
+
+  // MARK: Production-unwired sanity
+
+  @Test("WhisperKitEngineAdapter exists at Sources/EnviousWisprPipeline/")
+  func productionFileExists() throws {
+    let path = "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift"
+    let url = repoRoot().appending(path: path)
+    #expect(FileManager.default.fileExists(atPath: url.path))
+  }
+
+  // MARK: Helpers
+
+  /// Feed one synthetic buffer stamped with `session` — the kernel always
+  /// hands the adapter buffers stamped with the begun session.
+  private func feed(_ adapter: WhisperKitEngineAdapter, samples: [Float], session: SessionID) {
+    guard let buffer = FakeAudioCapture.makeBuffer(samples: samples) else {
+      Issue.record("failed to synthesize a test buffer")
+      return
+    }
+    adapter.acceptAudio(
+      AudioBufferHandoff(
+        buffer: buffer, frameCount: samples.count, sequence: 1, sessionID: session))
+  }
+
+  /// 16 kHz mono Float32 samples with small non-zero amplitude (so VAD-derived
+  /// LID padded samples never collapse to silence padding).
+  private func speechSamples(count: Int) -> [Float] {
+    (0..<count).map { _ in 0.1 }
+  }
+
+  private func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}
+
+// MARK: - Test-only inspectors on the adapter
+
+extension WhisperKitEngineAdapter {
+  var retainedPCMForTests: [Float] { retainedPCMForUnitTests }
+  var observedSpeechSegmentsForTests: [SpeechSegment] { observedSpeechSegmentsForUnitTests }
+}

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -799,6 +799,142 @@ import Testing
     // layer's `handleASRServiceInterruption` (Rung 5) wires the callback.
   }
 
+  // MARK: Codex r7 matrix gap closure
+
+  @Test(
+    "finalize without an active session returns .empty(false) and never decodes (Codex r7 S0)"
+  )
+  func finalizeWithoutSessionShortCircuits() async {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty(let hadSpeechEvidence) = outcome, hadSpeechEvidence == false else {
+      Issue.record("expected .empty(false), got \(outcome)")
+      return
+    }
+    let txCount = await backend.transcribeCount
+    let observeCount = await backend.observeLIDCount
+    #expect(txCount == 0, "no transcribe runs without an active session")
+    #expect(observeCount == 0, "no LID runs without an active session")
+  }
+
+  @Test(
+    "finalize after a successful terminal finalize returns .empty(false) — no re-decode (Codex r7 S4)"
+  )
+  func finalizeAfterTerminalShortCircuits() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "first", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    let txCountAfterFirst = await backend.transcribeCount
+    // Second finalize on the same terminal session must short-circuit.
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .empty(let hadSpeechEvidence) = outcome, hadSpeechEvidence == false else {
+      Issue.record("expected .empty(false) on re-finalize, got \(outcome)")
+      return
+    }
+    let txCountAfterSecond = await backend.transcribeCount
+    #expect(
+      txCountAfterFirst == txCountAfterSecond,
+      "second finalize must NOT call transcribe again")
+  }
+
+  @Test(
+    "observeSpeechSegments is dropped after cancel and after a terminal finalize (Codex r7 S3/S4)"
+  )
+  func observeSpeechSegmentsDroppedAfterTerminal() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "done", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    // After terminal finalize, late observe must NOT repopulate.
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 99_999)])
+    #expect(
+      adapter.observedSpeechSegmentsForTests.isEmpty,
+      "post-terminal observeSpeechSegments must be a no-op")
+  }
+
+  @Test(
+    "observeSpeechSegments is dropped after cancel (Codex r7 S3)"
+  )
+  func observeSpeechSegmentsDroppedAfterCancel() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    await adapter.cancel()
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 99_999)])
+    #expect(
+      adapter.observedSpeechSegmentsForTests.isEmpty,
+      "post-cancel observeSpeechSegments must be a no-op")
+  }
+
+  @Test(
+    "observeSpeechSegments without a live session is dropped (Codex r7 S0)"
+  )
+  func observeSpeechSegmentsWithoutSessionIsDropped() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    #expect(
+      adapter.observedSpeechSegmentsForTests.isEmpty,
+      "observeSpeechSegments without a live session must be a no-op")
+  }
+
+  @Test(
+    "applyUnloadPolicy refuses to arm during an active session (Codex r7 S1)"
+  )
+  func applyUnloadPolicyRefusedDuringActiveSession() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    adapter.applyUnloadPolicy(.immediately)
+    // Yield so any putative unload task would have run.
+    for _ in 0..<50 { await Task.yield() }
+    let count = await backend.unloadCount
+    #expect(count == 0, "unload must NOT fire while a session is active")
+  }
+
+  @Test(
+    "applyUnloadPolicy armed under session A does NOT unload after beginSession(B) (Codex r7 S5)"
+  )
+  func applyUnloadPolicyArmedUnderADoesNotFireUnderB() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    // Drive A through to terminal (so applyUnloadPolicy may arm).
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "done", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+    // Now apply policy in the terminal A state — armed unload task starts.
+    adapter.applyUnloadPolicy(.immediately)
+    // Begin session B before the unload task hops back.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    // Yield so any putative unload task would have run.
+    for _ in 0..<50 { await Task.yield() }
+    let count = await backend.unloadCount
+    #expect(count == 0, "unload from A's armed task must NOT fire under B")
+  }
+
   // MARK: Production-unwired sanity
 
   @Test("WhisperKitEngineAdapter exists at Sources/EnviousWisprPipeline/")


### PR DESCRIPTION
## Summary

PR-5 Rung 3 of the engine-kernel refactor epic (#827). Builds `WhisperKitEngineAdapter` — the second production `ASREngineAdapter` conformer — production-unwired. The adapter wraps `WhisperKitBackend` + `LanguageDetector` + `WhisperKitIncrementalSession` and lifts the WhisperKit-engine-internal orchestration (LID, batch decode, incremental worker, observed-segment-derived `clipTimestamps`, model-unload policy) from `WhisperKitPipeline.swift`. The old pipeline file stays byte-identical in this rung; the factory site (Rung 4) and App-layer routing flip (Rung 5) come later.

## Key design choices

- **Coordinate-space carve-out** (epic §0.5 LESSON `observeSpeechSegments-coordinate-space`): the adapter ignores `batchSamples` and decodes against its own retained raw PCM so segment-derived `clipTimestamps` (the #452/#560 hallucination-suppression mechanism) stay coordinate-aligned. The protocol comment at `ASREngineAdapter.swift:240-247` was revised to carve out Parakeet (MUST use `batchSamples`) vs WhisperKit (MUST NOT).
- **Testability seam** (OQ-4): the adapter declares a local `package protocol WhisperKitBackendDriving: Actor` and retro-conforms `WhisperKitBackend`; tests inject `StubWhisperKitBackend` (an actor conforming to the same protocol) without loading a real WhisperKit model. The `: Actor` constraint mirrors `package protocol ASRBackend: Actor` at `Sources/EnviousWisprASR/ASRProtocol.swift:14`.
- **Diagnostics additive**: `KernelASRAdapterDiagnostics` gains `rawSampleCount` + 7 incremental fields the WhisperKit adapter populates on every terminal outcome, surfaced through `ASREngineTelemetryProviding` for the kernel's lifecycle sink to read at Rung 5 cutover.
- **EngineIdentityFreezeTests widened**: literal scan extended from `.parakeet` only to BOTH `.parakeet` AND `.whisperKit` across the three kernel-side reader sites. Adversarial-regression + negative-control tests added for the second engine.

## Review process

Council coverage (1 round) + Codex grounded plan review (3 rounds, terminal PROCEED-AS-PLANNED).

Codex code-diff review took 9 rounds with a (surface × session-state) matrix at r7 per the EW workflow rule `matrix-review-for-cross-product-surfaces`. Defect trajectory:

| Round | Defects | Notes |
|---|---|---|
| r1 | 3 | batchSamples docblock, VAD-unavailable signal, stale-finalize mutation |
| r2 | 3 | adapter-side no-speech gate dropped, worker stale guard, batch-decode stale guards |
| r3 | 3 | post-peekMemory guard, orphan-worker cancel on beginSession, stale-buffer drop |
| r4 | 1 new + 1 repeat | warmUpFromCache load-on-PTT bug + coordinate-space (deferred to Rung 5) |
| r5 | 1 | warmUpFromCache load-race vs prepare() single-flight |
| r6 | 1 | post-makeIncrementalSession beginSession stale guard |
| r7 | 4 (matrix) | finalize entry guard, observeSpeechSegments live-session guard, post-start beginSession guard, applyUnloadPolicy session-keying |
| r8 | 1 new + 1 repeat | unload-task final cancellation re-check + coordinate-space repeat |
| r9 | 0 | clean |

The coordinate-space concern (pre-roll buffer origin vs segment origin) was flagged repeatedly. It is documented in the adapter file header as a Rung 5 cutover obligation — adapter is production-unwired this rung so the bug cannot fire in production; Rung 5's 5-language Live UAT matrix will verify before user-visible behavior changes.

## Test plan

- [x] `swift build -c release` exit 0
- [x] `scripts/swift-test.sh` full pass (1438 tests, 176 suites)
- [x] 58 new behavioral tests for `WhisperKitEngineAdapter`
- [x] 9 freeze tests for `EngineIdentityFreezeTests` (extended for `.whisperKit`)
- [x] Codex code-diff review CLEAN (r9)
- [ ] Live UAT: N/A — adapter is production-unwired this rung. Rung 5 cutover carries the 5-language persona matrix.

## Files

- `Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift` (new, ~870 LOC including the local `WhisperKitBackendDriving: Actor` seam)
- `Sources/EnviousWisprPipeline/ASREngineAdapter.swift` (+~24 lines: docblock carve-out at `:240-247`)
- `Sources/EnviousWisprPipeline/KernelTelemetryState.swift` (+14 lines: incremental + rawSampleCount diagnostics fields)
- `Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift` (new)
- `Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterLastResultLifecycleTests.swift` (new)
- `Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift` (new, actor stub)
- `Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift` (extended for `.whisperKit`)

Plan: `docs/feature-requests/issue-827-2026-05-27-pr5-rung3-whisperkit-adapter.md`.
Parent epic: `docs/feature-requests/issue-827-2026-05-20-engine-kernel-epic.md`.