### PR TITLE
refactor(engine-kernel): PR-5 Rung 4.5 — WhisperKit telemetry parity + Category L inventory (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -126,9 +126,14 @@ public enum KernelDictationDriverFactory {
   /// architecture freeze locks the production-unwired invariant until Rung 5
   /// removes that test.
   public static func makeForWhisperKit(inputs: WhisperKitInputs) -> KernelDictationDriver {
+    // PR-5 Rung 4.5 (#827): plumb the audio-capture session-id source to the
+    // adapter so it can snapshot at `beginSession` (race-safe for delayed LID
+    // perf signposts like `t_clipboard_write`).
+    let captureSource = inputs.audioCapture
     let adapter = WhisperKitEngineAdapter(
       backend: inputs.whisperKitBackend,
-      languageDetector: inputs.languageDetector)
+      languageDetector: inputs.languageDetector,
+      audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID })
     return assembleDriver(
       adapter: adapter,
       audioCapture: inputs.audioCapture,

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -203,6 +203,16 @@ struct KernelFinalizationWiring {
       outcome.pasteDurationSeconds = pipelineEnd - pasteStart
       Self.updateTranscriptMetrics(outcome: outcome, context: context)
       Self.logPipelineTimingTotal(outcome: outcome)
+      // PR-5 Rung 4.5 (#827): LID perf signpost `t_clipboard_write` —
+      // gated on engine LID capability (NOT paste outcome). OLD pipeline
+      // at `WhisperKitPipeline.swift:1079-1086` emits after finalize
+      // regardless of cascade tier, including clipboard-only + auto-copy.
+      // Source session id + LID-shape from `adapter.lastASRDiagnostics`
+      // (per-session captured in adapter at `beginSession`).
+      if adapter.capabilities.supportsLanguageDetection {
+        Self.emitLIDClipboardWriteSignpost(
+          diagnostics: (adapter as? any ASREngineTelemetryProviding)?.lastASRDiagnostics)
+      }
       return deliveryOutcome
     }
 
@@ -266,6 +276,38 @@ struct KernelFinalizationWiring {
           + "paste=\(String(format: "%.3f", outcome.pasteDurationSeconds))s)",
         level: .info, category: "PipelineTiming"
       )
+    }
+  }
+
+  /// PR-5 Rung 4.5 (#827): LID perf signpost `t_clipboard_write` — fires
+  /// when finalization completes for WhisperKit-mode sessions, regardless
+  /// of paste outcome. Source session id + LID shape from
+  /// `adapter.lastASRDiagnostics` (per-session captured in the WK adapter
+  /// at `beginSession`; race-safe vs delayed emit). Matches OLD
+  /// `WhisperKitPipeline.swift:1079-1086` emit format.
+  private static func emitLIDClipboardWriteSignpost(
+    diagnostics: KernelASRAdapterDiagnostics?
+  ) {
+    let id = diagnostics?.lidCaptureSessionID ?? 0
+    let ts = String(format: "%.6f", CFAbsoluteTimeGetCurrent())
+    var fields = [
+      "lid_perf_signpost",
+      "name=t_clipboard_write",
+      "timestamp_s=\(ts)",
+      "session_id=\(id)",
+    ]
+    if let voiced = diagnostics?.lidVoicedDurationSec {
+      fields.append("voiced_duration_s=\(String(format: "%.3f", voiced))")
+    }
+    if let lidWindow = diagnostics?.lidWindowCount {
+      fields.append("lid_window_count=\(lidWindow)")
+    }
+    if let clipKind = diagnostics?.lidClipKind {
+      fields.append("clip_kind=\(clipKind)")
+    }
+    let message = fields.joined(separator: " ")
+    Task {
+      await AppLogger.shared.log(message, level: .info, category: "KernelFinalizationWiring")
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -77,6 +77,16 @@ struct KernelASRAdapterDiagnostics {
   var incrementalStrategy: String? = nil
   var incrementalMode: String? = nil
   var incrementalTailDecodeMs: Int? = nil
+
+  // PR-5 Rung 4.5 (#827): LID perf signpost transport. The WhisperKit adapter
+  // populates these during finalize so `KernelFinalizationWiring.deliver` can
+  // emit `t_clipboard_write` with the same `session_id` + LID-shape fields the
+  // OLD pipeline carried (`WhisperKitPipeline.swift:1079-1086`). Parakeet does
+  // not populate these; the wiring gates the emit on engine identity.
+  var lidCaptureSessionID: UInt64? = nil
+  var lidVoicedDurationSec: Double? = nil
+  var lidWindowCount: Int? = nil
+  var lidClipKind: String? = nil
 }
 
 @MainActor

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -897,6 +897,17 @@ final class RecordingSessionKernel {
       break
     }
 
+    // PR-5 Rung 4.5 (#827): LID perf signpost `t_release` — fires on every
+    // accepted-stop reason (manual, VAD-auto-stop, max-duration cap) so
+    // perf-trace joining works across all session-ending paths. OLD WK
+    // emitted from `requestStop` only (`WhisperKitPipeline.swift:551-552`);
+    // the unified kernel transition is the symmetric, complete site.
+    // Gated on engine capability (LID support) — Parakeet has no LID and
+    // does not emit this signpost.
+    if adapter.capabilities.supportsLanguageDetection {
+      emitLIDReleaseSignpost(sessionID: audioCapture.currentCaptureSessionID)
+    }
+
     // Stopping. The `stopping` path owns the capture stop: marking
     // `.stopping` before the await tells a concurrent `finishTerminal`
     // (a cancel landing mid-stop) not to fire a second, racing stop — it
@@ -1938,6 +1949,19 @@ final class RecordingSessionKernel {
     // Kernel logs carry FSM states / SessionIDs / counters only — never
     // transcript text (PR-3 plan §3.10 privacy boundary).
     Task { await AppLogger.shared.log("[kernel] \(message)", level: .debug, category: "Kernel") }
+  }
+
+  /// PR-5 Rung 4.5 (#827): emit `t_release` LID perf signpost on accepted-stop.
+  /// Timestamp-only variant — `voiced_duration_s`, `lid_window_count`,
+  /// `clip_kind` are not known here (LID has not run yet). Matches the OLD
+  /// signature's all-optional-tail at `WhisperKitPipeline.swift:1438-1452`.
+  /// Format matches `WhisperKitEngineAdapter.logLIDPerfSignpost`.
+  private func emitLIDReleaseSignpost(sessionID: UInt64) {
+    let ts = String(format: "%.6f", CFAbsoluteTimeGetCurrent())
+    let message = "lid_perf_signpost name=t_release timestamp_s=\(ts) session_id=\(sessionID)"
+    Task {
+      await AppLogger.shared.log(message, level: .info, category: "RecordingSessionKernel")
+    }
   }
 
   #if DEBUG

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -159,6 +159,14 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// returns and the stale-session guard passes.
   private(set) var lastLanguageDetection: LanguageDetectionResult?
 
+  /// Source for the audio-capture session id. Read once per `finalize`
+  /// call into a function-local snapshot (`sessionIDForLog`) — not stored
+  /// on `self`, so a concurrent `beginSession(B)` cannot retroactively
+  /// change session A's in-flight signposts. PR-5 Rung 4.5 (#827) reuses
+  /// the existing `audioCapture: any AudioCaptureInterface` plumbed
+  /// through `KernelDictationDriverFactory.WhisperKitInputs:62-69`.
+  private let audioCaptureSessionIDSource: @MainActor () -> UInt64
+
   // MARK: ASREngineAdapter — engine interruption
 
   /// Optional adapter-local interruption hook. WhisperKit has no
@@ -171,10 +179,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
 
   init(
     backend: any WhisperKitBackendDriving,
-    languageDetector: LanguageDetector = LanguageDetector()
+    languageDetector: LanguageDetector = LanguageDetector(),
+    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 }
   ) {
     self.backend = backend
     self.languageDetector = languageDetector
+    self.audioCaptureSessionIDSource = audioCaptureSessionIDSource
   }
 
   // MARK: ASREngineAdapter — identity & capability
@@ -274,6 +284,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
+    // PR-5 Rung 4.5 (#827): the audio-capture session id is read at
+    // finalize entry into a function-local snapshot, not here — kernel
+    // calls `beginSession` BEFORE `beginCapturePhase` mints the id, and
+    // a shared-property capture would race interleaved sessions. See
+    // `finalize`.
 
     // Cancel any pending model-unload timer a prior session armed. Rung 2B's
     // kernel `cancelPendingUnload` hook already fires synchronously before
@@ -387,6 +402,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   func finalize(batchSamples: [Float]?) async -> ASREngineOutcome {
     _ = batchSamples  // intentionally ignored — see coordinate-space note
     lastFailureError = nil
+    // PR-5 Rung 4.5 (#827): capture `currentCaptureSessionID` at finalize
+    // entry, NOT at `beginSession`. Codex code-diff review caught this:
+    // kernel calls `adapter.beginSession()` BEFORE `audioCapture.beginCapturePhase()`,
+    // but `currentCaptureSessionID` only increments inside the capture-phase
+    // call. By finalize entry, the capture phase has completed (kernel's
+    // `runForwardPath` flow guarantees this), so the source returns the
+    // active session's id.
+    //
+    // `sessionIDForLog` is a function-local immutable snapshot — every
+    // signpost emitted in this finalize call passes it explicitly. A
+    // concurrent `beginSession(B)` that resets the shared adapter property
+    // mid-finalize cannot misattribute this session's post-await signposts
+    // (Codex code-diff r2 caught the shared-mutable-property race).
+    let sessionIDForLog = audioCaptureSessionIDSource()
     if isCancelled {
       isTerminal = true
       retainedPCM.removeAll()
@@ -448,6 +477,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // adapter logs the LID-bound signposts only).
     logLIDPerfSignpost(
       "t_state_flip",
+      sessionID: sessionIDForLog,
       voicedDuration: voicedDurationSec,
       lidWindowCount: lidWindowCount,
       clipKind: clipKind
@@ -473,6 +503,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     )
     logLIDPerfSignpost(
       "t_lid_settled",
+      sessionID: sessionIDForLog,
       voicedDuration: voicedDurationSec,
       lidWindowCount: lidWindowCount,
       clipKind: clipKind
@@ -501,6 +532,22 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
         level: .info, category: "WhisperKitEngineAdapter"
       )
     }
+
+    // PR-5 Rung 4.5 (#827): Sentry breadcrumb "Language detected", byte-identical
+    // to OLD `WhisperKitPipeline.swift:814-823`. Payload is derived metadata only
+    // (no transcript text, no raw audio) per `sentry-operations.md`
+    // RULE: telemetry-privacy-boundary. Locked-mode never reaches LID
+    // (`LanguageDetector.swift:152-171`), so this fires on auto-mode paths only.
+    SentryBreadcrumb.add(
+      stage: "asr", message: "Language detected",
+      data: [
+        "lang": lidResult.lang ?? "nil",
+        "tier": lidResult.tier.rawValue,
+        "confidence": String(format: "%.3f", lidResult.confidence),
+        "margin": String(format: "%.3f", lidResult.margin),
+        "voiced_s": String(format: "%.2f", lidResult.voicedDuration),
+        "abstained": lidResult.abstained,
+      ])
 
     // LID PostHog telemetry — adapter-owned per `supportsLanguageDetection`
     // TODO at `ASREngineAdapter.swift:60-65`.
@@ -549,6 +596,16 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // through `lastASRDiagnostics` on every terminal outcome.
     var diagnostics = KernelASRAdapterDiagnostics()
     diagnostics.rawSampleCount = rawSamples.count
+    // PR-5 Rung 4.5 (#827): LID perf-signpost transport for kernel-side
+    // `t_release` and wiring-side `t_clipboard_write` emits. Populated here
+    // so every terminal write of `lastASRDiagnostics` carries them. Uses the
+    // finalize-local `sessionIDForLog` snapshot so a concurrent
+    // `beginSession(B)` cannot retroactively change session A's diagnostics
+    // payload (Codex code-diff r2 race).
+    diagnostics.lidCaptureSessionID = sessionIDForLog
+    diagnostics.lidVoicedDurationSec = voicedDurationSec
+    diagnostics.lidWindowCount = lidWindowCount
+    diagnostics.lidClipKind = clipKind
 
     let asrText: String
     let asrLanguage: String?
@@ -606,6 +663,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
         // Batch fallback over raw retained PCM.
         logLIDPerfSignpost(
           "t_asr_start",
+          sessionID: sessionIDForLog,
           voicedDuration: voicedDurationSec,
           lidWindowCount: lidWindowCount,
           clipKind: clipKind
@@ -614,6 +672,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
         let batchOutcome = await runBatchDecode(samples: asrSamples)
         logLIDPerfSignpost(
           "t_asr_end",
+          sessionID: sessionIDForLog,
           voicedDuration: voicedDurationSec,
           lidWindowCount: lidWindowCount,
           clipKind: clipKind
@@ -648,6 +707,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       // `.auto` mode (or worker setup failed): batch only.
       logLIDPerfSignpost(
         "t_asr_start",
+        sessionID: sessionIDForLog,
         voicedDuration: voicedDurationSec,
         lidWindowCount: lidWindowCount,
         clipKind: clipKind
@@ -656,6 +716,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       let batchOutcome = await runBatchDecode(samples: asrSamples)
       logLIDPerfSignpost(
         "t_asr_end",
+        sessionID: sessionIDForLog,
         voicedDuration: voicedDurationSec,
         lidWindowCount: lidWindowCount,
         clipKind: clipKind
@@ -881,20 +942,32 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     }
   }
 
-  // MARK: LID perf signposts (5 of 6 — the 6th, `t_clipboard_write`, is
-  // kernel-owned in the new model and fires after `KernelFinalizationWiring.deliver`;
-  // Rung 5 wires that emission).
+  // MARK: LID perf signposts
+  //
+  // PR-5 Rung 4.5 (#827): all six signpost names carry `session_id` for trace
+  // joinability across interleaved sessions. The kernel emits `t_release`
+  // from its unified accepted-stop transition; the wiring emits
+  // `t_clipboard_write` from `KernelFinalizationWiring.deliver` reading the
+  // session id from `lastASRDiagnostics.lidCaptureSessionID`. The four
+  // adapter-emitted names are `t_state_flip`, `t_lid_start`, `t_lid_settled`,
+  // `t_decode_start` (see call sites above).
 
   private func logLIDPerfSignpost(
     _ name: String,
+    sessionID: UInt64,
     voicedDuration: TimeInterval? = nil,
     lidWindowCount: Int? = nil,
     clipKind: String? = nil
   ) {
+    // `sessionID` passed in explicitly (not read from `self`) so a stale
+    // finalize that resumes after a fresh `beginSession` reset the adapter's
+    // `capturedCaptureSessionID` still emits with its session's id. Codex
+    // code-diff review r2 caught the prior shared-property read race.
     var fields = [
       "lid_perf_signpost",
       "name=\(name)",
       "timestamp_s=\(String(format: "%.6f", CFAbsoluteTimeGetCurrent()))",
+      "session_id=\(sessionID)",
     ]
     if let voicedDuration {
       fields.append("voiced_duration_s=\(String(format: "%.3f", voicedDuration))")

--- a/Tests/EnviousWisprTests/Pipeline/LIDPerfSignpostSessionIDTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LIDPerfSignpostSessionIDTests.swift
@@ -1,0 +1,140 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - LIDPerfSignpostSessionIDTests (epic #827, PR-5 Rung 4.5)
+//
+// Coverage for the LID perf signpost `session_id` plumbing restored in this
+// rung. The OLD `WhisperKitPipeline` emitted `session_id` on every signpost
+// line via `audioCapture.currentCaptureSessionID`
+// (`WhisperKitPipeline.swift:1438-1452`). The new adapter dropped the
+// parameter — this rung restores it, and CAPTURES the value once per session
+// at `beginSession` rather than resolving via a late closure (Codex grounded
+// review r1 finding: direct sources increment generation on every
+// `startCapture`, so a delayed `t_clipboard_write` reading live would see
+// session B while emitting session A telemetry).
+//
+// What these tests assert:
+// 1. Adapter init takes an `audioCaptureSessionIDSource` closure and reads
+//    it ONCE per `beginSession`.
+// 2. `KernelASRAdapterDiagnostics.lidCaptureSessionID` carries the captured
+//    value through to wiring after finalize.
+// 3. The same diagnostics carry voiced duration, LID window count, and clip
+//    kind so the kernel-side and wiring-side emitters can format their
+//    signpost lines.
+
+@MainActor
+@Suite struct LIDPerfSignpostSessionIDTests {
+
+  // MARK: Capture at finalize entry (NOT beginSession)
+
+  @Test("adapter does NOT read audioCaptureSessionIDSource at beginSession")
+  func adapterDoesNotCaptureAtBeginSession() async throws {
+    var readCount = 0
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(),
+      audioCaptureSessionIDSource: {
+        readCount += 1
+        return 42
+      })
+
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    // Kernel calls beginSession BEFORE beginCapturePhase mints a new id, so
+    // reading the source here would capture a stale value. The adapter must
+    // defer the read until finalize entry.
+    #expect(readCount == 0, "no read at beginSession; capture deferred to finalize")
+  }
+
+  @Test("adapter reads audioCaptureSessionIDSource at finalize entry")
+  func adapterCapturesSessionIDAtFinalizeEntry() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "ok", language: "en", duration: 1.0,
+        processingTime: 0.1, backendType: .whisperKit))
+    var readCount = 0
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend,
+      audioCaptureSessionIDSource: {
+        readCount += 1
+        return 555
+      })
+
+    try await adapter.beginSession(
+      SessionID(),
+      options: TranscriptionOptions(language: "en"),  // locked
+      streaming: false)
+    // Feed a buffer so finalize has audio to process.
+    let buf = AVAudioPCMBuffer(
+      pcmFormat: AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!,
+      frameCapacity: 16000)!
+    buf.frameLength = 16000
+    adapter.acceptAudio(
+      AudioBufferHandoff(buffer: buf, frameCount: 16000, sequence: 1, sessionID: SessionID()))
+
+    _ = await adapter.finalize(batchSamples: nil)
+    #expect(readCount >= 1, "finalize reads the source at least once")
+
+    let diag = try #require(adapter.lastASRDiagnostics)
+    #expect(diag.lidCaptureSessionID == 555)
+  }
+
+  // MARK: Diagnostics transport
+
+  @Test("finalize populates lidCaptureSessionID on diagnostics for wiring transport")
+  func finalizePopulatesLIDDiagnosticsForWiring() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "hola mundo", language: "es", duration: 1.0,
+        processingTime: 0.1, backendType: .whisperKit))
+
+    let capturedID: UInt64 = 7777
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend,
+      audioCaptureSessionIDSource: { capturedID })
+
+    try await adapter.beginSession(
+      SessionID(),
+      options: TranscriptionOptions(language: nil),  // .auto so LID runs
+      streaming: false)
+
+    // Feed a non-trivial PCM so the finalize path runs LID + decode.
+    let samples = [Float](repeating: 0.1, count: 32000)  // 2s @ 16kHz
+    let buf = AVAudioPCMBuffer(
+      pcmFormat: AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!,
+      frameCapacity: AVAudioFrameCount(samples.count))!
+    buf.frameLength = AVAudioFrameCount(samples.count)
+    for i in 0..<samples.count {
+      buf.floatChannelData![0][i] = samples[i]
+    }
+    adapter.acceptAudio(
+      AudioBufferHandoff(
+        buffer: buf,
+        frameCount: samples.count,
+        sequence: 1,
+        sessionID: SessionID()))
+
+    _ = await adapter.finalize(batchSamples: nil)
+
+    let diag = try #require(adapter.lastASRDiagnostics)
+    #expect(diag.lidCaptureSessionID == capturedID)
+    // LID-shape transport fields populated alongside the captured id.
+    #expect(diag.lidVoicedDurationSec != nil)
+    #expect(diag.lidWindowCount != nil)
+    #expect(diag.lidClipKind != nil)
+  }
+
+  @Test("KernelASRAdapterDiagnostics defaults: LID fields all nil before finalize")
+  func diagnosticsDefaultsLIDFieldsNil() {
+    let diag = KernelASRAdapterDiagnostics()
+    #expect(diag.lidCaptureSessionID == nil)
+    #expect(diag.lidVoicedDurationSec == nil)
+    #expect(diag.lidWindowCount == nil)
+    #expect(diag.lidClipKind == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Restore LID perf signposts and the Sentry `"Language detected"` breadcrumb the new WhisperKit code dropped versus the still-live `WhisperKitPipeline`. Telemetry-only; no functional change.
- `t_release` emits from the kernel's unified accepted-stop transition (covers manual, VAD-auto-stop, max-duration — not only manual stop as OLD did).
- `t_clipboard_write` emits from `KernelFinalizationWiring.deliver` after finalization completes, gated on engine LID capability (not paste outcome — OLD logs even on clipboard-only paths).
- Session id captured at finalize entry into a function-local snapshot, passed explicitly through every signpost emit so a concurrent `beginSession(B)` cannot misattribute session A's in-flight telemetry. Codex code-diff review r2 caught two iterations of this race; round 3 returned CLEAN.
- `KernelASRAdapterDiagnostics` gains four optional LID transport fields so wiring can read session id + LID shape from `lastASRDiagnostics` at emit time.
- PR-1 behavior inventory §B.8 amended with Category L (Language Identification) — three rows including the deferred coordinate-alignment obligation pointing at #872.

## What's NOT in this rung

- **Pre-roll coordinate fix for WhisperKit batch decode (P1).** Deferred to #872. Codex grounded review r1 returned PIVOT on the original mechanism (race against queued `Task { @MainActor }` enqueues); founder decision 2026-05-27: prioritize refactor completion, defer fix until post-credits-refresh. WhisperKit users are on the legacy pipeline today (production-unwired in the new code), so zero user impact. Telemetry shipped here is the post-Rung-5 cutover detection signal.
- App caller flip to the new factory (Rung 5).
- `WhisperKitPipeline.swift` deletion (Rung 5).
- 5-language WhisperKit Live UAT matrix (Rung 5).
- LID-to-polish wiring (Rung 5 cutover obligation).

## Plan + review trail

- Plan: `docs/feature-requests/issue-827-2026-05-27-pr5-rung4.5-whisperkit-parity.md`.
- 2026-05-27 Codex seam audit found 4 gaps; this rung ships 2 telemetry + inventory.
- Council coverage (GPT + Gemini): 12 findings, all addressed or routed.
- Codex grounded review on plan: r1 PIVOT (drove scope shrink + #872 split); r2 PROCEED-WITH-REVISIONS (4 precision fixes applied); r3 confirmed plan-text consistent with code reality.
- Codex code-diff review: r1 caught the beginSession-vs-beginCapturePhase ordering bug; r2 caught a shared-mutable-property race; r3 CLEAN.
- Architectural freeze test caught my use of the `.whisperKit` literal in two gates → refactored to `capabilities.supportsLanguageDetection`.

## Test plan

- [x] `scripts/swift-test.sh` — 1447 tests green (4 new in `LIDPerfSignpostSessionIDTests`)
- [x] `swift build -c release` exit 0
- [x] Parakeet PTT smoke (menu-driven recording, sub-second TOTAL = 0.706s)
- [x] Codex code-diff review CLEAN
- [x] Architecture DoD: no new coordinator, no public-API widening, no protocol surface change

## References

- Parent epic: #827
- Deferred coordinate fix: #872
- Sibling Parakeet rung: PR-4.5 (merged #844)