### PR TITLE
test(pipeline): fix release-config unload-test flake that reddened main after #874

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -81,13 +81,22 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
   @ObservationIgnored
   private var lastFiredState: PipelineState
 
+  /// Heart-path error sink for the driver's own direct `.asrInterrupted`
+  /// captureError emit. Defaulted to the production global so the only behavior
+  /// change is testability — the factory threads the same injected sink it
+  /// gives the emitter and lifecycle sink, so a test observes every driver-
+  /// owned captureError path through one sink (Codex review #875).
+  private let captureErrorSink: KernelDictationDriverFactory.HeartPathCaptureErrorSink
+
   init(
     kernel: RecordingSessionKernel,
     observer: KernelHeartPathTelemetryObserver,
     outcome: KernelFinalizationOutcome,
     context: KernelSessionContext,
     steps: LimbSteps,
-    adapter: any ASREngineAdapter
+    adapter: any ASREngineAdapter,
+    captureErrorSink: @escaping KernelDictationDriverFactory.HeartPathCaptureErrorSink =
+      KernelDictationDriverFactory.defaultCaptureErrorSink
   ) {
     self.kernel = kernel
     self.observer = observer
@@ -95,6 +104,7 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
     self.context = context
     self.steps = steps
     self.adapter = adapter
+    self.captureErrorSink = captureErrorSink
     self.lastFiredState = Self.pipelineState(for: kernel.state, externalError: nil)
   }
 
@@ -285,14 +295,14 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
       let backendID = adapter.engineIdentity.rawValue
       let backendLabel =
         adapter.engineIdentity.backendType == .whisperKit ? "WhisperKit" : "Parakeet"
-      SentryBreadcrumb.captureError(
+      captureErrorSink(
         NSError(
           domain: "EnviousWispr", code: -3,
           userInfo: [
             NSLocalizedDescriptionKey: "ASR XPC service crashed (\(backendLabel))"
           ]),
-        category: .xpcServiceError, stage: "asr",
-        extra: ["was_recording": false, "backend": backendID])
+        .xpcServiceError, "asr",
+        ["was_recording": false, "backend": backendID], nil)
       setExternalError(Self.asrInterruptedMessage)
     case .idle, .completed, .failed, .cancelled, .discarded, .noSpeech,
       .audioInterrupted, .asrInterrupted:

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -31,6 +31,40 @@ import Foundation
 @MainActor
 public enum KernelDictationDriverFactory {
 
+  /// Heart-path infrastructure-error sink. Defaults to the global
+  /// `SentryBreadcrumb.captureError` so production behavior is byte-identical;
+  /// tests inject a per-instance spy/no-op closure so a pipeline-under-test
+  /// never touches the process-global `SentryBreadcrumb.captureErrorDelegate`.
+  /// That global is the cross-test pollution vector behind the release-config
+  /// one-per-run flake (#875): a `@MainActor` test suspended at an `await`
+  /// yields the main actor to a sibling test whose pipeline fires
+  /// `captureError` into whatever delegate is currently installed. Injecting
+  /// the sink removes pipelines-under-test from that path entirely.
+  /// Carries the optional `RecordingSnapshot` so this one sink can stand in for
+  /// EVERY heart-path `captureError` route under the driver — the emitter
+  /// (always `snapshot: nil`), `KernelLifecycleTelemetrySink`'s plain and
+  /// snapshot-carrying variants, and the driver's direct `.asrInterrupted`
+  /// emit. A single injected sink therefore observes all of them, so the
+  /// cancellation "zero Sentry errors" test catches a regression through any
+  /// path — not only the emitter (Codex review #875).
+  package typealias HeartPathCaptureErrorSink = @MainActor (
+    _ error: any Error,
+    _ category: SentryBreadcrumb.ErrorCategory,
+    _ stage: String,
+    _ extra: [String: Any]?,
+    _ snapshot: SentryBreadcrumb.RecordingSnapshot?
+  ) -> Void
+
+  /// The production default — forwards to the global `SentryBreadcrumb`,
+  /// including the snapshot (nil collapses to the no-snapshot call, so every
+  /// consumer stays byte-identical to its prior in-line default). Named once
+  /// here so both inputs structs share one source of truth.
+  package static let defaultCaptureErrorSink: HeartPathCaptureErrorSink = {
+    error, category, stage, extra, snapshot in
+    SentryBreadcrumb.captureError(
+      error, category: category, stage: stage, extra: extra, snapshot: snapshot)
+  }
+
   /// Package-typed inputs for the Parakeet engine branch. Narrowed from
   /// `public` to `package` in PR-5 Rung 5: the only consumers are the
   /// `EnviousWispr` App target and `EnviousWisprTests`, both in the same
@@ -45,9 +79,16 @@ public enum KernelDictationDriverFactory {
     package let keychainManager: KeychainManager
     package let captureTelemetry: CaptureTelemetryState
     package let pasteCompletionRegistry: PasteCompletionRegistry
+    /// Heart-path error sink (defaulted to the production global). See
+    /// `HeartPathCaptureErrorSink`.
+    package let captureErrorSink: HeartPathCaptureErrorSink
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
-    /// and would prevent App callers from constructing this struct.
+    /// and would prevent App callers from constructing this struct. `@MainActor`
+    /// because `captureErrorSink`'s default is a main-actor-isolated value;
+    /// every caller (App init, `@MainActor` test suites) is already on the
+    /// main actor.
+    @MainActor
     package init(
       audioCapture: any AudioCaptureInterface,
       asrManager: any ASRManagerInterface,
@@ -55,7 +96,8 @@ public enum KernelDictationDriverFactory {
       transcriptStore: TranscriptStore,
       keychainManager: KeychainManager,
       captureTelemetry: CaptureTelemetryState,
-      pasteCompletionRegistry: PasteCompletionRegistry
+      pasteCompletionRegistry: PasteCompletionRegistry,
+      captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -64,6 +106,7 @@ public enum KernelDictationDriverFactory {
       self.keychainManager = keychainManager
       self.captureTelemetry = captureTelemetry
       self.pasteCompletionRegistry = pasteCompletionRegistry
+      self.captureErrorSink = captureErrorSink
     }
   }
 
@@ -79,12 +122,18 @@ public enum KernelDictationDriverFactory {
     package let keychainManager: KeychainManager
     package let captureTelemetry: CaptureTelemetryState
     package let pasteCompletionRegistry: PasteCompletionRegistry
+    /// Heart-path error sink (defaulted to the production global). See
+    /// `HeartPathCaptureErrorSink`.
+    package let captureErrorSink: HeartPathCaptureErrorSink
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
     /// production caller in Rung 5 must explicitly pass the `LanguageDetector`
     /// it already constructs with `onLanguageFlip` telemetry wiring
-    /// (epic plan §3.4, council consensus 2026-05-27).
+    /// (epic plan §3.4, council consensus 2026-05-27). `@MainActor` for the
+    /// same reason as `ParakeetInputs.init` — the `captureErrorSink` default
+    /// is main-actor-isolated.
+    @MainActor
     package init(
       audioCapture: any AudioCaptureInterface,
       whisperKitBackend: WhisperKitBackend,
@@ -93,7 +142,8 @@ public enum KernelDictationDriverFactory {
       transcriptStore: TranscriptStore,
       keychainManager: KeychainManager,
       captureTelemetry: CaptureTelemetryState,
-      pasteCompletionRegistry: PasteCompletionRegistry
+      pasteCompletionRegistry: PasteCompletionRegistry,
+      captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -103,6 +153,7 @@ public enum KernelDictationDriverFactory {
       self.keychainManager = keychainManager
       self.captureTelemetry = captureTelemetry
       self.pasteCompletionRegistry = pasteCompletionRegistry
+      self.captureErrorSink = captureErrorSink
     }
   }
 
@@ -149,7 +200,8 @@ public enum KernelDictationDriverFactory {
       transcriptStore: inputs.transcriptStore,
       keychainManager: inputs.keychainManager,
       captureTelemetry: inputs.captureTelemetry,
-      pasteCompletionRegistry: inputs.pasteCompletionRegistry)
+      pasteCompletionRegistry: inputs.pasteCompletionRegistry,
+      captureErrorSink: inputs.captureErrorSink)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -173,7 +225,8 @@ public enum KernelDictationDriverFactory {
       transcriptStore: inputs.transcriptStore,
       keychainManager: inputs.keychainManager,
       captureTelemetry: inputs.captureTelemetry,
-      pasteCompletionRegistry: inputs.pasteCompletionRegistry)
+      pasteCompletionRegistry: inputs.pasteCompletionRegistry,
+      captureErrorSink: inputs.captureErrorSink)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -188,7 +241,8 @@ public enum KernelDictationDriverFactory {
     transcriptStore: TranscriptStore,
     keychainManager: KeychainManager,
     captureTelemetry: CaptureTelemetryState,
-    pasteCompletionRegistry: PasteCompletionRegistry
+    pasteCompletionRegistry: PasteCompletionRegistry,
+    captureErrorSink: @escaping HeartPathCaptureErrorSink
   ) -> KernelDictationDriver {
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     let limbSteps = LimbSteps(
@@ -224,10 +278,19 @@ public enum KernelDictationDriverFactory {
     // a separate follow-up; this callback intentionally discards tokens.
     limbSteps.llmPolish.onToken = { _ in }
 
-    // 5. Telemetry emitter (factory-internal; App never sees it).
+    // 5. Telemetry emitter (factory-internal; App never sees it). The
+    //    capture-error sink is threaded from inputs (defaulted to the global
+    //    `SentryBreadcrumb.captureError`), so production is byte-identical and
+    //    tests inject a per-instance sink to stay off the process-global
+    //    delegate (#875 cross-test pollution fix).
     let emitter = HeartPathTelemetryEmitter(
       backend: adapter.engineIdentity.backendType,
-      captureTelemetry: captureTelemetry
+      captureTelemetry: captureTelemetry,
+      // The emitter never carries a snapshot — adapt the unified sink down to
+      // its snapshot-less shape.
+      captureError: { error, category, stage, extra in
+        captureErrorSink(error, category, stage, extra, nil)
+      }
     )
 
     let telemetryRelay = TelemetryRelay()
@@ -293,6 +356,16 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: captureTelemetry,
       telemetryState: telemetryState,
       modelLoadWedgeTelemetry: { telemetryRelay.modelLoadWedgeTelemetry() },
+      // Route both lifecycle captureError variants through the same injected
+      // sink so a test observing one sink sees every error this sink can emit
+      // (Codex review #875). Production stays byte-identical: the default sink
+      // forwards (error, …, snapshot) to `SentryBreadcrumb.captureError`.
+      captureError: { error, category, stage, extra in
+        captureErrorSink(error, category, stage, extra, nil)
+      },
+      captureErrorWithSnapshot: { error, category, stage, extra, snapshot in
+        captureErrorSink(error, category, stage, extra, snapshot)
+      },
       // Div 6 of seam audit (TP:273-291): route `.noAudioCaptured` through
       // the emitter so the rich payload (sourceType, isActivelyCapturing,
       // device IDs) AND the stall/XPC-failure dedup contract reach Sentry —
@@ -313,14 +386,18 @@ public enum KernelDictationDriverFactory {
       emitLifecycleEvent: { [lifecycleSink] event in lifecycleSink.emit(event) }
     )
 
-    // 10. Driver.
+    // 10. Driver. Pass the unified sink so the driver's direct
+    //     `.asrInterrupted` captureError emit (XPC crash fallback) also routes
+    //     through the injected sink — full parity with the old global delegate
+    //     spy for tests (Codex review #875).
     let driver = KernelDictationDriver(
       kernel: kernel,
       observer: observer,
       outcome: outcome,
       context: context,
       steps: limbSteps,
-      adapter: adapter
+      adapter: adapter,
+      captureErrorSink: captureErrorSink
     )
     driver.start()  // arms driver-side state observation (PR-4a)
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -494,6 +494,14 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     let take = min(count, remaining)
     retainedPCM.append(contentsOf: UnsafeBufferPointer(start: channel, count: take))
   }
+
+  /// Test-only handle to the in-flight per-buffer feed tasks. A test captures
+  /// this snapshot BEFORE `cancel()`/`beginSession()` (which clear the array)
+  /// and `await`s the captured handles afterward to assert deterministically
+  /// that a queued feed saw the terminated session and skipped — instead of
+  /// yield-polling `feedAudioCount`. Each task always returns (it guards on the
+  /// session check and returns), so the await is bounded.
+  internal var feedTasksForUnitTests: [Task<Void, Never>] { feedTasks }
 }
 
 extension ParakeetEngineAdapter: ASREngineTelemetryProviding {}

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1123,6 +1123,13 @@ extension WhisperKitEngineAdapter {
   internal var retainedPCMForUnitTests: [Float] { retainedPCM }
   /// Test-only read of the kernel-supplied speech segments.
   internal var observedSpeechSegmentsForUnitTests: [SpeechSegment] { observedSpeechSegments }
+  /// Test-only handle to the armed model-unload task. Tests `await
+  /// adapter.modelUnloadTaskForUnitTests?.value` to wait for an armed
+  /// `.immediately` unload deterministically instead of yield-polling — the
+  /// task always completes (it returns whether or not it fires `unload()`),
+  /// so the await is bounded. Avoids the release-config flake where the
+  /// scheduled unload had not run within a fixed `Task.yield()` budget.
+  internal var modelUnloadTaskForUnitTests: Task<Void, Never>? { modelUnloadTask }
 }
 
 // MARK: - WhisperKitBackendDriving — local seam for testability (OQ-4 option a)

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -71,21 +71,18 @@ struct HeartPathTelemetryWiringTests {
     }
   }
 
-  /// Install a spy on `SentryBreadcrumb.captureErrorDelegate` for the
-  /// duration of the test, then restore the prior delegate. The
-  /// delegate hook (`SentryBreadcrumb.swift:145`) fires synchronously
-  /// before the SDK dispatch, so spy.calls is observable immediately
-  /// after the pipeline method returns.
-  private static func withCaptureSpy(
-    _ body: (CaptureSpy) -> Void
-  ) {
-    let spy = CaptureSpy()
-    let prior = SentryBreadcrumb.captureErrorDelegate
-    SentryBreadcrumb.captureErrorDelegate = { _, category, stage, extra in
+  /// Build a spy-backed capture sink to inject into a pipeline. Replaces the
+  /// former `SentryBreadcrumb.captureErrorDelegate` global install — that
+  /// process-global is shared across all `@MainActor` tests and is the #875
+  /// cross-test pollution vector. The injected sink fires synchronously on the
+  /// main actor, so `spy.calls` is observable immediately after the pipeline
+  /// method returns.
+  private static func spySink(
+    _ spy: CaptureSpy
+  ) -> KernelDictationDriverFactory.HeartPathCaptureErrorSink {
+    { _, category, stage, extra, _ in
       spy.record(.init(category: category, stage: stage, extra: extra ?? [:]))
     }
-    defer { SentryBreadcrumb.captureErrorDelegate = prior }
-    body(spy)
   }
 
   // MARK: - Test doubles
@@ -98,7 +95,11 @@ struct HeartPathTelemetryWiringTests {
     NoOpASRManager()
   }
 
-  private static func makePipeline() -> KernelDictationDriver {
+  private static func makePipeline(
+    captureErrorSink: @escaping KernelDictationDriverFactory.HeartPathCaptureErrorSink = {
+      _, _, _, _, _ in
+    }
+  ) -> KernelDictationDriver {
     let audio = makeStubAudio()
     let vad = KernelDictationDriverFactory.makeSharedVADSignalSource(audioCapture: audio)
     return KernelDictationDriverFactory.makeForParakeet(
@@ -109,7 +110,8 @@ struct HeartPathTelemetryWiringTests {
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        captureErrorSink: captureErrorSink
       ))
   }
 
@@ -150,18 +152,17 @@ struct HeartPathTelemetryWiringTests {
   /// witness: Parakeet omits the `"backend"` key.
   @Test("KernelDictationDriver interruption extras omit backend key (Parakeet wiring)")
   func parakeetPipelineWiringOmitsBackendExtra() {
-    let pipeline = Self.makePipeline()
+    let spy = CaptureSpy()
+    let pipeline = Self.makePipeline(captureErrorSink: Self.spySink(spy))
 
-    Self.withCaptureSpy { spy in
-      pipeline.handleCaptureSessionInterruption(Self.interruptionContext(sessionID: 1))
+    pipeline.handleCaptureSessionInterruption(Self.interruptionContext(sessionID: 1))
 
-      #expect(spy.calls.count == 1)
-      let call = spy.calls[0]
-      #expect(call.category == .audioCaptureFailed)
-      #expect(call.stage == "audio")
-      #expect(call.extra["backend"] == nil)
-      #expect(call.extra["capture_session_id"] as? Int == 1)
-    }
+    #expect(spy.calls.count == 1)
+    let call = spy.calls[0]
+    #expect(call.category == .audioCaptureFailed)
+    #expect(call.stage == "audio")
+    #expect(call.extra["backend"] == nil)
+    #expect(call.extra["capture_session_id"] as? Int == 1)
   }
 
   /// Codex gap #3 (Sentry-emit half) — pipeline-level emit dedup. Two
@@ -171,33 +172,31 @@ struct HeartPathTelemetryWiringTests {
   /// terminal-state flip — that lives in the next test.
   @Test("KernelDictationDriver.handleCaptureStall dedups Sentry emits per session")
   func parakeetPipelineStallDedupsSentryPerSession() {
-    let pipeline = Self.makePipeline()
+    let spy = CaptureSpy()
+    let pipeline = Self.makePipeline(captureErrorSink: Self.spySink(spy))
 
-    Self.withCaptureSpy { spy in
-      pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
-      pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 7))
 
-      #expect(spy.calls.count == 1)
-      #expect(spy.calls[0].category == .audioCaptureStalled)
-      #expect(spy.calls[0].extra["capture_session_id"] as? Int == 7)
-    }
+    #expect(spy.calls.count == 1)
+    #expect(spy.calls[0].category == .audioCaptureStalled)
+    #expect(spy.calls[0].extra["capture_session_id"] as? Int == 7)
   }
 
   /// Sanity companion to the dedup test: a different `sessionID` re-arms
   /// the dedup, proving it is not a global one-shot.
   @Test("KernelDictationDriver.handleCaptureStall re-arms Sentry emits on session change")
   func parakeetPipelineStallReArmsOnSession() {
-    let pipeline = Self.makePipeline()
+    let spy = CaptureSpy()
+    let pipeline = Self.makePipeline(captureErrorSink: Self.spySink(spy))
 
-    Self.withCaptureSpy { spy in
-      pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))
-      pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))  // suppressed
-      pipeline.handleCaptureStall(Self.stallContext(sessionID: 2))  // fresh session
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))  // suppressed
+    pipeline.handleCaptureStall(Self.stallContext(sessionID: 2))  // fresh session
 
-      #expect(spy.calls.count == 2)
-      let sessions = spy.calls.compactMap { $0.extra["capture_session_id"] as? Int }
-      #expect(sessions == [1, 2])
-    }
+    #expect(spy.calls.count == 2)
+    let sessions = spy.calls.compactMap { $0.extra["capture_session_id"] as? Int }
+    #expect(sessions == [1, 2])
   }
 
   /// Codex gap #3 — `guard fired else { return }` in
@@ -252,8 +251,12 @@ struct HeartPathTelemetryWiringTests {
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        // Asserts on STATE, not Sentry — no-op sink keeps the stall captureError
+        // off the process-global delegate (#875).
+        captureErrorSink: { _, _, _, _, _ in }
       ))
+    let stateWaiter = PipelineStateWaiter(pipeline)
 
     // Step 1: pre-dedup the emitter's stall flag while pipeline is .idle.
     // `handleCaptureStall` calls telemetry.stallFired (which dedups
@@ -272,10 +275,8 @@ struct HeartPathTelemetryWiringTests {
     )
     try await pipeline.handle(event: .toggleRecording(config))
 
-    let reachedRecording = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .recording
-    }
-    #expect(reachedRecording)
+    await stateWaiter.wait(for: .recording)
+    #expect(pipeline.state == .recording)
 
     // Step 3: same-session stall, now from .recording. Emitter returns
     // false (deduped). With `guard fired else { return }`: state stays
@@ -288,22 +289,6 @@ struct HeartPathTelemetryWiringTests {
 
     await pipeline.cancelRecording()
   }
-}
-
-@MainActor
-private func pollUntil(
-  timeout: Duration,
-  interval: Duration = .milliseconds(10),
-  condition: @escaping @MainActor () -> Bool
-) async -> Bool {
-  let deadline = ContinuousClock.now + timeout
-  while ContinuousClock.now < deadline {
-    if condition() {
-      return true
-    }
-    try? await Task.sleep(for: interval)
-  }
-  return condition()
 }
 
 // MARK: - Stubs (test-local)

--- a/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelEngineHookCallSitesTests.swift
@@ -331,16 +331,12 @@ struct KernelEngineHookCallSitesTests {
     let preWarmTask = Task { @MainActor in
       try? await fx.kernel.preWarm()
     }
-    // Yield until the engine has entered warmUpFromCache.
-    var entered = false
-    for _ in 0..<200 {
-      if fx.engine.warmUpFromCacheCallCount > 0 {
-        entered = true
-        break
-      }
-      await Task.yield()
-    }
-    #expect(entered, "FakeEngine.warmUpFromCache must have been entered")
+    // Signal-wait until the engine has entered warmUpFromCache (it then parks
+    // on the blocker), rather than racing a fixed yield budget (#875).
+    await fx.engine.waitForWarmUpFromCacheCount(1)
+    #expect(
+      fx.engine.warmUpFromCacheCallCount >= 1,
+      "FakeEngine.warmUpFromCache must have been entered")
     // While preWarm is parked, mint a new session via start() — this bumps
     // the kernel's currentSessionID off staleSID and transitions state out
     // of .idle. The post-await guard MUST see this and short-circuit.

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -231,11 +231,14 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
     feed(adapter, samples: [0.1], session: sid)  // dispatches a feed task
+    // Capture the in-flight feed task BEFORE cancel (cancel clears the array).
     // cancel()'s synchronous prefix sets isTerminal/streamingActive before it
     // suspends, so the queued feed task runs after and sees the terminated
-    // session.
+    // session. Await the captured handle deterministically — it guards on the
+    // session check and returns without feeding (bounded; no fixed yield).
+    let pendingFeeds = adapter.feedTasksForUnitTests
     await adapter.cancel()
-    for _ in 0..<50 { await Task.yield() }
+    for task in pendingFeeds { await task.value }
     #expect(manager.feedAudioCount == 0, "the queued feed saw the terminated session and skipped")
   }
 
@@ -250,7 +253,9 @@ import Testing
     feed(adapter, samples: [0.1], session: sidA)
     // finalize() for session A suspends inside the slow finalizeStreaming.
     async let outcomeA = adapter.finalize(batchSamples: nil)
-    for _ in 0..<10 { await Task.yield() }
+    // Signal-wait until finalize actually entered finalizeStreaming, rather
+    // than racing a fixed yield budget (#875).
+    await manager.waitForFinalizeStreamingCount(1)
     // Session B begins while A's finalize is still suspended.
     try await adapter.beginSession(SessionID(), options: .default, streaming: true)
     _ = await outcomeA
@@ -400,6 +405,12 @@ final class StubParakeetASRManager: ASRManagerInterface {
   var lastUnloadPolicy: ModelUnloadPolicy?
   var lastTranscribeSamples: [Float] = []
 
+  // Signal-based waiter for `finalizeStreamingCount` — `finalize` suspends
+  // inside the slow finalizeStreaming, so the test awaits
+  // `waitForFinalizeStreamingCount(1)` to know it entered, instead of
+  // yield-polling (#875).
+  private var finalizeStreamingWaiters = CountWaiters("finalizeStreamingCount")
+
   func loadModel() async throws {
     loadModelCount += 1
     isModelLoaded = true
@@ -433,11 +444,31 @@ final class StubParakeetASRManager: ASRManagerInterface {
 
   func finalizeStreaming() async throws -> ASRResult {
     finalizeStreamingCount += 1
+    finalizeStreamingWaiters.notify(reached: finalizeStreamingCount)
     if slowFinalizeStreaming {
       for _ in 0..<200 { await Task.yield() }
     }
     if finalizeStreamingThrows { throw FakeASRError.decode }
     return finalizeStreamingResult
+  }
+
+  /// Await until `finalizeStreamingCount >= target`. Resolves immediately if
+  /// already reached; always resolves within `timeout`.
+  func waitForFinalizeStreamingCount(_ target: Int, timeout: Duration = .seconds(5)) async {
+    if finalizeStreamingCount >= target { return }
+    let id = UUID()
+    let timeoutTask = Task { [weak self] in
+      try? await Task.sleep(for: timeout)
+      self?.resumeFinalizeStreamingWaiter(id)
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      finalizeStreamingWaiters.install(id: id, target: target, continuation)
+    }
+    timeoutTask.cancel()
+  }
+
+  private func resumeFinalizeStreamingWaiter(_ id: UUID) {
+    finalizeStreamingWaiters.resume(id: id)
   }
 
   func cancelStreaming() async {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -127,6 +127,11 @@ final class FakeEngine: ASREngineAdapter {
 
   private(set) var cancelPendingUnloadCallCount = 0
   private(set) var warmUpFromCacheCallCount = 0
+  // Signal-based waiter for `warmUpFromCacheCallCount` — `preWarm` parks inside
+  // `warmUpFromCache` (blocked on `warmUpFromCacheBlocker`), so the test can't
+  // await the parked `preWarm` task. It awaits `waitForWarmUpFromCacheCount(1)`
+  // instead of yield-polling the counter (#875).
+  private var warmUpFromCacheWaiters = CountWaiters("warmUpFromCacheCallCount")
   private(set) var observeSpeechSegmentsCallCount = 0
   /// The segments argument from the most recent `observeSpeechSegments(_:)`
   /// call — lets VAD-source-precedence tests assert the kernel passes its own
@@ -399,6 +404,7 @@ final class FakeEngine: ASREngineAdapter {
 
   func warmUpFromCache() async throws {
     warmUpFromCacheCallCount += 1
+    warmUpFromCacheWaiters.notify(reached: warmUpFromCacheCallCount)
     eventLog.append(.warmUpFromCache)
     if blockWarmUpFromCache {
       await withCheckedContinuation {
@@ -408,6 +414,24 @@ final class FakeEngine: ASREngineAdapter {
     }
     if warmUpFromCacheThrows {
       throw FakeEngineCacheError.simulated
+    }
+  }
+
+  /// Await until `warmUpFromCacheCallCount >= target`. Resolves immediately if
+  /// already reached, else parks until `warmUpFromCache` is entered.
+  ///
+  /// PURE signal wait — NO wall-clock timeout net, because this file lives
+  /// under `Simulator/` where `SimulatorWallClockBanTests` forbids any
+  /// wall-clock sleep API (determinism rests on `FakeClock`). The signal is
+  /// deterministic (`preWarm` always calls `warmUpFromCache`); were it ever to
+  /// not arrive, the test hangs and surfaces as a loud CI job timeout — a
+  /// visible failure, not the silent false-pass the timeout net guards against
+  /// elsewhere.
+  func waitForWarmUpFromCacheCount(_ target: Int) async {
+    if warmUpFromCacheCallCount >= target { return }
+    let id = UUID()
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      warmUpFromCacheWaiters.install(id: id, target: target, continuation)
     }
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -55,6 +55,12 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
   var makeIncrementalSessionCount = 0
   var unloadCount = 0
 
+  // Signal-based waiter for `transcribeCount`. Tests await
+  // `waitForTranscribeCount(1)` to know `finalize` reached the (suspended)
+  // transcribe path, instead of yield-polling — actor isolation makes the
+  // check + install atomic; the timeout net guarantees resolution (#875).
+  private var transcribeWaiters = CountWaiters("transcribeCount")
+
   // MARK: Setters (callable from MainActor tests)
 
   func setIsReady(_ v: Bool) { isReady = v }
@@ -90,6 +96,7 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     -> ASRResult
   {
     transcribeCount += 1
+    transcribeWaiters.notify(reached: transcribeCount)
     lastTranscribeSamples = audioSamples
     lastTranscribeOptions = options
     if slowTranscribe {
@@ -98,6 +105,23 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     if let err = transcribeThrows { throw err }
     return transcribeResult
   }
+
+  /// Await until `transcribeCount >= target`. Resolves immediately if already
+  /// reached; always resolves within `timeout`.
+  func waitForTranscribeCount(_ target: Int, timeout: Duration = .seconds(5)) async {
+    if transcribeCount >= target { return }
+    let id = UUID()
+    let timeoutTask = Task { [weak self] in
+      try? await Task.sleep(for: timeout)
+      await self?.resumeTranscribeWaiter(id)
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      transcribeWaiters.install(id: id, target: target, continuation)
+    }
+    timeoutTask.cancel()
+  }
+
+  private func resumeTranscribeWaiter(_ id: UUID) { transcribeWaiters.resume(id: id) }
 
   func observeLID(samples: [Float], maxWindows: Int) async -> LIDObservationBatch {
     observeLIDCount += 1
@@ -132,6 +156,11 @@ actor StubIncrementalSession: WhisperKitIncrementalSession {
   /// worker decode suspended while a new session begins.
   var slowFinalize = false
 
+  // Signal-based waiter for `cancelCount` — the orphan-worker cancel runs in a
+  // detached task off `beginSession`, so tests await `waitForCancelCount(1)`
+  // instead of yield-polling (#875).
+  private var cancelWaiters = CountWaiters("cancelCount")
+
   init(result: IncrementalResult) {
     self.finalizeResult = result
   }
@@ -158,7 +187,25 @@ actor StubIncrementalSession: WhisperKitIncrementalSession {
 
   func cancel() async {
     cancelCount += 1
+    cancelWaiters.notify(reached: cancelCount)
   }
+
+  /// Await until `cancelCount >= target`. Resolves immediately if already
+  /// reached; always resolves within `timeout`.
+  func waitForCancelCount(_ target: Int, timeout: Duration = .seconds(5)) async {
+    if cancelCount >= target { return }
+    let id = UUID()
+    let timeoutTask = Task { [weak self] in
+      try? await Task.sleep(for: timeout)
+      await self?.resumeCancelWaiter(id)
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      cancelWaiters.install(id: id, target: target, continuation)
+    }
+    timeoutTask.cancel()
+  }
+
+  private func resumeCancelWaiter(_ id: UUID) { cancelWaiters.resume(id: id) }
 }
 
 // MARK: - IncrementalResult convenience constructors

--- a/Tests/EnviousWisprTests/Pipeline/TestSupport/PipelineSignalWaiters.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TestSupport/PipelineSignalWaiters.swift
@@ -1,0 +1,150 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// Signal-based test waiters for the kernel-driver suites (#875).
+//
+// Replaces real-time poll loops (`pollUntil` + `Task.sleep` cadence) and
+// fixed `for _ in 0..<N { await Task.yield() }` budgets — both flake under
+// release-config CI optimization, where contended scheduling overshoots the
+// budget and a state/count that lands in 2s locally lands past the window in
+// CI (swift-patterns.md `tests-no-real-time-scheduling-precision`,
+// `signal-spy-fire-and-forget-logs`; no-arbitrary-timeouts.md
+// `prefer-signal-based-detection`).
+//
+// Both waiters mirror `SignalPipelineLogger`: the "already satisfied?" check
+// and the waiter install are atomic within one isolation domain (no `await`
+// between them), each waiter has a UUID so it resumes exactly once, and an
+// internal timeout task guarantees the continuation always resolves so a
+// never-arriving signal surfaces as a fast failure instead of a hang
+// (swift-patterns.md `tests-no-unconditional-continuation-await`).
+
+/// Awaits a mapped `PipelineState` on a `KernelDictationDriver` via its
+/// `onStateChange` callback instead of polling `driver.state`. Records every
+/// state the driver fires (history) and advances a cursor as each `wait(for:)`
+/// consumes a match, so a test that passes through the same state more than
+/// once (e.g. two recording sessions) matches each occurrence in order rather
+/// than re-matching the first. Test bodies `await` sequentially, so at most one
+/// waiter is parked at a time.
+@MainActor
+final class PipelineStateWaiter {
+  private struct Waiter {
+    let id: UUID
+    let predicate: (PipelineState) -> Bool
+    let continuation: CheckedContinuation<Void, Never>
+  }
+
+  private let driver: KernelDictationDriver
+  private var history: [PipelineState] = []
+  /// Index of the first history entry not yet consumed by a `wait(for:)`.
+  private var cursor: Int = 0
+  private var pending: Waiter?
+
+  /// Subscribes to `driver.onStateChange`. Seeds `history` with the driver's
+  /// current state so a state reached before subscription is not missed.
+  init(_ driver: KernelDictationDriver) {
+    self.driver = driver
+    history.append(driver.state)
+    driver.onStateChange = { [weak self] state in
+      // `onStateChange` fires synchronously on the `@MainActor` driver, so
+      // recording on the main actor is safe and keeps history ordered.
+      MainActor.assumeIsolated { self?.record(state) }
+    }
+  }
+
+  private func record(_ state: PipelineState) {
+    history.append(state)
+    guard let waiter = pending, waiter.predicate(state) else { return }
+    cursor = history.count  // consume through this state
+    pending = nil
+    waiter.continuation.resume()
+  }
+
+  /// Await until a state matching `predicate` is observed. Consumes the first
+  /// unconsumed matching state in history (immediate return) or parks until one
+  /// arrives. Always resolves within `timeout` (the test then fails on its
+  /// post-wait assertion rather than hanging).
+  func wait(
+    for predicate: @escaping (PipelineState) -> Bool,
+    timeout: Duration = .seconds(5)
+  ) async {
+    if let index = (cursor..<history.count).first(where: { predicate(history[$0]) }) {
+      cursor = index + 1
+      return
+    }
+    let id = UUID()
+    let timeoutTask = Task { [weak self] in
+      try? await Task.sleep(for: timeout)
+      self?.resume(id)
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      pending = Waiter(id: id, predicate: predicate, continuation: continuation)
+    }
+    timeoutTask.cancel()
+  }
+
+  /// Convenience: await an exact state.
+  func wait(for state: PipelineState, timeout: Duration = .seconds(5)) async {
+    await wait(for: { $0 == state }, timeout: timeout)
+  }
+
+  private func resume(_ id: UUID) {
+    guard let waiter = pending, waiter.id == id else { return }
+    pending = nil
+    // Reaching here means the timeout fired before any matching state — a real
+    // signal failure, not a satisfied wait. Record it so the test fails instead
+    // of silently proceeding past a state that never arrived.
+    Issue.record("PipelineStateWaiter timed out waiting for a matching pipeline state")
+    waiter.continuation.resume()
+  }
+}
+
+/// Count-reached signal embedded in a test stub (actor or `@MainActor` class).
+/// The owner holds the authoritative counter and calls `notify(reached:)` after
+/// each increment; a waiter parks until the count reaches its target. All
+/// methods must be called from the owner's isolation — that isolation provides
+/// the atomicity `SignalPipelineLogger` gets from `@MainActor` (the
+/// "already reached?" check, install, and `notify` never interleave). The
+/// owner pairs this with a timeout task that calls `resume(id:)` so a target
+/// that never arrives resolves instead of hanging.
+struct CountWaiters {
+  private struct Waiter {
+    let id: UUID
+    let target: Int
+    let continuation: CheckedContinuation<Void, Never>
+  }
+  /// Names the observed counter for the timeout failure message.
+  let label: String
+  private var waiters: [Waiter] = []
+
+  init(_ label: String) {
+    self.label = label
+  }
+
+  /// Resume + remove every waiter whose target the new count has reached.
+  mutating func notify(reached count: Int) {
+    let ready = waiters.filter { $0.target <= count }
+    waiters.removeAll { waiter in ready.contains { $0.id == waiter.id } }
+    for waiter in ready { waiter.continuation.resume() }
+  }
+
+  /// Park a waiter for `target`. Caller must have already checked that the
+  /// current count is below `target` in the same isolated, await-free run.
+  mutating func install(id: UUID, target: Int, _ continuation: CheckedContinuation<Void, Never>) {
+    waiters.append(Waiter(id: id, target: target, continuation: continuation))
+  }
+
+  /// Timeout-net resume: resolve a still-pending waiter by id (resume-once —
+  /// removed first so `notify` cannot also resume it). Finding a pending waiter
+  /// here means the target count never arrived within the timeout — a real
+  /// signal failure, so record it as a test failure instead of letting the
+  /// caller proceed as if the count was reached.
+  mutating func resume(id: UUID) {
+    guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+    let waiter = waiters.remove(at: index)
+    Issue.record("CountWaiters[\(label)] timed out waiting for count to reach \(waiter.target)")
+    waiter.continuation.resume()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/V2/CancellationSilentUnwindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/CancellationSilentUnwindTests.swift
@@ -18,9 +18,14 @@ import Testing
 /// action, not a failure mode, and any error-class breadcrumb during unwind
 /// would alert-spam the live triage Routine.
 ///
-/// Surface: pipeline cancellation path. Uses the same
-/// `SentryBreadcrumb.captureErrorDelegate` spy pattern as
-/// `HeartPathTelemetryWiringTests`.
+/// Surface: pipeline cancellation path. Injects a per-instance capture sink
+/// into the pipeline (via `KernelDictationDriverFactory` inputs) instead of
+/// installing the process-global `SentryBreadcrumb.captureErrorDelegate`. The
+/// global is shared across all `@MainActor` tests: while this test is suspended
+/// at an `await`, a sibling test's pipeline could fire `captureError` into the
+/// global delegate this test had installed, recording a stray breadcrumb and
+/// flaking the `spy.calls.isEmpty` assertion (#875, release-config one-per-run).
+/// A per-instance sink keeps this pipeline off that global entirely.
 @MainActor
 @Suite("V2 Lane C — cancellation unwinds without Sentry error spam")
 struct CancellationSilentUnwindTests {
@@ -52,16 +57,6 @@ struct CancellationSilentUnwindTests {
     }
   }
 
-  private static func withCaptureSpy(_ body: (CaptureSpy) async throws -> Void) async rethrows {
-    let spy = CaptureSpy()
-    let prior = SentryBreadcrumb.captureErrorDelegate
-    SentryBreadcrumb.captureErrorDelegate = { _, category, stage, _ in
-      spy.record(.init(category: category, stage: stage))
-    }
-    defer { SentryBreadcrumb.captureErrorDelegate = prior }
-    try await body(spy)
-  }
-
   @Test("cancelRecording from .recording emits zero Sentry error breadcrumbs")
   func testCancellationSilentUnwind() async throws {
     let fixture = try SyntheticAudioFixture.make(
@@ -80,6 +75,7 @@ struct CancellationSilentUnwindTests {
         )
       )
     )
+    let spy = CaptureSpy()
     let vad = KernelDictationDriverFactory.makeSharedVADSignalSource(
       audioCapture: audioCapture)
     let pipeline = KernelDictationDriverFactory.makeForParakeet(
@@ -90,8 +86,12 @@ struct CancellationSilentUnwindTests {
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        captureErrorSink: { _, category, stage, _, _ in
+          spy.record(.init(category: category, stage: stage))
+        }
       ))
+    let stateWaiter = PipelineStateWaiter(pipeline)
 
     let config = DictationSessionConfig.testDefault(
       autoPasteToActiveApp: false,
@@ -101,47 +101,31 @@ struct CancellationSilentUnwindTests {
       llmModel: "gpt-test"
     )
 
-    try await Self.withCaptureSpy { spy in
-      try await pipeline.handle(event: .toggleRecording(config))
+    try await pipeline.handle(event: .toggleRecording(config))
 
-      let reachedRecording = await pollUntil(timeout: .seconds(1)) {
-        pipeline.state == .recording
-      }
-      #expect(reachedRecording, "must reach .recording before cancellation")
+    await stateWaiter.wait(for: .recording)
+    #expect(pipeline.state == .recording, "must reach .recording before cancellation")
 
-      // Scope the assertion to the cancel phase. PR-4b.4 (#827): the kernel
-      // has its own no-buffer stall watchdog that may emit an
-      // `audioCaptureStalled` breadcrumb during the recording window when
-      // `FixtureAudioCapture`'s synthetic stream produces no live buffers.
-      // That pre-cancel emission is a fixture-driven artifact, not the
-      // unwind behavior under test. The product invariant ("cancellation is
-      // a legitimate user action, not a failure") concerns whether the
-      // cancel path itself routes through error telemetry — clear the spy
-      // so only post-cancel emissions count toward the assertion.
-      spy.clear()
+    // Scope the assertion to the cancel phase. PR-4b.4 (#827): the kernel
+    // has its own no-buffer stall watchdog that may emit an
+    // `audioCaptureStalled` breadcrumb during the recording window when
+    // `FixtureAudioCapture`'s synthetic stream produces no live buffers.
+    // That pre-cancel emission is a fixture-driven artifact, not the
+    // unwind behavior under test. The product invariant ("cancellation is
+    // a legitimate user action, not a failure") concerns whether the
+    // cancel path itself routes through error telemetry — clear the spy
+    // so only post-cancel emissions count toward the assertion.
+    spy.clear()
 
-      await pipeline.cancelRecording()
+    await pipeline.cancelRecording()
 
-      #expect(pipeline.state == .idle, "cancelRecording must return to .idle")
-      #expect(asrManager.transcribeCallCount == 0, "ASR must not be called on cancelled session")
+    #expect(pipeline.state == .idle, "cancelRecording must return to .idle")
+    #expect(asrManager.transcribeCallCount == 0, "ASR must not be called on cancelled session")
 
-      #expect(
-        spy.calls.isEmpty,
-        "cancel path must emit zero Sentry error breadcrumbs (got: \(spy.calls.map(\.stage)))")
-    }
+    // The injected sink fires synchronously on the main actor, so spy.calls is
+    // final the instant cancelRecording returns — no drain wait needed.
+    #expect(
+      spy.calls.isEmpty,
+      "cancel path must emit zero Sentry error breadcrumbs (got: \(spy.calls.map(\.stage)))")
   }
-}
-
-@MainActor
-private func pollUntil(
-  timeout: Duration,
-  interval: Duration = .milliseconds(10),
-  condition: @escaping @MainActor () -> Bool
-) async -> Bool {
-  let deadline = ContinuousClock.now + timeout
-  while ContinuousClock.now < deadline {
-    if condition() { return true }
-    try? await Task.sleep(for: interval)
-  }
-  return condition()
 }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -43,8 +43,14 @@ struct DedupSurvivesStallTests {
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        // No-op sink: this test asserts on STATE flips, not on Sentry. Inject a
+        // no-op so the pipeline's stall captureError never reaches the
+        // process-global delegate, where it could pollute a concurrent test's
+        // installed spy (#875).
+        captureErrorSink: { _, _, _, _, _ in }
       ))
+    let stateWaiter = PipelineStateWaiter(pipeline)
 
     let config = DictationSessionConfig.testDefault(
       autoPasteToActiveApp: false,
@@ -56,10 +62,8 @@ struct DedupSurvivesStallTests {
 
     // ─── Session 1 ─────────────────────────────────────────────────────────
     try await pipeline.handle(event: .toggleRecording(config))
-    let reachedRecording1 = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .recording
-    }
-    #expect(reachedRecording1, "session 1 must reach .recording")
+    await stateWaiter.wait(for: .recording)
+    #expect(pipeline.state == .recording, "session 1 must reach .recording")
 
     // First stall in session 1 — emitter fires (no prior dedup); the kernel's
     // recording-exit continuation resumes the forward-path coroutine, which
@@ -67,38 +71,34 @@ struct DedupSurvivesStallTests {
     // `.error("No audio detected -- try again.")`). The transition is async
     // because the forward path runs in a separate Task — poll until it lands.
     pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))
-    let reachedError1 = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .error("No audio detected — try again.")
-    }
-    #expect(reachedError1, "first stall in session 1 must flip state to .error")
+    await stateWaiter.wait(for: .error("No audio detected — try again."))
+    #expect(
+      pipeline.state == .error("No audio detected — try again."),
+      "first stall in session 1 must flip state to .error")
 
     // Reset to idle so we can start session 2. `cancelRecording()` is a
     // no-op once the pipeline is in `.error` (its guard checks for
     // `.recording` / `.loadingModel`); `reset()` is the path that takes the
     // pipeline back to `.idle` from any state.
     pipeline.reset()
-    let reachedIdle = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .idle
-    }
-    #expect(reachedIdle, "reset() must return to .idle")
+    await stateWaiter.wait(for: .idle)
+    #expect(pipeline.state == .idle, "reset() must return to .idle")
 
     // ─── Session 2 ─────────────────────────────────────────────────────────
     try await pipeline.handle(event: .toggleRecording(config))
-    let reachedRecording2 = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .recording
-    }
-    #expect(reachedRecording2, "session 2 must reach .recording — dedup must not block restart")
+    await stateWaiter.wait(for: .recording)
+    #expect(
+      pipeline.state == .recording,
+      "session 2 must reach .recording — dedup must not block restart")
 
     // Stall in session 2 (fresh sessionID). Emitter must NOT consider this
     // deduped from session 1's prior fire — the pipeline guard must advance
     // to .error. If dedup state had leaked across recordings, state would
     // remain .recording and this test would fail.
     pipeline.handleCaptureStall(Self.stallContext(sessionID: 2))
-    let reachedError2 = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .error("No audio detected — try again.")
-    }
+    await stateWaiter.wait(for: .error("No audio detected — try again."))
     #expect(
-      reachedError2,
+      pipeline.state == .error("No audio detected — try again."),
       "stall in fresh session 2 must fire — dedup state must not survive restart")
 
     await pipeline.cancelRecording()
@@ -120,20 +120,6 @@ struct DedupSurvivesStallTests {
       inputDeviceUIDSystemDefault: nil
     )
   }
-}
-
-@MainActor
-private func pollUntil(
-  timeout: Duration,
-  interval: Duration = .milliseconds(10),
-  condition: @escaping @MainActor () -> Bool
-) async -> Bool {
-  let deadline = ContinuousClock.now + timeout
-  while ContinuousClock.now < deadline {
-    if condition() { return true }
-    try? await Task.sleep(for: interval)
-  }
-  return condition()
 }
 
 // MARK: - Test stubs

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -63,8 +63,9 @@ import Testing
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
     adapter.applyUnloadPolicy(.immediately)
-    // Yield so the scheduled `Task` runs `backend.unload()` and posts back.
-    for _ in 0..<50 { await Task.yield() }
+    // Await the armed unload task to completion (deterministic, bounded) —
+    // a fixed `Task.yield()` budget is not enough under release-config CI.
+    await adapter.modelUnloadTaskForUnitTests?.value
     #expect(adapter.readiness == .notReady)
     let unloadCount = await backend.unloadCount
     #expect(unloadCount == 1)
@@ -773,7 +774,9 @@ import Testing
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.immediately)
-    for _ in 0..<50 { await Task.yield() }
+    // Await the armed unload task deterministically (release-config CI does
+    // not complete it within a fixed `Task.yield()` budget — #874 red main).
+    await adapter.modelUnloadTaskForUnitTests?.value
     let count = await backend.unloadCount
     #expect(count == 1)
   }

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -114,8 +114,10 @@ import Testing
     await backend.setPrepareIfCachedResult(true)
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUpFromCache()
-    // Give any putative background task a chance to run.
-    for _ in 0..<50 { await Task.yield() }
+    // warmUpFromCache awaits its own work and (by design, Codex r5) spawns no
+    // background load task, so the counts are final the instant it returns —
+    // assert synchronously instead of yield-polling for a task that never
+    // exists (#875).
     let pifCount = await backend.prepareIfCachedCount
     let prepareCount = await backend.prepareCount
     #expect(pifCount == 0, "warmUpFromCache must NOT call prepareIfCached")
@@ -251,8 +253,9 @@ import Testing
     // be cancelled and dropped so auto mode does NOT enter the worker path.
     await backend.setIncrementalSessionFactory(nil)
     try await adapter.beginSession(SessionID(), options: .default, streaming: false)
-    // Yield so the detached worker.cancel() task runs.
-    for _ in 0..<10 { await Task.yield() }
+    // Signal-wait for the detached worker.cancel() task, rather than racing a
+    // fixed yield budget (#875).
+    await stubSession.waitForCancelCount(1)
     let cancels = await stubSession.cancelCount
     #expect(cancels == 1, "orphan worker must be cancelled on beginSession")
   }
@@ -685,21 +688,11 @@ import Testing
     feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
     adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
     async let outcomeA = adapter.finalize(batchSamples: nil)
-    // Signal-based wait: poll the backend's transcribeCount until finalize
-    // has actually entered the slow transcribe path. Pure-yield racing is
-    // fragile — `async let` schedules finalize but doesn't guarantee it
-    // reaches the suspend point before the test's next await
-    // (~/.claude/rules/no-arbitrary-timeouts.md `prefer-signal-based-detection`).
-    var entered = false
-    for _ in 0..<200 {
-      let count = await backend.transcribeCount
-      if count == 1 {
-        entered = true
-        break
-      }
-      await Task.yield()
-    }
-    #expect(entered, "finalize did not reach backend.transcribe within 200 yields")
+    // Signal-wait until finalize actually entered the slow transcribe path,
+    // rather than racing a fixed yield budget — `async let` schedules finalize
+    // but doesn't guarantee it reached the suspend point (#875;
+    // no-arbitrary-timeouts.md `prefer-signal-based-detection`).
+    await backend.waitForTranscribeCount(1)
     // Session B begins while A's finalize is still suspended in transcribe.
     try await adapter.beginSession(SessionID(), options: .default, streaming: false)
     _ = await outcomeA
@@ -724,17 +717,8 @@ import Testing
     feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
     adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
     async let outcomeA = adapter.finalize(batchSamples: nil)
-    // Wait for finalize to reach transcribe.
-    var entered = false
-    for _ in 0..<200 {
-      let count = await backend.transcribeCount
-      if count == 1 {
-        entered = true
-        break
-      }
-      await Task.yield()
-    }
-    #expect(entered, "finalize did not reach backend.transcribe within 200 yields")
+    // Signal-wait until finalize entered transcribe (#875).
+    await backend.waitForTranscribeCount(1)
     // Session B begins, feeds fresh audio + segments.
     let sidB = SessionID()
     try await adapter.beginSession(sidB, options: .default, streaming: false)
@@ -763,7 +747,10 @@ import Testing
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.never)
-    for _ in 0..<50 { await Task.yield() }
+    // `.never` arms no task — the inspector is nil synchronously after the
+    // call, so no unload can fire. Assert directly instead of yield-polling
+    // for an absence (#875).
+    #expect(adapter.modelUnloadTaskForUnitTests == nil, ".never schedules no unload task")
     let count = await backend.unloadCount
     #expect(count == 0)
   }
@@ -787,8 +774,15 @@ import Testing
     let adapter = WhisperKitEngineAdapter(backend: backend)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.twoMinutes)
+    // Capture the armed task, cancel it, then await the captured handle: its
+    // sleep throws on cancellation and the task returns without unloading, so
+    // the await is bounded (no fixed yield). Assert the inspector cleared and
+    // no unload fired (#875).
+    let armed = adapter.modelUnloadTaskForUnitTests
     adapter.cancelPendingUnload()
-    for _ in 0..<50 { await Task.yield() }
+    await armed?.value
+    #expect(
+      adapter.modelUnloadTaskForUnitTests == nil, "cancelPendingUnload clears the armed task")
     let count = await backend.unloadCount
     #expect(count == 0, "armed timer was cancelled before its deadline; no unload fired")
   }
@@ -968,8 +962,12 @@ import Testing
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     adapter.applyUnloadPolicy(.immediately)
-    // Yield so any putative unload task would have run.
-    for _ in 0..<50 { await Task.yield() }
+    // applyUnloadPolicy refuses to arm during an active session — the
+    // inspector is nil synchronously after the call, so no unload task exists
+    // to fire. Assert directly instead of yield-polling for an absence (#875).
+    #expect(
+      adapter.modelUnloadTaskForUnitTests == nil,
+      "no unload task may be armed during an active session")
     let count = await backend.unloadCount
     #expect(count == 0, "unload must NOT fire while a session is active")
   }
@@ -992,10 +990,16 @@ import Testing
     _ = await adapter.finalize(batchSamples: nil)
     // Now apply policy in the terminal A state — armed unload task starts.
     adapter.applyUnloadPolicy(.immediately)
-    // Begin session B before the unload task hops back.
+    // Capture A's armed task with a synchronous read (no MainActor yield), so
+    // beginSession(B)'s synchronous prefix still cancels + clears it before it
+    // can run. Begin B, then await the captured handle: cancellation + the
+    // session-keying re-check make it return without unloading — bounded (#875).
+    let armedUnderA = adapter.modelUnloadTaskForUnitTests
     try await adapter.beginSession(SessionID(), options: .default, streaming: false)
-    // Yield so any putative unload task would have run.
-    for _ in 0..<50 { await Task.yield() }
+    await armedUnderA?.value
+    #expect(
+      adapter.modelUnloadTaskForUnitTests == nil,
+      "beginSession(B) cancels and clears A's armed unload task")
     let count = await backend.unloadCount
     #expect(count == 0, "unload from A's armed task must NOT fire under B")
   }


### PR DESCRIPTION
## Repair: main red after #874 (release-config test flake)

`main-post-merge-build` failed the release-config test pass on:
`WhisperKitEngineAdapterTests.applyUnloadPolicy(.immediately) calls backend.unload()` — `(count → 0) == 1`.

**Not a product bug.** `applyUnloadPolicy(.immediately)` schedules a `Task` (two MainActor hops + `await backend.unload()`). The two `count == 1` tests yield-polled a fixed `for _ in 0..<50 { await Task.yield() }` budget — enough in debug, not under release optimization on contended CI, so the unload hadn't run when the count was read.

**Fix** (per `swift-patterns.md` `tests-no-real-time-scheduling-precision`): await the armed unload task to completion (bounded — the task always returns) via a new internal `modelUnloadTaskForUnitTests` inspector, instead of yield-polling. Only the two `count == 1` tests changed; the `count == 0` cases pass regardless of timing (and one deliberately polls an orphaned/cancelled task it can't await).

**Why it escaped the PR gate:** PR `build-check` runs release *build* + debug *tests*; release-config tests run only in `main-post-merge` (`ci-pipeline.md` `release-tests-run-post-merge`). The documented prevention (`gotchas-release.md` `release-test-target-compile` — run `scripts/swift-test.sh -c release` locally) was not run on #874. My miss.

**Verified:** `scripts/swift-test.sh -c release --filter WhisperKitEngineAdapterTests` → 55/55 pass. Release build clean.

Part of #827.