### PR TITLE
refactor(engine-kernel): PR-6 — KernelAdapterFactory construction-owner seam (#827)

### DIFF
--- a/Sources/EnviousWispr/App/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/App/EnviousWisprApp.swift
@@ -134,8 +134,10 @@ struct EnviousWisprApp: App {
 
     // PR-5 Rung 5 (#827): WhisperKit recordings now flow through a second
     // `KernelDictationDriver` built by the factory's WhisperKit branch. The
-    // App's WhisperKit-side dispatch surface stays one driver per backend
-    // until PR-6 introduces the hot-swap factory. LID-to-polish wiring is
+    // App still builds one driver per backend; PR-6 (#827) introduced the
+    // `KernelAdapterFactory` construction owner that the driver factory calls
+    // into, not a single-dispatch-surface consolidation (still two drivers).
+    // LID-to-polish wiring is
     // owned by `KernelFinalizationWiring.processText` via the
     // `ASREngineLanguageIdentifying` cast on the adapter; the silent
     // App-init cache pre-load is owned by the driver's

--- a/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
@@ -1,0 +1,49 @@
+import EnviousWisprASR
+import Foundation
+
+/// The single concrete `ASREngineAdapter` construction owner (epic #827, PR-6).
+///
+/// Before PR-6 the driver-assembly factory (`KernelDictationDriverFactory`)
+/// constructed both concrete adapters inline, so it named `ParakeetEngineAdapter`
+/// and `WhisperKitEngineAdapter` directly and engine construction was entangled
+/// with driver assembly. PR-6 moves the two construction expressions here so
+/// there is one home that knows how to build each engine's adapter, and the
+/// driver-assembly factory names no concrete adapter type in code.
+///
+/// This is a construction OWNER, not a runtime `backendType -> adapter` dispatch
+/// map: each make function takes exactly the dependencies its engine needs (the
+/// type-system-enforced per-engine surface chosen in PR-5 Rung 4, which
+/// deliberately rejected a single optional all-engines dependency bundle).
+/// Backend selection stays in the existing typed driver/App wiring; this type
+/// only constructs.
+///
+/// Hot-swap (epic goal #4): adding an engine is "write the `ASREngineAdapter`
+/// conformer plus a make function here," touching zero lines of
+/// `RecordingSessionKernel`. The kernel already consumes an opaque
+/// `any ASREngineAdapter`; the PR-2 fake engine is the standing kernel-isolation
+/// proof. `EngineIdentityFreezeTests` Test A locks construction to this file.
+@MainActor
+package enum KernelAdapterFactory {
+
+  /// The single Parakeet adapter construction site in `Sources/`.
+  package static func makeParakeetAdapter(
+    asrManager: any ASRManagerInterface
+  ) -> any ASREngineAdapter {
+    ParakeetEngineAdapter(asrManager: asrManager)
+  }
+
+  /// The single WhisperKit adapter construction site in `Sources/`.
+  /// `audioCaptureSessionIDSource` mirrors the adapter's own parameter (PR-5
+  /// Rung 4.5) so the adapter can snapshot the capture session id at
+  /// `beginSession` for race-safe delayed LID perf signposts.
+  package static func makeWhisperKitAdapter(
+    backend: any WhisperKitBackendDriving,
+    languageDetector: LanguageDetector,
+    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64
+  ) -> any ASREngineAdapter {
+    WhisperKitEngineAdapter(
+      backend: backend,
+      languageDetector: languageDetector,
+      audioCaptureSessionIDSource: audioCaptureSessionIDSource)
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -192,7 +192,11 @@ public enum KernelDictationDriverFactory {
   /// Build the driver stack for the Parakeet engine and arm both observation
   /// arms before returning. Live App caller in `EnviousWisprApp`.
   package static func makeForParakeet(inputs: ParakeetInputs) -> KernelDictationDriver {
-    let adapter = ParakeetEngineAdapter(asrManager: inputs.asrManager)
+    // PR-6 (#827): concrete adapter construction is owned by
+    // `KernelAdapterFactory` (the single construction site). This file no
+    // longer names a concrete adapter type in code (EngineIdentityFreezeTests
+    // Test B); it assembles around the opaque `any ASREngineAdapter` returned.
+    let adapter = KernelAdapterFactory.makeParakeetAdapter(asrManager: inputs.asrManager)
     return assembleDriver(
       adapter: adapter,
       audioCapture: inputs.audioCapture,
@@ -213,8 +217,10 @@ public enum KernelDictationDriverFactory {
     // PR-5 Rung 4.5 (#827): plumb the audio-capture session-id source to the
     // adapter so it can snapshot at `beginSession` (race-safe for delayed LID
     // perf signposts like `t_clipboard_write`).
+    // PR-6 (#827): concrete adapter construction is owned by
+    // `KernelAdapterFactory`; this file names no concrete adapter type in code.
     let captureSource = inputs.audioCapture
-    let adapter = WhisperKitEngineAdapter(
+    let adapter = KernelAdapterFactory.makeWhisperKitAdapter(
       backend: inputs.whisperKitBackend,
       languageDetector: inputs.languageDetector,
       audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID })

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -430,6 +430,98 @@ import Testing
       """)
   }
 
+  // MARK: PR-6 (#827): concrete adapter construction confined to KernelAdapterFactory
+
+  /// The whole-word concrete adapter type names PR-6 confines.
+  private static let concreteAdapterTypeNames = [
+    "ParakeetEngineAdapter", "WhisperKitEngineAdapter",
+  ]
+
+  /// The one allowlisted construction home (epic #827, PR-6).
+  private static let adapterConstructionOwner =
+    "Sources/EnviousWisprPipeline/KernelAdapterFactory.swift"
+
+  private static let driverAssemblyFactory =
+    "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift"
+
+  /// Test A. Every concrete adapter CONSTRUCTION CALL (`TypeName(`) in
+  /// `Sources/` lives only in `KernelAdapterFactory.swift`. The construction-call
+  /// pattern (`\bTypeName\s*\(`) is deliberately narrower than a whole-word type
+  /// scan: it does NOT match the adapters' own `class`/`extension` declarations
+  /// (followed by `:` or `{`, never `(`) nor the 10 `category: "WhisperKitEngineAdapter"`
+  /// `AppLogger` string literals, which is exactly why a whole-word repo-wide ban
+  /// would false-fail (Codex r4). `scanSources` skips comment-only lines, so the
+  /// `// MARK: - …Adapter (` headers are not counted either.
+  @Test("concrete adapter construction calls live only in KernelAdapterFactory (PR-6 #827)")
+  func adapterConstructionConfinedToKernelAdapterFactory() throws {
+    for name in Self.concreteAdapterTypeNames {
+      let hits = try Self.scanSources(pattern: #"\b"# + name + #"\s*\("#)
+      let offenders = hits.filter {
+        !$0.hasPrefix(Self.adapterConstructionOwner + ":")
+      }
+      #expect(
+        offenders.isEmpty,
+        """
+        Concrete adapter construction `\(name)(` found in `Sources/` code outside
+        \(Self.adapterConstructionOwner):
+        \(offenders.joined(separator: "\n"))
+        PR-6 (#827) confines all concrete `ASREngineAdapter` construction to
+        `KernelAdapterFactory`. Add a `make…Adapter` function there and call it.
+        """)
+    }
+  }
+
+  /// Test B. The driver-assembly factory names NO concrete adapter type in code
+  /// (whole-word: catches construction, `: Type` annotations, `.init`-style refs).
+  /// Scoped to this one file, where the post-PR-6 invariant is "zero concrete-type
+  /// mentions in code"; `scanSources` skips comments so the file's doc-comment
+  /// mentions (`:14-22`) stay legal under the code-only policy.
+  @Test("KernelDictationDriverFactory names no concrete adapter type in code (PR-6 #827)")
+  func driverFactoryNamesNoConcreteAdapterTypeInCode() throws {
+    for name in Self.concreteAdapterTypeNames {
+      let hits = try Self.scanSources(pattern: #"\b"# + name + #"\b"#)
+        .filter { $0.hasPrefix(Self.driverAssemblyFactory + ":") }
+      #expect(
+        hits.isEmpty,
+        """
+        \(Self.driverAssemblyFactory) names concrete adapter type `\(name)` in code:
+        \(hits.joined(separator: "\n"))
+        Post-PR-6 (#827) the driver-assembly factory must name no concrete adapter
+        type in code (comments are allowed). Route construction through
+        `KernelAdapterFactory`.
+        """)
+    }
+  }
+
+  // MARK: PR-6 adversarial + negative controls
+
+  @Test("the construction-call scanner flags an adapter constructed outside the factory (PR-6)")
+  func adversarialAdapterConstructionFlagged() {
+    let source = "    let adapter = WhisperKitEngineAdapter(backend: backend)"
+    #expect(
+      Self.regexFlags(source: source, pattern: #"\bWhisperKitEngineAdapter\s*\("#),
+      "an adapter construction call must be flagged by the construction-call scanner")
+  }
+
+  @Test(
+    "the construction-call scanner does NOT flag log strings, extensions, or class decls (PR-6)")
+  func negativeControlNonConstructionReferencesNotFlagged() {
+    let pattern = #"\bWhisperKitEngineAdapter\s*\("#
+    let logString =
+      #"      await AppLogger.shared.log(m, level: .info, category: "WhisperKitEngineAdapter")"#
+    let extensionDecl = "extension WhisperKitEngineAdapter: ASREngineTelemetryProviding {}"
+    let classDecl = "final class WhisperKitEngineAdapter: ASREngineAdapter {"
+    #expect(
+      Self.regexFlags(source: logString, pattern: pattern) == false,
+      "a `category: \"WhisperKitEngineAdapter\"` log string must NOT be flagged")
+    #expect(
+      Self.regexFlags(source: extensionDecl, pattern: pattern) == false,
+      "an `extension WhisperKitEngineAdapter` declaration must NOT be flagged")
+    #expect(
+      Self.regexFlags(source: classDecl, pattern: pattern) == false,
+      "a `final class WhisperKitEngineAdapter` declaration must NOT be flagged")
+  }
+
   // MARK: Helpers
 
   private static func readSource(_ relative: String) throws -> String {

--- a/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
@@ -1,0 +1,76 @@
+import AVFoundation
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - KernelAdapterFactoryTests (epic #827, PR-6)
+//
+// Identity unit tests for `KernelAdapterFactory`'s two make functions. The
+// freeze tests (`EngineIdentityFreezeTests` Test A / Test B) lock concrete
+// adapter construction to this factory at source level; these runtime tests
+// close the §7 gap the `any ASREngineAdapter` return type leaves open: the
+// compiler does not prove `makeWhisperKitAdapter` returns a `.whisperKit`
+// identity adapter, so assert each make function yields the right identity.
+//
+// There is no shared `FakeASRManager` (the ASR-manager fakes are `private` to
+// `SetupCoordinatorTests` / `DictationSessionConfigFactoryTests`), so this file
+// defines its own minimal local `ASRManagerInterface` conformer (Codex r2).
+
+@MainActor
+@Suite struct KernelAdapterFactoryTests {
+
+  @Test("makeParakeetAdapter returns a .parakeet-identity adapter")
+  func makeParakeetAdapterHasParakeetIdentity() {
+    let adapter = KernelAdapterFactory.makeParakeetAdapter(
+      asrManager: MinimalASRManager())
+    #expect(adapter.engineIdentity.backendType == .parakeet)
+  }
+
+  @Test("makeWhisperKitAdapter returns a .whisperKit-identity adapter")
+  func makeWhisperKitAdapterHasWhisperKitIdentity() {
+    // `WhisperKitBackend()` is the lazy actor (no CoreML load until prepare()),
+    // matching `KernelDictationDriverFactoryWhisperKitTests`.
+    let adapter = KernelAdapterFactory.makeWhisperKitAdapter(
+      backend: WhisperKitBackend(),
+      languageDetector: LanguageDetector(),
+      audioCaptureSessionIDSource: { 0 })
+    #expect(adapter.engineIdentity.backendType == .whisperKit)
+  }
+}
+
+/// Minimal local `ASRManagerInterface` conformer. The factory only needs an
+/// object satisfying the protocol; `ParakeetEngineAdapter`'s identity is
+/// `.parakeet` regardless of manager behavior, so every member is an inert stub.
+@MainActor
+private final class MinimalASRManager: ASRManagerInterface {
+  var activeBackendType: ASRBackendType = .parakeet
+  var isModelLoaded = false
+  var isStreaming = false
+  var downloadProgress: Double = 0
+  var downloadPhase = ""
+  var downloadDetail = ""
+  var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
+  var onServiceInterrupted: (() -> Void)?
+
+  func loadModel() async throws {}
+  func loadModelSilently() async {}
+  func unloadModel() async {}
+  func setInitialBackendType(_ type: ASRBackendType) {}
+  func switchBackend(to type: ASRBackendType) async {}
+  var activeBackendSupportsStreaming: Bool { get async { false } }
+  func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
+    ASRResult(text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+  }
+  func startStreaming(options: TranscriptionOptions) async throws {}
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {}
+  func finalizeStreaming() async throws -> ASRResult {
+    ASRResult(text: "", language: "en", duration: 0, processingTime: 0, backendType: .parakeet)
+  }
+  func cancelStreaming() async {}
+  func noteTranscriptionComplete(policy: ModelUnloadPolicy) {}
+  func cancelIdleTimer() {}
+  func cancelInFlightLoad() {}
+}


### PR DESCRIPTION
## PR-6 of epic #827 — the hot-swap seam

Extracts concrete `ASREngineAdapter` construction out of `KernelDictationDriverFactory` into a new stateless `@MainActor enum KernelAdapterFactory` — the single concrete-adapter construction site in `Sources/`. The driver-assembly factory now names no concrete adapter type in code and assembles around the opaque `any ASREngineAdapter` it returns. Delivers epic goal #4 (hot-swap): adding an engine is "write the conformer + a make function," with zero kernel changes.

### Design (Option B, council + Codex settled)
Per-engine typed make functions (`makeParakeetAdapter`, `makeWhisperKitAdapter`), NOT a `switch backendType` fed by an optional all-engines dependency bundle. Council (GPT + Gemini) and Codex grounded review (5 rounds to PROCEED-AS-PLANNED) confirmed the optional bundle stays rejected (it would move compile-time guarantees to runtime). This is a construction OWNER, not a runtime dispatch map — backend selection stays in the existing typed driver/App wiring (still one driver per backend; no dispatch consolidation).

Production behavior is byte-identical: same two adapters, same dependencies, relocated construction.

### Tests
- `EngineIdentityFreezeTests` **Test A** (construction-call `TypeName(` confined to `KernelAdapterFactory.swift`) + **Test B** (`KernelDictationDriverFactory` names no concrete type in code) + adversarial/negative controls. Test A uses the construction-call pattern (not a whole-word ban) so it does not false-fail on the adapters' own class/extension declarations or their 10 `category: "WhisperKitEngineAdapter"` log strings.
- `KernelAdapterFactoryTests` identity assertions (each make function returns the right `engineIdentity.backendType`).

### Validation
- `swift build -c release` clean; full release suite **1377 tests green**.
- Live UAT (debug build, both engines): Parakeet PASS (backend stamped `parakeet`), WhisperKit PASS (backend stamped `whisperKit`, LID lang=en conf=0.99, signposts present). Heart path intact on both; zero Sentry heart-path errors.
- Codex code-diff review: no correctness or backend break.

### Disclosed pre-existing debt (NOT closed here)
`KernelDictationDriver.swift:295-297` carries an `== .whisperKit` identity literal that should be a capability flag (`gate-on-capability-not-identity-literal`). Pre-dates PR-6, out of scope; follow-up issue to be filed.

Part of #827.