### PR TITLE
feat(pipeline): PR-7 — cold-start engine-readiness cohort on PTT-to-recording log (#827)

### DIFF
--- a/Sources/EnviousWispr/App/DictationRuntime/ASREngineReadiness+ColdStartCohort.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/ASREngineReadiness+ColdStartCohort.swift
@@ -1,0 +1,19 @@
+import EnviousWisprPipeline
+
+extension ASREngineReadiness {
+  /// PR-7 (#827): stable cold-start cohort token for the `PTT-to-recording`
+  /// log line (`engineReadinessAtPTT=`). Exhaustive `switch` (not `rawValue`)
+  /// so a new `ASREngineReadiness` case is a compile error here, not a silent
+  /// unlabeled cohort that would pollute the §3a cold-start SLO. `ready` = warm
+  /// (no load cost this press); `notReady` = cold (full load); `warming` = a
+  /// load is in flight (mid-flight, kept distinct so it skews neither cohort).
+  /// Lives in the App module (telemetry concern), kept off `RecordingStarter`
+  /// so the start-path home stays within its method/line ceilings.
+  var coldStartCohortToken: String {
+    switch self {
+    case .notReady: return "notReady"
+    case .warming: return "warming"
+    case .ready: return "ready"
+    }
+  }
+}

--- a/Sources/EnviousWispr/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/RecordingStarter.swift
@@ -84,6 +84,9 @@ final class RecordingStarter {
     dictationLifecycleCoordinator?.cancelPendingWarning()
     let isWhisperKit = asrManager.activeBackendType == .whisperKit
     let active: any DictationPipeline = isWhisperKit ? whisperKitKernelDriver : kernelDriver
+    // PR-7 (#827): snapshot engine readiness BEFORE prewarm so the cold-start
+    // log cohorts warm/cold/mid-flight; snapshot-at-entry avoids retro-labeling.
+    let readinessAtEntry = (isWhisperKit ? whisperKitKernelDriver : kernelDriver).engineReadiness
     if isWhisperKit {
       guard !whisperKitKernelDriver.state.isActive else { return }
     } else {
@@ -198,7 +201,7 @@ final class RecordingStarter {
     }
     Task {
       await AppLogger.shared.log(
-        "COLD-START [RecordingStarter] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet")",
+        "COLD-START [RecordingStarter] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet") engineReadinessAtPTT=\(readinessAtEntry.coldStartCohortToken)",
         level: .info, category: "Pipeline"
       )
     }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -145,6 +145,15 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
   /// The polish error from the last session, or `nil`.
   public var lastPolishError: String? { outcome.polishError }
 
+  /// PR-7 (#827): the active engine adapter's normalized readiness, exposed
+  /// read-only so the App layer can stamp the cold-start cohort
+  /// (`engineReadinessAtPTT`) onto the `PTT-to-recording` log line at trigger
+  /// entry. `adapter` is package-scoped; this is the only App-visible window
+  /// onto its readiness. Sourcing the cohort here (not `asrManager.isModelLoaded`)
+  /// is correct for both engines: WhisperKit's live driver uses a separate
+  /// in-process backend, so the shared ASR manager's flag does not reflect it.
+  public var engineReadiness: ASREngineReadiness { adapter.readiness }
+
   // MARK: PR-4b.2 — direct methods + property (mirror old Parakeet pipeline App surface)
 
   /// Async cancel request. Wraps `kernel.cancel()` for App callers

--- a/Tests/EnviousWisprTests/App/RecordingStarterReadinessTokenTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterReadinessTokenTests.swift
@@ -1,0 +1,32 @@
+import EnviousWisprPipeline
+import Testing
+
+@testable import EnviousWispr
+
+/// PR-7 (#827): the cold-start cohort token stamped onto the `PTT-to-recording`
+/// log line (`ASREngineReadiness.coldStartCohortToken`). The end-to-end value
+/// (cold press -> `notReady`, warm press -> `ready`) is proven by Live UAT
+/// reading `app.log`; this suite locks the pure readiness -> token mapping so a
+/// future `ASREngineReadiness` case cannot ship an unlabeled cohort (the
+/// `switch` is exhaustive, so a new case is a compile error, surfaced here at
+/// build time) and so the exact token strings the §3a / PR-10 SLO parser reads
+/// cannot silently drift.
+@MainActor
+@Suite("Cold-start readiness cohort token")
+struct RecordingStarterReadinessTokenTests {
+
+  @Test("notReady maps to the cold-cohort token")
+  func notReadyToken() {
+    #expect(ASREngineReadiness.notReady.coldStartCohortToken == "notReady")
+  }
+
+  @Test("warming maps to the mid-flight-cohort token")
+  func warmingToken() {
+    #expect(ASREngineReadiness.warming.coldStartCohortToken == "warming")
+  }
+
+  @Test("ready maps to the warm-cohort token")
+  func readyToken() {
+    #expect(ASREngineReadiness.ready.coldStartCohortToken == "ready")
+  }
+}


### PR DESCRIPTION
## PR-7 — Cold-start engine-readiness cohort on the `PTT-to-recording` log (epic #827)

Part of #827. Tier: SMALL. Lane: Code.

### What
Adds `engineReadinessAtPTT=<notReady|warming|ready>` to the cold-start `PTT-to-recording` log line, sampled from the **active kernel driver's adapter readiness** at trigger entry (snapshot-at-entry, before this press's prewarm). This lets the §3a cold-start SLO and PR-10's latency gate separate the warm cohort (model resident), cold cohort (this press paid the load), and mid-flight cohort from the log alone.

- New read-only `KernelDictationDriver.engineReadiness` accessor (`adapter` is package-scoped; this is the only App-visible window onto its readiness).
- Sourced from `adapter.readiness`, **not** `asrManager.isModelLoaded` — the latter is Parakeet/XPC-centric and does not reflect WhisperKit's separate in-process backend.
- 3-state, not a boolean: a mid-flight `.warming` re-press would otherwise pollute the cold cohort and skew the p95 (council finding).
- Token mapping lives in a top-level `ASREngineReadiness` extension (App module), kept off `RecordingStarter` so its method/line ceilings stay green.

### Re-scope (the substantive decision)
PR-7 was planned (#827 bible §3.7) as the cold-start warm-up with 5 steps. Three shipped as a side effect of the PR-3/4/5 kernel cutover, which landed *after* §3.7 was written:
- Warm-up state contract + UI warm-up state ("Loading model..." in the main window; menu bar processing/disabled state) — **already shipped** via kernel `.preparing`/`.warmingUp` → `PipelineState.loadingModel`.
- The genuine remainder is the telemetry cohort field (this PR).
- **WhisperKit signal-based in-load wedge detection splits to follow-up #879**: its only in-process load signal (`modelStateCallback`) is a 2-tick bookend that cannot observe the opaque CoreML `MLModel.load` span where the realistic wedge lives, and validating any real signal needs a CoreML-load fault-injection harness (its own scope). A manual recovery floor already exists (`cancel()` during `.warmingUp` → `detachedAdapterCancel`; the `ModelLoadWatchdog` post-condition path); #879 upgrades it to automatic.

### Review trail
- Council (GPT + Gemini) coverage + Codex grounded review **r1 → r2 → r3** converged (defects shrank 5 substantive → 1 substantive → 1 cosmetic; the cosmetic fix was applied and empirically verified against the cited code).
- Codex code-diff review: CLEAN on correctness, thread-safety (synchronous `@MainActor` read, no hot-path hop), scope, zero-dash, exhaustive switch, test wiring, no parser-consumer breakage.

### Validation
- `swift build -c release` exit 0; `scripts/swift-test.sh` **1464 tests / 180 suites, 0 failures**.
- Exhaustive `coldStartCohortToken` unit test (a new `ASREngineReadiness` case is a compile error; locks the exact token strings the SLO parser reads).
- Synthetic Live UAT via `test_ptt` (PTT path — the menu path does not emit this line), **both backends, both cohorts**:
  - WhisperKit cold press → `engineReadinessAtPTT=notReady` (total=171ms); warm re-press → `ready` (total=19ms).
  - Parakeet cold press → `notReady` (total=20ms).
  - Heart path intact every time (transcripts landed, content checks PASS).

### Note for review
The token mapping was initially drafted as a `static func` on `RecordingStarter`; that tripped `RecordingStarterCeilingsTests` (nonPrivateMethodCount 2→3 and lineCount 250→263). Moved to a top-level `ASREngineReadiness` extension in the App module — no ceiling bump, keeps the mapping testable, places the telemetry concern in the App layer.