### PR TITLE
test(pipeline): fix #882 false-passing 5-min VAD-stop test

### DIFF
--- a/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
@@ -115,8 +115,14 @@ struct AudioEventRouterTests {
     }
 
     let legacyStore = DictationRuntimeFixtures.tempStore()
+    // Share the SAME VAD source with the WhisperKit driver, mirroring production
+    // (`EnviousWisprApp.swift:101-102`). Without this, the helper's own
+    // `makeSharedVADSignalSource` builds a second source and re-binds
+    // `audio.onVADAutoStop` to it — orphaning the Parakeet kernel's stop path so
+    // `fireVADAutoStop()` reaches nobody and the recording survives to the 300s
+    // cap (#882: the false-pass + 5-minute hang this test used to exhibit).
     let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
-      audioCapture: audio, store: legacyStore)
+      audioCapture: audio, store: legacyStore, sharedVAD: vad)
     // Post-PR-4b.4 of #827: the App router takes the same driver the kernel
     // path uses; there is no separate "legacy Parakeet" pipeline to satisfy.
     let router = AudioEventRouter(
@@ -135,21 +141,35 @@ struct AudioEventRouterTests {
           useStreamingASR: false
         )))
 
-    // Drain state changes until the driver is in `.recording`. Each await
-    // resumes the instant the next state arrives; no polling, no sleep.
-    while await waiter.next() != PipelineState.recording {}
+    // Drain state changes until the driver is in `.recording`. Reaching
+    // recording runs through warm-up, so allow a generous bound; a stall here
+    // is a real failure, not a flaky pass.
+    while true {
+      guard let state = await waiter.next(timeout: .seconds(5)) else {
+        Issue.record("driver did not reach .recording within 5s")
+        return
+      }
+      if state == PipelineState.recording { break }
+    }
 
-    // The kernel claims `audio.onVADAutoStop` via `CaptureVADSignalSource`.
-    // If the fix held, AudioEventRouter did NOT overwrite that claim, so
-    // firing VAD auto-stop reaches the kernel and triggers a state transition.
+    // The kernel claims `audio.onVADAutoStop` via the shared `CaptureVADSignalSource`.
+    // Firing VAD auto-stop must reach the kernel (claim not overwritten by the
+    // WhisperKit driver's construction, nor by `AudioEventRouter`) and trigger a
+    // prompt stop.
     audio.fireVADAutoStop()
 
-    // Wait for the next state change. If the kernel's claim survived, this
-    // resumes promptly with a non-.recording state. If the claim was
-    // overwritten, no state change fires and the test deadlocks (the suite's
-    // surrounding test-runner timeout is the only safety net — which is what
-    // we want: a real failure, not a flaky pass).
-    let next = await waiter.next()
+    // A correctly-wired VAD-stop transitions in milliseconds. The ONLY other way
+    // this recording stops is the 300s max-duration cap — so a sub-2s transition
+    // PROVES the manual VAD-stop actually reached the kernel. If the claim were
+    // stolen/dropped, no prompt transition fires: this times out and fails fast
+    // (#882 — previously it hung to the 300s cap and FALSE-PASSED via the cap's
+    // separate `maxDuration` signal path).
+    guard let next = await waiter.next(timeout: .seconds(2)) else {
+      Issue.record(
+        "VAD auto-stop produced no state transition within 2s: the kernel onVADAutoStop claim was not honored (the regression #882 guards against)"
+      )
+      return
+    }
     #expect(next != PipelineState.recording)
     withExtendedLifetime(router) {}
   }
@@ -216,30 +236,53 @@ struct AudioEventRouterTests {
 }
 
 /// Signal-based waiter for `KernelDictationDriver.onStateChange`. Resumes
-/// the instant the next state is delivered — no `Task.sleep`, no real-time
-/// deadline. Mirror of the `SignalPipelineLogger` shape but specialized to
-/// `PipelineState`. Buffers states arriving before any `next()` call so the
-/// test cannot miss a transition that fires before it gets a chance to await.
+/// the instant the next state is delivered. Buffers states arriving before any
+/// `next()` call so the test cannot miss a transition that fires before it gets
+/// a chance to await. Mirror of the `SignalPipelineLogger`/`PipelineStateWaiter`
+/// shape — including a timeout backstop so a regression FAILS FAST instead of
+/// parking the continuation forever and hanging the whole test runner
+/// (swift-patterns.md `tests-no-unconditional-continuation-await`, #445/#696).
 @MainActor
 private final class DriverStateWaiter {
   private var pending: [PipelineState] = []
-  private var waiter: CheckedContinuation<PipelineState, Never>?
+  private var waiter: CheckedContinuation<PipelineState?, Never>?
+  private var timeoutTask: Task<Void, Never>?
 
   func receive(_ state: PipelineState) {
     if let waiter {
       self.waiter = nil
+      timeoutTask?.cancel()
+      timeoutTask = nil
       waiter.resume(returning: state)
     } else {
       pending.append(state)
     }
   }
 
-  func next() async -> PipelineState {
+  /// Returns the next state, or `nil` if none arrives within `timeout`. A `nil`
+  /// return is the fail-fast signal (the caller records an `Issue`): the only
+  /// non-prompt stop in this suite is the 300s max-recording cap, so a
+  /// correctly-wired transition always arrives in well under `timeout`. The
+  /// timeout task is the only `Task.sleep` here and it never feeds a SUT
+  /// measurement — it is a pure deadline backstop (allowed exception in
+  /// swift-patterns.md `tests-no-real-time-scheduling-precision`).
+  func next(timeout: Duration = .seconds(2)) async -> PipelineState? {
     if !pending.isEmpty {
       return pending.removeFirst()
     }
-    return await withCheckedContinuation { cont in
+    return await withCheckedContinuation { (cont: CheckedContinuation<PipelineState?, Never>) in
       waiter = cont
+      timeoutTask = Task { @MainActor [weak self] in
+        // A cancelled timeout — the common case where `receive` resumed first
+        // and cancelled us — must EXIT, not fall through and resume whatever
+        // waiter is parked NOW; otherwise a stale drain-loop timeout steals the
+        // next await's continuation and resolves it with a spurious nil.
+        do { try await Task.sleep(for: timeout) } catch { return }
+        guard let self, let parked = self.waiter else { return }
+        self.waiter = nil
+        self.timeoutTask = nil
+        parked.resume(returning: nil)
+      }
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -130,12 +130,24 @@ enum DictationRuntimeFixtures {
   /// factory's `makeForWhisperKit(inputs:)`. The fixture function keeps its
   /// historical name (`makeWhisperKitPipeline`) so callers do not change;
   /// only the return type narrows to `KernelDictationDriver`.
+  ///
+  /// `sharedVAD` (#882): production builds ONE `CaptureVADSignalSource` and
+  /// passes the same instance to both drivers (`EnviousWisprApp.swift:101-102`),
+  /// so `audioCapture.onVADAutoStop` is bound exactly once. A test that builds
+  /// both a Parakeet and a WhisperKit driver MUST share the source the same
+  /// way, or this helper's own `makeSharedVADSignalSource` call re-binds (steals)
+  /// the callback and orphans the first driver's VAD-stop path. Pass the
+  /// Parakeet driver's source here to mirror production; default `nil` keeps the
+  /// historical fresh-source behavior for single-driver callers.
   static func makeWhisperKitPipeline(
     audioCapture: any AudioCaptureInterface,
-    store: TranscriptStore
+    store: TranscriptStore,
+    sharedVAD: CaptureVADSignalSource? = nil
   ) -> KernelDictationDriver {
-    let vad = KernelDictationDriverFactory.makeSharedVADSignalSource(
-      audioCapture: audioCapture)
+    let vad =
+      sharedVAD
+      ?? KernelDictationDriverFactory.makeSharedVADSignalSource(
+        audioCapture: audioCapture)
     let detector = LanguageDetector(onLanguageFlip: { _ in })
     return KernelDictationDriverFactory.makeForWhisperKit(
       inputs: .init(


### PR DESCRIPTION
## What
Fixes `kernelVADOwnerSurvivesAppRouterConstruction` — a test that took **306 seconds** and **false-passed** (it passed whether or not the behavior it claims to verify actually worked).

## Root cause (instrumented + Codex grounded-reviewed)
The test built **two** `CaptureVADSignalSource` instances: one for the Parakeet driver (line 96) and a second inside the `makeWhisperKitPipeline` fixture. The second `bind()` stole `audio.onVADAutoStop`, orphaning the Parakeet kernel's stop path. The manual `fireVADAutoStop()` reached an instance with no kernel subscriber, so the recording survived to the 300s max-duration cap, which stopped it via a different signal path. The assertion `next != .recording` therefore passed regardless of the VAD-stop wiring.

**Test-fidelity bug only — not a product bug.** Production binds ONE shared source for both drivers (`EnviousWisprApp.swift:101-102`, enforced by `vadSignalSourceHasSingleConstructionSite`).

## Fix (test-only)
- `makeWhisperKitPipeline` gains an optional `sharedVAD:` param (default `nil` preserves behavior for all ~12 other callers); this test passes the Parakeet driver's source so both drivers share one binding, mirroring production.
- `DriverStateWaiter` gains a bounded `next(timeout:)`; a cancelled timeout task now exits instead of stealing the next continuation. The unbounded await it replaces was itself the `tests-no-unconditional-continuation-await` anti-pattern (#445/#696). The ~2s bound IS the correctness check: a correctly-wired VAD-stop transitions in ms, and the only other stop is the 300s cap, so a sub-2s transition proves the signal reached the kernel.

## Validation
- Isolated test: **0.12s** (was 306s).
- Fail-fast proven: with the wiring broken, fails in **2.1s** with a clear message (was: hang to 300s + false-pass).
- Full suite: **1,464 tests green, execution 12.3s** (was ~306s — this one test was ~96% of test-run wall-clock).
- Codex grounded review: PROCEED-AS-PLANNED. Codex code-diff review: CLEAN.
- Independently flagged as a flake by the test-trustworthiness audit (#881).
- Council: Codex-only loop (test-infra change, no product surface; precedent: PR #806).

Closes #882. Part of #881.