### PR TITLE
perf(build): single-source -F flag so CI build steps match the test graph

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -65,13 +65,26 @@ jobs:
             ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
             ${{ runner.os }}-spm-
 
+      # COMPILE_FLAGS comes from scripts/swift-test.sh (single source) so this build
+      # graph matches the test step's graph and the test step reuses these objects
+      # instead of recompiling every first-party module (#885). Captured into a string
+      # first (a failing emitter aborts the step under set -e), then split into an
+      # array so the flags pass as separate argv without unquoted word-splitting.
       - name: Build (debug)
         if: steps.changes.outputs.needs_build == 'true'
-        run: swift build
+        run: |
+          set -euo pipefail
+          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
+          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
+          swift build "${COMPILE_FLAGS[@]}"
 
       - name: Build (release)
         if: steps.changes.outputs.needs_build == 'true'
-        run: swift build -c release --arch arm64
+        run: |
+          set -euo pipefail
+          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
+          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
+          swift build -c release --arch arm64 "${COMPILE_FLAGS[@]}"
 
       - name: Run logic tests
         if: steps.changes.outputs.needs_build == 'true'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -87,13 +87,26 @@ jobs:
             ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
             ${{ runner.os }}-spm-
 
+      # COMPILE_FLAGS comes from scripts/swift-test.sh (single source) so this build
+      # graph matches the test step's graph and the test step reuses these objects
+      # instead of recompiling every first-party module (#885). Captured into a string
+      # first (a failing emitter aborts the step under set -e), then split into an
+      # array so the flags pass as separate argv without unquoted word-splitting.
       - name: Build (debug)
         if: steps.changes.outputs.needs_build == 'true'
-        run: swift build
+        run: |
+          set -euo pipefail
+          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
+          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
+          swift build "${COMPILE_FLAGS[@]}"
 
       - name: Build (release)
         if: steps.changes.outputs.needs_build == 'true'
-        run: swift build -c release --arch arm64
+        run: |
+          set -euo pipefail
+          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
+          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
+          swift build -c release --arch arm64 "${COMPILE_FLAGS[@]}"
 
       - name: XPC error hygiene self-test
         if: steps.changes.outputs.needs_build == 'true'

--- a/scripts/swift-test.sh
+++ b/scripts/swift-test.sh
@@ -32,13 +32,27 @@ if [ ! -d "$FRAMEWORKS_DIR/Testing.framework" ]; then
 fi
 
 # Shared flag set — single source of truth for CLT Testing.framework wiring.
+# COMPILE_FLAGS is the compile-graph-affecting subset. The CI workflow `swift build`
+# steps consume it verbatim via `--print-compile-flags` so their build graph matches
+# this script's `swift test` graph; without the match, the test step recompiles every
+# first-party module the build step already built (#885). Keep this the one source —
+# do not duplicate the flag in the print branch below or in the workflows.
+COMPILE_FLAGS=(-Xswiftc "-F${FRAMEWORKS_DIR}")
 CLT_FLAGS=(
-    -Xswiftc "-F${FRAMEWORKS_DIR}"
+    "${COMPILE_FLAGS[@]}"
     -Xlinker "-F${FRAMEWORKS_DIR}"
     -Xlinker -rpath -Xlinker "${FRAMEWORKS_DIR}"
     -Xlinker -rpath -Xlinker "${USR_LIB_DIR}"
     -Xlinker -rpath -Xlinker "${INTEROP_LIB_DIR}"
 )
+
+# Emit only the compile-graph-affecting flags for the CI `swift build` steps. Runs
+# after the Testing.framework check above, so a missing framework exits non-zero and
+# the caller's `FLAGS="$(...)"` assignment aborts under `set -e`.
+if [[ "${1:-}" == "--print-compile-flags" ]]; then
+    printf '%s ' "${COMPILE_FLAGS[@]}"; printf '\n'
+    exit 0
+fi
 
 NO_RUN=0
 REMAINING_ARGS=()


### PR DESCRIPTION
## What

Aligns the four workflow `swift build` steps (debug + release, in `pr-check.yml` and `main-post-merge.yml`) with the compile flag `scripts/swift-test.sh` already passes for `swift test`, so the test step **reuses** the build step's objects instead of recompiling every first-party module from scratch.

Closes #885.

## Why

`swift-test.sh` adds `-Xswiftc -F<CLT-frameworks>` (Testing.framework search path). `-Xswiftc` changes the swiftc invocation for every first-party module, so llbuild treats the test build as a different graph and recompiles everything `swift build` just built.

- **CI evidence (Xcode `latest-stable`, macos-26):** PR-7 run `Build (debug)` = 141 first-party `Compiling` lines, `Run logic tests` = the same 141 again; main-post-merge run = 149 + 149.
- **Local A/B (M4 Pro):** mismatched flags recompile 162 first-party modules; aligned flags recompile 0 (confirmed with the real `swift-test.sh`).
- **Cold-worktree demonstrative (this branch):** `Build (debug)` compiles 164 first-party → `swift-test.sh --no-run` reuses them at **0** recompiles. Release build clean with the flag (`--arch arm64` is a keying no-op).

## How

A shared `COMPILE_FLAGS=(-Xswiftc "-F${FRAMEWORKS_DIR}")` array in `swift-test.sh` is the single source for both `swift test` (spliced into `CLT_FLAGS`, byte-identical to before) and a new `--print-compile-flags` mode. The workflow build steps consume it via assignment-then-use + `read -ra` (a failing emitter aborts under `set -e`; flags pass as separate argv with no unquoted word-splitting).

No `-Xlinker` flags on `swift build`, so the shipped binary is functionally unchanged. The #804 rolling-cache-key / restore / save / sole-writer invariants are untouched (only the build `run:` bodies change). The PR triggers `needs_build=true` via the `scripts/` edit (no inert Swift line needed).

## Validation

- ShellCheck (`swift-test.sh`) + actionlint (both workflows): clean.
- Council (coverage) caught + fixed 2 real defects (bash `-e` command-sub doesn't fail loudly → assignment-then-use; duplicated literal → shared array).
- Codex grounded review: PROCEED-AS-PLANNED (r2). Codex code-diff review: clean.
- This PR's own `build-check` is the live confirmation: `Run logic tests` should show 0 first-party recompiles.