### PR TITLE
refactor(pipeline): PR-8 text-processing concurrency isolation (#827)

### DIFF
--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -42,6 +42,22 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// Injectable prompt planner. DefaultPromptPlanner in production, mockable in tests.
   public var promptPlanner: any PromptPlanning = DefaultPromptPlanner()
 
+  /// Injectable polisher factory (#827 PR-8). Default reproduces the per-provider
+  /// connector switch; returns nil for `.none` so the call site owns the
+  /// breadcrumb plus throw. Tests inject a controllable polisher to exercise the
+  /// post-await settings snapshot. Mirrors `promptPlanner` above; `internal`
+  /// because only the same-module factory and `@testable` tests reach it.
+  typealias PolisherFactory = @MainActor (LLMProvider, KeychainManager) -> (any TranscriptPolisher)?
+  var makePolisher: PolisherFactory = { provider, keychain in
+    switch provider {
+    case .openAI: OpenAIConnector(keychainManager: keychain)
+    case .gemini: GeminiConnector(keychainManager: keychain)
+    case .ollama: OllamaConnector()
+    case .appleIntelligence: AppleIntelligenceConnector()
+    case .none: nil
+    }
+  }
+
   /// Called before LLM processing starts (pipeline uses this to set .polishing state).
   public var onWillProcess: (() -> Void)?
 
@@ -109,11 +125,19 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     onWillProcess?()
+    // #827 PR-8: snapshot the mutable provider/model at entry. process()
+    // suspends at the polish await; a concurrent PipelineSettingsSync mutation
+    // on the shared re-polish step would otherwise tear the post-await reads
+    // (provider/model attribution in ctx, the family label, and the two
+    // telemetry helpers). Mirrors WordCorrectionStep's entry snapshot. Every
+    // read below uses these locals, never `self`, so reentrancy cannot tear it.
+    let provider = llmProvider
+    let model = llmModel
     SentryBreadcrumb.add(
       stage: "polish", message: "LLM polish started",
       data: [
-        "provider": llmProvider.rawValue,
-        "model": llmModel,
+        "provider": provider.rawValue,
+        "model": model,
       ])
 
     // Short-circuit: ultra-short transcripts get passed through verbatim.
@@ -153,25 +177,19 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
     Task {
       await AppLogger.shared.log(
-        "LLM polish requested: provider=\(llmProvider.rawValue), model=\(llmModel)",
+        "LLM polish requested: provider=\(provider.rawValue), model=\(model)",
         level: .verbose, category: "LLM"
       )
     }
 
-    let polisher: any TranscriptPolisher =
-      switch llmProvider {
-      case .openAI: OpenAIConnector(keychainManager: keychainManager)
-      case .gemini: GeminiConnector(keychainManager: keychainManager)
-      case .ollama: OllamaConnector()
-      case .appleIntelligence: AppleIntelligenceConnector()
-      case .none:
-        SentryBreadcrumb.captureError(
-          LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
-        throw LLMError.providerUnavailable
-      }
+    guard let polisher = makePolisher(provider, keychainManager) else {
+      SentryBreadcrumb.captureError(
+        LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
+      throw LLMError.providerUnavailable
+    }
 
     let keychainId: String? =
-      switch llmProvider {
+      switch provider {
       case .openAI: KeychainManager.openAIKeyID
       case .gemini: KeychainManager.geminiKeyID
       default: nil
@@ -179,7 +197,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
     let (thinkingBudget, reasoningEffort) = resolveThinkingConfig()
     let maxTokens: Int = {
-      if llmProvider == .ollama {
+      if provider == .ollama {
         // Estimate tokens (~3 chars per token for English), add headroom.
         // For 921-char input: 921/3 + 100 = 407 tokens (~2x actual output of ~195).
         // The pipeline-level timeout (15s) caps runaway generation.
@@ -192,7 +210,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
         // a rambly generation can't outrun the 15s pipeline timeout.
         // `done_reason=stop` ends generation early for short transcripts.
         let floor =
-          OllamaSetupService.isThinkingCapableModel(llmModel)
+          OllamaSetupService.isThinkingCapableModel(model)
           ? LLMConstants.ollamaThinkingMaxTokens
           : LLMConstants.ollamaMaxTokens
         return max(context.text.count / 3 + 100, floor)
@@ -211,7 +229,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     let detectedLanguage = languageDetection?.lang ?? context.language
 
     let config = LLMProviderConfig(
-      model: llmModel,
+      model: model,
       apiKeyKeychainId: keychainId,
       maxTokens: maxTokens,
       temperature: 0,
@@ -221,7 +239,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     )
 
     // Apple Intelligence: own prompt path (unchanged, out of scope for planner).
-    if llmProvider == .appleIntelligence {
+    if provider == .appleIntelligence {
       let enriched = appleIntelligenceInstructions(polishInstructions)
       var resolvedInstructions = enriched
       var userText = context.text
@@ -255,14 +273,16 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
         throw afmErr.underlying
       }
       let llmEnd = CFAbsoluteTimeGetCurrent()
-      logPolishCompletion(result: result, duration: llmEnd - llmStart)
+      logPolishCompletion(
+        result: result, duration: llmEnd - llmStart, provider: provider, model: model)
       let validatedText = validatePolishOutput(
-        polished: result.polishedText, original: context.text, mode: .message
+        polished: result.polishedText, original: context.text, mode: .message,
+        provider: provider, model: model
       )
       var ctx = context
       ctx.polishedText = validatedText
-      ctx.llmProvider = llmProvider.rawValue
-      ctx.llmModel = llmModel
+      ctx.llmProvider = provider.rawValue
+      ctx.llmModel = model
       ctx.polishMetadata = result.polishMetadata
       ctx.pipelineFellBackToRaw =
         (result.polishMetadata?.filterFellBackToRaw ?? false) || (validatedText == context.text)
@@ -278,8 +298,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
     let input = PromptBuildInput(
       transcript: context.text,
-      provider: llmProvider,
-      modelID: llmModel,
+      provider: provider,
+      modelID: model,
       appName: context.targetAppName,
       language: context.language,
       polishVocabulary: polishVocabulary,
@@ -298,9 +318,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     )
     let llmEnd = CFAbsoluteTimeGetCurrent()
 
-    let family = DefaultPromptPlanner.family(for: llmProvider, modelID: llmModel)
+    let family = DefaultPromptPlanner.family(for: provider, modelID: model)
     logPolishCompletion(
       result: result, duration: llmEnd - llmStart,
+      provider: provider, model: model,
       extraData: [
         "polish_mode": plan.mode.rawValue,
         "prompt_family": family.rawValue,
@@ -309,13 +330,14 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     let validatedText = validatePolishOutput(
       polished: result.polishedText,
       original: context.text,
-      mode: plan.mode
+      mode: plan.mode,
+      provider: provider, model: model
     )
 
     var ctx = context
     ctx.polishedText = validatedText
-    ctx.llmProvider = llmProvider.rawValue
-    ctx.llmModel = llmModel
+    ctx.llmProvider = provider.rawValue
+    ctx.llmModel = model
     ctx.polishMetadata = result.polishMetadata
     ctx.pipelineFellBackToRaw =
       (result.polishMetadata?.filterFellBackToRaw ?? false) || (validatedText == context.text)
@@ -327,7 +349,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// Validate LLM polish output with mode-aware thresholds.
   /// Falls back to original text when the output looks like a hallucination,
   /// content drop, or question-to-answer conversion.
-  func validatePolishOutput(polished: String, original: String, mode: PolishMode) -> String {
+  func validatePolishOutput(
+    polished: String, original: String, mode: PolishMode,
+    provider: LLMProvider, model: String
+  ) -> String {
     guard !original.isEmpty else { return polished }
 
     // Mode-aware thresholds (from plan Appendix C)
@@ -354,7 +379,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
         await AppLogger.shared.log(
           "LLM polish validator: expansion \(polished.count)/\(original.count) chars "
             + "exceeds \(expansionThreshold) (mode=\(mode.rawValue)) — falling back "
-            + "(provider=\(llmProvider.rawValue), model=\(llmModel))",
+            + "(provider=\(provider.rawValue), model=\(model))",
           level: .info, category: "LLM"
         )
       }
@@ -371,7 +396,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       Task {
         await AppLogger.shared.log(
           "LLM polish validator: content drop \(polishedWords.count)/\(originalWords.count) words "
-            + "(mode=\(mode.rawValue)) — falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
+            + "(mode=\(mode.rawValue)) — falling back (provider=\(provider.rawValue), model=\(model))",
           level: .info, category: "LLM"
         )
       }
@@ -383,7 +408,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       Task {
         await AppLogger.shared.log(
           "LLM polish validator: question-to-answer conversion detected — "
-            + "falling back (provider=\(llmProvider.rawValue), model=\(llmModel))",
+            + "falling back (provider=\(provider.rawValue), model=\(model))",
           level: .info, category: "LLM"
         )
       }
@@ -495,11 +520,12 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
   private func logPolishCompletion(
     result: LLMResult, duration: Double,
+    provider: LLMProvider, model: String,
     extraData: [String: String] = [:]
   ) {
     var data: [String: String] = [
-      "provider": llmProvider.rawValue,
-      "model": llmModel,
+      "provider": provider.rawValue,
+      "model": model,
       "duration_s": String(format: "%.3f", duration),
       "char_count": String(result.polishedText.count),
     ]
@@ -509,7 +535,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     Task {
       await AppLogger.shared.log(
         "LLM polish complete: \(result.polishedText.count) chars in \(String(format: "%.3f", duration))s "
-          + "(provider=\(llmProvider.rawValue), model=\(llmModel))",
+          + "(provider=\(provider.rawValue), model=\(model))",
         level: .info, category: "PipelineTiming"
       )
     }

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -49,8 +49,10 @@ internal final class TextProcessingRunner {
       // @Sendable contract. Safety: op is @MainActor and its return value
       // (TextProcessingContext) is Sendable, so when op runs inside the
       // task group's child task and returns to the parent, the result
-      // crosses isolation safely. Same bridge pattern as the existing
-      // `unsafeStep` use below.
+      // crosses isolation safely. This is the SOLE nonisolated(unsafe) in the
+      // runner: it quarantines the @MainActor-to-@Sendable impedance inside this
+      // executor seam (swift-patterns timing-seam-shapes) rather than widening
+      // Core's withThrowingTimeout. (#827 PR-8)
       nonisolated(unsafe) let unsafeOp = op
       return try await withThrowingTimeout(seconds: seconds) {
         try await unsafeOp()
@@ -82,16 +84,13 @@ internal final class TextProcessingRunner {
     for step in steps where step.isEnabled {
       let stepName = step.name
       let input = context
-      // nonisolated(unsafe) is safe: the task group inherits @MainActor isolation,
-      // so step.process() still runs on MainActor — no real isolation crossing.
-      nonisolated(unsafe) let unsafeStep = step
       let stepStart = CFAbsoluteTimeGetCurrent()
       let budgetSeconds =
-        Double(unsafeStep.maxDuration.components.seconds)
-        + Double(unsafeStep.maxDuration.components.attoseconds) / 1e18
+        Double(step.maxDuration.components.seconds)
+        + Double(step.maxDuration.components.attoseconds) / 1e18
       do {
         context = try await timeoutExecutor(budgetSeconds) {
-          try await unsafeStep.process(input)
+          try await step.process(input)
         }
         let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
         let inputText = input.polishedText ?? input.text

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishReentrancyTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishReentrancyTests.swift
@@ -1,0 +1,176 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #827 PR-8 (text-processing concurrency isolation): regression for the
+/// settings torn-read in `LLMPolishStep.process()`.
+///
+/// `LLMPolishStep` is `@MainActor` with mutable `llmProvider`/`llmModel`. The
+/// method suspends at the polish `await`; on the saved-transcript re-polish
+/// path `PipelineSettingsSync` can rewrite those properties on the SAME
+/// instance during that suspension (user switches provider mid-re-polish).
+/// Before the fix, the post-await reads (`ctx.llmProvider`, the family label,
+/// the two telemetry helpers) observe the mutated value, mis-attributing the
+/// result. After the fix, `process()` snapshots provider/model at entry and
+/// uses the snapshot everywhere, so the recorded provider is the one that
+/// actually polished.
+///
+/// Determinism: the mock polisher signals entry via an `AsyncStream` (the same
+/// pattern as `TextProcessingChainRacesTests`) and suspends on an actor gate
+/// the test releases AFTER mutating, so the mutation is guaranteed to land
+/// while `process()` is parked at the polish await. No `Task.sleep`, no
+/// real-clock dependency (`tests-no-real-time-scheduling-precision`); the test
+/// observes entry through a synchronous stream value, not a raw continuation
+/// (`tests-no-unconditional-continuation-await`).
+@MainActor
+@Suite("LLMPolishStep reentrancy")
+struct LLMPolishReentrancyTests {
+
+  /// Release gate the mock awaits; the test releases it after mutating.
+  private actor ReleaseGate {
+    private var released = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func release() {
+      released = true
+      waiter?.resume()
+      waiter = nil
+    }
+    func wait() async {
+      if released { return }
+      await withCheckedContinuation { waiter = $0 }
+    }
+  }
+
+  /// Controllable polisher. Nonisolated + Sendable so `await polisher.polish`
+  /// genuinely suspends the MainActor (the reentrancy window). Implements only
+  /// the legacy `text:` method; the planner path reaches it via the protocol's
+  /// default `envelope:` bridge.
+  private struct GatePolisher: TranscriptPolisher {
+    let onStart: @Sendable () -> Void
+    let gate: ReleaseGate
+    let result: String
+
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      onStart()
+      await gate.wait()
+      return LLMResult(polishedText: result)
+    }
+  }
+
+  /// A sentence long enough to clear the short-transcript short-circuit and
+  /// pass the polish validator (similar length in / out).
+  private static let inputSentence =
+    "so i was thinking we could maybe ship the new thing some time next week or so"
+  private static let polishedSentence =
+    "So I was thinking we could maybe ship the new thing some time next week."
+
+  /// Runs `process()` with the polisher parked, mutates provider/model
+  /// mid-await, then completes. Returns the finalized context.
+  private func runTornReadScenario(
+    initialProvider: LLMProvider,
+    initialModel: String,
+    mutateTo mutatedProvider: LLMProvider,
+    mutatedModel: String
+  ) async throws -> TextProcessingContext {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = initialProvider
+    step.llmModel = initialModel
+
+    let started = AsyncStream.makeStream(of: Void.self)
+    let cont = started.continuation
+    let gate = ReleaseGate()
+    step.makePolisher = { _, _ in
+      GatePolisher(
+        onStart: {
+          cont.yield(())
+          cont.finish()
+        },
+        gate: gate,
+        result: Self.polishedSentence
+      )
+    }
+
+    let context = TextProcessingContext(text: Self.inputSentence, language: "en")
+    let task = Task { @MainActor in try await step.process(context) }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // polisher entered; process() parked at the await, MainActor free
+
+    step.llmProvider = mutatedProvider  // reentrant mutation during the polish suspension
+    step.llmModel = mutatedModel
+    await gate.release()
+
+    return try await task.value
+  }
+
+  @Test("planner path: a provider switch mid-polish does not tear the recorded provider/model")
+  func plannerPathTornRead() async throws {
+    let ctx = try await runTornReadScenario(
+      initialProvider: .openAI,
+      initialModel: "gpt-4o-mini",
+      mutateTo: .gemini,
+      mutatedModel: "gemini-2.0-flash"
+    )
+    // RED before the snapshot fix (records the mutated .gemini); GREEN after.
+    #expect(ctx.llmProvider == LLMProvider.openAI.rawValue)
+    #expect(ctx.llmModel == "gpt-4o-mini")
+  }
+
+  @Test("AFM path: a provider switch mid-polish does not tear the recorded provider/model")
+  func afmPathTornRead() async throws {
+    let ctx = try await runTornReadScenario(
+      initialProvider: .appleIntelligence,
+      initialModel: "apple-intelligence",
+      mutateTo: .gemini,
+      mutatedModel: "gemini-2.0-flash"
+    )
+    #expect(ctx.llmProvider == LLMProvider.appleIntelligence.rawValue)
+    #expect(ctx.llmModel == "apple-intelligence")
+  }
+
+  @Test("control: with no mid-polish mutation, the actual provider/model is recorded")
+  func noMutationControl() async throws {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .openAI
+    step.llmModel = "gpt-4o-mini"
+
+    let gate = ReleaseGate()
+    await gate.release()  // no mutation: let polish run straight through
+    step.makePolisher = { _, _ in
+      GatePolisher(onStart: {}, gate: gate, result: Self.polishedSentence)
+    }
+
+    let context = TextProcessingContext(text: Self.inputSentence, language: "en")
+    let ctx = try await step.process(context)
+
+    #expect(ctx.llmProvider == LLMProvider.openAI.rawValue)
+    #expect(ctx.llmModel == "gpt-4o-mini")
+  }
+
+  @Test("nil polisher factory throws providerUnavailable (so the runner keeps raw text)")
+  func nilFactoryThrowsProviderUnavailable() async throws {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .openAI
+    step.llmModel = "gpt-4o-mini"
+    step.makePolisher = { _, _ in nil }
+
+    let context = TextProcessingContext(text: Self.inputSentence, language: "en")
+    do {
+      _ = try await step.process(context)
+      Issue.record("expected LLMError.providerUnavailable, got success")
+    } catch let error as LLMError {
+      #expect(error == .providerUnavailable)
+    } catch {
+      Issue.record("expected LLMError.providerUnavailable, got \(error)")
+    }
+  }
+}


### PR DESCRIPTION
## PR-8: text-processing concurrency isolation

Part of #827 (engine-kernel epic, §324). Tier: REFACTOR. Plan: `docs/feature-requests/issue-827-2026-05-29-pr8-text-processing-isolation.md`.

### What and why

Two concurrency-hygiene defects on the post-ASR text-processing chain, both addressed; the big "move text processing into a `TextProcessingActor`" option was evaluated and **rejected**.

**DEFECT-1 — inert `nonisolated(unsafe)` removed.** `TextProcessingRunner` carried two `nonisolated(unsafe)` annotations on the heart path. Line 54 (`unsafeOp`) is a genuine `@MainActor`->`@Sendable` bridge into Core's `withThrowingTimeout` and stays, quarantined inside the consumer per the `timing-seam-shapes` house rule (Core's API is not widened). Line 87 (`unsafeStep`) bridged nothing — both the closure and the captured `step` were already `@MainActor` — so it is deleted, satisfying §324's "quarantine to one tested bridge" clause. The genuine bridge is exercised by standing tests (`TextProcessingChainRacesTests`, `LimbFailureFallbackTests`).

**DEFECT-3 — torn read snapshotted.** `LLMPolishStep.process()` re-read its mutable `llmProvider`/`llmModel` after the multi-second polish `await`. On the saved-transcript re-polish path a mid-polish provider switch (live-mirrored by `PipelineSettingsSync`) could tear those reads. Fix: snapshot both at `process()` entry and thread the snapshot through every post-await read site and the two telemetry helpers (`validatePolishOutput`, `logPolishCompletion`), per `telemetry-snapshot-not-shared-property` (identical to `WordCorrectionStep`'s existing entry snapshot). Severity is log/telemetry attribution only — the persisted `Transcript` already used `TranscriptPolishService`'s own pre-await snapshot.

**No production behavior change on the live dictation path.** The new injectable `makePolisher` factory's default closure reproduces the previous inline provider switch exactly (including the `.none` `providerUnavailable` breadcrumb + throw), and there is no concurrent settings writer during the polish await on the live path. The snapshot future-proofs the durable live consumer.

**`TextProcessingActor` rejected:** actors are reentrant (would not fix the torn read), the only heavy CPU step is already offloaded, and an actor would re-isolate the step-mutation surface (net heart-path debt). Ratified by council (GPT + Gemini) + Codex grounded review.

### Tests

- New `LLMPolishReentrancyTests`: deterministic red-then-green reentrancy regression covering the planner and Apple Intelligence branches, a no-mutation control, and a nil-factory guard. (Verified RED before the snapshot, GREEN after.)
- Full suite green: **1468 tests / 181 suites, 0 failures**, including the kernel scenario-inventory simulator suite, FSM invariants, and the bridge matrix (the §324 full-simulator obligation, run unfiltered).
- Static guard: no post-snapshot bare `self.llmProvider`/`self.llmModel` read remains in `process()` or the two helpers; exactly one `nonisolated(unsafe)` declaration remains in the runner.

### Validation

- `swift build -c release` exit 0.
- Live UAT (synthetic, debug build) PASS on **both backends** (Parakeet + WhisperKit): heart path completes, polish runs (Gemini), and the modified attribution helpers emit the correct `provider`/`model`.
- DEFECT-2 deterministic cumulative-CPU measurement captured. Three of four operations in budget; the emoji formatter exceeds the 8ms frame budget on long input **when enabled** -> targeted-`@concurrent` follow-up filed (does not block PR-8; default config PASSes). See #887.
- Codex code-diff review: clean.
- Zero em/en dashes in new code and comments.

### Blast radius

`EnviousWisprPipeline` only (`TextProcessingRunner.swift`, `LLMPolishStep.swift`) + one new test file. No Core/UI/persistence/XPC/audio/ASR change, no eval-corpus or network-diagnostic surface, no new `LLMError`. Single-commit revert.