### PR TITLE
test(pipeline): TO-1 — make the last two real-clock flake/slow tests deterministic (#881)

### DIFF
--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -8,10 +8,14 @@ import Testing
 /// Issue #782: timing-coupled tests migrated to a `ManualClock` seam so the
 /// suite no longer depends on real `Task.sleep` for the SUT's measured cadence.
 /// Each test that drives an asserted threshold passes a manual clock to the
-/// watcher and advances it deterministically with `tick(seconds:)`. Tests whose
-/// sleeps are non-load-bearing (pre-first-signal, identical-mtime, stop()
-/// release, raceWithSignalWatcher orchestration) keep real `Task.sleep` because
-/// the sleep duration does not feed any asserted measurement.
+/// watcher and advances it deterministically with `tick(seconds:)` — including
+/// pre-first-signal, which crosses the fire floor in logical time and asserts
+/// `hasFired == false` (#881 TO-1). Tests whose sleeps are non-load-bearing
+/// (identical-mtime, stop() release, raceWithSignalWatcher orchestration) keep
+/// real `Task.sleep` because the sleep duration does not feed any asserted
+/// measurement. The one real `Task.sleep` that survives in pre-first-signal is
+/// the 100ms continuation-park before `stop()`, which is scheduling, not a
+/// measured cadence.
 ///
 /// The watcher is `@MainActor`-isolated; tests must run on `@MainActor`.
 /// Synthetic signal streams are injected directly (no real ProgressFile).
@@ -43,15 +47,26 @@ struct LoadProgressWatcherTests {
 
   @Test("Pre-first-signal silence does NOT fire (uncovered case per plan §2.2)")
   func preFirstSignalDoesNotFire() async {
-    let watcher = LoadProgressWatcher()
+    // Deterministic clock so the 20 nil ticks cross the 800ms fire floor in
+    // logical time (~2.0s) without burning ~1000ms of real wall-clock per run.
+    // The point of the test is that even past the floor, a watcher that never
+    // observed a real signal must NOT fire (the pre-first-signal guard returns
+    // before any silence/floor evaluation). The old real-clock sleep made this
+    // slow AND under-asserted — it never checked `hasFired`, so a regression
+    // firing past the floor would have stayed green (#881 TO-1).
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(currentTime: { clock.now })
     watcher.start()
     for _ in 0..<20 {
       watcher.observeTick(observedMtime: nil, observedPhase: "")
-      await sleep(ms: 50)
+      clock.tick(seconds: 0.1)  // 20 * 0.1s = 2.0s, well past the 0.8s floor
     }
     let snap = watcher.snapshot
     #expect(snap.signalCountTotal == 0)
     #expect(snap.firstSignalLatencyMs == nil)
+    #expect(
+      watcher.hasFired == false,
+      "pre-first-signal silence must never fire, even after the 800ms floor elapses")
     // No signal ever observed → wedged() must remain pending forever, but
     // stop() must release any awaiter cleanly.
     let waiter = Task { @MainActor in

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -101,6 +101,7 @@ struct HeartPathIntegrationTests {
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry()
       ))
+    let stateWaiter = PipelineStateWaiter(pipeline)
     #expect(pipeline.currentSessionConfig == nil)
 
     let config = DictationSessionConfig.testDefault(
@@ -122,10 +123,8 @@ struct HeartPathIntegrationTests {
     #expect(captured?.llmProvider == LLMProvider.openAI)
     #expect(captured?.llmModel == "gpt-test")
 
-    let reachedRecording = await pollUntil(timeout: .seconds(1)) {
-      pipeline.state == .recording
-    }
-    #expect(reachedRecording)
+    await stateWaiter.wait(for: .recording)
+    #expect(pipeline.state == .recording)
 
     await pipeline.cancelRecording()
 
@@ -733,22 +732,6 @@ private enum MockFailure: LocalizedError, Equatable {
       return "Streaming should not be used in this integration test"
     }
   }
-}
-
-@MainActor
-private func pollUntil(
-  timeout: Duration,
-  interval: Duration = .milliseconds(10),
-  condition: @escaping @MainActor () -> Bool
-) async -> Bool {
-  let deadline = ContinuousClock.now + timeout
-  while ContinuousClock.now < deadline {
-    if condition() {
-      return true
-    }
-    try? await Task.sleep(for: interval)
-  }
-  return condition()
 }
 
 /*


### PR DESCRIPTION
## What

Trust-sweep test-only batch **TO-1** (parent #881, findings #4 + #17). Makes the last two real-clock-coupled tests deterministic. **No `Sources/` change.**

## Changes

- **`earlyCancellationDoesNotCrashOrDeliver`** (`HeartPathIntegrationTests`): replaced the 1s real-clock `pollUntil { state == .recording }` with the signal-based `PipelineStateWaiter(pipeline).wait(for: .recording)`, mirroring the direct siblings (`HeartPathTelemetryWiringTests`, `CancellationSilentUnwindTests`). The poll could flake red under release-config MainActor saturation; the waiter parks on `onStateChange` and `Issue.record`s loudly on its safety timeout instead of silently overshooting. Removed the now-unused file-local `pollUntil` helper (sole caller). **~1s worst case → 0.08s.**

- **`preFirstSignalDoesNotFire`** (`LoadProgressWatcherTests`): the old test slept ~1s of real wall-clock across 20 nil ticks **and never asserted `hasFired`** — a regression that fired pre-first-signal after the 800ms floor would have stayed green. Rewrote onto the existing `ManualClock` seam: advance logical time to ~2.0s (well past the 0.8s floor) and assert `watcher.hasFired == false`, which now genuinely locks "no signal observed → never fire, even past the floor." Kept the single 100ms continuation-park sleep before `stop()` (scheduling, not a measured cadence). **~1.1s → 0.1s.**

## Validation

- Both full suites green: `HeartPathIntegrationTests` (4) + `LoadProgressWatcherTests` (14).
- **Regression-catch proven**: a temporary SUT change that fires pre-first-signal past the floor turns `preFirstSignalDoesNotFire` red on the new `hasFired == false` assertion; reverted.
- Codex code-diff review clean (round 1 flagged the missing past-floor coverage on the first cut; round 2 clean after the `ManualClock` + `hasFired` rewrite).

Part of #881.