### PR TITLE
refactor(pipeline): PR-9 delete DictationPipeline protocol + kernel-ownership freeze test (#827)

### DIFF
--- a/Sources/EnviousWispr/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/RecordingFinalizer.swift
@@ -63,7 +63,7 @@ final class RecordingFinalizer {
   func userStop() async {
     recordingLockedAccess.set(false)
     lastUserStopRequest = ContinuousClock.now
-    let active: any DictationPipeline =
+    let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
     do {
       try await active.handle(event: .requestStop)

--- a/Sources/EnviousWispr/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWispr/App/DictationRuntime/RecordingStarter.swift
@@ -83,7 +83,7 @@ final class RecordingStarter {
   func start() async {
     dictationLifecycleCoordinator?.cancelPendingWarning()
     let isWhisperKit = asrManager.activeBackendType == .whisperKit
-    let active: any DictationPipeline = isWhisperKit ? whisperKitKernelDriver : kernelDriver
+    let active: KernelDictationDriver = isWhisperKit ? whisperKitKernelDriver : kernelDriver
     // PR-7 (#827): snapshot engine readiness BEFORE prewarm so the cold-start
     // log cohorts warm/cold/mid-flight; snapshot-at-entry avoids retro-labeling.
     let readinessAtEntry = (isWhisperKit ? whisperKitKernelDriver : kernelDriver).engineReadiness
@@ -157,8 +157,9 @@ final class RecordingStarter {
           )))
     } catch {
       heartControlRecovery.recover(
-        error: error, pipeline: active, op: "toggle-from-prewarm",
-        message: ModelLoadWatchdog.userMessage)
+        error: error, op: "toggle-from-prewarm",
+        message: ModelLoadWatchdog.userMessage,
+        setExternalError: active.setExternalError)
       return
     }
     let totalMs = Self.elapsedMs(since: pttStart)
@@ -213,7 +214,7 @@ final class RecordingStarter {
   /// snapshot picks up the right paste capability.
   func toggle(source: TriggerSource) async {
     dictationLifecycleCoordinator?.cancelPendingWarning()
-    let active: any DictationPipeline =
+    let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
     let isWK = asrManager.activeBackendType == .whisperKit
     if !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive) {
@@ -235,8 +236,9 @@ final class RecordingStarter {
           )))
     } catch {
       heartControlRecovery.recover(
-        error: error, pipeline: active, op: "toggle",
-        message: ModelLoadWatchdog.userMessage)
+        error: error, op: "toggle",
+        message: ModelLoadWatchdog.userMessage,
+        setExternalError: active.setExternalError)
     }
   }
 

--- a/Sources/EnviousWispr/App/HeartControlRecovery.swift
+++ b/Sources/EnviousWispr/App/HeartControlRecovery.swift
@@ -1,5 +1,3 @@
-import EnviousWisprCore
-import EnviousWisprPipeline
 import EnviousWisprServices
 import Foundation
 
@@ -10,7 +8,7 @@ import Foundation
 /// - `logDispatchFailure` — log only. Use when the caller has already reset overlay + lock
 ///   before the dispatch (Stop, WhisperKit Cancel paths).
 /// - `recover` — full recovery: log, hide overlay, clear lock, surface user-facing message
-///   via the pipeline. Use when the caller has NOT pre-reset state (Toggle paths).
+///   via the driver's `setExternalError` closure. Use when the caller has NOT pre-reset state (Toggle paths).
 ///
 /// `CancellationError` is treated as a coordinated unwind in both shapes: skipped from the
 /// log (mirrors prior inline behavior at the former root-state file pre-warm catch), but `recover`
@@ -29,7 +27,8 @@ struct HeartControlRecovery {
   }
 
   func recover(
-    error: any Error, pipeline: any DictationPipeline, op: String, message: String
+    error: any Error, op: String, message: String,
+    setExternalError: @MainActor (String) -> Void
   ) {
     let isCancellation = error is CancellationError
     if !isCancellation {
@@ -40,7 +39,7 @@ struct HeartControlRecovery {
     hideOverlay()
     setLocked(false)
     if !isCancellation {
-      pipeline.setExternalError(message)
+      setExternalError(message)
     }
   }
 }

--- a/Sources/EnviousWispr/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWispr/App/PipelineSettingsSync.swift
@@ -112,11 +112,6 @@ final class PipelineSettingsSync {
         break
       }
       let backend = settings.selectedBackend
-      // Issue #289: invalidate any stall-recovery token on either pipeline
-      // so a deferred cleanup from a pre-switch stall doesn't tear down
-      // the pipeline that's about to become active.
-      kernelDriver.clearPendingStallRecovery()
-      whisperKitKernelDriver.clearPendingStallRecovery()
       Task { [weak self] in
         await self?.asrManager.switchBackend(to: backend)
         SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -5,18 +5,19 @@ import Foundation
 
 // MARK: - KernelDictationDriver (epic #827, PR-4 §3.1)
 //
-// Adapts `RecordingSessionKernel` to the `DictationPipeline` surface the App
-// layer consumes. The App calls the active engine through `DictationPipeline`
+// Adapts `RecordingSessionKernel` to the recording-driver surface the App
+// layer consumes. The App calls the active engine through this concrete driver
 // and reads `state` / `overlayIntent` / `currentTranscript` / `lastPolishError`
 // / the four limb-step accessors / `onStateChange` / DEBUG `forceCancelNow()`
-// off the concrete pipeline type. The kernel exposes none of that — it has
-// synchronous triggers and its own `RecordingSessionState` vocabulary.
+// off it. The kernel exposes none of that — it has synchronous triggers and
+// its own `RecordingSessionState` vocabulary.
 //
 // The driver translates: `PipelineEvent` -> kernel triggers, `RecordingSessionState`
-// -> `PipelineState` / `OverlayIntent`. It is a permanent translation layer
-// until PR-9 deletes `DictationPipeline`; it carries real behavior (event
+// -> `PipelineState` / `OverlayIntent`. It carries real behavior (event
 // translation, state mapping, the limb-step home, the external-error surface)
-// and is NOT a forwarding shim — the old Parakeet pipeline path is gone.
+// and is NOT a forwarding shim — the old Parakeet pipeline path is gone. PR-9
+// of #827 deleted the `DictationPipeline` protocol; this is the single concrete
+// driver and the App holds it directly (`KernelOwnershipFreezeTests`).
 //
 // PR-4a ships this production-unwired: no App-layer caller constructs it.
 // PR-4b re-points the 13 App files at this type.
@@ -44,10 +45,10 @@ struct LimbSteps {
   let llmPolish: LLMPolishStep
 }
 
-/// Wraps `RecordingSessionKernel` as a `DictationPipeline` for the App layer.
+/// Wraps `RecordingSessionKernel` as the App layer's recording driver.
 @MainActor
 @Observable
-public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryTarget {
+public final class KernelDictationDriver: HeartPathTelemetryTarget {
 
   private let kernel: RecordingSessionKernel
   private let observer: KernelHeartPathTelemetryObserver
@@ -330,7 +331,7 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
     context.config
   }
 
-  // MARK: DictationPipeline
+  // MARK: Caller-facing event + overlay surface
 
   public var overlayIntent: OverlayIntent {
     if let lastExternalError {
@@ -472,10 +473,6 @@ public final class KernelDictationDriver: DictationPipeline, HeartPathTelemetryT
     lastExternalError = message
     fireStateChangeIfNeeded()
   }
-
-  /// Intentional no-op (PR-4 §3.7). The kernel's `SessionID` structurally
-  /// replaces the stall-recovery token (D11) — there is nothing to clear.
-  public func clearPendingStallRecovery() {}
 
   // MARK: HeartPathTelemetryTarget — forwards to the observer (PR-4 §3.9)
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -11,8 +11,8 @@ import Foundation
 /// added the second-engine branch; PR-5 Rung 5 narrowed the factory surface
 /// from `public` to `package` and added the shared VAD signal source seam).
 ///
-/// The App layer needs a `DictationPipeline`-conforming object but cannot
-/// construct one directly: `RecordingSessionKernel`, `ParakeetEngineAdapter`,
+/// The App layer needs a `KernelDictationDriver` but cannot construct one
+/// directly: `RecordingSessionKernel`, `ParakeetEngineAdapter`,
 /// `WhisperKitEngineAdapter`, `KernelHeartPathTelemetryObserver`, `LimbSteps`,
 /// `KernelFinalizationOutcome`, `KernelSessionContext`, `KernelFinalizationWiring`,
 /// `HeartPathTelemetryEmitter`, `KernelLifecycleTelemetrySink`, and

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -1,12 +1,19 @@
 import EnviousWisprCore
 import Foundation
 
+// Pipeline vocabulary shared across the recording driver and its consumers:
+// the event input (`PipelineEvent`), the UI output (`OverlayIntent`), the
+// interruption message constants, and the heart-path telemetry-target protocol.
+// The `DictationPipeline` driver protocol that once lived here was deleted in
+// PR-9 of #827 — `KernelDictationDriver` is the single concrete driver and the
+// App consumes it directly. `KernelOwnershipFreezeTests` keeps it deleted.
+
 /// Known interruption message strings used to route .error state to .interruption overlay intent.
 public enum InterruptionMessages {
   public static let micDisconnected = "Microphone disconnected"
 }
 
-/// Events that any dictation pipeline must handle.
+/// Events the recording driver handles.
 public enum PipelineEvent: Sendable {
   case preWarm
   /// Toggle recording. Carries the per-recording configuration snapshot; pipelines
@@ -44,30 +51,6 @@ public enum OverlayIntent: Equatable, Sendable {
   /// language. Renders State A (strikes 1+2: Lock + Dismiss) or State B (strike 3:
   /// Dismiss only with Settings copy). Auto-dismissed after 6 seconds; pauses on hover.
   case passiveChip(payload: LanguageChipPayload)
-}
-
-/// Abstraction over dictation pipelines (Parakeet streaming, WhisperKit batch, etc.).
-/// Each pipeline owns its own state machine and emits `OverlayIntent` for UI.
-@MainActor
-public protocol DictationPipeline: AnyObject {
-  var overlayIntent: OverlayIntent { get }
-  /// Issue #289: `.preWarm` may now throw if the audio input fails to
-  /// start (XPC transport error, AVAudioEngine start refusal, etc.). Other
-  /// events never throw today but the unified signature lets callers observe
-  /// failures without a second protocol method.
-  func handle(event: PipelineEvent) async throws
-  /// Surface an error to the pipeline from outside (e.g. the former root state after
-  /// `handle(.preWarm)` threw). Intentionally dumb: sets `state = .error(msg)`
-  /// and clears transient state. No retry scheduling, no transition logic.
-  func setExternalError(_ message: String)
-
-  /// Issue #289: invalidate any pending stall-recovery cleanup token so a
-  /// deferred `finishStallRecovery` won't call `stopCapture()` on a session
-  /// this pipeline no longer owns. Called by `PipelineSettingsSync` on
-  /// backend switch — the deactivating pipeline may still hold a token for a
-  /// pre-switch stall, and the shared `AudioCaptureInterface.currentCaptureSessionID`
-  /// doesn't advance until the other pipeline reaches `beginCapturePhase()`.
-  func clearPendingStallRecovery()
 }
 
 /// Issue #285 — heart-path telemetry callbacks that the former root state routes to

--- a/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
@@ -2,25 +2,29 @@ import Foundation
 import Testing
 
 @testable import EnviousWispr
-@testable import EnviousWisprPipeline
 @testable import EnviousWisprServices
 
 /// #585 — HeartControlRecovery extracted from the former root state.
 ///
 /// These tests assert the recovery contract via injected closures + Sentry's
 /// test-only `captureErrorDelegate` hook. CancellationError must be treated as
-/// a coordinated unwind (no Sentry capture, no pipeline error surface), while
-/// every other error must produce the full diagnostic trail.
+/// a coordinated unwind (no Sentry capture, no error surface), while every
+/// other error must produce the full diagnostic trail.
+///
+/// PR-9 (#827) deleted the `DictationPipeline` protocol; `recover` now takes a
+/// narrow `setExternalError` closure, so the old `FakePipeline` conformer is
+/// replaced by this minimal error-surface spy.
 @Suite("HeartControlRecovery (#585)")
 @MainActor
 struct HeartControlRecoveryTests {
 
-  final class FakePipeline: DictationPipeline {
-    var overlayIntent: OverlayIntent = .hidden
-    var setExternalErrorCalls: [String] = []
-    func handle(event: PipelineEvent) async throws {}
-    func setExternalError(_ message: String) { setExternalErrorCalls.append(message) }
-    func clearPendingStallRecovery() {}
+  /// `@MainActor` so `setExternalError` matches the `recover` parameter's
+  /// `@MainActor (String) -> Void` type (which is implicitly `Sendable` in
+  /// Swift 6); production passes a `@MainActor` driver method for the same reason.
+  @MainActor
+  final class ErrorSurfaceSpy {
+    var calls: [String] = []
+    func setExternalError(_ message: String) { calls.append(message) }
   }
 
   final class CaptureSpy: @unchecked Sendable {
@@ -97,18 +101,20 @@ struct HeartControlRecoveryTests {
   func recoverNonCancellationFullRecovery() {
     let hide = HideCallCounter()
     let locked = LockedCallCounter()
-    let pipeline = FakePipeline()
+    let sink = ErrorSurfaceSpy()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked, backend: "parakeet")
     withSentrySpy { spy in
       struct BoomError: Error {}
-      recovery.recover(error: BoomError(), pipeline: pipeline, op: "toggle", message: "Try again.")
+      recovery.recover(
+        error: BoomError(), op: "toggle", message: "Try again.",
+        setExternalError: sink.setExternalError)
       #expect(spy.calls.count == 1)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle")
       #expect(spy.calls.first?.extra?["backend"] as? String == "parakeet")
     }
     #expect(hide.count == 1, "overlay must be hidden")
     #expect(locked.values == [false], "lock must be cleared")
-    #expect(pipeline.setExternalErrorCalls == ["Try again."])
+    #expect(sink.calls == ["Try again."])
   }
 
   @Test(
@@ -116,30 +122,32 @@ struct HeartControlRecoveryTests {
   func recoverCancellationSilentReset() {
     let hide = HideCallCounter()
     let locked = LockedCallCounter()
-    let pipeline = FakePipeline()
+    let sink = ErrorSurfaceSpy()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
     withSentrySpy { spy in
       recovery.recover(
-        error: CancellationError(), pipeline: pipeline, op: "toggle", message: "Try again.")
+        error: CancellationError(), op: "toggle", message: "Try again.",
+        setExternalError: sink.setExternalError)
       #expect(spy.calls.isEmpty, "CancellationError must not capture to Sentry")
     }
     #expect(hide.count == 1, "overlay must still be hidden so user UI isn't stuck")
     #expect(locked.values == [false], "lock must still be cleared")
     #expect(
-      pipeline.setExternalErrorCalls.isEmpty,
-      "cancellation must NOT surface a user-facing error on the pipeline")
+      sink.calls.isEmpty,
+      "cancellation must NOT surface a user-facing error")
   }
 
   @Test("recover passes op string verbatim — distinguishes call sites at triage time")
   func recoverPassesOpVerbatim() {
     let hide = HideCallCounter()
     let locked = LockedCallCounter()
-    let pipeline = FakePipeline()
+    let sink = ErrorSurfaceSpy()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
     withSentrySpy { spy in
       struct E: Error {}
       recovery.recover(
-        error: E(), pipeline: pipeline, op: "toggle-from-prewarm", message: "")
+        error: E(), op: "toggle-from-prewarm", message: "",
+        setExternalError: sink.setExternalError)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle-from-prewarm")
     }
   }

--- a/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
@@ -58,7 +58,6 @@ import Testing
     _ = driver.currentSessionConfig
     driver.onStateChange = { _ in }
     driver.setExternalError("probe")
-    driver.clearPendingStallRecovery()
     driver.handleEngineInterruption()
     driver.handleASRServiceInterruption()
     driver.reset()

--- a/Tests/EnviousWisprTests/Architecture/KernelOwnershipFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelOwnershipFreezeTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Testing
+
+// MARK: - KernelOwnershipFreezeTests (epic #827, PR-9 — terminal guard)
+//
+// The engine-kernel refactor collapsed two recording pipelines into one
+// `RecordingSessionKernel`, adapted by the single `KernelDictationDriver`.
+// PR-9 deleted the old `DictationPipeline` driver protocol. This suite is the
+// permanent guard that no SECOND recording-orchestration brain reappears and
+// that the lifecycle FSM + the event entry point stay single-owner. It models
+// `AppStateFreezeTests` (#763 terminal guard) and complements
+// `EngineIdentityFreezeTests` (which guards engine-identity literals, the old
+// WhisperKit pipeline, and adapter construction — not kernel ownership).
+//
+// Four invariants:
+//   1. `DictationPipeline` (the deleted driver protocol) never returns to
+//      `Sources/**`; in `Tests/**` it may appear only in this file.
+//   2. `enum RecordingSessionState` (the lifecycle FSM) has exactly ONE source
+//      declaration — fail-closed `== 1`, so a silent rename trips the guard.
+//   3. `func handle(event: PipelineEvent)` (the driver's event entry point) has
+//      exactly ONE source declaration — fail-closed `== 1`.
+//   4. `TranscriptionPipeline` (the deleted Parakeet pipeline type) never
+//      returns to `Sources/**`.
+//
+// Known blind spot (named, not fixed): a semantically-equivalent second FSM
+// declared under a DIFFERENT enum name evades invariant 2. The protocol-token
+// ban (1) + the single `handle(event:)` entry lock (3) + Codex code-diff review
+// are the covering layers; a name-blind structural detector is out of scope.
+
+@Suite struct KernelOwnershipFreezeTests {
+
+  // Whole-word so `KernelDictationDriver` / `KernelDictationDriverFactory` do
+  // not false-positive on the deleted `DictationPipeline` protocol name.
+  private static let dictationPipelineToken = #"\bDictationPipeline\b"#
+  // Whole-word so `WhisperKitPipelineState` etc. do not false-positive.
+  private static let transcriptionPipelineToken = #"\bTranscriptionPipeline\b"#
+  // The `enum` keyword precedes the name only at the declaration; a usage such
+  // as `RecordingSessionState.idle` is never preceded by `enum`.
+  private static let recordingSessionStateDecl = #"\benum\s+RecordingSessionState\b"#
+  // `PipelineEvent` appears as the parameter TYPE only in the declaration; call
+  // sites pass a value (`handle(event: .requestStop)`), never the type name.
+  private static let handleEventDecl = #"func\s+handle\(event:\s*PipelineEvent\)"#
+
+  // MARK: 1 — the deleted driver protocol stays deleted
+
+  @Test("DictationPipeline protocol is absent from Sources/ (PR-9 deleted it)")
+  func dictationPipelineAbsentFromSources() throws {
+    let hits = try Self.scanSources(pattern: Self.dictationPipelineToken)
+    #expect(
+      hits.isEmpty,
+      """
+      The deleted `DictationPipeline` driver protocol reappears in Sources/:
+      \(hits.joined(separator: "\n"))
+      PR-9 of #827 deleted it. `KernelDictationDriver` is the single concrete
+      recording driver and the App holds it directly. Do not reintroduce a
+      shared driver protocol — that is a second orchestration brain.
+      """)
+  }
+
+  @Test("DictationPipeline appears in Tests/ only in this freeze file")
+  func dictationPipelineAbsentFromTestsExceptThisFile() throws {
+    let offenders = try Self.scanTests(
+      pattern: Self.dictationPipelineToken, allowing: ["KernelOwnershipFreezeTests.swift"])
+    #expect(
+      offenders.isEmpty,
+      """
+      Test files reference the deleted `DictationPipeline` protocol:
+      \(offenders.joined(separator: "\n"))
+      Re-point the test at the concrete `KernelDictationDriver`.
+      """)
+  }
+
+  // MARK: 2 — the lifecycle FSM has exactly one owner (fail-closed)
+
+  @Test("enum RecordingSessionState has exactly one source declaration")
+  func recordingSessionStateHasSingleDeclaration() throws {
+    let hits = try Self.scanSources(pattern: Self.recordingSessionStateDecl)
+    #expect(
+      hits.count == 1,
+      """
+      Expected exactly ONE `enum RecordingSessionState` declaration, found \(hits.count):
+      \(hits.joined(separator: "\n"))
+      The lifecycle FSM is owned solely by `RecordingSessionKernel`. A count of 0
+      means the enum was renamed (update this guard in lockstep); a count >1 means
+      a second FSM was introduced (a second orchestration brain).
+      """)
+  }
+
+  // MARK: 3 — the event entry point has exactly one owner (fail-closed)
+
+  @Test("func handle(event: PipelineEvent) has exactly one source declaration")
+  func handleEventHasSingleDeclaration() throws {
+    let hits = try Self.scanSources(pattern: Self.handleEventDecl)
+    #expect(
+      hits.count == 1,
+      """
+      Expected exactly ONE `func handle(event: PipelineEvent)` declaration, found \(hits.count):
+      \(hits.joined(separator: "\n"))
+      The event entry point is owned solely by `KernelDictationDriver`. A count of
+      0 means the signature changed (update this guard in lockstep); a count >1
+      means a second driver routes engines around the kernel.
+      """)
+  }
+
+  // MARK: 4 — the deleted Parakeet pipeline type stays deleted
+
+  @Test("TranscriptionPipeline type is absent from Sources/ (deleted PR-4b.4)")
+  func transcriptionPipelineAbsentFromSources() throws {
+    let hits = try Self.scanSources(pattern: Self.transcriptionPipelineToken)
+    #expect(
+      hits.isEmpty,
+      """
+      The deleted `TranscriptionPipeline` type reappears in Sources/:
+      \(hits.joined(separator: "\n"))
+      It was deleted at PR-4b.4 (#827) when Parakeet moved onto the kernel.
+      """)
+  }
+
+  // MARK: Adversarial — the matchers flag real reintroductions
+
+  @Test("a re-added DictationPipeline protocol declaration is flagged")
+  func adversarialProtocolReintroductionFlagged() {
+    let line = "public protocol DictationPipeline: AnyObject {"
+    #expect(Self.regexFlags(source: line, pattern: Self.dictationPipelineToken))
+  }
+
+  @Test("a second enum RecordingSessionState declaration is flagged")
+  func adversarialSecondFSMFlagged() {
+    let line = "  internal enum RecordingSessionState { case idle }"
+    #expect(Self.regexFlags(source: line, pattern: Self.recordingSessionStateDecl))
+  }
+
+  @Test("a second func handle(event: PipelineEvent) declaration is flagged")
+  func adversarialSecondHandleEventFlagged() {
+    let line = "  public func handle(event: PipelineEvent) async throws {"
+    #expect(Self.regexFlags(source: line, pattern: Self.handleEventDecl))
+  }
+
+  @Test("a TranscriptionPipeline construction is flagged")
+  func adversarialTranscriptionPipelineFlagged() {
+    let line = "    let p = TranscriptionPipeline()"
+    #expect(Self.regexFlags(source: line, pattern: Self.transcriptionPipelineToken))
+  }
+
+  // MARK: Fail-closed — a silent rename (count 0) must NOT satisfy `== 1`
+
+  @Test("single-declaration locks are fail-closed: 0 and 2 both fail the == 1 check")
+  func singleDeclarationLocksAreFailClosed() {
+    let zero = "let x = 1\nlet y = 2\n"
+    let two = "enum RecordingSessionState {}\nenum RecordingSessionState {}\n"
+    #expect(Self.countMatches(in: zero, pattern: Self.recordingSessionStateDecl) == 0)
+    #expect(Self.countMatches(in: two, pattern: Self.recordingSessionStateDecl) == 2)
+    // Both differ from 1, so the live `== 1` assertion fails closed in either case.
+  }
+
+  // MARK: Negative controls — legitimate code is NOT flagged
+
+  @Test("KernelDictationDriver / KernelDictationDriverFactory are not flagged by the protocol ban")
+  func negativeControlDriverNamesNotFlagged() {
+    let cls = "public final class KernelDictationDriver: HeartPathTelemetryTarget {"
+    let factory = "public enum KernelDictationDriverFactory {"
+    #expect(Self.regexFlags(source: cls, pattern: Self.dictationPipelineToken) == false)
+    #expect(Self.regexFlags(source: factory, pattern: Self.dictationPipelineToken) == false)
+  }
+
+  @Test("WhisperKitPipelineState is not flagged by the TranscriptionPipeline ban")
+  func negativeControlSubstringNotFlagged() {
+    let line = "    let s: WhisperKitPipelineState = .idle"
+    #expect(Self.regexFlags(source: line, pattern: Self.transcriptionPipelineToken) == false)
+  }
+
+  @Test("a handle(event:) CALL site is not flagged by the declaration matcher")
+  func negativeControlCallSiteNotFlagged() {
+    let line = "      try await active.handle(event: .requestStop)"
+    #expect(Self.regexFlags(source: line, pattern: Self.handleEventDecl) == false)
+  }
+
+  @Test("a comment-only mention of a banned token is skipped by the scanner")
+  func negativeControlCommentMentionSkipped() {
+    // The scanner skips comment-only lines so historical breadcrumbs do not trip
+    // the freeze. A comment mentioning the deleted protocol must not count.
+    let source = "  // DictationPipeline was deleted in PR-9 of #827\n  let x = 1\n"
+    #expect(Self.countMatches(in: source, pattern: Self.dictationPipelineToken) == 0)
+  }
+
+  // MARK: - Helpers (mirror EngineIdentityFreezeTests / AppStateFreezeTests)
+
+  /// Recursive scan over every `Sources/**/*.swift` file. Returns
+  /// `relative/path.swift:LINE: trimmed` for each non-comment line whose regex
+  /// matches. Comment-only lines (first non-whitespace `//` or `///`) are
+  /// skipped so historical-breadcrumb mentions of deleted names do not trip the
+  /// freeze.
+  private static func scanSources(pattern: String) throws -> [String] {
+    try scan(root: "Sources", pattern: pattern, allowing: [])
+  }
+
+  /// Same scan over `Tests/**/*.swift`, excluding any file whose basename is in
+  /// `allowing` (this freeze file legitimately contains the banned tokens).
+  private static func scanTests(pattern: String, allowing: [String]) throws -> [String] {
+    try scan(root: "Tests", pattern: pattern, allowing: allowing)
+  }
+
+  private static func scan(root: String, pattern: String, allowing: [String]) throws -> [String] {
+    let regex = try NSRegularExpression(pattern: pattern)
+    let rootURL = repoRoot().appending(path: root)
+    let enumerator = FileManager.default.enumerator(
+      at: rootURL, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+    var hits: [String] = []
+    while let url = enumerator?.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      if allowing.contains(url.lastPathComponent) { continue }
+      let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+      let relative = url.path.replacingOccurrences(of: repoRoot().path + "/", with: "")
+      for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
+        .enumerated()
+      {
+        let text = String(line)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") { continue }
+        let ns = text as NSString
+        if regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil {
+          hits.append("\(relative):\(idx + 1): \(trimmed)")
+        }
+      }
+    }
+    return hits
+  }
+
+  /// Count matches over a synthetic multi-line string, applying the same
+  /// comment-only-line skip the real scanner uses. Used by the fail-closed and
+  /// comment-skip tests to exercise the matcher without touching disk.
+  private static func countMatches(in source: String, pattern: String) -> Int {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return 0 }
+    var count = 0
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+      let text = String(line)
+      if text.trimmingCharacters(in: .whitespaces).hasPrefix("//") { continue }
+      let ns = text as NSString
+      if regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil {
+        count += 1
+      }
+    }
+    return count
+  }
+
+  /// True iff the regex matches any line in `source` (no comment skip — used by
+  /// the adversarial / negative-control single-line probes).
+  private static func regexFlags(source: String, pattern: String) -> Bool {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+      let text = String(line)
+      let ns = text as NSString
+      if regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil {
+        return true
+      }
+    }
+    return false
+  }
+
+  /// Repo root, anchored off `#filePath` — this file lives at
+  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
+  private static func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -133,14 +133,6 @@ import Testing
     #expect(h.driver.state != .error("device unplugged"))
   }
 
-  @Test("clearPendingStallRecovery is an inert no-op")
-  func clearPendingStallRecoveryIsNoOp() {
-    let h = makeDriver()
-    let before = h.driver.state
-    h.driver.clearPendingStallRecovery()
-    #expect(h.driver.state == before)
-  }
-
   // MARK: currentTranscript / lastPolishError side-channel
 
   @Test("currentTranscript and lastPolishError read the finalization side-channel")


### PR DESCRIPTION
Final cleanup rung of the engine-kernel epic (#827). Deletes the now-vestigial `DictationPipeline` driver protocol and installs the permanent kernel-ownership freeze test.

## What changed
- **Delete the `DictationPipeline` protocol** (one source conformer, four `any DictationPipeline` consumers). Rename `DictationPipeline.swift` → `PipelineVocabulary.swift`; the surviving `PipelineEvent` / `OverlayIntent` / `InterruptionMessages` / `HeartPathTelemetryTarget` stay.
- **Retype the four consumers**: three App locals to the concrete `KernelDictationDriver`; `HeartControlRecovery.recover` to a narrow `@MainActor (String) -> Void` `setExternalError` closure (drops its now-unused `EnviousWisprPipeline`/`Core` imports).
- **Remove `clearPendingStallRecovery()`** — a no-op since the kernel's `SessionID` replaced the stall-recovery token — and its two inert `PipelineSettingsSync` backend-switch call sites.
- **Install `KernelOwnershipFreezeTests`**: `DictationPipeline` + `TranscriptionPipeline` token bans (`count == 0`); fail-closed single-declaration locks (`count == 1`) on `enum RecordingSessionState` and `func handle(event: PipelineEvent)`; adversarial + negative-control + comment-skip coverage.

No behavior change, no persisted-format change.

## Validation
- 1481 tests green (incl. the new freeze suite + migrated tests); `swift build -c release` clean.
- Codex grounded review: PROCEED-AS-PLANNED (r2). Codex code-diff review: SHIP.
- Live UAT: Parakeet PTT, WhisperKit, and backend switch **both directions** all green (confirms the removed no-op calls are inert).

## Review trail
- Plan: `docs/feature-requests/issue-827-2026-05-29-pr9-delete-remnants-freeze.md`
- Council coverage (GPT + Gemini) + 2 Codex grounded rounds + 1 Codex code-diff round.

Deferred (council + Codex concur): the kernel FSM-transition-table + task-bag extraction is a separate follow-up; this PR's freeze test is the prerequisite that makes it safe.

Part of #827.