### PR TITLE
test(app): TO-3 — real assertions for four driver-state tests (#881)

### DIFF
--- a/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
@@ -60,10 +60,14 @@ struct ASREventRouterTests {
       whisperKitKernelDriver: whisperKit
     )
 
-    // Both pipelines are idle (.idle is the default state). The callback
-    // should no-op without dispatching to either pipeline. The test passes
-    // as long as no precondition fires.
+    // Both pipelines are idle (.idle is the default state). The idle branch
+    // only logs — it must not dispatch into either driver. #881 TO-3: pin that
+    // by asserting both drivers stay .idle after the callback (the prior test
+    // had zero #expect, so a future idle-branch side effect that flipped a
+    // driver off .idle would have gone uncaught here).
     asr.onServiceInterrupted?()
+    #expect(parakeet.state == .idle)
+    #expect(whisperKit.state == .idle)
     withExtendedLifetime(router) {}
   }
 

--- a/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
@@ -148,12 +148,17 @@ import Testing
 
   @Test func startIfEnabledHonorsSettingsHotkeyFlag() {
     let fx = Self.makeFixture()
-    // The full start path registers Carbon hotkeys; in a unit test we only
-    // verify the gate doesn't crash and is callable in both directions.
+    // #881 TO-3: assert the gate is actually honored via the observable
+    // `isEnabled` flag (set synchronously by HotkeyService.start()), not just
+    // that the call doesn't crash. The prior test had zero #expect, so it
+    // stayed green under gate-inverted, gate-removed, and gate-never-starts
+    // regressions.
     fx.settings.hotkeyEnabled = false
-    fx.controller.startIfEnabled()  // no-op
+    fx.controller.startIfEnabled()  // gate closed → start() must NOT run
+    #expect(fx.hotkeyService.isEnabled == false)
     fx.settings.hotkeyEnabled = true
-    fx.controller.startIfEnabled()  // calls hotkeyService.start()
+    fx.controller.startIfEnabled()  // gate open → start() runs
+    #expect(fx.hotkeyService.isEnabled == true)
     fx.hotkeyService.stop()
   }
 

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -34,14 +34,18 @@ struct LiveRecordingStateTests {
   @Test("pipelineState routes through asrManager.activeBackendType")
   func pipelineStateRoutesByBackend() {
     let state = makeState()
-    // Default backend (.parakeet) → reads pipeline.state which is .idle
+    // #881 TO-3: drive the WhisperKit driver to a DISTINCT observable state so
+    // the two routing arms return values neither branch can produce by accident.
+    // The prior test left both drivers .idle, so it stayed green even if the
+    // router ignored activeBackendType, inverted the condition, or read the
+    // wrong driver in the WhisperKit arm.
+    state.whisperKitKernelDriver.setExternalError("wk-marker")
+    // Parakeet arm → reads the (error-free) parakeet driver → .idle.
     state.asrManager.setInitialBackendType(.parakeet)
     #expect(state.pipelineState == .idle)
-    // Switch to WhisperKit branch — reads whisperKitKernelDriver.state.asPipelineState
-    // (also .idle by default). Both arms return .idle, but the switch exercises
-    // the routing code path; differential state validation belongs in UAT.
+    // WhisperKit arm → reads the WhisperKit driver → .error("wk-marker").
     state.asrManager.setInitialBackendType(.whisperKit)
-    #expect(state.pipelineState == .idle)
+    #expect(state.pipelineState == .error("wk-marker"))
   }
 
   @Test("audioLevel reads through the audioCapture existential")

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -129,12 +129,30 @@ import Testing
   }
 
   @Test func resetActiveCallsCorrectBackend() {
-    let fx = Self.makeFixture()
-    // Both pipelines start in .idle. After `.reset()` they stay .idle —
-    // we verify the call does not crash on either branch.
-    fx.asr.activeBackendType = .parakeet
-    fx.finalizer.resetActive()
-    fx.asr.activeBackendType = .whisperKit
-    fx.finalizer.resetActive()
+    // #881 TO-3: seed BOTH drivers with a distinct external error so each
+    // driver's state getter reports `.error(...)`. resetActive() must clear
+    // ONLY the active backend's driver (reset() nils lastExternalError) and
+    // leave the other backend's error intact — proving the branch routes to
+    // exactly the active backend. The prior test asserted nothing ("does not
+    // crash"), so it stayed green under always-reset-parakeet, inverted-branch,
+    // and reset-neither regressions alike.
+    do {  // Parakeet active.
+      let fx = Self.makeFixture()
+      fx.kernelDriver.setExternalError("parakeet-err")
+      fx.whisperKitKernelDriver.setExternalError("whisperkit-err")
+      fx.asr.activeBackendType = .parakeet
+      fx.finalizer.resetActive()
+      #expect(fx.kernelDriver.state == .idle)
+      #expect(fx.whisperKitKernelDriver.state == .error("whisperkit-err"))
+    }
+    do {  // WhisperKit active.
+      let fx = Self.makeFixture()
+      fx.kernelDriver.setExternalError("parakeet-err")
+      fx.whisperKitKernelDriver.setExternalError("whisperkit-err")
+      fx.asr.activeBackendType = .whisperKit
+      fx.finalizer.resetActive()
+      #expect(fx.whisperKitKernelDriver.state == .idle)
+      #expect(fx.kernelDriver.state == .error("parakeet-err"))
+    }
   }
 }


### PR DESCRIPTION
## What

Trust-sweep test-only batch **TO-3** (parent #881, findings #8, #10, #11, #20). Replaces four zero/weak driver-state assertions with real ones. **No `Sources/` change** — all four observe already-public state (`setExternalError` + the `state` getter, `HotkeyService.isEnabled`); no spies, no seams.

## Changes

- **#8 `resetActiveCallsCorrectBackend`** (`RecordingFinalizerCancelPathTests`): was a pure "does not crash" with both drivers idle. Now seeds **both** drivers with a distinct external error and, per active backend, asserts only the active driver clears to `.idle` while the other keeps its error — proving `resetActive()` routes to exactly the active backend.
- **#10 `pipelineStateRoutesByBackend`** (`LiveRecordingStateTests`): both arms returned `.idle`, so a mis-route was invisible. Now seeds the WhisperKit driver with `.error("wk-marker")` so the two arms return distinct values.
- **#11 `startIfEnabledHonorsSettingsHotkeyFlag`** (`HotkeyControllerInstallTests`): had zero `#expect`. Now asserts `HotkeyService.isEnabled` stays `false` when the gate is closed and flips `true` when open.
- **#20 `serviceInterruptedSafeWhenIdle`** (`ASREventRouterTests`): had zero `#expect` ("passes as long as no precondition fires"). Now pins both drivers staying `.idle` after the interrupt callback's idle branch.

## Validation

- All four green on clean SUT.
- **Regression-catch proven** (one combined break, all four red): always-reset-parakeet (#8), router-ignores-backend (#10), inverted gate (#11), idle-branch side effect (#20) each turn their test red; all reverted.
- Codex code-diff review clean: "only strengthens existing tests... no discrete correctness issue introduced."

Part of #881.