### PR TITLE
test(pipeline): TO-4 — real assertions for reset-clears-error + dash normalization (#881)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -245,17 +245,21 @@ import Testing
       // post-PR-4b.4 Live UAT scenario (the full cycle has to unwind).
       let fx = makeFixture()
       await forceState(fx.kernel, to: .preparing)
+      // #881 TO-4: seed an external error so the driver's public state reports
+      // .error(...) via the mapper short-circuit, then prove reset() clears it.
+      // The old test ended in `_ = fx.driver.state  // no crash on read`, which
+      // stayed green even if reset() stopped nil-ing lastExternalError (the
+      // getter is pure and cannot crash). This pins the real reset() contract.
+      fx.driver.setExternalError("boom")
+      #expect(fx.driver.state == .error("boom"))
       fx.driver.reset()
       await drain()
-      // The driver public state should NOT remain in .loadingModel — the
-      // reset must cancel and proceed. kernel.cancel from .preparing sets
-      // cancelRequested without immediately transitioning; in this
-      // forced-state fixture there's no forward path to consume the flag,
-      // so the kernel stays at .preparing — that's expected behavior.
-      // The matrix freeze locks "reset() does NOT crash from an active
-      // state" via the kernel.reset() preconditions (which would assert
-      // if the kernel weren't terminal).
-      _ = fx.driver.state  // no crash on read
+      // reset() nils lastExternalError synchronously, so the external-error
+      // short-circuit no longer applies. kernel.cancel from .preparing leaves
+      // the kernel ~.preparing in this forced-state fixture (no forward path to
+      // consume the cancel flag), so the public state falls back to the mapped
+      // kernel state — crucially NOT .error("boom").
+      #expect(fx.driver.state != .error("boom"))
     }
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
@@ -73,10 +73,14 @@ struct FreezeSuiteNormalizationTests {
 
   @Test("em / en dashes between words survive as separators")
   func dashHandling() {
-    // Dashes are not in the stripped set; they remain, and a surrounding-space
-    // form collapses cleanly. The freeze clips avoid dash-ambiguous dictation;
-    // this pins that a dash does not crash or mangle normalization.
-    #expect(norm("a — b").contains("a"))
-    #expect(norm("a — b").contains("b"))
+    // Dashes are not in the stripped set; they survive verbatim, and the single
+    // spaces around them collapse to exactly one space each. #881 TO-4: pin the
+    // exact form (like the 18 sibling `norm(...) == ...` asserts) instead of the
+    // old `.contains("a")` / `.contains("b")`, which stayed green if the dash
+    // were dropped ("a b"), remapped ("a-b"), or whitespace-mangled ("a  —  b").
+    // Also exercise the EN dash (U+2013) the test name promises — the old body
+    // never touched it.
+    #expect(norm("a — b") == "a — b")  // em dash U+2014
+    #expect(norm("a \u{2013} b") == "a \u{2013} b")  // en dash U+2013
   }
 }


### PR DESCRIPTION
## What

Trust-sweep test-only batch **TO-4** (parent #881, findings #2 + #14). **No `Sources/` change.**

## Changes

- **#2 `resetTolerantOfActiveStates`** (`KernelDictationDriverBridgeMatrixTests`): the test forced the kernel to `.preparing`, called `reset()`, then ended in `_ = fx.driver.state  // no crash on read` — asserting nothing, so it stayed green even if `reset()` stopped clearing the external error (the state getter is pure and cannot crash). Now seeds `setExternalError("boom")` so the public state reports `.error("boom")`, then after `reset()` asserts the state is **not** `.error("boom")` — pinning that `reset()` nils `lastExternalError`.

- **#14 `dashHandling`** (`FreezeSuiteNormalizationTests`): the test named "em / en dashes" only checked `norm("a — b").contains("a")` / `.contains("b")`, which pass even if the dash is dropped (`"a b"`), remapped (`"a-b"`), or the whitespace run mangled (`"a  —  b"`), and never exercised the en dash at all. Now asserts exact form `norm("a — b") == "a — b"` (matching the 18 sibling exact-form asserts) and adds the en dash `norm("a \u{2013} b") == "a \u{2013} b"`.

## Validation

- Both green on clean SUT.
- **Regression-catch proven**: removing the external-error clear from `reset()` reds #2; adding the dashes to the stripped-punctuation set reds #14 (both assertions); reverted.
- Codex code-diff review clean: "only strengthens existing test assertions around reset external-error clearing and dash normalization... no actionable regression introduced."

Part of #881.