### PR TITLE
test: TO-5 — real assertions for ambiguity-margin, alias-filter, EnhancementError (#881)

### DIFF
--- a/Tests/EnviousWisprTests/EnviousWisprTests.swift
+++ b/Tests/EnviousWisprTests/EnviousWisprTests.swift
@@ -317,12 +317,14 @@ struct WordCorrectorTests {
       CustomWord(canonical: "Kubernetes"),
       CustomWord(canonical: "Kubernotes"),
     ]
-    let (result, _) = corrector.correct("kuberntes works", against: words)
-    // Either corrected to Kubernetes (if margin sufficient) or left unchanged (if ambiguous)
-    // The key test: it should not crash and should produce a deterministic result
-    #expect(
-      result.contains("kuberntes") || result.contains("Kubernetes") || result.contains("Kubernotes")
-    )
+    let (result, replacements) = corrector.correct("kuberntes works", against: words)
+    // #881 TO-5: assert the documented decline-on-tie directly on the return
+    // tuple (like the sibling `== "use apt to install"` / `replacements.count
+    // == 0` asserts), not the old three-way `.contains(...)` disjunction that
+    // passed for ANY of declined / corrected-to-Kubernetes / corrected-to-
+    // Kubernotes — i.e. for every possible outcome.
+    #expect(result == "kuberntes works")
+    #expect(replacements.count == 0)
   }
 
   // MARK: - Case preservation in corrections

--- a/Tests/EnviousWisprTests/LLM/TranscriptPolishServiceTests.swift
+++ b/Tests/EnviousWisprTests/LLM/TranscriptPolishServiceTests.swift
@@ -22,8 +22,21 @@ struct EnhancementErrorTests {
 
   @Test("different transcript IDs are distinct")
   func distinctTranscripts() {
-    let error1 = EnhancementError(transcriptID: UUID(), message: "error 1")
-    let error2 = EnhancementError(transcriptID: UUID(), message: "error 2")
+    // #881 TO-5: pin that each error carries EXACTLY the id + message it was
+    // constructed with. The old test asserted only `id1 != id2`, where the
+    // distinctness came from stdlib UUID() uniqueness, not from any
+    // EnhancementError behavior — it passed even if the init hard-coded a
+    // constant id, swapped fields, or dropped the message. These per-instance
+    // assertions catch all of those; distinctness then follows from our
+    // faithful per-instance storage.
+    let id1 = UUID()
+    let id2 = UUID()
+    let error1 = EnhancementError(transcriptID: id1, message: "error 1")
+    let error2 = EnhancementError(transcriptID: id2, message: "error 2")
+    #expect(error1.transcriptID == id1)
+    #expect(error1.message == "error 1")
+    #expect(error2.transcriptID == id2)
+    #expect(error2.message == "error 2")
     #expect(error1.transcriptID != error2.transcriptID)
   }
 }

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -73,10 +73,12 @@ struct WordSuggestionServiceTests {
     // "X" canonical with phonetic alternates
     let raw = ["ecks", "eks"]
     let kept = WordSuggestionService.filterDegeneratedAliases(raw, canonical: "X")
-    // ecks and eks are far enough from X to survive (score check)
-    // The exact survival depends on WordCorrector.score; this test is a sanity check that
-    // single-char canonical does not crash or misbehave catastrophically.
-    #expect(kept.count >= 0)  // Smoke; allow either to be filtered or kept
+    // #881 TO-5: both phonetic aliases score far below the 0.95 near-duplicate
+    // gate and neither equals "x", so both must survive in input order. The old
+    // `kept.count >= 0` was always true — it could not catch a score-gate
+    // inversion or threshold drift that silently dropped valid aliases (the
+    // exact Kubernetes-class degeneration the suite exists to prevent).
+    #expect(kept == ["ecks", "eks"])
   }
 }
 


### PR DESCRIPTION
## What

Trust-sweep test-only batch **TO-5** (parent #881, findings #7, #18, #21) — the **last** test-only batch. **No `Sources/` change.** All three assert directly on already-observable return values (each expected value verified empirically before committing).

## Changes

- **#7 `ambiguityMarginRejectsTie`** (`EnviousWisprTests` / `WordCorrector`): the old three-way `result.contains("kuberntes") || .contains("Kubernetes") || .contains("Kubernotes")` passed for **every** possible outcome. Now asserts the documented decline-on-tie directly: `result == "kuberntes works"` and `replacements.count == 0` (confirmed: the two canonicals genuinely tie within the 0.05 margin → correction rejected).
- **#18 `singleCharCanonical`** (`WordSuggestionServiceTests`): replaced the always-true `kept.count >= 0` with `kept == ["ecks", "eks"]` (confirmed both phonetic aliases survive the 0.95 near-duplicate gate in order). Catches a score-gate inversion / threshold drift that silently drops valid aliases.
- **#21 `distinctTranscripts`** (`TranscriptPolishServiceTests` / `EnhancementError`): the old test asserted only `id1 != id2`, where distinctness came from stdlib `UUID()` — not from `EnhancementError`. Now pins that each error carries exactly the id + message it was constructed with (catches hard-coded-constant, field-swap, dropped-message inits); distinctness then follows from faithful per-instance storage.

## Validation

- All three green on clean SUT.
- **Regression-catch proven**: removing the Pass-5 ambiguity-margin guard reds #7; dropping the 0.95 gate to 0.0 reds #18; dropping the message in the `EnhancementError` init reds #21; all reverted.
- Codex code-diff review clean: "only strengthen existing tests, and the new expectations match the current WordCorrector, WordSuggestionService, and EnhancementError behavior... no actionable regression introduced."

Part of #881. Completes the **test-only** half of the sweep (13 of 22 findings).