### PR TITLE
fix(pipeline): clear stale polish error on reset; drop engine-identity literal (#859, #878)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -226,6 +226,15 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     // (Codex review #11 r3 / `PipelineStateChangeHandler` guard).
     if kernel.state == .idle {
       outcome.transcript = nil
+      // Clear the post-recording polish error alongside the transcript — both
+      // are last-session outcome fields surfaced publicly (`currentTranscript`
+      // / `lastPolishError`). Idle-gated (not unconditional like
+      // `lastExternalError`) for the same reason as the transcript: a `reset()`
+      // that no-ops because the kernel sits in `.finalizing` must leave the
+      // in-flight outcome intact for completion telemetry. Without this, a
+      // prior session's "AI polish failed" surface lingered into the next
+      // dictation (#859).
+      outcome.polishError = nil
     }
     fireStateChangeIfNeeded()
   }
@@ -303,8 +312,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // so this direct-emit fallback path carries parity with the sink
       // path's tagging.
       let backendID = adapter.engineIdentity.rawValue
-      let backendLabel =
-        adapter.engineIdentity.backendType == .whisperKit ? "WhisperKit" : "Parakeet"
+      // Engine display name via the identity accessor, not a hard-coded
+      // engine-identity literal (`gate-on-capability-not-identity-literal`,
+      // #878). This file is now an `EngineIdentityFreezeTests` reader site, so
+      // the banned literal can't return. (The freeze scanner is line-regex, not
+      // comment-aware, so this comment must avoid the banned token too.)
+      let backendLabel = adapter.engineIdentity.displayName
       captureErrorSink(
         NSError(
           domain: "EnviousWispr", code: -3,
@@ -444,6 +457,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // `.completed` is observed.
       if kernel.state == .idle {
         outcome.transcript = nil
+        // Mirror the sync `reset()` method: clear the stale polish-error
+        // surface alongside the transcript (#859). Both reset entry points
+        // intentionally parallel each other (doc-comment at the sync method).
+        outcome.polishError = nil
       }
       // PR-4.5 #9 (Codex r5): when the kernel is already idle, `reset()` is a
       // no-op, so the kernel-state observation does NOT fire. After

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -54,6 +54,9 @@ import Testing
     "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift",
     "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift",
     "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+    // #878: the ASR-interruption direct-emit path reads `engineIdentity.displayName`
+    // for its Sentry label; was an `== .whisperKit` literal until PR-6 debt cleanup.
+    "Sources/EnviousWisprPipeline/KernelDictationDriver.swift",
   ]
 
   /// The observer file no longer holds an emitter default — it must never

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -258,6 +258,51 @@ import Testing
       h.driver.reset()
       #expect(h.driver.currentTranscript?.text == "in-flight save")
     }
+
+    @Test(
+      "reset() clears the stale polish error once the kernel is idle (#859)",
+      .bug(
+        "https://github.com/saurabhav88/EnviousWispr/issues/859", "stale polishError survives reset"
+      )
+    )
+    func resetWhenIdleClearsStalePolishError() {
+      let h = makeDriver()
+      // A prior session's polish failure left a message on the public surface.
+      h.outcome.polishError = "AI polish failed"
+      #expect(h.driver.lastPolishError == "AI polish failed")
+      h.driver.reset()  // kernel is at idle (resting)
+      #expect(
+        h.driver.lastPolishError == nil,
+        "reset() at idle must clear the stale polish-error surface")
+    }
+
+    @Test("handle(.reset) clears the stale polish error once the kernel is idle (#859)")
+    func handleResetWhenIdleClearsStalePolishError() async throws {
+      let h = makeDriver()
+      h.outcome.polishError = "AI polish failed"
+      try await h.driver.handle(event: .reset)  // kernel is at idle (resting)
+      #expect(
+        h.driver.lastPolishError == nil,
+        "handle(.reset) at idle must mirror reset() and clear the polish-error surface")
+    }
+
+    @Test(
+      "reset() preserves the polish error when the kernel is in the finalizing safe-point (#859)"
+    )
+    func resetDuringFinalizingPreservesPolishError() {
+      let h = makeDriver()
+      // Mirror the transcript safe-point contract: a reset arriving during the
+      // finalizing window must not erase the in-flight outcome before
+      // `.completed` is observed for completion telemetry.
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.kernel.testForceTransition(to: .recording))
+      #expect(h.kernel.testForceTransition(to: .stopping))
+      #expect(h.kernel.testForceTransition(to: .transcribing))
+      #expect(h.kernel.testForceTransition(to: .finalizing))
+      h.outcome.polishError = "in-flight polish error"
+      h.driver.reset()
+      #expect(h.driver.lastPolishError == "in-flight polish error")
+    }
   #endif
 
   // MARK: Helpers


### PR DESCRIPTION
Two isolated dictation-driver hygiene fixes surfaced by the engine-kernel epic (#827), SMALL tier.

## #859 — stale polish error survives reset
Both reset entry points (`reset()` and the `handle(.reset)` event case — intentional mirrors) cleared the active-error surface and the last-session transcript (on idle) but **not** `outcome.polishError`. Since the public `lastPolishError` reads that field, a prior session's "AI polish failed" message could linger into the next dictation. Both paths now clear it in the same `if kernel.state == .idle` block as the transcript — idle-gated (not unconditional) so the finalizing safe-point window still delivers the outcome for completion telemetry.

## #878 — engine-identity literal at a non-factory reader site
The ASR-interruption Sentry label derived the engine name via `adapter.engineIdentity.backendType == .whisperKit ? ...`, a literal banned by `gate-on-capability-not-identity-literal`. Replaced with the existing `adapter.engineIdentity.displayName` accessor and added the file to `EngineIdentityFreezeTests.identityReaderSites` so the literal can't return.
**Behavior delta:** the Parakeet crash label becomes `"...(Parakeet v3)"` (app-wide display naming); the `backend` tag/extra is unchanged. The captured error has no explicit fingerprint, so this rare XPC-crash error may form a one-time grouping split for Parakeet; accepted (rare, one-time, filterable by the unchanged backend extra).

## Validation
- 3 new regression tests in `KernelDictationDriverTests` (idle clears via both reset paths; `.finalizing` preserves — mirrors the transcript safe-point contract). Asserted via public `lastPolishError`.
- `EngineIdentityFreezeTests` now scans this file (21 tests green); driver has zero banned tokens incl. comments (the scanner is line-regex, not comment-aware).
- `swift build -c release` clean; targeted suites green.
- Process: council coverage + Codex grounded review (r1 PROCEED-WITH-REVISIONS → both-reset-paths + softened-Sentry-claim applied) + Codex code-diff review (no findings).
- Live UAT skipped (skip-note): no heart-path or dictation-observable runtime change; reset-state correctness is unit-tested, label change is build-verified.

Part of #830
Closes #878