### PR TITLE
fix(pipeline): count only successfully-fed streaming buffers in diagnostics (#867)

### DIFF
--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -56,8 +56,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// task is the completion signal — no wall-clock deadline. A `ContinuousClock`
   /// deadline raced the `@MainActor` scheduler: under contention it fired before
   /// queued feed tasks ran, dropping tail audio (Codex PR-4a r4, reproduced as a
-  /// `finalizeDrainsStreamingFeeds` flake). Each task `try?`-awaits `feedAudio`,
-  /// so it always completes — on success or a thrown XPC error — never hangs.
+  /// `finalizeDrainsStreamingFeeds` flake). Each task awaits `feedAudio` inside a
+  /// `do/catch` (the task type is `Task<Void, Never>`), so it always completes —
+  /// on success or a swallowed thrown error — never hangs.
   private var feedTasks: [Task<Void, Never>] = []
 
   // MARK: Batch-rescue PCM retention (§3.2a)
@@ -239,8 +240,20 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       // (old Parakeet pipeline).
       guard self.sessionID == handoffSession, self.streamingActive, !self.isTerminal
       else { return }
-      try? await self.asrManager.feedAudio(pcmBuffer)
-      self.streamingBuffersFed += 1
+      do {
+        try await self.asrManager.feedAudio(pcmBuffer)
+        self.streamingBuffersFed += 1
+      } catch {
+        // The host-side `feedAudio` call threw (transient ASR/XPC error). Do NOT
+        // count this buffer as fed — `streamingBuffersFed` (surfaced as
+        // `asr.streaming_buffers_fed` in ASREmptyResultDiagnostics) counts buffers
+        // whose feed call returned successfully, so `fed < dispatched` stays
+        // visible in empty-result triage as the signal that some feed calls did
+        // not complete (#867). The delta itself is the failure count, so the
+        // catch stays silent (a per-buffer breadcrumb would be noisy at ~39Hz).
+        // The task is still `Task<Void, Never>` and completes, so `finalize()`'s
+        // drain barrier is unaffected.
+      }
     }
     feedTasks.append(task)
   }

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -222,6 +222,48 @@ import Testing
       "finalize() waited for every dispatched feed — no tail buffer dropped")
   }
 
+  @Test(
+    "acceptAudio does not count a buffer whose feed throws (#867)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/867",
+      "feed-throw overcounts streamingBuffersFed")
+  )
+  func feedThrowDoesNotIncrementBuffersFed() async throws {
+    let manager = StubParakeetASRManager()
+    manager.feedAudioThrows = true  // every feed fails (transient ASR/XPC)
+    manager.finalizeStreamingResult = makeResult("streamed text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    feed(adapter, samples: [0.1], session: sid)
+    feed(adapter, samples: [0.2], session: sid)
+    _ = await adapter.finalize(batchSamples: nil)
+    let diag = try #require(adapter.lastASRDiagnostics)
+    #expect(diag.streamingBuffersDispatched == 2, "both buffers were dispatched")
+    #expect(
+      diag.streamingBuffersFed == 0,
+      "neither buffer counts as fed because the feed threw, preserving the dropped-feed signal for empty-result triage (#867)"
+    )
+  }
+
+  @Test("acceptAudio counts every buffer whose feed succeeds (#867 success bracket)")
+  func successfulFeedsAreAllCounted() async throws {
+    let manager = StubParakeetASRManager()
+    // feedAudioThrows stays false — every feed succeeds.
+    manager.finalizeStreamingResult = makeResult("streamed text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    feed(adapter, samples: [0.1], session: sid)
+    feed(adapter, samples: [0.2], session: sid)
+    _ = await adapter.finalize(batchSamples: nil)
+    let diag = try #require(adapter.lastASRDiagnostics)
+    #expect(diag.streamingBuffersDispatched == 2)
+    #expect(
+      diag.streamingBuffersFed == 2,
+      "the normal path still counts every successfully-fed buffer (no regression)")
+  }
+
   // MARK: Stale-async session guards (Codex r2)
 
   @Test("a feed queued before a cancel is not fed into the terminated session")
@@ -386,6 +428,9 @@ final class StubParakeetASRManager: ASRManagerInterface {
     text: "default-batch", language: "en", duration: 1, processingTime: 0,
     backendType: .parakeet)
   var transcribeThrows = false
+  /// When set, `feedAudio` throws — models a transient ASR/XPC feed failure that
+  /// the per-buffer feed task swallows (#867).
+  var feedAudioThrows = false
   /// When set, `feedAudio` yields many times before completing — models a
   /// streaming feed still in flight when `finalize()` is called.
   var slowFeed = false
@@ -439,6 +484,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
     if slowFeed {
       for _ in 0..<100 { await Task.yield() }
     }
+    if feedAudioThrows { throw FakeASRError.feed }
     feedAudioCount += 1
   }
 
@@ -479,5 +525,5 @@ final class StubParakeetASRManager: ASRManagerInterface {
   func cancelIdleTimer() { cancelIdleTimerCount += 1 }
   func cancelInFlightLoad() { cancelInFlightLoadCount += 1 }
 
-  enum FakeASRError: Error { case streamingSetup, decode }
+  enum FakeASRError: Error { case streamingSetup, decode, feed }
 }


### PR DESCRIPTION
SMALL-tier diagnostic-counter correctness fix in the Parakeet streaming-feed path.

## Problem
`ParakeetEngineAdapter.acceptAudio` dispatched each captured buffer to streaming ASR via `try? await feedAudio()` then incremented `streamingBuffersFed` unconditionally. The `try?` swallowed a thrown feed error, so the counter bumped even when the host-side feed call failed. That counter surfaces as `asr.streaming_buffers_fed` in empty-result Sentry diagnostics, so a dropped-feed run showed fed == dispatched and masked the exact condition triage is looking for.

## Fix
Wrap the feed in `do/catch`; increment only when the call returns successfully. The paired `streamingBuffersDispatched` counter is unchanged, so `fed < dispatched` is now the visible signal that some feed calls did not complete. The counter is diagnostic-only (no control-flow branches on it), so heart-path behavior is unchanged. The catch stays silent on purpose: the dispatched-minus-fed delta already counts failures, and a per-buffer breadcrumb would be noisy at ~39Hz.

Counter semantics clarified in comments per grounded review: "host-side feed call returned successfully" (the XPC feed is effectively fire-and-forget), not "ASR consumed the buffer."

## Validation
- Tests (`ParakeetEngineAdapterTests`): a stub feed that throws gives dispatched 2 / fed 0 (regression, red on the parent commit); the success path gives dispatched 2 / fed 2 (no regression). Adds a `feedAudioThrows` flag to the stub.
- `swift build -c release` clean; 28 adapter-suite tests green.
- Process: council coverage + Codex grounded review (PROCEED-WITH-REVISIONS: counter-semantics comment accuracy + success-path bracket test applied) + Codex code-diff review (no correctness findings).
- Live UAT skipped (skip-note): the change only narrows a diagnostic counter on the failure branch; no heart-path or dictation-observable runtime change. Real feed failures are rare and not deterministically reproducible in Live UAT.

Part of #830