### PR TITLE
chore(content): link complete-guide posts to comparison pages (#877)

### DIFF
--- a/website/src/content/blog/mac-dictation-for-content-creators-the-complete-guide.md
+++ b/website/src/content/blog/mac-dictation-for-content-creators-the-complete-guide.md
@@ -86,3 +86,5 @@ Dictation is not a magic wand. It produces first drafts faster than typing. The 
 ## Where to start
 
 If you only try one thing this week, dictate the first draft of your next piece of writing instead of typing it. Use whatever tool you already have, or [download EnviousWispr free](https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg) if you want an on-device starting point. Compare your dictated draft against what a typed draft of the same piece usually feels like. Either it sticks because the voice comes through, or it does not.
+
+*Sizing up dictation tools for creative work? See [vs WisprFlow](/compare/wisprflow/), [vs Superwhisper](/compare/superwhisper/), or [browse all comparisons](/compare/).*

--- a/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
+++ b/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
@@ -87,3 +87,5 @@ For the deeper explainer: [On-device vs cloud dictation: which is actually priva
 If you only do one thing this week, swap typing for dictation on your three highest-volume text channels: email, your team Slack, and your meeting-notes habit. Re-evaluate after five working days. Either it sticks because the time savings are obvious, or it does not, and you lost nothing.
 
 If you want a free, on-device tool to try this with: [download EnviousWispr](https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg). No account, works offline, runs on Apple Silicon.
+
+*Comparing dictation tools for everyday productivity? See [vs WisprFlow](/compare/wisprflow/), [vs Apple Dictation](/compare/apple-dictation/), or [browse all comparisons](/compare/).*


### PR DESCRIPTION
## What

Adds the standard italic comparison-link footer to the two "complete guide" blog posts that were the only posts (of 25) with **zero** internal links to the `/compare/*` pages:

- **Mac dictation for productivity** → vs WisprFlow, vs Apple Dictation, + browse all
- **Mac dictation for content creators** → vs WisprFlow, vs Superwhisper, + browse all

## Why

GSC (28d to 2026-05-27) shows the `/compare/*` spokes are the site's strongest organic asset, sitting at position ~9-10 on hundreds of impressions (#877). Internal links from topically relevant posts distribute authority to those spokes. These two high-intent guide posts were leaking that signal by not linking at all.

## Lane / validation

- **Content lane.** Build-check + visual confirm passed locally: `astro build` clean (46 pages), rendered `/compare/` links verified in `dist` HTML for both posts.
- Matches the existing footer pattern used by the other 22 linking posts (descriptive anchors, varied text, no em/en dashes).
- `council-skip: zero-blast-radius (user-facing copy)` — 4 inserted lines, 2 files, no schema/frontmatter change.

Part of #877 (one sub-lever; the issue's main position-lift is authority-bound and tracked separately under #483/#526).