### PR TITLE
test: make three weak/tautological self-tests real (#860, #907, #826)

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -23,6 +23,19 @@ enum RouterCeilingParser {
 
   static func classBody(named typeName: String, at path: String) throws -> String {
     let source = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+    // Search the declaration AND balance the body braces over a CODE VIEW
+    // (string-literal contents + `//` comments blanked to spaces, length
+    // preserved), so a `final class X {` or a stray `{`/`}` inside a comment or
+    // string literal cannot mis-anchor the declaration or unbalance the scan
+    // (#826). `codeView` preserves Character count 1:1, so an offset into the
+    // code view is the same offset into the real source; the body is sliced
+    // from the REAL source because the per-line property/method classifiers
+    // (`isStoredPropertyDeclaration`, `isClosureTyped`, ...) parse the real
+    // declaration text (type names, attributes, default values) — only the
+    // fold's continuation check masks comments/strings internally via `codeView`.
+    let code = codeView(source)
+    let sourceChars = Array(source)
+    let codeChars = Array(code)  // same Character count as sourceChars
     let declarations = [
       "final class \(typeName) {",
       "final class \(typeName):",
@@ -30,34 +43,37 @@ enum RouterCeilingParser {
       "class \(typeName):",
     ]
     guard
-      let openRange = declarations.compactMap({ source.range(of: $0) }).min(by: {
-        $0.lowerBound < $1.lowerBound
-      })
+      let declOffset =
+        declarations
+        .compactMap({ code.range(of: $0) })
+        .map({ code.distance(from: code.startIndex, to: $0.lowerBound) })
+        .min()
     else {
       Issue.record("\(typeName) declaration not found at \(path)")
       throw POSIXError(.ENOENT)
     }
-    // Anchor on the class's OWN `{`: scan forward from the start of the
-    // declaration (`final class TypeName` / `class TypeName`). Between that
-    // start and the class brace the source holds only the type name and an
-    // optional `: Conformance, ...` list — never a `{` — so the first `{`
-    // found is unambiguously the class brace, for every declaration shape.
-    guard let openBrace = source[openRange.lowerBound...].firstIndex(of: "{") else {
+    // The class's OWN `{`: the first brace at or after the declaration start, in
+    // the code view (so a brace inside a comment/string between the declaration
+    // and the class body is never mistaken for it). Between the declaration
+    // start and the class brace the code holds only the type name and an
+    // optional `: Conformance, ...` list — never a real `{`.
+    guard let openBrace = (declOffset..<codeChars.count).first(where: { codeChars[$0] == "{" })
+    else {
       Issue.record("\(typeName) declaration has no opening brace")
       throw POSIXError(.EILSEQ)
     }
     var depth = 0
     var idx = openBrace
-    while idx < source.endIndex {
-      let c = source[idx]
+    while idx < codeChars.count {
+      let c = codeChars[idx]
       if c == "{" { depth += 1 }
       if c == "}" {
         depth -= 1
         if depth == 0 {
-          return String(source[source.index(after: openBrace)..<idx])
+          return String(sourceChars[(openBrace + 1)..<idx])
         }
       }
-      idx = source.index(after: idx)
+      idx += 1
     }
     Issue.record("\(typeName) class body has unbalanced braces")
     throw POSIXError(.EILSEQ)
@@ -82,8 +98,7 @@ enum RouterCeilingParser {
     var depth = 0
     var count = 0
     for line in foldContinuationLines(body) {
-      let opens = line.filter { $0 == "{" }.count
-      let closes = line.filter { $0 == "}" }.count
+      let (opens, closes) = braceCounts(line)
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0, isNonPrivateMethodDeclaration(line) {
         count += 1
@@ -110,14 +125,23 @@ enum RouterCeilingParser {
 
   // MARK: - Private
 
+  /// Net `{` / `}` counts for a line, measured on its CODE VIEW so a brace
+  /// inside a string literal or `//` comment does not shift brace depth. Every
+  /// depth-tracking loop below uses this, not raw `filter`, so a `}` in a
+  /// string/comment can neither drop a real declaration below depth 0 nor close
+  /// a scope early (#826).
+  private static func braceCounts(_ line: String) -> (opens: Int, closes: Int) {
+    let code = codeView(line)
+    return (code.filter { $0 == "{" }.count, code.filter { $0 == "}" }.count)
+  }
+
   private static func countTopLevelStoredProperties(
     in body: String, where predicate: (String) -> Bool
   ) -> Int {
     var depth = 0
     var count = 0
     for line in foldContinuationLines(body) {
-      let opens = line.filter { $0 == "{" }.count
-      let closes = line.filter { $0 == "}" }.count
+      let (opens, closes) = braceCounts(line)
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0 {
         if isStoredPropertyDeclaration(line), predicate(line) {
@@ -143,8 +167,7 @@ enum RouterCeilingParser {
     var i = 0
     while i < physical.count {
       var buffer = physical[i]
-      let opens = buffer.filter { $0 == "{" }.count
-      let closes = buffer.filter { $0 == "}" }.count
+      let (opens, closes) = braceCounts(buffer)
       let depthForThisLine = depth - max(0, closes - opens)
       if depthForThisLine == 0 {
         while isUnterminatedDeclaration(buffer), i + 1 < physical.count {
@@ -153,7 +176,9 @@ enum RouterCeilingParser {
         }
       }
       result.append(buffer)
-      depth += buffer.filter { $0 == "{" }.count - buffer.filter { $0 == "}" }.count
+      // Recount after folding: `buffer` may now span several physical lines.
+      let (bufOpens, bufCloses) = braceCounts(buffer)
+      depth += bufOpens - bufCloses
       i += 1
     }
     return result
@@ -188,40 +213,58 @@ enum RouterCeilingParser {
   }
 
   /// Returns `buffer` with string-literal contents and `//` line comments
-  /// removed, so bracket-balance and trailing-operator checks see only code.
-  /// A `//` or a bracket inside a `"..."` literal must not be read as syntax
-  /// (a `let x = "https://"` is a complete declaration, not a continuation).
-  /// Handles single-line `"..."` with `\` escapes; multi-line (`"""`) and raw
-  /// (`#"..."#`) string literals are out of scope — no ceiling-tested class
-  /// declaration uses them.
+  /// blanked to spaces (Character count preserved 1:1), so bracket-balance,
+  /// trailing-operator checks, AND `classBody`'s declaration search + brace
+  /// scan see only real code while every offset still aligns with `buffer`. A
+  /// `//` or a bracket inside a `"..."` literal must not be read as syntax (a
+  /// `let x = "https://"` is a complete declaration, not a continuation; a `}`
+  /// inside a string must not close a class body). Handles single-line `"..."`
+  /// with `\` escapes; multi-line (`"""`) and raw (`#"..."#`) string literals
+  /// are out of scope — no ceiling-tested class declaration uses them.
   private static func codeView(_ buffer: String) -> String {
     let chars = Array(buffer)
     var result: [Character] = []
+    result.reserveCapacity(chars.count)
     var inString = false
     var i = 0
     while i < chars.count {
       let c = chars[i]
       if inString {
         if c == "\\" {
-          i += 2  // skip the escaped character
+          // Blank the escape pair (`\"`, `\\`, ...): two input chars, two spaces
+          // out, so the escaped char cannot end the string and length is kept.
+          result.append(" ")
+          if i + 1 < chars.count { result.append(" ") }
+          i += 2
           continue
         }
         if c == "\"" {
           inString = false
-        } else if c == "\n" {
+          result.append(" ")  // blank the closing quote (kept as a space, 1:1)
+          i += 1
+          continue
+        }
+        if c == "\n" {
           inString = false  // a single-line literal cannot cross a newline
           result.append(c)
+          i += 1
+          continue
         }
+        result.append(" ")  // blank string content
         i += 1
         continue
       }
       if c == "\"" {
         inString = true
+        result.append(" ")  // blank the opening quote
         i += 1
         continue
       }
       if c == "/", i + 1 < chars.count, chars[i + 1] == "/" {
-        while i < chars.count, chars[i] != "\n" { i += 1 }  // drop to EOL
+        while i < chars.count, chars[i] != "\n" {
+          result.append(" ")  // blank the comment to end of line
+          i += 1
+        }
         continue
       }
       result.append(c)

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParserTests.swift
@@ -50,6 +50,76 @@ import Testing
     #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
   }
 
+  // MARK: - #826 — comment/string-aware declaration anchor + brace scan
+
+  @Test func classBody_ignoresDeclarationTextInComment() throws {
+    // A doc comment quoting the declaration must not mis-anchor the scan. Before
+    // #826 the raw `range(of:)` matched the comment first and the brace scan
+    // latched onto the comment's `{`, throwing "unbalanced braces".
+    let body = try classBody(
+      of: """
+        // Example usage: `final class Probe {` is the declaration shape.
+        final class Probe {
+          let alpha: AlphaDep
+          let beta: BetaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  @Test func classBody_ignoresDeclarationTextInStringLiteral() throws {
+    // A string literal holding the declaration text (here a top-level `let`
+    // before the real class) must not mis-anchor the scan.
+    let body = try classBody(
+      of: """
+        let fake = "final class Probe {"
+        final class Probe {
+          let alpha: AlphaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func classBody_ignoresBraceInStringLiteralBody() throws {
+    // A `}` inside a string literal must not close the class body early. Before
+    // #826 the raw brace scan saw the string's `}` and truncated the body,
+    // dropping the trailing collaborator.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let pattern: Matcher = makeMatcher("unbalanced } brace")
+          let alpha: AlphaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
+  @Test func classBody_ignoresBraceInComment() throws {
+    // A `}` inside a `//` comment must not close the class body early.
+    let body = try classBody(
+      of: """
+        final class Probe {
+          // a stray closing brace } sits in this comment
+          let alpha: AlphaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 1)
+  }
+
+  @Test func classBody_preservesOffsetsAcrossNonASCII() throws {
+    // The code view blanks masked chars to spaces by Character, so a non-ASCII
+    // char inside a string (alongside a brace) must not shift the code-view to
+    // source offset mapping — the body slice stays correct (#826 / offset unit).
+    let body = try classBody(
+      of: """
+        final class Probe {
+          let note: Label = makeLabel("café ☕ }")
+          let alpha: AlphaDep
+        }
+        """)
+    #expect(RouterCeilingParser.collaboratorCount(in: body) == 2)
+  }
+
   @Test func collaboratorCount_excludesVarStoredProperty() throws {
     // `var` is owned mutable state, not a collaborator (architecture-rules.md).
     let body = try classBody(

--- a/Tests/EnviousWisprTests/Core/CustomWordsManagerCountingTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordsManagerCountingTests.swift
@@ -104,12 +104,20 @@ struct CustomWordsManagerCountingTests {
     // 49 unique increments: below threshold → no auto-flush → disk unchanged.
     manager.recordReplacements(words.prefix(49).map(\.id))
     let at49 = try Self.readWords(at: path)
+    #expect(
+      at49.count == 50,
+      "all 50 seeded words must still be on disk — guards the allSatisfy below from a vacuous pass on an empty read"
+    )
     #expect(at49.allSatisfy { $0.frequencyUsed == 0 }, "49 pending must not auto-flush")
 
     // The 50th unique increment crosses the threshold → immediate auto-flush,
     // with NO manual flush call.
     manager.recordReplacements([words[49].id])
     let at50 = try Self.readWords(at: path)
+    #expect(
+      at50.count == 50,
+      "all 50 seeded words must be present after auto-flush — guards the allSatisfy below from a vacuous pass"
+    )
     #expect(
       at50.allSatisfy { $0.frequencyUsed == 1 },
       "crossing the 50-count threshold auto-flushes all pending increments")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FreezeSuiteNormalizationTests.swift
@@ -68,7 +68,17 @@ struct FreezeSuiteNormalizationTests {
   func nfcNormalization() {
     let composed = "café"  // single é
     let decomposed = "cafe\u{0301}"  // e + combining acute
-    #expect(norm(composed) == norm(decomposed))
+    // Compare unicode SCALARS, not String ==. Swift String equality is
+    // canonical-equivalence-aware, so `decomposed == composed` (and
+    // `norm(composed) == norm(decomposed)`) are already true WITHOUT any
+    // normalization — a String-level assert here passes even if `normalize`
+    // were a no-op. Scalar comparison exposes whether NFC actually composed it.
+    #expect(
+      Array(norm(decomposed).unicodeScalars) == Array(composed.unicodeScalars),
+      "decomposed e-acute must normalize to the NFC composed scalar (#860)")
+    #expect(
+      norm(decomposed).unicodeScalars.count == 4,
+      "NFC-composed café is 4 scalars (c,a,f,é); a no-op normalize would leave 5")
   }
 
   @Test("em / en dashes between words survive as separators")

--- a/scripts/freeze-suite/compare-to-baseline.sh
+++ b/scripts/freeze-suite/compare-to-baseline.sh
@@ -186,7 +186,7 @@ _GOLDEN_VECTORS = [
     ("Hello World", "hello world"),
     ("  hello   world  ", "hello world"),
     ("hello\tworld", "hello world"),
-    ("hello world", "hello world"),  # NBSP
+    ("hello\u00a0world", "hello world"),  # NBSP (U+00A0) collapses to a regular space
     ("hello​world", "hello world"),  # ZWSP
     ("hello world.", "hello world"),
     ("u.s. army", "u.s. army"),
@@ -200,7 +200,7 @@ _GOLDEN_VECTORS = [
     ("a/b", "ab"),
     ("one, two; three", "one two three"),
     ("sub-second latency", "sub-second latency"),
-    ("café", normalize("café")),  # NFC composed == decomposed
+    ("cafe\u0301", "caf\u00e9"),  # decomposed (e + U+0301) normalizes to NFC composed e-acute (U+00E9)
     ("a — b", "a — b"),  # em-dash survives
     ("“It’s done.”", "it's done"),
 ]


### PR DESCRIPTION
Test-honesty batch, all consolidated under the CI test-quality epic. No product code.

## #860 - tautological normalization self-test
The freeze-suite Python self-test had `("café", normalize("café"))`: both sides ran the `normalize()` under test (`x == x`), so it could not catch an accent/Unicode regression. Replaced with a decomposed input and a composed expected so it actually exercises the NFC step, and fixed the mislabeled "NBSP" vector that used a regular space. The Swift mirror now compares at the **unicode-scalar** level rather than `String ==`: Swift string equality is canonical-equivalence-aware, so `"cafe\u{0301}" == "café"` is already true and a String-level assert would pass even if `normalize` were a no-op.

## #907 - vacuous allSatisfy
The CustomWords 50-count threshold test read words from disk into `at49`/`at50` then asserted `allSatisfy { ... }`, which passes vacuously if the read returns an empty array. Added `count == 50` guards before both checks.

## #826 - comment/string-blind ceiling parser
`RouterCeilingParser.classBody` found the class declaration via a raw text search and balanced braces over raw source, and its depth-tracking loops counted raw `{`/`}` per line. A `final class X {` or a stray `{`/`}` inside a `//` comment or string literal could mis-anchor the declaration, unbalance the body scan, or drop a real declaration below depth 0. The fix makes `codeView` offset-preserving (mask to spaces, length kept 1:1), searches and brace-balances `classBody` over the code view (slicing the body from the real source by integer offset), and routes every depth-tracking brace count through a new code-view-based `braceCounts()` helper. Adds 5 fixtures (declaration in comment/string, brace in comment/string, non-ASCII offset preservation).

## Validation
- 153 tests across 25 suites green: every architecture **ceiling** suite (no real class count changed), the 5 new parser fixtures, `FreezeSuiteNormalizationTests`, `CustomWordsManagerCountingTests`, `EngineIdentityFreezeTests`. The Python golden-vector self-test passes against the real `normalize` (verified standalone).
- The 5 parser fixtures are red before the fix: the 2 fake-declaration cases throw on the original parser; the 3 body-brace cases were observed red on a `classBody`-only fix (count 0).
- `swift build -c release` clean.
- Process: council coverage + Codex grounded review (high effort, ran a raw-vs-fixed scan across every ceiling-tested class to prove no slice changes; revisions applied: scalar Swift assert, NBSP vector, 5 fixtures, depth-tracking extension) + Codex code-diff review (high effort, no findings).
- Live UAT skipped (skip-note): test/script-only change, no product code or runtime behavior; the parser change is validated by the full ceiling suite.

Part of #385