### PR TITLE
build(tuist): add Xcode/Tuist build graph as native targets (PR1 of #913)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,15 @@
 
 # Xcode
 DerivedData/
+*.xcodeproj/
 *.xcworkspace
 xcuserdata/
 *.xcodeproj/xcuserdata/
 *.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+*.xcresult
+
+# Tuist generated artifacts (project/workspace are CLI-generated, never committed)
+Derived/
 
 # Swift Package Manager
 .build/

--- a/Project.swift
+++ b/Project.swift
@@ -1,0 +1,291 @@
+import ProjectDescription
+
+let appBundleId = "com.enviouswispr.app"
+let audioServiceBundleId = "com.enviouswispr.audioservice"
+let asrServiceBundleId = "com.enviouswispr.asrservice"
+
+let deploymentTargets: DeploymentTargets = .macOS("14.0")
+
+// One stable Swift package-access identifier shared by every first-party
+// module + app + XPC + test target. This is what lets Swift `package`-level
+// symbols cross our native module boundaries (SE-0386). It is deliberately a
+// fixed string, NOT derived from the checkout directory, so it is identical in
+// the root checkout, side-worktrees, and CI. (#913 PR1 — decided by 3-way
+// consensus: Codex + council GPT/Gemini; see learnings ledger.)
+let packageAccessIdentifier = "enviouswispr"
+
+let commonSettings: SettingsDictionary = [
+  "ARCHS": "arm64",
+  "VALID_ARCHS": "arm64",
+  "ONLY_ACTIVE_ARCH": "NO",
+  "MACOSX_DEPLOYMENT_TARGET": "14.0",
+  "SWIFT_VERSION": "6.0",
+  "SWIFT_STRICT_CONCURRENCY": "complete",
+  "SUPPORTED_PLATFORMS": "macosx",
+  "SWIFT_PACKAGE_NAME": SettingValue(stringLiteral: packageAccessIdentifier),
+  "CODE_SIGNING_ALLOWED": "NO",
+  "CODE_SIGNING_REQUIRED": "NO",
+]
+
+// Performance-correctness: optimization is set EXPLICITLY per configuration so
+// it is never silently left at a default. Release must match `swift build -c
+// release` (full whole-module optimization) so the Xcode-built app runs exactly
+// as fast as today's hand-rolled build. (#913 — founder directive: optimize for
+// performance, not convenience.)
+let debugConfigSettings: SettingsDictionary = [
+  "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+  "SWIFT_COMPILATION_MODE": "singlefile",
+  "GCC_OPTIMIZATION_LEVEL": "0",
+  "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) DEBUG",
+  "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) DEBUG=1",
+]
+
+let releaseConfigSettings: SettingsDictionary = [
+  "SWIFT_OPTIMIZATION_LEVEL": "-O",
+  "SWIFT_COMPILATION_MODE": "wholemodule",
+  "GCC_OPTIMIZATION_LEVEL": "s",
+]
+
+let projectSettings = Settings.settings(
+  base: commonSettings,
+  configurations: [
+    .debug(name: "Debug", settings: debugConfigSettings),
+    .release(name: "Release", settings: releaseConfigSettings),
+  ]
+)
+
+// First-party modules are NATIVE Tuist targets, statically linked. The app and
+// both XPC services each get their own copy of the code they need (no runtime
+// @rpath dependency on internal frameworks) — matching the current SwiftPM
+// behavior and the lowest-risk shape for heart-path XPC launch.
+func firstPartyLibrary(
+  _ name: String,
+  dependencies: [TargetDependency],
+  hasResources: Bool = false
+) -> Target {
+  .target(
+    name: name,
+    destinations: .macOS,
+    product: .staticFramework,
+    bundleId: "com.enviouswispr.\(name)",
+    deploymentTargets: deploymentTargets,
+    infoPlist: .default,
+    sources: hasResources
+      ? [.glob("Sources/\(name)/**", excluding: ["Sources/\(name)/Resources/**"])]
+      : ["Sources/\(name)/**"],
+    resources: hasResources ? ["Sources/\(name)/Resources/**"] : [],
+    dependencies: dependencies,
+    settings: projectSettings
+  )
+}
+
+let firstPartyTargetDeps: [TargetDependency] = [
+  .target(name: "EnviousWisprCore"),
+  .target(name: "EnviousWisprStorage"),
+  .target(name: "EnviousWisprPostProcessing"),
+  .target(name: "EnviousWisprAudio"),
+  .target(name: "EnviousWisprServices"),
+  .target(name: "EnviousWisprASR"),
+  .target(name: "EnviousWisprLLM"),
+  .target(name: "EnviousWisprPipeline"),
+]
+
+let project = Project(
+  name: "EnviousWispr",
+  organizationName: "Envious Labs",
+  packages: [
+    // Brings the root SwiftPM package so external products (WhisperKit,
+    // FluidAudio, Sparkle, PostHog, Sentry) resolve through its pinned
+    // dependencies. First-party libs are NOT consumed as products — they are
+    // the native targets below.
+    .local(path: ".")
+  ],
+  settings: projectSettings,
+  targets: [
+    // ---- 8 first-party modules (native static frameworks) ----
+    firstPartyLibrary("EnviousWisprCore", dependencies: []),
+    firstPartyLibrary(
+      "EnviousWisprStorage",
+      dependencies: [
+        .target(name: "EnviousWisprCore")
+      ]),
+    firstPartyLibrary(
+      "EnviousWisprPostProcessing",
+      dependencies: [
+        .target(name: "EnviousWisprCore")
+      ], hasResources: true),
+    firstPartyLibrary(
+      "EnviousWisprAudio",
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .package(product: "FluidAudio"),
+      ]),
+    firstPartyLibrary(
+      "EnviousWisprServices",
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .package(product: "PostHog"),
+        .package(product: "Sentry"),
+      ]),
+    firstPartyLibrary(
+      "EnviousWisprASR",
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprAudio"),
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+      ]),
+    firstPartyLibrary(
+      "EnviousWisprLLM",
+      dependencies: [
+        .target(name: "EnviousWisprCore")
+      ]),
+    firstPartyLibrary(
+      "EnviousWisprPipeline",
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprASR"),
+        .target(name: "EnviousWisprAudio"),
+        .target(name: "EnviousWisprLLM"),
+        .target(name: "EnviousWisprPostProcessing"),
+        .target(name: "EnviousWisprServices"),
+        .target(name: "EnviousWisprStorage"),
+        // Transitive: Audio/ASR import FluidAudio, whose plain C-target modules
+        // (FastClusterWrapper, MachTaskSelfWrapper) only land on a DIRECT
+        // depender's module search path. Xcode (unlike SwiftPM) doesn't
+        // propagate them transitively, so any module importing Audio/ASR must
+        // re-declare FluidAudio for the .swiftmodule import-closure to resolve.
+        .package(product: "FluidAudio"),
+      ]),
+
+    // ---- XPC services ----
+    .target(
+      name: "EnviousWisprAudioService",
+      destinations: .macOS,
+      product: .xpc,
+      productName: "EnviousWisprAudioService",
+      bundleId: audioServiceBundleId,
+      deploymentTargets: deploymentTargets,
+      infoPlist: .file(path: "Sources/EnviousWisprAudioService/Resources/Info.plist"),
+      sources: ["Sources/EnviousWisprAudioService/**"],
+      entitlements: .file(
+        path: "Sources/EnviousWisprAudioService/Resources/EnviousWisprAudioService.entitlements"),
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprAudio"),
+        // Transitive FluidAudio C-target modules (see Pipeline note above).
+        .package(product: "FluidAudio"),
+      ],
+      settings: projectSettings
+    ),
+    .target(
+      name: "EnviousWisprASRService",
+      destinations: .macOS,
+      product: .xpc,
+      productName: "EnviousWisprASRService",
+      bundleId: asrServiceBundleId,
+      deploymentTargets: deploymentTargets,
+      infoPlist: .file(path: "Sources/EnviousWisprASRService/Resources/Info.plist"),
+      sources: ["Sources/EnviousWisprASRService/**"],
+      entitlements: .file(
+        path: "Sources/EnviousWisprASRService/Resources/EnviousWisprASRService.entitlements"),
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprASR"),
+        .target(name: "EnviousWisprAudio"),
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+      ],
+      settings: projectSettings
+    ),
+
+    // ---- App ----
+    .target(
+      name: "EnviousWispr",
+      destinations: .macOS,
+      product: .app,
+      productName: "EnviousWispr",
+      bundleId: appBundleId,
+      deploymentTargets: deploymentTargets,
+      infoPlist: .file(path: "Sources/EnviousWispr/Resources/Info.plist"),
+      sources: ["Sources/EnviousWispr/**"],
+      resources: [
+        "Sources/EnviousWispr/Resources/AppIcon.icns"
+      ],
+      entitlements: .file(path: "Sources/EnviousWispr/Resources/EnviousWispr.entitlements"),
+      dependencies: firstPartyTargetDeps + [
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+        .target(name: "EnviousWisprAudioService"),
+        .target(name: "EnviousWisprASRService"),
+      ],
+      settings: projectSettings
+    ),
+
+    // ---- Test bundles ----
+    // This bundle's graph is intentionally BROADER than Package.swift's
+    // testTarget list. SwiftPM let the test target name only a subset and
+    // propagated the rest transitively (e.g. FluidAudio/Sparkle via the app
+    // dep, Services/ASR via Pipeline). Xcode does not propagate, so every
+    // module a test imports DIRECTLY must be a declared edge. Verified: tests
+    // import all 8 first-party modules + FluidAudio + Sparkle directly, so the
+    // full first-party set + those two externals is the exact, minimal set.
+    .target(
+      name: "EnviousWisprTests",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: "com.enviouswispr.tests",
+      deploymentTargets: deploymentTargets,
+      infoPlist: .default,
+      sources: ["Tests/EnviousWisprTests/**"],
+      dependencies: firstPartyTargetDeps + [
+        .target(name: "EnviousWispr"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+      ],
+      settings: projectSettings
+    ),
+    .target(
+      name: "EnviousWisprASRTests",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: "com.enviouswispr.asrtests",
+      deploymentTargets: deploymentTargets,
+      infoPlist: .default,
+      sources: ["Tests/EnviousWisprASRTests/**"],
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprASR"),
+        .package(product: "WhisperKit"),
+        // Static-link FluidAudio: the test bundle links EnviousWisprASR (a
+        // static framework that uses FluidAudio), so its symbols must be
+        // resolved here too (Xcode doesn't propagate transitive static-link).
+        .package(product: "FluidAudio"),
+      ],
+      settings: projectSettings
+    ),
+  ],
+  schemes: [
+    .scheme(
+      name: "EnviousWispr",
+      shared: true,
+      buildAction: .buildAction(
+        targets: ["EnviousWispr"],
+        findImplicitDependencies: true
+      ),
+      testAction: .targets(
+        ["EnviousWisprTests", "EnviousWisprASRTests"],
+        configuration: "Debug"
+      )
+    ),
+    .scheme(
+      name: "EnviousWispr-Release",
+      shared: true,
+      buildAction: .buildAction(
+        targets: ["EnviousWispr"],
+        findImplicitDependencies: true
+      )
+    ),
+  ]
+)

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,0 +1,5 @@
+import ProjectDescription
+
+let tuist = Config(
+  project: .tuist()
+)


### PR DESCRIPTION
## PR1 — Tuist/Xcode build graph (native targets)

Part of #913 (Xcode-build-engine migration). First of 8 PRs. **Build-graph proof only** — nothing reaches users; the old SwiftPM path stays fully intact (`Package.swift` unchanged) and the required CI check is unaffected.

### What this does
Adds `Tuist.swift` + `Project.swift` so `tuist generate` produces an Xcode project that builds the app + both XPC services + both test bundles + all 8 first-party modules — Debug and Release, arm64-only, macOS 14, Swift 6 strict concurrency.

### Shape (decided by 3-way consensus: Codex + council GPT/Gemini)
The 8 first-party modules are **native Tuist `.staticFramework` targets** sharing one stable `SWIFT_PACKAGE_NAME = "enviouswispr"`, so Swift `package`-level symbols cross module boundaries independent of the checkout directory. External dependencies resolve through the root package via `.local(path: ".")`.

This is the roadmap's pre-sanctioned fallback. The originally-planned "8 SwiftPM products + native app/XPC" shape was proven to require a package-access identifier derived from the checkout directory name (fragile across worktrees/CI). Static linking matches the current build and keeps XPC launch free of `@rpath`/library-validation risk (validated against how Apple's iWork + iTerm2 assemble their bundles).

### Verified empirically
- `tuist generate` clean; Debug + Release builds **succeed**.
- **Performance:** Release compiles with `-O` + whole-module (explicit per-config), matching `swift build -c release`.
- Structural gates: both XPC services under `Contents/XPCServices` with correct bundle ids + `CFBundlePackageType=XPC!` + `XPCService.ServiceType=Application`; app plist id/`LSUIElement`/feed/EdKey correct; exactly one swiftmodule per module per config; no internal frameworks embedded (static confirmed).
- Bonus: the spoken-emoji dictionary now lands in the app bundle (`Bundle.module` resolves) — a free preview of the #341 fix.
- `xcodebuild test`: **1384 pass.** The only failures (102) are architecture freeze/ceiling tests that read their own source via working-directory-relative paths — broken solely because the Xcode test tool runs from `/`. Routed to **PR3** (the PR that switches CI to the Xcode test tool), per founder decision. PR1's own required check still runs on the old tool and is green.

### Generated artifacts
`.gitignore` now ignores `*.xcodeproj/`, `*.xcworkspace`, `Derived/`, `*.xcresult`. No generated project files are committed.