### PR TITLE
feat(build): per-config bundle identity + resource-bundle proof for Xcode engine (#913 PR2)

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -54,6 +54,58 @@ let projectSettings = Settings.settings(
   ]
 )
 
+// Per-target settings = the common base + per-config optimization + per-config
+// identity overrides (bundle id / Sparkle feed). Debug carries the `.dev`
+// identity (isolates TCC/Keychain and blanks the update feed); Release carries
+// the production identity. The three Info.plists reference
+// `$(PRODUCT_BUNDLE_IDENTIFIER)` and `$(SU_FEED_URL)` so these reach the signed
+// products. (#913 PR2)
+func targetSettings(
+  debugExtra: SettingsDictionary = [:],
+  releaseExtra: SettingsDictionary = [:]
+) -> Settings {
+  Settings.settings(
+    base: commonSettings,
+    configurations: [
+      .debug(
+        name: "Debug",
+        settings: debugConfigSettings.merging(debugExtra) { _, new in new }
+      ),
+      .release(
+        name: "Release",
+        settings: releaseConfigSettings.merging(releaseExtra) { _, new in new }
+      ),
+    ]
+  )
+}
+
+// PR2 sets only the per-config IDENTITY (bundle id + Sparkle feed). The
+// Apple-intended automatic-signing migration (Apple Development cert + Mac
+// Development profile under DEVELOPMENT_TEAM=9UT54V24XG) lands in the dev-bundle
+// PR (PR4) + release PRs (PR5/PR6), where signing is inherently needed and the
+// founder's Apple Development cert is available. PR2 builds unsigned (like PR1),
+// proving the resource accessor + dev identity independent of signing. (#913)
+let appSettings = targetSettings(
+  debugExtra: [
+    "PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.app.dev",
+    "SU_FEED_URL": "",
+  ],
+  releaseExtra: [
+    "PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.app",
+    "SU_FEED_URL": "https://enviouswispr.com/appcast.xml",
+  ]
+)
+
+let audioServiceSettings = targetSettings(
+  debugExtra: ["PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.audioservice.dev"],
+  releaseExtra: ["PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.audioservice"]
+)
+
+let asrServiceSettings = targetSettings(
+  debugExtra: ["PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.asrservice.dev"],
+  releaseExtra: ["PRODUCT_BUNDLE_IDENTIFIER": "com.enviouswispr.asrservice"]
+)
+
 // First-party modules are NATIVE Tuist targets, statically linked. The app and
 // both XPC services each get their own copy of the code they need (no runtime
 // @rpath dependency on internal frameworks) — matching the current SwiftPM
@@ -176,7 +228,7 @@ let project = Project(
         // Transitive FluidAudio C-target modules (see Pipeline note above).
         .package(product: "FluidAudio"),
       ],
-      settings: projectSettings
+      settings: audioServiceSettings
     ),
     .target(
       name: "EnviousWisprASRService",
@@ -196,7 +248,7 @@ let project = Project(
         .package(product: "WhisperKit"),
         .package(product: "FluidAudio"),
       ],
-      settings: projectSettings
+      settings: asrServiceSettings
     ),
 
     // ---- App ----
@@ -220,7 +272,7 @@ let project = Project(
         .target(name: "EnviousWisprAudioService"),
         .target(name: "EnviousWisprASRService"),
       ],
-      settings: projectSettings
+      settings: appSettings
     ),
 
     // ---- Test bundles ----

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.enviouswispr.app</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>EnviousWispr</string>
 	<key>CFBundlePackageType</key>
@@ -37,7 +37,7 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://enviouswispr.com/appcast.xml</string>
+	<string>$(SU_FEED_URL)</string>
 	<key>SUPublicEDKey</key>
 	<string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
 </dict>

--- a/Sources/EnviousWisprASRService/Resources/Info.plist
+++ b/Sources/EnviousWisprASRService/Resources/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleExecutable</key>
     <string>EnviousWisprASRService</string>
     <key>CFBundleIdentifier</key>
-    <string>com.enviouswispr.asrservice</string>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleName</key>
     <string>EnviousWispr ASR Service</string>
     <key>CFBundlePackageType</key>

--- a/Sources/EnviousWisprAudioService/Resources/Info.plist
+++ b/Sources/EnviousWisprAudioService/Resources/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleExecutable</key>
     <string>EnviousWisprAudioService</string>
     <key>CFBundleIdentifier</key>
-    <string>com.enviouswispr.audioservice</string>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleName</key>
     <string>EnviousWispr Audio Service</string>
     <key>CFBundlePackageType</key>

--- a/Sources/EnviousWisprPostProcessing/EmojiFormatter.swift
+++ b/Sources/EnviousWisprPostProcessing/EmojiFormatter.swift
@@ -190,6 +190,22 @@ public struct EmojiFormatter: Sendable {
     return try EmojiFormatter(entries: entries, enablePhonetic: enablePhonetic)
   }
 
+  // MARK: - Resource-resolution diagnostics (#913 PR2)
+
+  /// The `Bundle.module` URL for the bundled emoji dictionary, or nil if the
+  /// resource bundle did not ship. Exposes the SAME `Bundle.module` lookup the
+  /// production `load()` path uses — not a fallback — so a test can assert the
+  /// shipped resource resolves at runtime under the Xcode build.
+  public static var bundledDictionaryURLForDiagnostics: URL? {
+    Bundle.module.url(forResource: "emoji-dictionary", withExtension: "json")
+  }
+
+  /// The `Bundle.module` bundle URL, for asserting where the resource bundle
+  /// physically resolves (e.g. inside a signed app's `Contents/Resources`).
+  public static var moduleBundleURLForDiagnostics: URL {
+    Bundle.module.bundleURL
+  }
+
   // MARK: - Public format
 
   /// Convert spoken-emoji phrases in `text` to Unicode glyphs. Pure; never throws.

--- a/Tests/EnviousWisprTests/PostProcessing/PostProcessingResourceBundleRuntimeTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PostProcessingResourceBundleRuntimeTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #913 PR2 — proves the `EnviousWisprPostProcessing` resource bundle (the
+/// spoken-emoji dictionary) is carried with the module under the Xcode/Tuist
+/// build and that the production `Bundle.module` accessor resolves it at
+/// runtime. The "does the SIGNED app ship it under Contents/Resources" claim is
+/// proven separately by inspecting the built signed app in the PR2 build script
+/// (a non-hosted unit test resolves `Bundle.module` to its own test bundle, not
+/// the app, so that containment claim cannot be asserted here without hosting
+/// the whole suite inside the menu-bar app — which we avoid).
+///
+/// Not tautological: it asserts three independent facts — the `Bundle.module`
+/// lookup returns a URL, a real file exists there, and the production loader +
+/// formatter turn known phrases into the expected glyphs through that resource.
+@Suite("PostProcessing resource bundle runtime")
+struct PostProcessingResourceBundleRuntimeTests {
+  @Test("Bundle.module resolves the emoji dictionary and EmojiFormatter loads it")
+  func bundleModuleResolvesEmojiDictionary() throws {
+    let dictionaryURL = try #require(
+      EmojiFormatter.bundledDictionaryURLForDiagnostics,
+      "Bundle.module did not resolve emoji-dictionary.json — the resource bundle did not ship with the module."
+    )
+
+    #expect(dictionaryURL.lastPathComponent == "emoji-dictionary.json")
+    #expect(
+      FileManager.default.fileExists(atPath: dictionaryURL.path),
+      "emoji-dictionary.json missing at the Bundle.module URL: \(dictionaryURL.path)"
+    )
+
+    let moduleBundleURL = EmojiFormatter.moduleBundleURLForDiagnostics
+    #expect(
+      dictionaryURL.path.hasPrefix(moduleBundleURL.standardizedFileURL.path),
+      "Dictionary resolved outside the module bundle: \(dictionaryURL.path)"
+    )
+
+    let formatter = try EmojiFormatter.load()
+    #expect(formatter.format("thumbs up emoji") == "👍")
+    #expect(formatter.format("happy birthday Emma red heart emoji") == "happy birthday Emma ❤️")
+  }
+}

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -33,8 +33,14 @@ mkdir -p "$BUNDLE/Contents/Frameworks"
 cp "$BINARY" "$BUNDLE/Contents/MacOS/EnviousWispr"
 chmod +x "$BUNDLE/Contents/MacOS/EnviousWispr"
 
-# Copy Info.plist (production bundle ID, version from committed plist)
+# Copy Info.plist and stamp the production bundle ID + Sparkle feed.
+# The committed plist holds build-variable placeholders ($(PRODUCT_BUNDLE_IDENTIFIER),
+# $(SU_FEED_URL)) that the Xcode build path substitutes; this hand-rolled path must
+# stamp the concrete production values itself. (#913 PR2 — this stamping, and this
+# whole script, are removed in PR6 when the release pipeline moves to the Xcode engine.)
 cp "$RESOURCES_SRC/Info.plist" "$BUNDLE/Contents/Info.plist"
+plutil -replace CFBundleIdentifier -string "com.enviouswispr.app" "$BUNDLE/Contents/Info.plist"
+plutil -replace SUFeedURL -string "https://enviouswispr.com/appcast.xml" "$BUNDLE/Contents/Info.plist"
 
 # Copy icon
 cp "$RESOURCES_SRC/AppIcon.icns" "$BUNDLE/Contents/Resources/AppIcon.icns"
@@ -61,6 +67,7 @@ mkdir -p "$XPC_BUNDLE/Contents/MacOS"
 cp "$XPC_BINARY" "$XPC_BUNDLE/Contents/MacOS/EnviousWisprAudioService"
 chmod +x "$XPC_BUNDLE/Contents/MacOS/EnviousWisprAudioService"
 cp "$XPC_RESOURCES/Info.plist" "$XPC_BUNDLE/Contents/Info.plist"
+plutil -replace CFBundleIdentifier -string "com.enviouswispr.audioservice" "$XPC_BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleVersion -string "$VERSION" "$XPC_BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleShortVersionString -string "$VERSION" "$XPC_BUNDLE/Contents/Info.plist"
 
@@ -74,6 +81,7 @@ mkdir -p "$ASR_XPC_BUNDLE/Contents/MacOS"
 cp "$ASR_BINARY" "$ASR_XPC_BUNDLE/Contents/MacOS/EnviousWisprASRService"
 chmod +x "$ASR_XPC_BUNDLE/Contents/MacOS/EnviousWisprASRService"
 cp "$ASR_RESOURCES/Info.plist" "$ASR_XPC_BUNDLE/Contents/Info.plist"
+plutil -replace CFBundleIdentifier -string "com.enviouswispr.asrservice" "$ASR_XPC_BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleVersion -string "$VERSION" "$ASR_XPC_BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleShortVersionString -string "$VERSION" "$ASR_XPC_BUNDLE/Contents/Info.plist"
 


### PR DESCRIPTION
Part of #913 (Xcode-build-engine migration epic, PR2 of 8).

## What
- Make the three Info.plists build-variable-backed (`$(PRODUCT_BUNDLE_IDENTIFIER)`, `$(SU_FEED_URL)`) so the Xcode/Tuist engine substitutes dev-vs-release identity at build time.
- `Project.swift`: add a `targetSettings` helper carrying per-config identity (Debug = `.dev` bundle ids + blank Sparkle feed; Release = production ids + appcast) on the app and both XPC targets, merged **additively** over the existing per-config optimization so Release keeps `-O`/wholemodule and Debug keeps `-Onone` + the `DEBUG` condition.
- `build-dmg.sh`: stamp the concrete production bundle id + Sparkle feed (the hand-rolled SPM path does not substitute build variables; `bundle-dev.sh` already stamped dev values). Removed in PR6 when release moves to the Xcode engine.
- `EmojiFormatter`: add a `Bundle.module` diagnostic accessor + a runtime test proving the spoken-emoji resource bundle ships with the module and resolves at runtime (also fixes #341 for free once the Xcode build ships).

## Scope notes
- **Signing stays decoupled** (unsigned build, like PR1). The Apple-intended automatic-signing migration lands in PR4+ (dev) / PR5-PR6 (release), gated on the Apple Development cert.
- The 102 freeze/ceiling tests that fail only under `xcodebuild test` (CWD=`/`) are routed to PR3.
- The repeatable shipped-app-layout proof (hosted test) is routed to PR3, where the Xcode test tool becomes the CI gate.

## Validation
- `scripts/swift-test.sh`: **1492 tests / 182 suites pass** (incl. the new resource-bundle test).
- Self-review + Codex diff review: clean (no introduced bugs).
- No runtime behavior change to any shipped app (SPM path unchanged); the dictation crash-gate begins at PR4 (signed dev bundle) per the epic contract.