### PR TITLE
ci(build): PR + post-merge checks on the Xcode engine; fix CWD-relative freeze tests (#913 PR3)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -8,6 +8,13 @@ concurrency:
   group: main-post-merge
   cancel-in-progress: true
 
+# Shared Xcode-engine constants (#913 PR3).
+env:
+  DERIVED_DATA_PATH: .derivedData/CI
+  XCODE_PROJECT: EnviousWispr.xcodeproj
+  XCODE_SCHEME: EnviousWispr
+  XCODE_RELEASE_SCHEME: EnviousWispr-Release
+
 jobs:
   main-post-merge-build:
     runs-on: macos-26
@@ -27,120 +34,178 @@ jobs:
       - name: Detect code changes
         id: changes
         run: |
+          set -euo pipefail
           CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "unknown")
           echo "==> Changed files:"
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)'; then
+          if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<< "$CHANGED"; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "==> Code changes detected — running post-merge build"
+            echo "==> CI build workflow changed — running post-merge Xcode build"
+          elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<< "$CHANGED"; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "==> Code changes detected — running post-merge Xcode build"
           else
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
             echo "==> Non-code changes only — skipping build"
           fi
 
-      - name: Compute SwiftPM cache key
-        id: spm-cache-key
+      - name: Verify environment
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          swift --version
+          xcodebuild -version
+          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
+          echo "macOS SDK: $SDK_VER"
+
+          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
+            echo "::error::Swift 6.0+ required"
+            exit 1
+          fi
+
+          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
+            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
+            exit 1
+          fi
+
+      - name: Install mise + Tuist
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mise" install tuist@4.195.11
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Compute Xcode build cache key
+        id: xcode-cache-key
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; } |
+            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
             shasum -a 256 | cut -c1-12
           )"
           echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
 
-      # main-post-merge.yml is the cache WRITER: it restores the freshest
-      # compatible cache, runs the full debug+release build+test matrix, then
-      # saves a new cache under the rolling commit-keyed primary key. Every PR
-      # then restores this fresh default-branch cache (see issue #804).
-      - name: Restore SwiftPM build cache
-        id: spm-cache
+      # main-post-merge.yml is the cache WRITER: restore freshest compatible
+      # cache, run the full debug+release build+test matrix, then save a new
+      # cache under the rolling commit-keyed primary key (issue #804).
+      - name: Restore Xcode build cache
+        id: xcode-cache
         if: steps.changes.outputs.needs_build == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          path: |
+            .derivedData/CI/SourcePackages
+            .derivedData/CI/Build
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
 
-      # COMPILE_FLAGS comes from scripts/swift-test.sh (single source) so this build
-      # graph matches the test step's graph and the test step reuses these objects
-      # instead of recompiling every first-party module (#885). Captured into a string
-      # first (a failing emitter aborts the step under set -e), then split into an
-      # array so the flags pass as separate argv without unquoted word-splitting.
-      - name: Build (debug)
+      - name: Build (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
-          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
-          swift build "${COMPILE_FLAGS[@]}"
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
 
-      - name: Build (release)
+      - name: Build (release, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
-          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
-          swift build -c release --arch arm64 "${COMPILE_FLAGS[@]}"
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_RELEASE_SCHEME" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
 
-      - name: Run logic tests
+      - name: Run logic tests (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          OUTPUT=$(scripts/swift-test.sh 2>&1) || true
-          echo "$OUTPUT"
-          # Fail on actual test failures
-          if echo "$OUTPUT" | grep -q "✘"; then
-            echo "::error::Swift tests have failures"
-            exit 1
-          fi
-          # Verify tests actually started (guard against silent no-op)
-          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
-          if [ "$STARTED" -eq 0 ]; then
-            echo "::error::No tests started — possible compilation failure"
-            exit 1
-          fi
-          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
-          echo "==> $STARTED test entries started, $PASSED reported passed, 0 failures"
+          set -o pipefail
+          xcodebuild test \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64 | tee xcode-test-debug.log
 
-      - name: Run logic tests (release config)
+          # Require a positive executed-test count (see pr-check.yml rationale):
+          # a presence-grep would green a zero-test run.
+          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+          if [ "$TESTS_RUN" -lt 1 ]; then
+            echo "::error::Xcode executed 0 debug tests (empty/misconfigured bundle) — failing"
+            exit 1
+          fi
+          echo "==> Xcode executed $TESTS_RUN tests (debug)"
+
+      # ENABLE_TESTABILITY=YES is required on the release TEST invocation only:
+      # the test targets use `@testable import`, which needs the first-party
+      # modules built with `-enable-testing`. Debug enables testability by
+      # default; Release does not, so without this the test build fails with
+      # "module built without '-enable-testing'". It is NOT set on the release
+      # `build` step above, so the shippable release artifact stays non-testable
+      # and fully optimized. (Mirrors the old `swift test -c release` behavior.)
+      - name: Run logic tests (release config, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          set +e
-          OUTPUT=$(scripts/swift-test.sh -c release 2>&1)
-          STATUS=$?
-          set -e
-          echo "$OUTPUT"
-          if [ "$STATUS" -ne 0 ]; then
-            echo "::error::scripts/swift-test.sh -c release exited $STATUS"
-            exit "$STATUS"
-          fi
-          if echo "$OUTPUT" | grep -q "✘"; then
-            echo "::error::Swift tests have failures (release config)"
+          set -o pipefail
+          xcodebuild test \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_RELEASE_SCHEME" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64 \
+            ENABLE_TESTABILITY=YES | tee xcode-test-release.log
+
+          # Require a positive executed-test count (see pr-check.yml rationale).
+          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-release.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+          if [ "$TESTS_RUN" -lt 1 ]; then
+            echo "::error::Xcode executed 0 release tests (empty/misconfigured bundle) — failing"
             exit 1
           fi
-          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
-          if [ "$STARTED" -eq 0 ]; then
-            echo "::error::No tests started in release config — possible compilation failure"
-            exit 1
-          fi
-          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
-          echo "==> release: $STARTED test entries started, $PASSED reported passed, 0 failures"
+          echo "==> Xcode executed $TESTS_RUN tests (release)"
 
       # Save only when the build/tests succeeded and the restore was not an exact
       # hit. The primary key carries github.sha, so a first run for this commit
-      # always saves; a rerun of the same commit exact-hits and skips (re-saving
-      # an existing key errors). Uses the restore step's resolved primary key.
-      - name: Save SwiftPM build cache
-        if: steps.changes.outputs.needs_build == 'true' && success() && steps.spm-cache.outputs.cache-hit != 'true'
+      # always saves; a rerun of the same commit exact-hits and skips.
+      - name: Save Xcode build cache
+        if: steps.changes.outputs.needs_build == 'true' && success() && steps.xcode-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .build
-          key: ${{ steps.spm-cache.outputs.cache-primary-key }}
+          path: |
+            .derivedData/CI/SourcePackages
+            .derivedData/CI/Build
+          key: ${{ steps.xcode-cache.outputs.cache-primary-key }}
 
       - name: Post result
         if: always()

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,12 +8,20 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Shared Xcode-engine constants for both macOS lanes (#913 PR3). The Ubuntu
+# aggregator inherits these harmlessly.
+env:
+  DERIVED_DATA_PATH: .derivedData/CI
+  XCODE_PROJECT: EnviousWispr.xcodeproj
+  XCODE_SCHEME: EnviousWispr
+  XCODE_RELEASE_SCHEME: EnviousWispr-Release
+
 jobs:
-  # Debug lane: debug build + XPC hygiene self-tests + debug-config logic tests.
-  # Runs in parallel with build-release (issue #906). Keeps runs-on/timeout from
-  # the pre-split single build-check job. needs_build gating stays at STEP level
-  # so a docs-only PR runs this job but skips the build/test steps and reports
-  # success — the build-check aggregator requires success from both lanes.
+  # Debug lane: Xcode debug build + XPC hygiene self-tests + debug-config logic
+  # tests via `xcodebuild test`. Runs in parallel with build-release (issue #906).
+  # needs_build gating stays at STEP level so a docs-only PR runs this job but
+  # skips the build/test steps and reports success — the build-check aggregator
+  # requires success from both lanes. (#913 PR3 moved this lane to the Xcode engine.)
   build-debug:
     runs-on: macos-26
     timeout-minutes: 45
@@ -35,16 +43,21 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "==> Changed files:"
           echo "$CHANGED"
-          # Check if ANY file outside website/, docs/, .github/, content-engine/ changed
-          if echo "$CHANGED" | grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)'; then
+          # A change to the build/test workflows must validate itself (the Xcode
+          # build/cache/test logic), so force a full build for those.
+          if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<< "$CHANGED"; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "==> Swift source changes detected — full build required"
+            echo "==> CI build workflow changed — full Xcode build required"
+          elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<< "$CHANGED"; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "==> Swift source changes detected — full Xcode build required"
           else
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
-            echo "==> No Swift source changes — skipping build"
+            echo "==> No Swift/build-workflow changes — skipping build"
           fi
 
       - name: Verify environment
@@ -52,6 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           swift --version
+          xcodebuild -version
           SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
           echo "macOS SDK: $SDK_VER"
 
@@ -65,55 +79,69 @@ jobs:
             exit 1
           fi
 
-      - name: Compute SwiftPM cache key
-        id: spm-cache-key
+      - name: Install mise + Tuist
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mise" install tuist@4.195.11
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          # Generated project / DerivedData must never be committed.
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Compute Xcode build cache key
+        id: xcode-cache-key
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; } |
+            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
             shasum -a 256 | cut -c1-12
           )"
           echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
 
-      # Rolling cache key: the github.sha suffix makes the primary key unique per
-      # commit so the cache is never an exact hit here. pr-check.yml is restore-only
-      # by design — main-post-merge.yml is the sole writer (see issue #804). The
-      # restore-keys prefixes fall back to the freshest compatible cache.
-      - name: Restore SwiftPM build cache
-        id: spm-cache
+      # Rolling key (github.sha suffix) so the primary key is never an exact hit
+      # here. pr-check.yml is restore-only by design — main-post-merge.yml is the
+      # sole writer (issue #804). restore-keys fall through to the freshest cache.
+      - name: Restore Xcode build cache
+        id: xcode-cache
         if: steps.changes.outputs.needs_build == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          path: |
+            .derivedData/CI/SourcePackages
+            .derivedData/CI/Build
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
 
-      # Two lanes restore concurrently and read-only. Usually they resolve to the
-      # same artifact, but a main-post-merge save landing between the two lane
-      # restores can make them fall through to different restore-key artifacts —
-      # timing-only, never a correctness issue (the build is valid with any
-      # stale/missing SwiftPM cache). Logged so divergence is observable (#906).
-      - name: Log SwiftPM cache restore
+      - name: Log Xcode cache restore
         if: steps.changes.outputs.needs_build == 'true'
         run: |
-          echo "==> SwiftPM cache (debug lane): matched=${{ steps.spm-cache.outputs.cache-matched-key }} hit=${{ steps.spm-cache.outputs.cache-hit }}"
+          echo "==> Xcode cache (debug lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
 
-      # COMPILE_FLAGS comes from scripts/swift-test.sh (single source) so this build
-      # graph matches the test step's graph and the test step reuses these objects
-      # instead of recompiling every first-party module (#885). Captured into a string
-      # first (a failing emitter aborts the step under set -e), then split into an
-      # array so the flags pass as separate argv without unquoted word-splitting.
-      - name: Build (debug)
+      - name: Build (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
-          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
-          swift build "${COMPILE_FLAGS[@]}"
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
 
       - name: XPC error hygiene self-test
         if: steps.changes.outputs.needs_build == 'true'
@@ -123,30 +151,35 @@ jobs:
         if: steps.changes.outputs.needs_build == 'true'
         run: scripts/check-xpc-error-hygiene.sh
 
-      - name: Run logic tests
+      - name: Run logic tests (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          OUTPUT=$(scripts/swift-test.sh 2>&1) || true
-          echo "$OUTPUT"
-          # Fail on actual test failures
-          if echo "$OUTPUT" | grep -q "✘"; then
-            echo "::error::Swift tests have failures"
-            exit 1
-          fi
-          # Verify tests actually started (guard against silent no-op)
-          STARTED=$(echo "$OUTPUT" | grep -c "started" || true)
-          if [ "$STARTED" -eq 0 ]; then
-            echo "::error::No tests started — possible compilation failure"
-            exit 1
-          fi
-          PASSED=$(echo "$OUTPUT" | grep -c "passed" || true)
-          echo "==> $STARTED test entries started, $PASSED reported passed, 0 failures"
+          set -o pipefail
+          xcodebuild test \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64 | tee xcode-test-debug.log
 
-  # Release lane: release build + FoundationModels compile probe. Runs in parallel
-  # with build-debug (issue #906). The FoundationModels probe rides this lane (it is
-  # a standalone macOS-26 SDK compile, ~5s, depends on neither build). Keeps
-  # runs-on/timeout from the pre-split single build-check job; step-level gating.
+          # Guard against a silent zero-test run: xcodebuild prints suite-level
+          # "passed" text even for an empty bundle, so a presence-grep would
+          # green a run where nothing executed. Require a positive executed
+          # count (summed across the Swift Testing per-target run summaries).
+          TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-debug.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
+          if [ "$TESTS_RUN" -lt 1 ]; then
+            echo "::error::Xcode executed 0 tests (empty/misconfigured bundle) — failing the gate"
+            exit 1
+          fi
+          echo "==> Xcode executed $TESTS_RUN tests (debug)"
+
+  # Release lane: Xcode release build + FoundationModels compile probe. Runs in
+  # parallel with build-debug (issue #906). The probe is a standalone macOS-26
+  # SDK compile (~5s). Step-level needs_build gating. (#913 PR3 → Xcode engine.)
   build-release:
     runs-on: macos-26
     timeout-minutes: 45
@@ -168,16 +201,19 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "==> Changed files:"
           echo "$CHANGED"
-          # Check if ANY file outside website/, docs/, .github/, content-engine/ changed
-          if echo "$CHANGED" | grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)'; then
+          if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<< "$CHANGED"; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "==> Swift source changes detected — full build required"
+            echo "==> CI build workflow changed — full Xcode build required"
+          elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<< "$CHANGED"; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "==> Swift source changes detected — full Xcode build required"
           else
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
-            echo "==> No Swift source changes — skipping build"
+            echo "==> No Swift/build-workflow changes — skipping build"
           fi
 
       - name: Verify environment
@@ -185,6 +221,7 @@ jobs:
         run: |
           set -euo pipefail
           swift --version
+          xcodebuild -version
           SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
           echo "macOS SDK: $SDK_VER"
 
@@ -198,45 +235,65 @@ jobs:
             exit 1
           fi
 
-      - name: Compute SwiftPM cache key
-        id: spm-cache-key
+      - name: Install mise + Tuist
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mise" install tuist@4.195.11
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Compute Xcode build cache key
+        id: xcode-cache-key
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
           TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; } |
+            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
             shasum -a 256 | cut -c1-12
           )"
           echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
 
-      # Restore-only (see build-debug lane comment + issue #804).
-      - name: Restore SwiftPM build cache
-        id: spm-cache
+      - name: Restore Xcode build cache
+        id: xcode-cache
         if: steps.changes.outputs.needs_build == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          path: |
+            .derivedData/CI/SourcePackages
+            .derivedData/CI/Build
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved') }}-
-            ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
+            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
 
-      - name: Log SwiftPM cache restore
+      - name: Log Xcode cache restore
         if: steps.changes.outputs.needs_build == 'true'
         run: |
-          echo "==> SwiftPM cache (release lane): matched=${{ steps.spm-cache.outputs.cache-matched-key }} hit=${{ steps.spm-cache.outputs.cache-hit }}"
+          echo "==> Xcode cache (release lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
 
-      # COMPILE_FLAGS single-sourced from scripts/swift-test.sh (#885) — only the -F
-      # flag re-keys the compile graph; -c release and --arch arm64 do not, so the
-      # shipped binary is functionally unchanged.
-      - name: Build (release)
+      - name: Build (release, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
-          FLAGS_STR="$(scripts/swift-test.sh --print-compile-flags)"
-          read -ra COMPILE_FLAGS <<< "$FLAGS_STR"
-          swift build -c release --arch arm64 "${COMPILE_FLAGS[@]}"
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_RELEASE_SCHEME" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
 
       - name: Verify FoundationModels compile probe
         if: steps.changes.outputs.needs_build == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ xcuserdata/
 # Tuist generated artifacts (project/workspace are CLI-generated, never committed)
 Derived/
 
+# Xcode DerivedData for the CI Xcode-engine build/test (#913 PR3)
+.derivedData/
+
 # Swift Package Manager
 .build/
 .swiftpm/

--- a/Project.swift
+++ b/Project.swift
@@ -337,6 +337,13 @@ let project = Project(
       buildAction: .buildAction(
         targets: ["EnviousWispr"],
         findImplicitDependencies: true
+      ),
+      // PR3: release-config test action so main-post-merge can run
+      // `xcodebuild test -scheme EnviousWispr-Release -configuration Release`,
+      // preserving the release-config test coverage the old post-merge job ran.
+      testAction: .targets(
+        ["EnviousWisprTests", "EnviousWisprASRTests"],
+        configuration: "Release"
       )
     ),
   ]

--- a/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/ASREventRouterCeilingsTests.swift
@@ -42,7 +42,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 65,
@@ -53,7 +53,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "EnviousWisprASR", "EnviousWisprCore", "EnviousWisprPipeline", "Foundation",

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
@@ -53,7 +53,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 120,
@@ -65,7 +65,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = ["AppKit", "EnviousWisprServices", "Foundation"]
     let extras = actual.subtracting(allowed)
@@ -82,7 +82,7 @@ import Testing
   /// in-class non-private method ceiling. `AppDelegate` must have no extension.
   @Test func appDelegateHasNoExtensions() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let pattern = #"^[[:space:]]*extension[[:space:]]+AppDelegate\b[^\n]*"#
     let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
     let ns = source as NSString
@@ -103,7 +103,7 @@ import Testing
   /// firing `assertionFailure` in a unit test is not viable.
   @Test func assertAttachedGuardsLifecycleEntryPoints() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     #expect(
       source.contains("assertAttached(sparkleUpdateController,"),
       "applicationWillFinishLaunching must guard its weak ref with assertAttached.")

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateOwnershipTests.swift
@@ -85,7 +85,7 @@ private struct NamedHomeViolation: Equatable {
 }
 
 private func appDelegateURL() -> URL {
-  URL(fileURLWithPath: "Sources/EnviousWispr/App/AppDelegate.swift")
+  RepoRoot.sourceURL("Sources/EnviousWispr/App/AppDelegate.swift")
 }
 
 private func classBodyOfAppDelegate() throws -> String {

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -84,7 +84,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 600,
@@ -96,7 +96,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     // `RouterCeilingParser.imports` surfaces every anchored `import` line,
     // including inside `#if DEBUG` — so `EnviousWisprPipeline` (imported only

--- a/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
@@ -70,7 +70,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 300,
@@ -84,7 +84,7 @@ import Testing
     // Guard against smuggling methods through an extension that escapes the
     // in-class non-private method count.
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let pattern = #"^[[:space:]]*extension[[:space:]]+AppWindowCoordinator\b"#
     let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
     let ns = source as NSString
@@ -99,7 +99,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = ["AppKit", "EnviousWisprCore", "Observation"]
     let extras = actual.subtracting(allowed)
@@ -138,7 +138,7 @@ import Testing
 /// real body.
 private func classBodyOfAppWindowCoordinator() throws -> String {
   let source = try String(
-    contentsOf: URL(fileURLWithPath: "Sources/EnviousWispr/App/AppWindowCoordinator.swift"),
+    contentsOf: RepoRoot.sourceURL("Sources/EnviousWispr/App/AppWindowCoordinator.swift"),
     encoding: .utf8)
   guard let openRange = source.range(of: "final class AppWindowCoordinator {") else {
     Issue.record("AppWindowCoordinator declaration not found at expected path/shape")

--- a/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
@@ -52,7 +52,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 125,
@@ -64,7 +64,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "AVFAudio", "EnviousWisprAudio", "EnviousWisprCore",

--- a/Tests/EnviousWisprTests/Architecture/CeilingsTestSupport.swift
+++ b/Tests/EnviousWisprTests/Architecture/CeilingsTestSupport.swift
@@ -10,7 +10,7 @@ import Testing
 /// Skeleton authored in `.codex/2026-05-18-pr5-plus-revision-r2-final.md` § 2.
 enum CeilingsTestSupport {
   static func source(at path: String) throws -> String {
-    try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+    try String(contentsOf: RepoRoot.sourceURL(path), encoding: .utf8)
   }
 
   static func lineCount(in source: String) -> Int {
@@ -177,7 +177,9 @@ enum CeilingsTestSupport {
     // The first non-attribute capture group lands at index 2 because group 1
     // captures the optional access modifier prefix; for `importPattern`, the
     // module name is also at index 2 (after the attrs group).
-    guard match.numberOfRanges > 2, let captureRange = Range(match.range(at: match.numberOfRanges - 1), in: line) else {
+    guard match.numberOfRanges > 2,
+      let captureRange = Range(match.range(at: match.numberOfRanges - 1), in: line)
+    else {
       return nil
     }
     return String(line[captureRange])

--- a/Tests/EnviousWisprTests/Architecture/CrossModulePublicGuardTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/CrossModulePublicGuardTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite struct CrossModulePublicGuardTests {
 
   @Test func noConfessionalCrossModulePublicExists() throws {
-    let sourcesRoot = URL(fileURLWithPath: "Sources")
+    let sourcesRoot = RepoRoot.sourceURL("Sources")
     var offenders: [String] = []
 
     // Exclude executable targets (app shell + XPC services). These are not

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -72,7 +72,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 350,
@@ -84,7 +84,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "EnviousWisprASR",

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -70,7 +70,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 200,
@@ -85,7 +85,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "Foundation", "EnviousWisprAudio", "EnviousWisprASR",

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -199,7 +199,7 @@ import Testing
 }
 
 private func envWisprAppURL() -> URL {
-  URL(fileURLWithPath: "Sources/EnviousWispr/App/EnviousWisprApp.swift")
+  RepoRoot.sourceURL("Sources/EnviousWispr/App/EnviousWisprApp.swift")
 }
 
 private func structBodyOfEnviousWisprApp() throws -> String {

--- a/Tests/EnviousWisprTests/Architecture/HeartPathBreadcrumbLiteralsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/HeartPathBreadcrumbLiteralsTests.swift
@@ -43,7 +43,7 @@ import Testing
 
   @Test func requiredLiteralsPresent() throws {
     let union = try Self.routerSourcePaths
-      .map { try String(contentsOf: URL(fileURLWithPath: $0), encoding: .utf8) }
+      .map { try String(contentsOf: RepoRoot.sourceURL($0), encoding: .utf8) }
       .joined(separator: "\n")
     var missing: [String] = []
     for literal in Self.requiredLiterals {

--- a/Tests/EnviousWisprTests/Architecture/HotkeyControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/HotkeyControllerCeilingsTests.swift
@@ -56,7 +56,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 150,
@@ -68,7 +68,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "Foundation", "EnviousWisprCore", "EnviousWisprServices",

--- a/Tests/EnviousWisprTests/Architecture/MenuBarControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/MenuBarControllerCeilingsTests.swift
@@ -61,7 +61,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 600,
@@ -76,7 +76,7 @@ import Testing
     // in-class non-private method count. The `NSMenuDelegate` conformance is
     // the one allowed extension.
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let pattern = #"^[[:space:]]*extension[[:space:]]+MenuBarController\b[^\n]*"#
     let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
     let ns = source as NSString
@@ -94,7 +94,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "AppKit", "EnviousWisprCore", "EnviousWisprServices", "Foundation",
@@ -130,7 +130,7 @@ import Testing
 /// first inner brace).
 private func classBodyOfMenuBarController() throws -> String {
   let source = try String(
-    contentsOf: URL(fileURLWithPath: "Sources/EnviousWispr/App/MenuBarController.swift"),
+    contentsOf: RepoRoot.sourceURL("Sources/EnviousWispr/App/MenuBarController.swift"),
     encoding: .utf8)
   guard let openRange = source.range(of: "final class MenuBarController: NSObject {") else {
     Issue.record("MenuBarController declaration not found at expected path/shape")

--- a/Tests/EnviousWisprTests/Architecture/RecordingFinalizerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingFinalizerCeilingsTests.swift
@@ -46,7 +46,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 150,
@@ -60,7 +60,7 @@ import Testing
     // Filters comment lines so doc text mentioning the forbidden symbol
     // to explain the constraint does not trigger.
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let code = source.split(separator: "\n", omittingEmptySubsequences: false)
       .filter { line in
         let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -78,7 +78,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "Foundation", "EnviousWisprASR", "EnviousWisprCore",

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -44,7 +44,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 250,
@@ -60,7 +60,7 @@ import Testing
     // dependency on it. Filters comment lines so doc text that NAMES the
     // forbidden symbol (to explain the constraint) does not trigger.
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let code = source.split(separator: "\n", omittingEmptySubsequences: false)
       .filter { line in
         let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -78,7 +78,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "Foundation", "EnviousWisprASR", "EnviousWisprAudio", "EnviousWisprCore",

--- a/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
+++ b/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Resolves the repository root from this file's compile-time location
+/// (`#filePath`), so source-reading freeze / ceiling tests work regardless of
+/// the process working directory.
+///
+/// The old SwiftPM test runner executed from the repo root, so a bare
+/// `URL(fileURLWithPath: "Sources/...")` resolved correctly. `xcodebuild test`
+/// runs with the working directory at `/` (#913 PR3), so those CWD-relative
+/// reads fail. Every source-reading test resolves its repo-relative path
+/// through here instead, making the reads CWD-independent.
+enum RepoRoot {
+  /// This file lives at `<root>/Tests/EnviousWisprTests/Architecture/RepoRoot.swift`,
+  /// so four parent hops reach `<root>`.
+  static let url: URL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()  // Architecture/
+    .deletingLastPathComponent()  // EnviousWisprTests/
+    .deletingLastPathComponent()  // Tests/
+    .deletingLastPathComponent()  // <root>/
+
+  /// Absolute URL for a repo-relative source path (e.g.
+  /// `"Sources/EnviousWispr/App/AppDelegate.swift"`). An already-absolute path
+  /// is returned unchanged, so callers that pass an absolute path (or this
+  /// helper applied twice) resolve identically.
+  static func sourceURL(_ relativePath: String) -> URL {
+    relativePath.hasPrefix("/")
+      ? URL(fileURLWithPath: relativePath)
+      : url.appending(path: relativePath)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
+++ b/Tests/EnviousWisprTests/Architecture/RouterCeilingParser.swift
@@ -22,7 +22,7 @@ import Testing
 enum RouterCeilingParser {
 
   static func classBody(named typeName: String, at path: String) throws -> String {
-    let source = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+    let source = try String(contentsOf: RepoRoot.sourceURL(path), encoding: .utf8)
     // Search the declaration AND balance the body braces over a CODE VIEW
     // (string-literal contents + `//` comments blanked to spaces, length
     // preserved), so a `final class X {` or a stray `{`/`}` inside a comment or

--- a/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
@@ -89,7 +89,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 800,
@@ -104,7 +104,7 @@ import Testing
     // the in-class non-private method count. Only the two Sparkle delegate
     // conformances are sanctioned.
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let pattern = #"^[[:space:]]*extension[[:space:]]+SparkleUpdateController\b"#
     let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
     let ns = source as NSString
@@ -120,7 +120,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "AppKit", "EnviousWisprCore", "EnviousWisprServices", "Foundation", "Sparkle",

--- a/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/WedgeRecoveryRouterCeilingsTests.swift
@@ -45,7 +45,7 @@ import Testing
 
   @Test func lineCount() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
       count <= 115,
@@ -57,7 +57,7 @@ import Testing
 
   @Test func allowedImports() throws {
     let source = try String(
-      contentsOf: URL(fileURLWithPath: Self.sourcePath), encoding: .utf8)
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let actual = RouterCeilingParser.imports(in: source)
     let allowed: Set<String> = [
       "EnviousWisprAudio", "EnviousWisprCore", "EnviousWisprPipeline",


### PR DESCRIPTION
Part of #913 (Xcode-build-engine migration epic, PR3 of 8).

## What
- **CI moves to the Xcode engine.** `pr-check.yml` and `main-post-merge.yml` now install Tuist via mise, `tuist generate --no-open`, then `xcodebuild build` / `xcodebuild test` against `EnviousWispr.xcodeproj` with a DerivedData cache (restore-only on PRs, writer on post-merge). The `build-check` aggregator job id is unchanged, preserving the required-status context. `release.yml` is untouched (release cutover is PR6).
- **Release test action** added to the `EnviousWispr-Release` scheme so post-merge runs release-config tests; `ENABLE_TESTABILITY=YES` is passed on that release **test** step only (the test targets use `@testable import`; Debug enables testability by default, Release does not) — the release **build** step stays non-testable and fully optimized.
- **Freeze/ceiling test fix.** ~102 architecture tests read their own source via CWD-relative paths — they passed under SwiftPM (CWD = repo root) but failed under `xcodebuild test` (CWD = `/`). A shared `#filePath`-derived `RepoRoot` resolver now resolves every repo-relative source read (both shared parsers + each direct reader), making them CWD-independent.
- `.gitignore`: add `.derivedData/`.

## Validation
- `xcodebuild test` (debug): **1492 pass / 0 fail**; (release): green.
- SwiftPM `scripts/swift-test.sh` still green (CWD = repo root path unchanged).
- Codex diff review: clean after fixing two gate issues it caught — (1) a zero-test run could slip the guard (now requires a positive executed-test count), (2) `set -o pipefail` + `echo | grep -q` change-detection could skip required builds via SIGPIPE (now uses here-strings).

## Follow-up (not blocking)
The test targets are app-hosted, so `xcodebuild test` launches the real app. Harmless on ephemeral CI runners (tests pass green), but non-hermetic and it collides with the local dev app's identity on a developer machine. Tracked as a dedicated fix to land before PR4's dictation UAT.