### PR TITLE
feat(settings): unify dev/release settings + canonical defaults source of truth (#923)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -58,6 +58,9 @@ public final class WisprBootstrapper {
     // pipelines (they read its `pasteCompletionRegistry`); `settingsSync` after
     // both pipelines + `setup`.
 
+    // #923: one-time dev→shared settings migration; MUST precede SettingsManager()
+    // (mutates the store it reads). Release/shipped builds no-op. See migration doc.
+    SettingsDefaultsMigration.migrateIfNeeded()
     let settings = SettingsManager()
     let permissions = PermissionsService()
     let keychainManager = KeychainManager()
@@ -493,8 +496,14 @@ public final class WisprBootstrapper {
 /// `@State` on the old App struct) and injects every App-owned home.
 private struct MainWindowRoot: View {
   let b: WisprBootstrapper
-  @State private var isOnboardingPresented: Bool =
-    !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+  @State private var isOnboardingPresented: Bool
+
+  init(b: WisprBootstrapper) {
+    self.b = b
+    // #923: derive from the SettingsManager instance, not a raw `.standard` read
+    // (which on the dev build would hit the wrong per-build store).
+    _isOnboardingPresented = State(initialValue: !b.settings.hasCompletedOnboarding)
+  }
 
   var body: some View {
     UnifiedWindowView()

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -116,7 +116,12 @@ final class OnboardingV2ViewModel {
 
       checklistStatuses[1] = .inProgress
       try await Task.sleep(nanoseconds: 1_500_000_000)
-      settings.llmProvider = .appleIntelligence
+      // #923: Apple Intelligence is now the canonical default
+      // (SettingsDefaultValues.llmProvider), so no write here. Writing the
+      // default would make every onboarded user look "customized" forever,
+      // polluting the default/custom distinction the migration relies on.
+      // Onboarded users get Apple Intelligence via the canonical default; this
+      // step stays a visual checklist beat + telemetry only.
       checklistStatuses[1] = .completed
       TelemetryService.shared.onboardingStepCompleted(step: "ai_config", result: "completed")
 

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -1,0 +1,63 @@
+import AppKit
+import EnviousWisprCore
+
+/// Canonical shipped defaults — the single source of truth for what a fresh
+/// install (or any uncustomized key) resolves to. Founder-ratified 2026-05-30
+/// (#923). `SettingsManager.init` reads every simple-literal fallback from here;
+/// logic-bearing fallbacks (legacy-key migrations, languageMode validation,
+/// What's-New nil-handling) stay as code in the initializer.
+///
+/// Human-readable enumeration of the full set lives in the canonical-defaults
+/// knowledge doc; this enum is the machine source. Keep the two in sync.
+enum SettingsDefaultValues {
+  static let selectedBackend: ASRBackendType = .parakeet
+  static let recordingMode: RecordingMode = .pushToTalk
+
+  // #923: AI polish is ON by default, Apple Intelligence. Previously the cold
+  // fallback was `.none` and onboarding wrote `.appleIntelligence` separately,
+  // which made the real default ambiguous. Apple Intelligence is on-device; on
+  // machines without it the polish limb degrades to raw text (heart path safe).
+  static let llmProvider: LLMProvider = .appleIntelligence
+  static let ollamaModel = "llama3.2"
+
+  static let autoCopyToClipboard = true
+  static let hotkeyEnabled = true
+
+  static let vadAutoStop = false
+  static let vadSilenceTimeout: Double = 1.5
+  static let vadSensitivity: Float = 0.5
+  static let vadEnergyGate = true
+
+  static let cancelKeyCode: Int = 53  // Escape
+  static let cancelModifiersRaw: UInt = 0
+  static let toggleKeyCode: Int = Int(ModifierKeyCodes.rightOption)
+  static let toggleModifiersRaw: UInt = 0
+  static let pushToTalkKeyCode: Int = 49  // Space
+  static let pushToTalkModifiersRaw: UInt = NSEvent.ModifierFlags.option.rawValue
+
+  static let modelUnloadPolicy: ModelUnloadPolicy = .never
+  static let restoreClipboardAfterPaste = true
+
+  static let wordCorrectionEnabled = true
+  static let fillerRemovalEnabled = true
+  // #923: spoken-emoji conversion ON by default. Safe — the formatter fires
+  // ONLY on explicit "<phrase> emoji" triggers; it never infers emoji from
+  // sentiment (personas.md emoji-control-current), so uncustomized users see no
+  // surprise emoji, just gain the explicit-trigger capability.
+  static let emojiFormatterEnabled = true
+
+  static let isDebugModeEnabled = false
+  static let debugLogLevel: DebugLogLevel = .info
+  static let useExtendedThinking = false
+
+  static let whisperKitLanguage = "en"
+  static let languageMode: LanguageMode = .auto
+
+  static let selectedInputDeviceUID = ""
+  static let noiseSuppression = false
+  static let preferredInputDeviceIDOverride = ""
+  static let environmentPreset: EnvironmentPreset = .normal
+
+  static let useStreamingASR = false
+  static let warmEnginePolicy: WarmEnginePolicy = .seconds30
+}

--- a/Sources/EnviousWisprServices/SettingsDefaults.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaults.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Resolves the `UserDefaults` store that backs user preferences. Kept narrow
+/// (Services-internal, not a Core-wide `UserDefaults` extension) so only the
+/// settings layer can reach the shared suite — grounded review flagged a
+/// Core-wide accessor as a footgun for future cache/TCC/debug code (#923).
+///
+/// Both builds resolve to the SAME store (`com.enviouswispr.app`):
+/// - Release build: its own bundle id IS `sharedSuite`, so `.standard`.
+/// - Dev build (`com.enviouswispr.app.dev`): redirects to the shared suite.
+///
+/// Non-sandboxed (verified: no `app-sandbox` entitlement), so opening another
+/// domain by name reads/writes the shared CFPreferences plist at
+/// `~/Library/Preferences/com.enviouswispr.app.plist`. Mirrors the prod/dev
+/// bundle-id branch `KeychainManager` already uses. The explicit bundle-id
+/// check sidesteps the documented `UserDefaults(suiteName:)`-returns-nil-on-
+/// own-bundle-id quirk; nil falls back to `.standard` (per-build, no worse than
+/// today) and the migration logs the degradation.
+enum SettingsDefaults {
+  static let sharedSuite = "com.enviouswispr.app"
+  static let devBundleID = "com.enviouswispr.app.dev"
+
+  static var store: UserDefaults {
+    // ONLY the dev build redirects to the shared suite. Release (its own id IS
+    // sharedSuite), the unit-test runner, and SwiftUI previews all use
+    // `.standard` — so tests never touch the production `com.enviouswispr.app`
+    // store, and release behavior is unchanged. Explicit dev-id gate (not a
+    // fall-through) is what makes that safe.
+    guard Bundle.main.bundleIdentifier == devBundleID else { return .standard }
+    return UserDefaults(suiteName: sharedSuite) ?? .standard
+  }
+}

--- a/Sources/EnviousWisprServices/SettingsDefaultsMigration.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultsMigration.swift
@@ -1,0 +1,66 @@
+import EnviousWisprCore
+import Foundation
+
+/// One-time, effective-state migration that seeds the shared settings store
+/// (`SettingsDefaults.store`) from the dev build's current state when the dev
+/// build's identity was split off the release identity (#913 PR2/PR4 gave the
+/// dev build `com.enviouswispr.app.dev`, splitting its `UserDefaults` away from
+/// the release `com.enviouswispr.app`). #923 reunifies them.
+///
+/// Effective-state, not copy-present-keys: for each unified key, an explicit dev
+/// value carries over (custom is custom); a key the dev store LACKS is CLEARED
+/// from the shared store so the canonical default re-applies. Clearing is what
+/// kills a stale shared value (e.g. an old F8 record-key) the dev build never set.
+///
+/// Sentinel lives in the DEV store, not the shared store, so wiping the release
+/// store (`defaults delete com.enviouswispr.app`) cannot resurrect stale dev
+/// values on the next dev launch.
+public enum SettingsDefaultsMigration {
+  /// Marker that this dev install has yielded its values to the shared store.
+  /// Stored in the dev build's OWN store (`UserDefaults.standard`).
+  static let devSentinelKey = "didYieldToSharedDefaults_v1"
+
+  /// Single source of truth for which keys unify — owned by `SettingsManager`.
+  static var unifiedKeys: [String] { SettingsManager.unifiedDefaultsKeys }
+
+  /// Idempotent, release-safe. MUST run before any `SettingsManager` is built
+  /// (it mutates the store `SettingsManager` will read). Defaults are injectable
+  /// for tests; production uses the real stores.
+  public static func migrateIfNeeded(
+    bundleID: String? = Bundle.main.bundleIdentifier,
+    devStore: UserDefaults = .standard,
+    shared: UserDefaults? = nil
+  ) {
+    let shared = shared ?? SettingsDefaults.store
+    // ONLY the dev build migrates — matches SettingsDefaults.store's dev-id gate.
+    // Release/shipped (its store IS the shared store) and any other identity
+    // (test runner, previews) are no-ops: nothing to migrate, no sentinel written.
+    guard bundleID == SettingsDefaults.devBundleID else { return }
+    // Once per dev install.
+    guard !devStore.bool(forKey: devSentinelKey) else { return }
+
+    var copied = 0
+    var cleared = 0
+    for key in unifiedKeys {
+      if let value = devStore.object(forKey: key) {
+        shared.set(value, forKey: key)  // explicit dev value wins
+        copied += 1
+      } else if shared.object(forKey: key) != nil {
+        shared.removeObject(forKey: key)  // dev rode the default → clear stale shared
+        cleared += 1
+      }
+    }
+    devStore.set(true, forKey: devSentinelKey)
+
+    // Privacy-safe: counts + action only, never values.
+    let copiedCount = copied
+    let clearedCount = cleared
+    Task {
+      await AppLogger.shared.log(
+        "settings unify migration: copied \(copiedCount), cleared \(clearedCount)",
+        level: .info,
+        category: "Settings"
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -45,16 +45,39 @@ public final class SettingsManager {
 
   public var onChange: ((SettingKey) -> Void)?
 
+  /// The store backing all user-preference reads/writes. Injected for testability;
+  /// production resolves to `SettingsDefaults.store` (the build-shared suite, #923).
+  /// EXCEPTION: the per-build `useXPCAudioService` knob deliberately uses
+  /// `UserDefaults.standard` directly, never this store.
+  private let defaults: UserDefaults
+
+  /// The UserDefaults keys SettingsManager owns that are UNIFIED across builds
+  /// (the #923 migration's source of truth). Excludes `useXPCAudioService`
+  /// (per-build XPC debug knob) and `noiseSuppression` (removed/forced-off).
+  public nonisolated static let unifiedDefaultsKeys: [String] = [
+    "selectedBackend", "recordingMode", "llmProvider", "llmModel", "ollamaModel",
+    "autoCopyToClipboard", "hotkeyEnabled", "vadAutoStop", "vadSilenceTimeout",
+    "vadSensitivity", "vadEnergyGate", "onboardingState", "hasCompletedOnboarding",
+    "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
+    "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
+    "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
+    "emojiFormatterEnabled", "isDebugModeEnabled", "debugLogLevel",
+    "useExtendedThinking", "whisperKitLanguage", "languageMode",
+    "selectedInputDeviceUID", "preferredInputDeviceIDOverride", "environmentPreset",
+    "useStreamingASR", "warmEnginePolicy",
+    WhatsNewConstants.lastSeenVersionDefaultsKey,
+  ]
+
   public var selectedBackend: ASRBackendType {
     didSet {
-      UserDefaults.standard.set(selectedBackend.rawValue, forKey: "selectedBackend")
+      defaults.set(selectedBackend.rawValue, forKey: "selectedBackend")
       onChange?(.selectedBackend)
     }
   }
 
   public var recordingMode: RecordingMode {
     didSet {
-      UserDefaults.standard.set(recordingMode.rawValue, forKey: "recordingMode")
+      defaults.set(recordingMode.rawValue, forKey: "recordingMode")
       onChange?(.recordingMode)
     }
   }
@@ -64,7 +87,7 @@ public final class SettingsManager {
       if oldValue != llmProvider {
         TelemetryService.shared.providerChanged(from: oldValue.rawValue, to: llmProvider.rawValue)
       }
-      UserDefaults.standard.set(llmProvider.rawValue, forKey: "llmProvider")
+      defaults.set(llmProvider.rawValue, forKey: "llmProvider")
       // Canonicalize model for the new provider
       if llmProvider == .appleIntelligence {
         llmModel = "apple-intelligence"
@@ -77,65 +100,65 @@ public final class SettingsManager {
 
   public var llmModel: String {
     didSet {
-      UserDefaults.standard.set(llmModel, forKey: "llmModel")
+      defaults.set(llmModel, forKey: "llmModel")
       onChange?(.llmModel)
     }
   }
 
   public var ollamaModel: String {
     didSet {
-      UserDefaults.standard.set(ollamaModel, forKey: "ollamaModel")
+      defaults.set(ollamaModel, forKey: "ollamaModel")
       onChange?(.ollamaModel)
     }
   }
 
   public var autoCopyToClipboard: Bool {
     didSet {
-      UserDefaults.standard.set(autoCopyToClipboard, forKey: "autoCopyToClipboard")
+      defaults.set(autoCopyToClipboard, forKey: "autoCopyToClipboard")
       onChange?(.autoCopyToClipboard)
     }
   }
 
   public var hotkeyEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(hotkeyEnabled, forKey: "hotkeyEnabled")
+      defaults.set(hotkeyEnabled, forKey: "hotkeyEnabled")
       onChange?(.hotkeyEnabled)
     }
   }
 
   public var vadAutoStop: Bool {
     didSet {
-      UserDefaults.standard.set(vadAutoStop, forKey: "vadAutoStop")
+      defaults.set(vadAutoStop, forKey: "vadAutoStop")
       onChange?(.vadAutoStop)
     }
   }
 
   public var vadSilenceTimeout: Double {
     didSet {
-      UserDefaults.standard.set(vadSilenceTimeout, forKey: "vadSilenceTimeout")
+      defaults.set(vadSilenceTimeout, forKey: "vadSilenceTimeout")
       onChange?(.vadSilenceTimeout)
     }
   }
 
   public var vadSensitivity: Float {
     didSet {
-      UserDefaults.standard.set(vadSensitivity, forKey: "vadSensitivity")
+      defaults.set(vadSensitivity, forKey: "vadSensitivity")
       onChange?(.vadSensitivity)
     }
   }
 
   public var vadEnergyGate: Bool {
     didSet {
-      UserDefaults.standard.set(vadEnergyGate, forKey: "vadEnergyGate")
+      defaults.set(vadEnergyGate, forKey: "vadEnergyGate")
       onChange?(.vadEnergyGate)
     }
   }
 
   public var onboardingState: OnboardingState {
     didSet {
-      UserDefaults.standard.set(onboardingState.rawValue, forKey: "onboardingState")
+      defaults.set(onboardingState.rawValue, forKey: "onboardingState")
       // Keep legacy key in sync so any existing observers see the right value.
-      UserDefaults.standard.set(onboardingState == .completed, forKey: "hasCompletedOnboarding")
+      defaults.set(onboardingState == .completed, forKey: "hasCompletedOnboarding")
       onChange?(.onboardingState)
     }
   }
@@ -148,114 +171,116 @@ public final class SettingsManager {
 
   public var cancelKeyCode: UInt16 {
     didSet {
-      UserDefaults.standard.set(Int(cancelKeyCode), forKey: "cancelKeyCode")
+      defaults.set(Int(cancelKeyCode), forKey: "cancelKeyCode")
       onChange?(.cancelKeyCode)
     }
   }
 
   public var cancelModifiers: NSEvent.ModifierFlags {
     didSet {
-      UserDefaults.standard.set(cancelModifiers.rawValue, forKey: "cancelModifiersRaw")
+      defaults.set(cancelModifiers.rawValue, forKey: "cancelModifiersRaw")
       onChange?(.cancelModifiers)
     }
   }
 
   public var toggleKeyCode: UInt16 {
     didSet {
-      UserDefaults.standard.set(Int(toggleKeyCode), forKey: "toggleKeyCode")
+      defaults.set(Int(toggleKeyCode), forKey: "toggleKeyCode")
       onChange?(.toggleKeyCode)
     }
   }
 
   public var toggleModifiers: NSEvent.ModifierFlags {
     didSet {
-      UserDefaults.standard.set(toggleModifiers.rawValue, forKey: "toggleModifiersRaw")
+      defaults.set(toggleModifiers.rawValue, forKey: "toggleModifiersRaw")
       onChange?(.toggleModifiers)
     }
   }
 
   public var pushToTalkKeyCode: UInt16 {
     didSet {
-      UserDefaults.standard.set(Int(pushToTalkKeyCode), forKey: "pushToTalkKeyCode")
+      defaults.set(Int(pushToTalkKeyCode), forKey: "pushToTalkKeyCode")
       onChange?(.pushToTalkKeyCode)
     }
   }
 
   public var pushToTalkModifiers: NSEvent.ModifierFlags {
     didSet {
-      UserDefaults.standard.set(pushToTalkModifiers.rawValue, forKey: "pushToTalkModifiersRaw")
+      defaults.set(pushToTalkModifiers.rawValue, forKey: "pushToTalkModifiersRaw")
       onChange?(.pushToTalkModifiers)
     }
   }
 
   public var modelUnloadPolicy: ModelUnloadPolicy {
     didSet {
-      UserDefaults.standard.set(modelUnloadPolicy.rawValue, forKey: "modelUnloadPolicy")
+      defaults.set(modelUnloadPolicy.rawValue, forKey: "modelUnloadPolicy")
       onChange?(.modelUnloadPolicy)
     }
   }
 
   public var restoreClipboardAfterPaste: Bool {
     didSet {
-      UserDefaults.standard.set(restoreClipboardAfterPaste, forKey: "restoreClipboardAfterPaste")
+      defaults.set(restoreClipboardAfterPaste, forKey: "restoreClipboardAfterPaste")
       onChange?(.restoreClipboardAfterPaste)
     }
   }
 
   public var wordCorrectionEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(wordCorrectionEnabled, forKey: "wordCorrectionEnabled")
+      defaults.set(wordCorrectionEnabled, forKey: "wordCorrectionEnabled")
       onChange?(.wordCorrectionEnabled)
     }
   }
 
   public var fillerRemovalEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(fillerRemovalEnabled, forKey: "fillerRemovalEnabled")
+      defaults.set(fillerRemovalEnabled, forKey: "fillerRemovalEnabled")
       onChange?(.fillerRemovalEnabled)
     }
   }
 
-  /// Spoken-emoji conversion toggle (#341). Default OFF until false-positive
-  /// rate is validated on real corpus per founder direction 2026-05-16.
+  /// Spoken-emoji conversion toggle (#341). Default ON (#923, founder-ratified
+  /// 2026-05-30): safe because the formatter fires only on explicit
+  /// "<phrase> emoji" triggers, never sentiment inference. Canonical default in
+  /// `SettingsDefaultValues.emojiFormatterEnabled`.
   public var emojiFormatterEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(emojiFormatterEnabled, forKey: "emojiFormatterEnabled")
+      defaults.set(emojiFormatterEnabled, forKey: "emojiFormatterEnabled")
       onChange?(.emojiFormatterEnabled)
     }
   }
 
   public var useStreamingASR: Bool {
     didSet {
-      UserDefaults.standard.set(useStreamingASR, forKey: "useStreamingASR")
+      defaults.set(useStreamingASR, forKey: "useStreamingASR")
       onChange?(.useStreamingASR)
     }
   }
 
   public var warmEnginePolicy: WarmEnginePolicy {
     didSet {
-      UserDefaults.standard.set(warmEnginePolicy.rawValue, forKey: "warmEnginePolicy")
+      defaults.set(warmEnginePolicy.rawValue, forKey: "warmEnginePolicy")
       onChange?(.warmEnginePolicy)
     }
   }
 
   public var isDebugModeEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(isDebugModeEnabled, forKey: "isDebugModeEnabled")
+      defaults.set(isDebugModeEnabled, forKey: "isDebugModeEnabled")
       onChange?(.isDebugModeEnabled)
     }
   }
 
   public var debugLogLevel: DebugLogLevel {
     didSet {
-      UserDefaults.standard.set(debugLogLevel.rawValue, forKey: "debugLogLevel")
+      defaults.set(debugLogLevel.rawValue, forKey: "debugLogLevel")
       onChange?(.debugLogLevel)
     }
   }
 
   public var useExtendedThinking: Bool {
     didSet {
-      UserDefaults.standard.set(useExtendedThinking, forKey: "useExtendedThinking")
+      defaults.set(useExtendedThinking, forKey: "useExtendedThinking")
       onChange?(.useExtendedThinking)
     }
   }
@@ -266,7 +291,7 @@ public final class SettingsManager {
   /// one-time migration and will be removed in a later stream.
   public var whisperKitLanguage: String {
     didSet {
-      UserDefaults.standard.set(whisperKitLanguage, forKey: "whisperKitLanguage")
+      defaults.set(whisperKitLanguage, forKey: "whisperKitLanguage")
       onChange?(.whisperKitLanguage)
     }
   }
@@ -277,7 +302,7 @@ public final class SettingsManager {
   public var languageMode: LanguageMode {
     didSet {
       if let data = try? JSONEncoder().encode(languageMode) {
-        UserDefaults.standard.set(data, forKey: "languageMode")
+        defaults.set(data, forKey: "languageMode")
       }
       onChange?(.languageMode)
     }
@@ -285,14 +310,14 @@ public final class SettingsManager {
 
   public var selectedInputDeviceUID: String {
     didSet {
-      UserDefaults.standard.set(selectedInputDeviceUID, forKey: "selectedInputDeviceUID")
+      defaults.set(selectedInputDeviceUID, forKey: "selectedInputDeviceUID")
       onChange?(.selectedInputDeviceUID)
     }
   }
 
   public var noiseSuppression: Bool {
     didSet {
-      UserDefaults.standard.set(noiseSuppression, forKey: "noiseSuppression")
+      defaults.set(noiseSuppression, forKey: "noiseSuppression")
       onChange?(.noiseSuppression)
     }
   }
@@ -300,7 +325,7 @@ public final class SettingsManager {
   /// User override for input device. Empty string means "Auto" (smart selection).
   public var preferredInputDeviceIDOverride: String {
     didSet {
-      UserDefaults.standard.set(
+      defaults.set(
         preferredInputDeviceIDOverride, forKey: "preferredInputDeviceIDOverride")
       onChange?(.preferredInputDeviceIDOverride)
     }
@@ -308,7 +333,7 @@ public final class SettingsManager {
 
   public var environmentPreset: EnvironmentPreset {
     didSet {
-      UserDefaults.standard.set(environmentPreset.rawValue, forKey: "environmentPreset")
+      defaults.set(environmentPreset.rawValue, forKey: "environmentPreset")
       onChange?(.environmentPreset)
     }
   }
@@ -320,6 +345,8 @@ public final class SettingsManager {
   /// Does NOT fire onChange — this is not a live-switchable setting.
   public var useXPCAudioService: Bool {
     didSet {
+      // PER-BUILD EXCEPTION (#923): write to the build's own store, never the
+      // shared `defaults`. Developer XPC debug knob, excluded from unification.
       UserDefaults.standard.set(useXPCAudioService, forKey: "useXPCAudioService")
     }
   }
@@ -328,7 +355,7 @@ public final class SettingsManager {
 
   public var lastSeenWhatsNewVersion: String {
     didSet {
-      UserDefaults.standard.set(
+      defaults.set(
         lastSeenWhatsNewVersion, forKey: WhatsNewConstants.lastSeenVersionDefaultsKey)
       hasUnreadWhatsNew = (lastSeenWhatsNewVersion != WhatsNewConstants.currentContentVersion)
     }
@@ -350,21 +377,37 @@ public final class SettingsManager {
     set { recordingMode = newValue ? .pushToTalk : .toggle }
   }
 
-  public init() {
-    let defaults = UserDefaults.standard
+  /// - Parameter defaults: the store backing all preferences. Pass `nil` (the
+  ///   default) for production (resolves to `SettingsDefaults.store`, the
+  ///   build-shared suite); tests inject a private suite. `nil` (not a direct
+  ///   `SettingsDefaults.store` default arg) keeps the accessor Services-internal.
+  public init(defaults: UserDefaults? = nil) {
+    let defaults = defaults ?? SettingsDefaults.store
+    self.defaults = defaults
     selectedBackend =
-      ASRBackendType(rawValue: defaults.string(forKey: "selectedBackend") ?? "") ?? .parakeet
+      ASRBackendType(rawValue: defaults.string(forKey: "selectedBackend") ?? "")
+      ?? SettingsDefaultValues.selectedBackend
     recordingMode =
-      RecordingMode(rawValue: defaults.string(forKey: "recordingMode") ?? "") ?? .pushToTalk
-    llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .none
+      RecordingMode(rawValue: defaults.string(forKey: "recordingMode") ?? "")
+      ?? SettingsDefaultValues.recordingMode
+    llmProvider =
+      LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "")
+      ?? SettingsDefaultValues.llmProvider
     llmModel = defaults.string(forKey: "llmModel") ?? LLMProvider.defaultModel(for: .openAI)
-    ollamaModel = defaults.string(forKey: "ollamaModel") ?? "llama3.2"
-    autoCopyToClipboard = defaults.object(forKey: "autoCopyToClipboard") as? Bool ?? true
-    hotkeyEnabled = true  // toggle removed; always enabled
-    vadAutoStop = defaults.object(forKey: "vadAutoStop") as? Bool ?? false
-    vadSilenceTimeout = defaults.object(forKey: "vadSilenceTimeout") as? Double ?? 1.5
-    vadSensitivity = defaults.object(forKey: "vadSensitivity") as? Float ?? 0.5
-    vadEnergyGate = defaults.object(forKey: "vadEnergyGate") as? Bool ?? true
+    ollamaModel = defaults.string(forKey: "ollamaModel") ?? SettingsDefaultValues.ollamaModel
+    autoCopyToClipboard =
+      defaults.object(forKey: "autoCopyToClipboard") as? Bool
+      ?? SettingsDefaultValues.autoCopyToClipboard
+    hotkeyEnabled = SettingsDefaultValues.hotkeyEnabled  // toggle removed; always enabled
+    vadAutoStop =
+      defaults.object(forKey: "vadAutoStop") as? Bool ?? SettingsDefaultValues.vadAutoStop
+    vadSilenceTimeout =
+      defaults.object(forKey: "vadSilenceTimeout") as? Double
+      ?? SettingsDefaultValues.vadSilenceTimeout
+    vadSensitivity =
+      defaults.object(forKey: "vadSensitivity") as? Float ?? SettingsDefaultValues.vadSensitivity
+    vadEnergyGate =
+      defaults.object(forKey: "vadEnergyGate") as? Bool ?? SettingsDefaultValues.vadEnergyGate
     // Migrate legacy hasCompletedOnboarding Bool → OnboardingState enum.
     // If the new "onboardingState" key exists, use it directly.
     // Otherwise, fall back to the old Bool (existing users → .completed).
@@ -379,51 +422,65 @@ public final class SettingsManager {
     }
 
     let savedCancelKeyCode = defaults.object(forKey: "cancelKeyCode") as? Int
-    cancelKeyCode = UInt16(savedCancelKeyCode ?? 53)
+    cancelKeyCode = UInt16(savedCancelKeyCode ?? SettingsDefaultValues.cancelKeyCode)
 
     let savedCancelModRaw = defaults.object(forKey: "cancelModifiersRaw") as? UInt
-    cancelModifiers = NSEvent.ModifierFlags(rawValue: savedCancelModRaw ?? 0)
+    cancelModifiers = NSEvent.ModifierFlags(
+      rawValue: savedCancelModRaw ?? SettingsDefaultValues.cancelModifiersRaw)
 
     let savedToggleKeyCode = defaults.object(forKey: "toggleKeyCode") as? Int
-    toggleKeyCode = UInt16(savedToggleKeyCode ?? Int(ModifierKeyCodes.rightOption))
+    toggleKeyCode = UInt16(savedToggleKeyCode ?? SettingsDefaultValues.toggleKeyCode)
 
     let savedToggleModRaw = defaults.object(forKey: "toggleModifiersRaw") as? UInt
-    toggleModifiers = NSEvent.ModifierFlags(rawValue: savedToggleModRaw ?? 0)
+    toggleModifiers = NSEvent.ModifierFlags(
+      rawValue: savedToggleModRaw ?? SettingsDefaultValues.toggleModifiersRaw)
 
     // PTT migration: old modifier-only → new key+modifier format
     let legacyPTTModRaw = defaults.object(forKey: "pushToTalkModifierRaw") as? UInt
     if let legacyMod = legacyPTTModRaw, defaults.object(forKey: "pushToTalkKeyCode") == nil {
       // Migrate old-style modifier-only PTT to modifier+Space
-      pushToTalkKeyCode = 49  // Space
+      pushToTalkKeyCode = UInt16(SettingsDefaultValues.pushToTalkKeyCode)  // Space
       pushToTalkModifiers = NSEvent.ModifierFlags(rawValue: legacyMod)
-      defaults.set(49, forKey: "pushToTalkKeyCode")
+      defaults.set(SettingsDefaultValues.pushToTalkKeyCode, forKey: "pushToTalkKeyCode")
       defaults.set(legacyMod, forKey: "pushToTalkModifiersRaw")
       defaults.removeObject(forKey: "pushToTalkModifierRaw")
       defaults.removeObject(forKey: "pushToTalkModifierKeyCode")
     } else {
       let savedPTTKeyCode = defaults.object(forKey: "pushToTalkKeyCode") as? Int
-      pushToTalkKeyCode = UInt16(savedPTTKeyCode ?? 49)
+      pushToTalkKeyCode = UInt16(savedPTTKeyCode ?? SettingsDefaultValues.pushToTalkKeyCode)
       let savedPTTModRaw = defaults.object(forKey: "pushToTalkModifiersRaw") as? UInt
       pushToTalkModifiers = NSEvent.ModifierFlags(
-        rawValue: savedPTTModRaw ?? NSEvent.ModifierFlags.option.rawValue)
+        rawValue: savedPTTModRaw ?? SettingsDefaultValues.pushToTalkModifiersRaw)
     }
 
     modelUnloadPolicy =
       ModelUnloadPolicy(
         rawValue: defaults.string(forKey: "modelUnloadPolicy") ?? ""
-      ) ?? .never
+      ) ?? SettingsDefaultValues.modelUnloadPolicy
     restoreClipboardAfterPaste =
-      defaults.object(forKey: "restoreClipboardAfterPaste") as? Bool ?? true
-    wordCorrectionEnabled = defaults.object(forKey: "wordCorrectionEnabled") as? Bool ?? true
-    fillerRemovalEnabled = defaults.object(forKey: "fillerRemovalEnabled") as? Bool ?? true
-    emojiFormatterEnabled = defaults.object(forKey: "emojiFormatterEnabled") as? Bool ?? false
-    isDebugModeEnabled = defaults.object(forKey: "isDebugModeEnabled") as? Bool ?? false
+      defaults.object(forKey: "restoreClipboardAfterPaste") as? Bool
+      ?? SettingsDefaultValues.restoreClipboardAfterPaste
+    wordCorrectionEnabled =
+      defaults.object(forKey: "wordCorrectionEnabled") as? Bool
+      ?? SettingsDefaultValues.wordCorrectionEnabled
+    fillerRemovalEnabled =
+      defaults.object(forKey: "fillerRemovalEnabled") as? Bool
+      ?? SettingsDefaultValues.fillerRemovalEnabled
+    emojiFormatterEnabled =
+      defaults.object(forKey: "emojiFormatterEnabled") as? Bool
+      ?? SettingsDefaultValues.emojiFormatterEnabled
+    isDebugModeEnabled =
+      defaults.object(forKey: "isDebugModeEnabled") as? Bool
+      ?? SettingsDefaultValues.isDebugModeEnabled
     debugLogLevel =
       DebugLogLevel(
         rawValue: defaults.string(forKey: "debugLogLevel") ?? ""
-      ) ?? .info
-    useExtendedThinking = defaults.object(forKey: "useExtendedThinking") as? Bool ?? false
-    whisperKitLanguage = defaults.string(forKey: "whisperKitLanguage") ?? "en"
+      ) ?? SettingsDefaultValues.debugLogLevel
+    useExtendedThinking =
+      defaults.object(forKey: "useExtendedThinking") as? Bool
+      ?? SettingsDefaultValues.useExtendedThinking
+    whisperKitLanguage =
+      defaults.string(forKey: "whisperKitLanguage") ?? SettingsDefaultValues.whisperKitLanguage
     // Load languageMode, or migrate from whisperKitLanguage on first launch
     // (Multilingual v1). Both paths normalize (lowercase) and validate against
     // the Whisper-supported 99-lang set; unsupported, empty, or case-variant
@@ -460,12 +517,21 @@ public final class SettingsManager {
       return migrated
     }()
     languageMode = resolvedLanguageMode
-    selectedInputDeviceUID = defaults.string(forKey: "selectedInputDeviceUID") ?? ""
-    noiseSuppression = false
-    preferredInputDeviceIDOverride = defaults.string(forKey: "preferredInputDeviceIDOverride") ?? ""
+    selectedInputDeviceUID =
+      defaults.string(forKey: "selectedInputDeviceUID")
+      ?? SettingsDefaultValues.selectedInputDeviceUID
+    noiseSuppression = SettingsDefaultValues.noiseSuppression
+    preferredInputDeviceIDOverride =
+      defaults.string(forKey: "preferredInputDeviceIDOverride")
+      ?? SettingsDefaultValues.preferredInputDeviceIDOverride
     environmentPreset =
-      EnvironmentPreset(rawValue: defaults.string(forKey: "environmentPreset") ?? "") ?? .normal
-    useXPCAudioService = defaults.object(forKey: "useXPCAudioService") as? Bool ?? true
+      EnvironmentPreset(rawValue: defaults.string(forKey: "environmentPreset") ?? "")
+      ?? SettingsDefaultValues.environmentPreset
+    // PER-BUILD EXCEPTION (#923): useXPCAudioService is a developer XPC debug
+    // knob, NOT a unified user preference — read/write via UserDefaults.standard
+    // (the build's own store), never the shared `defaults`. Matches the bootstrap
+    // read at WisprBootstrapper and stays out of unifiedDefaultsKeys.
+    useXPCAudioService = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
 
     // Migration (issue #614, 2026-05-04): the Formal/Standard/Friendly preset axis and the
     // hidden custom-prompt path were removed. Drop their orphaned UserDefaults keys so the
@@ -477,11 +543,12 @@ public final class SettingsManager {
     // key so existing users with `noiseSuppression=true` are migrated to raw audio on first
     // launch after upgrade. Idempotent: removeObject on an absent key is a no-op.
     defaults.removeObject(forKey: "noiseSuppression")
-    useStreamingASR = defaults.object(forKey: "useStreamingASR") as? Bool ?? false
+    useStreamingASR =
+      defaults.object(forKey: "useStreamingASR") as? Bool ?? SettingsDefaultValues.useStreamingASR
     warmEnginePolicy =
       WarmEnginePolicy(
         rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""
-      ) ?? .seconds30
+      ) ?? SettingsDefaultValues.warmEnginePolicy
 
     // What's New: fresh install (nil) defaults to current version so new users aren't badged.
     let storedWhatsNew =

--- a/Tests/EnviousWisprTests/Pipeline/DictationSessionConfig+TestDefault.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationSessionConfig+TestDefault.swift
@@ -2,7 +2,9 @@ import EnviousWisprCore
 
 extension DictationSessionConfig {
   /// Default snapshot for tests that don't care about specific settings values.
-  /// Mirrors the `SettingsManager` defaults at construction time.
+  /// A deterministic test baseline (polish OFF, no on-device-AI dependency in CI)
+  /// — NOT a mirror of the production `SettingsManager` defaults, which default
+  /// polish to Apple Intelligence and emoji on (#923, SettingsDefaultValues).
   static func testDefault(
     autoCopyToClipboard: Bool = true,
     inputMode: RecordingMode = .pushToTalk,

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -1,0 +1,149 @@
+import AppKit
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #923 — canonical defaults, store routing, exclusions, and the one-time
+/// effective-state migration. Every test uses an ephemeral suite so nothing
+/// touches the host process or the real `com.enviouswispr.app` store.
+@MainActor
+@Suite("SettingsDefaults (#923)")
+struct SettingsDefaultsRoutingTests {
+  init() { _ = NSApplication.shared }  // @MainActor AppKit-touching SUT (swift-patterns)
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.settingsDefaultsTest." + UUID().uuidString
+    let d = UserDefaults(suiteName: name)!
+    d.removePersistentDomain(forName: name)
+    return d
+  }
+
+  // MARK: - Canonical defaults (piece 0)
+
+  @Test("fresh install yields the founder-ratified canonical defaults")
+  func canonicalDefaults() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    // The two #923 corrections:
+    #expect(settings.emojiFormatterEnabled == true)
+    #expect(settings.llmProvider == .appleIntelligence)
+    // Unchanged canonical values (lock them so an accidental flip fails here):
+    #expect(settings.recordingMode == .pushToTalk)
+    #expect(settings.toggleKeyCode == ModifierKeyCodes.rightOption)
+    #expect(settings.cancelKeyCode == 53)
+    #expect(settings.selectedBackend == .parakeet)
+    #expect(settings.wordCorrectionEnabled == true)
+    #expect(settings.fillerRemovalEnabled == true)
+    #expect(settings.autoCopyToClipboard == true)
+    #expect(settings.restoreClipboardAfterPaste == true)
+    #expect(settings.vadAutoStop == false)
+    #expect(settings.vadSilenceTimeout == 1.5)
+    #expect(settings.languageMode == .auto)
+    #expect(settings.warmEnginePolicy == .seconds30)
+    #expect(settings.useStreamingASR == false)
+  }
+
+  // MARK: - Routing
+
+  @Test("writes land in the injected store, not .standard")
+  func writesRouteToInjectedStore() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.toggleKeyCode = 99
+    settings.emojiFormatterEnabled = false
+    #expect(suite.object(forKey: "toggleKeyCode") as? Int == 99)
+    #expect(suite.object(forKey: "emojiFormatterEnabled") as? Bool == false)
+    // Reconstructing from the same suite round-trips the explicit values.
+    let reloaded = SettingsManager(defaults: suite)
+    #expect(reloaded.toggleKeyCode == 99)
+    #expect(reloaded.emojiFormatterEnabled == false)
+  }
+
+  // MARK: - Exclusions (adversarial — these MUST stay per-build)
+
+  @Test("unifiedDefaultsKeys excludes per-build knobs")
+  func exclusionsHold() {
+    let keys = Set(SettingsManager.unifiedDefaultsKeys)
+    #expect(!keys.contains("useXPCAudioService"))
+    #expect(!keys.contains("useXPCASRService"))
+    #expect(!keys.contains("accessibilityWarningDismissed"))
+    #expect(!keys.contains("noiseSuppression"))
+    #expect(!keys.contains("sessionLanguagePriors"))
+  }
+
+  @Test("useXPCAudioService writes to .standard, never the injected store")
+  func useXPCStaysPerBuild() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.useXPCAudioService = false
+    // The per-build knob must NOT land in the injected (shared) suite.
+    #expect(suite.object(forKey: "useXPCAudioService") == nil)
+    #expect(UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool == false)
+    UserDefaults.standard.removeObject(forKey: "useXPCAudioService")  // cleanup
+  }
+
+  // MARK: - Migration (effective-state, dev-store sentinel)
+
+  @Test("dev migration copies explicit values, clears stale shared, sets dev sentinel")
+  func migrationEffectiveState() {
+    let dev = Self.freshSuite()
+    let shared = Self.freshSuite()
+    // dev explicitly chose a record key; shared holds a STALE value dev never set.
+    dev.set(99, forKey: "toggleKeyCode")
+    shared.set(100, forKey: "emojiFormatterEnabled")  // stale-only-in-shared (the F8-class ghost)
+
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
+
+    // explicit dev value carried over:
+    #expect(shared.object(forKey: "toggleKeyCode") as? Int == 99)
+    // stale shared value (absent in dev) cleared so the canonical default re-applies:
+    #expect(shared.object(forKey: "emojiFormatterEnabled") == nil)
+    // sentinel lives in the DEV store, not shared:
+    #expect(dev.bool(forKey: SettingsDefaultsMigration.devSentinelKey) == true)
+    #expect(shared.object(forKey: SettingsDefaultsMigration.devSentinelKey) == nil)
+  }
+
+  @Test("release build is a no-op (no writes, no sentinel)")
+  func migrationReleaseNoOp() {
+    let dev = Self.freshSuite()
+    let shared = Self.freshSuite()
+    dev.set(99, forKey: "toggleKeyCode")
+
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app", devStore: dev, shared: shared)
+
+    #expect(shared.object(forKey: "toggleKeyCode") == nil)
+    #expect(dev.bool(forKey: SettingsDefaultsMigration.devSentinelKey) == false)
+  }
+
+  @Test("idempotent: second run with sentinel set is a no-op")
+  func migrationIdempotent() {
+    let dev = Self.freshSuite()
+    let shared = Self.freshSuite()
+    dev.set(99, forKey: "toggleKeyCode")
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
+    // Change dev AFTER first migration; second run must not re-copy.
+    dev.set(55, forKey: "toggleKeyCode")
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
+    #expect(shared.object(forKey: "toggleKeyCode") as? Int == 99)  // not 55
+  }
+
+  @Test("dev-store sentinel survives a shared-store wipe (no resurrection)")
+  func sentinelSurvivesSharedWipe() {
+    let dev = Self.freshSuite()
+    let shared = Self.freshSuite()
+    dev.set(99, forKey: "toggleKeyCode")
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
+    // Simulate `defaults delete com.enviouswispr.app` (wipe the shared store).
+    shared.removeObject(forKey: "toggleKeyCode")
+    // Next dev launch: sentinel is in the DEV store (untouched), so NO re-copy.
+    SettingsDefaultsMigration.migrateIfNeeded(
+      bundleID: "com.enviouswispr.app.dev", devStore: dev, shared: shared)
+    #expect(shared.object(forKey: "toggleKeyCode") == nil)  // stale dev value NOT resurrected
+  }
+}


### PR DESCRIPTION
Closes #923.

## What
Two coupled fixes the founder ratified 2026-05-30:

**1. Canonical defaults, defined once.** A new `SettingsDefaultValues` is the single source of truth for every shipped default; `SettingsManager` resolves absent keys through it (logic-bearing fallbacks stay as code). Corrects two defaults to product intent:
- **Emoji formatting: off → on.** Safe — the formatter fires only on explicit "<phrase> emoji" triggers, never sentiment inference, so uncustomized users see no surprise emoji.
- **AI polish provider: cold `.none` → `.appleIntelligence`.** The real product default by construction, not a side effect of onboarding. Removed the now-redundant onboarding write so onboarded users stay "uncustomized" (clean default/custom distinction). Apple-Intelligence-unavailable machines degrade to raw text (limb).

**2. Unification.** The #913 PR2/PR4 bundle-id split silently split settings (UserDefaults is per-bundle-id). `SettingsDefaults.store` resolves the backing store: **only** the dev build (`com.enviouswispr.app.dev`) redirects to the shared `com.enviouswispr.app` suite; release, the test runner, and previews use `.standard` (tests never touch the production store). A one-time effective-state migration runs at startup before `SettingsManager`: copies the dev build's explicit values, **clears** shared keys the dev store lacks so the canonical default re-applies (this kills the stale-F8 ghost), with the sentinel in the **dev** store (robust to a release-store wipe). Release builds early-return.

Per-build exceptions stay on `.standard`: `useXPCAudioService`/`useXPCASRService`, `accessibilityWarningDismissed` (TCC-tied), LID priors, machine caches.

## Validation
- **1500 tests pass**, incl. 9 new (canonical defaults, routing, exclusions, effective-state migration, sentinel-survives-shared-wipe).
- **Codex code-diff review: SHIP** (zero real defects); 4 grounded-review rounds → PROCEED-AS-PLANNED; council coverage (unification + defaults dimensions).
- **Live UAT green on a real machine**: heart path intact (record → transcribe → paste), polish ran via Apple Intelligence, 1.77s pipeline. Migration verified empirically — the record key reads Right Option (61), **not the stale F8**; provider Apple Intelligence; emoji on.

## Release obligation
When this ships in a release, add a What's New line: "AI polish and spoken emoji are now on by default; both still controllable in Settings."