### PR TITLE
fix(ui): correct overlay phase labels — polish flip + smooth label-free warm start (#930)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -129,6 +129,31 @@ final class DictationLifecycleCoordinator {
       guard let self else { return }
       self.handleWhisperKit(newState: newState)
     }
+    // #930: the overlay-only sub-status channel. A `.transcribing` →
+    // `.polishing` flip mid-`.finalizing` does NOT change the public
+    // `PipelineState`, so it never reaches `onStateChange`; this dedicated
+    // callback refreshes the overlay label through the same show seam. It is
+    // display-only — wired ONLY to `showOverlayIntent`, never to lifecycle.
+    kernelDriver.onOverlayIntentChange = { [weak self] intent in
+      self?.showOverlayIntent(intent)
+    }
+    whisperKitKernelDriver.onOverlayIntentChange = { [weak self] intent in
+      self?.showOverlayIntent(intent)
+    }
+  }
+
+  /// The single overlay-show seam. Every overlay push — state-handler driven
+  /// (`makeStateChangeHandler`) and sub-status driven (`onOverlayIntentChange`)
+  /// — flows through here so the audio-level provider and lock state are
+  /// threaded identically. `RecordingOverlayPanel.show(intent:)` dedups on its
+  /// current intent, so a redundant identical push is dropped (#930).
+  private func showOverlayIntent(_ intent: OverlayIntent) {
+    let audioCapture = self.audioCapture
+    recordingOverlay.show(
+      intent: intent,
+      audioLevelProvider: { audioCapture.audioLevel },
+      isRecordingLocked: recordingLockedAccess.get()
+    )
   }
 
   // MARK: - Per-pipeline state-change handling
@@ -294,15 +319,7 @@ final class DictationLifecycleCoordinator {
 
   private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
     PipelineStateChangeHandler(
-      showOverlay: { [weak self] intent in
-        guard let self else { return }
-        let audioCapture = self.audioCapture
-        self.recordingOverlay.show(
-          intent: intent,
-          audioLevelProvider: { audioCapture.audioLevel },
-          isRecordingLocked: self.recordingLockedAccess.get()
-        )
-      },
+      showOverlay: { [weak self] intent in self?.showOverlayIntent(intent) },
       cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
       schedulePolishFailedWarning: { [weak self] in
         self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -82,6 +82,18 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   private var lastFiredState: PipelineState
 
+  /// Fired by the finalizing-sub-status observer (`observeFinalizingSubStatus`)
+  /// whenever the overlay's intent should refresh because of a `.transcribing`
+  /// → `.polishing` flip that does NOT change the public `PipelineState` (both
+  /// collapse to `.polishing`, so `onStateChange` never sees it). Display-only
+  /// enrichment: carries NO lifecycle authority and MUST be wired only to the
+  /// overlay show path — never to anything that mutates recording state,
+  /// schedules warnings, or appends transcripts. Distinct from `onStateChange`,
+  /// which carries the public `PipelineState` for lifecycle/menu/window
+  /// consumers (#930).
+  @ObservationIgnored
+  public var onOverlayIntentChange: ((OverlayIntent) -> Void)?
+
   /// Heart-path error sink for the driver's own direct `.asrInterrupted`
   /// captureError emit. Defaulted to the production global so the only behavior
   /// change is testability — the factory threads the same injected sink it
@@ -119,9 +131,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     await (adapter as? any ASREngineCacheModelLoadable)?.prepareModelIfCached()
   }
 
-  /// Begin observing the kernel for `onStateChange` fan-out.
+  /// Begin observing the kernel for `onStateChange` fan-out and overlay
+  /// sub-status flips.
   func start() {
     observeKernelState()
+    observeFinalizingSubStatus()
   }
 
   // MARK: Limb-step accessors (read by `PipelineSettingsSync` + custom-words)
@@ -353,8 +367,25 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     switch kernel.state {
     case .idle, .completed, .cancelled, .discarded, .noSpeech:
       return .hidden
-    case .preparing, .warmingUp:
+    case .warmingUp:
+      // A real model load is running — `runForwardPath` only transitions to
+      // `.warmingUp` when `adapter.readiness != .ready` — so the loading label
+      // is honest.
       return .processing(label: "Preparing dictation...")
+    case .preparing:
+      // `.preparing` is a sub-10ms bookkeeping step (mint session, spawn the
+      // forward path). On a WARM engine (`adapter.readiness == .ready`) no
+      // `.warmingUp` load follows, so "Preparing dictation..." is a phantom
+      // flash on every press (#930). Project straight to the recording pill so
+      // the overlay is created ONCE at press time and the real `.recording`
+      // (same `.recording(audioLevel: 0)` intent) dedups into it — no label,
+      // and no tear-down/rebuild stutter that a `.hidden` projection caused
+      // (UAT 2026-05-31: `.hidden` forced a fresh-create pop; the label flash
+      // was equally unwanted). On a COLD engine a real `.warmingUp` load
+      // follows, so keep the honest loading label.
+      return adapter.readiness == .ready
+        ? .recording(audioLevel: 0)
+        : .processing(label: "Preparing dictation...")
     case .recording:
       // The real level is supplied by `AudioCaptureManager` downstream — the
       // pipeline returns 0 here, exactly as the old Parakeet pipeline did.
@@ -562,6 +593,40 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     onStateChange?(mapped)
   }
 
+  /// Arm a SECOND, separate `withObservationTracking` on
+  /// `kernel.finalizingSubStatus` (NOT `kernel.state`) so the overlay can flip
+  /// "Transcribing…" → "Polishing…" mid-`.finalizing` — a sub-status change the
+  /// public `PipelineState` collapses to `.polishing`, so `observeKernelState`
+  /// never sees it (#930).
+  ///
+  /// Two deliberate shapes:
+  /// 1. Re-arm UNCONDITIONALLY via `defer`, BEFORE the `.finalizing` guard.
+  ///    `finalizingSubStatus` resets to `.transcribing` during
+  ///    `resetSessionState()` at the START of the next session, while the
+  ///    kernel is NOT `.finalizing`; if the re-arm sat behind the guard the
+  ///    observation would silently die after the first session.
+  /// 2. Push the overlay intent ONLY while `kernel.state == .finalizing`, and
+  ///    ONLY through `onOverlayIntentChange` — never `fireStateChangeIfNeeded` /
+  ///    `onStateChange`. The public `PipelineState` fan-out and `ASREventRouter`
+  ///    routing stay byte-identical; this channel is display-only.
+  ///
+  /// A late flip whose `@MainActor` hop lands after a new session is finalizing
+  /// re-reads the CURRENT `overlayIntent`, so the worst case is one redundant
+  /// push of the correct label, which the overlay dedups (`show(intent:)`).
+  private func observeFinalizingSubStatus() {
+    withObservationTracking {
+      _ = kernel.finalizingSubStatus
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        defer { self.observeFinalizingSubStatus() }
+        if self.kernel.state == .finalizing {
+          self.onOverlayIntentChange?(self.overlayIntent)
+        }
+      }
+    }
+  }
+
   /// Apply the session's frozen LLM config to the polish step. Mirrors the
   /// LLM portion of old Parakeet pipeline's `applySessionConfig(_:)`
   /// (old Parakeet pipeline). VAD + device UID portions
@@ -701,8 +766,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // and breaks the `.finalizing` safe point (verified Codex r1 on the
       // attempted Div 3 fix). The user-visible cost of the current
       // collapse is "Polishing..." appears a few hundred ms early in
-      // MainWindow; the `overlayIntent` getter already routes through
-      // `finalizingSubStatus` for the overlay-text path.
+      // MainWindow. The floating OVERLAY does not pay that cost: the
+      // `overlayIntent` getter routes through `finalizingSubStatus`, and the
+      // dedicated `observeFinalizingSubStatus` channel (#930) refreshes the
+      // overlay live on the flip WITHOUT touching this public mapper.
       return .polishing
     case .completed:
       return .complete

--- a/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
@@ -57,6 +57,7 @@ import Testing
     _ = driver.llmPolish
     _ = driver.currentSessionConfig
     driver.onStateChange = { _ in }
+    driver.onOverlayIntentChange = { _ in }  // #930 — App-consumed overlay channel
     driver.setExternalError("probe")
     driver.handleEngineInterruption()
     driver.handleASRServiceInterruption()

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -303,6 +303,116 @@ import Testing
       h.driver.reset()
       #expect(h.driver.lastPolishError == "in-flight polish error")
     }
+
+    // MARK: #930 — overlay phase labels
+
+    @Test(
+      "the finalizing sub-status flip pushes a fresh overlay intent (Transcribing -> Polishing)"
+    )
+    func finalizingSubStatusFlipPushesOverlay() async {
+      let h = makeDriver()
+      var pushed: [OverlayIntent] = []
+      h.driver.onOverlayIntentChange = { pushed.append($0) }
+      // Walk to the finalizing safe-point (sub-status defaults to .transcribing).
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.kernel.testForceTransition(to: .recording))
+      #expect(h.kernel.testForceTransition(to: .stopping))
+      #expect(h.kernel.testForceTransition(to: .transcribing))
+      #expect(h.kernel.testForceTransition(to: .finalizing))
+      // The polish step's onWillProcess equivalent — flip to .polishing.
+      h.kernel.testSetFinalizingSubStatus(.polishing)
+      await drainUntil { pushed.last == .processing(label: "Polishing...") }
+      #expect(
+        pushed.last == .processing(label: "Polishing..."),
+        "a .polishing sub-status while .finalizing must push the Polishing overlay")
+    }
+
+    @Test(
+      "a sub-status flip while NOT finalizing pushes nothing (display-only, guarded)"
+    )
+    func subStatusFlipOutsideFinalizingDoesNotPush() async {
+      let h = makeDriver()
+      var pushed: [OverlayIntent] = []
+      h.driver.onOverlayIntentChange = { pushed.append($0) }
+      // Kernel is at .idle — a sub-status mutation must not reach the overlay.
+      h.kernel.testSetFinalizingSubStatus(.polishing)
+      // Give any scheduled @MainActor hop a chance to land, then assert silence.
+      for _ in 0..<50 { await Task.yield() }
+      #expect(pushed.isEmpty, "no overlay push may fire while the kernel is not finalizing")
+    }
+
+    @Test(
+      "the sub-status observation survives the inter-session reset (two finalizing sessions)"
+    )
+    func subStatusObservationSurvivesInterSessionReset() async {
+      let h = makeDriver()
+      var pushed: [OverlayIntent] = []
+      h.driver.onOverlayIntentChange = { pushed.append($0) }
+      // Session 1 → finalizing → polishing.
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.kernel.testForceTransition(to: .recording))
+      #expect(h.kernel.testForceTransition(to: .stopping))
+      #expect(h.kernel.testForceTransition(to: .transcribing))
+      #expect(h.kernel.testForceTransition(to: .finalizing))
+      h.kernel.testSetFinalizingSubStatus(.polishing)
+      await drainUntil { pushed.last == .processing(label: "Polishing...") }
+      let afterSession1 = pushed.count
+      #expect(afterSession1 >= 1)
+      // End session 1 and reproduce the kill window: the sub-status resets to
+      // .transcribing while the kernel is NOT finalizing (terminal). If the
+      // re-arm sat behind the .finalizing guard, the observation would die here.
+      #expect(h.kernel.testForceTransition(to: .completed))
+      h.kernel.testSetFinalizingSubStatus(.transcribing)
+      for _ in 0..<50 { await Task.yield() }
+      // Session 2 → finalizing → polishing again. The push MUST fire a second
+      // time, proving the observation re-armed across the reset.
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.kernel.testForceTransition(to: .recording))
+      #expect(h.kernel.testForceTransition(to: .stopping))
+      #expect(h.kernel.testForceTransition(to: .transcribing))
+      #expect(h.kernel.testForceTransition(to: .finalizing))
+      h.kernel.testSetFinalizingSubStatus(.polishing)
+      await drainUntil {
+        pushed.count > afterSession1 && pushed.last == .processing(label: "Polishing...")
+      }
+      #expect(
+        pushed.last == .processing(label: "Polishing..."),
+        "session 2's polish flip must still push — the observer survived the reset")
+    }
+
+    @Test(
+      "a WARM .preparing projects straight to the recording pill — no phantom 'preparing' flash, no rebuild stutter"
+    )
+    func warmPreparingProjectsToRecordingPill() async throws {
+      let h = makeDriver()
+      // Warm the engine so `adapter.readiness == .ready` (no .warmingUp follows).
+      try await h.adapter.warmUp()
+      #expect(h.adapter.readiness == .ready)
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      // Same intent the real `.recording` emits, so the overlay is created once
+      // at press time and the real `.recording` dedups into it (UAT 2026-05-31:
+      // `.hidden` here caused a tear-down/rebuild stutter; the label was a
+      // phantom flash). No "Preparing dictation..." label on a warm press.
+      #expect(h.driver.overlayIntent == .recording(audioLevel: 0))
+    }
+
+    @Test("a COLD .preparing keeps the loading label (a real warm-up follows)")
+    func coldPreparingKeepsLoadingLabel() {
+      let h = makeDriver()
+      // Fresh adapter is `.notReady` — a real `.warmingUp` load will follow.
+      #expect(h.adapter.readiness == .notReady)
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.driver.overlayIntent == .processing(label: "Preparing dictation..."))
+    }
+
+    @Test(".warmingUp always keeps the loading label regardless of readiness")
+    func warmingUpKeepsLoadingLabel() {
+      let h = makeDriver()
+      // .warmingUp is only reached on a cold load, so the label is always honest.
+      #expect(h.kernel.testForceTransition(to: .preparing))
+      #expect(h.kernel.testForceTransition(to: .warmingUp))
+      #expect(h.driver.overlayIntent == .processing(label: "Preparing dictation..."))
+    }
   #endif
 
   // MARK: Helpers
@@ -311,6 +421,7 @@ import Testing
     let driver: KernelDictationDriver
     let kernel: RecordingSessionKernel
     let outcome: KernelFinalizationOutcome
+    let adapter: FakeEngine
   }
 
   private func makeDriver() -> Harness {
@@ -340,7 +451,7 @@ import Testing
       kernel: kernel, observer: observer, outcome: outcome,
       context: KernelSessionContext(), steps: steps, adapter: adapter)
     driver.start()
-    return Harness(driver: driver, kernel: kernel, outcome: outcome)
+    return Harness(driver: driver, kernel: kernel, outcome: outcome, adapter: adapter)
   }
 
   private func drainUntil(_ condition: @MainActor () -> Bool) async {


### PR DESCRIPTION
## What

Fixes two floating-pill (overlay) mislabels, both confirmed by live UAT.

**(A) Polish shown as "Transcribing…".** During AI polish the pill stayed on "Transcribing…" the entire wait, because the public pipeline state collapses both finalizing sub-phases to one value, so the kernel-state observer never saw the transcribing→polishing flip. Adds a dedicated, **overlay-only** observation channel (`observeFinalizingSubStatus`) on a second `withObservationTracking` over `kernel.finalizingSubStatus`, pushing a fresh `OverlayIntent` through a new `@ObservationIgnored onOverlayIntentChange` callback. Re-armed unconditionally via `defer` so it survives the inter-session reset. Display-only: never touches `onStateChange` / the public fan-out / ASR-crash routing — the `.finalizing` safe point stays byte-identical.

**(B) Phantom "Preparing dictation…" flash + start stutter on warm presses.** Split the combined `.preparing`/`.warmingUp` arm of the instance `overlayIntent` getter: warm `.preparing` (`adapter.readiness == .ready`) now returns `.recording(audioLevel: 0)` — the **same** intent the real `.recording` emits, so the pill is created **once** at press time and the real `.recording` dedups into it (no label, no rebuild stutter). Cold `.preparing` and all `.warmingUp` keep the honest "Preparing dictation…" load label. The public static `pipelineState(for:)` mapper is untouched (overlay-only scope).

## Why `.recording(0)` and not `.hidden`

Live UAT: projecting warm `.preparing` to `.hidden` removed the label but forced a from-scratch rebuild of the recording pill (visible "splash"/stutter); keeping the label was also unwanted. `.recording(audioLevel: 0)` is the only projection that is both label-free and smooth. Plan §3B "UAT REVISION 2026-05-31" records the reversal.

## Tradeoffs / known edges (founder-accepted)

- Warm `.preparing` → `.recording` announces "Recording started" to VoiceOver ~10 ms before audio truly starts — same bucket as the deferred screen-reader work.
- **Narrow race (Codex, validated unreachable):** if a hands-free lock could land within the ~10 ms warm-startup window, the recording pill could announce twice + rebuild once. A hands-free lock is a double-press; the second tap lands ≥~100 ms after the first, long past that window, so real input cannot reach it. Documented, not fixed.

## Validation

- Logic tests: `scripts/xcode-test.sh` — **1529 pass** (incl. 6 new #930 tests + public-surface probe).
- Grounded review (plan): PROCEED-AS-PLANNED (4 rounds).
- Code-diff review (`.recording` final): one finding, validated unreachable (above).
- Live UAT: founder confirmed polish flip (Transcribing→Polishing) + smooth label-free warm start on the default engine (Parakeet).

## Out of scope

Surfaced a **WhisperKit cold-load deadlock** during UAT (permanent freeze on backend swap; forensics filed to #879). Overlay-only; independent of this PR.

Closes #930