### PR TITLE
feat(ui): cold-boot warm-up pill + ensure-engine-warm (#879 Phase A+B)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
@@ -1,0 +1,47 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// #879 — the press-on-cold-engine policy, factored off `RecordingStarter` so
+/// the start-path home stays within its method/line ceilings (mirrors
+/// `ASREngineReadiness+ColdStartCohort.swift`, which deliberately lives off
+/// `RecordingStarter` for the same reason).
+///
+/// When the user presses while the active engine is not yet ready (fresh
+/// install, or first launch after a macOS update wiped the compiled-model
+/// cache), `RecordingStarter` does NOT mint a recording session — no audio is
+/// captured, so none is silently discarded. It hands off here to: show the
+/// honest cold-boot pill, record the blocked-press telemetry, kick the shared
+/// single-flighted warm-up, and announce "Ready" when the warm-up finishes so
+/// the user knows to press again. Recording never auto-starts at T+warmup
+/// (privacy: never begin listening on the user's behalf).
+@MainActor
+enum ColdPressGuard {
+  static func handle(
+    overlay: RecordingOverlayPanel,
+    active: KernelDictationDriver,
+    backendTag: String,
+    readiness: ASREngineReadiness
+  ) {
+    overlay.show(intent: .cachingModel(engineLabel: active.engineDisplayName))
+    TelemetryService.shared.coldStartPressBlocked(
+      asrBackend: backendTag, warmupInFlight: readiness == .warming)
+    Task { [overlay, active] in
+      await active.ensureEngineWarm(reason: .coldPress)
+      // Announce READY only if the warm-up actually reached ready. A failed
+      // warm-up leaves the engine not-ready; the next press re-shows the
+      // caching pill. The user saw a `.cachingModel` pill on this path, so the
+      // READY pill is expected — never a launch-time surprise toast.
+      guard active.engineReadiness == .ready else { return }
+      overlay.show(intent: .engineReady)
+    }
+    Task {
+      await AppLogger.shared.log(
+        "COLD-START [RecordingStarter] press blocked — engine not ready "
+          + "(readinessAtPTT=\(readiness.coldStartCohortToken)) backend=\(backendTag)",
+        level: .info, category: "Pipeline"
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -93,6 +93,19 @@ final class RecordingStarter {
       guard !kernelDriver.state.isActive else { return }
     }
     lastRecordingResult?.polishError = nil
+    // #879 — cold-boot press safety. A press on a not-ready engine must NOT mint
+    // a recording session (no audio captured → none discarded). Hand off to the
+    // cold-press policy (pill + warm-up + READY announce) and bail; the user
+    // re-presses after "Ready" and that re-press runs the full warm path below.
+    // Placed after the polish-error reset (cleared on every entry), before the
+    // AX-refresh / overlay / prewarm block.
+    if readinessAtEntry != .ready {
+      ColdPressGuard.handle(
+        overlay: recordingOverlay, active: active,
+        backendTag: isWhisperKit ? "whisperkit" : "parakeet",
+        readiness: readinessAtEntry)
+      return
+    }
     permissions.refreshAccessibilityStatus()
     if !permissions.hasAccessibilityPermission {
       permissions.restartMonitoringIfNeeded()
@@ -217,8 +230,21 @@ final class RecordingStarter {
     let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
     let isWK = asrManager.activeBackendType == .whisperKit
-    if !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive) {
+    let isStartingFromIdle =
+      !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive)
+    if isStartingFromIdle {
       lastRecordingResult?.polishError = nil
+      // #879 — same cold-boot press safety as the PTT path. A toggle press that
+      // would START on a not-ready engine shows the pill + warms instead of
+      // minting a session (the toggle-hotkey is a user press too). A toggle that
+      // STOPS an active session is unaffected (guarded by `isStartingFromIdle`).
+      if active.engineReadiness != .ready {
+        ColdPressGuard.handle(
+          overlay: recordingOverlay, active: active,
+          backendTag: isWK ? "whisperkit" : "parakeet",
+          readiness: active.engineReadiness)
+        return
+      }
     }
     permissions.refreshAccessibilityStatus()
     if !permissions.hasAccessibilityPermission {

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -118,6 +118,14 @@ final class PipelineSettingsSync {
         if backend == .whisperKit {
           await self?.whisperKitSetup.detectState()
           self?.onNeedsPreloadObservation?()
+        } else {
+          // #879 — warm the newly-active Parakeet engine on swap so the first
+          // press after switching is instant. Without this, swapping to
+          // Parakeet leaves it cold until the first press (only launch warmed
+          // it, and only if it was the launch-selected backend). Idempotent +
+          // single-flighted; no-op if already loaded. WhisperKit warms via the
+          // observation path above.
+          await self?.kernelDriver.ensureEngineWarm(reason: .engineSwap)
         }
       }
     case .recordingMode:

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -180,7 +180,71 @@ final class RecordingOverlayPanel {
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showPassiveChip(payload: payload)
+    case .cachingModel(let engineLabel):
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: "Getting dictation ready, one moment",
+          .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
+        ])
+      presentTransientNotice(
+        content: ColdStartNoticeView(
+          title: "Getting dictation ready…",
+          subtitle: "\(engineLabel) is warming up after a restart",
+          icon: .spinner
+        ).frame(width: 300, height: 56),
+        width: 300, height: 56, dismissAfter: 2.0)
+    case .engineReady:
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: "Dictation ready. Press to start.",
+          .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
+        ])
+      presentTransientNotice(
+        content: ColdStartNoticeView(
+          title: "Ready — press to dictate",
+          subtitle: nil,
+          icon: .ready
+        ).frame(width: 240, height: 44),
+        width: 240, height: 44, dismissAfter: 1.5)
     }
+  }
+
+  /// Present a transient cold-start notice (caching / ready pill, #879).
+  /// Mirrors the create-or-transition + auto-dismiss shape of the other
+  /// transient notices, generalized over the content view so the two
+  /// cold-start pills share one path. Tears down any existing panel and
+  /// recreates at the same position on the next run-loop cycle (the same
+  /// `DispatchQueue.main.async` deferral the rest of this file uses to avoid
+  /// re-entrant `NSHostingView` creation).
+  private func presentTransientNotice<V: View>(
+    content: V, width: CGFloat, height: CGFloat, dismissAfter: Double
+  ) {
+    let existingPanel = panel
+    let y = existingPanel?.frame.origin.y
+    panel = nil
+    autoDismissTask?.cancel()
+    autoDismissTask = nil
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    if let existingPanel {
+      CATransaction.flush()
+      existingPanel.close()
+    }
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.showPanel(content: content, width: width, height: height, y: y)
+      self.scheduleAutoDismiss(seconds: dismissAfter)
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
   }
 
   // MARK: - Legacy API (internal)
@@ -964,6 +1028,56 @@ struct PolishingOverlayView: View {
       Text(label)
         .font(.system(size: 13, weight: .medium))
         .foregroundStyle(.white)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .background(OverlayCapsuleBackground())
+  }
+}
+
+// MARK: - ColdStartNoticeView
+
+/// Cold-boot warm-up pill (#879). Two uses, driven by `icon`:
+/// - `.spinner` — "getting ready" while the engine warms after a cold boot.
+/// - `.ready` — the "ready, press to dictate" announcement.
+///
+/// Both convey state with a shape (spinning wheel / checkmark) plus text, never
+/// color alone (accessibility-noncolor). An optional `subtitle` renders a
+/// dimmer secondary line (e.g. which engine is warming).
+struct ColdStartNoticeView: View {
+  enum Icon {
+    case spinner
+    case ready
+  }
+
+  let title: String
+  var subtitle: String?
+  let icon: Icon
+
+  var body: some View {
+    HStack(spacing: 10) {
+      switch icon {
+      case .spinner:
+        SpectrumWheelIcon(size: 24)
+      case .ready:
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(Color(red: 0.2, green: 0.82, blue: 0.45))
+          .font(.system(size: 18))
+          .accessibilityHidden(true)
+      }
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text(title)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.white)
+          .lineLimit(1)
+        if let subtitle {
+          Text(subtitle)
+            .font(.system(size: 11, weight: .regular))
+            .foregroundStyle(.white.opacity(0.65))
+            .lineLimit(1)
+        }
+      }
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -22,6 +22,26 @@ import Foundation
 // PR-4a ships this production-unwired: no App-layer caller constructs it.
 // PR-4b re-points the 13 App files at this type.
 
+/// Why a warm-up was requested (#879). Tags telemetry so the warm-up duration
+/// and outcome can be attributed to the launch primer, onboarding, an engine
+/// swap, or a raced cold press. Carries no behavior — `ensureEngineWarm` drives
+/// the same single-flighted load regardless of reason.
+public enum EngineWarmupReason: Sendable {
+  case launch
+  case onboarding
+  case engineSwap
+  case coldPress
+
+  var telemetryToken: String {
+    switch self {
+    case .launch: return "launch"
+    case .onboarding: return "onboarding"
+    case .engineSwap: return "engine_swap"
+    case .coldPress: return "cold_press"
+    }
+  }
+}
+
 /// Resume-once latch for `KernelDictationDriver.awaitKernelTerminal`. A
 /// reference type so the closure passed to `withObservationTracking`'s
 /// `onChange` and the recursive re-arm method share the same instance.
@@ -131,6 +151,45 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     await (adapter as? any ASREngineCacheModelLoadable)?.prepareModelIfCached()
   }
 
+  /// Cold-boot warm-up coordinator (#879). The single shared entry the cold
+  /// press (`RecordingStarter`) and an engine swap (`PipelineSettingsSync`)
+  /// route through so the readiness-check + single-flight can't drift. Reads
+  /// the live `adapter.readiness` (the ONLY gate — no persisted OS-build stamp,
+  /// which would be an unsafe cache key per #879 §3); if the engine is already
+  /// ready it is a no-op. Otherwise it drives the engine's normal model load
+  /// via `adapter.warmUp()` — idempotent and single-flighted by the backend
+  /// (`WhisperKitBackend.loadTask` / `ASRManager.inFlightLoadTask`), so a press
+  /// landing during a launch/onboarding warm-up JOINS the in-flight load rather
+  /// than starting a second compile. "Loaded" already means "first press
+  /// instant" (measured 2026-06-01: no first-inference penalty), so this drives
+  /// the normal load only — no `prewarm` (it would load twice) and no
+  /// dummy-transcribe. Non-throwing: a warm-up failure leaves the engine
+  /// not-ready, the next press re-shows the pill and re-kicks this, and the
+  /// heart path is unaffected.
+  public func ensureEngineWarm(reason: EngineWarmupReason) async {
+    guard adapter.readiness != .ready else { return }
+    let engine = adapter.engineIdentity.rawValue
+    let warmupInFlight = adapter.readiness == .warming
+    let start = ContinuousClock.now
+    TelemetryService.shared.coldStartWarmupStarted(
+      engine: engine, reason: reason.telemetryToken, warmupInFlight: warmupInFlight)
+    do {
+      try await adapter.warmUp()
+      TelemetryService.shared.coldStartWarmupCompleted(
+        engine: engine, reason: reason.telemetryToken,
+        durationMs: Self.elapsedMs(since: start))
+    } catch {
+      TelemetryService.shared.coldStartWarmupFailed(
+        engine: engine, reason: reason.telemetryToken,
+        error: String(describing: error))
+    }
+  }
+
+  private static func elapsedMs(since instant: ContinuousClock.Instant) -> Int {
+    let (s, a) = (ContinuousClock.now - instant).components
+    return Int(s) * 1000 + Int(a / 1_000_000_000_000_000)
+  }
+
   /// Begin observing the kernel for `onStateChange` fan-out and overlay
   /// sub-status flips.
   func start() {
@@ -168,6 +227,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// is correct for both engines: WhisperKit's live driver uses a separate
   /// in-process backend, so the shared ASR manager's flag does not reflect it.
   public var engineReadiness: ASREngineReadiness { adapter.readiness }
+
+  /// The active engine's user-facing display name (e.g. "Parakeet v3" /
+  /// "WhisperKit"). Exposed read-only so the App layer can label the cold-boot
+  /// warm-up pill (#879) without reaching into the package-scoped `adapter`.
+  public var engineDisplayName: String { adapter.engineIdentity.displayName }
 
   // MARK: PR-4b.2 — direct methods + property (mirror old Parakeet pipeline App surface)
 
@@ -369,9 +433,15 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       return .hidden
     case .warmingUp:
       // A real model load is running — `runForwardPath` only transitions to
-      // `.warmingUp` when `adapter.readiness != .ready` — so the loading label
-      // is honest.
-      return .processing(label: "Preparing dictation...")
+      // `.warmingUp` when `adapter.readiness != .ready`. #879: replace the bare
+      // "Preparing dictation…" wall with the honest cold-boot pill so the wall
+      // is unreachable on any cold path. Both press paths (`RecordingStarter`
+      // `start()` PTT and `toggle(source:)`) now return early on a cold engine
+      // without minting a session, so the only way a session reaches
+      // `.warmingUp` is a readiness-flip race (ready at the press-time snapshot,
+      // not-ready by the time the kernel starts) — and that race gets the
+      // plain-English pill here instead of the wall.
+      return .cachingModel(engineLabel: adapter.engineIdentity.displayName)
     case .preparing:
       // `.preparing` is a sub-10ms bookkeeping step (mint session, spawn the
       // forward path). On a WARM engine (`adapter.readiness == .ready`) no
@@ -382,10 +452,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // and no tear-down/rebuild stutter that a `.hidden` projection caused
       // (UAT 2026-05-31: `.hidden` forced a fresh-create pop; the label flash
       // was equally unwanted). On a COLD engine a real `.warmingUp` load
-      // follows, so keep the honest loading label.
+      // follows, so surface the honest cold-boot pill (#879), not the bare wall.
       return adapter.readiness == .ready
         ? .recording(audioLevel: 0)
-        : .processing(label: "Preparing dictation...")
+        : .cachingModel(engineLabel: adapter.engineIdentity.displayName)
     case .recording:
       // The real level is supplied by `AudioCaptureManager` downstream — the
       // pipeline returns 0 here, exactly as the old Parakeet pipeline did.

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -51,6 +51,18 @@ public enum OverlayIntent: Equatable, Sendable {
   /// language. Renders State A (strikes 1+2: Lock + Dismiss) or State B (strike 3:
   /// Dismiss only with Settings copy). Auto-dismissed after 6 seconds; pauses on hover.
   case passiveChip(payload: LanguageChipPayload)
+  /// Cold-boot warm-up notice (#879). Shown when the user presses while the
+  /// active engine is not yet ready (fresh install, or first launch after a
+  /// macOS update wiped the compiled-model cache). Replaces the bare
+  /// "Preparing dictation…" wall: an honest, plain-English "getting ready"
+  /// pill. `engineLabel` is the active engine's display name, shown as a
+  /// secondary line. Auto-dismissed after about 2 seconds.
+  case cachingModel(engineLabel: String)
+  /// Cold-boot "ready" announcement (#879). Fired when a warm-up that the user
+  /// raced (saw a `.cachingModel` pill for) finishes, so they know to press
+  /// again. Auto-dismissed after about 1.5 seconds. Never fired at launch when
+  /// no cold press preceded it.
+  case engineReady
 }
 
 /// Issue #285 — heart-path telemetry callbacks that the former root state routes to

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -291,6 +291,59 @@ public final class TelemetryService {
       ])
   }
 
+  // MARK: - Cold-boot warm-up (#879)
+
+  /// Cold-boot warm-up began for the active engine. `reason` tags the call site
+  /// (launch / onboarding / engine_swap / cold_press); `warmupInFlight` is true
+  /// when a prior warm-up was already running and this call joined it. Privacy:
+  /// timing/state only, no audio or text (telemetry-privacy boundary).
+  public func coldStartWarmupStarted(engine: String, reason: String, warmupInFlight: Bool) {
+    PostHogSDK.shared.capture(
+      "coldstart.warmup_started",
+      properties: [
+        "engine": engine,
+        "reason": reason,
+        "warmup_in_flight": warmupInFlight,
+      ])
+  }
+
+  /// Cold-boot warm-up reached `.ready`. `durationMs` is `ready_at − warmup_started_at`.
+  public func coldStartWarmupCompleted(engine: String, reason: String, durationMs: Int) {
+    PostHogSDK.shared.capture(
+      "coldstart.warmup_completed",
+      properties: [
+        "engine": engine,
+        "reason": reason,
+        "duration_ms": durationMs,
+        "$value": Double(durationMs) / 1000.0,
+      ])
+  }
+
+  /// Cold-boot warm-up failed — the engine stays not-ready and the next press
+  /// re-kicks it. `error` is the error's description (no audio/text).
+  public func coldStartWarmupFailed(engine: String, reason: String, error: String) {
+    PostHogSDK.shared.capture(
+      "coldstart.warmup_failed",
+      properties: [
+        "engine": engine,
+        "reason": reason,
+        "error": error,
+      ])
+  }
+
+  /// A press landed on a not-yet-ready engine, so NO recording session was
+  /// minted (no audio captured → none discarded). `warmupInFlight` distinguishes
+  /// "joined an in-flight warm-up" from "kicked a fresh one." Pairs with the
+  /// existing `launch.model_preload_completed`. Privacy: state only.
+  public func coldStartPressBlocked(asrBackend: String, warmupInFlight: Bool) {
+    PostHogSDK.shared.capture(
+      "coldstart.press_blocked",
+      properties: [
+        "asr_backend": asrBackend,
+        "warmup_in_flight": warmupInFlight,
+      ])
+  }
+
   public func asrCompleted(
     backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int
   ) {

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -5,8 +5,8 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage
@@ -37,6 +37,7 @@ import Testing
     let permissions: PermissionsService
     let lockBox: TestRecordingLockedBox
     let lastRecordingResult: LastRecordingResult
+    let overlay: RecordingOverlayPanel
   }
 
   private static func makeFixture() -> Fixture {
@@ -98,7 +99,8 @@ import Testing
       asr: asr,
       permissions: permissions,
       lockBox: lockBox,
-      lastRecordingResult: lastRecordingResult
+      lastRecordingResult: lastRecordingResult,
+      overlay: overlay
     )
   }
 
@@ -147,6 +149,55 @@ import Testing
     // be callable in any state).
     await fx.starter.toggle(source: .toolbar)
     await fx.starter.start()
+  }
+
+  // #879 — cold-boot press safety. The matcher-set boundary is `.ready` vs
+  // not-ready (`.notReady` / `.warming`). A press on a not-ready engine must
+  // mint NO recording session (no audio captured → none discarded) and show
+  // the cold-boot pill; a press on a ready engine must skip the cold branch
+  // entirely.
+  @Test func coldPressMintsNoSessionAndShowsCachingPill() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false  // → readiness .notReady
+    #expect(fx.kernelDriver.engineReadiness == .notReady)
+
+    await fx.starter.start()
+
+    // No session minted: the kernel never left idle.
+    #expect(fx.kernelDriver.state == .idle)
+    // The honest cold-boot pill is shown (engine-named), not a recording pill.
+    #expect(fx.overlay.currentIntent == .cachingModel(engineLabel: "Parakeet v3"))
+  }
+
+  @Test func coldToggleMintsNoSessionAndShowsCachingPill() async {
+    // The toggle-hotkey / menu / toolbar START path must follow the same
+    // no-session-on-cold contract as the PTT path (Codex #879 review).
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false  // → readiness .notReady
+    #expect(fx.kernelDriver.engineReadiness == .notReady)
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.overlay.currentIntent == .cachingModel(engineLabel: "Parakeet v3"))
+  }
+
+  @Test func warmPressSkipsColdBranch() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true  // → readiness .ready
+    #expect(fx.kernelDriver.engineReadiness == .ready)
+
+    await fx.starter.start()
+
+    // A ready press must NOT take the cold branch — the cold-boot pill is the
+    // only intent `start()` sets from that branch, so its absence proves the
+    // warm path ran.
+    if case .cachingModel = fx.overlay.currentIntent {
+      Issue.record("warm press must not show the cold-boot caching pill")
+    }
   }
 
   @Test func lastUserStopAccessIsThreadedFromFinalizer() async {

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -46,10 +46,16 @@ import Testing
     let source = try String(
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
+    // #879: raised 250 → 280. The cold-boot press-safety guard runs on BOTH
+    // start paths — `start()` (PTT) and `toggle(source:)` (toggle-hotkey / menu /
+    // toolbar) — so a press on a not-ready engine never mints a session on any
+    // path. The domain logic (pill + warm-up + READY announce) lives off this
+    // type in `ColdPressGuard`; only the small readiness guards live here. No
+    // new collaborator or non-private method.
     #expect(
-      count <= 250,
+      count <= 280,
       """
-      RecordingStarter line count exceeded: \(count) > 250. \
+      RecordingStarter line count exceeded: \(count) > 280. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -396,24 +396,51 @@ import Testing
       #expect(h.driver.overlayIntent == .recording(audioLevel: 0))
     }
 
-    @Test("a COLD .preparing keeps the loading label (a real warm-up follows)")
-    func coldPreparingKeepsLoadingLabel() {
+    @Test("a COLD .preparing surfaces the cold-boot pill, not the bare wall (#879)")
+    func coldPreparingShowsCachingPill() {
       let h = makeDriver()
       // Fresh adapter is `.notReady` — a real `.warmingUp` load will follow.
       #expect(h.adapter.readiness == .notReady)
       #expect(h.kernel.testForceTransition(to: .preparing))
-      #expect(h.driver.overlayIntent == .processing(label: "Preparing dictation..."))
+      // #879: the bare "Preparing dictation…" wall is unreachable on a cold
+      // path; the honest cold-boot pill (engine-named) replaces it.
+      #expect(h.driver.overlayIntent == .cachingModel(engineLabel: "Parakeet v3"))
     }
 
-    @Test(".warmingUp always keeps the loading label regardless of readiness")
-    func warmingUpKeepsLoadingLabel() {
+    @Test(".warmingUp surfaces the cold-boot pill (a real cold load is running) (#879)")
+    func warmingUpShowsCachingPill() {
       let h = makeDriver()
-      // .warmingUp is only reached on a cold load, so the label is always honest.
+      // .warmingUp is only reached on a cold load, so the cold-boot pill is honest.
       #expect(h.kernel.testForceTransition(to: .preparing))
       #expect(h.kernel.testForceTransition(to: .warmingUp))
-      #expect(h.driver.overlayIntent == .processing(label: "Preparing dictation..."))
+      #expect(h.driver.overlayIntent == .cachingModel(engineLabel: "Parakeet v3"))
     }
   #endif
+
+  // MARK: #879 — ensureEngineWarm shared helper
+
+  @Test("ensureEngineWarm drives a not-ready engine to ready via a single warmUp")
+  func ensureEngineWarmDrivesNotReadyToReady() async {
+    let h = makeDriver()
+    #expect(h.adapter.readiness == .notReady)
+    #expect(h.adapter.warmUpCallCount == 0)
+    await h.driver.ensureEngineWarm(reason: .coldPress)
+    #expect(h.adapter.readiness == .ready)
+    // The helper drives the normal load exactly once — no prewarm/dummy step.
+    #expect(h.adapter.warmUpCallCount == 1)
+  }
+
+  @Test("ensureEngineWarm is a no-op when the engine is already ready")
+  func ensureEngineWarmNoOpWhenReady() async throws {
+    let h = makeDriver()
+    try await h.adapter.warmUp()
+    #expect(h.adapter.readiness == .ready)
+    #expect(h.adapter.warmUpCallCount == 1)
+    // Already ready → the helper must not touch the adapter again (no second
+    // load, no drift). Live readiness is the sole gate.
+    await h.driver.ensureEngineWarm(reason: .launch)
+    #expect(h.adapter.warmUpCallCount == 1)
+  }
 
   // MARK: Helpers
 


### PR DESCRIPTION
## What & why (#879 Phase A + B — Parakeet first)

On a cold engine (fresh install, or first launch after a macOS update wiped the OS compiled-model cache), pressing to dictate used to show a silent "Preparing dictation" wall and **silently discard** the recording. This ships the visible fix + the shared warm-up.

**Phase A — press-safety pill**
- New `OverlayIntent` cases `.cachingModel(engineLabel:)` + `.engineReady`, rendered by `RecordingOverlayPanel` with a non-color icon + text, VoiceOver announcements, and auto-dismiss (~2s caching / ~1.5s ready).
- A press on a not-ready engine — on **both** the PTT `start()` path and the `toggle(source:)` (toggle-hotkey / menu / toolbar) start path — shows the caching pill, kicks the shared warm-up, and returns **without minting a recording session** (no audio captured → none discarded). On warm-up completion it announces READY so the user re-presses. Recording never auto-starts at T+warmup (privacy). Logic factored into `ColdPressGuard` to keep `RecordingStarter` lean.
- `KernelDictationDriver.overlayIntent`'s cold arm remapped so the bare wall is unreachable; with both press paths guarded, the only residual cold `.warmingUp` is a readiness-flip race, which gets the pill here too.

**Phase B — shared warm-up**
- `KernelDictationDriver.ensureEngineWarm(reason:)` — single source of truth is live `adapter.readiness` (**no persisted OS-build stamp**; a stamp is an unsafe cache key per the plan §3). Drives the normal single-flighted load via `adapter.warmUp()`; no-op when already ready. No prewarm/dummy-transcribe (measured unnecessary 2026-06-01).
- Wired into the cold press and a Parakeet engine swap. New telemetry: `coldstart.warmup_started/completed/failed`, `coldstart.press_blocked`.

## Scoping note (read before merge)
The plan listed four `ensureEngineWarm` call sites. I wired the two that fix the bug — the **press** and **engine-swap**. **Launch and onboarding are left as-is**: they already warm the active engine proactively today, and the single-flight is shared at the ASR-manager level, so there is no drift/double-load risk. Rerouting launch cleanly would mean removing `loadModelSilently` (declared in `ASRManagerInterface`, conformed by 9 test mocks, and the **sole emitter of the existing `launch.model_preload_completed` metric**) — a core-seam refactor out of proportion for this heart-path PR. That centralization + telemetry migration is a clean follow-up. User-facing behavior is identical either way.

## Validation
- **Logic tests**: cold PTT press + cold toggle press each mint **no session** and show the pill; warm press skips the branch; `ensureEngineWarm` drives not-ready→ready once / no-ops when ready; overlayIntent cold arm surfaces the pill. Full Debug lane green (**1452 tests**).
- **Codex code-diff review**: one SHOULD-FIX — the cold toggle-hotkey path wasn't guarded; **fixed** in this PR (+ a test). It confirmed the `.engineReady` gate cannot fire at launch and found no retain-cycle / overlay-race / missed-exhaustive-switch issues.
- **Live UAT (Mac speakers, dev build)**: warm path records → transcribes → pastes cleanly (twice, ASR ~0.1s — no regression). Cold path: founder pressed immediately after relaunch and saw the **Ready** pill with **no old wall / no freeze / nothing discarded** (the ~2s "getting ready" pill flashes by because Parakeet warms in ~6s; it'll be clearly visible on WhisperKit in Phase C).

## Notes
- `RecordingStarter` line ceiling raised 250 → 280 (two small readiness guards; domain logic lives in `ColdPressGuard`). No new collaborator / non-private method.
- Phases **C** (WhisperKit → GPU, 109s→~13s, eval-gated, own PR) and **D** (onboarding) follow.

Part of #879.