### PR TITLE
perf(asr): WhisperKit compute units → GPU (#879 Phase C)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -7,18 +7,30 @@ import Foundation
 // can add real signal-based watchdog recovery without wall-clock timeouts.
 
 /// Hardcoded compute options optimized for Apple Silicon dictation.
-/// Audio encoder + text decoder → Neural Engine, mel spectrogram → GPU.
+/// Audio encoder + text decoder + mel spectrogram → GPU (#879 Phase C).
+///
+/// Moved encoder/decoder off the Neural Engine: the ANE path runs a from-scratch
+/// Espresso→ANE AOT compile on a cold/OS-update-wiped cache that measured ~109s,
+/// blocking the first press behind a long "preparing" window. The GPU path
+/// compiles ~13s cold (measured 2026-06-01) with no first-inference penalty
+/// (ASR 0.70s vs 0.75s) and verbatim jfk output, so the launch warm-up wins the
+/// race against the user's first press. `.cpuAndGPU` requests CPU/GPU placement
+/// and avoids requesting the Neural Engine; CoreML maps that choice per
+/// `MLComputeUnits` semantics on each device (WhisperKit forces CPU-only on the
+/// Simulator). The transcript-quality parity vs the prior ANE path is verified
+/// by live UAT before merge (#879 Phase C gate).
 private let dictationComputeOptions = ModelComputeOptions(
   melCompute: .cpuAndGPU,
-  audioEncoderCompute: .cpuAndNeuralEngine,
-  textDecoderCompute: .cpuAndNeuralEngine
+  audioEncoderCompute: .cpuAndGPU,
+  textDecoderCompute: .cpuAndGPU
 )
 
 /// WhisperKit ASR backend — broad language support with hardcoded dictation-optimized quality.
 ///
 /// Uses Argmax WhisperKit SPM for Whisper-based speech recognition.
 /// Decoding options and compute hardware allocation are hardcoded for optimal
-/// dictation accuracy on Apple Silicon (Neural Engine for encoder/decoder).
+/// dictation accuracy on Apple Silicon (GPU for mel/encoder/decoder — #879
+/// Phase C; the prior Neural Engine path cold-compiled ~109s on a wiped cache).
 ///
 /// The model must be downloaded via WhisperKitSetupService before calling prepare().
 public actor WhisperKitBackend: ASRBackend {


### PR DESCRIPTION
## What & why (#879 Phase C)

Move WhisperKit's audio-encoder + text-decoder from `.cpuAndNeuralEngine` to `.cpuAndGPU` (mel was already GPU). One constant in `WhisperKitBackend.dictationComputeOptions`.

The Neural Engine path runs a from-scratch Espresso→ANE AOT compile on a cold / OS-update-wiped compiled-model cache — measured **~109s**, which is what put a long "preparing" window in front of the first press. The GPU path compiles **~13s** cold (measured 2026-06-01) with **no first-inference penalty** (ASR 0.70s vs 0.75s) and verbatim jfk output, so the Phase A launch warm-up wins the race against the first press. This is what makes Phase A's cold-boot pill a brief flash rather than a long wall on WhisperKit.

`.cpuAndGPU` requests CPU/GPU placement and avoids requesting the ANE; CoreML maps it per `MLComputeUnits` on each device (WhisperKit forces CPU-only on the Simulator).

## Validation
- **Codex code-diff review: clean** (no blockers/should-fix). Confirmed: `dictationComputeOptions` is the single product-side compute source and is applied at load via `WhisperKitConfig(computeOptions:)`; no product source/test hard-assumes ANE for WhisperKit (only the intentionally-untouched `scripts/multilingual-eval` benchmark values); no product branch on compute-unit/ANE availability is affected. One NIT (comment overclaimed "never worse than ANE") fixed.
- **Founder live UAT on the GPU build** (substituting for the formal eval-corpus run, per quality-owner direction): cold-start showed the getting-ready→ready pill then warmed; engine felt **stable and snappy, faster than Neural Engine**; transcript quality reads as well as the ANE path.
- Package builds clean.

## Notes
- One unrelated observation from UAT — WhisperKit occasionally appends a trailing "thank you" (the model's known trailing-silence hallucination, **compute-path independent**, present on ANE too). Tracked separately in #936; not a regression from this change.
- `scripts/multilingual-eval` benchmark values left untouched (would only update if part of a formal eval evidence lane).

Part of #879.