### PR TITLE
refactor(asr): centralize all warm-up entry points through ensureEngineWarm (#879)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -107,47 +107,12 @@ public final class ASRManager: ASRManagerInterface {
     try await task.value
   }
 
-  /// Silent warmup: load the model in the background without mutating UI-visible download state.
-  /// Used at app launch. If a user-initiated load is already in progress, awaits it.
-  /// Issue #445: launch-time telemetry callback. Mirror of `ASRManagerProxy`.
-  public nonisolated(unsafe) static var launchPreloadReporter:
-    (@Sendable (String, String, Int) -> Void)?
-
-  public func loadModelSilently() async {
-    let start = ContinuousClock.now
-    let backendTag = activeBackendType.rawValue
-    if isModelLoaded {
-      Self.report(backend: backendTag, result: "already_loaded", start: start)
-      return
-    }
-    if let existing = inFlightLoadTask {
-      try? await existing.value
-      Self.report(backend: backendTag, result: "joined_in_flight", start: start)
-      return
-    }
-    do {
-      try await loadModel()
-      Self.report(backend: backendTag, result: "success", start: start)
-    } catch {
-      // Silent warmup failure is non-fatal. Record button triggers lazy-load as fallback.
-      Task {
-        await AppLogger.shared.log(
-          "Silent model warmup failed: \(error.localizedDescription)",
-          level: .info, category: "ASRManager"
-        )
-      }
-      Self.report(backend: backendTag, result: "failed", start: start)
-    }
-  }
-
-  private static func report(
-    backend: String, result: String, start: ContinuousClock.Instant
-  ) {
-    let elapsed = ContinuousClock.now - start
-    let (s, a) = elapsed.components
-    let ms = Int(s) * 1_000 + Int(a / 1_000_000_000_000_000)
-    launchPreloadReporter?(backend, result, ms)
-  }
+  // #879: the launch/onboarding warm-up entry (formerly `loadModelSilently` +
+  // the `launchPreloadReporter` callback) moved to the shared
+  // `KernelDictationDriver.ensureEngineWarm(reason:)`, which drives this
+  // `loadModel()` via the adapter and owns the `launch.model_preload_completed`
+  // telemetry for the `.launch` reason. The single-flight (`inFlightLoadTask`)
+  // still makes a press landing during a launch warm-up join the in-flight load.
 
   /// Transcribe raw audio samples (16kHz mono Float32).
   public func transcribe(audioSamples: [Float], options: TranscriptionOptions = .default)

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -21,7 +21,6 @@ public protocol ASRManagerInterface: AnyObject {
 
   // Model lifecycle
   func loadModel() async throws
-  func loadModelSilently() async
   func unloadModel() async  // periphery:ignore - called via existential type (ASRManager idle timer)
   func setInitialBackendType(_ type: ASRBackendType)
   func switchBackend(to type: ASRBackendType) async

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -102,61 +102,12 @@ public final class ASRManagerProxy: ASRManagerInterface {
     try await task.value
   }
 
-  /// Silent warmup: load the model in the background without mutating UI-visible download state.
-  /// Used at app launch. If a user-initiated load is already in progress, awaits it.
-  public func loadModelSilently() async {
-    let start = ContinuousClock.now
-    let backendTag = activeBackendType.rawValue
-    if isModelLoaded {
-      Self.emitLaunchPreloadTelemetry(
-        backend: backendTag, result: "already_loaded", start: start)
-      return
-    }
-    // If a load is already in progress, just await it silently.
-    if let existing = inFlightLoadTask {
-      try? await existing.value
-      Self.emitLaunchPreloadTelemetry(
-        backend: backendTag, result: "joined_in_flight", start: start)
-      return
-    }
-    do {
-      try await loadModel()
-      Self.emitLaunchPreloadTelemetry(backend: backendTag, result: "success", start: start)
-    } catch {
-      // Silent warmup failure is non-fatal. Record button triggers lazy-load as fallback.
-      Task {
-        await AppLogger.shared.log(
-          "Silent model warmup failed: \(error.localizedDescription)",
-          level: .info, category: "ASRManagerProxy"
-        )
-      }
-      Self.emitLaunchPreloadTelemetry(backend: backendTag, result: "failed", start: start)
-    }
-  }
-
-  /// Issue #445: launch-time telemetry callback. Set at app startup by
-  /// AppDelegate (one-line assignment, no former-root-state collaborator growth).
-  /// `EnviousWisprASR` cannot depend on `EnviousWisprServices` per
-  /// architecture-rules.md dependency direction, so the actual PostHog
-  /// emission lives outside this module — we just hand off the timing.
-  ///
-  /// Signature: `(backend, result, durationMs) -> Void`
-  /// `result` is one of "success", "already_loaded", "joined_in_flight", "failed".
-  public nonisolated(unsafe) static var launchPreloadReporter:
-    (@Sendable (String, String, Int) -> Void)?
-
-  /// Self-contained — does NOT grow the former root state. Emits a PostHog event so we can
-  /// finally see launch-time model-load behavior in production (success,
-  /// duration, failure rate). Pre-#445 this path was completely silent on
-  /// success by design.
-  private static func emitLaunchPreloadTelemetry(
-    backend: String, result: String, start: ContinuousClock.Instant
-  ) {
-    let elapsed = ContinuousClock.now - start
-    let (s, a) = elapsed.components
-    let ms = Int(s) * 1_000 + Int(a / 1_000_000_000_000_000)
-    launchPreloadReporter?(backend, result, ms)
-  }
+  // #879: `loadModelSilently` + the `launchPreloadReporter` launch-telemetry
+  // callback were removed here too. The launch/onboarding warm-up entry is now
+  // the shared `KernelDictationDriver.ensureEngineWarm(reason:)`, which drives
+  // `loadModel()` via the adapter and owns `launch.model_preload_completed` for
+  // the `.launch` reason. The `inFlightLoadTask` single-flight is unchanged, so
+  // a press during a launch warm-up still joins the in-flight load.
 
   /// Whether the progress-polling timer is currently scheduled. Internal only
   /// for the #586 regression test that exercises the polling lifecycle without

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -109,22 +109,11 @@ final class AppLifecycleCoordinator {
       NSApp.setActivationPolicy(.accessory)
     }
 
-    // Issue #445: launch-time telemetry callback wiring. ASRManagerProxy/
-    // ASRManager fire this closure from inside `loadModelSilently()` so the
-    // launch-warming path (previously silent on success) becomes visible in
-    // PostHog.
-    ASRManagerProxy.launchPreloadReporter = { backend, result, durationMs in
-      Task { @MainActor in
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: backend, result: result, durationMs: durationMs)
-      }
-    }
-    ASRManager.launchPreloadReporter = { backend, result, durationMs in
-      Task { @MainActor in
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: backend, result: result, durationMs: durationMs)
-      }
-    }
+    // #879: the launch-preload telemetry callback wiring was removed. The
+    // launch warm-up now routes through `KernelDictationDriver.ensureEngineWarm
+    // (reason: .launch)`, which emits `launch.model_preload_completed` directly
+    // (it depends on `EnviousWisprServices`, so no cross-module callback hop is
+    // needed the way the ASR-layer reporter required).
 
     // PR-B.2 of #763: the window-close observer lives on AppWindowCoordinator.
     appWindowCoordinator.installOnLaunch()

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -142,4 +142,13 @@ final class DictationRuntime {
   func cancelRecording() async { await finalizer.cancel() }
 
   func resetActivePipeline() { finalizer.resetActive() }
+
+  /// #879 Phase D — route onboarding's first-run model warm-up through the
+  /// shared `ensureEngineWarm(reason: .onboarding)` on the active engine's
+  /// driver, so the onboarding gate uses the same live-readiness check +
+  /// single-flight + telemetry as every other warm-up site. Returns the outcome
+  /// so the onboarding screen can drive its "download failed → Retry" UX.
+  func ensureActiveEngineWarmForOnboarding() async -> EngineWarmupOutcome {
+    await starter.activeDriver.ensureEngineWarm(reason: .onboarding)
+  }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -48,6 +48,14 @@ final class RecordingStarter {
     }
   }
 
+  /// The driver for the currently-active engine. #879 Phase D — lets the
+  /// runtime route onboarding's first-run warm-up through the active engine's
+  /// shared `ensureEngineWarm`. Computed (not a stored slot or a method), so it
+  /// adds no entanglement to this start-path home.
+  var activeDriver: KernelDictationDriver {
+    asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
+  }
+
   init(
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -157,9 +157,8 @@ public final class WisprBootstrapper {
     // into, not a single-dispatch-surface consolidation (still two drivers).
     // LID-to-polish wiring is
     // owned by `KernelFinalizationWiring.processText` via the
-    // `ASREngineLanguageIdentifying` cast on the adapter; the silent
-    // App-init cache pre-load is owned by the driver's
-    // `prepareBackendSilently()` via the `ASREngineCacheModelLoadable` cast.
+    // `ASREngineLanguageIdentifying` cast on the adapter; the launch warm-up
+    // is owned by the shared `ensureEngineWarm(reason: .launch)` (#879).
     let whisperKitKernelDriver = KernelDictationDriverFactory.makeForWhisperKit(
       inputs: KernelDictationDriverFactory.WhisperKitInputs(
         audioCapture: audioCapture,
@@ -175,13 +174,14 @@ public final class WisprBootstrapper {
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit
     // preload closure. `[weak whisperKitKernelDriver]` so it does not retain it.
-    // PR-5 Rung 5: `prepareBackendSilently()` forwards via the
-    // `ASREngineCacheModelLoadable` cast on the WhisperKit adapter (parity
-    // with OLD `WhisperKitPipeline.prepareBackendSilently()`).
+    // The WhisperKit launch warm-up routes through the shared
+    // `ensureEngineWarm(reason: .launch)` (gated by `SetupCoordinator` on
+    // `setupState == .ready`, so it only fires for a downloaded model — never
+    // an unprompted download for a non-opted-in user).
     let setup = SetupCoordinator(
       asrManager: asrManager,
       preloadAction: { [weak whisperKitKernelDriver] in
-        await whisperKitKernelDriver?.prepareBackendSilently()
+        await whisperKitKernelDriver?.ensureEngineWarm(reason: .launch)
       }
     )
 
@@ -248,11 +248,14 @@ public final class WisprBootstrapper {
     }
 
     // Pre-load the selected backend's model in the background to eliminate
-    // cold-start delay. Parakeet: direct silent load. WhisperKit:
-    // observation-based (waits for setupState to become .ready first).
+    // cold-start delay. Parakeet: shared warm-up via the active driver.
+    // WhisperKit: observation-based (waits for setupState to become .ready
+    // first, then `preloadAction` → `ensureEngineWarm`).
     if settings.selectedBackend == .parakeet {
-      Task { [weak asrManager] in
-        await asrManager?.loadModelSilently()
+      Task { [weak kernelDriver] in
+        // Discard the outcome so the Task's Success type stays Void
+        // (`EngineWarmupOutcome` is @MainActor-only, not Sendable).
+        _ = await kernelDriver?.ensureEngineWarm(reason: .launch)
       }
     }
     Task { [weak setup] in

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1,6 +1,7 @@
 import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprLLM
+import EnviousWisprPipeline
 import EnviousWisprServices
 import IOKit.pwr_mgt
 import SwiftUI
@@ -84,7 +85,15 @@ final class OnboardingV2ViewModel {
   /// Minimum free disk space required for model download + compilation (1 GB).
   private static let requiredDiskSpaceBytes: Int64 = 1_073_741_824
 
-  func startSetup(asrManager: any ASRManagerInterface, settings: SettingsManager) async {
+  /// #879 Phase D — the first-run model warm-up routes through the shared
+  /// `warmUp` closure (the active engine's `ensureEngineWarm(reason: .onboarding)`,
+  /// wired by `DictationRuntime`), so onboarding uses the same live-readiness
+  /// check + single-flight + telemetry as every other warm-up site. The closure
+  /// never throws (the helper reports failure as a value), so this maps a
+  /// `.failed` outcome to the existing "download failed → Retry" UX.
+  func startSetup(
+    warmUp: @MainActor () async -> EngineWarmupOutcome, settings: SettingsManager
+  ) async {
     settings.onboardingState = .settingUp
 
     // Disk space preflight — fail early with a friendly message instead of failing at 80%.
@@ -103,17 +112,32 @@ final class OnboardingV2ViewModel {
     checklistStatuses[0] = .inProgress
     preventSleep()
     startProgressPolling()
-    do {
-      try await asrManager.loadModel()
-      stopProgressPolling()
-      allowSleep()
-      // Check cancellation before advancing — window may have closed during download.
-      try Task.checkCancellation()
-      checklistStatuses[0] = .completed
-      installQuip = ""
-      stopQuipTimer()
-      TelemetryService.shared.onboardingStepCompleted(step: "model_download", result: "completed")
 
+    let outcome = await warmUp()
+    stopProgressPolling()
+    allowSleep()
+
+    // Window may have closed during the warm-up — leave onboardingState as
+    // .settingUp so the next launch re-runs the checklist from scratch (the
+    // model load itself is single-flighted, so it keeps loading in the
+    // background and the relaunch finds it ready / joins it).
+    if Task.isCancelled { return }
+
+    if case .failed(let error) = outcome {
+      let friendly = Self.friendlyError(error)
+      downloadError = friendly
+      rawErrorDetails = "\(error)"
+      checklistStatuses[0] = .error(friendly)
+      return
+    }
+
+    // .ready — the active engine is genuinely warm; advance the checklist beats.
+    checklistStatuses[0] = .completed
+    installQuip = ""
+    stopQuipTimer()
+    TelemetryService.shared.onboardingStepCompleted(step: "model_download", result: "completed")
+
+    do {
       checklistStatuses[1] = .inProgress
       try await Task.sleep(nanoseconds: 1_500_000_000)
       // #923: Apple Intelligence is now the canonical default
@@ -133,18 +157,8 @@ final class OnboardingV2ViewModel {
       try await Task.sleep(nanoseconds: 400_000_000)
       settings.onboardingState = .needsPermissions
       setupPhase = .permissions
-    } catch is CancellationError {
-      stopProgressPolling()
-      allowSleep()
-      // Task was cancelled (window closed mid-setup). Leave onboardingState as .settingUp
-      // so the next launch re-runs the checklist from scratch.
     } catch {
-      stopProgressPolling()
-      allowSleep()
-      let friendly = Self.friendlyError(error)
-      downloadError = friendly
-      rawErrorDetails = "\(error)"
-      checklistStatuses[0] = .error(friendly)
+      // Window closed during the post-warm checklist beats → leave .settingUp.
     }
   }
 
@@ -283,14 +297,13 @@ struct OnboardingV2View: View {
 
   @Environment(SettingsManager.self) private var settings
   @Environment(PermissionsService.self) private var permissions
-  @Environment(\.asrManager) private var asrManagerEnv
+  // #879 Phase D — onboarding's first-run warm-up routes through the shared
+  // `ensureEngineWarm` via `DictationRuntime` (injected by OnboardingWindowRoot),
+  // replacing the prior direct `asrManager.loadModel()`.
+  @Environment(DictationRuntime.self) private var dictationRuntime
   var onComplete: () -> Void
 
   @State private var viewModel = OnboardingV2ViewModel()
-
-  /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
-  /// environment (see `AppEnvironmentKeys.swift`).
-  private var asrManager: any ASRManagerInterface { asrManagerEnv! }
 
   var body: some View {
     ZStack {
@@ -323,7 +336,9 @@ struct OnboardingV2View: View {
         viewModel.downloadError == nil,
         case .pending = viewModel.checklistStatuses[0]
       else { return }
-      await viewModel.startSetup(asrManager: asrManager, settings: settings)
+      await viewModel.startSetup(
+        warmUp: { await dictationRuntime.ensureActiveEngineWarmForOnboarding() },
+        settings: settings)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift
@@ -4,10 +4,12 @@ import Foundation
 // PR-5 Rung 5 (#827) — optional adapter capabilities the kernel-side wiring
 // discovers via `as?` casts. Engines opt in by extending the adapter file
 // with the appropriate `extension` declaration. Parallel to (but separate
-// from) `ASREngineTelemetryProviding` in `KernelTelemetryState.swift`
-// because (a) these protocols expose control data (LID result, cache
-// pre-load) not telemetry, and (b) the cache pre-load is an active
-// lifecycle command, not a passive accessor.
+// from) `ASREngineTelemetryProviding` in `KernelTelemetryState.swift` because
+// these protocols expose control data (LID result) not telemetry.
+//
+// #879: `ASREngineCacheModelLoadable` (the cache-only silent pre-load command)
+// was removed — the launch warm-up now routes through the shared
+// `KernelDictationDriver.ensureEngineWarm(reason:)`.
 
 /// Adapter-side accessor for the engine's last completed language-detection
 /// result. `KernelFinalizationWiring.processText` stamps
@@ -18,16 +20,4 @@ import Foundation
 @MainActor
 protocol ASREngineLanguageIdentifying: AnyObject {
   var lastLanguageDetection: LanguageDetectionResult? { get }
-}
-
-/// Adapter-side silent model pre-load. WhisperKit conforms and loads the
-/// model into RAM from disk cache only (no network download). Parakeet does
-/// not conform — Parakeet's silent load is App-routed via
-/// `asrManager.loadModelSilently()`.
-///
-/// NOT to be confused with `WhisperKitEngineAdapter.warmUpFromCache()`,
-/// which is a readiness refresh, NOT a model pre-load (seam audit §1).
-@MainActor
-protocol ASREngineCacheModelLoadable: AnyObject {
-  func prepareModelIfCached() async
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -42,6 +42,17 @@ public enum EngineWarmupReason: Sendable {
   }
 }
 
+/// The outcome of an `ensureEngineWarm` call. The helper never throws into its
+/// callers (a warm-up failure must not crash the heart-path press), so it
+/// reports the result as a value. Most callers discard it (they re-read live
+/// readiness); onboarding consumes `.failed` to drive its "download failed →
+/// Retry" UX, which needs the underlying error. Not `Sendable` — produced and
+/// consumed on the `@MainActor`.
+public enum EngineWarmupOutcome {
+  case ready
+  case failed(any Error)
+}
+
 /// Resume-once latch for `KernelDictationDriver.awaitKernelTerminal`. A
 /// reference type so the closure passed to `withObservationTracking`'s
 /// `onChange` and the recursive re-arm method share the same instance.
@@ -75,10 +86,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   private let outcome: KernelFinalizationOutcome
   private let steps: LimbSteps
 
-  /// PR-5 Rung 5 (#827): the adapter the kernel drives. Held by the driver
-  /// so `prepareBackendSilently()` can route to the adapter's optional
-  /// `ASREngineCacheModelLoadable` capability. Package-scoped — the only
-  /// reader outside this file is internal-test code in the same module.
+  /// PR-5 Rung 5 (#827): the adapter the kernel drives. Held by the driver so
+  /// `ensureEngineWarm(reason:)` can read its live readiness and drive
+  /// `adapter.warmUp()`. Package-scoped — the only reader outside this file is
+  /// internal-test code in the same module.
   package let adapter: any ASREngineAdapter
 
   /// The per-session context the wiring's closures read (PR-4 §3.3 — "captured
@@ -141,47 +152,63 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     self.lastFiredState = Self.pipelineState(for: kernel.state, externalError: nil)
   }
 
-  /// PR-5 Rung 5 (#827) — silent pre-load entry point matching OLD
-  /// `WhisperKitPipeline.prepareBackendSilently()`. Forwards to the adapter
-  /// only when the adapter caches models (WhisperKit conforms to
-  /// `ASREngineCacheModelLoadable`); no-op for Parakeet (does not conform,
-  /// the cast returns nil). Called from `SetupCoordinator.preloadAction`
-  /// at App init.
-  package func prepareBackendSilently() async {
-    await (adapter as? any ASREngineCacheModelLoadable)?.prepareModelIfCached()
-  }
-
-  /// Cold-boot warm-up coordinator (#879). The single shared entry the cold
-  /// press (`RecordingStarter`) and an engine swap (`PipelineSettingsSync`)
-  /// route through so the readiness-check + single-flight can't drift. Reads
-  /// the live `adapter.readiness` (the ONLY gate — no persisted OS-build stamp,
-  /// which would be an unsafe cache key per #879 §3); if the engine is already
-  /// ready it is a no-op. Otherwise it drives the engine's normal model load
-  /// via `adapter.warmUp()` — idempotent and single-flighted by the backend
-  /// (`WhisperKitBackend.loadTask` / `ASRManager.inFlightLoadTask`), so a press
-  /// landing during a launch/onboarding warm-up JOINS the in-flight load rather
-  /// than starting a second compile. "Loaded" already means "first press
+  /// Cold-boot warm-up coordinator (#879). The SINGLE shared entry every warm-up
+  /// site routes through — launch (`WisprBootstrapper` for Parakeet,
+  /// `SetupCoordinator` for WhisperKit), onboarding (`OnboardingV2View`), engine
+  /// swap (`PipelineSettingsSync`), and the cold press (`RecordingStarter`) — so
+  /// the readiness-check + single-flight + telemetry live in one place and can't
+  /// drift. Reads the live `adapter.readiness` (the ONLY gate — no persisted
+  /// OS-build stamp, which would be an unsafe cache key per #879 §3); if the
+  /// engine is already ready it no-ops. Otherwise it drives the engine's normal
+  /// model load via `adapter.warmUp()` — idempotent and single-flighted by the
+  /// backend (`WhisperKitBackend.loadTask` / `ASRManager.inFlightLoadTask`), so a
+  /// press landing during a launch/onboarding warm-up JOINS the in-flight load
+  /// rather than starting a second compile. "Loaded" already means "first press
   /// instant" (measured 2026-06-01: no first-inference penalty), so this drives
   /// the normal load only — no `prewarm` (it would load twice) and no
-  /// dummy-transcribe. Non-throwing: a warm-up failure leaves the engine
-  /// not-ready, the next press re-shows the pill and re-kicks this, and the
-  /// heart path is unaffected.
-  public func ensureEngineWarm(reason: EngineWarmupReason) async {
-    guard adapter.readiness != .ready else { return }
+  /// dummy-transcribe.
+  ///
+  /// Never throws into callers (a warm-up failure must not crash the heart-path
+  /// press); it returns an `EngineWarmupOutcome` instead. Most callers discard
+  /// it and re-read live readiness; onboarding consumes `.failed` to drive its
+  /// "download failed → Retry" UX. For the `.launch` reason it also emits the
+  /// existing `launch.model_preload_completed` metric (already_loaded /
+  /// joined_in_flight / success / failed) so that dashboard keeps continuity
+  /// after this became the launch warm-up entry (replacing `loadModelSilently`).
+  @discardableResult
+  public func ensureEngineWarm(reason: EngineWarmupReason) async -> EngineWarmupOutcome {
     let engine = adapter.engineIdentity.rawValue
+    if adapter.readiness == .ready {
+      if reason == .launch {
+        TelemetryService.shared.launchModelPreloadCompleted(
+          backend: engine, result: "already_loaded", durationMs: 0)
+      }
+      return .ready
+    }
     let warmupInFlight = adapter.readiness == .warming
     let start = ContinuousClock.now
     TelemetryService.shared.coldStartWarmupStarted(
       engine: engine, reason: reason.telemetryToken, warmupInFlight: warmupInFlight)
     do {
       try await adapter.warmUp()
+      let ms = Self.elapsedMs(since: start)
       TelemetryService.shared.coldStartWarmupCompleted(
-        engine: engine, reason: reason.telemetryToken,
-        durationMs: Self.elapsedMs(since: start))
+        engine: engine, reason: reason.telemetryToken, durationMs: ms)
+      if reason == .launch {
+        TelemetryService.shared.launchModelPreloadCompleted(
+          backend: engine, result: warmupInFlight ? "joined_in_flight" : "success",
+          durationMs: ms)
+      }
+      return .ready
     } catch {
       TelemetryService.shared.coldStartWarmupFailed(
         engine: engine, reason: reason.telemetryToken,
         error: String(describing: error))
+      if reason == .launch {
+        TelemetryService.shared.launchModelPreloadCompleted(
+          backend: engine, result: "failed", durationMs: Self.elapsedMs(since: start))
+      }
+      return .failed(error)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1076,43 +1076,12 @@ extension WhisperKitEngineAdapter: ASREngineTelemetryProviding {}
 
 extension WhisperKitEngineAdapter: ASREngineLanguageIdentifying {}
 
-extension WhisperKitEngineAdapter: ASREngineCacheModelLoadable {
-  /// Silent model pre-load matching the OLD `WhisperKitPipeline.prepareBackendSilently()`
-  /// at `:349-377` byte-for-byte: checks `backend.isReady`, calls
-  /// `backend.prepareIfCached()` (cache-only, no download), logs the three OLD
-  /// messages to AppLogger under the surviving `"WhisperKitPipeline"` category,
-  /// swallows errors. Called from `KernelDictationDriver.prepareBackendSilently()`
-  /// via the `as? any ASREngineCacheModelLoadable` cast on the adapter.
-  package func prepareModelIfCached() async {
-    let isBackendReady = await backend.isReady
-    guard !isBackendReady else { return }
-    do {
-      let loaded = try await backend.prepareIfCached()
-      if loaded {
-        Task {
-          await AppLogger.shared.log(
-            "WhisperKit model pre-loaded successfully (background)",
-            level: .info, category: "WhisperKitPipeline"
-          )
-        }
-      } else {
-        Task {
-          await AppLogger.shared.log(
-            "WhisperKit model not cached, skipping silent pre-load",
-            level: .info, category: "WhisperKitPipeline"
-          )
-        }
-      }
-    } catch {
-      Task {
-        await AppLogger.shared.log(
-          "WhisperKit model pre-load failed: \(error.localizedDescription)",
-          level: .info, category: "WhisperKitPipeline"
-        )
-      }
-    }
-  }
-}
+// #879: the `ASREngineCacheModelLoadable` conformance (`prepareModelIfCached`)
+// was removed with `KernelDictationDriver.prepareBackendSilently()`. WhisperKit's
+// launch warm-up now routes through the shared `ensureEngineWarm(reason: .launch)`
+// (gated by `SetupCoordinator` on `setupState == .ready`), which drives
+// `warmUp()` → `backend.prepare()` (cache-first, with the existing download
+// fallback). The kernel's `preWarm` cache-refresh still uses `warmUpFromCache()`.
 
 // MARK: - Test-only inspectors (`@testable import` reaches `internal`)
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -271,13 +271,12 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("wedge_detected", properties: properties)
   }
 
-  /// Issue #445: launch-time telemetry. Emits when `loadModelSilently()`
-  /// completes (success, already-loaded, or failed) so we can finally see
-  /// what happens during launch warming. Pre-#445 the launch path was
-  /// invisible: `loadModelSilently()` is silent on success by design and
-  /// only logs on failure, so we had zero visibility into how long the
-  /// preload takes, whether it succeeds, or whether different users hit
-  /// different cold-path durations.
+  /// Issue #445 launch-time telemetry, now emitted by the shared
+  /// `KernelDictationDriver.ensureEngineWarm(reason: .launch)` (#879) when it
+  /// drives the launch warm-up — `result` is one of "success",
+  /// "already_loaded", "joined_in_flight", or "failed". Keeps continuity of the
+  /// `launch.model_preload_completed` dashboard after the launch warm-up entry
+  /// moved off `loadModelSilently`.
   public func launchModelPreloadCompleted(
     backend: String, result: String, durationMs: Int
   ) {

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -4,8 +4,8 @@ import EnviousWisprLLM
 import EnviousWisprServices
 import Foundation
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage
@@ -70,7 +70,6 @@ final class RouterTestASRManager: ASRManagerInterface {
   var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
 
   func loadModel() async throws {}
-  func loadModelSilently() async {}
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
   func switchBackend(to type: ASRBackendType) async { activeBackendType = type }

--- a/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
@@ -195,7 +195,6 @@ private final class FactoryFakeASRManager: ASRManagerInterface {
   var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
 
   func loadModel() async throws { fatalError("not used in DictationSessionConfigFactoryTests") }
-  func loadModelSilently() async { fatalError("not used in DictationSessionConfigFactoryTests") }
   func unloadModel() async { fatalError("not used in DictationSessionConfigFactoryTests") }
   func setInitialBackendType(_: ASRBackendType) { fatalError("not used") }
   func switchBackend(to _: ASRBackendType) async { fatalError("not used") }

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -57,14 +57,20 @@ import Testing
       named: "DictationRuntime", at: Self.sourcePath)
     let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
     // Parser counts `func`, not `init` or computed `var` (e.g. hotkeyDescription).
+    // #879: raised 6 → 7 for `ensureActiveEngineWarmForOnboarding()` — the
+    // onboarding screen routes its first-run warm-up through the runtime so it
+    // uses the same shared `ensureEngineWarm` as every other warm-up site. It is
+    // a thin forward to `starter.activeDriver.ensureEngineWarm(.onboarding)`, no
+    // new state.
     #expect(
-      count <= 6,
+      count <= 7,
       """
-      DictationRuntime non-private method ceiling exceeded: \(count) > 6 \
+      DictationRuntime non-private method ceiling exceeded: \(count) > 7 \
       non-private `func` declarations. PR10 baseline: \
       startHotkeyServiceIfEnabled, suspendHotkeys, resumeHotkeys, \
-      toggleRecording, cancelRecording, resetActivePipeline. Raising the \
-      ceiling requires a Bible §30 entry.
+      toggleRecording, cancelRecording, resetActivePipeline; #879 added \
+      ensureActiveEngineWarmForOnboarding. Raising the ceiling requires a \
+      Bible §30 entry.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -46,16 +46,16 @@ import Testing
     let source = try String(
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
-    // #879: raised 250 → 280. The cold-boot press-safety guard runs on BOTH
-    // start paths — `start()` (PTT) and `toggle(source:)` (toggle-hotkey / menu /
-    // toolbar) — so a press on a not-ready engine never mints a session on any
-    // path. The domain logic (pill + warm-up + READY announce) lives off this
-    // type in `ColdPressGuard`; only the small readiness guards live here. No
-    // new collaborator or non-private method.
+    // #879: raised 250 → 280 (cold-boot press-safety guards on both start
+    // paths), then 280 → 285 for the `activeDriver` computed var — a computed
+    // accessor (not a stored slot or method) that lets the runtime route
+    // onboarding's warm-up through the active engine's shared `ensureEngineWarm`.
+    // The domain logic still lives off this type in `ColdPressGuard`; no new
+    // collaborator or non-private method.
     #expect(
-      count <= 280,
+      count <= 285,
       """
-      RecordingStarter line count exceeded: \(count) > 280. \
+      RecordingStarter line count exceeded: \(count) > 285. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -82,7 +82,6 @@ private final class FakeASRManager: ASRManagerInterface {
   var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
 
   func loadModel() async throws { fatalError("not used in SetupCoordinatorTests") }
-  func loadModelSilently() async { fatalError("not used in SetupCoordinatorTests") }
   func unloadModel() async { fatalError("not used in SetupCoordinatorTests") }
   func setInitialBackendType(_: ASRBackendType) { fatalError("not used in SetupCoordinatorTests") }
   func switchBackend(to _: ASRBackendType) async { fatalError("not used in SetupCoordinatorTests") }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -608,7 +608,6 @@ internal final class MockASRManager: ASRManagerInterface {
   }
 
   func loadModel() async throws {}
-  func loadModelSilently() async {}
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
   func switchBackend(to type: ASRBackendType) async { activeBackendType = type }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -356,7 +356,6 @@ private final class NoOpASRManager: ASRManagerInterface {
   var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
 
   func loadModel() async throws {}
-  func loadModelSilently() async {}
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
   func switchBackend(to type: ASRBackendType) async { activeBackendType = type }

--- a/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
@@ -56,7 +56,6 @@ private final class MinimalASRManager: ASRManagerInterface {
   var onServiceInterrupted: (() -> Void)?
 
   func loadModel() async throws {}
-  func loadModelSilently() async {}
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) {}
   func switchBackend(to type: ASRBackendType) async {}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -442,6 +442,34 @@ import Testing
     #expect(h.adapter.warmUpCallCount == 1)
   }
 
+  @Test("ensureEngineWarm reports .ready when the warm-up succeeds")
+  func ensureEngineWarmReportsReady() async {
+    let h = makeDriver()
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .ready = outcome else {
+      Issue.record("expected .ready, got \(outcome)")
+      return
+    }
+    #expect(h.adapter.readiness == .ready)
+  }
+
+  @Test(
+    "ensureEngineWarm reports .failed(error) when warm-up throws — never throws into the caller")
+  func ensureEngineWarmReportsFailedOnThrow() async {
+    // `.wedgeOnLoad` + a prior cancel makes `warmUp()` throw immediately
+    // (`ASREngineError.wedged`). The helper must catch it and surface `.failed`
+    // so onboarding can drive its "download failed → Retry" UX — and the
+    // heart-path press never sees the throw.
+    let h = makeDriver(behavior: .wedgeOnLoad)
+    await h.adapter.cancel()
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .failed = outcome else {
+      Issue.record("expected .failed, got \(outcome)")
+      return
+    }
+    #expect(h.adapter.readiness != .ready)
+  }
+
   // MARK: Helpers
 
   private struct Harness {
@@ -451,8 +479,8 @@ import Testing
     let adapter: FakeEngine
   }
 
-  private func makeDriver() -> Harness {
-    let adapter = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+  private func makeDriver(behavior: FakeEngineBehavior = .batchSuccess(text: "x")) -> Harness {
+    let adapter = FakeEngine(behavior: behavior, clock: FakeClock())
     let kernel = RecordingSessionKernel(
       adapter: adapter,
       audioCapture: FakeAudioCapture(),

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -460,7 +460,6 @@ final class StubParakeetASRManager: ASRManagerInterface {
     loadModelCount += 1
     isModelLoaded = true
   }
-  func loadModelSilently() async {}
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
   func switchBackend(to type: ASRBackendType) async { activeBackendType = type }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -219,10 +219,6 @@ private final class NoOpASRManagerV2: ASRManagerInterface {
     loadProgressTickReporter?(Date(), "test-fake-load")
     isModelLoaded = true
   }
-  func loadModelSilently() async {
-    loadProgressTickReporter?(Date(), "test-fake-load")
-    isModelLoaded = true
-  }
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
   func switchBackend(to type: ASRBackendType) async { activeBackendType = type }


### PR DESCRIPTION
## What & why (#879 — completes the shared warm-up design)

The #879 plan specified **one** warm-up helper that every site routes through, so the readiness-check + single-flight + telemetry can't drift. Phase A+B shipped 2 of the 4 sites (cold press, engine swap) and deferred launch + onboarding for blast-radius. This lands those two — completing the migration per Rule 14 (no clean-up-later), rather than leaving a half-migrated split.

**Routing** — launch (Parakeet via `WisprBootstrapper`, WhisperKit via `SetupCoordinator.preloadAction`), onboarding (`OnboardingV2View` → `DictationRuntime.ensureActiveEngineWarmForOnboarding` → `RecordingStarter.activeDriver`), engine-swap, and the cold press now **all** go through `KernelDictationDriver.ensureEngineWarm(reason:)`.

**Helper** — now returns an `EngineWarmupOutcome` (`.ready` / `.failed(error)`) instead of swallowing silently, so onboarding keeps its "download failed → Retry" UX while still centralizing. Heart-path callers discard it. For the `.launch` reason it emits the existing `launch.model_preload_completed` metric (already_loaded / joined_in_flight / success / failed), preserving that dashboard's continuity.

**Removed (complete migration, no leftovers):** `ASRManagerInterface.loadModelSilently` + both impls + the `launchPreloadReporter` statics + `report` helpers + the `AppLifecycleCoordinator` reporter wiring; the orphaned `KernelDictationDriver.prepareBackendSilently` + the `ASREngineCacheModelLoadable` protocol + its WhisperKit conformance; and 8 test-mock stubs.

## Validation
- **Codex code-diff review: PROCEED — no blockers/should-fix.** Verified no remaining caller of any removed symbol, no lost warm-up path, the WhisperKit launch stays gated (no unprompted download for non-opted-in users), onboarding behavior parity (disk preflight / progress / error+Retry / cancel-resume) holds, launch-metric result strings are on the right branches, and no Sendable hazard from the non-Sendable outcome.
- **Full Debug lane green (1454 tests)**, incl. new `.ready` / `.failed` outcome tests.
- **Live smoke** (WhisperKit-GPU, dev build): launch warm-up warmed the engine; a warm PTT dictation records → transcribes → polishes → pastes cleanly — no heart-path regression.

## Notes
- Ceilings: `DictationRuntime` non-private methods 6→7 (the onboarding forward); `RecordingStarter` lines 280→285 (the `activeDriver` computed accessor). Both justified in-test.
- Codex NIT (kept, not deferred-migration debt): the lower-level `WhisperKitBackend.prepareIfCached()` cache-only primitive lost its production caller with `prepareModelIfCached`'s removal. It's a legitimate, tested backend capability orthogonal to the warm-up-entry concern (a protocol requirement + test-referenced, so Periphery won't flag it), and removing it would churn 5 files and rewrite a doc comment encoding a real race-avoidance invariant. The migration's own plumbing is fully removed. Left as a dormant primitive.

Part of #879.