### PR TITLE
chore(release): What's New notes for v2.1.0

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,45 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.1.0
+
+    Entry(
+      id: "polish-keeps-your-words",
+      icon: "checkmark.shield",
+      title: "Polish keeps your words, not your commands",
+      description:
+        "Dictate something that sounds like an instruction, like \"draft a Slack to Matt about the launch\", and on-device polish used to sometimes go write that message instead of cleaning up what you said. It now recognizes the difference and keeps your actual words.",
+      category: .smarterAIPolish,
+      version: "2.1.0"
+    ),
+    Entry(
+      id: "honest-warm-up-then-instant",
+      icon: "gauge.with.dots.needle.33percent",
+      title: "An honest warm-up, then instant presses",
+      description:
+        "Right after launch the speech engine takes a moment to warm up. You now see a clear indicator while that happens, instead of a start that looks frozen. Once it is warm, every press begins instantly with no flicker.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.0"
+    ),
+    Entry(
+      id: "whisperkit-on-gpu",
+      icon: "bolt",
+      title: "Faster WhisperKit transcription",
+      description:
+        "We moved the WhisperKit speech engine from your Mac's Neural Engine onto its GPU. In our testing that is the faster path for WhisperKit, so transcription warms up and finishes quicker.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.0"
+    ),
+    Entry(
+      id: "steadier-under-the-hood-2-1",
+      icon: "wrench.and.screwdriver",
+      title: "A steadier app under the hood",
+      description:
+        "We finished a major rebuild of how EnviousWispr is assembled and packaged. You won't see it directly, but it makes the app sturdier and lets us ship improvements to you faster and more safely.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.0"
+    ),
+
     // MARK: - v2.0.3
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.0.3"
+  public static let currentContentVersion = "2.1.0"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## What

Adds four user-facing **What's New** entries for the upcoming **v2.1.0** release and bumps `WhatsNewConstants.currentContentVersion` from `2.0.3` to `2.1.0` to match.

Entries (all copy approved verbatim by the founder in-session):
- **Polish keeps your words, not your commands** — on-device polish no longer executes dictated instructions (#832).
- **An honest warm-up, then instant presses** — the honest cold-boot warm-up indicator (#935).
- **Faster WhisperKit transcription** — WhisperKit moved from the Neural Engine onto the GPU (#937).
- **A steadier app under the hood** — the build-engine rebuild (#913).

The dictation-overlay phase-label fix (#930) is intentionally **omitted**: that bug was introduced by the engine refactor and never reached users. The spoken-emoji feature already shipped in v2.0.3, so it is not re-added.

## Lane / process note

Code lane (touches `Sources/`), but this is **copy-only data**: four `Entry` rows + one version-string constant. No logic, types, control-flow, or module-dependency change. Handled per the lightweight path that `whats-new-protocol.md` defines for routine pre-release notes:
- Founder approved the wording verbatim across three review rounds in-session (plan-council would only re-debate copy the owner already signed off).
- Codex diff review: **PASS** (unique ids, every new entry `version: "2.1.0"`, valid category cases, no em/en-dashes, plausible SF Symbols).
- Dev build green; AX visual check confirmed the 2.1.0 section renders at the top with both category groups and the 2.0.3 section below.

## Validation
- [x] Xcode dev build green (post-commit, push-freshness gate satisfied)
- [x] Codex code-diff review clean
- [x] What's New tab visually verified via AX inspection (newest section at top, copy reads cleanly, no truncation)

Refs #931 (pre-release punch list). Does not cut the tag — the founder gates the v2.1.0 release.