### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.3</string>
+	<string>2.1.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary

Version bump to v2.1.0 (Info.plist `CFBundleShortVersionString` + `CFBundleVersion`, 2.0.3 -> 2.1.0).

What's New content for 2.1.0 (the four entries + `currentContentVersion` bump) already landed on main via #943, so this PR is the version-bump-only step that precedes the `v2.1.0` tag.

Ships to users since v2.0.3: on-device polish keeping dictated words instead of executing commands (#832), the honest cold-boot warm-up indicator (#935), the WhisperKit Neural-Engine-to-GPU move (#937), and the build-engine rebuild (#913).

## Test plan
- [x] scripts/build-dev-app.sh — built locally (post-commit, push-freshness gate satisfied)
- [ ] build-check CI passes on this PR
- [ ] Tag v2.1.0 after merge triggers release pipeline