### PR TITLE
chore(release): update appcast for v2.1.0

### DIFF
--- a/website/public/appcast.xml
+++ b/website/public/appcast.xml
@@ -428,5 +428,18 @@
       />
     </item>
 
+        <item>
+      <title>Version 2.1.0</title>
+      <pubDate>Mon, 01 Jun 2026 20:12:56 -0400</pubDate>
+      <sparkle:version>2.1.0</sparkle:version>
+      <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
+      <enclosure
+        url="https://github.com/saurabhav88/EnviousWispr/releases/download/v2.1.0/EnviousWispr-2.1.0.dmg"
+        length="51179724"
+        type="application/octet-stream"
+        sparkle:edSignature="liiygLpdZGM5MTWlcC6vK1RSTRTHZ52N703dtz6pGGqEZduKSbChknMXubgOhptq3Qm28lvY3IJQP0UZxK5jDA=="
+      />
+    </item>
+
     </channel>
 </rss>


### PR DESCRIPTION
Publishes the Sparkle appcast entry for **v2.1.0** so existing users receive the auto-update.

The release pipeline (run 26789988444) shipped the GitHub Release + DMG successfully, but the `publish-appcast` limb failed: the direct bot push to main was rejected and the PR-fallback could not open a PR (`Resource not accessible by integration` — the workflow token lacks PR-create permission). The fallback did push the correct appcast change to this branch; merging it manually completes delivery.

Adds one `<item>`: `sparkle:version` 2.1.0, enclosure -> `releases/download/v2.1.0/EnviousWispr-2.1.0.dmg` (length 51179724, EdDSA-signed). No other changes.

Follow-up (separate issue): fix the appcast job's token so direct-push / PR-fallback works unattended.