### PR TITLE
feat(release): 2.1.1 — safe-update floor + spoken-form transformations notes (#953)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,12 @@ jobs:
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           VERSION: ${{ needs.preflight.outputs.version }}
+          # Issue #953: when set, forces hosts BELOW this version onto Sparkle's
+          # attended (prompted) update path instead of a silent background install
+          # (Sparkle marks the item a majorUpgrade -> SPUAutomaticUpdateDriver defers).
+          # Set deliberately per high-risk release (bundle/signing/installer/size change);
+          # leave empty for ordinary patches. Empty -> element omitted entirely.
+          SPARKLE_MIN_AUTOUPDATE_VERSION: "2.1.0"
         run: |
           DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
           DMG_SIZE=$(stat -f%z "$DMG_PATH")
@@ -343,13 +349,20 @@ jobs:
             exit 1
           fi
 
+          # Issue #953: optional major-upgrade floor. Build the element only when set;
+          # an empty element behaves like "absent" to Sparkle but we omit it cleanly.
+          MIN_AUTOUPDATE_ELEMENT=""
+          if [[ -n "${SPARKLE_MIN_AUTOUPDATE_VERSION}" ]]; then
+            MIN_AUTOUPDATE_ELEMENT=$'\n                '"<sparkle:minimumAutoupdateVersion>${SPARKLE_MIN_AUTOUPDATE_VERSION}</sparkle:minimumAutoupdateVersion>"
+          fi
+
           mkdir -p build
           cat > build/appcast-entry.xml << ENTRY
               <item>
                 <title>Version ${VERSION}</title>
                 <pubDate>${DATE}</pubDate>
                 <sparkle:version>${VERSION}</sparkle:version>
-                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>${MIN_AUTOUPDATE_ELEMENT}
                 <enclosure
                   url="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/EnviousWispr-${VERSION}.dmg"
                   length="${DMG_SIZE}"

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,27 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.1.1
+
+    Entry(
+      id: "speak-naturally-see-it-written",
+      icon: "textformat.123",
+      title: "Speak it naturally, see it written",
+      description:
+        "EnviousWispr now formats what you dictate the way you actually mean it, automatically: phone numbers, money, percentages, years, dates, times, ordinals, decimals, number ranges, emails, and web addresses. Say \"five five five, one two three, four five six seven\" and you get 555-123-4567; \"eighty million dollars\" becomes $80 million; \"nineteen eighty seven\" becomes 1987. It even works when AI polish is turned off.",
+      category: .newFeatures,
+      version: "2.1.1"
+    ),
+    Entry(
+      id: "more-reliable-updates",
+      icon: "arrow.triangle.2.circlepath",
+      title: "More reliable updates",
+      description:
+        "We improved how EnviousWispr installs new versions, so updates land cleanly instead of getting stuck partway. And if an update ever has trouble, the copy you already have keeps working.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.1"
+    ),
+
     // MARK: - v2.1.0
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.1.0"
+  public static let currentContentVersion = "2.1.1"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
Closes #953.

## What this ships (2.1.1)
1. **Auto-update reliability fix (#953):** the appcast generator now stamps `<sparkle:minimumAutoupdateVersion>` (set to `2.1.0` this release). Hosts below 2.1.0 are routed to Sparkle's **attended/prompted** update path instead of the silent background install that bricked users on the big-bundle v2.1.0 jump. Empty value -> element omitted (ordinary patches unaffected). Generator is the safety-critical piece: a keyless newer item would let 2.0.x hosts re-select silent (`SUAppcastDriver.m:230-246,525-534`).
2. **Transformation release notes:** What's New entry covering the spoken-form formatting that merged since v2.1.0 (#951 ITN + #952 classifier): phone numbers, money, percentages, years, dates, times, ordinals, decimals, number ranges, emails, web addresses.
3. Version bump 2.1.0 -> 2.1.1; `currentContentVersion` -> 2.1.1.

## Validation (local)
- **Generator:** ran the heredoc with the floor set and empty -> element emitted once / omitted cleanly; both XML-valid (Codex re-confirmed via xmllint).
- **Sparkle routing:** scratch program against real Sparkle 2.9.1 `SUStandardVersionComparator` -> hosts 1.9.4/2.0.0/2.0.3/2.0.4 route to attended; 2.1.0/2.1.1 do not; keyless control stays silent.
- **Banner unaffected:** widget code untouched; non-critical updates still surface via our banner (we are not marking critical).
- **Build:** `build-dev-app.sh` green, bundle 2.1.1. **Tests:** `xcode-test.sh` 1557 passed. **What's New visual check:** 2.1.1 section renders, fake 555 example, no real number, no em/en-dashes.
- **Codex code-diff review:** CLEAN.

## Notes
- Honest limit (documented in #953): already-staged install-on-quit payloads are rescued by nothing; those users re-download. Verified `FALSE` that a new version cancels a staged install (`SPUUpdater.m:904-909`).
- Reviews: council `sparkle-minimum-autoupdate-2026-06-03`; grounded review `docs/audits/2026-06-03-issue-953-grounded-review{,-r2}.txt` (PROCEED-AS-PLANNED).