### PR TITLE
feat(update): proactive update awareness — hourly checks + launch/foreground triggers + Settings row (#958)

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -44,5 +44,11 @@
 	<string>$(SU_FEED_URL)</string>
 	<key>SUPublicEDKey</key>
 	<string>jHq1RIQKDmtO64qtCdZ6jNdHNFrfyScE16yuu+ufvDw=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>3600</integer>
+	<key>SUAutomaticallyUpdate</key>
+	<false/>
 </dict>
 </plist>

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -1,8 +1,27 @@
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
-import Sparkle
+@preconcurrency import Sparkle
 import SwiftUI
+
+/// Issue #958: narrow test seam over the subset of `SPUUpdater` the proactive
+/// check reads/calls. `SPUUpdater.init` is `NS_UNAVAILABLE` and real
+/// construction touches defaults/appcast/signing, so `checkForUpdatesProactively`
+/// depends on this protocol; the real `SPUUpdater` satisfies it via the
+/// isolated conformance below, and `UpdateCoordinatorProactiveCheckTests`
+/// injects a fake. All members are main-thread-only (Sparkle requirement), so
+/// the protocol is `@MainActor`.
+@MainActor
+protocol ProactiveUpdaterProbe: AnyObject {
+  var automaticallyChecksForUpdates: Bool { get }
+  var lastUpdateCheckDate: Date? { get }
+  var sessionInProgress: Bool { get }
+  func checkForUpdatesInBackground()
+}
+
+/// Isolated conformance (per swift-concurrency-patterns isolated-conformance-first):
+/// pins satisfaction to `@MainActor` without widening `SPUUpdater`'s contract.
+@MainActor extension SPUUpdater: ProactiveUpdaterProbe {}
 
 /// App-target coordinator for the in-app update banner (issue #343).
 /// Owns the `UpdateAvailabilityService` and the `installAction` closure that
@@ -38,6 +57,84 @@ final class UpdateCoordinator {
       defaults: defaults,
       currentBundleVersion: AppConstants.appVersion
     )
+  }
+
+  // MARK: - Proactive update checks (issue #958)
+
+  /// Cooldown between proactive background checks, anchored on Sparkle's own
+  /// `lastUpdateCheckDate`. 1h matches the scheduled cadence (`SUScheduledCheckInterval`),
+  /// which is also Sparkle's enforced minimum interval.
+  static let proactiveCheckCooldown: TimeInterval = 3600
+
+  /// Issue #958: proactive, cooldown-gated background update check. Fires
+  /// Sparkle's BACKGROUND driver (→ gentle banner via the user-driver delegate
+  /// for non-critical updates), NOT the attended `checkForUpdates`. Called on
+  /// launch (right after `startUpdater()`) and on app-foreground. Returns
+  /// whether a check was actually triggered (for tests + telemetry).
+  ///
+  /// The `automaticallyChecksForUpdates` guard is a PRODUCT choice (respect a
+  /// user who explicitly opted out), not a Sparkle requirement — the direct
+  /// background call would run regardless. The cooldown is anchored on
+  /// `lastUpdateCheckDate` so launch / foreground / scheduled checks coalesce
+  /// (Sparkle also no-ops a background check while a session is in progress).
+  @discardableResult
+  func checkForUpdatesProactively(
+    trigger: String,
+    now: Date = Date(),
+    probe: (any ProactiveUpdaterProbe)? = nil
+  ) -> Bool {
+    let resolved: (any ProactiveUpdaterProbe)? = probe ?? updaterController?.updater
+    guard let updater = resolved else {
+      reportProactive(trigger: trigger, fired: false, reason: "no_updater")
+      return false
+    }
+    guard updater.automaticallyChecksForUpdates else {
+      reportProactive(trigger: trigger, fired: false, reason: "auto_checks_off")
+      return false
+    }
+    // Sparkle no-ops `checkForUpdatesInBackground` while a session is already in
+    // progress (SPUUpdater.m:664-667 / SPUUpdater.h:130). Skip here so we never
+    // claim `fired=true` for a call that would do nothing.
+    guard !updater.sessionInProgress else {
+      reportProactive(trigger: trigger, fired: false, reason: "session_in_progress")
+      return false
+    }
+    let elapsed =
+      updater.lastUpdateCheckDate.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+    guard elapsed >= Self.proactiveCheckCooldown else {
+      reportProactive(trigger: trigger, fired: false, reason: "cooldown")
+      return false
+    }
+    reportProactive(trigger: trigger, fired: true, reason: "fired")
+    updater.checkForUpdatesInBackground()
+    return true
+  }
+
+  /// Emits telemetry on EVERY proactive-check return path (bounded `reason`:
+  /// fired / cooldown / auto_checks_off / no_updater / session_in_progress) plus
+  /// an `.info` breadcrumb in `~/Library/Logs/EnviousWispr/app.log` for field
+  /// diagnosis + runtime UAT. `.info` (not `.debug`) so the line is not filtered
+  /// out by the file-sink log level. The breadcrumb is an unstructured `Task`
+  /// (AppLogger is an actor, this is a sync @MainActor method); a single
+  /// fire-and-forget log emit cannot affect the update limb.
+  private func reportProactive(trigger: String, fired: Bool, reason: String) {
+    TelemetryService.shared.updateProactiveCheckTriggered(
+      trigger: trigger, fired: fired, reason: reason)
+    Task {
+      await AppLogger.shared.log(
+        "proactive check trigger=\(trigger) fired=\(fired) reason=\(reason)",
+        level: .info, category: "Update")
+    }
+  }
+
+  /// Issue #958: user-initiated attended check from the Settings "Check for
+  /// Updates" row (§3D). Mirrors the menu wrapper
+  /// (`SparkleUpdateController.openUpdateCheckFromMenu`) but tags the source
+  /// `"settings"`. Shows Sparkle's own check UI ("Checking… / up to date /
+  /// update available").
+  func checkForUpdatesFromSettings() {
+    lastInstallSource = "settings"
+    updaterController?.checkForUpdates(nil)
   }
 
   // MARK: - Install-attempt persistence (cross-launch correlation)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -530,6 +530,8 @@ public final class WisprBootstrapper {
 
   public func applicationWillFinishLaunching() {
     sparkleUpdateController.startUpdater()
+    // #958: proactive launch check, right after startUpdater per Sparkle guidance.
+    sparkleUpdateController.updateCoordinator?.checkForUpdatesProactively(trigger: "launch")
   }
 
   public func applicationDidFinishLaunching() {
@@ -538,6 +540,8 @@ public final class WisprBootstrapper {
 
   public func applicationDidBecomeActive() {
     appLifecycleCoordinator.runDidBecomeActive()
+    // #958: proactive foreground check (post-sleep freshness), strict >=3600 gated.
+    sparkleUpdateController.updateCoordinator?.checkForUpdatesProactively(trigger: "foreground")
   }
 
   public func applicationWillTerminate() {

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -12,6 +12,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case clipboard
   case memory
   case permissions
+  case checkForUpdates
   #if DEBUG
     case diagnostics
   #endif
@@ -30,6 +31,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .clipboard: return "Clipboard"
     case .memory: return "Performance"
     case .permissions: return "Permissions"
+    case .checkForUpdates: return "Check for Updates"
     #if DEBUG
       case .diagnostics: return "Diagnostics"
     #endif
@@ -48,6 +50,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .clipboard: return "clipboard"
     case .memory: return "memorychip"
     case .permissions: return "lock.shield"
+    case .checkForUpdates: return "arrow.triangle.2.circlepath"
     #if DEBUG
       case .diagnostics: return "ladybug"
     #endif
@@ -60,7 +63,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .speechEngine, .audio, .shortcuts: return .record
     case .aiPolish, .wordCorrection: return .process
     case .clipboard: return .output
-    case .memory, .permissions: return .system
+    case .memory, .permissions, .checkForUpdates: return .system
     #if DEBUG
       case .diagnostics: return .system
     #endif

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -19,6 +19,18 @@ struct UnifiedWindowView: View {
                 if section == .whatsNew {
                   WhatsNewSidebarRow(isUnread: settings.hasUnreadWhatsNew)
                     .tag(section)
+                } else if section == .checkForUpdates {
+                  // Issue #958: action row (D1), NOT a navigation tag — fires the
+                  // attended check on tap and never becomes `selectedSection`.
+                  // Sparkle's own UI is the feedback.
+                  Button {
+                    updateCoordinatorHolder.coordinator?.checkForUpdatesFromSettings()
+                  } label: {
+                    Label(section.label, systemImage: section.icon)
+                      .frame(maxWidth: .infinity, alignment: .leading)
+                      .contentShape(Rectangle())
+                  }
+                  .buttonStyle(.plain)
                 } else {
                   Label(section.label, systemImage: section.icon)
                     .tag(section)
@@ -92,6 +104,10 @@ struct UnifiedWindowView: View {
       MemorySettingsView()
     case .permissions:
       PermissionsSettingsView()
+    case .checkForUpdates:
+      // Issue #958: D1 action row never selects this case (no `.tag`), but the
+      // exhaustive switch requires an arm.
+      EmptyView()
     #if DEBUG
       case .diagnostics:
         DiagnosticsSettingsView()

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -672,6 +672,31 @@ public final class TelemetryService {
     )
   }
 
+  /// Issue #958: a proactive launch/foreground trigger evaluated, whether it
+  /// actually fired a background check, and why. Emitted on EVERY return path.
+  /// Bounded cardinality: `trigger ∈ {launch, foreground}`, `fired ∈ {true,false}`,
+  /// `reason ∈ {fired, cooldown, auto_checks_off, no_updater, session_in_progress}`.
+  /// The non-fired cases are what the existing `update.sparkle_cycle_finished`
+  /// cannot show.
+  public func updateProactiveCheckTriggered(trigger: String, fired: Bool, reason: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.proactive_check_triggered",
+          stringProps: ["trigger": trigger, "reason": reason],
+          boolProps: ["fired": fired]
+        ))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.proactive_check_triggered",
+      properties: [
+        "trigger": trigger,
+        "fired": fired,
+        "reason": reason,
+      ]
+    )
+  }
+
   public func updateSparkleDefaultShown(version: String, isCritical: Bool, reason: String) {
     #if DEBUG
       testEventHook?(

--- a/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
+++ b/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
@@ -1,0 +1,192 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Issue #958 — unit tests for `UpdateCoordinator.checkForUpdatesProactively`
+/// (cooldown gate + auto-checks guard) and `checkForUpdatesFromSettings`
+/// (source tagging).
+///
+/// `SPUUpdater` is not test-constructible (`init NS_UNAVAILABLE`), so the
+/// proactive method takes a `probe:` seam (`ProactiveUpdaterProbe`). These
+/// tests inject `FakeProactiveUpdater` and drive the clock via `now:`. The
+/// `UpdateCoordinator` is built with `updaterController: nil`; the probe
+/// override supplies the updater for the proactive path.
+@MainActor
+@Suite("UpdateCoordinator proactive checks", .serialized)
+struct UpdateCoordinatorProactiveCheckTests {
+
+  /// Fake satisfying the narrow `ProactiveUpdaterProbe` seam.
+  @MainActor
+  final class FakeProactiveUpdater: ProactiveUpdaterProbe {
+    var automaticallyChecksForUpdates: Bool
+    var lastUpdateCheckDate: Date?
+    var sessionInProgress: Bool
+    private(set) var backgroundCheckCount = 0
+
+    init(autoChecks: Bool = true, lastCheck: Date? = nil, sessionInProgress: Bool = false) {
+      self.automaticallyChecksForUpdates = autoChecks
+      self.lastUpdateCheckDate = lastCheck
+      self.sessionInProgress = sessionInProgress
+    }
+
+    func checkForUpdatesInBackground() { backgroundCheckCount += 1 }
+  }
+
+  private func makeCoordinator() -> UpdateCoordinator {
+    // No real Sparkle controller; the proactive path uses the injected probe,
+    // and `checkForUpdatesFromSettings` is a no-op call against a nil updater
+    // (we only assert the source tag it sets).
+    UpdateCoordinator(updaterController: nil)
+  }
+
+  // MARK: - Cooldown gate
+
+  @Test("fires when the updater has never checked (lastUpdateCheckDate nil)")
+  func firesWhenNeverChecked() {
+    let coordinator = makeCoordinator()
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "launch", probe: fake)
+
+    #expect(fired == true)
+    #expect(fake.backgroundCheckCount == 1)
+  }
+
+  @Test("fires at exactly the cooldown boundary (elapsed == 3600)")
+  func firesAtCooldownBoundary() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let fake = FakeProactiveUpdater(
+      autoChecks: true,
+      lastCheck: now.addingTimeInterval(-UpdateCoordinator.proactiveCheckCooldown))
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
+
+    #expect(fired == true)
+    #expect(fake.backgroundCheckCount == 1)
+  }
+
+  @Test("skips just below the cooldown boundary (elapsed == 3599)")
+  func skipsJustBelowCooldown() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let fake = FakeProactiveUpdater(
+      autoChecks: true,
+      lastCheck: now.addingTimeInterval(-(UpdateCoordinator.proactiveCheckCooldown - 1)))
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
+
+    #expect(fired == false)
+    #expect(fake.backgroundCheckCount == 0)
+  }
+
+  // MARK: - Auto-checks opt-out guard (product choice)
+
+  @Test("skips when automatic checks are off, regardless of elapsed time")
+  func skipsWhenAutoChecksOff() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    // Elapsed is effectively infinite (never checked), but the user opted out.
+    let fake = FakeProactiveUpdater(autoChecks: false, lastCheck: nil)
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "launch", now: now, probe: fake)
+
+    #expect(fired == false)
+    #expect(fake.backgroundCheckCount == 0)
+  }
+
+  // MARK: - Session-in-progress guard (truthful fired=false)
+
+  @Test("skips when a Sparkle session is already in progress, even if cooldown elapsed")
+  func skipsWhenSessionInProgress() {
+    let coordinator = makeCoordinator()
+    // Cooldown satisfied (never checked) but a session is already running, so
+    // checkForUpdatesInBackground would no-op — must NOT claim fired=true.
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil, sessionInProgress: true)
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "foreground", probe: fake)
+
+    #expect(fired == false)
+    #expect(fake.backgroundCheckCount == 0)
+  }
+
+  // MARK: - No updater
+
+  @Test("returns false when there is no updater (nil probe + nil controller)")
+  func returnsFalseWithNoUpdater() {
+    let coordinator = makeCoordinator()
+    // probe defaults to nil; coordinator was built with updaterController: nil.
+    let fired = coordinator.checkForUpdatesProactively(trigger: "launch")
+    #expect(fired == false)
+  }
+
+  // MARK: - Settings attended check source tag
+
+  @Test("checkForUpdatesFromSettings tags the install source 'settings'")
+  func settingsCheckTagsSource() {
+    let coordinator = makeCoordinator()
+    #expect(coordinator.lastInstallSource == nil, "Precondition: no source yet.")
+    coordinator.checkForUpdatesFromSettings()
+    #expect(coordinator.lastInstallSource == "settings")
+  }
+
+  // MARK: - Telemetry (DEBUG-only testEventHook seam)
+
+  #if DEBUG
+
+    /// Sendable storage box for the `@Sendable` testEventHook closure.
+    @MainActor final class EventBox { var events: [CapturedTelemetryEvent] = [] }
+
+    @Test("emits proactive_check_triggered fired=true when it fires")
+    func emitsTelemetryFiredTrue() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      let coordinator = makeCoordinator()
+      let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
+      coordinator.checkForUpdatesProactively(trigger: "launch", probe: fake)
+
+      await Task.yield()
+      await Task.yield()
+
+      let evt = box.events.first { $0.name == "update.proactive_check_triggered" }
+      #expect(
+        evt != nil, "Expected update.proactive_check_triggered. Got \(box.events.map(\.name)).")
+      #expect(evt?.stringProps["trigger"] == "launch")
+      #expect(evt?.stringProps["reason"] == "fired")
+      #expect(evt?.boolProps["fired"] == true)
+    }
+
+    @Test("emits proactive_check_triggered fired=false when cooldown-skipped")
+    func emitsTelemetryFiredFalseOnCooldownSkip() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      let coordinator = makeCoordinator()
+      let now = Date(timeIntervalSince1970: 1_000_000)
+      let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: now.addingTimeInterval(-60))
+      coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
+
+      await Task.yield()
+      await Task.yield()
+
+      let evt = box.events.first { $0.name == "update.proactive_check_triggered" }
+      #expect(evt != nil)
+      #expect(evt?.stringProps["trigger"] == "foreground")
+      #expect(evt?.stringProps["reason"] == "cooldown")
+      #expect(evt?.boolProps["fired"] == false)
+    }
+
+  #endif  // DEBUG
+}


### PR DESCRIPTION
Closes #958. Part of #321.

## What this does
Makes EnviousWispr proactively surface a pending update instead of requiring the user to hunt for the menu's "Check for Updates". Plan: `docs/feature-requests/issue-958-2026-06-03-proactive-update-awareness.md`.

- **Hourly cadence + auto-checks on, auto-download off** (Info.plist): `SUEnableAutomaticChecks=true`, `SUScheduledCheckInterval=3600` (Sparkle's enforced minimum), `SUAutomaticallyUpdate=false`. Banner-driven manual install stays the default (founder-ratified; safer given the v2.1.0→2.1.1 silent-install brick, #956). `SUAllowsAutomaticUpdates` deliberately NOT set, so full auto-install remains an opt-in.
- **Proactive background checks** on launch (`applicationWillFinishLaunching`, right after `startUpdater()` per Sparkle guidance) and on foreground (`applicationDidBecomeActive`), via `UpdateCoordinator.checkForUpdatesProactively`. Cooldown-gated on `lastUpdateCheckDate` (>=3600) and skips when a Sparkle session is already in progress, so it never overstates a check. Drives the existing #343/#739 banner.
- **"Check for Updates" Settings row** (SYSTEM group) — a D1 action row that fires the attended check on click (source `"settings"`). Founder request for discoverability.
- **Telemetry** `update.proactive_check_triggered(trigger, fired, reason)` on every path + an `.info` field-diagnosis breadcrumb.
- **Test seam** `ProactiveUpdaterProbe` (SPUUpdater is not test-constructible) + `UpdateCoordinatorProactiveCheckTests` (cooldown boundaries, auto-checks-off, session-in-progress, source tag, telemetry).

## Validation
- Debug logic lane: 1566 tests pass (7 new).
- Grounded review (plan): PROCEED-AS-PLANNED (r4). Code-diff review: SHIP (r2, after fixing 2 confirmed bugs Codex caught — session-in-progress overstatement + breadcrumb log-level).
- Live UAT on the running app: proactive foreground trigger fires + cooldown works (app.log breadcrumb), Settings row renders in SYSTEM group + triggers the check + does not change the selected pane, heart path unaffected (founder dictation).
- Ships in a FUTURE release (no tag here; 2.1.1 shipped 2026-06-03).