### PR TITLE
fix(asr): stop cold-start pill firing on warm engine after no-speech taps

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -23,6 +23,28 @@ public final class ASRManager: ASRManagerInterface {
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
   private var inFlightLoadTask: Task<Void, any Error>?
 
+  /// #959 readiness-integrity token (see `ASRManagerProxy.loadGeneration`).
+  private var loadGeneration: UInt64 = 0
+
+  /// #959 single-flight identity (see `ASRManagerProxy.loadTaskSeq`).
+  private var loadTaskSeq: UInt64 = 0
+  private var activeLoadTaskID: UInt64 = 0
+
+  /// Bump the load generation so an in-flight load completion is superseded, and
+  /// log the `ready → notReady` transition tagged with cause. Called before any
+  /// supersession early-return. Ordinary session discard never calls this.
+  private func invalidateCurrentLoadGeneration(cause: String) {
+    loadGeneration &+= 1
+    if isModelLoaded {
+      Task {
+        await AppLogger.shared.log(
+          "[ASRManager] readiness ready→notReady (cause=\(cause)) backend=\(activeBackendType.rawValue)",
+          level: .info, category: "ASR"
+        )
+      }
+    }
+  }
+
   // Phase G5: existential-typed for test injection. Production callers pass
   // nothing; the defaults preserve today's wiring exactly. Tests pass fakes
   // that report `isReady=true` without a real model load, unblocking
@@ -63,7 +85,13 @@ public final class ASRManager: ASRManagerInterface {
 
   /// Switch to a different backend. Unloads the previous one.
   public func switchBackend(to type: ASRBackendType) async {
+    // #959: same-backend no-op guard FIRST so it never supersedes a valid load.
     guard type != activeBackendType else { return }
+    invalidateCurrentLoadGeneration(cause: "switch")
+    // #959 (Codex code-diff P2): retire the old backend's in-flight load task so
+    // a later `loadModel()` for the new backend starts fresh, not joins the stale.
+    inFlightLoadTask?.cancel()
+    inFlightLoadTask = nil
     await activeBackend.unload()
     activeBackendType = type
     isModelLoaded = false
@@ -80,6 +108,8 @@ public final class ASRManager: ASRManagerInterface {
 
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
+      // #959: capture the load generation; refuse to mark loaded if superseded.
+      let gen = self.loadGeneration
       self.downloadProgress = 0
       self.downloadPhase = "Preparing download..."
       self.downloadDetail = ""
@@ -100,10 +130,19 @@ public final class ASRManager: ASRManagerInterface {
       self.downloadProgress = 1.0
       self.downloadPhase = ""
       self.downloadDetail = ""
-      self.isModelLoaded = await self.activeBackend.isReady
+      // #959: read readiness first, THEN guard, so a cancel/unload/switch that
+      // landed during the `isReady` await can't be overwritten by a stale write.
+      let ready = await self.activeBackend.isReady
+      guard gen == self.loadGeneration else { throw ASRLoadSupersededError() }
+      self.isModelLoaded = ready
     }
+    loadTaskSeq &+= 1
+    let myTaskID = loadTaskSeq
     inFlightLoadTask = task
-    defer { inFlightLoadTask = nil }
+    activeLoadTaskID = myTaskID
+    // #959 (Codex code-diff P1): identity-guarded cleanup — only retire the
+    // handle if it is still ours, so a superseded load can't clear a retry's task.
+    defer { if activeLoadTaskID == myTaskID { inFlightLoadTask = nil } }
     try await task.value
   }
 
@@ -162,7 +201,10 @@ public final class ASRManager: ASRManagerInterface {
   /// Unload the active backend, freeing model RAM.
   /// Refuses to unload if a streaming session is active — cancel streaming first.
   public func unloadModel() async {
-    guard isModelLoaded else { return }
+    // #959: a live streaming session means the model is in use and there is no
+    // in-flight load to supersede — refuse FIRST, before bumping the generation,
+    // so the readiness `ready→notReady` log never falsely fires on a refusal
+    // (Codex code-diff P2 note). The model stays loaded.
     if isStreaming {
       Task {
         await AppLogger.shared.log(
@@ -172,6 +214,18 @@ public final class ASRManager: ASRManagerInterface {
       }
       return
     }
+    // Bump before the loaded-guard so an in-flight load (flag still false) is
+    // superseded too, not just a resident model.
+    invalidateCurrentLoadGeneration(cause: "unload")
+    // #959 (Codex re-review P2): retire the superseded in-flight load task the
+    // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
+    // that joins via single-flight before the doomed task finishes propagates
+    // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
+    // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
+    // is still false and the guard would early-return with the stale handle live.
+    inFlightLoadTask?.cancel()
+    inFlightLoadTask = nil
+    guard isModelLoaded else { return }
     await activeBackend.unload()
     isModelLoaded = false
   }
@@ -181,6 +235,8 @@ public final class ASRManager: ASRManagerInterface {
   /// next press triggers a fresh load. Mostly used in tests; production runs
   /// against `ASRManagerProxy` which has the full connection-invalidate path.
   public func cancelInFlightLoad() {
+    // #959: supersede the current load first so a stale completion can't resurrect it.
+    invalidateCurrentLoadGeneration(cause: "recoverFromWedge")
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     isModelLoaded = false

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -1,6 +1,16 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
 
+/// Thrown by `loadModel()` when the load it was running was superseded mid-flight
+/// by a `cancelInFlightLoad()` (wedge recovery), an `unloadModel()`, or a real
+/// `switchBackend(to:)` — detected via the manager's monotonic `loadGeneration`
+/// token (#959). The completion does NOT mark the model loaded; surfacing it as a
+/// throw (rather than a silent no-op) keeps `warmUp()` / `ensureEngineWarm()` from
+/// reporting a false "warm-up succeeded" on a model that is no longer resident.
+public struct ASRLoadSupersededError: Error, Equatable {
+  public init() {}
+}
+
 /// Abstraction over ASR management — enables swapping between in-process and XPC implementations.
 ///
 /// `ASRManager` (in-process) and `ASRManagerProxy` (XPC) both conform to this protocol.

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -44,7 +44,42 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
   private var inFlightLoadTask: Task<Void, any Error>?
 
+  /// #959 readiness-integrity token. Monotonic; `loadModel()` captures it at the
+  /// start of its load and refuses to write `isModelLoaded = true` if it changed
+  /// before the load completes (throws `ASRLoadSupersededError`). Bumped by
+  /// `invalidateCurrentLoadGeneration(cause:)` from `cancelInFlightLoad()` /
+  /// `unloadModel()` / a real `switchBackend(to:)`, so a cancelled, unloaded, or
+  /// switched-away load can never resurrect a false `.ready` on a dead/wrong engine.
+  private var loadGeneration: UInt64 = 0
+
+  /// #959 single-flight identity. Each `loadModel()` that creates a task tags it
+  /// with a fresh `loadTaskSeq` and records it as `activeLoadTaskID`. The task's
+  /// cleanup `defer` nils `inFlightLoadTask` ONLY if it is still the active task,
+  /// so a superseded load A (whose handle `cancelInFlightLoad()` already nilled,
+  /// letting retry B install its own task) cannot clear B's handle on A's exit
+  /// (Codex code-diff P1).
+  private var loadTaskSeq: UInt64 = 0
+  private var activeLoadTaskID: UInt64 = 0
+
   public init() {}
+
+  /// Invalidate whatever load is current: bump the generation so an in-flight
+  /// `loadModel()` completion (even one whose `isModelLoaded` is still `false`)
+  /// is superseded, and log the `ready → notReady` transition tagged with cause.
+  /// Called BEFORE any supersession early-return so an in-flight load is caught.
+  /// Ordinary `cancel()` (session discard) does NOT call this — its appearance
+  /// after a plain terminal is the recurrence signal for #959.
+  private func invalidateCurrentLoadGeneration(cause: String) {
+    loadGeneration &+= 1
+    if isModelLoaded {
+      Task {
+        await AppLogger.shared.log(
+          "[ASRManagerProxy] readiness ready→notReady (cause=\(cause)) backend=\(activeBackendType.rawValue)",
+          level: .info, category: "ASR"
+        )
+      }
+    }
+  }
 
   // MARK: - ASRManagerInterface: Model lifecycle
 
@@ -58,6 +93,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
+      // #959: capture the load generation at the start of this load. If a
+      // cancel/unload/switch bumps it before the load completes, the completion
+      // below throws `ASRLoadSupersededError` instead of marking the model loaded.
+      let gen = self.loadGeneration
       // Reset progress state before starting.
       self.downloadProgress = 0
       self.downloadPhase = "Preparing download..."
@@ -90,6 +129,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
           guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
         }
       }
+      // #959: a cancel/unload/switch that landed during the load bumped the
+      // generation — do NOT mark the (now superseded) model loaded; throw so
+      // `warmUp()` / `ensureEngineWarm()` report failure instead of false success.
+      guard gen == self.loadGeneration else { throw ASRLoadSupersededError() }
       // Success path — clear progress and mark loaded. (stopProgressPolling
       // runs from the defer above on every exit.)
       self.downloadProgress = 1.0
@@ -97,8 +140,14 @@ public final class ASRManagerProxy: ASRManagerInterface {
       self.downloadDetail = ""
       self.isModelLoaded = true
     }
+    loadTaskSeq &+= 1
+    let myTaskID = loadTaskSeq
     inFlightLoadTask = task
-    defer { inFlightLoadTask = nil }
+    activeLoadTaskID = myTaskID
+    // #959: identity-guarded cleanup — only retire the handle if it is still
+    // ours. A supersession (`cancelInFlightLoad`/`switchBackend`) nils the handle
+    // and a retry may install its own; this defer must not clobber that retry.
+    defer { if activeLoadTaskID == myTaskID { inFlightLoadTask = nil } }
     try await task.value
   }
 
@@ -149,6 +198,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
   }
 
   public func unloadModel() async {
+    // #959: bump BEFORE the loaded-guard so an in-flight load (whose
+    // `isModelLoaded` is still false) is superseded too, not just a resident model.
+    invalidateCurrentLoadGeneration(cause: "unload")
+    // #959 (Codex re-review P2): retire the superseded in-flight load task the
+    // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
+    // that joins via single-flight before the doomed task finishes propagates
+    // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
+    // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
+    // is still false and the guard would early-return with the stale handle live.
+    inFlightLoadTask?.cancel()
+    inFlightLoadTask = nil
     guard isModelLoaded else { return }
     await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
       serviceProxy { proxy in
@@ -171,7 +231,16 @@ public final class ASRManagerProxy: ASRManagerInterface {
   }
 
   public func switchBackend(to type: ASRBackendType) async {
+    // #959: keep the same-backend no-op guard FIRST so a no-op switch (settings
+    // re-applying the current backend) never supersedes a valid in-flight load.
     guard type != activeBackendType else { return }
+    // A real switch supersedes any in-flight load for the old backend.
+    invalidateCurrentLoadGeneration(cause: "switch")
+    // #959 (Codex code-diff P2): retire the old backend's in-flight load task so
+    // a subsequent `loadModel()` for the NEW backend starts fresh instead of
+    // joining the stale task and receiving `ASRLoadSupersededError`.
+    inFlightLoadTask?.cancel()
+    inFlightLoadTask = nil
     if isModelLoaded { await unloadModel() }
     activeBackendType = type
     isStreaming = false
@@ -355,6 +424,9 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// This is the programmatic equivalent of the user manually quitting and
   /// relaunching the app — same recovery mechanism, no user effort required.
   public func cancelInFlightLoad() {
+    // #959: supersede the current load FIRST so its completion can't resurrect
+    // readiness after this teardown (always destructive — no no-op guard here).
+    invalidateCurrentLoadGeneration(cause: "recoverFromWedge")
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     connection?.invalidate()

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -271,7 +271,25 @@ public protocol ASREngineAdapter: AnyObject {
 
   /// Idempotent discard. Calling it 2+ times has the same effect as once
   /// (PR-1 §B.2.2).
+  ///
+  /// #959: `cancel()` is the CHEAP, model-preserving session discard — the only
+  /// thing ordinary terminals (`noSpeech`/`discarded`/`cancelled`) call. It stops
+  /// streaming and clears per-session state, but MUST NOT tear down a healthy
+  /// resident model or invalidate the engine's load. A model that was `.ready`
+  /// before `cancel()` (no load in flight) stays `.ready`. For a genuinely
+  /// wedged load/decode, the kernel's wedge detectors call `recoverFromWedge()`
+  /// instead — never `cancel()`.
   func cancel() async
+
+  /// #959: HEAVY wedge recovery — tear the engine down hard so the next press
+  /// reloads fresh. Called ONLY by the kernel's load-wedge / finalize-wedge
+  /// detectors, never for an ordinary session discard. Does everything `cancel()`
+  /// does PLUS the engine-specific kill (Parakeet: XPC service teardown via
+  /// `cancelInFlightLoad()`; WhisperKit: in-process backend unload). MUST be
+  /// best-effort and deadline-bounded so a wedged in-process decode cannot hang
+  /// the kernel's recovery path. After it returns, `readiness` is expected
+  /// `.notReady` and the next press warms the engine.
+  func recoverFromWedge() async
 
   // MARK: Engine interruption
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -147,6 +147,10 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       isLoadInFlight = false
     }
     try await asrManager.loadModel()
+    // #959: a superseded load throws from `loadModel()`, but recheck readiness
+    // anyway so any "returned but not actually loaded" path reports failure to
+    // `ensureEngineWarm()` instead of a false "warm-up succeeded".
+    guard asrManager.isModelLoaded else { throw ASRLoadSupersededError() }
   }
 
   /// Latest phase string observed by the in-flight `loadProgressTickReporter`,
@@ -299,11 +303,10 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   // TODO(#NNN): finalize-wedge watchdog needs Parakeet progress signal.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
 
-  /// Idempotent discard. Cancels streaming and any wedged in-flight model load,
-  /// clears the retained PCM. `cancelInFlightLoad()` is what unblocks the
-  /// kernel's load-wedge recovery (issue #445); the kernel routes its
-  /// `detectLoadWedge` recovery through this same `cancel()`.
-  func cancel() async {
+  /// The cheap, model-preserving teardown shared by `cancel()` and
+  /// `recoverFromWedge()`: cancel streaming, clear per-session state. Touches
+  /// neither the model load nor the XPC connection.
+  private func discardSession() async {
     isCancelled = true
     isTerminal = true
     lastResult = nil
@@ -315,6 +318,33 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       streamingActive = false
       await asrManager.cancelStreaming()
     }
+  }
+
+  /// #959 CHEAP, model-preserving discard — what every ordinary terminal
+  /// (`noSpeech`/`discarded`/`cancelled`) routes through. A healthy RESIDENT
+  /// model stays loaded and `readiness` stays `.ready` (the warm-engine bug fix).
+  /// BUT a load that is still IN FLIGHT (a cold warm-up the user cancelled) is
+  /// released via `cancelInFlightLoad()` so the kernel's `warmUp()` await
+  /// unblocks promptly instead of hanging the overlay until the load finishes
+  /// (Codex code-diff P1). The `isLoadInFlight` gate is the distinction: a warm
+  /// resident model has no load in flight, so this never tears down a healthy
+  /// engine — that IS the seam split.
+  func cancel() async {
+    await discardSession()
+    if isLoadInFlight {
+      asrManager.cancelInFlightLoad()
+    }
+  }
+
+  /// #959 HEAVY wedge recovery. The cheap discard PLUS an UNCONDITIONAL
+  /// `cancelInFlightLoad()` — the issue #445 service-kill that invalidates the
+  /// XPC connection (terminating the service-side wedged load OR a stuck batch
+  /// decode, which has no in-flight load task) and forces a fresh reload. Called
+  /// ONLY by the kernel's load-wedge / finalize-wedge detectors.
+  /// `cancelInFlightLoad()` is synchronous and non-blocking, so no deadline is
+  /// needed for the Parakeet path.
+  func recoverFromWedge() async {
+    await discardSession()
     asrManager.cancelInFlightLoad()
   }
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1371,7 +1371,11 @@ final class RecordingSessionKernel {
           totalAttemptDurationMs: milliseconds(forTicks: now &- loadAttemptStartedAtTick)
         )
         bump()
-        await adapter.cancel()
+        // #959: a GENUINE load wedge — heavy recovery (tear down the engine),
+        // never the cheap model-preserving `cancel()` that ordinary terminals
+        // use. The `.wedged` terminal below already surfaces wedge telemetry
+        // (`KernelLifecycleTelemetrySink`), so no extra event is emitted here.
+        await adapter.recoverFromWedge()
         return
       }
       // A tick landed within the window — the load is still progressing.
@@ -1431,7 +1435,10 @@ final class RecordingSessionKernel {
       if currentTick() &- lastFinalizeTickAt >= UInt64(wedgeStallTicks) {
         finalizeWedgeDetected = true
         bump()
-        await adapter.cancel()
+        // #959: a GENUINE finalize/decode wedge — heavy recovery, not the cheap
+        // `cancel()`. Wedge telemetry is surfaced by the `.failed(.wedged)`
+        // terminal path (`KernelLifecycleTelemetrySink`).
+        await adapter.recoverFromWedge()
         return
       }
       // A finalize tick landed within the window — still progressing.

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -183,11 +183,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   init(
     backend: any WhisperKitBackendDriving,
     languageDetector: LanguageDetector = LanguageDetector(),
-    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 }
+    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 },
+    wedgeRecoveryUnloadDeadlineSec: Double = 2.0
   ) {
     self.backend = backend
     self.languageDetector = languageDetector
     self.audioCaptureSessionIDSource = audioCaptureSessionIDSource
+    self.wedgeRecoveryUnloadDeadlineSec = wedgeRecoveryUnloadDeadlineSec
   }
 
   // MARK: ASREngineAdapter — identity & capability
@@ -226,7 +228,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     do {
       try await task.value
       prepareTask = nil
-      cachedReadiness = .ready
+      // #959: recheck the backend's actual readiness after `prepare()` returns
+      // (a `recoverFromWedge()` that cancelled `prepareTask` rethrows above; this
+      // guards any "returned but not ready" path) so `ensureEngineWarm()` never
+      // reports a false success on an unready engine.
+      let ready = await captured.isReady
+      cachedReadiness = ready ? .ready : .notReady
+      guard ready else { throw ASRLoadSupersededError() }
     } catch {
       prepareTask = nil
       cachedReadiness = .notReady
@@ -915,6 +923,33 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       await worker.cancel()
     }
     cachedReadiness = await backend.isReady ? .ready : .notReady
+  }
+
+  /// #959 fail-open ceiling for the wedge-recovery unload. NOT a measured perf
+  /// threshold — it is the documented `withDeadline` fail-open budget: a healthy
+  /// in-process `unload()` is effectively instant; this bounds the rare case
+  /// where a wedged CoreML decode blocks `unload()` so recovery can never hang
+  /// the kernel. The abandoned unload finishes in the background. Injectable so
+  /// tests can drive a fast deadline; production uses the 2.0s default.
+  private let wedgeRecoveryUnloadDeadlineSec: Double
+
+  /// #959 HEAVY wedge recovery. The cheap discard (`cancel()`) PLUS a forced
+  /// in-process backend unload so the next press reloads fresh. WhisperKit
+  /// decodes IN-PROCESS, so a genuinely wedged CoreML decode could block
+  /// `unload()` on the same locked resource — the unload is therefore
+  /// deadline-bounded (fail-open: a blocked unload is abandoned rather than
+  /// hanging recovery; a pathological in-process freeze may still need a user
+  /// force-quit, unlike Parakeet's XPC service which the OS reaps). Called ONLY
+  /// by the kernel's wedge detectors. Dormant in practice: WhisperKit is
+  /// signal-free for load-wedge detection and exposes no `finalizeProgress`, so
+  /// no kernel wedge detector currently fires for it (whisperkit-research.md).
+  func recoverFromWedge() async {
+    await cancel()
+    let captured = backend
+    _ = await withDeadline(seconds: wedgeRecoveryUnloadDeadlineSec) {
+      await captured.unload()
+    }
+    cachedReadiness = .notReady
   }
 
   // MARK: ASREngineAdapter — cleanup

--- a/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
@@ -100,6 +100,150 @@ struct ASRManagerBackendInjectionTests {
   }
 }
 
+// MARK: - #959 load-generation readiness-integrity guard
+
+/// Verifies that only the CURRENT load may mark the model loaded, and that a
+/// superseded load fails loudly (throws `ASRLoadSupersededError`) instead of
+/// resurrecting a false `.ready`. Drives `ASRManager` (in-process) with a gated
+/// `FakeASRBackend` so a cancel/unload/switch can land WHILE a load is parked.
+@Suite("ASRManager load-generation guard (#959)")
+@MainActor
+struct ASRManagerLoadGenerationTests {
+
+  private func waitForPrepareEntered(_ backend: FakeASRBackend) async {
+    while await backend.prepareCount == 0 { await Task.yield() }
+  }
+
+  @Test("a load superseded by cancelInFlightLoad mid-flight throws and stays unloaded")
+  func cancelInFlightLoadSupersedes() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
+    let manager = ASRManager(
+      parakeetBackend: parakeet, whisperKitBackend: FakeASRBackend(initiallyReady: false))
+
+    let loadTask = Task { @MainActor in
+      await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
+    }
+    await waitForPrepareEntered(parakeet)
+    manager.cancelInFlightLoad()  // bumps the generation while the load is parked
+    await parakeet.releaseGate()
+    await loadTask.value
+    #expect(manager.isModelLoaded == false, "a superseded load must not resurrect readiness")
+  }
+
+  @Test("unloadModel during an in-flight load supersedes it (bump-before-guard, Codex r2)")
+  func unloadDuringInFlightLoadSupersedes() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
+    let manager = ASRManager(
+      parakeetBackend: parakeet, whisperKitBackend: FakeASRBackend(initiallyReady: false))
+
+    let loadTask = Task { @MainActor in
+      await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
+    }
+    await waitForPrepareEntered(parakeet)
+    // `isModelLoaded` is still false here; the bump must happen BEFORE the
+    // `guard isModelLoaded` early-return so the in-flight load is still caught.
+    await manager.unloadModel()
+    await parakeet.releaseGate()
+    await loadTask.value
+    #expect(manager.isModelLoaded == false)
+  }
+
+  @Test("same-backend switch during an in-flight load does NOT supersede it (Codex r3)")
+  func sameBackendSwitchDoesNotSupersede() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
+    let manager = ASRManager(
+      parakeetBackend: parakeet, whisperKitBackend: FakeASRBackend(initiallyReady: false))
+
+    let loadTask = Task { @MainActor in try await manager.loadModel() }
+    await waitForPrepareEntered(parakeet)
+    // No-op switch (already .parakeet): must return at the same-backend guard
+    // BEFORE bumping the generation, so the valid load completes successfully.
+    await manager.switchBackend(to: .parakeet)
+    await parakeet.releaseGate()
+    try await loadTask.value  // must NOT throw
+    #expect(
+      manager.isModelLoaded == true, "a no-op switch must not supersede a valid in-flight load")
+  }
+
+  @Test(
+    "a real backend switch during an in-flight load retires it so the new backend loads fresh (Codex P2)"
+  )
+  func realSwitchDuringInFlightLoadStartsFresh() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
+    let whisperKit = FakeASRBackend(initiallyReady: false)  // ungated — loads normally
+    let manager = ASRManager(parakeetBackend: parakeet, whisperKitBackend: whisperKit)
+
+    let loadTask = Task { @MainActor in
+      await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
+    }
+    await waitForPrepareEntered(parakeet)
+    await manager.switchBackend(to: .whisperKit)  // retires the parakeet load task
+    await parakeet.releaseGate()
+    await loadTask.value
+
+    // The next load must start FRESH for the new backend, not join the retired
+    // (superseded) parakeet task and receive ASRLoadSupersededError.
+    try await manager.loadModel()
+    #expect(manager.isModelLoaded == true)
+    #expect(manager.activeBackendType == .whisperKit)
+    let wkPrepares = await whisperKit.prepareCount
+    #expect(wkPrepares == 1, "new backend loaded fresh, not via the stale task")
+  }
+
+  @Test(
+    "unloadModel during an in-flight load retires it so a retry starts FRESH, not joins the doomed task (Codex re-review P2)"
+  )
+  func unloadDuringInFlightLoadRetiresTaskSoRetryStartsFresh() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
+    let manager = ASRManager(
+      parakeetBackend: parakeet, whisperKitBackend: FakeASRBackend(initiallyReady: false))
+
+    // Load A parks in prepare() holding generation G.
+    let loadTask = Task { @MainActor in
+      await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
+    }
+    await waitForPrepareEntered(parakeet)
+
+    // unloadModel bumps the generation (superseding A) AND must retire A's
+    // single-flight handle so the next load does not join A's doomed task.
+    await manager.unloadModel()
+
+    // Retry B: with the handle retired it starts a FRESH load (a second prepare);
+    // with the bug it would JOIN A via single-flight and never enter a new prepare.
+    let retry = Task { @MainActor in try await manager.loadModel() }
+
+    // Bounded poll — never a spin-on-condition that could hang under the bug.
+    var enteredFresh = false
+    for _ in 0..<10_000 {
+      if await parakeet.prepareCount >= 2 {
+        enteredFresh = true
+        break
+      }
+      await Task.yield()
+    }
+
+    await parakeet.releaseGate()  // resumes A (cancelled → throws) and B (if it parked fresh)
+    await loadTask.value
+
+    #expect(
+      enteredFresh, "retry must start a fresh load, not join the superseded in-flight task")
+    if enteredFresh {
+      try await retry.value  // the fresh load must succeed
+      #expect(manager.isModelLoaded == true)
+    } else {
+      _ = try? await retry.value  // bug path: drain B so the test doesn't leak a task
+    }
+  }
+
+  // Codex code-diff P1 (single-flight identity guard): a superseded load's `defer`
+  // must not clear a retry's `inFlightLoadTask`. Verified by inspection + Codex
+  // re-review rather than a dedicated test — reproducing it needs THREE concurrent
+  // same-backend loads (A superseded, B installed, C joins B), which the
+  // single-continuation `FakeASRBackend` gate cannot model without a multi-waiter
+  // rewrite disproportionate to a 2-line, provably-correct guard
+  // (`defer { if activeLoadTaskID == myTaskID { inFlightLoadTask = nil } }`).
+}
+
 // MARK: - Fake
 
 /// Minimal `ASRBackend` actor for tests. Reports controllable readiness and
@@ -110,8 +254,18 @@ final actor FakeASRBackend: ASRBackend {
   private(set) var unloadCount: Int = 0
   private(set) var prepareCount: Int = 0
 
-  init(initiallyReady: Bool) {
+  /// #959: when `gated`, `prepare()` parks until `releaseGate()` so a test can
+  /// supersede an in-flight load (cancel / unload / switch) BEFORE the load
+  /// completes, then release it to exercise the generation guard. The waiter list
+  /// is an array (not a single slot) so MULTIPLE concurrent loads can park at once
+  /// — e.g. a superseded load plus a fresh retry — and be released together
+  /// without one overwriting the other's continuation and deadlocking.
+  private let gated: Bool
+  private var gateContinuations: [CheckedContinuation<Void, Never>] = []
+
+  init(initiallyReady: Bool, gated: Bool = false) {
     self.ready = initiallyReady
+    self.gated = gated
   }
 
   // MARK: ASRBackend
@@ -122,7 +276,19 @@ final actor FakeASRBackend: ASRBackend {
 
   func prepare() async throws {
     prepareCount += 1
+    if gated {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        gateContinuations.append(c)
+      }
+    }
     ready = true
+  }
+
+  /// Release ALL parked `gated` `prepare()` calls (supports multiple waiters).
+  func releaseGate() {
+    let parked = gateContinuations
+    gateContinuations.removeAll()
+    for c in parked { c.resume() }
   }
 
   func transcribe(audioSamples: [Float], options: TranscriptionOptions)

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -206,6 +206,64 @@ import Testing
     }
   }
 
+  // MARK: #959 — cheap cancel() vs heavy recoverFromWedge() seam split
+
+  @Test("#959 cancel() preserves a loaded model — no service-kill, readiness stays .ready")
+  func cancelPreservesLoadedModel() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    await adapter.cancel()
+    #expect(
+      manager.cancelInFlightLoadCount == 0,
+      "ordinary discard must NOT call cancelInFlightLoad — the bug was tearing down a healthy engine"
+    )
+    #expect(manager.isModelLoaded, "resident model stays loaded after a cheap discard")
+    #expect(adapter.readiness == .ready, "readiness must remain .ready after a discard (#959)")
+  }
+
+  @Test("#959 recoverFromWedge() tears the engine down — cancelInFlightLoad fires exactly once")
+  func recoverFromWedgeTearsDownEngine() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.warmUp()
+    await adapter.recoverFromWedge()
+    #expect(
+      manager.cancelInFlightLoadCount == 1,
+      "wedge recovery is the ONLY path that invokes the #445 service-kill")
+  }
+
+  @Test("#959 cancel() still cancels an active streaming session (cheap-discard duties intact)")
+  func cancelStillCancelsStreaming() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    await adapter.cancel()
+    #expect(manager.cancelStreamingCount == 1, "cancel() must still tear down streaming")
+    #expect(manager.cancelInFlightLoadCount == 0, "but must NOT kill the model load")
+  }
+
+  @Test("#959 cancel() during an IN-FLIGHT cold load releases it so the kernel unblocks (Codex P1)")
+  func cancelDuringInFlightLoadReleasesIt() async throws {
+    let manager = StubParakeetASRManager()
+    manager.gateLoadModel = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let warmTask = Task { @MainActor in try? await adapter.warmUp() }
+    // Wait until warmUp() has entered loadModel() (parked on the gate) — now a
+    // load is genuinely in flight (`isLoadInFlight == true`).
+    while manager.loadModelCount == 0 { await Task.yield() }
+    await adapter.cancel()
+    #expect(
+      manager.cancelInFlightLoadCount == 1,
+      "cancel during an in-flight cold load must release it so the kernel's warmUp await unblocks")
+    manager.releaseLoadGate()
+    _ = await warmTask.value
+  }
+
   @Test("finalize drains in-flight streaming feeds before finalizeStreaming")
   func finalizeDrainsStreamingFeeds() async throws {
     let manager = StubParakeetASRManager()
@@ -437,6 +495,10 @@ final class StubParakeetASRManager: ASRManagerInterface {
   /// When set, `finalizeStreaming` yields many times before returning — models
   /// a finalize suspended in ASR while a new session begins.
   var slowFinalizeStreaming = false
+  /// #959: when set, `loadModel()` parks until `releaseLoadGate()` so a test can
+  /// drive `cancel()` while a cold load is genuinely in flight (`isLoadInFlight`).
+  var gateLoadModel = false
+  private var loadGate: CheckedContinuation<Void, Never>?
 
   // Observed counters
   var loadModelCount = 0
@@ -458,7 +520,15 @@ final class StubParakeetASRManager: ASRManagerInterface {
 
   func loadModel() async throws {
     loadModelCount += 1
+    if gateLoadModel {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in loadGate = c }
+    }
     isModelLoaded = true
+  }
+
+  func releaseLoadGate() {
+    loadGate?.resume()
+    loadGate = nil
   }
   func unloadModel() async {}
   func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -185,6 +185,39 @@ import Testing
       context.clock.drainPending()
     }
 
+    // MARK: #959 — seam routing: ordinary terminal uses cheap cancel(), wedge uses recoverFromWedge()
+
+    @Test("#959 an ordinary terminal routes through cheap cancel(), never recoverFromWedge()")
+    func ordinaryTerminalUsesCheapCancel() async {
+      let (context, wrapper) = makeWrapper()
+      await apply(.start, to: wrapper)
+      await apply(.cancel, to: wrapper)  // recording → cancelled (an ordinary discard)
+
+      #expect(wrapper.testKernel.state == .cancelled)
+      #expect(context.engine.cancelCallCount >= 1, "ordinary discard must call cheap cancel()")
+      #expect(
+        context.engine.recoverFromWedgeCallCount == 0,
+        "ordinary discard must NOT invoke heavy wedge recovery — that was the #959 bug")
+    }
+
+    @Test("#959 a load wedge routes through recoverFromWedge(), never cheap cancel()")
+    func loadWedgeUsesRecoverFromWedge() async {
+      let (context, wrapper) = makeWrapper(behavior: .wedgeOnLoad)
+      await apply(.start, to: wrapper)
+      context.clock.advance(by: 4)  // let the wedge watcher fire
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .failed(.modelWedged))
+      #expect(
+        context.engine.recoverFromWedgeCallCount == 1,
+        "a genuine load wedge must invoke heavy recovery")
+      #expect(
+        context.engine.cancelCallCount == 0,
+        "the wedge path must NOT also run the cheap discard (no session was begun)")
+
+      context.clock.drainPending()
+    }
+
     // MARK: Heart/limbs — raw text survives a limb failure
 
     @Test("a polish-limb failure still delivers the transcript")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -27,6 +27,7 @@ enum FakeEngineEvent: Equatable, Sendable {
   case observeSpeechSegments(count: Int)
   case finalize
   case cancel
+  case recoverFromWedge
 }
 
 /// Synthetic error type for the cache-preload failure-bypass test
@@ -108,6 +109,10 @@ final class FakeEngine: ASREngineAdapter {
   /// audio through instead of `nil`.
   private(set) var lastFinalizeBatchSamples: [Float]? = nil
   private(set) var cancelCallCount = 0
+  /// #959: counts `recoverFromWedge()` calls so seam tests can assert ordinary
+  /// terminals route through cheap `cancel()` while only the wedge detectors
+  /// route through heavy `recoverFromWedge()`.
+  private(set) var recoverFromWedgeCallCount = 0
   private(set) var lastUnloadPolicy: ModelUnloadPolicy?
   private(set) var lastSessionID: SessionID?
   /// The `streaming` flag the kernel passed on the last `beginSession()` —
@@ -246,11 +251,12 @@ final class FakeEngine: ASREngineAdapter {
     case .wedgeOnLoad:
       // The load emits a few progress ticks (arming the kernel's wedge
       // watcher) then goes silent — a genuine cadence stall (PR-3 plan §3.7).
-      // It suspends until `cancel()` resumes us; best-effort load
+      // It suspends until `recoverFromWedge()` resumes us (#959: the kernel's
+      // load-wedge detector calls that, not cheap `cancel()`); best-effort load
       // cancellation (D6): `warmUp()` throws once released.
-      // If `cancel()` ALREADY ran (cancel-before-warmUp ordering), there is no
-      // future `cancel()` to resume the continuation — parking would hang.
-      // Throw immediately instead.
+      // If a discard ALREADY ran (cancel-before-warmUp ordering set `isCancelled`),
+      // there is no future release to resume the continuation — parking would
+      // hang. Throw immediately instead.
       if isCancelled { throw ASREngineError.wedged }
       emitLoadTick()
       emitLoadTick()
@@ -377,7 +383,23 @@ final class FakeEngine: ASREngineAdapter {
     isTerminal = true
     // PR-5 Rung 2A: cancellation invalidates any prior session's result.
     lastResult = nil
-    // Release a wedged `warmUp()` / `finalize()` (best-effort, D6).
+    // #959: cheap discard — it does NOT release a wedged `warmUp()`/`finalize()`.
+    // The kernel only routes ordinary terminals here; releasing a wedge is the
+    // job of `recoverFromWedge()` below.
+  }
+
+  /// #959 HEAVY wedge recovery. Does the same teardown as `cancel()` PLUS
+  /// releasing any wedged `warmUp()` / `finalize()` continuation (best-effort,
+  /// D6) — the behavior that used to live in `cancel()`. Tracked under its OWN
+  /// counter (not `cancelCallCount`) so seam tests can assert routing: the
+  /// kernel's load-wedge / finalize-wedge detectors call this; ordinary
+  /// terminals call cheap `cancel()`.
+  func recoverFromWedge() async {
+    recoverFromWedgeCallCount += 1
+    eventLog.append(.recoverFromWedge)
+    isCancelled = true
+    isTerminal = true
+    lastResult = nil
     if let continuation = loadWedgeContinuation {
       loadWedgeContinuation = nil
       continuation.resume()

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngineTests.swift
@@ -181,16 +181,19 @@ struct FakeEngineTests {
     }
   }
 
-  @Test("wedgeOnFinalize: cancel() releases the wedged finalize as .cancelled")
-  func wedgeOnFinalizeReleasedByCancel() async {
+  @Test(
+    "wedgeOnFinalize: recoverFromWedge() releases the wedged finalize as .cancelled (cancel() does not)"
+  )
+  func wedgeOnFinalizeReleasedByRecoverFromWedge() async {
     let clock = FakeClock()
     let engine = FakeEngine(behavior: .wedgeOnFinalize, clock: clock)
     let finalizeTask = Task { @MainActor in await engine.finalize(batchSamples: nil) }
     await Task.yield()
-    await engine.cancel()
+    // #959: the heavy wedge-recovery path releases the wedge — NOT cheap cancel().
+    await engine.recoverFromWedge()
     let outcome = await finalizeTask.value
     guard case .cancelled = outcome else {
-      Issue.record("expected .cancelled after cancel released the wedge, got \(outcome)")
+      Issue.record("expected .cancelled after recoverFromWedge released the wedge, got \(outcome)")
       return
     }
   }

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -135,8 +135,18 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     return incrementalSessionFactory?()
   }
 
+  /// #959: when set, `unload()` blocks (models a wedged in-process CoreML
+  /// teardown) so a test can prove `recoverFromWedge()` is deadline-bounded.
+  var hangUnload = false
+  func setHangUnload(_ v: Bool) { hangUnload = v }
+
   func unload() async {
     unloadCount += 1
+    if hangUnload {
+      // Wedged: `withDeadline` abandons + cancels this task at its deadline.
+      try? await Task.sleep(for: .seconds(60))
+      return
+    }
     isReady = false
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -56,6 +56,32 @@ import Testing
     #expect(adapter.readiness == .ready)
   }
 
+  // MARK: #959 — heavy recoverFromWedge() (best-effort, deadline-bounded)
+
+  @Test("#959 recoverFromWedge() tears the engine down to .notReady for a fresh reload")
+  func recoverFromWedgeForcesNotReady() async throws {
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    await adapter.recoverFromWedge()
+    #expect(adapter.readiness == .notReady, "wedge recovery unloads the in-process backend")
+    #expect(await backend.unloadCount == 1)
+  }
+
+  @Test("#959 recoverFromWedge() returns within its deadline even if unload() hangs")
+  func recoverFromWedgeIsDeadlineBounded() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setHangUnload(true)
+    // Inject a fast fail-open deadline; a wedged in-process unload must NOT hang
+    // the kernel's recovery path.
+    let adapter = WhisperKitEngineAdapter(backend: backend, wedgeRecoveryUnloadDeadlineSec: 0.05)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    await adapter.recoverFromWedge()  // must return despite the hung unload
+    #expect(adapter.readiness == .notReady)
+  }
+
   @Test("readiness goes notReady after applyUnloadPolicy(.immediately) executes")
   func cachedReadinessAfterImmediateUnload() async throws {
     let backend = StubWhisperKitBackend()


### PR DESCRIPTION
Closes #959

## Problem
After the cold-start warm-up feature (#879), the "ready to record" pill could re-appear on an already-warm engine when a user tapped record and bailed quickly (double-click then cancel, or a light tap then "never mind"). Root cause: every ordinary recording terminal (no-speech / discarded / cancelled) routed through `adapter.cancel()`, which on the Parakeet adapter fired `cancelInFlightLoad()` — the #445 wedge recovery that kills the XPC connection and clears `isModelLoaded` — even on a healthy resident model. Readiness dropped to `.notReady`, so the #879 cold-press guard showed the pill on the next press.

## Fix
Split the `ASREngineAdapter` seam into two distinct operations:
- **`cancel()`** — cheap, model-preserving teardown for ordinary terminals. Cancels streaming and clears per-session state; a warm resident model stays loaded. Only releases a load that is genuinely *in flight* (a cold warm-up the user cancelled), so the kernel's `warmUp()` await unblocks promptly.
- **`recoverFromWedge()`** — the heavy #445 path (unconditional connection kill / reload), now called **only** by the kernel's load-wedge and finalize-wedge detectors.

Plus a `loadGeneration` readiness-integrity guard: a load superseded mid-flight by a cancel / unload / switch throws `ASRLoadSupersededError` instead of resurrecting a false `.ready`. Both managers (`ASRManager` in-process, `ASRManagerProxy` XPC) retire the in-flight single-flight task on supersession so a retry starts fresh rather than joining a doomed load.

New `[ASR] readiness ready→notReady (cause=…)` log line is the recurrence detector — an ordinary terminal must never produce `cause=recoverFromWedge`.

## Validation
- 1,579 logic tests green (`scripts/xcode-test.sh`), incl. new adapter-seam, load-generation, single-flight-identity, switch-mid-load, and unload-retire race tests. The unload-retire test was proven failing-first.
- Live UAT on the running app, both backends: heart path clean (Parakeet TOTAL 1.79s, WhisperKit 2.86s, exact transcripts). Log confirms ordinary terminals cause **zero** readiness drop and no "press blocked"; the only readiness transitions are the legitimate backend switch.
- Codex grounded review: 5 rounds to PROCEED-AS-PLANNED + dedicated seam regression sweep. Code-diff review: 3 rounds (3 findings → fixed; re-review confirmed + 1 new → fixed; final SHIP).

Tier: REFACTOR (multi-conformer protocol seam). Heart-path preserving — a failed limb still returns raw text.