### PR TITLE
test(asr): make SetupCoordinator preload tests real via injectable setup-state (#898)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
@@ -21,12 +21,23 @@ final class SetupCoordinator {
   private let asrManager: any ASRManagerInterface
   private let preloadAction: @MainActor () async -> Void
 
+  /// Reads WhisperKit setup readiness for the preload gate. Defaults to the owned
+  /// `whisperKitSetup` service, so production behavior is unchanged. A unit test
+  /// injects a reader that returns `.ready` to prove the parakeet backend guard —
+  /// not the (test-unreachable) readiness gate — is what suppresses preload (#898).
+  private let setupStateReader: @MainActor () -> WhisperKitSetupState
+
   init(
     asrManager: any ASRManagerInterface,
+    setupStateReader: (@MainActor () -> WhisperKitSetupState)? = nil,
     preloadAction: @escaping @MainActor () async -> Void
   ) {
     self.asrManager = asrManager
     self.preloadAction = preloadAction
+    // Bind the default reader inside init capturing the owned service as a local
+    // (a default parameter value cannot reference `self`).
+    let service = whisperKitSetup
+    self.setupStateReader = setupStateReader ?? { service.setupState }
   }
 
   /// Observe `whisperKitSetup.setupState` and invoke `preloadAction` when it becomes
@@ -44,7 +55,7 @@ final class SetupCoordinator {
         // restarts this observer; the re-entry sees the new activeBackendType.
         guard self.asrManager.activeBackendType == .whisperKit else { return }
 
-        let currentState = self.whisperKitSetup.setupState
+        let currentState = self.setupStateReader()
         if currentState == .ready {
           await self.preloadAction()
           return

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -18,44 +18,68 @@ import Testing
 @Suite @MainActor
 struct SetupCoordinatorTests {
 
-  /// Active backend = parakeet → preload action must NOT fire even if the user
-  /// later flips WhisperKit to .ready (no observation should be running).
-  @Test func parakeetBackendSkipsPreload() async throws {
+  /// With setup forced `.ready`, the parakeet backend guard is the sole preload
+  /// suppressor: an active parakeet backend must skip preload even when WhisperKit
+  /// setup is ready. Deleting or inverting the backend guard makes preload fire
+  /// for parakeet → this test goes red. (Before #898 both tests used a parakeet
+  /// backend whose setup could never reach `.ready`, so the readiness gate alone
+  /// guaranteed count == 0 and the backend guard was never exercised.)
+  @Test(
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/898", "parakeet backend guard untested"))
+  func parakeetBackendSkipsPreloadWhenReady() async throws {
     let fakeASR = FakeASRManager(backend: .parakeet)
     let counter = InvocationCounter()
     let coord = SetupCoordinator(
       asrManager: fakeASR,
+      setupStateReader: { .ready },
       preloadAction: { @MainActor in counter.increment() }
     )
 
     coord.startPreloadObservation()
+    await drainMainActorTasks()
 
-    // Yield once so the observation Task gets a chance to run and bail out
-    // on the .parakeet guard.
-    try await Task.sleep(nanoseconds: 50_000_000)
-
-    #expect(counter.count == 0, "preloadAction must not fire when active backend is parakeet")
+    #expect(
+      counter.count == 0,
+      "preloadAction must not fire for a parakeet backend even when setup is .ready"
+    )
   }
 
-  /// startPreloadObservation can be called repeatedly; each call cancels the
-  /// prior observation Task. Verify the invocation completes without crashing
-  /// (cancellation correctness — the task body uses `[weak self]` and a
-  /// while-not-cancelled loop).
-  @Test func repeatedStartCancelsPrior() async throws {
-    let fakeASR = FakeASRManager(backend: .parakeet)
+  /// With setup forced `.ready` and WhisperKit the active backend, rapid repeated
+  /// starts coalesce to a single preload: each `startPreloadObservation()` cancels
+  /// the prior observation Task before it runs, so only the last survives and fires
+  /// preload exactly once. Deleting `whisperKitPreloadTask?.cancel()` leaks all
+  /// three observers → count == 3 → this test goes red.
+  @Test(
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/898",
+      "repeated-start cancellation untested"))
+  func repeatedStartCoalescesToSinglePreload() async throws {
+    let fakeASR = FakeASRManager(backend: .whisperKit)
     let counter = InvocationCounter()
     let coord = SetupCoordinator(
       asrManager: fakeASR,
+      setupStateReader: { .ready },
       preloadAction: { @MainActor in counter.increment() }
     )
 
     coord.startPreloadObservation()
     coord.startPreloadObservation()
     coord.startPreloadObservation()
+    await drainMainActorTasks()
 
-    try await Task.sleep(nanoseconds: 50_000_000)
+    #expect(
+      counter.count == 1,
+      "rapid repeated starts must cancel prior observers and preload exactly once"
+    )
+  }
 
-    #expect(counter.count == 0)
+  /// Drain the main-actor task queue so the observation Task runs to completion
+  /// (firing preload) or bails at a guard, without a wall-clock sleep. The
+  /// observation Task is main-actor-isolated, so repeatedly yielding the test
+  /// task lets it make full progress (`tests-no-real-time-scheduling-precision`).
+  private func drainMainActorTasks(_ iterations: Int = 20) async {
+    for _ in 0..<iterations { await Task.yield() }
   }
 }
 


### PR DESCRIPTION
## What
Two `SetupCoordinatorTests` were tautological: both used a parakeet backend whose WhisperKit setup could never reach `.ready`, so the readiness gate alone forced `count == 0` and neither the parakeet backend guard nor the rapid-restart cancellation was ever exercised.

## Fix
Add a defaulted `@MainActor setupStateReader` closure to `SetupCoordinator.init`, bound inside `init` capturing the owned `whisperKitSetup` as a local (a default parameter value cannot reference `self`). Default reads the same owned service, so **production behavior is unchanged** (verified: the preload gate routes through the seam; the observation-tracking read is untouched; the sole production construction site passes `preloadAction:` by label, so the new middle defaulted param does not shift arguments).

With setup forced `.ready`, the two tests now prove:
- `parakeetBackendSkipsPreloadWhenReady` — parakeet backend skips preload (the backend guard is the sole suppressor)
- `repeatedStartCoalescesToSinglePreload` — rapid repeated starts cancel prior observers and preload exactly once

Drained deterministically via a bounded `Task.yield` loop (no wall-clock sleep) per `tests-no-real-time-scheduling-precision`.

## Validation
- Full logic suite: **1579 tests green** (`scripts/xcode-test.sh`).
- **Mutation-verified:** deleting the parakeet backend guard fails test #1 (`count → 1`); deleting `whisperKitPreloadTask?.cancel()` fails test #2 (`count → 3`).
- Codex local diff review: CLEAN (production unchanged, Swift 6 / actor isolation clean, tests honest, scope tight).
- Live UAT: N/A — owner-stays, no app surface change.

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining

Closes #898