### PR TITLE
fix(pipeline): recover faint speech past the no-speech gate (#964)

### DIFF
--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -409,9 +409,14 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   /// Streaming finalize, then batch rescue if streaming returned empty or
   /// failed. Mirrors the old Parakeet pipeline's `transcribeWithStreamingRescue`.
-  /// The kernel runs the VAD no-speech gate before `finalize()`, so reaching
-  /// here means speech evidence was voiced or unavailable — the rescue always
-  /// attempts batch when streaming yields nothing.
+  /// The kernel runs the VAD no-speech gate before `finalize()`. Reaching here
+  /// means speech evidence was voiced, unavailable, OR (since #964) zero VAD
+  /// segments but raw energy above the dead-air floor — the faint-speech
+  /// recovery path. In that last case an empty decode is fan/room noise, not a
+  /// failure: the adapter still reports `.empty(hadSpeechEvidence: true)` (it
+  /// saw samples), and the KERNEL re-maps it to `.noSpeech` because it knows the
+  /// segments were empty. The rescue always attempts batch when streaming
+  /// yields nothing.
   private func finalizeStreamingWithRescue(batchSamples: [Float]?) async -> ASREngineOutcome {
     var diagnostics = KernelASRAdapterDiagnostics(
       streamingBuffersDispatched: streamingBuffersDispatched,
@@ -508,10 +513,13 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       diagnostics.batchRescueResultChars = trimmed.count
       lastASRDiagnostics = diagnostics
       if trimmed.isEmpty {
-        // Past the kernel's VAD no-speech gate, an empty decode is a real ASR
-        // failure — `hadSpeechEvidence: true` routes the kernel to
-        // `failed(asrEmpty)` (PR-1 §B.1.2), matching today's "Couldn't catch
-        // that" path.
+        // The adapter saw samples, so it reports `hadSpeechEvidence: true`. Past
+        // the kernel's VAD no-speech gate this normally routes to
+        // `failed(asrEmpty)` (PR-1 §B.1.2) — today's "Couldn't catch that" path.
+        // Exception (#964): when the kernel reached ASR on the faint-speech
+        // recovery path (zero VAD segments but raw energy above the dead-air
+        // floor) it re-maps this empty result to `.noSpeech`. The kernel owns
+        // that decision; the adapter's report is unchanged.
         return .empty(hadSpeechEvidence: true)
       }
       return .transcript(result)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -996,44 +996,70 @@ final class RecordingSessionKernel {
     }
 
     // VAD no-speech gate (PR-1 §B.6) — keys on *confirmed* no-speech.
+    // #964: `.confirmedNoSpeech` means Silero found zero speech segments, which
+    // also swallows faint/whispered speech sitting below Silero's 0.5 threshold.
+    // Skip ASR only when the raw buffer is ALSO dead air; otherwise fall through
+    // and let Parakeet arbitrate (it returns empty on real silence/room noise —
+    // verified on synthetic probes plus 65 competitor whisper clips).
     let speechEvidence = vad.speechEvidenceAtStop()
+    // Set when we proceed to ASR despite zero VAD segments purely because raw
+    // energy beat the dead-air floor — used below to map an empty decode back to
+    // a quiet `.noSpeech` instead of a user-visible ASR failure (#964 R2).
+    var attemptedFromEnergyDespiteNoSegments = false
     if speechEvidence == .confirmedNoSpeech {
-      // Stamp BEFORE the transition so the lifecycle-event observer reads
-      // the source at `.noSpeech` mapping time (PR-4b.2 §3.6 r7).
-      lastNoSpeechSource = .vadGate
-      telemetryState.noSpeechTelemetry = KernelNoSpeechTelemetry(
-        mode: isStreamingSession ? "streaming" : "batch",
-        rawSampleCount: captureResult.samples.count,
-        peakAudioLevel: rawPeakAudioLevel
-      )
-      emitZombieZeroPeakIfNeeded(
-        rawSamples: captureResult.samples,
-        peakAudioLevel: rawPeakAudioLevel
-      )
-      // GAP 3 app.log parity: emit the VAD filtered log here too — for
-      // `.confirmedNoSpeech`, conditioner never runs (we return below),
-      // so the filtered count is 0 by definition. Without this, the
-      // no-speech path is missing one of the OLD TP debug lines (TP:772
-      // emitted before TP:800's no-speech gate). Codex r1 (P3) on GAP 3.
-      Task {
-        await AppLogger.shared.log(
-          "VAD filtered to 0 samples (0.0% voiced)",
-          level: .verbose, category: "Pipeline"
+      if Self.rawAudioIsDeadAir(captureResult.samples, peak: rawPeakAudioLevel) {
+        // Stamp BEFORE the transition so the lifecycle-event observer reads
+        // the source at `.noSpeech` mapping time (PR-4b.2 §3.6 r7).
+        lastNoSpeechSource = .vadGate
+        telemetryState.noSpeechTelemetry = KernelNoSpeechTelemetry(
+          mode: isStreamingSession ? "streaming" : "batch",
+          rawSampleCount: captureResult.samples.count,
+          peakAudioLevel: rawPeakAudioLevel
         )
+        emitZombieZeroPeakIfNeeded(
+          rawSamples: captureResult.samples,
+          peakAudioLevel: rawPeakAudioLevel
+        )
+        // GAP 3 app.log parity: emit the VAD filtered log here too — for
+        // dead-air `.confirmedNoSpeech`, conditioner never runs (we return
+        // below), so the filtered count is 0 by definition. Without this, the
+        // no-speech path is missing one of the OLD TP debug lines (TP:772
+        // emitted before TP:800's no-speech gate). Codex r1 (P3) on GAP 3.
+        Task {
+          await AppLogger.shared.log(
+            "VAD filtered to 0 samples (0.0% voiced)",
+            level: .verbose, category: "Pipeline"
+          )
+        }
+        // GAP 3 app.log parity: VAD-gate skip log (TP:800-804) — gives debug
+        // log readers a clear marker for "user pressed without speaking."
+        let peak = rawPeakAudioLevel
+        let cnt = capturedSampleCount
+        Task {
+          await AppLogger.shared.log(
+            "VAD gate: no speech, skipping ASR "
+              + "(samples=\(cnt), peak=\(String(format: "%.4f", peak)))",
+            level: .info, category: "Pipeline"
+          )
+        }
+        finishTerminal(.noSpeech, sid: sid)
+        return
       }
-      // GAP 3 app.log parity: VAD-gate skip log (TP:800-804) — gives debug
-      // log readers a clear marker for "user pressed without speaking."
+      // Faint speech: zero VAD segments but raw energy above the dead-air floor.
+      // Recover it by transcribing instead of dropping. With zero segments the
+      // conditioner returns the raw buffer unchanged (SampleFilter early-out),
+      // so Parakeet decodes the full capture.
+      attemptedFromEnergyDespiteNoSegments = true
       let peak = rawPeakAudioLevel
       let cnt = capturedSampleCount
       Task {
         await AppLogger.shared.log(
-          "VAD gate: no speech, skipping ASR "
+          "VAD gate: zero segments but raw energy above dead-air floor — "
+            + "transcribing to recover faint speech "
             + "(samples=\(cnt), peak=\(String(format: "%.4f", peak)))",
           level: .info, category: "Pipeline"
         )
       }
-      finishTerminal(.noSpeech, sid: sid)
-      return
     }
 
     // Condition the captured audio for ASR batch rescue (PR-4.5 #5) — VAD
@@ -1181,7 +1207,15 @@ final class RecordingSessionKernel {
       await runFinalizing(sid, asrText: result.text)
     case .empty(let hadSpeechEvidence):
       mergeAdapterDiagnosticsIntoASREmpty()
-      if !hadSpeechEvidence {
+      // #964 R2: if we reached ASR only because raw energy beat the dead-air
+      // floor despite zero VAD segments, an empty decode means fan/room noise —
+      // not a failed transcription. Route it to the quiet `.noSpeech` terminal,
+      // never the user-visible `.failed(.asrEmpty)` error. The adapter reports
+      // `hadSpeechEvidence: true` (it saw samples); the kernel knows the
+      // segments were empty, so it owns the final routing decision.
+      let effectiveSpeechEvidence =
+        hadSpeechEvidence && !attemptedFromEnergyDespiteNoSegments
+      if !effectiveSpeechEvidence {
         // Stamp BEFORE the transition so the observer reads the source
         // at `.noSpeech` mapping time (PR-4b.2 §3.6 r7).
         lastNoSpeechSource = .asrEmptyNoSpeech
@@ -1210,7 +1244,8 @@ final class RecordingSessionKernel {
           )
         }
       }
-      finishTerminal(hadSpeechEvidence ? .failed(.asrEmpty) : .noSpeech, sid: sid)
+      finishTerminal(
+        effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech, sid: sid)
     case .cancelled:
       finishTerminal(.cancelled, sid: sid)
     case .failed(.wedged):
@@ -1965,6 +2000,54 @@ final class RecordingSessionKernel {
 
   private func peakAudioLevel(in samples: [Float]) -> Float {
     samples.reduce(Float(0)) { max($0, abs($1)) }
+  }
+
+  /// Empirical dead-air energy thresholds for the #964 no-speech gate. See
+  /// `rawAudioIsDeadAir`. Deliberately LOW — these reject only genuine silence,
+  /// not an audible-but-faint utterance (measured -35 dB room noise peaks at
+  /// 0.0178, above a real whisper at 0.0109, so signal level alone can't split
+  /// faint speech from noise — Parakeet is the arbiter past this floor).
+  enum DeadAirFloor {
+    /// Peak absolute amplitude (linear, Float32). ~ -44 dBFS.
+    static let peak: Float = 0.006
+    /// Whole-buffer RMS.
+    static let rms: Float = 0.00125
+    /// Loudest 40 ms window RMS — catches a faint word inside a mostly-silent
+    /// buffer where the whole-buffer RMS stays low.
+    static let windowRms: Float = 0.002
+    /// 40 ms at 16 kHz.
+    static let windowSamples = 640
+  }
+
+  /// True when a raw capture buffer is dead air (no recoverable speech) for the
+  /// #964 gate: when Silero reports zero segments we skip ASR ONLY if the raw
+  /// audio is also below every `DeadAirFloor` threshold. Otherwise the kernel
+  /// falls through and lets Parakeet decide. Pure + static so the boundary
+  /// cases (just-below / just-above each threshold) unit-test without a kernel.
+  nonisolated static func rawAudioIsDeadAir(_ samples: [Float], peak: Float)
+    -> Bool
+  {
+    guard peak < DeadAirFloor.peak else { return false }
+    guard !samples.isEmpty else { return true }
+    var sumSquares: Float = 0
+    for s in samples { sumSquares += s * s }
+    let rms = (sumSquares / Float(samples.count)).squareRoot()
+    guard rms < DeadAirFloor.rms else { return false }
+    // Loudest non-overlapping 40 ms window. A faint word lifts a local window's
+    // RMS even when most of the buffer is silence around it; tiled windows keep
+    // this bounded at O(n).
+    let window = DeadAirFloor.windowSamples
+    guard samples.count >= window else { return rms < DeadAirFloor.windowRms }
+    var maxWindowRms = rms
+    var i = 0
+    while i + window <= samples.count {
+      var ss: Float = 0
+      for j in i..<(i + window) { ss += samples[j] * samples[j] }
+      let wr = (ss / Float(window)).squareRoot()
+      if wr > maxWindowRms { maxWindowRms = wr }
+      i += window
+    }
+    return maxWindowRms < DeadAirFloor.windowRms
   }
 
   private static func speechDurationMs(_ segments: [SpeechSegment]) -> Int {

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - RecordingSessionKernelDeadAirFloorTests (#964)
+//
+// Boundary coverage for `RecordingSessionKernel.rawAudioIsDeadAir`, the
+// energy floor that decides whether a `.confirmedNoSpeech` (zero VAD segments)
+// capture is genuinely silent (skip ASR) or faint speech to recover (fall
+// through to Parakeet). Per `matcher-set-adversarial-tests`, each of the three
+// thresholds (peak / whole-buffer RMS / loudest-40 ms-window RMS) is exercised
+// just-below and just-above, plus the realistic faint-whisper and dead-air
+// shapes the floor was tuned against.
+
+@Suite("RecordingSessionKernel dead-air floor (#964)")
+struct RecordingSessionKernelDeadAirFloorTests {
+
+  /// Mirror the kernel's own peak input (`rawPeakAudioLevel` = max abs sample).
+  private func peak(_ samples: [Float]) -> Float {
+    samples.reduce(Float(0)) { max($0, abs($1)) }
+  }
+
+  private func isDeadAir(_ samples: [Float]) -> Bool {
+    RecordingSessionKernel.rawAudioIsDeadAir(samples, peak: peak(samples))
+  }
+
+  // MARK: Peak threshold (0.006)
+
+  @Test("uniform sub-floor buffer is dead air")
+  func uniformSubFloorIsDeadAir() {
+    // 0.001 < every threshold → dead air.
+    #expect(isDeadAir([Float](repeating: 0.001, count: 16_000)))
+  }
+
+  @Test("a single sample just above the peak floor is NOT dead air")
+  func peakJustAboveIsNotDeadAir() {
+    // One loud sample (0.0061 ≥ 0.006) in otherwise-silent audio → recover.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    samples[8_000] = 0.0061
+    #expect(!isDeadAir(samples))
+  }
+
+  // MARK: Whole-buffer RMS threshold (0.00125)
+
+  @Test("uniform amplitude just below the RMS floor is dead air")
+  func rmsJustBelowIsDeadAir() {
+    // 0.0011 < peak floor, < RMS floor, < window floor → dead air.
+    #expect(isDeadAir([Float](repeating: 0.0011, count: 16_000)))
+  }
+
+  @Test("uniform amplitude above the RMS floor (but below peak) is NOT dead air")
+  func rmsJustAboveIsNotDeadAir() {
+    // 0.0013: peak 0.0013 < 0.006, but RMS 0.0013 > 0.00125 → recover.
+    #expect(!isDeadAir([Float](repeating: 0.0013, count: 16_000)))
+  }
+
+  // MARK: Loudest-window RMS threshold (0.002) — the faint-word case
+
+  @Test("a faint word inside silence is recovered (window RMS above floor)")
+  func faintWordInSilenceIsNotDeadAir() {
+    // Whole-buffer RMS stays tiny, but a 40 ms (640-sample) burst at 0.003
+    // raises a local window above the 0.002 window floor → recover. This is the
+    // headline #964 case: a soft leading word the whole-buffer average hides.
+    // The burst is aligned to the 640-sample tile grid (3840 = 6 × 640) so it
+    // fully occupies one window.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    for i in 3_840..<4_480 { samples[i] = 0.003 }
+    // Sanity: peak and whole-buffer RMS are both below their floors here, so
+    // ONLY the window check can save this buffer.
+    #expect(peak(samples) < RecordingSessionKernel.DeadAirFloor.peak)
+    #expect(!isDeadAir(samples))
+  }
+
+  @Test("a window just below the window floor is still dead air")
+  func windowJustBelowIsDeadAir() {
+    // 0.0019 burst: peak/whole-RMS tiny, window RMS 0.0019 < 0.002 → dead air.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    for i in 3_840..<4_480 { samples[i] = 0.0019 }
+    #expect(isDeadAir(samples))
+  }
+
+  @Test("a window just above the window floor is NOT dead air")
+  func windowJustAboveIsNotDeadAir() {
+    // 0.0021 burst: window RMS 0.0021 > 0.002 → recover.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    for i in 3_840..<4_480 { samples[i] = 0.0021 }
+    #expect(!isDeadAir(samples))
+  }
+
+  // MARK: Degenerate + realistic shapes
+
+  @Test("empty buffer is dead air")
+  func emptyBufferIsDeadAir() {
+    #expect(RecordingSessionKernel.rawAudioIsDeadAir([], peak: 0))
+  }
+
+  @Test("a buffer shorter than one window falls back to RMS-vs-window-floor")
+  func subWindowBufferUsesRmsFallback() {
+    // 320 samples (< 640-sample window) at 0.001 → RMS 0.001 < 0.002 → dead air.
+    #expect(isDeadAir([Float](repeating: 0.001, count: 320)))
+    // 320 samples at 0.0025 → peak 0.0025 < 0.006, but RMS 0.0025 > 0.00125
+    // → recover (RMS gate fires before the sub-window fallback).
+    #expect(!isDeadAir([Float](repeating: 0.0025, count: 320)))
+  }
+
+  @Test("a realistic faint whisper (peak ~0.011) is NOT dead air")
+  func realisticFaintWhisperIsNotDeadAir() {
+    // The measured faint-whisper peak (0.0109) sits above the peak floor — the
+    // exact speech #964 must stop dropping.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    for i in 2_000..<10_000 { samples[i] = (i % 2 == 0) ? 0.011 : -0.011 }
+    #expect(!isDeadAir(samples))
+  }
+
+  @Test("realistic room-tone dead air stays gated")
+  func realisticRoomToneIsDeadAir() {
+    // Low-level room tone: peak 0.004 < floor, with tiny broadband RMS.
+    var samples = [Float](repeating: 0.0, count: 16_000)
+    for i in samples.indices { samples[i] = (i % 7 == 0) ? 0.0008 : 0.0002 }
+    #expect(peak(samples) < RecordingSessionKernel.DeadAirFloor.peak)
+    #expect(isDeadAir(samples))
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -163,9 +163,14 @@ final class FakeAudioCapture: AudioCaptureInterface {
   // MARK: Harness control surface (scenario `CaptureDirective`s)
 
   /// Deliver one synthetic 16 kHz mono Float32 buffer onto the capture stream
-  /// and through `onBufferCaptured`.
-  func deliverBuffer(frameCount: Int = AudioConstants.captureBufferSize) {
-    let samples = [Float](repeating: 0.1, count: frameCount)
+  /// and through `onBufferCaptured`. `amplitude` controls the constant sample
+  /// value — the default 0.1 is well above the kernel's #964 dead-air floor; a
+  /// sub-floor value (e.g. 0.001) lets a scenario express a genuinely silent
+  /// capture so the no-speech gate can be exercised end-to-end.
+  func deliverBuffer(
+    frameCount: Int = AudioConstants.captureBufferSize, amplitude: Float = 0.1
+  ) {
+    let samples = [Float](repeating: amplitude, count: frameCount)
     accumulatedSamples.append(contentsOf: samples)
     deliveredBufferCount += 1
     guard let buffer = Self.makeBuffer(samples: samples) else { return }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -69,8 +69,12 @@ enum LimbDirective: Sendable {
 
 /// A directive to the `FakeAudioCapture` mid-scenario.
 enum CaptureDirective: Sendable {
-  /// Deliver one synthetic audio buffer.
+  /// Deliver one synthetic audio buffer (amplitude 0.1 — above the #964
+  /// dead-air floor).
   case deliverBuffer
+  /// Deliver one synthetic buffer below the #964 dead-air floor — a genuinely
+  /// silent capture (amplitude 0.001).
+  case deliverSilentBuffer
   /// Stall the capture stream (no buffers).
   case stall
   /// Raise an engine interruption (mic disconnect / route change).

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -245,6 +245,45 @@ enum ScenarioInventory {
       expected: ExpectedOutcome(
         terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
         transcript: .nonEmpty)),
+    // A20–A22: #964 faint-speech recovery. Silero reports zero segments
+    // (`.confirmedNoSpeech`), but the raw buffer above the dead-air floor must
+    // reach ASR instead of being dropped.
+    Scenario(
+      id: "A20", name: "#964 zero segments + energy -> ASR recovers faint speech",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "actually let's go"))),
+        .vad(.evidence(.confirmedNoSpeech)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
+    Scenario(
+      id: "A21", name: "#964 zero segments + energy + empty decode -> noSpeech (R2)",
+      steps: [
+        // Reaching ASR on the energy path then getting an empty decode is
+        // fan/room noise, NOT a failure — the kernel must map it to `.noSpeech`,
+        // never `.failed(.asrEmpty)`, despite the adapter's `hadSpeechEvidence`.
+        .engine(.setBehavior(.empty(hadSpeechEvidence: true))),
+        .vad(.evidence(.confirmedNoSpeech)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .noSpeech, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none)),
+    Scenario(
+      id: "A22", name: "#964 zero segments + dead air -> gate still skips ASR",
+      steps: [
+        // A silent tap (sub-floor amplitude) must still skip ASR entirely — the
+        // engine is never consulted, so the configured batch success is unused.
+        .engine(.setBehavior(.batchSuccess(text: "should never paste"))),
+        .vad(.evidence(.confirmedNoSpeech)),
+        .trigger(.start), .capture(.deliverSilentBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .noSpeech, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none)),
   ]
 
   // MARK: §1.3 regression locks (R1, R2)
@@ -402,6 +441,7 @@ enum ScenarioInventory {
   static let canonicalIDs: Set<String> = [
     "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10",
     "A11", "A12", "A13", "A14", "A15", "A16", "A17", "A18", "A19",
+    "A20", "A21", "A22",
     "R1", "R2",
     "C1", "C2", "C3", "C4", "C5", "C6",
     "L1", "L2", "L3", "L4", "L5", "L6",

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
@@ -8,10 +8,10 @@ import Testing
 @Suite("ScenarioInventory")
 struct ScenarioInventoryTests {
 
-  @Test("the inventory holds exactly the 33 canonical scenarios")
-  func inventoryHoldsThirtyThree() {
-    #expect(ScenarioInventory.all.count == 33)
-    #expect(ScenarioInventory.canonicalIDs.count == 33)
+  @Test("the inventory holds exactly the 36 canonical scenarios")
+  func inventoryHoldsThirtySix() {
+    #expect(ScenarioInventory.all.count == 36)
+    #expect(ScenarioInventory.canonicalIDs.count == 36)
   }
 
   @Test("the inventory's ID set matches the canonical ID set exactly")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -148,6 +148,10 @@ struct ScenarioRunner {
     switch captureDirective {
     case .deliverBuffer:
       context.capture.deliverBuffer()
+    case .deliverSilentBuffer:
+      // Below the #964 dead-air floor (peak/rms/window-rms all < threshold) so
+      // the kernel's no-speech gate still skips ASR on a genuinely silent tap.
+      context.capture.deliverBuffer(amplitude: 0.001)
     case .stall:
       // A stall fires the liveness-watchdog signal — not merely an absence
       // of buffers (C3 / C4). Routed through the kernel's external entry to


### PR DESCRIPTION
Closes #964

## Problem
The no-speech gate skipped ASR whenever Silero produced **zero VAD segments** (`.confirmedNoSpeech`). That also discarded faint/whispered speech sitting below Silero's threshold — the "competitor hears me from across the room but EnviousWispr doesn't, so I have to speak up" report.

## Fix
Skip ASR only when the raw buffer is **also** below a low dead-air energy floor (peak / whole-buffer RMS / loudest-40ms-window RMS, exact step-1 sliding scan). Otherwise fall through and let Parakeet arbitrate. Energy alone cannot separate faint speech from noise (measured −35 dB noise peaks above a real whisper), so the floor is deliberately low and **Parakeet is the arbiter past it** — it returns empty on real silence/noise (verified on synthetic probes + 65 competitor whisper clips).

- **R2 (critical):** an empty decode on the energy-recovery path is fan/room noise, not a failed transcription → kernel maps it to a quiet `.noSpeech`, never the user-visible `.failed(.asrEmpty)`. The normal voiced-empty path is unchanged (locked by scenario A11).
- **R1:** refreshed now-stale `ParakeetEngineAdapter` finalize comments.

Heart-path safe: raw transcription is never blocked; min-recording-duration discard still runs first; zero segments make `SampleFilter` return raw unchanged (no new zero-padding / RNNT-loop hazard).

## Tests
- 13 dead-air boundary unit tests (each threshold just-below/just-above; realistic faint-whisper + room-tone; **trailing-partial** and **boundary-straddling** bursts).
- Sim scenarios **A20** (faint speech recovered → pasted), **A21** (empty decode → `.noSpeech`, not an error), **A22** (genuine silence still gated, ASR never consulted).
- Full suite green: 1,592 tests, 0 failures.

## Validation
- Founder Live UAT on the rebuilt dev app: soft/far speech captured cleanly, **no regressions** (every take landed clean, ~0.5s).
- Codex code-diff review: **PROCEED** (clean after one sliding-window edge-case fix folded in).
- Offline scorecard stable: no-speech recoverable, zero hallucination on silence/noise.

Sequenced as PR-A of two; PR-B (#843, onset trim) follows separately.