### PR TITLE
fix(pipeline): preserve soft leading word past the onset trim (#843)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -14,6 +14,7 @@ internal struct ASREmptyResultDiagnostics {
   var finalSampleCount: Int?
   var samplesPaddedToMinimum: Bool?
   var usedRawFallbackAfterVAD: Bool?
+  var usedRawSoftOnsetPreservation: Bool?
 
   var streamingResultChars: Int?
   var streamingFinalizeFailed: Bool?
@@ -74,6 +75,9 @@ internal struct ASREmptyResultDiagnostics {
     put(finalSampleCount, key: "asr.final_sample_count", into: &extra)
     put(samplesPaddedToMinimum, key: "asr.samples_padded_to_minimum", into: &extra)
     put(usedRawFallbackAfterVAD, key: "asr.used_raw_fallback_after_vad", into: &extra)
+    put(
+      usedRawSoftOnsetPreservation,
+      key: "asr.used_raw_soft_onset_preservation", into: &extra)
 
     put(streamingResultChars, key: "asr.streaming_result_chars", into: &extra)
     put(streamingFinalizeFailed, key: "asr.streaming_finalize_failed", into: &extra)

--- a/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
+++ b/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
@@ -39,6 +39,13 @@ public struct ConditionedAudio: Equatable, Sendable {
   /// Matches the old Parakeet pipeline's raw-fallback branch.
   public let usedRawFallbackAfterVAD: Bool
 
+  /// `true` when #843 soft-onset preservation fired — a short take whose VAD
+  /// filter would have dropped a large early-onset prefix, so the conditioner
+  /// returned the full raw capture to keep the soft leading word ("Actually",
+  /// "Overall"). Distinct from `usedRawFallbackAfterVAD`, which fires only when
+  /// the filtered audio itself fell below the ASR minimum.
+  public let usedRawSoftOnsetPreservation: Bool
+
   /// `true` when the final sample count was below the ASR minimum and the
   /// conditioner appended silence to reach it. Matches the old Parakeet
   /// pipeline's short-utterance padding.
@@ -48,6 +55,17 @@ public struct ConditionedAudio: Equatable, Sendable {
   /// kept explicit so the telemetry surface does not depend on whether the
   /// caller bothered to recompute.
   public var finalSampleCount: Int { samples.count }
+
+  /// Human-readable label of which conditioning path produced `samples`, for
+  /// telemetry/triage. Soft-onset preservation and the too-aggressive fallback
+  /// both yield raw audio but for different reasons; `filteredSampleCount`
+  /// distinguishes a genuine trim from a no-op passthrough.
+  public var conditioningReason: String {
+    if usedRawSoftOnsetPreservation { return "rawSoftOnset" }
+    if usedRawFallbackAfterVAD { return "rawFallbackTooAggressive" }
+    if samplesPaddedToMinimum { return "filteredPaddedToMinimum" }
+    return "filtered"
+  }
 }
 
 /// Apply VAD-segment filtering, too-aggressive-filter raw fallback, and
@@ -73,14 +91,34 @@ public enum CapturedAudioConditioner {
     let filtered = SampleFilter.filter(from: rawSamples, segments: vadSegments)
     let filteredCount = filtered.count
 
-    // Step 2: too-aggressive-filter raw fallback at the conditioner layer
-    //. Even with non-empty
-    // segments, SampleFilter's merge can produce fewer than `minimumSamples`
-    // if voiced regions were sparse. If raw audio would meet the minimum,
-    // prefer raw — losing words is worse than ASR seeing extra silence.
     var working = filtered
     var usedRawFallback = false
-    if working.count < minimumSamples && rawSamples.count >= minimumSamples {
+    var usedRawSoftOnset = false
+    let rawMeetsMinimum = rawSamples.count >= minimumSamples
+
+    // Step 2a: #843 soft-onset preservation. A soft vowel-initial leading word
+    // ("Actually", "Overall") sits just before the first VAD segment and the
+    // filter trims it away. When a SHORT take's speech starts EARLY and the
+    // filter would drop a LARGE fraction of the raw audio, that dropped prefix
+    // is very likely the real onset — feed the full raw capture to ASR instead.
+    // Parakeet handles the extra leading silence and returns empty on true
+    // silence/noise (verified on synthetic probes + 65 competitor clips).
+    // R3 (Codex): only when raw ALREADY meets the ASR minimum, so this branch
+    // never routes a sub-minimum buffer into the Step 3 zero-padding below — the
+    // RNNT decoder-loop hazard (gotchas-audio: "Do not pad silence").
+    if rawMeetsMinimum,
+      shouldPreserveSoftOnset(
+        rawCount: rawSamples.count,
+        filteredCount: filteredCount,
+        vadSegments: vadSegments)
+    {
+      working = rawSamples
+      usedRawSoftOnset = true
+    } else if working.count < minimumSamples && rawMeetsMinimum {
+      // Step 2b: too-aggressive-filter raw fallback (pre-existing). Even with
+      // non-empty segments, SampleFilter's merge can produce fewer than
+      // `minimumSamples` if voiced regions were sparse. Prefer raw — losing
+      // words is worse than ASR seeing extra silence.
       working = rawSamples
       usedRawFallback = true
     }
@@ -100,6 +138,44 @@ public enum CapturedAudioConditioner {
       samples: working,
       filteredSampleCount: filteredCount,
       usedRawFallbackAfterVAD: usedRawFallback,
+      usedRawSoftOnsetPreservation: usedRawSoftOnset,
       samplesPaddedToMinimum: padded)
+  }
+
+  // MARK: #843 soft-onset preservation
+
+  /// Thresholds for soft-onset preservation. Derived from the empirical capture
+  /// audit on #843: the dropped "Actually"/"Overall" takes were short (≤2.7 s),
+  /// their single VAD segment started early, and the trim removed 55-63% of the
+  /// raw audio. Deliberately conservative so a long dictation's legitimate
+  /// trailing-silence trim is never mistaken for onset loss.
+  enum SoftOnset {
+    /// Only short takes. A long dictation dropping ≥25% is real silence trim,
+    /// not a clipped first word.
+    static let maxRawSamples = Int(8 * AudioConstants.sampleRate)  // 8.0 s
+    /// The earliest segment must start within this window for the dropped
+    /// prefix to be a plausible onset rather than a long pre-speech pause.
+    static let maxFirstSegmentStartSample = Int(2 * AudioConstants.sampleRate)  // 2.0 s
+    /// Fraction of raw the filter must drop before we treat it as onset loss.
+    static let minDroppedFraction = 0.25
+  }
+
+  /// True when the VAD filter looks like it clipped a soft leading word: a short
+  /// take, with at least one segment that starts early, where filtering dropped
+  /// a large fraction of the raw audio. Pure + internal so the boundary cases
+  /// (drop% / segment-start / raw-length, each just below and just above the
+  /// threshold) unit-test directly.
+  static func shouldPreserveSoftOnset(
+    rawCount: Int, filteredCount: Int, vadSegments: [SpeechSegment]
+  ) -> Bool {
+    guard rawCount > 0, rawCount <= SoftOnset.maxRawSamples else { return false }
+    // Earliest segment start (segments are not guaranteed sorted).
+    guard let firstStart = vadSegments.map(\.startSample).min() else { return false }
+    guard firstStart < SoftOnset.maxFirstSegmentStartSample else { return false }
+    // Filtering dropped ≥ minDroppedFraction of the raw audio. (When the filter
+    // no-op'd — empty/sub-threshold segments — filteredCount == rawCount, so the
+    // drop is 0 and this is false.)
+    let dropped = rawCount - filteredCount
+    return Double(dropped) >= SoftOnset.minDroppedFraction * Double(rawCount)
   }
 }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1163,6 +1163,7 @@ final class RecordingSessionKernel {
       finalSampleCount: conditioned.finalSampleCount,
       samplesPaddedToMinimum: conditioned.samplesPaddedToMinimum,
       usedRawFallbackAfterVAD: conditioned.usedRawFallbackAfterVAD,
+      usedRawSoftOnsetPreservation: conditioned.usedRawSoftOnsetPreservation,
       speechSegments: vadSegments
     )
     // PR-4.5 §8 metadata-only telemetry: sample counts + booleans, no audio
@@ -1172,7 +1173,8 @@ final class RecordingSessionKernel {
     // genuinely short utterance.
     log(
       "conditioner raw=\(captureResult.samples.count) filtered=\(conditioned.filteredSampleCount) "
-        + "rawFallback=\(conditioned.usedRawFallbackAfterVAD) padded=\(conditioned.samplesPaddedToMinimum) "
+        + "rawFallback=\(conditioned.usedRawFallbackAfterVAD) softOnset=\(conditioned.usedRawSoftOnsetPreservation) "
+        + "padded=\(conditioned.samplesPaddedToMinimum) reason=\(conditioned.conditioningReason) "
         + "final=\(conditioned.finalSampleCount)")
 
     // Transcribing.

--- a/Tests/EnviousWisprTests/Pipeline/CapturedAudioConditionerSoftOnsetTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CapturedAudioConditionerSoftOnsetTests.swift
@@ -1,0 +1,155 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - CapturedAudioConditionerSoftOnsetTests (#843)
+//
+// Boundary coverage for soft-onset preservation: when the VAD filter would clip
+// a soft leading word ("Actually", "Overall") the conditioner feeds the full
+// raw capture to ASR instead. Per `matcher-set-adversarial-tests`, each of the
+// three gates (dropped-fraction, first-segment-start, raw-length) is exercised
+// just below and just above its threshold, plus the R3 zero-padding guard, the
+// real audited takes, and #950 tail integrity.
+
+@Suite("CapturedAudioConditioner soft-onset preservation (#843)")
+struct CapturedAudioConditionerSoftOnsetTests {
+
+  // 16 kHz: 8 s = 128_000 samples, 2 s = 32_000, 1 s (ASR minimum) = 16_000.
+  private let maxRaw = 128_000
+  private let maxFirstStart = 32_000
+
+  private func seg(_ start: Int, _ end: Int) -> SpeechSegment {
+    SpeechSegment(startSample: start, endSample: end)
+  }
+
+  private func shouldPreserve(raw: Int, filtered: Int, segs: [SpeechSegment]) -> Bool {
+    CapturedAudioConditioner.shouldPreserveSoftOnset(
+      rawCount: raw, filteredCount: filtered, vadSegments: segs)
+  }
+
+  // MARK: dropped-fraction gate (25%)
+
+  @Test("drop exactly at 25% preserves (boundary inclusive)")
+  func dropAtThresholdPreserves() {
+    // raw 40_000, dropped 10_000 == 0.25 × 40_000 → preserve.
+    #expect(shouldPreserve(raw: 40_000, filtered: 30_000, segs: [seg(5_000, 25_000)]))
+  }
+
+  @Test("drop just below 25% does NOT preserve")
+  func dropJustBelowDoesNotPreserve() {
+    // dropped 9_999 < 10_000 → keep filtered.
+    #expect(!shouldPreserve(raw: 40_000, filtered: 30_001, segs: [seg(5_000, 25_000)]))
+  }
+
+  // MARK: first-segment-start gate (2.0 s)
+
+  @Test("first segment starting just inside 2.0 s preserves")
+  func segmentStartJustInsidePreserves() {
+    #expect(shouldPreserve(raw: 40_000, filtered: 29_000, segs: [seg(maxFirstStart - 1, 39_000)]))
+  }
+
+  @Test("first segment starting at exactly 2.0 s does NOT preserve")
+  func segmentStartAtBoundaryDoesNotPreserve() {
+    // Guard is `< 32_000`, so 32_000 is a long pre-speech pause, not an onset.
+    #expect(!shouldPreserve(raw: 40_000, filtered: 29_000, segs: [seg(maxFirstStart, 39_000)]))
+  }
+
+  // MARK: raw-length gate (8.0 s)
+
+  @Test("raw length at exactly 8 s preserves (boundary inclusive)")
+  func rawLengthAtBoundaryPreserves() {
+    // 25%+ dropped, early start, raw == 128_000.
+    #expect(shouldPreserve(raw: maxRaw, filtered: 90_000, segs: [seg(4_000, 100_000)]))
+  }
+
+  @Test("raw longer than 8 s does NOT preserve (legitimate silence trim)")
+  func rawTooLongDoesNotPreserve() {
+    // A long dictation dropping 30% is real trailing silence, not a clipped word.
+    #expect(!shouldPreserve(raw: maxRaw + 1, filtered: 90_000, segs: [seg(4_000, 100_000)]))
+  }
+
+  // MARK: degenerate inputs
+
+  @Test("no segments does NOT preserve")
+  func noSegmentsDoesNotPreserve() {
+    #expect(!shouldPreserve(raw: 40_000, filtered: 40_000, segs: []))
+  }
+
+  @Test("zero raw does NOT preserve")
+  func zeroRawDoesNotPreserve() {
+    #expect(!shouldPreserve(raw: 0, filtered: 0, segs: [seg(0, 0)]))
+  }
+
+  @Test("earliest of several unsorted segments is what counts")
+  func earliestUnsortedSegmentCounts() {
+    // Segments out of order; the earliest (5_000) is well inside 2 s → preserve.
+    #expect(
+      shouldPreserve(
+        raw: 40_000, filtered: 26_000, segs: [seg(35_000, 39_000), seg(5_000, 20_000)]))
+    // Earliest at 32_000 (== boundary) → not an onset.
+    #expect(
+      !shouldPreserve(
+        raw: 40_000, filtered: 26_000, segs: [seg(35_000, 39_000), seg(maxFirstStart, 38_000)]))
+  }
+
+  // MARK: end-to-end condition()
+
+  @Test("soft-onset fires end-to-end: full raw returned, not padded, reason rawSoftOnset")
+  func conditionReturnsRawOnSoftOnset() {
+    // 41_600 raw (2.6 s) with one early segment; the filter trims ~63% so the
+    // soft-onset branch returns the full raw. Mirrors the audited "Actually,
+    // let's go for dinner" take (1780524120277).
+    let raw = [Float](repeating: 0.1, count: 41_600)
+    let result = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(8_000, 20_000)])
+    #expect(result.usedRawSoftOnsetPreservation)
+    #expect(!result.usedRawFallbackAfterVAD)
+    #expect(!result.samplesPaddedToMinimum)
+    #expect(result.samples.count == 41_600)
+    #expect(result.conditioningReason == "rawSoftOnset")
+  }
+
+  @Test("#950 tail integrity: preserved raw equals the original buffer exactly")
+  func preservedRawIsByteForByteIdentical() {
+    // Distinct ramp so any truncation/reorder is caught, not just a count match.
+    var raw = [Float](repeating: 0, count: 41_600)
+    for i in raw.indices { raw[i] = Float(i % 97) / 97.0 }
+    let result = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(8_000, 20_000)])
+    #expect(result.usedRawSoftOnsetPreservation)
+    #expect(result.samples == raw)  // full tail preserved, no truncation
+  }
+
+  @Test("R3 guard: sub-minimum raw never soft-onset-preserves (no zero-padded raw)")
+  func subMinimumRawDoesNotSoftOnsetPreserve() {
+    // 12_000 raw (< 16_000 ASR minimum). The SHAPE otherwise qualifies — early
+    // segment, ≥25% trim — yet soft-onset must NOT fire, because it would route a
+    // sub-minimum buffer into the zero-padding step (the RNNT-loop hazard). The
+    // pre-existing path runs instead and pads to the minimum.
+    let raw = [Float](repeating: 0.1, count: 12_000)
+    // The shape qualifies on its own (only the sub-minimum guard in condition()
+    // blocks it):
+    #expect(
+      CapturedAudioConditioner.shouldPreserveSoftOnset(
+        rawCount: 12_000, filteredCount: 8_000, vadSegments: [seg(5_000, 10_000)]))
+    let result = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(5_000, 10_000)])
+    #expect(!result.usedRawSoftOnsetPreservation)
+    #expect(result.samplesPaddedToMinimum)
+    #expect(result.samples.count == 16_000)
+  }
+
+  @Test("normal long take with small trim stays filtered")
+  func longTakeStaysFiltered() {
+    // 6 s raw, speech across most of it → filter drops < 25% and stays well above
+    // the minimum → filtered audio used, soft-onset does not fire.
+    let raw = [Float](repeating: 0.1, count: 96_000)
+    let result = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(2_000, 92_000)])
+    #expect(!result.usedRawSoftOnsetPreservation)
+    #expect(result.conditioningReason == "filtered")
+    #expect(result.samples.count < raw.count)  // it really did trim
+  }
+}


### PR DESCRIPTION
Closes #843

## Problem
A soft vowel-initial leading word ("Actually", "Overall") sits just before the first VAD segment, so the conditioner's trim shaves it off. The founder's capture audit proved it: raw "Actually, let's go for dinner" trimmed to "Let's go for dinner" on ~a third of soft-onset takes.

## Fix (Codex "option 4", kernel-side conditioner)
After computing the VAD-filtered audio, if the take is short (raw ≤ 8s), has ≥1 segment that starts early (< 2.0s), and filtering would drop ≥ 25% of the raw audio, return the **full raw capture** instead. Sidesteps the pre-roll index-offset trap (#827 burned 5 rounds on it). Parakeet handles the extra leading silence and returns empty on true silence/noise (verified on synthetic probes + 65 competitor clips), so this does not trade onset recovery for hallucination.

- **R3 (Codex):** gated on raw already meeting the ASR minimum, so the raw-preserve branch never routes a sub-minimum buffer into the zero-padding step (RNNT decoder-loop hazard).
- Telemetry: `usedRawSoftOnsetPreservation` + `conditioningReason` threaded through the ASR-empty diagnostics + kernel conditioner log.
- Deliberately scoped to the proven feed-raw fix; the secondary `speechPadding` 0.0→0.1 flip (changes segmentation globally) is left for separate validation.

## Tests
- 17 boundary cases: drop% / first-segment-start / raw-length each just below & above threshold; the R3 sub-minimum guard; the two audited "Actually" takes; #950 byte-for-byte tail integrity; the early-start-but-trailing-silence tradeoff case (Codex r1).
- Full suite green: 1,604 tests, 0 failures.

## Validation
- Codex code-diff review: **PROCEED** (clean after a doc/test-only round).
- Founder Live UAT on the combined PR-A+PR-B build: the fix engaged correctly on a 26%-drop soft-onset take (`softOnset=true`, full raw fed) and correctly stayed on the filtered path for 12 other takes — fires when it should, no misfires.

Second of the two-PR "capture generously" sequence; PR-A (#964) already merged.