### PR TITLE
fix(settings): remove misleading Recording Environment picker (#969)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -149,9 +149,6 @@ final class PipelineSettingsSync {
       reconcileOllamaEviction(settings: settings)
     case .hotkeyEnabled:
       if settings.hotkeyEnabled { hotkeyService.start() } else { hotkeyService.stop() }
-    case .environmentPreset:
-      // Cascade into `vadSensitivity` for the next recording's snapshot.
-      settings.vadSensitivity = settings.environmentPreset.vadSensitivity
     case .cancelKeyCode:
       hotkeyService.cancelKeyCode = settings.cancelKeyCode
     case .cancelModifiers:

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -2,7 +2,7 @@ import EnviousWisprCore
 import EnviousWisprServices
 import SwiftUI
 
-/// Transcription engine, multi-language options, recording environment, and cleanup settings.
+/// Transcription engine, multi-language options, and cleanup settings.
 struct SpeechEngineSettingsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(SetupCoordinator.self) private var setup
@@ -121,15 +121,8 @@ struct SpeechEngineSettingsView: View {
         }
       }
 
-      // ── Section 3: Recording Environment ─────────────────────────────
-      BrandedSection(header: "Recording Environment") {
-        BrandedRow {
-          EnvironmentPresetCards(
-            selection: Binding(
-              get: { settings.environmentPreset },
-              set: { settings.environmentPreset = $0 }
-            ))
-        }
+      // ── Section 3: Auto-Stop ─────────────────────────────────────────
+      BrandedSection(header: "Auto-Stop") {
         BrandedRow {
           VStack(alignment: .leading, spacing: 4) {
             Toggle("Stop recording on silence", isOn: $settings.vadAutoStop)
@@ -341,91 +334,5 @@ struct SpeechEngineSettingsView: View {
     }
     .buttonStyle(.borderless)
     .help("Re-check model status")
-  }
-}
-
-// ── Environment preset card picker ───────────────────────────────────────────
-
-private struct PresetInfo {
-  let preset: EnvironmentPreset
-  let emoji: String
-  let name: String
-  let description: String
-}
-
-private let presets: [PresetInfo] = [
-  PresetInfo(
-    preset: .quiet, emoji: "🤫", name: "Quiet", description: "Library, bedroom, quiet office"),
-  PresetInfo(preset: .normal, emoji: "🏠", name: "Normal", description: "Home, private office"),
-  PresetInfo(preset: .noisy, emoji: "🏢", name: "Noisy", description: "Open office, café, outdoors"),
-]
-
-private struct EnvironmentPresetCards: View {
-  @Binding var selection: EnvironmentPreset
-
-  var body: some View {
-    HStack(spacing: 8) {
-      ForEach(presets, id: \.preset) { info in
-        PresetCard(info: info, isSelected: selection == info.preset) {
-          selection = info.preset
-        }
-      }
-    }
-  }
-}
-
-private struct PresetCard: View {
-  let info: PresetInfo
-  let isSelected: Bool
-  let onTap: () -> Void
-
-  var body: some View {
-    Button(action: onTap) {
-      VStack(spacing: 4) {
-        ZStack(alignment: .topTrailing) {
-          Color.clear.frame(height: 1)  // layout anchor
-          if isSelected {
-            Image(systemName: "checkmark.circle.fill")
-              .font(.system(size: 11))
-              .foregroundStyle(.white)
-              .background(Color.stAccent)
-              .clipShape(Circle())
-              .offset(x: 2, y: -2)
-          }
-        }
-        .frame(height: 12)
-
-        Text(info.emoji)
-          .font(.system(size: 22))
-
-        Text(info.name)
-          .font(.system(size: 12.5, weight: .semibold))
-          .foregroundStyle(.primary)
-
-        Text(info.description)
-          .font(.system(size: 10.5))
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-          .lineLimit(2)
-      }
-      .padding(.vertical, 10)
-      .padding(.horizontal, 8)
-      .frame(maxWidth: .infinity)
-      .contentShape(Rectangle())
-      .background(
-        RoundedRectangle(cornerRadius: 9)
-          .fill(isSelected ? Color.stAccent.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
-          .overlay(
-            RoundedRectangle(cornerRadius: 9)
-              .stroke(
-                isSelected ? Color.stAccent : Color(nsColor: .separatorColor),
-                lineWidth: isSelected ? 1.5 : 1)
-          )
-          .shadow(color: isSelected ? Color.stAccent.opacity(0.20) : .clear, radius: 4, y: 2)
-      )
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel("\(info.name) — \(info.description)")
-    .accessibilityValue(isSelected ? "selected" : "")
   }
 }

--- a/Sources/EnviousWisprCore/SettingsEnums.swift
+++ b/Sources/EnviousWisprCore/SettingsEnums.swift
@@ -8,17 +8,3 @@ public enum OnboardingState: String, Codable, Sendable {
   case needsPermissions = "needsCompletion"
   case completed = "completed"
 }
-
-public enum EnvironmentPreset: String, CaseIterable, Codable, Sendable {
-  case quiet = "quiet"
-  case normal = "normal"
-  case noisy = "noisy"
-
-  public var vadSensitivity: Float {
-    switch self {
-    case .quiet: return 0.8
-    case .normal: return 0.5
-    case .noisy: return 0.2
-    }
-  }
-}

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -56,7 +56,6 @@ enum SettingsDefaultValues {
   static let selectedInputDeviceUID = ""
   static let noiseSuppression = false
   static let preferredInputDeviceIDOverride = ""
-  static let environmentPreset: EnvironmentPreset = .normal
 
   static let useStreamingASR = false
   static let warmEnginePolicy: WarmEnginePolicy = .seconds30

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -37,7 +37,6 @@ public final class SettingsManager {
     case selectedInputDeviceUID
     case noiseSuppression
     case preferredInputDeviceIDOverride
-    case environmentPreset
     case useXPCAudioService
     case useStreamingASR
     case warmEnginePolicy
@@ -63,7 +62,7 @@ public final class SettingsManager {
     "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
     "emojiFormatterEnabled", "isDebugModeEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
-    "selectedInputDeviceUID", "preferredInputDeviceIDOverride", "environmentPreset",
+    "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
     "useStreamingASR", "warmEnginePolicy",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
   ]
@@ -331,13 +330,6 @@ public final class SettingsManager {
     }
   }
 
-  public var environmentPreset: EnvironmentPreset {
-    didSet {
-      defaults.set(environmentPreset.rawValue, forKey: "environmentPreset")
-      onChange?(.environmentPreset)
-    }
-  }
-
   /// Use XPC audio service instead of in-process AudioCaptureManager.
   /// Default: true (Step 7 — XPC is the standard path).
   /// Cold flag — read at launch only. Changing requires app restart.
@@ -524,9 +516,6 @@ public final class SettingsManager {
     preferredInputDeviceIDOverride =
       defaults.string(forKey: "preferredInputDeviceIDOverride")
       ?? SettingsDefaultValues.preferredInputDeviceIDOverride
-    environmentPreset =
-      EnvironmentPreset(rawValue: defaults.string(forKey: "environmentPreset") ?? "")
-      ?? SettingsDefaultValues.environmentPreset
     // PER-BUILD EXCEPTION (#923): useXPCAudioService is a developer XPC debug
     // knob, NOT a unified user preference — read/write via UserDefaults.standard
     // (the build's own store), never the shared `defaults`. Matches the bootstrap

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -391,14 +391,13 @@ def read(label):
 
 _CARD_GROUPS = {
     "engine": ["Fast (English)", "Multi-Language"],
-    "environment": ["Quiet", "Normal", "Noisy"],
     "style": ["Formal", "Standard", "Friendly"],
 }
 
 def read_cards(group):
     """Read which card is selected in a card group.
 
-    Groups: 'engine', 'environment', 'style'.
+    Groups: 'engine', 'style'.
     Returns dict of {card_name: selected_bool}.
     Usage: read_cards('engine')  read_cards('style')
     """
@@ -926,7 +925,7 @@ def scan(toggle=False):
         ("History", [], [], [], []),  # skip button scan — 711 rows make it slow
         ("Transcription",
          ["Stop recording on silence", "Remove filler words"],
-         [], ["engine", "environment"], []),
+         [], ["engine"], []),
         ("Microphone", [], ["Input"], [], []),
         ("Shortcuts", [], [], [], []),
         ("AI Polish", ["Deep reasoning"], ["Provider", "Model"],


### PR DESCRIPTION
## What

Removes the **"Recording Environment: Quiet / Normal / Noisy"** settings picker completely. It promised noise-handling it never delivered — the backing `environmentPreset` cascaded only into `vadSensitivity` (the auto-stop silence EMA), never into segment detection or capture. After #964 (faint-speech recovery) and #843 (soft-onset preservation), the control was both inert and inaccurate. Removing it makes the settings page honest.

## Changes

- **Removed:** preset picker row + card/struct helpers in the Speech Engine settings view; `EnvironmentPreset` enum; `environmentPreset` default; SettingsManager key / property / load-line / persist-keys entry; `PipelineSettingsSync` cascade case; runtime-UAT harness card-group vocabulary.
- **Kept + renamed:** the legitimate auto-stop controls (the "Stop recording on silence" toggle and "Pause duration" slider) that shared the section, now under an accurate **"Auto-Stop"** header.
- **No migration:** `vadSensitivity` stays plumbed at its 0.5 default forever (no UI). Existing users' persisted value is left as-is; the orphaned `"environmentPreset"` UserDefaults key is harmless (never read again).

## Validation

- Full **1,603-test suite green** (settings persistence unaffected).
- **Codex grounded code-diff review: PROCEED-AS-PLANNED** — zero remaining `environmentPreset`/`EnvironmentPreset` refs repo-wide, init valid, scope surgical, no test regressions.
- Dev build + **settings-page AX inspection** confirm the picker is gone and the auto-stop toggle/slider remain under the "Auto-Stop" header.

Lane: Code (SMALL). `council-skip: removal-only, no design ambiguity; section-rename + migration settled at Gate 2`.

Closes #969