### PR TITLE
test(asr): drive real loadModel throw path via connection-preflight seam (#899)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -61,7 +61,21 @@ public final class ASRManagerProxy: ASRManagerInterface {
   private var loadTaskSeq: UInt64 = 0
   private var activeLoadTaskID: UInt64 = 0
 
-  public init() {}
+  /// #899 test seam — the connection-preflight step `loadModel()` runs before it
+  /// reaches `serviceProxy`. Production default establishes the real XPC
+  /// connection exactly as `ensureConnection()` does today, so behavior is
+  /// identical by default. A test supplies a no-op preflight, leaving
+  /// `connection` nil, so production's real `serviceProxy` nil-connection branch
+  /// fires `onProxyError` → `serviceUnreachable`, exercising the real
+  /// `defer { self.stopProgressPolling() }` (#586 leak guard). Closure takes the
+  /// proxy as a parameter (not a captured `self`) so the default is a plain
+  /// expression with no self-capture; bound inside `init` so it can name the
+  /// private `ensureConnection()`.
+  private let connectionPreflight: @MainActor (ASRManagerProxy) -> Void
+
+  public init(connectionPreflight: (@MainActor (ASRManagerProxy) -> Void)? = nil) {
+    self.connectionPreflight = connectionPreflight ?? { $0.ensureConnection() }
+  }
 
   /// Invalidate whatever load is current: bump the generation so an in-flight
   /// `loadModel()` completion (even one whose `isModelLoaded` is still `false`)
@@ -102,7 +116,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
       self.downloadPhase = "Preparing download..."
       self.downloadDetail = ""
 
-      self.ensureConnection()
+      self.connectionPreflight(self)
       self.resendConfigIfNeeded()
 
       // Codex finding (2026-05-07): clear any stale progress file from a

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
@@ -15,9 +15,12 @@ import Testing
 /// `isProgressPollingActiveForTesting` honest, so a future refactor cannot
 /// silently break the defer guarantee.
 ///
-/// Full failure-path coverage through real `loadModel()` requires a
-/// fake-XPC service infrastructure; that is intentionally not built tonight.
-/// See issue thread for follow-up.
+/// `loadModelClearsPollingOnTransportError` (#899) drives the *real*
+/// `loadModel()` to its `serviceUnreachable` throw via the connection-preflight
+/// seam, so deleting the production `defer { self.stopProgressPolling() }` makes
+/// it red. (It supersedes the old `deferWrapPatternSimulation`, which only
+/// re-implemented the pattern locally and passed because the test itself called
+/// `stopProgressPolling`.)
 @MainActor
 @Suite("ASRManagerProxy progress polling")
 struct ASRManagerProxyProgressPollingTests {
@@ -76,31 +79,26 @@ struct ASRManagerProxyProgressPollingTests {
     #expect(proxy.isProgressPollingActiveForTesting == false)
   }
 
-  @Test("polling state survives a simulated loadModel throw (defer-wrap pattern)")
-  func deferWrapPatternSimulation() {
-    // Mirrors the exact pattern at ASRManagerProxy.swift:77-81. If a future
-    // refactor removes the defer-stop, this test still passes only because
-    // the test itself calls stopProgressPolling — that is intentional: the
-    // test documents the contract; the regression risk is in the call site.
-    let proxy = ASRManagerProxy()
+  @Test(
+    "loadModel stops progress polling when the XPC transport is unreachable",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/586",
+      "XPC error leaks progress timer"
+    )
+  )
+  func loadModelClearsPollingOnTransportError() async {
+    // No-op connection preflight: the real XPC connection is never established,
+    // so production's real `serviceProxy` nil-connection branch fires
+    // `onProxyError` → `serviceUnreachable`. That drives the *real*
+    // `defer { self.stopProgressPolling() }` inside `loadModel()` — the #586
+    // leak guard. Deleting that defer leaves the timer alive after the awaited
+    // throw, so this test goes red.
+    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
 
-    func simulateThrowingLoad() throws {
-      proxy.startProgressPolling()
-      defer { proxy.stopProgressPolling() }
-      throw SimulatedXPCError.serviceUnreachable
-    }
-
-    do {
-      try simulateThrowingLoad()
-      Issue.record("expected simulateThrowingLoad to throw")
-    } catch {
-      // expected
+    await #expect(throws: XPCASRTransportError.self) {
+      try await proxy.loadModel()
     }
 
     #expect(proxy.isProgressPollingActiveForTesting == false)
-  }
-
-  private enum SimulatedXPCError: Error {
-    case serviceUnreachable
   }
 }


### PR DESCRIPTION
Closes #899. Part of trust-sweep epic #897.

## What
The old `deferWrapPatternSimulation` was tautological: it re-implemented the start/defer-stop/throw pattern locally and asserted cleanup via the test's OWN `defer proxy.stopProgressPolling()`, never reaching production's `defer { self.stopProgressPolling() }` in `loadModel()` (the #586 progress-timer leak guard). The real throw path was unreachable from a unit test because `loadModel()` builds a real `NSXPCConnection` that has no live service in the CLI test process.

## How
Added a defaulted connection-preflight DI seam to `ASRManagerProxy`:
- `private let connectionPreflight: @MainActor (ASRManagerProxy) -> Void`, bound in `init` to `{ $0.ensureConnection() }` by default (proxy passed as parameter, not captured self, so the default is self-free; bound inside init so it can name the private `ensureConnection()`).
- `loadModel()` calls `self.connectionPreflight(self)` where it previously called `self.ensureConnection()`.
- Production behavior is **identical by default** (real `NSXPCConnection` still built). A test supplies a no-op preflight, leaving `connection` nil, so production's real `serviceProxy` nil-connection branch fires `onProxyError` -> `serviceUnreachable`, exercising the real `defer`.

New `loadModelClearsPollingOnTransportError` drives the real `loadModel()` to the throw and asserts `isProgressPollingActiveForTesting == false`.

## Validation
- Full logic suite green (1603 tests); Release-config build green.
- **Mutation proof:** deleting the production `defer { self.stopProgressPolling() }` makes ONLY the new test red (other 5 lifecycle tests stay green); reverting -> all 6 green.
- Codex code-diff review: CLEAN (seam path, throw type, Swift-6 isolation, production parity, no coverage loss), every claim grep-verified.
- Live UAT: N/A (production behavior identical by default; no user-visible surface).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining