### PR TITLE
test(pipeline): verify logical tick rate via injected clock seam (#900)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -122,7 +122,13 @@ struct KernelFinalizationWiring {
     textProcessingRunner: TextProcessingRunner,
     save: @escaping @MainActor (Transcript) throws -> Void,
     deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult,
-    pasteCompletionRegistry: PasteCompletionRegistry?
+    pasteCompletionRegistry: PasteCompletionRegistry?,
+    // #900 clock seam — defaults to today's live expression, so production
+    // behavior is identical (the closure capture adds one call). A test injects
+    // a manual clock to advance logical time by hand and assert the tick rate,
+    // instead of sleeping (which `tests-no-real-time-scheduling-precision` bans).
+    // Trailing-defaulted so the other construction sites stay source-compatible.
+    currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
   ) {
     // processText — run the limb chain, write the polish side-channel, return
     // the final display text. `onPolishStarted` is wired into
@@ -256,7 +262,7 @@ struct KernelFinalizationWiring {
     // (PR-4 §3.6). `currentTick` quantizes `systemUptime` to 100 ms ticks
     // (precedent: `LoadProgressWatcher.currentTime`).
     currentTick = {
-      UInt64(ProcessInfo.processInfo.systemUptime / Self.tickDurationSeconds)
+      UInt64(currentTime() / Self.tickDurationSeconds)
     }
     sleepTicks = { ticks in
       try? await Task.sleep(for: .seconds(Double(ticks) * Self.tickDurationSeconds))

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -28,12 +28,30 @@ import Testing
     #expect(windowSeconds >= 0.8)
   }
 
-  @Test("the logical clock advances and sleepTicks returns")
-  func clock() async {
-    let wiring = makeWiring()
-    let first = wiring.currentTick()
-    #expect(first == wiring.currentTick() || wiring.currentTick() >= first)
-    await wiring.sleepTicks(0)  // a zero-tick sleep returns promptly
+  @Test(
+    "currentTick advances by the number of whole logical ticks elapsed",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/900",
+      "logical tick rate was unverified (tautology)"
+    )
+  )
+  func currentTickAdvancesWithClock() async {
+    // Inject a manual clock so logical time advances by hand — no Task.sleep
+    // cadence (`tests-no-real-time-scheduling-precision`). The old test asserted
+    // `first == currentTick() || currentTick() >= first`, true for any monotonic
+    // or even frozen clock, so a frozen clock or wrong tick divisor passed.
+    let clock = ManualClock()
+    let wiring = makeWiring(currentTime: { clock.now })
+    let first = wiring.currentTick()  // floor(0 / 0.1) == 0
+
+    // Advance 3.5 ticks: landing mid-window means floating-point error in
+    // `UInt64(now / tickDurationSeconds)` cannot straddle a tick boundary, so
+    // exactly 3 whole ticks have elapsed. (Advancing a clean 3.0 ticks would
+    // rely on the lucky rounding of `0.1 * 3 / 0.1`; 3.5 is boundary-safe.)
+    clock.advance(by: KernelFinalizationWiring.tickDurationSeconds * 3.5)
+    #expect(wiring.currentTick() == first + 3)
+
+    await wiring.sleepTicks(0)  // a zero-tick sleep returns promptly (liveness)
   }
 
   // MARK: processText
@@ -240,7 +258,8 @@ import Testing
     save: @escaping @MainActor (Transcript) throws -> Void = { _ in },
     deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult = {
       _ in Self.deliveredResult
-    }
+    },
+    currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
   ) -> KernelFinalizationWiring {
     KernelFinalizationWiring(
       outcome: outcome,
@@ -250,8 +269,18 @@ import Testing
       textProcessingRunner: TextProcessingRunner(),
       save: save,
       deliverPaste: deliverPaste,
-      pasteCompletionRegistry: nil)
+      pasteCompletionRegistry: nil,
+      currentTime: currentTime)
   }
+}
+
+/// Hand-advanced logical clock for the tick-rate test. Local `@MainActor` copy:
+/// the `ManualClock` in `LoadProgressWatcherTests` is `private` to that suite and
+/// cannot be reused. Satisfies the `@MainActor () -> TimeInterval` clock seam.
+@MainActor
+private final class ManualClock {
+  private(set) var now: TimeInterval = 0
+  func advance(by seconds: TimeInterval) { now += seconds }
 }
 
 private enum WiringTestError: Error { case storage }


### PR DESCRIPTION
Closes #900. Part of trust-sweep epic #897.

## What
The old `clock` test asserted `first == currentTick() || currentTick() >= first` — true for any monotonic non-decreasing clock AND a frozen one, so it could never fail. The kernel's wedge/stall detection quantizes time into 100 ms ticks; a regression that froze the clock or used a wrong divisor passed silently.

## How
Added a trailing-defaulted clock seam to `KernelFinalizationWiring.init`:
`currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }`, and backed `currentTick` with it (`UInt64(currentTime() / Self.tickDurationSeconds)`). Production behavior is **identical by default** (closure capture adds one call). Trailing-defaulted so the factory and metadata-test construction sites stay source-compatible.

New `currentTickAdvancesWithClock` injects a manual clock, advances 3.5 ticks (mid-window, so floating-point error in `UInt64(now / 0.1)` can't straddle a tick boundary), and asserts `currentTick() == first + 3` — no `Task.sleep` cadence, per `tests-no-real-time-scheduling-precision`. `ManualClock` is a local `@MainActor` helper (the one in `LoadProgressWatcherTests` is private to that suite).

## Validation
- Full logic suite green (1603 tests); Release-config build green.
- **Mutation proof:** a frozen clock (returns 42) makes the new test red (42 != 45); a wrong divisor (0.2) makes it red (1 != 3); the old test stayed green for both. Reverting -> all green.
- Codex code-diff review: CLEAN (seam, source compat, floating-point, rule compliance, isolation, no coverage loss), every claim grep-verified.
- Live UAT: N/A (production behavior identical by default; internal stall-detection clock, no user surface).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining