### PR TITLE
test(llm): count network requests via injected executor seam (#901)

### DIFF
--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -7,12 +7,25 @@ import Foundation
 public struct OllamaConnector: TranscriptPolisher {
   private let baseURL: String
 
+  /// #901 test seam — the network transport for both call sites (evict + polish
+  /// retry loop). Defaults to today's exact expression, so production behavior is
+  /// identical. A test injects a request-counting fake to assert the empty-name
+  /// evict guard makes zero calls (the old test only bounded wall-clock against a
+  /// non-routable host, which a deleted guard still satisfied via fast ECONNREFUSED).
+  private let networkExecutor: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
   /// Simplified prompt for weak/small models that struggle with complex instructions.
   private static let weakModelSystemPrompt =
     "Fix grammar and punctuation. Return only the corrected text."
 
-  public init(baseURL: String = "http://localhost:11434") {
+  public init(
+    baseURL: String = "http://localhost:11434",
+    networkExecutor: @Sendable @escaping (URLRequest) async throws -> (Data, URLResponse) = {
+      try await LLMNetworkSession.shared.session.data(for: $0)
+    }
+  ) {
     self.baseURL = baseURL
+    self.networkExecutor = networkExecutor
   }
 
   public func polish(
@@ -168,7 +181,7 @@ public struct OllamaConnector: TranscriptPolisher {
       request.httpBody = try JSONSerialization.data(
         withJSONObject: Self.makeEvictRequestBody(model: modelName)
       )
-      let (_, response) = try await LLMNetworkSession.shared.session.data(for: request)
+      let (_, response) = try await networkExecutor(request)
       let status = (response as? HTTPURLResponse)?.statusCode ?? 0
       let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
       let result = (200...299).contains(status) ? "unloaded" : "error"
@@ -293,7 +306,7 @@ public struct OllamaConnector: TranscriptPolisher {
       do {
         let (data, response): (Data, URLResponse)
         do {
-          (data, response) = try await LLMNetworkSession.shared.session.data(for: request)
+          (data, response) = try await networkExecutor(request)
         } catch let urlError as URLError {
           switch urlError.code {
           case .notConnectedToInternet, .cannotFindHost:

--- a/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
@@ -107,19 +107,67 @@ struct OllamaConnectorRequestBodyTests {
     #expect(OllamaConnector.effectiveOllamaModel(provider: .ollama, model: "") == nil)
   }
 
-  // MARK: - evictModel fire-and-forget guard (#295)
+  // MARK: - evictModel fire-and-forget guard (#295, hardened #901)
 
-  /// Empty model names are a no-op — the method must return immediately
-  /// without hitting the network. Regression guard for callers that pass
-  /// the stored model field without first checking `isEmpty`.
-  @Test func evictModelWithEmptyNameIsNoOp() async {
-    // Pointed at a non-routable address so any accidental network
-    // call would time out rather than succeed; the test completes
-    // in well under the 3s connector timeout because the guard
-    // short-circuits before `URLSession.data(for:)` is invoked.
-    let connector = OllamaConnector(baseURL: "http://127.0.0.1:1")
-    let start = Date()
+  /// Empty model names are a no-op — the guard must return before any network
+  /// call. The old test only bounded wall-clock (< 0.5s) against a non-routable
+  /// host, which a deleted `!modelName.isEmpty` guard still satisfied via fast
+  /// ECONNREFUSED. This counts requests instead: empty name => zero calls.
+  @Test("empty model name evicts without any network call")
+  func evictModelWithEmptyNameMakesNoRequest() async {
+    let counter = RequestCounter()
+    let connector = OllamaConnector(networkExecutor: { _ in
+      await counter.bump()
+      throw URLError(.cannotConnectToHost)  // evict is fire-and-forget; the throw is ignored
+    })
     await connector.evictModel("")
-    #expect(Date().timeIntervalSince(start) < 0.5)
+    #expect(await counter.count == 0)  // guard active: the network was never reached
   }
+
+  /// The other side of the routing flip (`matcher-set-adversarial-tests`): a
+  /// non-empty name must reach the network exactly once. Pins the guard from
+  /// both sides so deleting it is caught regardless of which case regresses.
+  @Test("non-empty model name evicts via exactly one network call")
+  func evictModelWithNonEmptyNameMakesOneRequest() async {
+    let counter = RequestCounter()
+    let connector = OllamaConnector(networkExecutor: { _ in
+      await counter.bump()
+      throw URLError(.cannotConnectToHost)  // evict ignores the throw
+    })
+    await connector.evictModel("gemma4:latest")
+    #expect(await counter.count == 1)
+  }
+
+  /// The polish call site must also route through the injected executor and
+  /// surface a transport failure (not silently swallow it). The evict-only count
+  /// tests can't catch a bad polish reroute.
+  @Test("polish surfaces a transport failure through the injected executor")
+  func polishSurfacesExecutorError() async {
+    let connector = OllamaConnector(networkExecutor: { _ in
+      throw URLError(.notConnectedToInternet)  // maps to providerUnavailable, fail-fast
+    })
+    let config = LLMProviderConfig(
+      model: "gemma4:latest",
+      apiKeyKeychainId: nil,
+      maxTokens: 128,
+      temperature: 0.3,
+      thinkingBudget: nil,
+      reasoningEffort: nil
+    )
+    await #expect(throws: LLMError.self) {
+      _ = try await connector.polish(
+        text: "hello",
+        instructions: PolishInstructions(systemPrompt: "sys"),
+        config: config,
+        onToken: nil
+      )
+    }
+  }
+}
+
+/// Counts how many times the injected network executor is invoked. An actor so
+/// the `@Sendable` executor closure can mutate it from any concurrency domain.
+private actor RequestCounter {
+  private(set) var count = 0
+  func bump() { count += 1 }
 }


### PR DESCRIPTION
Closes #901. Part of trust-sweep epic #897.

## What
`evictModelWithEmptyNameIsNoOp` claimed to verify the empty-model-name guard but only asserted a wall-clock bound (< 0.5s) against a non-routable host. Deleting the `!modelName.isEmpty` clause still passed: the loopback refuses in sub-millisecond ECONNREFUSED, well under the bound. The test verified nothing about the guard, and the 0.5s number violated `timeout-numbers-need-distribution-evidence`.

## How
Added a defaulted `networkExecutor` seam to `OllamaConnector.init` (`@Sendable (URLRequest) async throws -> (Data, URLResponse)`, defaulted to today's `LLMNetworkSession.shared.session.data(for:)`) and routed BOTH network call sites through it (evict + the polish retry loop) — no half-instrumented connector. Production behavior identical by default.

Tests now count requests instead of timing them (signal-based, per `prefer-signal-based-detection`):
- empty name => 0 calls
- non-empty => exactly 1 (both sides of the routing flip, per `matcher-set-adversarial-tests`)
- a third test injects a throwing executor and confirms `polish()` surfaces the failure through the existing `URLError -> providerUnavailable` mapping (fail-fast, not retried), so a bad polish reroute that swallowed errors would be caught.

## Validation
- Full logic suite green (1605 tests); Release-config build green.
- **Mutation proof:** deleting `!modelName.isEmpty,` makes the empty-name test red (count 1, not 0) while the non-empty test stays green; reverting -> all green.
- Codex code-diff review: CLEAN (both reroutes, @Sendable/isolation, polish error path, evict tolerance, production parity, no coverage loss), all claims grep-verified.
- Live UAT: N/A (Ollama polish is a limb; production behavior identical by default).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining