### PR TITLE
test(app): observe stop/cancel timestamp at dispatch entry via seams (#902)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
@@ -30,6 +30,21 @@ final class RecordingFinalizer {
 
   private var lastUserStopRequest: ContinuousClock.Instant?
 
+  /// #902 test seams — the stop/cancel dispatch steps. Defaults are today's exact
+  /// inline calls, so production behavior is identical. Two separate closures
+  /// because `userStop()` dispatches `.requestStop` (throwing) while `cancel()`
+  /// calls `cancelRecording()` (non-throwing, different method). A test injects a
+  /// closure that reads `lastUserStopRequest` at dispatch entry to prove the
+  /// timestamp is set BEFORE the suspending await — the ordering invariant
+  /// `RecordingStarter`'s post-await wedge guards depend on, which the old test
+  /// (reading only after the await resolved) could never verify.
+  var requestStopDispatch: @MainActor (KernelDictationDriver) async throws -> Void = {
+    try await $0.handle(event: .requestStop)
+  }
+  var cancelRecordingDispatch: @MainActor (KernelDictationDriver) async -> Void = {
+    await $0.cancelRecording()
+  }
+
   /// Read accessor exposed to `RecordingStarter` so the start path's
   /// post-condition wedge guard can detect "user stopped during start"
   /// without granting Starter write access to the underlying state.
@@ -66,7 +81,7 @@ final class RecordingFinalizer {
     let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
     do {
-      try await active.handle(event: .requestStop)
+      try await requestStopDispatch(active)
     } catch {
       heartControlRecovery.logDispatchFailure(error, op: "stop")
     }
@@ -87,7 +102,7 @@ final class RecordingFinalizer {
     let active: KernelDictationDriver =
       asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
     guard active.state == .recording || active.state == .loadingModel else { return }
-    await active.cancelRecording()
+    await cancelRecordingDispatch(active)
   }
 
   func markLocked() {

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -4,8 +4,8 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage
@@ -96,22 +96,60 @@ import Testing
     #expect(fx.lockBox.isLocked == false)
   }
 
-  @Test func userStopMarksTimestampBeforeAwait() async {
-    // Timing invariant: the timestamp must be visible to Starter's wedge
-    // guard immediately after userStop() begins. With pipelines idle, the
-    // dispatch await returns quickly; after userStop() resolves, the
-    // accessor must read a non-nil value.
+  /// The ordering invariant `RecordingStarter`'s post-await wedge guards depend
+  /// on: `lastUserStopRequest` must be set BEFORE `userStop()` enters its
+  /// suspending dispatch await. The injected dispatch closure reads the timestamp
+  /// at dispatch entry. (The old `userStopMarksTimestampBeforeAwait` read only
+  /// after the await resolved, so it passed whether the timestamp was set before
+  /// or after the await — it could never catch a reordering.)
+  @Test(
+    "userStop sets the stop timestamp before entering the dispatch await",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/902",
+      "stop timestamp ordering"
+    )
+  )
+  func userStopSetsTimestampBeforeDispatchAwait() async {
     let fx = Self.makeFixture()
-    #expect(fx.finalizer.lastUserStopAccess.read() == nil)
-    await fx.finalizer.userStop()
-    #expect(fx.finalizer.lastUserStopAccess.read() != nil)
+    let finalizer = fx.finalizer
+    let obs = DispatchObservation()
+    finalizer.requestStopDispatch = { driver in
+      obs.dispatchRan = true
+      obs.stampAtEntry = finalizer.lastUserStopAccess.read()
+      try await driver.handle(event: .requestStop)  // forward — an idle driver ignores stop
+    }
+    await finalizer.userStop()
+    #expect(obs.dispatchRan)  // the dispatch closure was actually reached
+    #expect(obs.stampAtEntry != nil)  // the timestamp was already set at dispatch entry
   }
 
-  @Test func cancelMarksTimestampBeforeAwait() async {
+  /// The same ordering invariant for `cancel()`. Its dispatch is guarded by
+  /// `.recording`/`.loadingModel`, so the active driver is force-transitioned to
+  /// `.recording` to reach the dispatch. The cancel closure observes only (no
+  /// forward) because real `cancelRecording()` awaits terminal convergence.
+  @Test(
+    "cancel sets the stop timestamp before entering the dispatch await",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/902",
+      "cancel timestamp ordering"
+    )
+  )
+  func cancelSetsTimestampBeforeDispatchAwait() async {
     let fx = Self.makeFixture()
-    #expect(fx.finalizer.lastUserStopAccess.read() == nil)
-    await fx.finalizer.cancel()
-    #expect(fx.finalizer.lastUserStopAccess.read() != nil)
+    fx.asr.activeBackendType = .parakeet
+    // idle -> recording is a forbidden direct transition; walk through .preparing
+    // first, matching the kernel FSM (KernelDictationDriverTests precedent).
+    _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .preparing)
+    _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .recording)
+    let finalizer = fx.finalizer
+    let obs = DispatchObservation()
+    finalizer.cancelRecordingDispatch = { _ in
+      obs.dispatchRan = true
+      obs.stampAtEntry = finalizer.lastUserStopAccess.read()
+    }
+    await finalizer.cancel()
+    #expect(obs.dispatchRan)  // the state guard passed and the dispatch was reached
+    #expect(obs.stampAtEntry != nil)  // the timestamp was already set at dispatch entry
   }
 
   @Test func markLockedFlipsTheLockAndUpdatesOverlay() {
@@ -155,4 +193,14 @@ import Testing
       #expect(fx.kernelDriver.state == .error("parakeet-err"))
     }
   }
+}
+
+/// Records what an injected dispatch closure observed at the moment it was
+/// entered. A `@MainActor` reference type so the dispatch closure (itself
+/// `@MainActor`, hence implicitly `Sendable` in Swift 6) can capture and mutate
+/// it without a mutable-local-capture diagnostic.
+@MainActor
+private final class DispatchObservation {
+  var dispatchRan = false
+  var stampAtEntry: ContinuousClock.Instant?
 }


### PR DESCRIPTION
Closes #902. Part of trust-sweep epic #897.

## What
`userStopMarksTimestampBeforeAwait` and `cancelMarksTimestampBeforeAwait` read the stop timestamp only AFTER the dispatch await fully resolved, so the value was non-nil whether it was set before the await (correct) or after (broken). The test names and the production doc comment both claim the timestamp is set BEFORE the suspending dispatch await — the ordering invariant `RecordingStarter`'s post-await wedge guards rely on to detect "user stopped during start" — but neither test could ever catch a reordering.

## How
Added two defaulted dispatch seams to `RecordingFinalizer` (separate, because `userStop()` dispatches `.requestStop` via the throwing `handle(event:)` while `cancel()` calls the non-throwing `cancelRecording()`):
- `requestStopDispatch: @MainActor (KernelDictationDriver) async throws -> Void`
- `cancelRecordingDispatch: @MainActor (KernelDictationDriver) async -> Void`

defaulted to today's exact inline calls, so production behavior is identical. The new tests inject a closure that reads `lastUserStopRequest` AT dispatch entry and asserts it is already set. The cancel test force-transitions the active driver idle -> preparing -> recording so cancel's state guard passes and the dispatch is reached. Observation is captured through a `@MainActor` reference box (the `@MainActor` closure is implicitly Sendable in Swift 6 and cannot capture a mutable local).

## Validation
- Full logic suite green (1605 tests); Release-config build green.
- **Mutation proof:** moving each `lastUserStopRequest = ContinuousClock.now` to after its dispatch makes ONLY its ordering test red (dispatch ran, timestamp nil at entry); every other test stays green; reverting -> all green.
- Codex code-diff review: CLEAN (seam correctness, two-seam justification, isolation, cancel-test validity, production parity, no coverage loss), all claims grep-verified.
- Live UAT: N/A (production behavior identical by default; internal ordering invariant, no user surface).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining