### PR TITLE
test(pipeline): drive real kernel preWarm rethrow via FakeAudioCapture seam (#903)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
@@ -4,6 +4,8 @@ import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprPipeline
+
 /// Issue #289 — verify the `AudioCaptureInterface.preWarm` contract now
 /// propagates errors. Full pipeline-level integration tests for the
 /// `handle(event:)` / `handleCaptureStall` recovery paths are gapped for
@@ -14,13 +16,33 @@ import Testing
 @Suite("PreWarm throws contract")
 struct PreWarmThrowsTests {
 
-  @Test("conforming mock can throw on preWarm, callers observe error")
+  /// Drives the REAL `RecordingSessionKernel.preWarm()` over a throwing capture
+  /// and asserts the kernel rethrows, so `RecordingStarter` can surface
+  /// "Microphone unavailable" to the user. The old `preWarmPropagatesError` only
+  /// proved a stub configured to throw threw — it never touched the kernel, so
+  /// deleting the kernel's rethrow (`RecordingSessionKernel.swift:648`) left it
+  /// green.
+  @Test(
+    "the kernel rethrows a preWarm failure from the audio capture",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/289",
+      "preWarm error must propagate so the start path can surface it"
+    )
+  )
   @MainActor
-  func preWarmPropagatesError() async {
-    let mock = ThrowingAudioCapture()
+  func kernelRethrowsPreWarmError() async {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "default"), clock: clock)
+    let capture = FakeAudioCapture()
+    capture.preWarmError = PreWarmFailedError.simulated
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let session = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
     await #expect(throws: PreWarmFailedError.self) {
-      try await mock.preWarm()
+      try await session.testKernel.preWarm()
     }
+    #expect(capture.preWarmCallCount == 1)  // the kernel actually reached capture.preWarm()
   }
 
   @Test("mock preWarm returns cleanly when not configured to throw")
@@ -36,53 +58,7 @@ enum PreWarmFailedError: Error, Equatable {
   case simulated
 }
 
-// MARK: - Minimal AudioCaptureInterface conformers for protocol-contract tests
-
-@MainActor
-final class ThrowingAudioCapture: AudioCaptureInterface {
-  var isCapturing: Bool = false
-  var audioLevel: Float = 0
-  var capturedSamples: [Float] = []
-  var currentAudioRoute: String = "unknown"
-  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
-  var onVADAutoStop: (() -> Void)?
-  var onCaptureStalled: ((CaptureStallContext) -> Void)?
-  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
-  var onXPCServiceError: ((XPCErrorContext) -> Void)?
-  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
-  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
-  var currentCaptureSessionID: UInt64 = 0
-  var isActivelyCapturing: Bool = false
-  var captureSourceType: String = "mock"
-  var noiseSuppressionEnabled: Bool = false
-  var selectedInputDeviceUID: String = ""
-  var preferredInputDeviceIDOverride: String = ""
-  var warmEnginePolicy: WarmEnginePolicy = .off
-
-  func startEnginePhase() async throws {}
-  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
-    AsyncStream { $0.finish() }
-  }
-  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-    AsyncStream { $0.finish() }
-  }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
-  func rebuildEngine() {}
-  func buildEngine(noiseSuppression: Bool) {}
-  func preWarm() async throws {
-    throw PreWarmFailedError.simulated
-  }
-  func abortPreWarm() {}
-  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-    true
-  }
-  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
-  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
-    ([], 0)
-  }
-  func getVADSegments() async -> [SpeechSegment] { [] }
-}
+// MARK: - Minimal AudioCaptureInterface conformer for the default-success check
 
 @MainActor
 final class PassthroughAudioCapture: AudioCaptureInterface {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -37,6 +37,9 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var failCaptureStart = false
   /// `startEnginePhase()` throws `.permissionDenied` (mic permission revoked).
   var permissionDenied = false
+  /// `preWarm()` throws this when non-nil (#903 — lets a test drive the real
+  /// `RecordingSessionKernel.preWarm()` rethrow path). Nil = preWarm succeeds.
+  var preWarmError: Error?
 
   // MARK: Observed counters (for FakeAudioCaptureTests teardown assertion)
 
@@ -132,6 +135,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   func preWarm() async throws {
     preWarmCallCount += 1
+    if let preWarmError { throw preWarmError }
   }
 
   func abortPreWarm() {


### PR DESCRIPTION
Closes #903. Part of trust-sweep epic #897. Test-infra only (no Sources change).

## What
`preWarmPropagatesError` only proved a stub hard-coded to throw did throw — a tautology. It never instantiated `RecordingSessionKernel`, so the contract it named (the kernel rethrows `audioCapture.preWarm()` failures so `RecordingStarter` can surface "Microphone unavailable") was unverified; deleting the kernel's `catch { throw error }` left it green.

## How
Added a settable `var preWarmError: Error?` to the shared `FakeAudioCapture` double (mirrors the existing `failEngineStart` injection idiom), thrown from its `preWarm()` after the call-count increment. The new `kernelRethrowsPreWarmError` builds a real `RecordingSessionKernel` over a throwing `FakeAudioCapture` (via the existing `KernelRecordingSession.testKernel` helper) and asserts the kernel rethrows `PreWarmFailedError`. Deleted the now-unused `ThrowingAudioCapture` stub.

## Validation
- Full logic suite green (1605 tests). No `Sources/` change — test target compiles via the suite.
- **Mutation proof:** swallowing the kernel rethrow (`RecordingSessionKernel.swift:648`) makes the new test red ("an error was expected but none was thrown") while the default-success test stays green; reverting -> both green.
- Codex code-diff review: CLEAN (seam correctness, error fidelity, fake knob, dead code, import/access, no drift), all claims grep-verified.
- Live UAT: N/A — test-only.

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining