### PR TITLE
test(app): count accessibility refresh per start/toggle via seam (#904)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -27,6 +27,10 @@ final class RecordingStarter {
   let settings: SettingsManager
   let permissions: PermissionsService
   let recordingOverlay: RecordingOverlayPanel
+  /// #904 test seam — the accessibility re-arm step `start()`/`toggle()` run.
+  /// Default (bound in init capturing `permissions`, since a default arg can't
+  /// reference an init param) is today's block; a test injects a counting spy.
+  let accessibilityRefresh: @MainActor () -> Void
 
   var heartControlRecovery: HeartControlRecovery
   var recordingLockedAccess: DictationLifecycleCoordinator.RecordingLockedAccess
@@ -68,7 +72,8 @@ final class RecordingStarter {
     recordingLockedAccess: DictationLifecycleCoordinator.RecordingLockedAccess,
     lastUserStopAccess: RecordingFinalizer.LastUserStopAccess,
     lastRecordingResult: LastRecordingResult,
-    dictationLifecycleCoordinator: DictationLifecycleCoordinator?
+    dictationLifecycleCoordinator: DictationLifecycleCoordinator?,
+    accessibilityRefresh: (@MainActor () -> Void)? = nil
   ) {
     self.audioCapture = audioCapture
     self.asrManager = asrManager
@@ -82,6 +87,12 @@ final class RecordingStarter {
     self.lastUserStopAccess = lastUserStopAccess
     self.lastRecordingResult = lastRecordingResult
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
+    let perms = permissions
+    self.accessibilityRefresh =
+      accessibilityRefresh ?? {
+        perms.refreshAccessibilityStatus()
+        if !perms.hasAccessibilityPermission { perms.restartMonitoringIfNeeded() }
+      }
   }
 
   /// Hotkey PTT start path. Mirrors the former root-state file (pre-PR10):
@@ -114,10 +125,7 @@ final class RecordingStarter {
         readiness: readinessAtEntry)
       return
     }
-    permissions.refreshAccessibilityStatus()
-    if !permissions.hasAccessibilityPermission {
-      permissions.restartMonitoringIfNeeded()
-    }
+    accessibilityRefresh()
     recordingOverlay.show(
       intent: .recording(audioLevel: 0),
       audioLevelProvider: { [audioCapture] in audioCapture.audioLevel },
@@ -254,10 +262,7 @@ final class RecordingStarter {
         return
       }
     }
-    permissions.refreshAccessibilityStatus()
-    if !permissions.hasAccessibilityPermission {
-      permissions.restartMonitoringIfNeeded()
-    }
+    accessibilityRefresh()
     do {
       try await active.handle(
         event: .toggleRecording(

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -40,7 +40,7 @@ import Testing
     let overlay: RecordingOverlayPanel
   }
 
-  private static func makeFixture() -> Fixture {
+  private static func makeFixture(accessibilityRefresh: (@MainActor () -> Void)? = nil) -> Fixture {
     // `RecordingOverlayPanel.show(intent: .recording, ...)` posts an
     // `NSAccessibility` notification against `NSApp.mainWindow`. `NSApp`
     // is an implicitly-unwrapped optional that crashes the test process
@@ -89,7 +89,8 @@ import Testing
       recordingLockedAccess: lockAccess,
       lastUserStopAccess: finalizer.lastUserStopAccess,
       lastRecordingResult: lastRecordingResult,
-      dictationLifecycleCoordinator: nil
+      dictationLifecycleCoordinator: nil,
+      accessibilityRefresh: accessibilityRefresh
     )
     return Fixture(
       starter: starter,
@@ -140,15 +141,31 @@ import Testing
     #expect(fx.lastRecordingResult.polishError == nil)
   }
 
-  @Test func toggleAndStartBothRefreshAccessibilityStatus() async {
-    let fx = Self.makeFixture()
+  /// The old `toggleAndStartBothRefreshAccessibilityStatus` had ZERO `#expect` —
+  /// it only checked crash-freedom, so deleting the AX re-arm block from
+  /// `start()`/`toggle()` left it green. This injects a counting spy and asserts
+  /// each path refreshes accessibility exactly once. The engine MUST be marked
+  /// ready (`isModelLoaded = true`) — otherwise both paths return at the
+  /// cold-engine guard BEFORE the AX block and the spy never increments.
+  @Test(
+    "start() and toggle() each refresh accessibility exactly once",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/904",
+      "AX re-arm on start/toggle was unverified (zero-assertion test)"
+    )
+  )
+  func startAndToggleEachRefreshAccessibilityOnce() async {
+    let counter = AXRefreshCounter()
+    let fx = Self.makeFixture(accessibilityRefresh: { counter.count += 1 })
     fx.asr.activeBackendType = .parakeet
-    // Smoke-level: simply verify that toggle() and start() do not crash
-    // even when AX is denied (the start-path code calls
-    // refreshAccessibilityStatus + restartMonitoringIfNeeded; both must
-    // be callable in any state).
-    await fx.starter.toggle(source: .toolbar)
+    fx.asr.isModelLoaded = true  // → readiness .ready, so start/toggle pass the cold-engine guard
+    #expect(fx.kernelDriver.engineReadiness == .ready)
+
     await fx.starter.start()
+    #expect(counter.count == 1)  // start() refreshed once
+
+    await fx.starter.toggle(source: .toolbar)
+    #expect(counter.count == 2)  // toggle() refreshed once more
   }
 
   // #879 — cold-boot press safety. The matcher-set boundary is `.ready` vs
@@ -218,4 +235,12 @@ import Testing
   // `lastUserStopAccessIsThreadedFromFinalizer` test pins the wiring of
   // the closure; the guard itself mirrors the post-toggle check at
   // lines 162-165 (covered by behavioral observation in Live UAT).
+}
+
+/// Counts accessibility-refresh invocations for #904. A `@MainActor` reference
+/// type because the seam closure is `@MainActor` (implicitly `Sendable` in
+/// Swift 6) and the `@MainActor` suite supplies it.
+@MainActor
+private final class AXRefreshCounter {
+  var count = 0
 }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -52,10 +52,16 @@ import Testing
     // onboarding's warm-up through the active engine's shared `ensureEngineWarm`.
     // The domain logic still lives off this type in `ColdPressGuard`; no new
     // collaborator or non-private method.
+    // #904 (trust sweep): raised 285 → 292 for the `accessibilityRefresh` test
+    // seam — a defaulted `@MainActor () -> Void` closure that makes the AX
+    // re-arm-on-revocation step in `start()`/`toggle()` observable (the old test
+    // had zero assertions). The closure does NOT count as a collaborator
+    // (collaboratorCount still ≤ 7) and is not a non-private method; only the
+    // paper-line ceiling moves. Production behavior is identical by default.
     #expect(
-      count <= 285,
+      count <= 292,
       """
-      RecordingStarter line count exceeded: \(count) > 285. \
+      RecordingStarter line count exceeded: \(count) > 292. \
       Raise via Bible §30 only.
       """)
   }


### PR DESCRIPTION
Closes #904. Part of trust-sweep epic #897.

## What
`toggleAndStartBothRefreshAccessibilityStatus` had ZERO `#expect` — it only checked crash-freedom, so deleting the AX re-arm-on-revocation block from `start()`/`toggle()` (which re-arms the accessibility warning banner when the user revokes permission at runtime) left it green. `PermissionsService` is a concrete final class with no seam, and `AXIsProcessTrusted()` is false on test hosts, so nothing observable flipped.

## How
Added a defaulted `accessibilityRefresh: @MainActor () -> Void` to `RecordingStarter`, bound inside init (capturing the `permissions` param, since a default-argument expression cannot reference an init param) to today's two-line block. Routed `start()` and `toggle()` through it. Production behavior identical by default. The new `startAndToggleEachRefreshAccessibilityOnce` injects a `@MainActor` counting spy and asserts each path refreshes exactly once. The test marks the engine ready (`isModelLoaded = true`) so both paths pass the cold-engine guard and reach the AX block (else the spy never increments — the fake-test trap).

## Ceiling
Raised `RecordingStarter`'s paper-line ceiling 285 -> 292 for the seam (per `ceiling-bumps-need-bible-and-test`), with a ratchet-history entry in the test. The collaborator (<= 7) and non-private method (<= 2) ceilings — the entanglement signals that matter — are UNCHANGED; the closure does not count as a collaborator.

## Validation
- Full logic suite green (1605 tests); Release-config build green.
- **Two-sided mutation proof:** deleting the start refresh makes the count-1 assert red; deleting the toggle refresh makes the count-2 assert red; reverting -> green.
- Codex code-diff review: CLEAN across seam correctness, production parity, the cold-guard trap, isolation, the ceiling bump (closure correctly excluded from collaborator count), construction sites, and no drift — all grep-verified.
- Live UAT: N/A (production behavior identical by default; internal AX re-arm, no user surface).

## Architecture Closeout
- Module/owner chosen: `RecordingStarter` (existing start-path runtime internal) — it already performs the AX refresh.
- Why correct: seam added to the type that already owns the behavior; no responsibility moved, no new type.
- Whether any central type grew: paper lines only (+7, ceiling bumped with changelog); entanglement ceilings unchanged.
- Whether access control widened: no.
- Whether any temporary compromise remains: no.
- Whether dependency direction remains clean: yes (no new imports; allowed-imports test green).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining