### PR TITLE
test(vad): drive SilenceDetector VAD via injectable StreamingVad seam (#905)

### DIFF
--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -2,6 +2,29 @@ import EnviousWisprCore
 @preconcurrency import FluidAudio
 import Foundation
 
+/// #905 test seam — the narrow per-chunk VAD streaming surface `SilenceDetector`
+/// depends on. Lets a fake substitute for the concrete FluidAudio `VadManager`
+/// (which needs a real Silero CoreML model, unreachable in a unit test), so the
+/// "streaming clock advances on every chunk, before the energy gate" contract
+/// (#604 followup) can be tested behaviorally instead of by grepping source text.
+///
+/// `SilenceDetector` is an `actor` (not `@MainActor`), so an `any StreamingVad`
+/// existential is fine here — `avoid-any-mainactor-protocol-hotpath` does not
+/// bind, and per-chunk existential dispatch at ~10 Hz is negligible. The real
+/// `VadManager` conforms via an empty extension; the field is still built lazily
+/// in `prepare()`, defaulting to the real manager, so production is unchanged.
+internal protocol StreamingVad: Sendable {
+  func processStreamingChunk(
+    _ audioChunk: [Float],
+    state: VadStreamState,
+    config: VadSegmentationConfig,
+    returnSeconds: Bool,
+    timeResolution: Int
+  ) async throws -> VadStreamResult
+}
+
+extension VadManager: StreamingVad {}
+
 public struct SmoothedVADConfig: Sendable {
   public var emaAlpha: Float = 0.3
   public var onsetThreshold: Float = 0.5
@@ -82,7 +105,10 @@ enum SmoothedVADPhase: Sendable {
 /// they have different timing, different thresholds, and serve different consumers
 /// (WhisperKit clipTimestamps vs recording-stop UX). See issue #604.
 public actor SilenceDetector {
-  private var vadManager: VadManager?
+  private var vadManager: (any StreamingVad)?
+  /// #905 seam — builds the VAD lazily in `prepare()`. Defaults to the real
+  /// `VadManager`; a test injects a fake. Behavior-identical by default.
+  private let makeStreamingVad: @Sendable () async throws -> any StreamingVad
   private var streamState: VadStreamState = .initial()
   public private(set) var speechDetected = false
   public private(set) var isReady = false
@@ -116,15 +142,30 @@ public actor SilenceDetector {
   public init(
     silenceTimeout: TimeInterval = 1.5, vadConfig: SmoothedVADConfig = SmoothedVADConfig()
   ) {
+    // Delegate to the internal seam init with the real VAD factory. The seam is
+    // internal (not public) so the protocol stays inside the module — #905 keeps
+    // this MEDIUM, not REFACTOR. Tests reach the seam via `@testable import`.
+    self.init(
+      silenceTimeout: silenceTimeout, vadConfig: vadConfig,
+      makeStreamingVad: { try await VadManager(config: VadConfig(defaultThreshold: 0.5)) })
+  }
+
+  /// #905 seam init — internal so the `StreamingVad` parameter does not widen the
+  /// public surface. `@testable` tests inject a fake here.
+  init(
+    silenceTimeout: TimeInterval = 1.5,
+    vadConfig: SmoothedVADConfig = SmoothedVADConfig(),
+    makeStreamingVad: @Sendable @escaping () async throws -> any StreamingVad
+  ) {
     self.silenceTimeout = silenceTimeout
     self.vadConfig = vadConfig
+    self.makeStreamingVad = makeStreamingVad
   }
 
   /// Load the Silero VAD model. Call once before processing.
   public func prepare() async throws {
     guard !isReady else { return }
-    let config = VadConfig(defaultThreshold: 0.5)
-    vadManager = try await VadManager(config: config)
+    vadManager = try await makeStreamingVad()
     isReady = true
   }
 
@@ -183,7 +224,9 @@ public actor SilenceDetector {
       result = try await vad.processStreamingChunk(
         samples,
         state: streamState,
-        config: segConfig
+        config: segConfig,
+        returnSeconds: false,
+        timeResolution: 1
       )
     } catch {
       Task {

--- a/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Audio/SilenceDetectorBoundaryTests.swift
@@ -157,70 +157,81 @@ struct SilenceDetectorBoundaryTests {
   // FluidAudio's VadStreamEvent.sampleIndex is computed in VadStreamState's
   // internal sample clock, which only advances inside processStreamingChunk.
   // Skipping that call on energy-gated chunks would drift the FluidAudio clock
-  // away from our buffer index, producing wrong SpeechSegment boundaries.
-  // Codex flagged this on 2026-05-04 against an earlier draft of this branch.
+  // away from our buffer index, producing wrong SpeechSegment boundaries
+  // (Codex flagged this on 2026-05-04). The contract: processStreamingChunk runs
+  // on EVERY chunk, before the energy gate can zero the smoothed-EMA input.
   //
-  // The fix is in `processChunk`: the energy gate now only suppresses
-  // rawProbability fed to advanceStateMachine; it never bypasses
-  // processStreamingChunk. This test locks the contract by inspecting the
-  // source text — runtime end-to-end coverage would require the real Silero
-  // CoreML model and network access (out of scope for unit tests).
+  // #905 replaced an earlier text-grep test (which read SilenceDetector.swift as
+  // a String and asserted the call literal appeared before the gate literal —
+  // blind to wrong arguments, drifted indices, or a runtime branch hiding the
+  // skip) with these behavioral tests: a fake `StreamingVad` records each call
+  // and the `processedSamples` clock it was handed, so a gated chunk that skips
+  // the call (the pre-#604 regression) or a dropped `streamState = result.state`
+  // is caught by running the real `processChunk`, not by grepping source.
 
-  @Test("energy gate must not bypass processStreamingChunk")
-  func energyGateDoesNotBypassFluidAudioClock() throws {
-    let detectorPath = SilenceDetectorBoundaryTests.findSilenceDetectorSource()
-    let source = try String(contentsOfFile: detectorPath, encoding: .utf8)
-
-    // Locate the function body of processChunk.
-    guard let funcRange = source.range(of: "public func processChunk(") else {
-      Issue.record("Could not locate processChunk in SilenceDetector.swift")
-      return
-    }
-    // The function body extends to the next top-level function declaration
-    // ("internal func advanceStateMachine") which immediately follows it.
-    guard let nextFuncRange = source.range(of: "internal func advanceStateMachine(") else {
-      Issue.record("Could not locate advanceStateMachine in SilenceDetector.swift")
-      return
-    }
-    let processChunkBody = String(source[funcRange.lowerBound..<nextFuncRange.lowerBound])
-
-    // The energy-gate path must NOT skip processStreamingChunk. This catches a
-    // regression where someone re-introduces the pre-#604 pattern of
-    // "if energyGated { rawProbability = 0; skip VAD inference }".
-    let containsCall = processChunkBody.contains("vad.processStreamingChunk(")
-    #expect(
-      containsCall,
-      "processChunk must call vad.processStreamingChunk to keep FluidAudio's clock aligned with the buffer"
+  @Test(
+    "energy-gated quiet chunks still advance the FluidAudio streaming clock",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/905",
+      "energy gate must not skip the per-chunk VAD streaming call"
     )
+  )
+  func gatedChunksStillAdvanceStreamingClock() async throws {
+    let fake = FakeStreamingVad()
+    // energyGateThreshold > 0 so a silent chunk (RMS 0) is energy-gated — the
+    // exact case the pre-#604 bug skipped the streaming call on.
+    let detector = SilenceDetector(
+      vadConfig: SmoothedVADConfig(energyGateThreshold: 0.5),
+      makeStreamingVad: { fake }
+    )
+    try await detector.prepare()
 
-    // Ordering guard: after the #604 fix, processStreamingChunk runs FIRST
-    // (always), and the energy-gate check runs AFTER, only zeroing the
-    // rawProbability fed to the smoothed-EMA path. If a regression moves the
-    // gate back BEFORE the call (the pre-#604 shape), it's likely once again
-    // bypassing the call on quiet chunks. This assertion catches that
-    // structural drift.
-    if let gateRange = processChunkBody.range(of: "vadConfig.energyGateThreshold > 0"),
-      let callRange = processChunkBody.range(of: "vad.processStreamingChunk(")
-    {
-      #expect(
-        callRange.lowerBound < gateRange.lowerBound,
-        "processStreamingChunk must run before the energy-gate check; otherwise the gate is likely bypassing the call (pre-#604 shape)"
-      )
-    }
+    let quiet = [Float](repeating: 0.0, count: SilenceDetector.chunkSize)
+    _ = await detector.processChunk(quiet)
+    _ = await detector.processChunk(quiet)
+
+    let seen = await fake.seenProcessedSamples
+    #expect(seen.count == 2)  // the streaming call fired on BOTH gated chunks
+    #expect(seen[1] > seen[0])  // state propagated — the clock advanced across chunks
   }
 
-  /// Resolves the absolute path to SilenceDetector.swift. Walks up from this
-  /// test file to find the package root, then descends into Sources.
-  private static func findSilenceDetectorSource() -> String {
-    var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-    for _ in 0..<10 {
-      let candidate = dir.appendingPathComponent(
-        "Sources/EnviousWisprAudio/SilenceDetector.swift")
-      if FileManager.default.fileExists(atPath: candidate.path) {
-        return candidate.path
-      }
-      dir.deleteLastPathComponent()
-    }
-    return "Sources/EnviousWisprAudio/SilenceDetector.swift"
+  @Test("a non-gated (loud) chunk also advances the streaming clock")
+  func loudChunkAlsoAdvancesStreamingClock() async throws {
+    let fake = FakeStreamingVad()
+    let detector = SilenceDetector(
+      vadConfig: SmoothedVADConfig(energyGateThreshold: 0.5),
+      makeStreamingVad: { fake }
+    )
+    try await detector.prepare()
+
+    // RMS 0.8 ≥ threshold 0.5 → NOT energy-gated (the adversarial other side).
+    let loud = [Float](repeating: 0.8, count: SilenceDetector.chunkSize)
+    _ = await detector.processChunk(loud)
+    _ = await detector.processChunk(loud)
+
+    let seen = await fake.seenProcessedSamples
+    #expect(seen.count == 2)
+    #expect(seen[1] > seen[0])
+  }
+}
+
+/// Records each `processStreamingChunk` call and the `processedSamples` clock it
+/// was handed, then returns a result that advances that clock by the chunk size
+/// (mirroring FluidAudio's `VadManager+Streaming`). An `actor` so it satisfies
+/// the `Sendable` `StreamingVad` seam under Swift 6.
+actor FakeStreamingVad: StreamingVad {
+  private(set) var seenProcessedSamples: [Int] = []
+
+  func processStreamingChunk(
+    _ audioChunk: [Float],
+    state: VadStreamState,
+    config: VadSegmentationConfig,
+    returnSeconds: Bool,
+    timeResolution: Int
+  ) async throws -> VadStreamResult {
+    seenProcessedSamples.append(state.processedSamples)
+    var next = state
+    next.processedSamples += audioChunk.count
+    return VadStreamResult(state: next, event: nil, probability: 0.0)
   }
 }


### PR DESCRIPTION
Closes #905. Part of trust-sweep epic #897. Tier: MEDIUM (per-chunk audio path).

## What
`energyGateDoesNotBypassFluidAudioClock` read `SilenceDetector.swift` as a String and asserted the call literal appeared before the energy-gate literal — a pure text-grep test that never ran the SUT. The contract (#604: the streaming call runs on EVERY chunk, before the energy gate, so a gated quiet chunk still advances FluidAudio's `processedSamples` clock) was unverified and blind to wrong arguments / drifted indices / a runtime branch hiding the skip.

## How
Introduced an internal `StreamingVad` protocol (the narrow per-chunk surface); the real `VadManager` conforms via an empty extension. The field retypes to `(any StreamingVad)?`, still built lazily in `prepare()` via a factory closure defaulted to the real `VadManager` — behavior-identical by default. `SilenceDetector` is an `actor` (not `@MainActor`), so the existential is fine (`avoid-any-mainactor-protocol-hotpath` does not bind); ~10 Hz dispatch is negligible. The seam lives on an INTERNAL init (the public init delegates to it) so the protocol never widens the public surface — keeps this MEDIUM, not REFACTOR.

The new behavioral tests inject an actor fake recording `processedSamples` per call: two energy-gated quiet chunks must each fire a streaming call with the clock advancing across them; an adversarial loud (non-gated) chunk pins the other side.

## Validation
- Full logic suite green (1606 tests); Release-config build green.
- **Mutation proof:** re-introducing the pre-#604 skip (gated chunk bypasses the VAD call) makes the gated-chunk test red (0 calls, not 2) while the loud-chunk test stays green; reverting -> both green.
- **Live UAT (both engines) — PASS:**
  - Parakeet: transcript landed in clipboard, VAD segments=1 (91.2% voiced), `TOTAL 1.729s (ASR=0.118s)`.
  - WhisperKit: transcript landed, `TOTAL 3.002s (ASR=1.437s)` (normal for WK).
  - Both exercised the shared `SilenceDetector.processChunk` VAD path with no per-chunk latency regression; no crash, no overlay-stuck. (TTS via macOS `say` fallback — the OpenAI echo path needs gcloud-business auth which is not active this session.)
- Codex code-diff review: CLEAN across behavior parity, public-surface/tier, conformance, actor init delegation, test validity, fake-yield, and drift — all grep-verified.

## Architecture Closeout
- Module/owner chosen: `SilenceDetector` (already owns the VAD dependency).
- Why correct: the seam injects what it already holds; internal protocol stays inside `EnviousWisprAudio`.
- Whether any central type grew: one internal protocol + one factory field; no public surface change.
- Whether access control widened: no — `StreamingVad` is internal; public init signature unchanged.
- Whether any temporary compromise remains: no.
- Whether dependency direction remains clean: yes (FluidAudio already imported; no new edge).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining