### PR TITLE
fix(test): DEBUG-gate the #902 cancel-ordering test to repair the release lane

### DIFF
--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -127,30 +127,36 @@ import Testing
   /// `.recording`/`.loadingModel`, so the active driver is force-transitioned to
   /// `.recording` to reach the dispatch. The cancel closure observes only (no
   /// forward) because real `cancelRecording()` awaits terminal convergence.
-  @Test(
-    "cancel sets the stop timestamp before entering the dispatch await",
-    .bug(
-      "https://github.com/saurabhav88/EnviousWispr/issues/902",
-      "cancel timestamp ordering"
+  // `kernelForTesting` + `testForceTransition` are DEBUG-only seams
+  // (`KernelDictationDriver.swift` `#if DEBUG`), so this test wraps itself in
+  // `#if DEBUG` — same pattern as ASREventRouterTests. Otherwise the release-config
+  // test lane (post-merge) fails to compile and reports an empty bundle.
+  #if DEBUG
+    @Test(
+      "cancel sets the stop timestamp before entering the dispatch await",
+      .bug(
+        "https://github.com/saurabhav88/EnviousWispr/issues/902",
+        "cancel timestamp ordering"
+      )
     )
-  )
-  func cancelSetsTimestampBeforeDispatchAwait() async {
-    let fx = Self.makeFixture()
-    fx.asr.activeBackendType = .parakeet
-    // idle -> recording is a forbidden direct transition; walk through .preparing
-    // first, matching the kernel FSM (KernelDictationDriverTests precedent).
-    _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .preparing)
-    _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .recording)
-    let finalizer = fx.finalizer
-    let obs = DispatchObservation()
-    finalizer.cancelRecordingDispatch = { _ in
-      obs.dispatchRan = true
-      obs.stampAtEntry = finalizer.lastUserStopAccess.read()
+    func cancelSetsTimestampBeforeDispatchAwait() async {
+      let fx = Self.makeFixture()
+      fx.asr.activeBackendType = .parakeet
+      // idle -> recording is a forbidden direct transition; walk through .preparing
+      // first, matching the kernel FSM (KernelDictationDriverTests precedent).
+      _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .preparing)
+      _ = fx.kernelDriver.kernelForTesting.testForceTransition(to: .recording)
+      let finalizer = fx.finalizer
+      let obs = DispatchObservation()
+      finalizer.cancelRecordingDispatch = { _ in
+        obs.dispatchRan = true
+        obs.stampAtEntry = finalizer.lastUserStopAccess.read()
+      }
+      await finalizer.cancel()
+      #expect(obs.dispatchRan)  // the state guard passed and the dispatch was reached
+      #expect(obs.stampAtEntry != nil)  // the timestamp was already set at dispatch entry
     }
-    await finalizer.cancel()
-    #expect(obs.dispatchRan)  // the state guard passed and the dispatch was reached
-    #expect(obs.stampAtEntry != nil)  // the timestamp was already set at dispatch entry
-  }
+  #endif
 
   @Test func markLockedFlipsTheLockAndUpdatesOverlay() {
     let fx = Self.makeFixture()


### PR DESCRIPTION
Repairs the main post-merge failure introduced by #902.

## Problem
`cancelSetsTimestampBeforeDispatchAwait` (added in #902) uses `kernelForTesting` + `testForceTransition`, which are `#if DEBUG`-only seams on `KernelDictationDriver`. The PR build-check (debug) and my local runs compiled it fine, but the post-merge **release-config** test lane (`#if DEBUG` false) could not compile it — "Xcode executed 0 release tests (empty/misconfigured bundle)" — reddening main post-merge for #902, #903, #904 (and #905, which carried the same broken test forward).

## Fix
Wrap that one test in `#if DEBUG`, matching the established `ASREventRouterTests` pattern for DEBUG-only kernel seams. The `userStop` ordering test (no kernel seam) stays unconditional.

## Validation (both configs this time)
- `scripts/xcode-test.sh --release`: **1508 tests** (non-empty bundle, compiles clean) — the exact lane that failed.
- `scripts/xcode-test.sh` (debug): both ordering tests run and pass.
- Codex review: CLEAN.

Process note: #902 should have run `scripts/xcode-test.sh --release` at ship time per `definition-of-done` ("add `--release` when the PR adds `#if DEBUG`-gated test symbols"). Captured for the session log.