### PR TITLE
test: make preWarm-success real + count polish executor (#983)

### DIFF
--- a/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
@@ -143,7 +143,9 @@ struct OllamaConnectorRequestBodyTests {
   /// tests can't catch a bad polish reroute.
   @Test("polish surfaces a transport failure through the injected executor")
   func polishSurfacesExecutorError() async {
+    let counter = RequestCounter()
     let connector = OllamaConnector(networkExecutor: { _ in
+      await counter.bump()
       throw URLError(.notConnectedToInternet)  // maps to providerUnavailable, fail-fast
     })
     let config = LLMProviderConfig(
@@ -162,6 +164,12 @@ struct OllamaConnectorRequestBodyTests {
         onToken: nil
       )
     }
+    // The throw alone doesn't prove the polish path reached the network: a
+    // pre-network guard (config validation, empty-model) throwing an LLMError
+    // would also satisfy the expectation above. Counting the executor pins the
+    // failure to the injected transport actually running — deleting the polish
+    // reroute and hard-throwing earlier drops the count to 0 and reddens this.
+    #expect(await counter.count == 1)
   }
 }
 

--- a/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PreWarmThrowsTests.swift
@@ -1,4 +1,3 @@
-@preconcurrency import AVFoundation
 import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
@@ -45,63 +44,27 @@ struct PreWarmThrowsTests {
     #expect(capture.preWarmCallCount == 1)  // the kernel actually reached capture.preWarm()
   }
 
-  @Test("mock preWarm returns cleanly when not configured to throw")
+  /// The success-path twin of `kernelRethrowsPreWarmError`: drives the REAL
+  /// `RecordingSessionKernel.preWarm()` over a capture that succeeds and asserts
+  /// the kernel reaches `capture.preWarm()` and returns without throwing. The old
+  /// `preWarmSucceedsByDefault` only called a local mock's `preWarm()` and checked
+  /// the mock's own counter — it ran zero production code, so any kernel mutation
+  /// (never calling preWarm on the happy path, or always throwing) left it green.
+  @Test("the kernel completes preWarm cleanly when the audio capture succeeds")
   @MainActor
-  func preWarmSucceedsByDefault() async throws {
-    let mock = PassthroughAudioCapture()
-    try await mock.preWarm()
-    #expect(mock.preWarmCallCount == 1)
+  func kernelCompletesPreWarmOnSuccess() async throws {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "default"), clock: clock)
+    let capture = FakeAudioCapture()  // preWarmError == nil → success path
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let session = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    try await session.testKernel.preWarm()  // real kernel; must not throw
+    #expect(capture.preWarmCallCount == 1)  // the kernel actually reached capture.preWarm()
   }
 }
 
 enum PreWarmFailedError: Error, Equatable {
   case simulated
-}
-
-// MARK: - Minimal AudioCaptureInterface conformer for the default-success check
-
-@MainActor
-final class PassthroughAudioCapture: AudioCaptureInterface {
-  var isCapturing: Bool = false
-  var audioLevel: Float = 0
-  var capturedSamples: [Float] = []
-  var currentAudioRoute: String = "unknown"
-  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
-  var onVADAutoStop: (() -> Void)?
-  var onCaptureStalled: ((CaptureStallContext) -> Void)?
-  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
-  var onXPCServiceError: ((XPCErrorContext) -> Void)?
-  var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
-  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
-  var currentCaptureSessionID: UInt64 = 0
-  var isActivelyCapturing: Bool = false
-  var captureSourceType: String = "mock"
-  var noiseSuppressionEnabled: Bool = false
-  var selectedInputDeviceUID: String = ""
-  var preferredInputDeviceIDOverride: String = ""
-  var warmEnginePolicy: WarmEnginePolicy = .off
-
-  private(set) var preWarmCallCount: Int = 0
-
-  func startEnginePhase() async throws {}
-  func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
-    AsyncStream { $0.finish() }
-  }
-  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-    AsyncStream { $0.finish() }
-  }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
-  func rebuildEngine() {}
-  func buildEngine(noiseSuppression: Bool) {}
-  func preWarm() async throws { preWarmCallCount += 1 }
-  func abortPreWarm() {}
-  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-    true
-  }
-  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
-  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
-    ([], 0)
-  }
-  func getVADSegments() async -> [SpeechSegment] { [] }
 }


### PR DESCRIPTION
Part of #983 (trust-sweep round 2 from the Codex re-audit of #897).

Two test fixes, both mutation-proven, test-only (no production change):

**`preWarmSucceedsByDefault` → `kernelCompletesPreWarmOnSuccess`** (was the one outright FAKE test, from #289). The old test built a local mock, called the mock's own `preWarm()`, and asserted the mock's own counter — zero production code. Rewritten as the success-path twin of `kernelRethrowsPreWarmError`: drives the real `RecordingSessionKernel.preWarm()` over a succeeding capture and asserts the kernel reaches `capture.preWarm()` without throwing. Removing the kernel's `audioCapture.preWarm()` call reddens it (proven). Deletes the now-dead `PassthroughAudioCapture` conformer and its unused `AVFoundation` import.

**`polishSurfacesExecutorError`** (ours, from #901). Asserted only that *some* `LLMError` threw — a pre-network guard would satisfy that too. Now counts executor invocations (mirrors the sibling `evictModel...MakesOneRequest`), so a polish reroute that throws before reaching the injected transport drops the count to 0 and reddens. Proven: the throw-expectation alone stayed green under that mutation; the new `count == 1` assertion caught it.

Codex code-diff review: CLEAN on both (confirmed behavioral, no scope drift, no Swift 6 concurrency issue, deletion unused).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining