### PR TITLE
test(app): assert overlay update + positive warm-press intent (#983)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -603,6 +603,12 @@ final class RecordingOverlayPanel {
     isRecordingLocked = locked
   }
 
+  /// Read-only mirror of the private lock flag, for tests that verify
+  /// `markLocked()` / `updateLockState(_:)` actually toggled the overlay rather
+  /// than only the shared lock setter. Mirrors the
+  /// `ASRManagerProxy.isProgressPollingActiveForTesting` test-accessor pattern.
+  internal var isRecordingLockedForTesting: Bool { isRecordingLocked }
+
   /// Show the passive language-detection chip as a floating panel. Mirrors the
   /// `showAccessibilityToast` shape: defers creation to next run loop cycle,
   /// guards against rapid replace via the generation token. Auto-dismiss is 6s

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -75,10 +75,6 @@ import Testing
     )
   }
 
-  @Test func constructionDoesNotCrash() {
-    _ = Self.makeFixture()
-  }
-
   @Test func cancelIsNoOpWhenParakeetIdle() async {
     let fx = Self.makeFixture()
     fx.asr.activeBackendType = .parakeet
@@ -161,8 +157,13 @@ import Testing
   @Test func markLockedFlipsTheLockAndUpdatesOverlay() {
     let fx = Self.makeFixture()
     #expect(fx.lockBox.isLocked == false)
+    #expect(fx.overlay.isRecordingLockedForTesting == false)
     fx.finalizer.markLocked()
     #expect(fx.lockBox.isLocked == true)
+    // The test name promises the overlay is updated too — markLocked() calls
+    // recordingOverlay.updateLockState(true). The old test asserted only the
+    // shared lock setter, so deleting the overlay update left it green.
+    #expect(fx.overlay.isRecordingLockedForTesting == true)
   }
 
   @Test func userStopClearsLockBeforeDispatch() async {

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -105,10 +105,6 @@ import Testing
     )
   }
 
-  @Test func constructionDoesNotCrash() {
-    _ = Self.makeFixture()
-  }
-
   @Test func isProcessingFalseWhenBothPipelinesIdle() {
     let fx = Self.makeFixture()
     fx.asr.activeBackendType = .parakeet
@@ -209,11 +205,15 @@ import Testing
 
     await fx.starter.start()
 
-    // A ready press must NOT take the cold branch — the cold-boot pill is the
-    // only intent `start()` sets from that branch, so its absence proves the
-    // warm path ran.
-    if case .cachingModel = fx.overlay.currentIntent {
-      Issue.record("warm press must not show the cold-boot caching pill")
+    // A ready press must take the WARM path, which shows the recording overlay.
+    // The old test only checked the cold-boot pill's ABSENCE — a broken warm
+    // path that returned early without recording also has no cold pill and
+    // stayed green. Asserting the positive recording intent reddens that
+    // early-return mutation while still proving the cold branch was skipped.
+    guard case .recording = fx.overlay.currentIntent else {
+      Issue.record(
+        "warm press must show the recording overlay; got \(fx.overlay.currentIntent)")
+      return
     }
   }
 


### PR DESCRIPTION
Part of #983 (trust-sweep round 2 from the Codex re-audit of #897). Two pre-existing weak App tests hardened + two redundant smoke tests removed. Mutation-proven.

**`markLockedFlipsTheLockAndUpdatesOverlay`** asserted only the shared lock setter, never the overlay — despite the name. Adds a narrow internal test accessor (`RecordingOverlayPanel.isRecordingLockedForTesting`, mirroring `ASRManagerProxy.isProgressPollingActiveForTesting`) and asserts the overlay lock state. Removing `markLocked()`'s `updateLockState(true)` reddens it (proven).

**`warmPressSkipsColdBranch`** checked only the ABSENCE of the cold-boot pill — a broken warm path that returns early without recording also has no cold pill and stayed green. Now asserts the positive `.recording` overlay intent; an early-return warm path reddens with "got .hidden" (proven).

**Deleted two `constructionDoesNotCrash` crash-only tests** — every behavioral test in each suite already constructs the same fixture, so construction is implicitly covered; the standalone tests added count, not signal.

One narrow internal test accessor added (computed `var`, no stored-property or public-surface change); the rest is test-only. Architecture suite green (no ceiling on `RecordingOverlayPanel`). Codex code-diff review: CLEAN (all four items PASS).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining