### PR TITLE
test(asr): detect a leaked + an unscheduled progress-poll timer (#983)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -178,6 +178,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// via `@testable import EnviousWisprASR`.
   internal var isProgressPollingActiveForTesting: Bool { progressPollTimer != nil }
 
+  /// Read-only handle to the live polling timer, for the #586 leak-regression
+  /// test that must hold a reference to the PRIOR timer across a re-arm and
+  /// assert it was invalidated (a leak is invisible through the `!= nil` flag
+  /// above, which only ever sees the newest timer). Read-only window onto the
+  /// existing private state — adds no behavior and no new stored property.
+  internal var progressPollTimerForTesting: Timer? { progressPollTimer }
+
   internal func startProgressPolling() {
     stopProgressPolling()
     // Read progress from shared file — bypasses XPC entirely.

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
@@ -25,13 +25,26 @@ import Testing
 @Suite("ASRManagerProxy progress polling")
 struct ASRManagerProxyProgressPollingTests {
 
-  @Test("startProgressPolling activates the timer")
-  func startActivates() {
+  @Test("startProgressPolling schedules a live timer on the main run loop")
+  func startActivates() throws {
     let proxy = ASRManagerProxy()
-    #expect(proxy.isProgressPollingActiveForTesting == false)
+    #expect(proxy.progressPollTimerForTesting == nil)
 
     proxy.startProgressPolling()
-    #expect(proxy.isProgressPollingActiveForTesting == true)
+    let timer = try #require(proxy.progressPollTimerForTesting)
+    // The timer must be live AND actually scheduled on the main run loop. The
+    // old `!= nil` flag (and even a plain `isValid` check) stayed green if
+    // `RunLoop.main.add` were deleted — a stored-but-never-scheduled `Timer`
+    // is still valid and non-nil, yet never fires. `CFRunLoopContainsTimer`
+    // checks the scheduling deterministically and synchronously, without
+    // firing the timer or touching the shared `ProgressFile` (a real-timer
+    // test would need both, which `tests-no-real-time-scheduling-precision`
+    // and the process-global-state guidance steer away from). Production adds
+    // the timer to `RunLoop.main` `.common` modes, so check `.commonModes`.
+    #expect(timer.isValid)  // not invalidated / not a dead timer
+    #expect(
+      CFRunLoopContainsTimer(CFRunLoopGetMain(), timer as CFRunLoopTimer, .commonModes),
+      "the polling timer must be scheduled on the main run loop, not merely stored")
 
     proxy.stopProgressPolling()
   }
@@ -46,21 +59,27 @@ struct ASRManagerProxyProgressPollingTests {
     #expect(proxy.isProgressPollingActiveForTesting == false)
   }
 
-  @Test("re-arming via startProgressPolling does not leak the prior timer")
+  @Test("re-arming via startProgressPolling invalidates the prior timer (no leak)")
   func reArmingDoesNotLeak() {
     let proxy = ASRManagerProxy()
     proxy.startProgressPolling()
-    let firstActive = proxy.isProgressPollingActiveForTesting
-    #expect(firstActive == true)
+    let firstTimer = proxy.progressPollTimerForTesting
+    #expect(firstTimer?.isValid == true)
 
-    // start without an explicit stop in between should still result in a
-    // single active timer — startProgressPolling's first line calls
-    // stopProgressPolling() to invalidate any prior timer before scheduling.
+    // Re-arm without an explicit stop. startProgressPolling's first line calls
+    // stopProgressPolling(), which invalidates the prior timer before scheduling
+    // a new one. Holding the prior timer reference lets us PROVE that: a leak
+    // (the old timer left running on the run loop) is invisible through the
+    // `!= nil` flag, which only ever sees the newest timer. If that cleanup is
+    // removed, firstTimer stays valid and this reddens.
     proxy.startProgressPolling()
-    #expect(proxy.isProgressPollingActiveForTesting == true)
+    let secondTimer = proxy.progressPollTimerForTesting
+    #expect(firstTimer?.isValid == false, "the prior timer must be invalidated, not leaked")
+    #expect(secondTimer?.isValid == true, "the re-armed timer is live")
+    #expect(firstTimer !== secondTimer, "re-arm installs a distinct timer")
 
     proxy.stopProgressPolling()
-    #expect(proxy.isProgressPollingActiveForTesting == false)
+    #expect(proxy.progressPollTimerForTesting == nil)
   }
 
   @Test("stopProgressPolling is idempotent — calling twice is safe")


### PR DESCRIPTION
Part of #983 (trust-sweep round 2 from the Codex re-audit of #897). Two pre-existing weak #586 timer-lifecycle tests, both mutation-proven.

**`reArmingDoesNotLeak`** observed only the newest stored timer through the `!= nil` flag, so a leaked PRIOR timer (re-arm without invalidating it) was invisible — the exact leak the test is named for. Now holds the prior timer reference across the re-arm and asserts it is invalidated (`.isValid == false`) and distinct from the new one. Removing `startProgressPolling`'s leading `stopProgressPolling()` reddens it (proven).

**`startActivates`** asserted only `timer != nil`, so an immediately-invalidated timer OR a timer stored but never scheduled on the run loop both stayed green. Now asserts the timer is live (`.isValid`) AND scheduled, via `CFRunLoopContainsTimer(CFRunLoopGetMain(), timer, .commonModes)` — deterministic and synchronous, no real-timer firing, no shared `ProgressFile`. Both a dead-timer mutation and deleting `RunLoop.main.add` redden it (both proven).

Adds one narrow read-only test accessor (`progressPollTimerForTesting`, a window onto the existing private timer; no behavior, no new stored property), mirroring `isProgressPollingActiveForTesting`.

Codex code-diff review: first pass returned MUST-FIX (an earlier "scheduling isn't observable" version left the `RunLoop.main.add` deletion uncaught); the `CFRunLoopContainsTimer` revision was re-reviewed CLEAN (`.commonModes` confirmed correct against Apple docs).

council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining