### PR TITLE
chore(release): bump version to 2.1.2

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -28,6 +28,45 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.1.2
+
+    Entry(
+      id: "automatic-update-checks",
+      icon: "sparkles",
+      title: "EnviousWispr keeps itself current",
+      description:
+        "The app now looks for new versions on its own: when you open it, when you come back to it, and quietly in the background. So a waiting improvement finds you instead of you having to go looking. There's also a clear \"Check for Updates\" control in Settings if you ever want to look right now.",
+      category: .newFeatures,
+      version: "2.1.2"
+    ),
+    Entry(
+      id: "soft-and-distant-speech-captured",
+      icon: "waveform",
+      title: "Soft and distant speech no longer gets dropped",
+      description:
+        "If you spoke quietly, whispered, or sat back from your mic, EnviousWispr would sometimes capture nothing at all. It now hears those faint and far-away words and writes them down, including a soft first word that used to get clipped off the start.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.2"
+    ),
+    Entry(
+      id: "no-false-warming-up-notice",
+      icon: "bolt.badge.checkmark",
+      title: "No more false \"warming up\" notice",
+      description:
+        "Tapping record again right after a quick tap or a \"changed my mind\" cancel could flash the \"warming up\" notice as if the app were starting cold, even though it was already warm and ready. That stray notice is gone: a warm app just records.",
+      category: .qualityOfLife,
+      version: "2.1.2"
+    ),
+    Entry(
+      id: "removed-recording-environment-picker",
+      icon: "slider.horizontal.3",
+      title: "Removed a setting that promised something it didn't do",
+      description:
+        "The \"Recording Environment\" choice (Quiet, Normal, Noisy) sounded like it changed how well the app hears you in different surroundings. It never did that. We removed it so Settings only shows controls that actually do what they say.",
+      category: .qualityOfLife,
+      version: "2.1.2"
+    ),
+
     // MARK: - v2.1.1
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.1.1"
+  public static let currentContentVersion = "2.1.2"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.1.2 with What's New entries for user-visible changes shipped since v2.1.1.

Four What's New entries (newest section at top, verified rendering via wispr-eyes on the dev build):
- Automatic update awareness — hourly + launch/foreground checks + Settings "Check for Updates" row (#958)
- Soft and distant speech no longer dropped, soft first word preserved (#964, #843)
- No false "warming up" notice on a warm engine after quick/cancelled taps (#959)
- Removed the misleading Recording Environment picker (#969)

`WhatsNewConstants.currentContentVersion` bumped to 2.1.2 to match.

## Test plan

- [x] scripts/build-dev-app.sh — built locally from the release worktree
- [x] What's New tab visually verified (v2.1.2 section renders at top, all four entries, clean copy)
- [ ] build-check CI passes on this PR
- [ ] Tag v2.1.2 after merge triggers release pipeline