### PR TITLE
fix(asr): warm-respawn idle-reaped Parakeet model instead of cold pill (#959)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -572,9 +572,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
         level: .info, category: "XPC"
       )
     }
+    // #959: align with the connection-loss handlers — supersede the load + log
+    // cause BEFORE clearing loaded state, and clear `isModelLoaded` explicitly
+    // (the async invalidationHandler also clears it, but make this path
+    // self-consistent so readiness is unambiguous after a wedge).
+    if isModelLoaded || isStreaming || inFlightLoadTask != nil {
+      invalidateCurrentLoadGeneration(cause: "xpc_wedge")
+    }
     connection?.invalidate()
     connection = nil
     isStreaming = false
+    isModelLoaded = false
     needsReinit = true
   }
 
@@ -603,19 +611,30 @@ public final class ASRManagerProxy: ASRManagerInterface {
         guard let proxy else { return }
         let wasStreaming = proxy.isStreaming
         let wasLoaded = proxy.isModelLoaded
+        let wasInFlight = proxy.inFlightLoadTask != nil
+        // #959: supersede the current/in-flight load (and log the ready→notReady
+        // cause) BEFORE clearing `isModelLoaded`, so the cause log fires and a
+        // load completing after this teardown cannot resurrect a false `.ready`.
+        // Widened to `wasInFlight` so a connection lost mid-load is superseded
+        // even though `isModelLoaded` is still false.
+        if wasLoaded || wasStreaming || wasInFlight {
+          proxy.invalidateCurrentLoadGeneration(cause: "xpc_interruption")
+        }
         if proxy.isModelLoaded {
           proxy.isModelLoaded = false
           proxy.isStreaming = false
         }
         proxy.needsReinit = true
+        // #959: fire the interruption signal BEFORE the fire-and-forget log so
+        // the router's idle-marker set is not delayed behind the `await` (shrinks
+        // the kill-vs-press gap). Surface only if ASR was active/resident.
+        if wasStreaming || wasLoaded {
+          proxy.onServiceInterrupted?()
+        }
         await AppLogger.shared.log(
           "[ASRManagerProxy] XPC interruptionHandler fired — wasStreaming=\(wasStreaming), wasLoaded=\(wasLoaded)",
           level: .info, category: "XPC"
         )
-        // Surface crash to pipeline if ASR was active (streaming or batch in-flight)
-        if wasStreaming || wasLoaded {
-          proxy.onServiceInterrupted?()
-        }
       }
     }
   }
@@ -627,6 +646,12 @@ public final class ASRManagerProxy: ASRManagerInterface {
       Task { @MainActor [weak proxy] in
         guard let proxy else { return }
         let wasActive = proxy.isStreaming || proxy.isModelLoaded
+        let wasInFlight = proxy.inFlightLoadTask != nil
+        // #959: same as the interruption handler — supersede current/in-flight
+        // load + log cause BEFORE clearing `isModelLoaded`.
+        if wasActive || wasInFlight {
+          proxy.invalidateCurrentLoadGeneration(cause: "xpc_invalidation")
+        }
         proxy.connection = nil
         if proxy.isModelLoaded {
           proxy.isModelLoaded = false

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
@@ -35,6 +35,15 @@ final class ASREventRouter {
         self.kernelDriver.handleASRServiceInterruption()
       } else if wkState == .recording || wkState == .transcribing {
         self.whisperKitKernelDriver.handleASRServiceInterruption()
+      } else {
+        // #959: the Parakeet ASR service (this `asrManager`) was reaped while
+        // idle — `onServiceInterrupted` only fires when a resident model was
+        // loaded (`wasLoaded || wasStreaming`), and neither driver is active, so
+        // this is the reap-while-idle case that drops readiness to `.notReady`.
+        // Mark the Parakeet driver so the next press warm-respawns (re-warm ~0.2s
+        // + record) instead of showing the #879 cold pill. The driver owns the
+        // marker + reclaim telemetry (keeps this router's import set minimal).
+        self.kernelDriver.markResidentModelLostWhileIdle()
       }
     }
   }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
@@ -18,6 +18,29 @@ import Foundation
 /// (privacy: never begin listening on the user's behalf).
 @MainActor
 enum ColdPressGuard {
+  /// #959 — resolve a press on a not-ready engine. Returns `true` for a
+  /// warm-respawn (the resident model was reaped while idle AND the user keeps it
+  /// resident, `.never`): consumes the marker, records the branch, and the caller
+  /// FALLS THROUGH to the normal start so the press records (~0.2s re-warm under
+  /// the kernel watchdog, overlay morphed to recording). Returns `false` for a
+  /// genuine cold press: shows the #879 pill (no session) and the caller returns.
+  /// Keeps the decision off `RecordingStarter` (same ceiling rationale as `handle`).
+  static func resolveNotReadyPress(
+    overlay: RecordingOverlayPanel,
+    active: KernelDictationDriver,
+    backendTag: String,
+    readiness: ASREngineReadiness,
+    modelUnloadPolicy: ModelUnloadPolicy
+  ) -> Bool {
+    if active.residentModelLostWhileIdle && modelUnloadPolicy == .never {
+      active.residentModelLostWhileIdle = false
+      TelemetryService.shared.serviceRespawnStarted(asrBackend: backendTag)
+      return true
+    }
+    handle(overlay: overlay, active: active, backendTag: backendTag, readiness: readiness)
+    return false
+  }
+
   static func handle(
     overlay: RecordingOverlayPanel,
     active: KernelDictationDriver,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -118,13 +118,17 @@ final class RecordingStarter {
     // re-presses after "Ready" and that re-press runs the full warm path below.
     // Placed after the polish-error reset (cleared on every entry), before the
     // AX-refresh / overlay / prewarm block.
+    // #959: a not-ready press is EITHER a warm-respawn (idle-reaped warm model,
+    // re-warm ~0.2s → fall through and record) OR a genuine cold boot (#879 pill,
+    // no session). `resolveNotReadyPress` owns that decision off this type.
     if readinessAtEntry != .ready {
-      ColdPressGuard.handle(
+      let warmRespawn = ColdPressGuard.resolveNotReadyPress(
         overlay: recordingOverlay, active: active,
         backendTag: isWhisperKit ? "whisperkit" : "parakeet",
-        readiness: readinessAtEntry)
-      return
+        readiness: readinessAtEntry, modelUnloadPolicy: settings.modelUnloadPolicy)
+      if !warmRespawn { return }
     }
+    let isWarmRespawn = readinessAtEntry != .ready
     accessibilityRefresh()
     recordingOverlay.show(
       intent: .recording(audioLevel: 0),
@@ -174,6 +178,11 @@ final class RecordingStarter {
       return
     }
     let preWarmMs = Self.elapsedMs(since: pttStart)
+    // #959: set the warm-respawn overlay latch ONLY here — after every pre-toggle
+    // abort guard has passed and immediately before the kernel dispatch — so an
+    // aborted start never leaves a latch set (which would wrongly morph a later
+    // genuine-cold press's overlay). The driver clears it at `.recording`/terminal.
+    if isWarmRespawn { active.beginWarmRespawnOverlay() }
     do {
       try await active.handle(
         event: .toggleRecording(
@@ -248,6 +257,7 @@ final class RecordingStarter {
     let isWK = asrManager.activeBackendType == .whisperKit
     let isStartingFromIdle =
       !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive)
+    var isWarmRespawn = false
     if isStartingFromIdle {
       lastRecordingResult?.polishError = nil
       // #879 — same cold-boot press safety as the PTT path. A toggle press that
@@ -255,14 +265,19 @@ final class RecordingStarter {
       // minting a session (the toggle-hotkey is a user press too). A toggle that
       // STOPS an active session is unaffected (guarded by `isStartingFromIdle`).
       if active.engineReadiness != .ready {
-        ColdPressGuard.handle(
+        // #959: warm-respawn falls through to record; genuine cold keeps the
+        // #879 pill. Same decision helper as the PTT path.
+        isWarmRespawn = ColdPressGuard.resolveNotReadyPress(
           overlay: recordingOverlay, active: active,
           backendTag: isWK ? "whisperkit" : "parakeet",
-          readiness: active.engineReadiness)
-        return
+          readiness: active.engineReadiness, modelUnloadPolicy: settings.modelUnloadPolicy)
+        if !isWarmRespawn { return }
       }
     }
     accessibilityRefresh()
+    // #959: set the overlay latch immediately before the kernel dispatch (toggle
+    // has no pre-warm abort path, but keep the set-just-before-dispatch rule).
+    if isWarmRespawn { active.beginWarmRespawnOverlay() }
     do {
       try await active.handle(
         event: .toggleRecording(

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -105,6 +105,28 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// outside (`setExternalError`). Cleared on the next start / reset.
   private var lastExternalError: String?
 
+  /// #959 — set by `ASREventRouter` when the OS reaps this engine's idle ASR
+  /// service while a resident model was loaded (readiness drops to `.notReady`
+  /// with no active session). It is the ONLY signal that distinguishes "warm
+  /// model reaped while idle" (re-warm ~0.2s) from "never-loaded true cold boot"
+  /// (~6s). `RecordingStarter` consumes it to warm-respawn instead of showing
+  /// the #879 cold pill. Cleared on consume (in the starter), on any successful
+  /// load reaching `.recording` (below), and on `ensureEngineWarm` success.
+  @ObservationIgnored
+  public var residentModelLostWhileIdle = false
+
+  /// #959 — latch set by `RecordingStarter` immediately before it dispatches
+  /// `.toggleRecording` on the warm-respawn branch. While set, `overlayIntent`
+  /// routes `.preparing`/`.warmingUp` through the #930 warm `.recording` morph
+  /// (no `.cachingModel` pill) for the sub-second re-warm. Cleared when the
+  /// kernel reaches `.recording` (emitting `service_respawn_completed`) or any
+  /// terminal (no emit). Set ONLY just before the kernel dispatch so a pre-toggle
+  /// abort never leaks a latch.
+  @ObservationIgnored
+  public private(set) var warmRespawnInFlight = false
+  @ObservationIgnored
+  private var warmRespawnStartedAt: ContinuousClock.Instant?
+
   /// Fired by the kernel-state observer whenever the mapped `PipelineState`
   /// changes. The App's `DictationLifecycleCoordinator` is the consumer.
   @ObservationIgnored
@@ -181,6 +203,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public func ensureEngineWarm(reason: EngineWarmupReason) async -> EngineWarmupOutcome {
     let engine = adapter.engineIdentity.rawValue
     if adapter.readiness == .ready {
+      // #959: a load has succeeded — drop any stale idle-reap marker so a later
+      // genuine cold boot still shows the pill. Covers the launch/backend-swap
+      // warm paths, which complete here WITHOUT a kernel state transition.
+      residentModelLostWhileIdle = false
       if reason == .launch {
         TelemetryService.shared.launchModelPreloadCompleted(
           backend: engine, result: "already_loaded", durationMs: 0)
@@ -193,6 +219,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       engine: engine, reason: reason.telemetryToken, warmupInFlight: warmupInFlight)
     do {
       try await adapter.warmUp()
+      residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
       let ms = Self.elapsedMs(since: start)
       TelemetryService.shared.coldStartWarmupCompleted(
         engine: engine, reason: reason.telemetryToken, durationMs: ms)
@@ -470,7 +497,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // `.warmingUp` is a readiness-flip race (ready at the press-time snapshot,
       // not-ready by the time the kernel starts) — and that race gets the
       // plain-English pill here instead of the wall.
-      return .cachingModel(engineLabel: adapter.engineIdentity.displayName)
+      // #959: a warm-respawn (idle ASR service reaped, model still cached,
+      // re-warm ~0.2s) sets the latch — route through the #930 warm `.recording`
+      // morph so no cold pill flashes for the sub-second reload. True cold boot
+      // (latch unset) keeps the honest pill.
+      return warmRespawnInFlight
+        ? .recording(audioLevel: 0)
+        : .cachingModel(engineLabel: adapter.engineIdentity.displayName)
     case .preparing:
       // `.preparing` is a sub-10ms bookkeeping step (mint session, spawn the
       // forward path). On a WARM engine (`adapter.readiness == .ready`) no
@@ -482,7 +515,9 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // (UAT 2026-05-31: `.hidden` forced a fresh-create pop; the label flash
       // was equally unwanted). On a COLD engine a real `.warmingUp` load
       // follows, so surface the honest cold-boot pill (#879), not the bare wall.
-      return adapter.readiness == .ready
+      // #959: a warm-respawn also takes the warm morph (latch set) even though
+      // readiness is briefly `.notReady` during the ~0.2s reload.
+      return (warmRespawnInFlight || adapter.readiness == .ready)
         ? .recording(audioLevel: 0)
         : .cachingModel(engineLabel: adapter.engineIdentity.displayName)
     case .recording:
@@ -679,9 +714,57 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       Task { @MainActor [weak self] in
         guard let self else { return }
         self.clearContextConfigIfTerminalOrIdle()
+        self.updateWarmRespawnLatch()
         self.fireStateChangeIfNeeded()
         self.observeKernelState()
       }
+    }
+  }
+
+  /// #959 — called by `RecordingStarter` immediately before the warm-respawn
+  /// `.toggleRecording` dispatch (after the pre-warm cancellation guards), so a
+  /// pre-toggle abort never leaves a latch set. Latches the warm overlay morph
+  /// and the start instant for the respawn-duration metric.
+  public func beginWarmRespawnOverlay() {
+    warmRespawnInFlight = true
+    warmRespawnStartedAt = ContinuousClock.now
+  }
+
+  /// #959 — called by `ASREventRouter` when the OS reaps this engine's idle ASR
+  /// service while a resident model was loaded. Sets the marker AND emits the
+  /// reclaim telemetry here (the driver already owns the `EnviousWisprServices`
+  /// import) so `ASREventRouter` keeps its minimal import set.
+  public func markResidentModelLostWhileIdle() {
+    residentModelLostWhileIdle = true
+    TelemetryService.shared.serviceReclaimed(asrBackend: adapter.engineIdentity.rawValue)
+  }
+
+  /// #959 — clear the warm-respawn latch + idle-reap marker as the kernel moves.
+  /// On the first `.recording`: the model loaded successfully — clear the marker
+  /// and, if the latch was set, emit `service_respawn_completed` (start→recording)
+  /// and drop the latch. On any terminal reached without recording (cancel /
+  /// fail / abort): drop the latch WITHOUT emitting completed.
+  private func updateWarmRespawnLatch() {
+    switch kernel.state {
+    case .recording:
+      residentModelLostWhileIdle = false
+      guard warmRespawnInFlight else { return }
+      if let started = warmRespawnStartedAt {
+        TelemetryService.shared.serviceRespawnCompleted(
+          engine: adapter.engineIdentity.rawValue,
+          durationMs: Self.elapsedMs(since: started))
+      }
+      warmRespawnInFlight = false
+      warmRespawnStartedAt = nil
+    case .idle, .completed, .cancelled, .discarded, .noSpeech, .failed,
+      .audioInterrupted, .asrInterrupted, .stopping, .transcribing, .finalizing:
+      // Reached a non-recording state — if a warm-respawn latch is still set the
+      // start aborted before capture; drop it without emitting completed.
+      guard warmRespawnInFlight else { return }
+      warmRespawnInFlight = false
+      warmRespawnStartedAt = nil
+    case .preparing, .warmingUp:
+      break  // still warming — keep the latch so the overlay stays morphed
     }
   }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -361,6 +361,42 @@ public final class TelemetryService {
       ])
   }
 
+  /// #959 — the OS reaped the idle ASR XPC service while a resident model was
+  /// loaded (readiness dropped to `.notReady` with no active session). This is
+  /// the reclaim-frequency signal (per-user/hour → OS-fight watch). The reap
+  /// cause (`xpc_interruption` / `xpc_invalidation`) is in the proxy's app.log
+  /// `readiness ready→notReady (cause=…)` line; the router that emits this only
+  /// observes "a resident model was lost while idle". Privacy: state only.
+  public func serviceReclaimed(asrBackend: String) {
+    PostHogSDK.shared.capture(
+      "coldstart.service_reclaimed",
+      properties: [
+        "asr_backend": asrBackend,
+        "was_idle": true,
+      ])
+  }
+
+  /// #959 — a press took the warm-respawn branch (idle-reaped warm model): the
+  /// press proceeds to record instead of showing the cold pill. Pairs with
+  /// `service_respawn_completed` to measure the avoided-pill rate.
+  public func serviceRespawnStarted(asrBackend: String) {
+    PostHogSDK.shared.capture(
+      "coldstart.service_respawn_started",
+      properties: ["asr_backend": asrBackend])
+  }
+
+  /// #959 — the warm-respawn press reached `.recording`. `durationMs` is
+  /// press→recording; p95/p99 is the slow-warm / memory-pressure watch.
+  public func serviceRespawnCompleted(engine: String, durationMs: Int) {
+    PostHogSDK.shared.capture(
+      "coldstart.service_respawn_completed",
+      properties: [
+        "engine": engine,
+        "duration_ms": durationMs,
+        "$value": Double(durationMs) / 1000.0,
+      ])
+  }
+
   public func asrCompleted(
     backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int
   ) {

--- a/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
 
 /// PR8 of #763 — unit tests for `ASREventRouter`.
@@ -149,6 +149,55 @@ struct ASREventRouterTests {
       await Task.yield()
 
       #expect(whisperKit.state == .polishing)
+      withExtendedLifetime(router) {}
+    }
+  #endif
+
+  // MARK: - #959 idle reap → resident-model-lost marker
+
+  @Test("idle ASR reap sets the resident-model-lost marker on the Parakeet driver")
+  func idleReapSetsResidentModelLostMarker() {
+    let audio = RouterTestAudioCapture()
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    let parakeet = DictationRuntimeFixtures.makeParakeetDriver(
+      audioCapture: audio, asrManager: asr, store: store)
+    let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audio, store: store)
+    let router = ASREventRouter(
+      asrManager: asr, kernelDriver: parakeet, whisperKitKernelDriver: whisperKit)
+
+    #expect(parakeet.residentModelLostWhileIdle == false)
+    // Both pipelines idle → `onServiceInterrupted` (fired only when a resident
+    // model was lost) is the reap-while-idle case → marker is set.
+    asr.onServiceInterrupted?()
+    #expect(parakeet.residentModelLostWhileIdle == true)
+    withExtendedLifetime(router) {}
+  }
+
+  #if DEBUG
+    @Test("active ASR interruption routes to the driver and does NOT set the idle marker")
+    func activeInterruptionDoesNotSetIdleMarker() async {
+      let audio = RouterTestAudioCapture()
+      let asr = RouterTestASRManager()
+      let store = DictationRuntimeFixtures.tempStore()
+      let parakeet = DictationRuntimeFixtures.makeParakeetDriver(
+        audioCapture: audio, asrManager: asr, store: store)
+      let whisperKit = DictationRuntimeFixtures.makeWhisperKitPipeline(
+        audioCapture: audio, store: store)
+      let router = ASREventRouter(
+        asrManager: asr, kernelDriver: parakeet, whisperKitKernelDriver: whisperKit)
+
+      let kernel = parakeet.kernelForTesting
+      #expect(kernel.testForceTransition(to: .preparing))
+      #expect(kernel.testForceTransition(to: .recording))
+      #expect(parakeet.state == .recording)
+      asr.onServiceInterrupted?()
+      await Task.yield()
+
+      // Active session → the crash routes to `handleASRServiceInterruption`,
+      // NOT the idle-reap marker branch.
+      #expect(parakeet.residentModelLostWhileIdle == false)
       withExtendedLifetime(router) {}
     }
   #endif

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -38,6 +38,7 @@ import Testing
     let lockBox: TestRecordingLockedBox
     let lastRecordingResult: LastRecordingResult
     let overlay: RecordingOverlayPanel
+    let settings: SettingsManager
   }
 
   private static func makeFixture(accessibilityRefresh: (@MainActor () -> Void)? = nil) -> Fixture {
@@ -54,7 +55,12 @@ import Testing
       audioCapture: audio, asrManager: asr, store: store)
     let whisperKitKernelDriver = DictationRuntimeFixtures.makeWhisperKitPipeline(
       audioCapture: audio, store: store)
-    let settings = SettingsManager()
+    // #959: isolate each fixture's settings in its own UserDefaults suite so a
+    // test that changes `modelUnloadPolicy` (e.g. `warmRespawnRequiresNeverPolicy`)
+    // cannot pollute `UserDefaults.standard` for sibling tests. A fresh suite has
+    // no `modelUnloadPolicy` key, so it defaults to `.never` (SettingsDefaultValues).
+    let settings = SettingsManager(
+      defaults: UserDefaults(suiteName: "ew-test-\(UUID().uuidString)")!)
     let overlay = RecordingOverlayPanel()
     let permissions = PermissionsService()
     let lockBox = TestRecordingLockedBox()
@@ -101,7 +107,8 @@ import Testing
       permissions: permissions,
       lockBox: lockBox,
       lastRecordingResult: lastRecordingResult,
-      overlay: overlay
+      overlay: overlay,
+      settings: settings
     )
   }
 
@@ -235,6 +242,94 @@ import Testing
   // `lastUserStopAccessIsThreadedFromFinalizer` test pins the wiring of
   // the closure; the guard itself mirrors the post-toggle check at
   // lines 162-165 (covered by behavioral observation in Live UAT).
+
+  // MARK: - #959 warm-respawn (idle XPC reclaim) press routing
+
+  /// A press on a not-ready engine whose model was reaped while idle
+  /// (`residentModelLostWhileIdle`) under the default `.never` policy must NOT
+  /// show the cold pill — it consumes the marker and falls through to the normal
+  /// start (which shows the recording overlay), so the user's press records.
+  @Test func warmRespawnStartConsumesMarkerAndSkipsColdPill() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false  // → readiness .notReady
+    fx.kernelDriver.residentModelLostWhileIdle = true
+    fx.settings.modelUnloadPolicy = .never  // explicit: user keeps the model resident
+
+    await fx.starter.start()
+
+    // Marker consumed (single press) and NO cold pill — the PTT fall-through
+    // shows the recording overlay instead.
+    #expect(fx.kernelDriver.residentModelLostWhileIdle == false)
+    #expect(fx.overlay.currentIntent != .cachingModel(engineLabel: "Parakeet v3"))
+    guard case .recording = fx.overlay.currentIntent else {
+      Issue.record("warm-respawn must show the recording overlay; got \(fx.overlay.currentIntent)")
+      return
+    }
+  }
+
+  @Test func warmRespawnToggleConsumesMarkerAndSkipsColdPill() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false
+    fx.kernelDriver.residentModelLostWhileIdle = true
+    fx.settings.modelUnloadPolicy = .never
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.residentModelLostWhileIdle == false)
+    #expect(fx.overlay.currentIntent != .cachingModel(engineLabel: "Parakeet v3"))
+  }
+
+  /// The marker only short-circuits the pill when the user keeps the model
+  /// resident (`.never`). Under a timed unload policy the user WANTS the model
+  /// gone, so a not-ready press is a genuine cold start: show the pill, keep the
+  /// marker (the cold branch does not consume it), mint no session.
+  @Test func warmRespawnRequiresNeverPolicy() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false
+    fx.kernelDriver.residentModelLostWhileIdle = true
+    fx.settings.modelUnloadPolicy = .fiveMinutes
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.overlay.currentIntent == .cachingModel(engineLabel: "Parakeet v3"))
+    #expect(fx.kernelDriver.residentModelLostWhileIdle == true)  // not consumed on cold branch
+  }
+
+  /// Adversarial (`matcher-set-adversarial-tests`): the marker in its
+  /// NON-intended class. A genuine cold boot (marker false) must STILL block —
+  /// the warm-respawn path must never fire for a never-loaded engine.
+  @Test func genuineColdWithMarkerUnsetStillBlocks() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = false
+    #expect(fx.kernelDriver.residentModelLostWhileIdle == false)  // never reaped
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.overlay.currentIntent == .cachingModel(engineLabel: "Parakeet v3"))
+  }
+
+  /// Driver-level: the overlay latch is set by `beginWarmRespawnOverlay()`, and a
+  /// successful load (`ensureEngineWarm` reaching `.ready`) drops a stale marker
+  /// so a later genuine cold boot still shows the pill.
+  @Test func driverLatchSetAndMarkerClearedOnWarm() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+
+    #expect(fx.kernelDriver.warmRespawnInFlight == false)
+    fx.kernelDriver.beginWarmRespawnOverlay()
+    #expect(fx.kernelDriver.warmRespawnInFlight == true)
+
+    fx.kernelDriver.residentModelLostWhileIdle = true
+    fx.asr.isModelLoaded = true  // ensureEngineWarm sees readiness .ready
+    _ = await fx.kernelDriver.ensureEngineWarm(reason: .coldPress)
+    #expect(fx.kernelDriver.residentModelLostWhileIdle == false)
+  }
 }
 
 /// Counts accessibility-refresh invocations for #904. A `@MainActor` reference

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -58,10 +58,18 @@ import Testing
     // had zero assertions). The closure does NOT count as a collaborator
     // (collaboratorCount still ≤ 7) and is not a non-private method; only the
     // paper-line ceiling moves. Production behavior is identical by default.
+    // #959 (idle XPC reclaim): raised 292 → 305 for the warm-respawn branch on
+    // both start paths (a not-ready press routes to `ColdPressGuard
+    // .resolveNotReadyPress` — warm-respawn falls through to record, genuine cold
+    // still pills) + the `warmRespawnInFlight` overlay-latch set just before each
+    // kernel dispatch. The decision + telemetry live OFF this type in
+    // `ColdPressGuard`; the latch lives on `KernelDictationDriver` — so
+    // collaboratorCount stays ≤ 7 and nonPrivateMethodCount stays ≤ 2 (no new
+    // slot or method); only the paper-line ceiling moves.
     #expect(
-      count <= 292,
+      count <= 305,
       """
-      RecordingStarter line count exceeded: \(count) > 292. \
+      RecordingStarter line count exceeded: \(count) > 305. \
       Raise via Bible §30 only.
       """)
   }


### PR DESCRIPTION
Closes #959.

## Problem
macOS reaps the idle Parakeet ASR XPC service **even with `modelUnloadPolicy = .never`**. The connection's interruption/invalidation handler clears `isModelLoaded`, so the next press read `.notReady` and routed to the #879 `ColdPressGuard` — showing the "warming up / ready to record" pill on a still-warm engine (re-warm ~0.2 s vs ~6 s true cold) and swallowing the press. The #961 fix closed the tap/no-speech path; this is a distinct, idle-driven mechanism. Reporter on v2.1.2 kept firing `coldstart.press_blocked` after 12–70 min idle gaps (PostHog), root cause independently confirmed by a Codex xhigh pass.

## Fix
- **`ASRManagerProxy`** — connection-loss handlers tag the readiness-drop cause (`xpc_interruption` / `xpc_invalidation`) and bump `loadGeneration` on `wasLoaded || wasStreaming || inFlightLoadTask != nil` (covers a connection lost mid-load), **before** clearing `isModelLoaded`; `onServiceInterrupted` fires before the fire-and-forget log; `handleASRXPCOperationWedge` clears `isModelLoaded`.
- **`ASREventRouter`** — an idle reap of a resident model sets `KernelDictationDriver.residentModelLostWhileIdle` and emits `coldstart.service_reclaimed` (via a driver method, so the router keeps its minimal import set / collaborator ceiling).
- **`RecordingStarter`** — a not-ready press routes through `ColdPressGuard.resolveNotReadyPress`: a warm-respawn (marker + `.never`) **falls through to the normal start** (the kernel re-warms under its existing load watchdog, then captures — correct audio order, existing cancellation guards apply); genuine cold keeps the pill and mints no session. The `warmRespawnInFlight` overlay latch is set **only just before the kernel dispatch**, so a pre-toggle abort can't leak it.
- **`KernelDictationDriver`** — the marker + latch; `overlayIntent` morphs `.preparing`/`.warmingUp` to `.recording` while latched (no cold pill for the sub-second reload); latch cleared + duration emitted at `.recording`, cleared without emit at any terminal; marker cleared on any successful load (`observeKernelState` `.recording` + `ensureEngineWarm` success).
- **Telemetry** — `coldstart.service_reclaimed` / `service_respawn_started` / `service_respawn_completed` (reclaim frequency, avoided-pill rate, respawn latency for the slow-warm / OS-fight watch).

Deferred (per council + grounded review): proactive eager re-warm on reap (risks fighting OS memory pressure; reactive press-time fix resolves the symptom). The in-process `ASRManager` has no XPC connection-loss path, so no mirror was needed.

## Review
- Plan: `docs/feature-requests/issue-959-...` (local). Council coverage (GPT + Gemini) → grounded review (Codex, 5 rounds → PROCEED-AS-PLANNED).
- Code-diff: Codex PASS, no P0–P3 (`docs/audits/2026-06-05-issue959-codex-code-diff-review.txt`).

## Validation
- **Logic tests**: `scripts/xcode-test.sh` green (8 new: warm-respawn routing both paths, policy gate, adversarial genuine-cold-still-blocks, router marker set/not-set, driver latch/clear).
- **Smoke**: `build-dev-app.sh` exit 0, launched no crash.
- **Live UAT** (DEBUG build, `EW_FAULT_INJECTION=1`, `force_xpc_kill` idle reap): **proven via PostHog (dev)** — `coldstart.service_reclaimed` (14:22:00.2) → `coldstart.service_respawn_started` parakeet (14:22:05.9) → `coldstart.service_respawn_completed` (14:22:06.2, ~0.3 s press→recording). Transcript captured the **first word** ("Actually") + "meeting"; zero `coldstart.press_blocked` / no cold pill. Run dir: `.validation/runs/20260605-141927-9ce6f6d/`.
- **Skip-note**: genuine-cold live cache-wipe substituted by unit coverage (unchanged `ColdPressGuard` cold body; latch set only on the warm-respawn branch).

### Architecture Closeout
- Module/owner chosen: marker + latch on `KernelDictationDriver` (engine-runtime state); decision in `ColdPressGuard`; writer `ASREventRouter`; reader `RecordingStarter`.
- Why correct: per `state-ownership.md` rows 3 + 10; invariant is per-driver runtime readiness, not app-shell state. No new type.
- Central type grew? No new collaborator/method on `RecordingStarter` (line ceiling 292→305 with Bible note; collaborator ≤7, methods ≤2 unchanged). `ASREventRouter` ceilings unchanged.
- Access widened? Driver gained `public` marker/latch + two methods for cross-module (router/starter) access; narrow.
- Temporary compromise? None.
- Dependency direction clean? Yes (no new import edges; `ASREventRouter` Services import avoided).