### PR TITLE
feat(pipeline): tail-trim diagnostic telemetry (#950)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -32,6 +32,15 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var itnLatencyMs: Double?
   public var itnLenBefore: Int?
   public var itnLenAfter: Int?
+  /// #950 tail-trim diagnostic. Populated only for eligible Parakeet batch
+  /// successes; nil for streaming, WhisperKit, non-success, and pre-#950
+  /// transcripts on disk (additive optional Codable, back-compatible).
+  /// `tailDroppedMs` = trailing audio (ms) the VAD trim discarded after the last
+  /// detected word (0 = ran, nothing dropped). `tailHadEnergy` = that discarded
+  /// tail was above the dead-air floor (non-dead-air energy, NOT confirmed voice);
+  /// nil when `tailDroppedMs == 0` (no tail slice). Metadata only.
+  public var tailDroppedMs: Int?
+  public var tailHadEnergy: Bool?
 
   public init(
     asrLatencySeconds: Double? = nil,
@@ -54,7 +63,9 @@ public struct ExecutionMetrics: Codable, Sendable {
     itnSkipReason: String? = nil,
     itnLatencyMs: Double? = nil,
     itnLenBefore: Int? = nil,
-    itnLenAfter: Int? = nil
+    itnLenAfter: Int? = nil,
+    tailDroppedMs: Int? = nil,
+    tailHadEnergy: Bool? = nil
   ) {
     self.asrLatencySeconds = asrLatencySeconds
     self.llmLatencySeconds = llmLatencySeconds
@@ -77,6 +88,8 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.itnLatencyMs = itnLatencyMs
     self.itnLenBefore = itnLenBefore
     self.itnLenAfter = itnLenAfter
+    self.tailDroppedMs = tailDroppedMs
+    self.tailHadEnergy = tailHadEnergy
   }
 }
 

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -65,9 +65,24 @@ public struct ASREngineCapabilities: Sendable {
   /// AppLogger lines. The lifecycle sink only owns kernel-level events.
   public let supportsLanguageDetection: Bool
 
-  public init(supportsStreaming: Bool, supportsLanguageDetection: Bool) {
+  /// The engine's ASR decodes the kernel-conditioned (VAD-trimmed) batch buffer
+  /// passed to `finalize(batchSamples:)` (Parakeet). `false` for engines that
+  /// ignore `batchSamples` and decode the raw capture instead (WhisperKit, which
+  /// derives `clipTimestamps` from VAD segments over the raw audio). Gates the
+  /// #950 tail-trim diagnostic: "audio dropped before ASR by the VAD trim" is
+  /// only meaningful when the engine actually consumes the trimmed buffer.
+  /// Defaulted `true` so existing constructions stay source-compatible; the only
+  /// `false` is WhisperKit.
+  public let decodesConditionedBatchSamples: Bool
+
+  public init(
+    supportsStreaming: Bool,
+    supportsLanguageDetection: Bool,
+    decodesConditionedBatchSamples: Bool = true
+  ) {
     self.supportsStreaming = supportsStreaming
     self.supportsLanguageDetection = supportsLanguageDetection
+    self.decodesConditionedBatchSamples = decodesConditionedBatchSamples
   }
 }
 

--- a/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
+++ b/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
@@ -51,6 +51,14 @@ public struct ConditionedAudio: Equatable, Sendable {
   /// pipeline's short-utterance padding.
   public let samplesPaddedToMinimum: Bool
 
+  /// #950 — count of trailing raw samples the VAD trim discarded after the last
+  /// valid voiced segment's padded end. `0` when the filter no-op'd
+  /// (empty / sub-4800-voiced / malformed segments) OR a raw-keeping path fired
+  /// (`usedRawFallbackAfterVAD` / `usedRawSoftOnsetPreservation`, which feed the
+  /// FULL raw buffer to ASR). Metadata only; diagnostic counterpart to
+  /// `filteredSampleCount`. Computed by `droppedTrailingSamples`.
+  public let droppedTailSampleCount: Int
+
   /// Final sample count of `samples` — redundant with `samples.count` but
   /// kept explicit so the telemetry surface does not depend on whether the
   /// caller bothered to recompute.
@@ -134,12 +142,49 @@ public enum CapturedAudioConditioner {
       padded = true
     }
 
+    // #950 tail-trim diagnostic. 0 on the raw-keeping paths (we fed the FULL raw
+    // buffer to ASR, so nothing was dropped); else what the VAD trim discarded
+    // after the last valid voiced segment's padded end.
+    let droppedTail =
+      (usedRawFallback || usedRawSoftOnset)
+      ? 0
+      : droppedTrailingSamples(rawSampleCount: rawSamples.count, vadSegments: vadSegments)
+
     return ConditionedAudio(
       samples: working,
       filteredSampleCount: filteredCount,
       usedRawFallbackAfterVAD: usedRawFallback,
       usedRawSoftOnsetPreservation: usedRawSoftOnset,
-      samplesPaddedToMinimum: padded)
+      samplesPaddedToMinimum: padded,
+      droppedTailSampleCount: droppedTail)
+  }
+
+  /// #950 — trailing raw samples discarded by the VAD trim after the last valid
+  /// voiced segment's padded end. Mirrors `SampleFilter.filter`'s no-op rules so
+  /// it never reports a phantom drop the filter did not actually make: skips
+  /// malformed segments (`endSample <= startSample`), returns `0` when total
+  /// valid voiced audio is `< 4800` (the filter returns raw there). All counts
+  /// are 16kHz mono scalar samples; `padding` matches `SampleFilter`'s default.
+  /// Overflow-hardened to parity with `SampleFilter` (#387) — pure, total.
+  static func droppedTrailingSamples(
+    rawSampleCount: Int, vadSegments: [SpeechSegment], padding: Int = 1600
+  ) -> Int {
+    guard !vadSegments.isEmpty else { return 0 }
+    var voiced = 0  // saturates at 4800 (only the >=4800 gate cares)
+    var lastEnd = 0  // true max valid endSample, independent of voiced saturation
+    for segment in vadSegments where segment.endSample > segment.startSample {
+      lastEnd = max(lastEnd, segment.endSample)
+      if voiced < 4800 {
+        let (len, lenOverflow) =
+          segment.endSample.subtractingReportingOverflow(segment.startSample)
+        let (sum, sumOverflow) = voiced.addingReportingOverflow(lenOverflow ? 4800 : len)
+        voiced = (lenOverflow || sumOverflow) ? 4800 : sum
+      }
+    }
+    guard voiced >= 4800 else { return 0 }
+    let (paddedEnd, endOverflow) = lastEnd.addingReportingOverflow(max(0, padding))
+    let keptThrough = endOverflow ? rawSampleCount : min(rawSampleCount, paddedEnd)
+    return max(0, rawSampleCount - keptThrough)
   }
 
   // MARK: #843 soft-onset preservation

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -330,7 +330,10 @@ public enum KernelDictationDriverFactory {
       textProcessingRunner: textProcessingRunner,
       save: { transcript in try transcriptStore.save(transcript) },
       deliverPaste: { request in await PasteCascadeExecutor().deliver(request) },
-      pasteCompletionRegistry: pasteCompletionRegistry
+      pasteCompletionRegistry: pasteCompletionRegistry,
+      // #950 — share the SAME telemetry state the kernel stamps so the metrics
+      // builder reads the tail-trim diagnostic for `asr.completed`.
+      telemetryState: telemetryState
     )
 
     // 7. Kernel.

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -128,7 +128,13 @@ struct KernelFinalizationWiring {
     // a manual clock to advance logical time by hand and assert the tick rate,
     // instead of sleeping (which `tests-no-real-time-scheduling-precision` bans).
     // Trailing-defaulted so the other construction sites stay source-compatible.
-    currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+    // #950 — the SAME shared `KernelTelemetryState` the kernel stamps and the
+    // lifecycle sink reads; the metrics builder reads the kernel-computed
+    // tail-trim diagnostic from it for the PostHog `asr.completed` event.
+    // Defaulted (fresh, tail fields nil) so other construction sites stay
+    // source-compatible; the factory passes the shared instance.
+    telemetryState: KernelTelemetryState = KernelTelemetryState()
   ) {
     // processText — run the limb chain, write the polish side-channel, return
     // the final display text. `onPolishStarted` is wired into
@@ -243,7 +249,8 @@ struct KernelFinalizationWiring {
       outcome.pipelineEndedAtSeconds = pipelineEnd
       outcome.pasteResult = pasteResult
       outcome.pasteDurationSeconds = pipelineEnd - pasteStart
-      Self.updateTranscriptMetrics(outcome: outcome, context: context)
+      Self.updateTranscriptMetrics(
+        outcome: outcome, context: context, telemetryState: telemetryState)
       Self.logPipelineTimingTotal(outcome: outcome)
       // PR-5 Rung 4.5 (#827): LID perf signpost `t_clipboard_write` —
       // gated on engine LID capability (NOT paste outcome). OLD pipeline
@@ -289,7 +296,8 @@ struct KernelFinalizationWiring {
 
   private static func updateTranscriptMetrics(
     outcome: KernelFinalizationOutcome,
-    context: KernelSessionContext
+    context: KernelSessionContext,
+    telemetryState: KernelTelemetryState
   ) {
     guard var transcript = outcome.transcript else { return }
     let asrLatency =
@@ -326,7 +334,12 @@ struct KernelFinalizationWiring {
       itnSkipReason: outcome.itnSkipReason,
       itnLatencyMs: outcome.itnLatencyMs,
       itnLenBefore: outcome.itnLenBefore,
-      itnLenAfter: outcome.itnLenAfter
+      itnLenAfter: outcome.itnLenAfter,
+      // #950 tail-trim diagnostic — kernel-computed, read from the shared
+      // telemetry state (eligible Parakeet batch only; nil for streaming /
+      // WhisperKit / non-success). Carried onto `asr.completed`.
+      tailDroppedMs: telemetryState.asrCompletedTelemetry?.droppedTailMs,
+      tailHadEnergy: telemetryState.asrCompletedTelemetry?.tailHadEnergy
     )
     outcome.transcript = transcript
   }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -393,6 +393,15 @@ final class KernelLifecycleTelemetrySink {
     if let incremental = telemetryState.asrCompletedTelemetry?.incrementalAccepted {
       payload["incremental"] = incremental
     }
+    // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
+    // `tail_dropped_ms` always present when set (incl. 0); `tail_had_energy` only
+    // when a tail was dropped. Metadata only — no audio/content.
+    if let droppedMs = telemetryState.asrCompletedTelemetry?.droppedTailMs {
+      payload["tail_dropped_ms"] = droppedMs
+    }
+    if let hadEnergy = telemetryState.asrCompletedTelemetry?.tailHadEnergy {
+      payload["tail_had_energy"] = hadEnergy
+    }
     return payload
   }
 

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -58,6 +58,12 @@ struct KernelASRCompletedTelemetry {
   // OLD `WhisperKitPipeline.swift:1049-1052` ASR-completed breadcrumb carried.
   // nil for Parakeet (no incremental concept) → sink omits the key.
   var incrementalAccepted: Bool? = nil
+  // #950 tail-trim diagnostic, eligible Parakeet batch only. `droppedTailMs`
+  // always set (incl. 0) on the eligible success path so the Sentry breadcrumb
+  // carries a denominator; `tailHadEnergy` only when droppedTailMs > 0 (no tail
+  // slice otherwise). nil → sink omits the key.
+  var droppedTailMs: Int? = nil
+  var tailHadEnergy: Bool? = nil
 }
 
 struct KernelASRAdapterDiagnostics {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1122,6 +1122,29 @@ final class RecordingSessionKernel {
     let conditioned = CapturedAudioConditioner.condition(
       rawSamples: captureResult.samples, vadSegments: vadSegments)
     let vadSpeechDurationMs = Self.speechDurationMs(vadSegments)
+
+    // #950 tail-trim diagnostic. Eligible = the engine decodes the conditioned
+    // (VAD-trimmed) batch buffer (Parakeet, via capability) AND this is a batch
+    // session; only then does "trailing audio the VAD trim dropped before ASR"
+    // mean anything (WhisperKit decodes the raw capture, so the trim does not
+    // touch its ASR input). Metadata only; never gates the heart path.
+    let tailEligible =
+      adapter.capabilities.decodesConditionedBatchSamples && !isStreamingSession
+    let droppedTailSamples = tailEligible ? conditioned.droppedTailSampleCount : 0
+    // Always set (incl. 0) for eligible batch so the analytics denominator holds;
+    // nil (omitted) for streaming / non-conditioned-batch engines.
+    let tailDroppedMs: Int? = tailEligible ? droppedTailSamples / 16 : nil
+    var tailHadEnergy: Bool? = nil
+    var tailPeak: Float = 0
+    if droppedTailSamples > 0 {
+      // Intentional copy: `rawAudioIsDeadAir` takes `[Float]`, and `Array(...)`
+      // also rebases the slice to the 0-based indexing its window scan assumes.
+      // Bounded by `droppedTailSamples`, materialized ONCE on the cold stop path
+      // (not the RT audio thread); sync, cannot throw.
+      let tailSlice = Array(captureResult.samples.suffix(droppedTailSamples))
+      tailPeak = tailSlice.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
+      tailHadEnergy = !Self.rawAudioIsDeadAir(tailSlice, peak: tailPeak)
+    }
     // GAP 3 app.log parity: VAD filter ratio log (TP:772-776).
     let rawCount = captureResult.samples.count
     let filteredCount = conditioned.filteredSampleCount
@@ -1175,7 +1198,14 @@ final class RecordingSessionKernel {
       "conditioner raw=\(captureResult.samples.count) filtered=\(conditioned.filteredSampleCount) "
         + "rawFallback=\(conditioned.usedRawFallbackAfterVAD) softOnset=\(conditioned.usedRawSoftOnsetPreservation) "
         + "padded=\(conditioned.samplesPaddedToMinimum) reason=\(conditioned.conditioningReason) "
-        + "final=\(conditioned.finalSampleCount)")
+        + "final=\(conditioned.finalSampleCount) "
+        // #950 tail-trim diagnostic — sid for dogfood correlation, capturedMs to
+        // surface flush-loss (short capture + droppedTailMs=0), and the tail peak
+        // float (debug-log only, never analytics — privacy boundary).
+        + "sid=\(sid.raw) capturedMs=\(captureResult.samples.count / 16) "
+        + "droppedTailMs=\(tailDroppedMs.map(String.init) ?? "n/a") "
+        + "tailEnergy=\(tailHadEnergy.map(String.init) ?? "n/a") "
+        + "tailPeak=\(String(format: "%.4f", tailPeak))")
 
     // Transcribing.
     let asrStart = CFAbsoluteTimeGetCurrent()
@@ -1204,7 +1234,10 @@ final class RecordingSessionKernel {
         // the ASR-completed Sentry breadcrumb (parity with OLD
         // `WhisperKitPipeline.swift:1049-1052`). nil for Parakeet.
         incrementalAccepted: (adapter as? ASREngineTelemetryProviding)?
-          .lastASRDiagnostics?.incrementalAccepted
+          .lastASRDiagnostics?.incrementalAccepted,
+        // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
+        droppedTailMs: tailDroppedMs,
+        tailHadEnergy: tailHadEnergy
       )
       await runFinalizing(sid, asrText: result.text)
     case .empty(let hadSpeechEvidence):

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -204,7 +204,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// LID. Static — the kernel branches on `capabilities`, never on engine
   /// identity (epic §3.4).
   var capabilities: ASREngineCapabilities {
-    ASREngineCapabilities(supportsStreaming: false, supportsLanguageDetection: true)
+    // decodesConditionedBatchSamples: false — WhisperKit ignores `batchSamples`
+    // and decodes the raw capture via clipTimestamps (#950 tail-trim diagnostic
+    // is meaningless for it; the VAD trim does not drop its ASR input).
+    ASREngineCapabilities(
+      supportsStreaming: false, supportsLanguageDetection: true,
+      decodesConditionedBatchSamples: false)
   }
 
   var readiness: ASREngineReadiness { cachedReadiness }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -95,7 +95,8 @@ public final class TelemetryService {
     if let asrLat = m?.asrLatencySeconds {
       asrCompleted(
         backend: t.backendType.rawValue, result: "success", coldStart: m?.coldStart ?? false,
-        latencySeconds: asrLat, charCount: t.text.count)
+        latencySeconds: asrLat, charCount: t.text.count,
+        tailDroppedMs: m?.tailDroppedMs, tailHadEnergy: m?.tailHadEnergy)
     }
     if let llmLat = m?.llmLatencySeconds, llmLat > 0, t.llmProvider != nil {
       llmPolishCompleted(
@@ -398,18 +399,24 @@ public final class TelemetryService {
   }
 
   public func asrCompleted(
-    backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int
+    backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int,
+    // #950 tail-trim diagnostic — eligible Parakeet batch only; nil omitted.
+    // Metadata only (Int ms + Bool); no audio/content. `tailDroppedMs` always set
+    // (incl. 0) when eligible so the denominator holds; `tailHadEnergy` only when
+    // a tail was actually dropped.
+    tailDroppedMs: Int? = nil, tailHadEnergy: Bool? = nil
   ) {
-    PostHogSDK.shared.capture(
-      "asr.completed",
-      properties: [
-        "backend": backend,
-        "result": result,
-        "cold_start": coldStart,
-        "latency_seconds": String(format: "%.3f", latencySeconds),
-        "char_count": charCount,
-        "$value": latencySeconds,
-      ])
+    var properties: [String: Any] = [
+      "backend": backend,
+      "result": result,
+      "cold_start": coldStart,
+      "latency_seconds": String(format: "%.3f", latencySeconds),
+      "char_count": charCount,
+      "$value": latencySeconds,
+    ]
+    if let tailDroppedMs { properties["tail_dropped_ms"] = tailDroppedMs }
+    if let tailHadEnergy { properties["tail_had_energy"] = tailHadEnergy }
+    PostHogSDK.shared.capture("asr.completed", properties: properties)
   }
 
   public func llmPolishCompleted(

--- a/Tests/EnviousWisprTests/Pipeline/CapturedAudioConditionerTailTrimTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CapturedAudioConditionerTailTrimTests.swift
@@ -1,0 +1,109 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - CapturedAudioConditionerTailTrimTests (#950)
+//
+// Boundary coverage for the tail-trim diagnostic `droppedTrailingSamples` and the
+// `ConditionedAudio.droppedTailSampleCount` field. The helper must MIRROR
+// `SampleFilter.filter`'s no-op rules exactly (skip malformed segments; return 0
+// when total valid voiced < 4800), else it would report a phantom drop the filter
+// never made. All counts are 16 kHz mono scalar samples (1600 = 100 ms padding).
+
+@Suite("CapturedAudioConditioner tail-trim diagnostic (#950)")
+struct CapturedAudioConditionerTailTrimTests {
+
+  private func seg(_ start: Int, _ end: Int) -> SpeechSegment {
+    SpeechSegment(startSample: start, endSample: end)
+  }
+
+  private func dropped(_ raw: Int, _ segs: [SpeechSegment]) -> Int {
+    CapturedAudioConditioner.droppedTrailingSamples(rawSampleCount: raw, vadSegments: segs)
+  }
+
+  // MARK: no-op mirrors (helper returns 0 where SampleFilter returns raw)
+
+  @Test("no segments → 0")
+  func noSegments() {
+    #expect(dropped(100_000, []) == 0)
+  }
+
+  @Test("malformed-only segments (end <= start) → 0 (skipped, sub-4800)")
+  func malformedOnly() {
+    #expect(dropped(100_000, [seg(5_000, 5_000), seg(9_000, 4_000)]) == 0)
+  }
+
+  @Test("valid voiced just below 4800 → 0 (SampleFilter no-op gate)")
+  func subThresholdVoiced() {
+    // 4799 voiced < 4800 → filter returns raw → no drop.
+    #expect(dropped(100_000, [seg(0, 4_799)]) == 0)
+  }
+
+  @Test("valid voiced exactly 4800 → drops (boundary inclusive)")
+  func thresholdVoicedInclusive() {
+    // voiced 4800 ≥ 4800; lastEnd 4800, padded 6400, dropped 100_000-6400.
+    #expect(dropped(100_000, [seg(0, 4_800)]) == 93_600)
+  }
+
+  // MARK: tail math
+
+  @Test("mid-buffer last segment, gap > padding → dropped = raw-(end+1600)")
+  func midBufferDrop() {
+    #expect(dropped(100_000, [seg(1_000, 50_000)]) == 48_400)
+  }
+
+  @Test("last segment ends at rawCount → 0 (padding clamps to rawCount)")
+  func endsAtRaw() {
+    #expect(dropped(50_000, [seg(1_000, 50_000)]) == 0)
+  }
+
+  @Test("padded end exceeds rawCount → 0 (clamp)")
+  func paddedEndPastRaw() {
+    // lastEnd 50_000, padded 51_600 > raw 51_000 → keptThrough clamps to raw.
+    #expect(dropped(51_000, [seg(1_000, 50_000)]) == 0)
+  }
+
+  @Test("unsorted segments → uses max valid endSample, not last element")
+  func unsortedUsesMaxEnd() {
+    // Out-of-order; max end is 70_000 → dropped = 100_000-(70_000+1600).
+    #expect(dropped(100_000, [seg(60_000, 70_000), seg(1_000, 50_000)]) == 28_400)
+  }
+
+  // MARK: condition() integration — the raw-keeping paths report 0
+
+  @Test("soft-onset path → droppedTailSampleCount 0 (full raw kept)")
+  func softOnsetReportsZero() {
+    // raw 40_000 (≤8s), seg starts at 5_000 (<2s), filter drops ≥25% → soft-onset
+    // fires, working = full raw → nothing dropped.
+    let raw = [Float](repeating: 0.1, count: 40_000)
+    let out = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(5_000, 25_000)])
+    #expect(out.usedRawSoftOnsetPreservation)
+    #expect(out.droppedTailSampleCount == 0)
+  }
+
+  @Test("too-aggressive raw fallback → droppedTailSampleCount 0 (full raw kept)")
+  func rawFallbackReportsZero() {
+    // raw 130_000 (>8s so soft-onset's maxRaw gate fails), tiny voiced segment so
+    // filtered < 16_000 → raw fallback fires, working = full raw → nothing dropped.
+    let raw = [Float](repeating: 0.1, count: 130_000)
+    let out = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(1_000, 6_000)])
+    #expect(out.usedRawFallbackAfterVAD)
+    #expect(out.droppedTailSampleCount == 0)
+  }
+
+  @Test("normal long-dictation trim → droppedTailSampleCount is the trailing gap")
+  func normalTrimReportsDrop() {
+    // raw 200_000 (>8s, no soft-onset), filtered ≥ minimum (no fallback): the
+    // genuine trailing-trim case the #950 diagnostic exists to catch.
+    let raw = [Float](repeating: 0.1, count: 200_000)
+    let out = CapturedAudioConditioner.condition(
+      rawSamples: raw, vadSegments: [seg(1_000, 150_000)])
+    #expect(!out.usedRawSoftOnsetPreservation)
+    #expect(!out.usedRawFallbackAfterVAD)
+    #expect(out.droppedTailSampleCount == 48_400)  // 200_000 - (150_000 + 1600)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -242,6 +242,61 @@ import Testing
       ])
   }
 
+  @Test(".asrCompleted carries both tail keys when a tail was dropped (#950)")
+  func asrCompletedCarriesTailKeysWhenDropped() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: 0.3, charCount: 5, mode: "batch", language: "en",
+      droppedTailMs: 250, tailHadEnergy: true)
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+    sink.emit(.asrCompleted)
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "asr", message: "ASR completed",
+          dataKeys: [
+            "backend", "char_count", "duration_s", "language", "mode",
+            "tail_dropped_ms", "tail_had_energy",
+          ])
+      ])
+  }
+
+  @Test(".asrCompleted carries tail_dropped_ms=0 but omits tail_had_energy when no tail (#950)")
+  func asrCompletedCarriesZeroDropOmitsEnergy() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: 0.3, charCount: 5, mode: "batch", language: "en",
+      droppedTailMs: 0, tailHadEnergy: nil)
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+    sink.emit(.asrCompleted)
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "asr", message: "ASR completed",
+          dataKeys: [
+            "backend", "char_count", "duration_s", "language", "mode", "tail_dropped_ms",
+          ])
+      ])
+  }
+
+  @Test(".asrCompleted omits both tail keys when nil (streaming / WhisperKit, #950)")
+  func asrCompletedOmitsTailKeysWhenNil() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: 0.3, charCount: 5, mode: "streaming", language: "en")
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+    sink.emit(.asrCompleted)
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "asr", message: "ASR completed",
+          dataKeys: ["backend", "char_count", "duration_s", "language", "mode"])
+      ])
+  }
+
   @Test(".pipelineCompleted emits the TP:1032 breadcrumb")
   func pipelineCompletedEmission() {
     let recorder = Recorder()

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -32,11 +32,14 @@ import Testing
 
   // MARK: Capabilities + readiness
 
-  @Test("capabilities: Parakeet streams, detects no language")
+  @Test("capabilities: Parakeet streams, detects no language, decodes conditioned batch")
   func capabilities() {
     let adapter = ParakeetEngineAdapter(asrManager: StubParakeetASRManager())
     #expect(adapter.capabilities.supportsStreaming)
     #expect(!adapter.capabilities.supportsLanguageDetection)
+    // #950 — Parakeet decodes the kernel-conditioned (VAD-trimmed) batch buffer,
+    // so the tail-trim diagnostic applies to it.
+    #expect(adapter.capabilities.decodesConditionedBatchSamples)
   }
 
   @Test("readiness reflects the ASR manager's load state")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -35,11 +35,14 @@ import Testing
 
   // MARK: Capabilities + readiness
 
-  @Test("capabilities: WhisperKit decodes batch-only and detects language")
+  @Test("capabilities: WhisperKit decodes batch-only, detects language, ignores conditioned batch")
   func capabilities() {
     let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
     #expect(adapter.capabilities.supportsStreaming == false)
     #expect(adapter.capabilities.supportsLanguageDetection == true)
+    // #950 — WhisperKit ignores `batchSamples` and decodes the raw capture, so
+    // the VAD trim does not touch its ASR input; tail-trim diagnostic excluded.
+    #expect(adapter.capabilities.decodesConditionedBatchSamples == false)
   }
 
   @Test("readiness transitions: init → notReady; warmUp → ready; cancel keeps notReady")


### PR DESCRIPTION
## What

Adds a metadata-only diagnostic that, on every eligible Parakeet-batch dictation, records **how much trailing audio our VAD trim discarded after the last detected word** (`tail_dropped_ms`) and **whether that discarded tail carried non-dead-air energy** (`tail_had_energy`). Emitted to the debug `app.log` (with session id, captured duration, and tail peak for correlation/tuning), the Sentry breadcrumb, and the PostHog `asr.completed` event. **No behavior change** — the audio handed to ASR is byte-identical.

`Updates #950` (this is the diagnostic, not the fix — telemetry-first per founder direction; the issue stays open for the dogfooding verdict).

## Why

Long Parakeet-batch dictations intermittently lose their final sentence (#950). This session **ruled out the transcription engine**: FluidAudio batch decode kept the full tail on synthetic clips to 103s (incl. stutter variants), so the loss is upstream in our own VAD trim, which keeps audio only through the last voiced segment's padded end. But a tail-truncated recording is a **successful, non-empty** transcript, so it bypasses every existing VAD diagnostic — we had no way to tell "trimmed silence" (correct) from "trimmed your voice" (the bug). This signal is that instrument, and the prerequisite for conclusive dogfooding.

## Scope / placement

- `droppedTrailingSamples` (pure, mirrors `SampleFilter`'s no-op rules + overflow hardening) + `ConditionedAudio.droppedTailSampleCount` — `CapturedAudioConditioner`.
- Energy classification (reuses #964 `rawAudioIsDeadAir`) + eligibility gate + stamp + app.log line — `RecordingSessionKernel`.
- Gated to engines that decode the conditioned batch buffer via a new `decodesConditionedBatchSamples` capability (Parakeet `true`; **WhisperKit `false`** — it decodes the raw capture, so the trim never touches its ASR input).
- PostHog threading mirrors the #145 ITN precedent (`ExecutionMetrics` → `TelemetryService.asrCompleted`), reading the kernel-stamped value from the shared `KernelTelemetryState`.

Nil/zero semantics: eligible batch always emits `tail_dropped_ms` (incl. 0) for a denominator; `tail_had_energy` only when a tail was dropped; both omitted for streaming / WhisperKit / non-success. Privacy boundary holds — only Int ms + Bool reach the sinks; the float tail peak stays in the debug log only.

## Validation

- **Plan** (`docs/feature-requests/issue-950-2026-06-05-tail-trim-telemetry.md`): council (GPT-5.5 + Gemini-3.1) + Codex grounded review **3 rounds → PROCEED-AS-PLANNED**.
- **Tests**: `scripts/xcode-test.sh` green — **1625 tests, 0 failures**. New: 11 conditioner boundary/integration tests, 2 capability tests (Parakeet true / WhisperKit false), 3 analytics-payload tests (present/zero/omitted).
- **Release-config build**: `swift build -c release` exit 0.
- **Codex code-diff review**: clean — no correctness findings (ordering/concurrency, math, privacy, heart-path safety, nil/zero all verified).
- **Live UAT** (real audio, debug build): a 58s Parakeet recording logged `capturedMs=57985 droppedTailMs=0 tailEnergy=n/a sid=3949E39D-…`; full transcript landed in clipboard, heart path intact. On three real recordings the trim dropped **zero** (1 continuous segment each), confirming the signal reads correctly and that continuous-playback inputs structurally can't reproduce the multi-segment trim case — exactly why the diagnostic ships for organic dogfooding.

## Heart / limbs

Telemetry-only; never gates, blocks, or alters the heart path. Single-commit revert; additive Codable optionals (decode nil for old records) + additive analytics keys, no migration.