### PR TITLE
feat(settings): import names from Contacts into custom words (#636)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ scripts/*
 !scripts/build-release-dmg.sh
 !scripts/build-dev-app.sh
 !scripts/check-xpc-error-hygiene.sh
+!scripts/check-contacts-data-flow.sh
 !scripts/xcode-test.sh
 !scripts/indexnow-submit.py
 # UAT scripts — required by workflow tooling (workflow-process.md §1 step 9 + §11)

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,14 @@ let package = Package(
       path: "Sources/EnviousWisprPostProcessing",
       resources: [.process("Resources")]
     ),
+    // Leaf module (Core only) wrapping the Contacts framework behind a narrow
+    // read-only protocol for the Import-from-Contacts feature (#636). Consumed
+    // by EnviousWisprAppKit; no .library product (internal-only).
+    .target(
+      name: "EnviousWisprContacts",
+      dependencies: ["EnviousWisprCore"],
+      path: "Sources/EnviousWisprContacts"
+    ),
     .target(
       name: "EnviousWisprAudio",
       dependencies: [
@@ -110,6 +118,7 @@ let package = Package(
         "EnviousWisprASR",
         "EnviousWisprLLM",
         "EnviousWisprPipeline",
+        "EnviousWisprContacts",
         .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
         "Sparkle",
@@ -160,6 +169,7 @@ let package = Package(
         // #919: link the app-shell code from the library, NOT the app target,
         // so `swift test` / `xcodebuild test` never launch the app.
         "EnviousWisprAppKit",
+        "EnviousWisprContacts",
       ],
       path: "Tests/EnviousWisprTests"
     ),

--- a/Project.swift
+++ b/Project.swift
@@ -207,7 +207,7 @@ let project = Project(
   ],
   settings: projectSettings,
   targets: [
-    // ---- 8 first-party modules (native static frameworks) ----
+    // ---- 9 first-party modules (native static frameworks) ----
     firstPartyLibrary("EnviousWisprCore", dependencies: []),
     firstPartyLibrary(
       "EnviousWisprStorage",
@@ -266,6 +266,16 @@ let project = Project(
         .package(product: "FluidAudio"),
       ]),
 
+    // App-layer-scoped leaf (Core only): the Contacts-framework shim for #636.
+    // Consumed only by EnviousWisprAppKit + the test bundle, so it is added to
+    // those targets explicitly rather than to the shared `firstPartyTargetDeps`
+    // engine set.
+    firstPartyLibrary(
+      "EnviousWisprContacts",
+      dependencies: [
+        .target(name: "EnviousWisprCore")
+      ]),
+
     // #919: app-shell library (homes + views + composition root + the
     // WisprBootstrapper front door). The unit-test target links THIS, so
     // `xcodebuild test` never launches the app. WhisperKit/FluidAudio/Sparkle
@@ -273,6 +283,7 @@ let project = Project(
     firstPartyLibrary(
       "EnviousWisprAppKit",
       dependencies: firstPartyTargetDeps + [
+        .target(name: "EnviousWisprContacts"),
         .package(product: "WhisperKit"),
         .package(product: "FluidAudio"),
         .package(product: "Sparkle"),
@@ -379,6 +390,7 @@ let project = Project(
       sources: ["Tests/EnviousWisprTests/**"],
       dependencies: firstPartyTargetDeps + [
         .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprContacts"),
         .package(product: "FluidAudio"),
         .package(product: "Sparkle"),
       ],

--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>EnviousWispr uses AppleScript to paste your dictated text into the active app when direct insertion is not available.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>EnviousWispr reads the names in your contacts so dictation can spell the people you know correctly. Your address book is never uploaded.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -45,6 +45,7 @@ final class AppLifecycleCoordinator {
   private let permissions: PermissionsService
   private let keychainManager: KeychainManager
   private let customWordsCoordinator: CustomWordsCoordinator
+  private let contactsImportCoordinator: ContactsImportCoordinator
   private let aiAvailability: AIAvailabilityCoordinator
   private let audioCapture: any AudioCaptureInterface
   private let asrManager: any ASRManagerInterface
@@ -63,6 +64,7 @@ final class AppLifecycleCoordinator {
     permissions: PermissionsService,
     keychainManager: KeychainManager,
     customWordsCoordinator: CustomWordsCoordinator,
+    contactsImportCoordinator: ContactsImportCoordinator,
     aiAvailability: AIAvailabilityCoordinator,
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
@@ -80,6 +82,7 @@ final class AppLifecycleCoordinator {
     self.permissions = permissions
     self.keychainManager = keychainManager
     self.customWordsCoordinator = customWordsCoordinator
+    self.contactsImportCoordinator = contactsImportCoordinator
     self.aiAvailability = aiAvailability
     self.audioCapture = audioCapture
     self.asrManager = asrManager
@@ -194,6 +197,13 @@ final class AppLifecycleCoordinator {
       model: settings.llmModel,
       keychainManager: keychainManager
     )
+
+    // #636: opt-in launch re-scan of Contacts. Add-only, off the launch path —
+    // an unawaited background Task so a slow Contacts read never blocks launch.
+    // Limb: the coordinator itself no-ops unless access is granted.
+    if settings.contactsSyncOnLaunchEnabled {
+      Task { await contactsImportCoordinator.syncNewContacts() }
+    }
 
     // Onboarding auto-open is handled by ActionWirer inside the main Window
     // scene. No deferred dispatch required here.

--- a/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
@@ -1,0 +1,212 @@
+import EnviousWisprContacts
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Observation
+
+/// Orchestrates a user-initiated import of contact names into the custom-word
+/// list, and tracks what was imported (#636).
+///
+/// Limb, not heart: raw dictation never depends on this. It cross-cuts the
+/// Contacts framework (via `ContactNameProvider`), the import log
+/// (`ImportedContactsStateStore`), and custom-word mutation (via
+/// `CustomWordsCoordinator`) — genuine top-level orchestration, so it lives at
+/// the App layer and is injected by `WisprBootstrapper`.
+///
+/// Counts shown to the user are in PEOPLE, not correction terms: one contact
+/// yields a full-name canonical plus any distinctive lone tokens (1-3 terms),
+/// but the confirm sheet and the pill speak in contacts ("42 names").
+@MainActor @Observable
+final class ContactsImportCoordinator {
+  enum ImportPhase: Equatable {
+    case idle
+    case requesting
+    case importing
+    case imported(count: Int)  // contacts added this round (transient green-check feedback)
+    case denied
+    case failed(String)
+  }
+
+  /// Honest preview surfaced to the confirm sheet before any write.
+  struct ImportPreview: Equatable {
+    let newWords: [CustomWord]  // terms to add (full names + distinctive tokens)
+    let newContactIDs: [String]  // distinct contacts contributing those terms
+    let newContactCount: Int  // = newContactIDs.count, the "N names" shown
+    let alreadyPresentCount: Int  // contacts already in the list / already imported
+  }
+
+  private(set) var phase: ImportPhase = .idle
+  /// Distinct contacts imported so far — drives the persistent "N imported" pill.
+  private(set) var importedCount: Int
+  /// Non-nil while the confirm sheet should be shown.
+  private(set) var pendingPreview: ImportPreview?
+
+  private let provider: any ContactNameProvider
+  private let customWords: CustomWordsCoordinator
+  private let stateStore: ImportedContactsStateStore
+
+  /// Priority for imported names: sorts AFTER user-typed terms (priority 0) in
+  /// the 50-term polish cap, so a large import never crowds out hand-typed
+  /// vocabulary (§3.5). `WordCorrector` ignores priority, so this is a
+  /// polish-prompt quality lever only, never a correction lever.
+  private let importedPriority = 10
+
+  init(
+    provider: any ContactNameProvider = CNContactStoreProvider(),
+    customWords: CustomWordsCoordinator,
+    stateStore: ImportedContactsStateStore = ImportedContactsStateStore()
+  ) {
+    self.provider = provider
+    self.customWords = customWords
+    self.stateStore = stateStore
+    self.importedCount = stateStore.load().importedContactIDs.count
+  }
+
+  var authorizationStatus: ContactsAuthorization { provider.authorizationStatus() }
+
+  /// Step 1 (user taps Import): request access if needed, fetch, shape, dedupe,
+  /// and stage a preview for the confirm sheet. Writes nothing.
+  func prepareImport() async {
+    guard phase != .requesting, phase != .importing, pendingPreview == nil else { return }
+    phase = .requesting
+
+    switch provider.authorizationStatus() {
+    case .denied, .restricted:
+      phase = .denied
+      return
+    case .notDetermined:
+      guard await provider.requestAccess() else {
+        phase = .denied
+        return
+      }
+    case .authorized:
+      break
+    }
+
+    do {
+      let candidates = try await provider.fetchCandidateNames()
+      pendingPreview = buildPreview(ContactNameShaper.shape(candidates))
+      phase = .idle  // sheet shows off `pendingPreview`; phase tracks async/terminal only
+    } catch {
+      phase = .failed(error.localizedDescription)
+    }
+  }
+
+  /// Step 2 (user confirms): commit the staged preview — batch-add + log.
+  func confirmImport() {
+    guard let preview = pendingPreview else { return }
+    pendingPreview = nil
+    guard !preview.newWords.isEmpty else {
+      phase = .idle
+      return
+    }
+    phase = .importing
+    guard let createdIDs = customWords.addBatch(preview.newWords) else {
+      phase = .failed(customWords.customWordError ?? "Couldn't save, try again")
+      return
+    }
+    do {
+      try persistLog(contactIDs: preview.newContactIDs, wordIDs: createdIDs)
+    } catch {
+      // Words were added but the import log didn't save. Surface it: the words
+      // persist (removable by hand) but the pill can't track them. Telemetry
+      // fires only on full success.
+      phase = .failed("Couldn't finish the import, try again")
+      return
+    }
+    TelemetryService.shared.contactsImported(count: preview.newContactCount, trigger: "manual")
+    phase = .imported(count: preview.newContactCount)
+  }
+
+  /// User dismisses the confirm sheet without importing.
+  func cancelImport() {
+    pendingPreview = nil
+    phase = .idle
+  }
+
+  /// Opt-in launch sync: add-only, no UI, safe off the launch path. Adds only
+  /// contacts not already imported; never updates or deletes.
+  func syncNewContacts() async {
+    guard provider.authorizationStatus() == .authorized else { return }
+    do {
+      let candidates = try await provider.fetchCandidateNames()
+      let preview = buildPreview(ContactNameShaper.shape(candidates))
+      guard !preview.newWords.isEmpty,
+        let createdIDs = customWords.addBatch(preview.newWords), !createdIDs.isEmpty
+      else { return }
+      try persistLog(contactIDs: preview.newContactIDs, wordIDs: createdIDs)
+      TelemetryService.shared.contactsImported(
+        count: preview.newContactCount, trigger: "launch_sync")
+    } catch {
+      // Limb: stay silent on failure (incl. a log-save failure from persistLog);
+      // the existing word list is untouched and telemetry does not fire.
+    }
+  }
+
+  /// Bulk-remove exactly the import-created words still present, then clear the
+  /// log. Manually-deleted words are already absent and skipped silently.
+  func bulkRemoveImported() {
+    let state = stateStore.load()
+    guard !state.importedWordIDs.isEmpty else { return }
+    // Only erase ownership if BOTH the removal and the log reset succeed —
+    // otherwise words could remain while the pill loses track of them.
+    if let error = customWords.removeBatch(ids: state.importedWordIDs) {
+      phase = .failed(error)
+      return
+    }
+    do {
+      try stateStore.save(.empty)
+    } catch {
+      phase = .failed("Couldn't update the import list, try again")
+      return
+    }
+    importedCount = 0
+    phase = .idle
+  }
+
+  // MARK: - Private
+
+  private func buildPreview(_ shaped: [ShapedName]) -> ImportPreview {
+    let state = stateStore.load()
+    let alreadyImportedContacts = Set(state.importedContactIDs)
+    let existingCanonicals = Set(customWords.customWords.map { $0.canonical.lowercased() })
+
+    var newWords: [CustomWord] = []
+    var newContactIDs = Set<String>()
+    var seenCanonical = Set<String>()
+
+    for item in shaped {
+      // Idempotent re-scan: a contact we already imported is skipped wholesale.
+      if alreadyImportedContacts.contains(item.contactID) { continue }
+      let key = item.canonical.lowercased()
+      // Canonical already in the list (user-typed, built-in, or another contact).
+      if existingCanonicals.contains(key) || seenCanonical.contains(key) { continue }
+      seenCanonical.insert(key)
+      newWords.append(
+        CustomWord(
+          canonical: item.canonical,
+          category: .person,
+          priority: importedPriority,
+          source: .user))
+      newContactIDs.insert(item.contactID)
+    }
+
+    // Contacts present in the address book but contributing no new term (already
+    // imported, or every canonical already exists) are "already in your list".
+    let allContactIDs = Set(shaped.map { $0.contactID })
+    let alreadyPresent = allContactIDs.subtracting(newContactIDs).count
+
+    return ImportPreview(
+      newWords: newWords,
+      newContactIDs: Array(newContactIDs),
+      newContactCount: newContactIDs.count,
+      alreadyPresentCount: alreadyPresent)
+  }
+
+  private func persistLog(contactIDs: [String], wordIDs: [UUID]) throws {
+    var state = stateStore.load()
+    state.record(contactIDs: contactIDs, wordIDs: wordIDs, at: Date())
+    try stateStore.save(state)
+    importedCount = state.importedContactIDs.count
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -13,9 +13,17 @@ final class CustomWordsCoordinator {
   /// Called after any mutation so the former root state can sync words to pipelines.
   var onWordsChanged: (([CustomWord]) -> Void)?
 
-  private let manager = CustomWordsManager()
+  private let manager: CustomWordsManager
 
   init() {
+    self.manager = CustomWordsManager()
+    customWords = manager.load() ?? []
+  }
+
+  /// Test seam (#636): inject a temp-file-backed manager so hermetic tests of
+  /// the contacts-import flow never touch the production custom-words file.
+  package init(manager: CustomWordsManager) {
+    self.manager = manager
     customWords = manager.load() ?? []
   }
 
@@ -45,10 +53,38 @@ final class CustomWordsCoordinator {
     }
   }
 
+  /// Bulk-add for the contacts import (#636). Returns the IDs actually created
+  /// (for the import log), or nil on failure (check `customWordError`).
+  func addBatch(_ words: [CustomWord]) -> [UUID]? {
+    do {
+      let created = try manager.addBatch(words, to: &customWords)
+      onWordsChanged?(customWords)
+      customWordError = nil
+      return created
+    } catch {
+      customWordError = error.localizedDescription
+      return nil
+    }
+  }
+
   @discardableResult
   func remove(id: UUID) -> String? {
     do {
       try manager.remove(id: id, from: &customWords)
+      onWordsChanged?(customWords)
+      customWordError = nil
+      return nil
+    } catch {
+      customWordError = error.localizedDescription
+      return customWordError
+    }
+  }
+
+  /// Bulk-remove by ID (contacts-import pill, #636).
+  @discardableResult
+  func removeBatch(ids: [UUID]) -> String? {
+    do {
+      try manager.removeBatch(ids: ids, from: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
       return nil

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -205,7 +205,8 @@ final class PipelineSettingsSync {
       break  // Frozen per recording; see `DictationSessionConfig`.
     case .whisperKitLanguage:
       break  // Deprecated — legacy migration only (SettingsManager:460-484).
-    case .onboardingState, .hasCompletedOnboarding, .useXPCAudioService:
+    case .onboardingState, .hasCompletedOnboarding, .useXPCAudioService,
+      .contactsSyncOnLaunchEnabled:
       break  // UI-only or cold flag.
     }
   }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -42,6 +42,7 @@ public final class WisprBootstrapper {
   let permissions: PermissionsService
   let asrManager: any ASRManagerInterface
   let customWordsCoordinator: CustomWordsCoordinator
+  let contactsImportCoordinator: ContactsImportCoordinator
   let setup: SetupCoordinator
   let audioDeviceList: AudioDeviceList
   let aiAvailability: AIAvailabilityCoordinator
@@ -74,6 +75,10 @@ public final class WisprBootstrapper {
     let audioDeviceList = AudioDeviceList()
     let captureTelemetry = CaptureTelemetryState()
     let customWordsCoordinator = CustomWordsCoordinator()
+    // #636: contacts-import orchestrator. Reads only the tiny import-log file at
+    // construction (no Contacts framework call until the user acts).
+    let contactsImportCoordinator = ContactsImportCoordinator(
+      customWords: customWordsCoordinator)
     let customWordsPropagator = CustomWordsPropagator()
     // #633 Phase 9: owns enabled vocabulary-pack state; merges pack terms into
     // the corrector lane (default OFF). Wired into `wireCustomWords` below.
@@ -432,6 +437,7 @@ public final class WisprBootstrapper {
       permissions: permissions,
       keychainManager: keychainManager,
       customWordsCoordinator: customWordsCoordinator,
+      contactsImportCoordinator: contactsImportCoordinator,
       aiAvailability: aiAvailability,
       audioCapture: audioCapture,
       asrManager: asrManager,
@@ -466,6 +472,7 @@ public final class WisprBootstrapper {
     self.permissions = permissions
     self.asrManager = asrManager
     self.customWordsCoordinator = customWordsCoordinator
+    self.contactsImportCoordinator = contactsImportCoordinator
     self.setup = setup
     self.audioDeviceList = audioDeviceList
     self.aiAvailability = aiAvailability
@@ -602,6 +609,7 @@ private struct MainWindowRoot: View {
       .environment(b.settings)
       .environment(b.permissions)
       .environment(b.customWordsCoordinator)
+      .environment(b.contactsImportCoordinator)
       .environment(b.setup)
       .environment(b.audioDeviceList)
       .environment(b.aiAvailability)

--- a/Sources/EnviousWisprAppKit/Views/Settings/ContactsImportConfirm.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ContactsImportConfirm.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Confirmation surface shown before any contact name is written (#636).
+/// Shows an honest count and the on-device disclaimer. The import only happens
+/// when the user taps the primary action here.
+struct ContactsImportConfirm: View {
+  let preview: ContactsImportCoordinator.ImportPreview
+  let onConfirm: () -> Void
+  let onCancel: () -> Void
+
+  private var hasNewNames: Bool { preview.newContactCount > 0 }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("Import from Contacts")
+        .font(.title3)
+        .bold()
+
+      if hasNewNames {
+        Text(addCountMessage)
+          .font(.body)
+        Text(
+          "EnviousWispr never uploads your address book. These names are added to your "
+            + "word list on this Mac so dictation spells them right."
+        )
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+      } else {
+        Text("All your contacts are already in your word list.")
+          .font(.body)
+      }
+
+      HStack {
+        Spacer()
+        if hasNewNames {
+          Button("Cancel", action: onCancel)
+            .keyboardShortcut(.cancelAction)
+          Button(addButtonTitle, action: onConfirm)
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+        } else {
+          Button("Done", action: onCancel)
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+        }
+      }
+    }
+    .padding(24)
+    .frame(width: 420)
+  }
+
+  private var addCountMessage: String {
+    let names = Self.pluralizedNames(preview.newContactCount)
+    if preview.alreadyPresentCount > 0 {
+      let already = preview.alreadyPresentCount
+      let verb = already == 1 ? "is" : "are"
+      return "We'll add \(names) from your contacts. \(already) \(verb) already in your list."
+    }
+    return "We'll add \(names) from your contacts."
+  }
+
+  private var addButtonTitle: String {
+    "Add \(Self.pluralizedNames(preview.newContactCount))"
+  }
+
+  private static func pluralizedNames(_ count: Int) -> String {
+    count == 1 ? "1 name" : "\(count) names"
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -1,10 +1,17 @@
+import AppKit
+import EnviousWisprServices
 import SwiftUI
 
 /// Phase 4 (#634) — Learning section of the Your Words settings tab. Two rows:
-/// auto-learn (Phase 7 #629) and contacts import (Phase 6 #636). Both ship
-/// disabled with "Coming soon" captions until those phases land. Bible §10.2.
+/// auto-learn (Phase 7 #629, still "Coming soon") and contacts import (Phase 6
+/// #636, live). Bible §10.2.
 struct LearningSection: View {
+  @Environment(ContactsImportCoordinator.self) private var contactsImport
+  @Environment(SettingsManager.self) private var settings
+
   var body: some View {
+    @Bindable var settings = settings
+
     BrandedSection(header: "Learning") {
       // Row 1: Auto-learn from transcripts (Phase 7 #629)
       BrandedRow(showDivider: true) {
@@ -34,27 +41,115 @@ struct LearningSection: View {
 
       // Row 2: Import from Contacts (Phase 6 #636)
       BrandedRow(showDivider: false) {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
           HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 2) {
               Text("Import from Contacts")
                 .font(.body)
               Text(
-                "Add the names of people you know to your custom word list. Names stay on your Mac."
+                "Add the names of people you know to your word list, so dictation spells them right."
               )
               .font(.stHelper)
               .foregroundStyle(.stTextTertiary)
             }
             Spacer()
-            Button("Review") {}
-              .disabled(true)
+            importControl
           }
-          Text("Coming soon")
+
+          if case .imported(let count) = contactsImport.phase {
+            Label(addedFeedback(count), systemImage: "checkmark.circle.fill")
+              .font(.stHelper)
+              .foregroundStyle(.green)
+          }
+          if case .failed(let message) = contactsImport.phase {
+            Text(message)
+              .font(.stHelper)
+              .foregroundStyle(.red)
+          }
+          if contactsImport.phase == .denied {
+            Text("Contacts access is off. Turn it on in System Settings, then try again.")
+              .font(.stHelper)
+              .foregroundStyle(.stTextTertiary)
+          }
+
+          Toggle("Keep in sync on launch", isOn: $settings.contactsSyncOnLaunchEnabled)
+            .toggleStyle(BrandedToggleStyle())
+            .padding(.top, 2)
+          Text("Check for new contacts each time EnviousWispr starts. Off by default.")
             .font(.stHelper)
             .foregroundStyle(.stTextTertiary)
-            .padding(.top, 2)
         }
       }
+    }
+    .sheet(isPresented: confirmSheetBinding) {
+      if let preview = contactsImport.pendingPreview {
+        ContactsImportConfirm(
+          preview: preview,
+          onConfirm: { contactsImport.confirmImport() },
+          onCancel: { contactsImport.cancelImport() })
+      }
+    }
+  }
+
+  /// Right-side control: spinner while working, Open Settings if denied, the
+  /// "N imported ✕" pill plus an Import/Re-scan button otherwise.
+  @ViewBuilder private var importControl: some View {
+    HStack(spacing: 8) {
+      if contactsImport.importedCount > 0 {
+        importedPill
+      }
+      actionButton
+    }
+  }
+
+  @ViewBuilder private var actionButton: some View {
+    switch contactsImport.phase {
+    case .requesting, .importing:
+      ProgressView()
+        .controlSize(.small)
+    case .denied:
+      Button("Open Settings") { openContactsSettings() }
+    default:
+      Button(contactsImport.importedCount > 0 ? "Re-scan" : "Import") {
+        Task { await contactsImport.prepareImport() }
+      }
+    }
+  }
+
+  private var importedPill: some View {
+    HStack(spacing: 4) {
+      Text("\(contactsImport.importedCount) imported")
+        .font(.stHelper)
+      Button {
+        contactsImport.bulkRemoveImported()
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+      }
+      .buttonStyle(.plain)
+      .help("Remove all imported names")
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .background(Capsule().fill(Color.secondary.opacity(0.15)))
+  }
+
+  private var confirmSheetBinding: Binding<Bool> {
+    Binding(
+      get: { contactsImport.pendingPreview != nil },
+      set: { presented in
+        if !presented { contactsImport.cancelImport() }
+      })
+  }
+
+  private func addedFeedback(_ count: Int) -> String {
+    count == 1 ? "Added 1 name" : "Added \(count) names"
+  }
+
+  private func openContactsSettings() {
+    if let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts")
+    {
+      NSWorkspace.shared.open(url)
     }
   }
 }

--- a/Sources/EnviousWisprContacts/CNContactStoreProvider.swift
+++ b/Sources/EnviousWisprContacts/CNContactStoreProvider.swift
@@ -1,0 +1,54 @@
+@preconcurrency import Contacts
+import Foundation
+
+/// Production `ContactNameProvider` backed by `CNContactStore`.
+///
+/// One-shot reads only: every call constructs a fresh store and releases it,
+/// with no `CNContactStoreDidChange` subscription and no retained handle. This
+/// is the bounded-window guardrail (bible §2.4 guardrail 3) — the feature reads
+/// when the user (or opt-in launch sync) asks, never continuously.
+public struct CNContactStoreProvider: ContactNameProvider {
+  public init() {}
+
+  public func authorizationStatus() -> ContactsAuthorization {
+    switch CNContactStore.authorizationStatus(for: .contacts) {
+    case .authorized: return .authorized
+    case .denied: return .denied
+    case .restricted: return .restricted
+    case .notDetermined: return .notDetermined
+    // macOS never returns `.limited`; treat any future case as fail-closed.
+    @unknown default: return .restricted
+    }
+  }
+
+  public func requestAccess() async -> Bool {
+    let store = CNContactStore()
+    do {
+      return try await store.requestAccess(for: .contacts)
+    } catch {
+      return false
+    }
+  }
+
+  public func fetchCandidateNames() async throws -> [CandidateName] {
+    let store = CNContactStore()
+    let keys: [CNKeyDescriptor] = [
+      CNContactGivenNameKey as CNKeyDescriptor,
+      CNContactFamilyNameKey as CNKeyDescriptor,
+      CNContactIdentifierKey as CNKeyDescriptor,
+    ]
+    let request = CNContactFetchRequest(keysToFetch: keys)
+    // `enumerateContacts` runs synchronously; this method is `nonisolated async`
+    // so the blocking enumeration executes off the main actor.
+    var results: [CandidateName] = []
+    try store.enumerateContacts(with: request) { contact, _ in
+      let given = contact.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+      let family = contact.familyName.trimmingCharacters(in: .whitespacesAndNewlines)
+      // Skip phone-only / no-name entries (the "Spam Caller" failure mode).
+      guard !given.isEmpty || !family.isEmpty else { return }
+      results.append(
+        CandidateName(contactID: contact.identifier, given: given, family: family))
+    }
+    return results
+  }
+}

--- a/Sources/EnviousWisprContacts/ContactNameProvider.swift
+++ b/Sources/EnviousWisprContacts/ContactNameProvider.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// macOS Contacts authorization state, framework-agnostic so callers outside
+/// this module never import Contacts.
+///
+/// macOS authorization is all-or-nothing: there is NO `.limited` case (that is
+/// iOS 18+ only). This corrects the bible §12.6 assumption.
+public enum ContactsAuthorization: Sendable, Equatable {
+  case notDetermined
+  case authorized
+  case denied
+  case restricted
+}
+
+/// One real, named contact reduced to only the fields this feature reads.
+///
+/// `contactID` is `CNContact.identifier` — opaque, stable across launches, and
+/// the dedupe / re-scan key. No phone, email, photo, note, or organization is
+/// ever carried (names-only, bible §12). `given` / `family` are already
+/// whitespace-trimmed by the provider; at least one is non-empty.
+public struct CandidateName: Sendable, Equatable {
+  public let contactID: String
+  public let given: String
+  public let family: String
+
+  public init(contactID: String, given: String, family: String) {
+    self.contactID = contactID
+    self.given = given
+    self.family = family
+  }
+}
+
+/// A read-only, on-device source of contact names. The production conformer
+/// (`CNContactStoreProvider`) wraps `CNContactStore`; tests use a fake.
+///
+/// Invariants the caller MUST uphold:
+/// - `NSContactsUsageDescription` is present in the app's Info.plist before any
+///   method that touches `CNContactStore` runs — Apple aborts the process
+///   otherwise.
+/// - `fetchCandidateNames()` is not called when status is `.denied` /
+///   `.restricted`.
+public protocol ContactNameProvider: Sendable {
+  /// Current authorization without prompting.
+  func authorizationStatus() -> ContactsAuthorization
+  /// Prompt for access if `.notDetermined`; returns whether access is granted.
+  func requestAccess() async -> Bool
+  /// One-shot read of every real, named contact. No persistent observer.
+  func fetchCandidateNames() async throws -> [CandidateName]
+}

--- a/Sources/EnviousWisprContacts/ContactNameShaper.swift
+++ b/Sources/EnviousWisprContacts/ContactNameShaper.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// One contact name reduced to a single canonical term to import, tagged with
+/// the originating contact so the coordinator can track per-contact provenance.
+public struct ShapedName: Sendable, Equatable {
+  public let contactID: String
+  public let canonical: String
+
+  public init(contactID: String, canonical: String) {
+    self.contactID = contactID
+    self.canonical = canonical
+  }
+}
+
+/// Pure logic that turns raw contact names into the exact set of canonical terms
+/// to import. This is the §3.4 design hinge in code.
+///
+/// `WordCorrector` registers every space-free (single-token) canonical as an
+/// EXACT self-entry that rewrites the spoken word unconditionally on Pass 3 —
+/// no fuzzy/threshold/stopword guard. So a lone common word like "Will" or
+/// "May" imported as a single-token canonical would capitalize that word every
+/// time the user dictates it. Multi-word canonicals get NO exact self-entry
+/// (they fire only on the full phrase). The shaping rules below exploit that:
+///
+/// - When both names are present, always emit the full `"First Last"` canonical
+///   (safe: multi-word, phrase-only) — this covers the name in context even when
+///   neither part survives as a lone token.
+/// - Additionally emit `given` or `family` ALONE only when that token is
+///   distinctive (not a common English word, length ≥ 2, letters-only) so
+///   "Ramachandran" / "Vasquez" still correct when said alone.
+/// - A lone common-word name (in the stoplist) is skipped as a single token; the
+///   full-name entry still covers it. A single-field contact whose only name is a
+///   common word produces nothing (better than corrupting speech).
+public enum ContactNameShaper {
+  /// Lone tokens shorter than this are not imported on their own (still covered
+  /// by the full-name entry). Guards single letters / initials.
+  static let minLoneTokenLength = 2
+
+  public static func shape(_ candidates: [CandidateName]) -> [ShapedName] {
+    var out: [ShapedName] = []
+    for candidate in candidates {
+      let given = candidate.given
+      let family = candidate.family
+      let givenValid = isNameLike(given)
+      let familyValid = isNameLike(family)
+
+      var canonicals: [String] = []
+      if givenValid && familyValid {
+        canonicals.append("\(given) \(family)")
+        if isDistinctiveLoneToken(given) { canonicals.append(given) }
+        if isDistinctiveLoneToken(family) { canonicals.append(family) }
+      } else if givenValid {
+        if isDistinctiveLoneToken(given) { canonicals.append(given) }
+      } else if familyValid {
+        if isDistinctiveLoneToken(family) { canonicals.append(family) }
+      }
+
+      // De-dupe within one contact (e.g. given == family) — case-insensitive.
+      var seen = Set<String>()
+      for canonical in canonicals where seen.insert(canonical.lowercased()).inserted {
+        out.append(ShapedName(contactID: candidate.contactID, canonical: canonical))
+      }
+    }
+    return out
+  }
+
+  /// A token is name-like if it has at least one letter and no decimal digit
+  /// (rejects phone-number-in-name junk while allowing accents, hyphens,
+  /// apostrophes: "O'Brien", "Jean-Luc", "Nguyễn").
+  static func isNameLike(_ token: String) -> Bool {
+    guard !token.isEmpty else { return false }
+    var hasLetter = false
+    for scalar in token.unicodeScalars {
+      if CharacterSet.decimalDigits.contains(scalar) { return false }
+      if CharacterSet.letters.contains(scalar) { hasLetter = true }
+    }
+    return hasLetter
+  }
+
+  static func isDistinctiveLoneToken(_ token: String) -> Bool {
+    guard isNameLike(token) else { return false }
+    guard token.count >= minLoneTokenLength else { return false }
+    return !commonWordStoplist.contains(token.lowercased())
+  }
+
+  /// Common English words that are also common given/family names. A lone token
+  /// matching one of these is NOT imported on its own (the full-name entry still
+  /// covers it). Erring generous on purpose: a false skip merely loses lone-token
+  /// correction, while a miss capitalizes ordinary speech. Extensible.
+  static let commonWordStoplist: Set<String> = [
+    // Modal verbs / very high-frequency words that are also names.
+    "will", "may", "mark", "bill", "drew", "rose", "grant", "chase", "chance",
+    "hope", "grace", "faith", "joy", "art", "guy", "frank", "rich", "wade",
+    "reed", "reid", "lance", "miles", "jack", "pat", "ray", "dean", "dale",
+    // Seasons / months / time words used as names.
+    "summer", "autumn", "april", "june", "august", "dawn", "noel",
+    // Flowers / plants / nature names.
+    "holly", "ivy", "lily", "daisy", "rose", "violet", "iris", "fern", "olive",
+    "sage", "basil", "rosemary", "ginger", "jasmine", "poppy", "heather",
+    "willow", "hazel", "laurel", "myrtle", "berry", "cherry", "plum",
+    // Gems / precious words.
+    "pearl", "ruby", "amber", "crystal", "jade", "opal", "coral", "gem",
+    // Animals / birds used as names.
+    "robin", "jay", "wren", "dove", "lark", "drake", "fox", "wolf", "bear",
+    "hawk", "finch", "raven", "swift", "bird",
+    // Sky / water / earth words.
+    "star", "sky", "rain", "storm", "river", "brook", "lake", "bay", "ocean",
+    "sea", "stone", "wood", "woods", "cliff", "glen", "ford", "heath", "vale",
+    "field", "fields", "hill", "hills", "lane", "park", "parks", "meadow",
+    // Colors used as surnames.
+    "gray", "grey", "brown", "white", "black", "green",
+    // Occupational surnames that are common words.
+    "king", "knight", "baker", "cook", "hunter", "fisher", "carter", "potter",
+    "porter", "mason", "marshall", "marshal", "sawyer", "archer", "chandler",
+    "fletcher", "weaver", "tanner", "shepherd", "gardener", "page", "abbott",
+    "bishop", "major", "sterling", "noble", "earl", "duke", "bell",
+    // Sweet / mood / texture nicknames.
+    "honey", "candy", "sugar", "sunny", "sandy", "misty", "stormy", "rocky",
+    "buddy", "sonny", "merry", "melody", "harmony", "bliss",
+    // Short function words (defensive — a malformed or single-field contact
+    // could carry one; length guard already drops single letters).
+    "an", "the", "is", "it", "in", "on", "of", "to", "at", "as", "be", "by",
+    "do", "go", "he", "if", "me", "my", "no", "or", "so", "up", "us", "we",
+  ]
+}

--- a/Sources/EnviousWisprContacts/ImportedContactsStateStore.swift
+++ b/Sources/EnviousWisprContacts/ImportedContactsStateStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// On-disk record of what the contacts import created.
+///
+/// Two jobs: (1) `importedContactIDs` lets a re-scan skip contacts already
+/// imported (idempotent re-import); (2) `importedWordIDs` is the exact set the
+/// bulk-remove pill deletes. **Opaque IDs only — never a name string.** That is
+/// the privacy invariant the `check-contacts-data-flow.sh` hook enforces.
+///
+/// Net-new file: an absent file decodes as `.empty` (no prior import). Decode is
+/// forward-compatible (`decodeIfPresent`); unknown future keys are ignored.
+public struct ImportedContactsState: Codable, Sendable, Equatable {
+  public var version: Int
+  public var lastImportedAt: Date?
+  public var importedContactIDs: [String]
+  public var importedWordIDs: [UUID]
+
+  public init(
+    version: Int = 1,
+    lastImportedAt: Date? = nil,
+    importedContactIDs: [String] = [],
+    importedWordIDs: [UUID] = []
+  ) {
+    self.version = version
+    self.lastImportedAt = lastImportedAt
+    self.importedContactIDs = importedContactIDs
+    self.importedWordIDs = importedWordIDs
+  }
+
+  public static let empty = ImportedContactsState()
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    self.version = try c.decodeIfPresent(Int.self, forKey: .version) ?? 1
+    self.lastImportedAt = try c.decodeIfPresent(Date.self, forKey: .lastImportedAt)
+    self.importedContactIDs =
+      try c.decodeIfPresent([String].self, forKey: .importedContactIDs) ?? []
+    self.importedWordIDs =
+      try c.decodeIfPresent([UUID].self, forKey: .importedWordIDs) ?? []
+  }
+
+  /// Merge a fresh import into this state: union new contact + word IDs
+  /// (insertion-order preserving, deduped) and stamp the timestamp.
+  public mutating func record(contactIDs: [String], wordIDs: [UUID], at date: Date) {
+    var seenContacts = Set(importedContactIDs)
+    for id in contactIDs where seenContacts.insert(id).inserted {
+      importedContactIDs.append(id)
+    }
+    var seenWords = Set(importedWordIDs)
+    for id in wordIDs where seenWords.insert(id).inserted {
+      importedWordIDs.append(id)
+    }
+    lastImportedAt = date
+  }
+}
+
+/// Loads/saves `imported-contacts-state.json` in the EnviousWispr Application
+/// Support directory, mirroring `CustomWordsManager`'s file hardening (0700 dir
+/// with a Spotlight-exclusion marker, 0600 atomic file write).
+public struct ImportedContactsStateStore: Sendable {
+  private let fileURL: URL
+
+  public init() {
+    if let baseURL = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first {
+      let appSupport = baseURL.appendingPathComponent("EnviousWispr", isDirectory: true)
+      Self.prepareDirectory(at: appSupport)
+      self.fileURL = appSupport.appendingPathComponent("imported-contacts-state.json")
+    } else {
+      let fallback = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "EnviousWispr", isDirectory: true)
+      Self.prepareDirectory(at: fallback)
+      self.fileURL = fallback.appendingPathComponent("imported-contacts-state.json")
+    }
+    Self.tightenFileIfPresent(at: fileURL)
+  }
+
+  /// Test seam: inject an explicit file URL so unit tests hit a per-test temp
+  /// file instead of the production path. Production uses the zero-arg `init()`.
+  package init(fileURL: URL) {
+    self.fileURL = fileURL
+    Self.prepareDirectory(at: fileURL.deletingLastPathComponent())
+    Self.tightenFileIfPresent(at: fileURL)
+  }
+
+  /// Absent or unreadable file → `.empty` (treated as no prior import).
+  public func load() -> ImportedContactsState {
+    guard FileManager.default.fileExists(atPath: fileURL.path),
+      let data = try? Data(contentsOf: fileURL),
+      let state = try? JSONDecoder().decode(ImportedContactsState.self, from: data)
+    else { return .empty }
+    return state
+  }
+
+  public func save(_ state: ImportedContactsState) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(state)
+    let tmpURL = fileURL.deletingLastPathComponent().appendingPathComponent(
+      ".imported-contacts-state.json.tmp")
+    let fm = FileManager.default
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+      let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try fh.write(contentsOf: data)
+      try fh.close()
+      if fm.fileExists(atPath: fileURL.path) {
+        _ = try fm.replaceItemAt(fileURL, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: fileURL)
+      }
+    } catch {
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
+  }
+
+  private static func prepareDirectory(at url: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+    try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    let marker = url.appendingPathComponent(".metadata_never_index")
+    if !fm.fileExists(atPath: marker.path) {
+      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
+    }
+  }
+
+  private static func tightenFileIfPresent(at url: URL) {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else { return }
+    try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -296,6 +296,61 @@ public final class CustomWordsManager {
     words = mergedWords(file: file)
   }
 
+  /// Bulk-insert custom words with a single file read + write. Mirrors
+  /// `add(word:to:)` per word — canonical trim, reject-empty, case-insensitive
+  /// de-dupe (against existing terms AND earlier entries in this same batch),
+  /// alias sanitize, and the tombstoned-built-in restore branch — but collapses
+  /// the O(n) per-word `loadFile`/`saveFile` into one of each so a large import
+  /// (thousands of names) never rewrites the file per word.
+  ///
+  /// Returns the UUIDs of the user words this call actually appended, in input
+  /// order. De-duplicated inputs and tombstoned-built-in restores are NOT in the
+  /// returned set: the caller (contacts import) treats the result as the
+  /// import's owned set for bulk-removal, and a restored built-in is not
+  /// import-owned.
+  public func addBatch(_ incoming: [CustomWord], to words: inout [CustomWord]) throws
+    -> [UUID]
+  {
+    var file = loadFile() ?? CustomWordsFile()
+    // Seed dedupe from BOTH the in-memory merged list and the on-disk file so a
+    // stale `words` snapshot can't produce a duplicate at batch scale.
+    var seen = Set(words.map { $0.canonical.lowercased() })
+    seen.formUnion(file.words.map { $0.canonical.lowercased() })
+    var createdIDs: [UUID] = []
+
+    for word in incoming {
+      let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { continue }
+      let key = trimmed.lowercased()
+      guard !seen.contains(key) else { continue }
+
+      // Tombstoned-built-in restore (mirrors the built-in branch of add(word:)).
+      // A LIVE built-in is already in `seen` (it is in merged `words`), so a
+      // built-in match here means it was tombstoned: un-delete it instead of
+      // adding a duplicate user word. Restored built-ins are not in createdIDs.
+      if let builtin = Self.builtinDefaults.first(where: {
+        $0.word.canonical.caseInsensitiveCompare(trimmed) == .orderedSame
+      }) {
+        file.deletedBuiltinIds.removeAll { $0 == builtin.id }
+        seen.insert(key)
+        continue
+      }
+
+      var sanitized = word
+      sanitized.canonical = trimmed
+      sanitized.aliases = sanitized.aliases
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+      file.words.append(sanitized)
+      createdIDs.append(sanitized.id)
+      seen.insert(key)
+    }
+
+    try saveFile(file)
+    words = mergedWords(file: file)
+    return createdIDs
+  }
+
   public func remove(id: UUID, from words: inout [CustomWord]) throws {
     let word = words.first { $0.id == id }
     var file = loadFile() ?? CustomWordsFile()
@@ -312,6 +367,33 @@ public final class CustomWordsManager {
     }
 
     file.words.removeAll { $0.id == id }
+    try saveFile(file)
+    words = mergedWords(file: file)
+  }
+
+  /// Bulk-remove by ID with a single file read + write. Mirrors `remove(id:)`
+  /// per ID — including tombstoning a built-in whose canonical matches a removed
+  /// word — but collapses to one `loadFile`/`saveFile`. IDs not present are
+  /// skipped. Used by the contacts-import bulk-remove pill (#636) to avoid an
+  /// O(n) per-word rewrite when clearing a large import.
+  public func removeBatch(ids: [UUID], from words: inout [CustomWord]) throws {
+    guard !ids.isEmpty else { return }
+    let idSet = Set(ids)
+    var file = loadFile() ?? CustomWordsFile()
+
+    // Tombstone any built-ins whose canonical matches a removed word (mirror
+    // remove(id:)). Import-created words are user words, so this is normally
+    // inert for the import path, but keeps batch semantics identical to single.
+    for id in ids {
+      guard let word = words.first(where: { $0.id == id }) else { continue }
+      if let builtin = Self.builtinDefaults.first(where: {
+        $0.word.canonical.lowercased() == word.canonical.lowercased()
+      }), !file.deletedBuiltinIds.contains(builtin.id) {
+        file.deletedBuiltinIds.append(builtin.id)
+      }
+    }
+
+    file.words.removeAll { idSet.contains($0.id) }
     try saveFile(file)
     words = mergedWords(file: file)
   }

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -40,6 +40,9 @@ enum SettingsDefaultValues {
 
   static let wordCorrectionEnabled = true
   static let fillerRemovalEnabled = true
+  // #636: opt-in launch re-scan of Contacts (add-only). Default OFF — the
+  // feature only runs when the user enables both import and this sub-toggle.
+  static let contactsSyncOnLaunchEnabled = false
   // #923: spoken-emoji conversion ON by default. Safe — the formatter fires
   // ONLY on explicit "<phrase> emoji" triggers; it never infers emoji from
   // sentiment (personas.md emoji-control-current), so uncustomized users see no

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -29,6 +29,7 @@ public final class SettingsManager {
     case wordCorrectionEnabled
     case fillerRemovalEnabled
     case emojiFormatterEnabled
+    case contactsSyncOnLaunchEnabled
     case isDebugModeEnabled
     case debugLogLevel
     case useExtendedThinking
@@ -60,7 +61,7 @@ public final class SettingsManager {
     "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
     "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
     "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
-    "emojiFormatterEnabled", "isDebugModeEnabled", "debugLogLevel",
+    "emojiFormatterEnabled", "contactsSyncOnLaunchEnabled", "isDebugModeEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
     "useStreamingASR", "warmEnginePolicy",
@@ -235,6 +236,16 @@ public final class SettingsManager {
     didSet {
       defaults.set(fillerRemovalEnabled, forKey: "fillerRemovalEnabled")
       onChange?(.fillerRemovalEnabled)
+    }
+  }
+
+  /// Opt-in: re-read Contacts on launch and add any new names (#636). Default
+  /// OFF. Add-only — never updates or deletes existing terms. Limb: the launch
+  /// path never awaits or blocks on it.
+  public var contactsSyncOnLaunchEnabled: Bool {
+    didSet {
+      defaults.set(contactsSyncOnLaunchEnabled, forKey: "contactsSyncOnLaunchEnabled")
+      onChange?(.contactsSyncOnLaunchEnabled)
     }
   }
 
@@ -458,6 +469,9 @@ public final class SettingsManager {
     fillerRemovalEnabled =
       defaults.object(forKey: "fillerRemovalEnabled") as? Bool
       ?? SettingsDefaultValues.fillerRemovalEnabled
+    contactsSyncOnLaunchEnabled =
+      defaults.object(forKey: "contactsSyncOnLaunchEnabled") as? Bool
+      ?? SettingsDefaultValues.contactsSyncOnLaunchEnabled
     emojiFormatterEnabled =
       defaults.object(forKey: "emojiFormatterEnabled") as? Bool
       ?? SettingsDefaultValues.emojiFormatterEnabled

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -290,6 +290,16 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("wedge_detected", properties: properties)
   }
 
+  /// #636: contacts import completed. Privacy-safe by construction — emits the
+  /// COUNT of contacts added and the trigger only, NEVER a name. The
+  /// `check-contacts-data-flow.sh` hook allow-lists this as the one permitted
+  /// telemetry sink in the contacts code.
+  public func contactsImported(count: Int, trigger: String) {
+    PostHogSDK.shared.capture(
+      "contacts_imported",
+      properties: ["count": count, "$value": count, "trigger": trigger])
+  }
+
   /// Issue #445 launch-time telemetry, now emitted by the shared
   /// `KernelDictationDriver.ensureEngineWarm(reason: .launch)` (#879) when it
   /// drives the launch warm-up — `result` is one of "success",

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -24,6 +24,11 @@ import Testing
 /// unchanged at 3. Allowlist count rises 10 → 19 (3 owned `var` + 16 injected
 /// `let`); non-private `func`s `runDidFinishLaunching`, `runDidBecomeActive`,
 /// `runWillTerminate` unchanged (`init` is not a `func`).
+/// Bible §30 entry (#636, 2026-06-06): `contactsImportCoordinator` added — the
+/// App-layer orchestrator for Import-from-Contacts. Injected `let`, read by
+/// `runDidFinishLaunching` for the opt-in launch sync only. Allowlist 19 → 20
+/// (3 owned `var` + 17 injected `let`); non-private method count unchanged at 3.
+/// A narrow new coordinator, not god-object accretion (issue-636 §3b).
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
@@ -36,6 +41,7 @@ import Testing
     "permissions",
     "keychainManager",
     "customWordsCoordinator",
+    "contactsImportCoordinator",
     "aiAvailability",
     "audioCapture",
     "asrManager",
@@ -60,7 +66,7 @@ import Testing
       extras.isEmpty && missing.isEmpty,
       """
       AppLifecycleCoordinator stored-property set drifted from the \
-      19-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      20-name allowlist. Unexpected: \(extras.sorted()). Missing: \
       \(missing.sorted()). Adding a stored property is god-object drift — \
       raising the allowlist requires a Bible §30 entry. Removing one means \
       this allowlist must shrink in the same PR.

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -91,13 +91,17 @@ import Testing
   /// - 27 → 28 in #633 Phase 9 (2026-06-06): App-owned `vocabularyPackManager`
   ///   for the opt-in word packs — owns enabled-pack state and merges pack
   ///   terms into the corrector lane, injected into the main Window scene.
+  /// - 28 → 29 in #636 (2026-06-06): App-owned `contactsImportCoordinator` for
+  ///   Import-from-Contacts — orchestrates the opt-in import + bulk-remove,
+  ///   injected into the main Window scene and read by AppLifecycleCoordinator
+  ///   for the opt-in launch sync. A narrow new coordinator (issue-636 §3b).
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 28,
+      count <= 29,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 28. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 29. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/EnviousWisprTests/Contacts/ContactNameShaperTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactNameShaperTests.swift
@@ -1,0 +1,96 @@
+import EnviousWisprContacts
+import Testing
+
+/// #636 — the §3.4 design hinge: shaping contact names so a lone common word
+/// never becomes a single-token canonical (which `WordCorrector` would rewrite
+/// unconditionally on its exact pass).
+@Suite("ContactNameShaper — import shaping (#636)")
+struct ContactNameShaperTests {
+  private func canonicals(_ candidates: [CandidateName]) -> [String] {
+    ContactNameShaper.shape(candidates).map(\.canonical)
+  }
+
+  private func contact(_ given: String, _ family: String, id: String = "id") -> CandidateName {
+    CandidateName(contactID: id, given: given, family: family)
+  }
+
+  @Test("Distinctive full name yields the full canonical plus both lone tokens")
+  func distinctiveFullName() {
+    let out = canonicals([contact("Rajesh", "Ramachandran")])
+    #expect(out.contains("Rajesh Ramachandran"))
+    #expect(out.contains("Rajesh"))
+    #expect(out.contains("Ramachandran"))
+  }
+
+  // matcher-set-adversarial-tests: the common-word first name "Will" must NEVER
+  // become a lone single-token canonical — that would capitalize the spoken
+  // verb "will" on every dictation via the corrector's exact pass.
+  @Test("Common-word first name kept only in the full name, never as a lone token")
+  func commonWordFirstNameNotLone() {
+    let out = canonicals([contact("Will", "Vasquez")])
+    #expect(out.contains("Will Vasquez"))  // full phrase is safe (multi-word)
+    #expect(out.contains("Vasquez"))  // distinctive surname lone is fine
+    #expect(!out.contains("Will"))  // lone common word is NEVER imported
+  }
+
+  @Test("Common-word surname also excluded as a lone token")
+  func commonWordSurnameNotLone() {
+    // "cook" is an occupational common word in the stoplist.
+    let out = canonicals([contact("Aisha", "Cook")])
+    #expect(out.contains("Aisha Cook"))
+    #expect(out.contains("Aisha"))
+    #expect(!out.contains("Cook"))
+  }
+
+  @Test("Single-field contact whose only name is a common word yields nothing")
+  func loneCommonWordOnlyProducesNothing() {
+    #expect(canonicals([contact("May", "")]).isEmpty)
+    #expect(canonicals([contact("", "Rose")]).isEmpty)
+  }
+
+  @Test("Distinctive single-field contact yields just that token")
+  func distinctiveSingleField() {
+    #expect(canonicals([contact("", "Vasquez")]) == ["Vasquez"])
+    #expect(canonicals([contact("Ramachandran", "")]) == ["Ramachandran"])
+  }
+
+  @Test("Names containing digits are treated as junk")
+  func digitsAreJunk() {
+    // Family field is a phone fragment → dropped; distinctive given kept.
+    #expect(canonicals([contact("Spam", "555-1234")]) == ["Spam"])
+    // Given field has a digit → not name-like → contact yields nothing.
+    #expect(canonicals([contact("Line 2", "")]).isEmpty)
+  }
+
+  @Test("Single-letter initials are not captured as lone tokens")
+  func initialsNotLone() {
+    let out = canonicals([contact("J", "Okafor")])
+    #expect(out.contains("J Okafor"))
+    #expect(out.contains("Okafor"))
+    #expect(!out.contains("J"))
+  }
+
+  @Test("Two-character distinctive surname is kept")
+  func shortDistinctiveSurnameKept() {
+    #expect(canonicals([contact("", "Ng")]) == ["Ng"])
+  }
+
+  @Test("Identical given and family dedupe within one contact")
+  func intraContactDedupe() {
+    let out = canonicals([contact("Aaron", "Aaron")])
+    #expect(out.contains("Aaron Aaron"))
+    #expect(out.filter { $0 == "Aaron" }.count == 1)
+  }
+
+  @Test("Both-empty contact yields nothing")
+  func bothEmpty() {
+    #expect(canonicals([contact("", "")]).isEmpty)
+  }
+
+  @Test("Per-contact provenance is preserved on every shaped term")
+  func provenancePreserved() {
+    let shaped = ContactNameShaper.shape([contact("Rajesh", "Ramachandran", id: "abc")])
+    #expect(!shaped.isEmpty)
+    #expect(shaped.allSatisfy { $0.contactID == "abc" })
+  }
+}

--- a/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
@@ -1,0 +1,191 @@
+import EnviousWisprContacts
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// Test double for the on-device contacts source. `@unchecked Sendable` is the
+/// established pattern for a test fixture (the coordinator calls it sequentially
+/// behind `await`, so the call counters never race).
+private final class FakeContactProvider: ContactNameProvider, @unchecked Sendable {
+  var status: ContactsAuthorization
+  var grantResult: Bool
+  var candidates: [CandidateName]
+  private(set) var fetchCount = 0
+  private(set) var requestCount = 0
+
+  init(
+    status: ContactsAuthorization, grant: Bool = true, candidates: [CandidateName] = []
+  ) {
+    self.status = status
+    self.grantResult = grant
+    self.candidates = candidates
+  }
+
+  func authorizationStatus() -> ContactsAuthorization { status }
+  func requestAccess() async -> Bool {
+    requestCount += 1
+    return grantResult
+  }
+  func fetchCandidateNames() async throws -> [CandidateName] {
+    fetchCount += 1
+    return candidates
+  }
+}
+
+@MainActor
+@Suite("ContactsImportCoordinator — orchestration (#636)")
+struct ContactsImportCoordinatorTests {
+  private static func tempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("EnviousWispr-test-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func make(
+    provider: FakeContactProvider
+  ) -> (ContactsImportCoordinator, ImportedContactsStateStore, CustomWordsCoordinator, URL) {
+    let dir = Self.tempDir()
+    let cwCoord = CustomWordsCoordinator(
+      manager: CustomWordsManager(fileURL: dir.appendingPathComponent("custom-words.json")))
+    let store = ImportedContactsStateStore(
+      fileURL: dir.appendingPathComponent("imported-contacts-state.json"))
+    let coord = ContactsImportCoordinator(
+      provider: provider, customWords: cwCoord, stateStore: store)
+    return (coord, store, cwCoord, dir)
+  }
+
+  private func cleanup(_ dir: URL) { try? FileManager.default.removeItem(at: dir) }
+
+  private func contact(_ given: String, _ family: String, id: String) -> CandidateName {
+    CandidateName(contactID: id, given: given, family: family)
+  }
+
+  @Test("Denied authorization sets .denied and writes nothing")
+  func deniedNoWrite() async {
+    let provider = FakeContactProvider(status: .denied)
+    let (coord, store, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    #expect(coord.phase == .denied)
+    #expect(provider.fetchCount == 0)
+    #expect(coord.pendingPreview == nil)
+    #expect(store.load().importedWordIDs.isEmpty)
+  }
+
+  @Test("notDetermined prompts; a refusal sets .denied")
+  func notDeterminedRefused() async {
+    let provider = FakeContactProvider(status: .notDetermined, grant: false)
+    let (coord, _, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    #expect(provider.requestCount == 1)
+    #expect(coord.phase == .denied)
+    #expect(provider.fetchCount == 0)
+  }
+
+  @Test("Authorized import stages a preview; confirm writes words + log")
+  func successFlow() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, store, cw, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    #expect(coord.pendingPreview?.newContactCount == 1)
+    coord.confirmImport()
+    #expect(coord.phase == .imported(count: 1))
+    #expect(store.load().importedContactIDs == ["c1"])
+    #expect(!store.load().importedWordIDs.isEmpty)
+    #expect(cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
+    #expect(coord.importedCount == 1)
+  }
+
+  @Test("Log-save failure after addBatch surfaces .failed, not a false .imported")
+  func logSaveFailureSurfaces() async {
+    let dir = Self.tempDir()
+    defer { cleanup(dir) }
+    // Good custom-words manager (addBatch succeeds) but a log store at an
+    // unwritable path so save() throws — the orphaned-words risk Codex flagged.
+    let cwCoord = CustomWordsCoordinator(
+      manager: CustomWordsManager(fileURL: dir.appendingPathComponent("custom-words.json")))
+    let badStore = ImportedContactsStateStore(
+      fileURL: URL(fileURLWithPath: "/dev/null/nope/imported-contacts-state.json"))
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let coord = ContactsImportCoordinator(
+      provider: provider, customWords: cwCoord, stateStore: badStore)
+    await coord.prepareImport()
+    coord.confirmImport()
+    if case .failed = coord.phase {
+    } else {
+      Issue.record("expected .failed when the import log cannot save, got \(coord.phase)")
+    }
+    #expect(coord.importedCount == 0)
+  }
+
+  @Test("Re-importing an already-imported contact previews zero new")
+  func reimportZeroNew() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, _, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.prepareImport()
+    #expect(coord.pendingPreview?.newContactCount == 0)
+    #expect(coord.pendingPreview?.alreadyPresentCount == 1)
+  }
+
+  @Test("prepareImport is ignored while a preview is already pending")
+  func reentrancyGuard() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, _, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    let fetchesAfterFirst = provider.fetchCount
+    await coord.prepareImport()  // pendingPreview != nil → guarded
+    #expect(provider.fetchCount == fetchesAfterFirst)
+  }
+
+  @Test("bulkRemoveImported removes the imported words and clears the log")
+  func bulkRemove() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, store, cw, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    #expect(coord.importedCount == 1)
+    coord.bulkRemoveImported()
+    #expect(coord.importedCount == 0)
+    #expect(store.load().importedWordIDs.isEmpty)
+    #expect(!cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
+  }
+
+  @Test("syncNewContacts no-ops when not authorized (fetch never called)")
+  func syncGateNotAuthorized() async {
+    let provider = FakeContactProvider(status: .notDetermined)
+    let (coord, store, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.syncNewContacts()
+    #expect(provider.fetchCount == 0)
+    #expect(store.load().importedWordIDs.isEmpty)
+  }
+
+  @Test("syncNewContacts is add-only: second run with the same contacts adds nothing")
+  func syncAddOnly() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, store, _, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    await coord.syncNewContacts()
+    #expect(store.load().importedContactIDs == ["c1"])
+    let countAfterFirst = store.load().importedWordIDs.count
+    await coord.syncNewContacts()
+    #expect(store.load().importedWordIDs.count == countAfterFirst)
+  }
+}

--- a/Tests/EnviousWisprTests/Contacts/ImportedContactsStateStoreTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ImportedContactsStateStoreTests.swift
@@ -1,0 +1,73 @@
+import EnviousWisprContacts
+import Foundation
+import Testing
+
+/// #636 — the import log: opaque IDs only, absent-file → empty, union semantics.
+@Suite("ImportedContactsStateStore — import log (#636)")
+struct ImportedContactsStateStoreTests {
+  private static func tempURL() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("EnviousWispr-test-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("imported-contacts-state.json")
+  }
+
+  private static func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+  }
+
+  @Test("Absent file loads as empty state")
+  func absentFileIsEmpty() {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let state = ImportedContactsStateStore(fileURL: url).load()
+    #expect(state.importedContactIDs.isEmpty)
+    #expect(state.importedWordIDs.isEmpty)
+    #expect(state.lastImportedAt == nil)
+  }
+
+  @Test("Save then load round-trips the IDs and timestamp")
+  func roundTrip() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let store = ImportedContactsStateStore(fileURL: url)
+    let w1 = UUID()
+    let w2 = UUID()
+    var state = ImportedContactsState.empty
+    state.record(
+      contactIDs: ["c1", "c2"], wordIDs: [w1, w2], at: Date(timeIntervalSince1970: 1000))
+    try store.save(state)
+
+    let reloaded = ImportedContactsStateStore(fileURL: url).load()
+    #expect(reloaded.importedContactIDs == ["c1", "c2"])
+    #expect(reloaded.importedWordIDs == [w1, w2])
+    #expect(reloaded.lastImportedAt == Date(timeIntervalSince1970: 1000))
+  }
+
+  @Test("record() unions new IDs without duplicating, preserving order")
+  func recordDedupes() {
+    let w1 = UUID()
+    let w2 = UUID()
+    let w3 = UUID()
+    var state = ImportedContactsState.empty
+    state.record(contactIDs: ["c1"], wordIDs: [w1, w2], at: Date(timeIntervalSince1970: 1))
+    state.record(contactIDs: ["c1", "c2"], wordIDs: [w2, w3], at: Date(timeIntervalSince1970: 2))
+    #expect(state.importedContactIDs == ["c1", "c2"])
+    #expect(state.importedWordIDs == [w1, w2, w3])
+    #expect(state.lastImportedAt == Date(timeIntervalSince1970: 2))
+  }
+
+  @Test("Saving .empty clears prior IDs (the bulk-remove reset)")
+  func saveEmptyClears() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let store = ImportedContactsStateStore(fileURL: url)
+    var state = ImportedContactsState.empty
+    state.record(contactIDs: ["c1"], wordIDs: [UUID()], at: Date(timeIntervalSince1970: 5))
+    try store.save(state)
+    try store.save(.empty)
+    let reloaded = store.load()
+    #expect(reloaded.importedContactIDs.isEmpty)
+    #expect(reloaded.importedWordIDs.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Contacts/ImportedVocabularyPriorityTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ImportedVocabularyPriorityTests.swift
@@ -1,0 +1,36 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import Testing
+
+/// #636 §3.5 — imported names carry a priority that sorts AFTER user-typed terms
+/// in the 50-term polish cap, so a large import never crowds out hand-typed
+/// vocabulary.
+@Suite("Imported vocabulary priority (#636 §3.5)")
+struct ImportedVocabularyPriorityTests {
+  private func userTerm(_ i: Int) -> CustomWord {
+    CustomWord(canonical: "UserTerm\(String(format: "%03d", i))", priority: 0)
+  }
+  private func importedName(_ i: Int) -> CustomWord {
+    CustomWord(
+      canonical: "ImportedName\(String(format: "%03d", i))", category: .person, priority: 10)
+  }
+
+  @Test("49 user terms + many imported: all user terms reach the polish prompt")
+  func userTermsKeepTheirSlots() {
+    var words = (0..<49).map(userTerm)
+    words += (0..<100).map(importedName)
+    let rendered = CustomVocabularyFormatter.render(words) ?? ""
+    for i in 0..<49 {
+      #expect(rendered.contains("UserTerm\(String(format: "%03d", i))"))
+    }
+  }
+
+  @Test("51 user terms fill all 50 slots; no imported name reaches the prompt")
+  func userTermsCrowdOutImported() {
+    var words = (0..<51).map(userTerm)
+    words.append(
+      CustomWord(canonical: "ImportedNameZZZ", category: .person, priority: 10))
+    let rendered = CustomVocabularyFormatter.render(words) ?? ""
+    #expect(!rendered.contains("ImportedNameZZZ"))
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
@@ -1,0 +1,48 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+import Testing
+
+/// #636 §3a — corrector latency at import scale. The per-dictation cost is
+/// `WordCorrector.correct(using:)` over a prebuilt `Lookups`; the live ceiling
+/// is the 3-second whole-step Word-Correction timeout (`WordCorrectionStep`).
+/// This reports per (vocab-size) bucket and asserts a generous floor well under
+/// that cap — the printed numbers are the signal; the assert is a regression
+/// backstop, not a tight bound (timeout-numbers-need-distribution-evidence).
+@Suite("Corrector latency at import scale (#636 §3a)")
+struct ContactsImportCorrectorBenchmark {
+  /// Worst case for the fuzzy passes: distinctive single-token person canonicals
+  /// (each becomes an exact self-entry AND a single-token fuzzy candidate).
+  private func personVocab(_ n: Int) -> [CustomWord] {
+    (0..<n).map {
+      CustomWord(canonical: "Surnamenum\($0)", category: .person, priority: 10)
+    }
+  }
+
+  @Test("Per-dictation correct(using:) stays well under the 3s step cap at +2000 terms")
+  func latencyAtScale() {
+    let sentence = "loop in Surnamenum1500 on the SSO thread before standup with the team"
+    let sizes = [0, 500, 1000, 2000]
+    let iterations = 8
+    var maxPerCallMs = 0.0
+
+    for size in sizes {
+      let lookups = WordCorrector.buildLookups(words: personVocab(size))
+      _ = WordCorrector().correct(sentence, using: lookups)  // warm
+      let start = Date()
+      for _ in 0..<iterations {
+        _ = WordCorrector().correct(sentence, using: lookups)
+      }
+      let perCallMs = Date().timeIntervalSince(start) / Double(iterations) * 1000.0
+      maxPerCallMs = max(maxPerCallMs, perCallMs)
+      print(
+        String(
+          format: "[#636 corrector-latency] +%4d person terms: %.3f ms/dictation", size, perCallMs))
+    }
+
+    // Step cap is 3000 ms; a regression would have to be ~3x before the user
+    // ever sees a graceful skip. 1500 ms floor is a catastrophic-regression
+    // backstop, not a measured bound.
+    #expect(maxPerCallMs < 1500.0)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBatchTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBatchTests.swift
@@ -1,0 +1,110 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #636 — `addBatch` / `removeBatch`: single-save bulk ops mirroring the
+/// per-word `add(word:)` / `remove(id:)` semantics.
+@MainActor
+@Suite("CustomWordsManager — addBatch / removeBatch (#636)")
+struct CustomWordsBatchTests {
+  private static func tempManager() -> (CustomWordsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("EnviousWispr-test-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsManager(fileURL: url), url)
+  }
+
+  private static func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+  }
+
+  private func person(_ canonical: String) -> CustomWord {
+    CustomWord(canonical: canonical, category: .person, priority: 10)
+  }
+
+  @Test("All-new batch creates every word and returns their IDs in input order")
+  func allNew() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let a = person("Ramachandran Test")
+    let b = person("Vasquez Test")
+    let ids = try mgr.addBatch([a, b], to: &words)
+    #expect(ids == [a.id, b.id])
+    #expect(words.contains { $0.canonical == "Ramachandran Test" })
+    #expect(words.contains { $0.canonical == "Vasquez Test" })
+  }
+
+  @Test("Case-insensitive duplicates are skipped; only new IDs returned")
+  func skipsDuplicates() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let first = person("Okafor Test")
+    _ = try mgr.addBatch([first], to: &words)
+
+    let dup = person("okafor test")  // case-insensitive duplicate of existing
+    let fresh = person("Nakamura Test")
+    let ids = try mgr.addBatch([dup, fresh], to: &words)
+    #expect(ids == [fresh.id])
+    #expect(words.filter { $0.canonical.lowercased() == "okafor test" }.count == 1)
+  }
+
+  @Test("Duplicates within the same batch collapse to one")
+  func intraBatchDedupe() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let one = person("Same Person")
+    let two = person("same person")
+    let ids = try mgr.addBatch([one, two], to: &words)
+    #expect(ids == [one.id])
+  }
+
+  @Test("Empty / blank-canonical input is a no-op")
+  func emptyAndBlank() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let before = words.count
+    #expect(try mgr.addBatch([], to: &words).isEmpty)
+    #expect(try mgr.addBatch([person("   ")], to: &words).isEmpty)
+    #expect(words.count == before)
+  }
+
+  @Test("Batch additions persist across a reload")
+  func persistsAcrossReload() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    _ = try mgr.addBatch([person("Persisted Person")], to: &words)
+    let reloaded = CustomWordsManager(fileURL: url).load() ?? []
+    #expect(reloaded.contains { $0.canonical == "Persisted Person" })
+  }
+
+  @Test("removeBatch removes exactly the given IDs and leaves the rest")
+  func removeBatchExact() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let a = person("Remove One")
+    let b = person("Keep Two")
+    _ = try mgr.addBatch([a, b], to: &words)
+    try mgr.removeBatch(ids: [a.id], from: &words)
+    #expect(!words.contains { $0.id == a.id })
+    #expect(words.contains { $0.id == b.id })
+  }
+
+  @Test("removeBatch with empty IDs is a no-op")
+  func removeBatchEmpty() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let before = words.count
+    try mgr.removeBatch(ids: [], from: &words)
+    #expect(words.count == before)
+  }
+}

--- a/scripts/check-contacts-data-flow.sh
+++ b/scripts/check-contacts-data-flow.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# check-contacts-data-flow.sh — release-blocking privacy guard for #636.
+#
+# Contact names (a `CandidateName`'s given/family and the canonical they shape
+# into) are on-device only. Inside the contacts-touching code they must NEVER
+# reach a telemetry / crash-report / log / support-bundle SINK. Once a contact
+# name has become an ordinary `CustomWord` it rides the shared vocabulary path
+# (corrector = on-device; cloud polish = founder-accepted, plan §3.5) — that is
+# the one accepted exception, and it lives OUTSIDE the files scanned here.
+#
+# Two-tier sink rule (so a hard sink can never hide on the same line as the one
+# allowed call):
+#   - HARD sinks (log / crash / export): ANY occurrence in a scanned file fails.
+#   - TELEMETRY sinks (PostHog / TelemetryService): allowed ONLY on a line that
+#     also invokes `contactsImported(` (the integer count + trigger event; never
+#     a name). Any other telemetry call fails.
+#
+# Scans the contacts product files AND the contacts test directory (the plan's
+# "test fixtures" sink surface). Mirrors `check-dependency-direction.sh`: a
+# tracked structural guard run by the local push gate. Run from the package root.
+# Bash-3.2 compatible (macOS system /bin/bash).
+set -euo pipefail
+
+# Files / dirs where contact-specific data flows before it becomes a plain CustomWord.
+CONTACT_PATHS=(
+  "Sources/EnviousWisprContacts"
+  "Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift"
+  "Sources/EnviousWisprAppKit/Views/Settings/ContactsImportConfirm.swift"
+  "Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift"
+  "Tests/EnviousWisprTests/Contacts"
+)
+
+HARD_SINK='SentrySDK|SentryBreadcrumb|addBreadcrumb|setContext|setTag|beforeSend|AppLogger|os_log|OSLog|Logger\(|NSLog|captureMessage|captureError|print\(|debugPrint|SupportBundle|DiagnosticsExport|exportLogs'
+TELEMETRY_SINK='TelemetryService|PostHogSDK'
+ALLOW='contactsImported\('
+
+violations=0
+scanned=0
+
+flag() {
+  echo "CONTACTS-LEAK: $1"
+  violations=$((violations + 1))
+}
+
+# Strip a `file:lineno:` grep prefix, then drop line/block comments.
+code_of() {
+  printf '%s' "$1" | cut -d: -f3- | sed -E 's|//.*$||; s|/\*.*$||'
+}
+
+for path in "${CONTACT_PATHS[@]}"; do
+  [ -e "$path" ] || continue
+  scanned=$((scanned + 1))
+
+  # Tier 1 — hard sinks: any non-comment occurrence fails.
+  while IFS= read -r hit; do
+    code=$(code_of "$hit")
+    [ -z "${code// /}" ] && continue
+    printf '%s' "$code" | grep -qE "$HARD_SINK" && flag "$hit"
+  done < <(grep -rEn "$HARD_SINK" "$path" --include='*.swift' 2>/dev/null || true)
+
+  # Tier 2 — telemetry sinks: fail unless the line is the allowed count event.
+  while IFS= read -r hit; do
+    code=$(code_of "$hit")
+    [ -z "${code// /}" ] && continue
+    printf '%s' "$code" | grep -qE "$TELEMETRY_SINK" || continue  # token was comment-only
+    printf '%s' "$code" | grep -qE "$ALLOW" && continue  # allowed integer-count event
+    flag "$hit"
+  done < <(grep -rEn "$TELEMETRY_SINK" "$path" --include='*.swift' 2>/dev/null || true)
+done
+
+if [ "$scanned" -eq 0 ]; then
+  echo "OK: no contacts-touching files present (nothing to check)."
+  exit 0
+fi
+
+if [ "$violations" -gt 0 ]; then
+  echo "FAIL: $violations potential contact-data leak(s) into a telemetry/log/crash/export sink." >&2
+  echo "Contact names are on-device only (#636). Route only integer counts via contactsImported(count:trigger:)." >&2
+  exit 1
+fi
+echo "OK: no contact-data leak into any sink across $scanned contacts-touching path(s)."

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -6,7 +6,7 @@
 # Edit `permitted_imports_for` below when Package.swift changes (and update the
 # Bible if the new edge represents an architectural decision):
 #   EnviousWispr           -> AppKit (thin launchable shell; #919). Imports ONLY the kit.
-#   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline (app-shell library; #919, top of stack)
+#   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprAudioService -> Core, Audio (XPC executable)
 #   EnviousWisprASRService -> Core, ASR, Audio (XPC executable)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
@@ -15,6 +15,7 @@
 #   EnviousWisprLLM        -> Core
 #   EnviousWisprAudio      -> Core
 #   EnviousWisprPostProcessing -> Core
+#   EnviousWisprContacts   -> Core (Contacts-framework shim; #636, App-layer-scoped leaf)
 #   EnviousWisprStorage    -> Core
 #   EnviousWisprCore       -> (no app deps)
 #
@@ -30,13 +31,14 @@ permitted_imports_for() {
     EnviousWisprAudio)             echo "EnviousWisprCore" ;;
     EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio" ;;
     EnviousWisprPostProcessing)    echo "EnviousWisprCore" ;;
+    EnviousWisprContacts)          echo "EnviousWisprCore" ;;
     EnviousWisprStorage)           echo "EnviousWisprCore" ;;
     EnviousWisprLLM)               echo "EnviousWisprCore" ;;
     EnviousWisprServices)          echo "EnviousWisprCore" ;;
     EnviousWisprPipeline)          echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprLLM EnviousWisprPostProcessing EnviousWisprServices EnviousWisprStorage" ;;
     EnviousWisprAudioService)      echo "EnviousWisprCore EnviousWisprAudio" ;;
     EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio" ;;
-    EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprPipeline" ;;
+    EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprPipeline EnviousWisprContacts" ;;
     EnviousWispr)                  echo "EnviousWisprAppKit" ;;
     *)                             return 1 ;;
   esac


### PR DESCRIPTION
## Import from Contacts (#636)

Closes #636. Custom Words v2, Phase 6. Plan: `docs/feature-requests/issue-636-2026-06-06-import-from-contacts.md` (grounded-review clean, round 3; §17 records build deltas).

### What users get
One tap on **Import from Contacts** in Your Words reads the names of people they know (on-device), shows an honest count behind a clear disclaimer ("EnviousWispr never uploads your address book"), adds them to the custom-word list, and shows a green check plus an **"N imported ✕"** pill that bulk-removes just the import-created entries. An opt-in **"Keep in sync on launch"** toggle (default OFF) re-reads at launch and adds any new contacts, add-only.

So when they dictate a coworker's hard-to-spell name, it comes out right the first time. This directly attacks the #1 user-reported friction: adding custom words by hand felt cumbersome.

### How it's built
- New leaf module `EnviousWisprContacts`: a read-only `CNContactStore` shim, a pure name **shaper**, and the import-log store. Deps Core only.
- App-layer `ContactsImportCoordinator` (injected via `WisprBootstrapper`), orchestrating permission → fetch → dedupe → confirm → batch-add → log.
- `CustomWordsManager.addBatch` / `removeBatch`: single-save bulk ops (no O(n) per-word rewrites at import scale).
- `contactsSyncOnLaunchEnabled` setting (default off); unawaited launch-sync `Task`.
- `NSContactsUsageDescription` added; no entitlement (non-sandboxed hardened runtime).

### Privacy
- Names are read on-device. Imported names join the **existing** custom-words lanes: the corrector (on-device) and, for cloud-polish users, the polish prompt — the same accepted path the rest of their dictated text already takes (deprioritized so hand-typed terms keep their 50 slots).
- Tracked release-blocking hook `scripts/check-contacts-data-flow.sh` fails the push if a contact field reaches any telemetry / crash / log / export sink. Adversarially tested.
- Telemetry emits an integer `contacts_imported` count + trigger only, never a name.

### The name-corruption trap (why shaping matters)
A lone single-token canonical becomes an exact self-entry in `WordCorrector` and would rewrite the spoken word every time (dictating the verb "will" → "Will"). So each contact contributes the full "First Last" phrase (multi-word, safe) plus distinctive lone tokens, with common-word first/last names skipped via a bundled stoplist. Adversarial test included ("Will Vasquez" keeps "Will Vasquez" and "Vasquez", never lone "Will").

### Validation
- `scripts/xcode-test.sh` green: 1597 + 87 tests pass, including 33 new contacts tests and the updated #763 architecture-ceiling allowlists.
- Release-config build green.
- Leak hook green (and proven to fire on an injected leak).
- Codex code-diff review clean.
- Corrector-latency benchmark per (vocab-size) bucket.

### Heads-up: corrector latency at heavy-import scale
Per-dictation `correct(using:)` scales ~0.19 ms/term: +500 ≈ 99 ms, +1000 ≈ 188 ms, +2000 ≈ 376 ms. All comfortably under the 3 s Word-Correction step cap (so no graceful-skip fires), but a user who imports 2000+ distinctive surnames adds ~376 ms to every dictation. Within budget; the prune-imported contingency (plan §3a) is ready if real users report latency after large imports.

Tier LARGE. Heart path untouched (feature is a limb, off by default).