### PR TITLE
docs(blog): four feature posts on a daily auto-publish schedule

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches: [main]
     paths: ['website/**']
-  # schedule removed — re-enable when new scheduled blog posts are queued
-  # - cron: '7 14 * * *'
+  schedule:
+    # Daily rebuild at 14:07 UTC (~10:07 America/New_York) so future-dated blog
+    # posts go live on their pubDate without a push. The build recomputes
+    # "today" in Eastern (see website/src/utils/posts.ts isPublishedPost), so a
+    # post dated for today becomes visible on the first run on/after that date.
+    # Runs well after midnight ET in both EST and EDT, so posts always publish
+    # on the correct calendar day. Safe to leave on year-round (a day with no
+    # newly-due post just redeploys identical output).
+    - cron: '7 14 * * *'
   workflow_dispatch: # Manual trigger
 
 concurrency:

--- a/website/src/content/blog/dictate-in-a-whisper-soft-speech.md
+++ b/website/src/content/blog/dictate-in-a-whisper-soft-speech.md
@@ -1,0 +1,78 @@
+---
+title: "Dictate in a Whisper: Capturing Soft and Quiet Speech"
+description: "EnviousWispr now reliably captures quiet, whispered, and far-from-the-mic speech, including the soft first word that used to get clipped. Dictate at midnight or in an open office without raising your voice."
+pubDate: 2026-06-07
+tags: ["dictation", "macos", "privacy", "accessibility"]
+draft: false
+author: "Saurabh Vaish"
+keywords:
+  - "whisper dictation mac"
+  - "quiet dictation"
+  - "dictate without disturbing others"
+  - "dictate at night"
+  - "soft speech voice to text"
+faqs:
+  - question: "Can I dictate in a whisper with EnviousWispr?"
+    answer: "Yes. EnviousWispr is built to capture quiet and whispered speech, including soft words at the very start of a sentence that used to get dropped. You can speak in a low voice at night or in a shared office and still get an accurate transcript. It runs on-device on Apple Silicon, so your audio never leaves your Mac."
+  - question: "Why did my first word sometimes get cut off before?"
+    answer: "Voice detection trims silence so the transcription engine only hears speech. If your first word was very soft, the old behavior sometimes mistook it for silence and trimmed it away. EnviousWispr now recognizes when a real but quiet opening word is about to be discarded and keeps it, so a soft 'Actually' or 'Overall' stays in your text."
+  - question: "Do I need to change a setting to capture quiet speech?"
+    answer: "No. This is the default behavior for everyone. There is no whisper mode to turn on and no sensitivity slider to tune. The app handles soft and far-away speech automatically."
+  - question: "Is whispered dictation private?"
+    answer: "Yes. EnviousWispr captures audio, detects speech, and transcribes entirely on your Mac. Nothing is sent to a server, so whispering at midnight stays between you and your keyboard."
+---
+
+You learn a specific kind of quiet when other people are around. The near-whisper next to a sleeping partner. The low murmur at a shared desk when you do not want the person across from you to hear your half-formed draft. The careful voice in a quiet train car.
+
+Dictation is supposed to help in exactly those moments, and for a long time it did the opposite. You would lower your voice, and the words would simply not show up. So you either spoke louder than felt comfortable or gave up and went back to typing.
+
+EnviousWispr now captures that quiet speech. You can whisper, speak softly, or sit back from your mic, and the words still land.
+
+## Why quiet speech used to disappear
+
+Before any words reach the transcription engine, the app has to answer one question many times a second: is this sound speech, or is it silence? That step matters. It trims the dead air so the engine only works on the parts where you are actually talking, which keeps things fast and keeps stray room noise out of your text.
+
+The trouble is that a whisper sits much closer to silence than a normal speaking voice does. When the bar for "this is speech" was set for ordinary talking, a soft voice fell underneath it. The app heard you, decided it was probably just quiet room noise, and trimmed it away. You got a short transcript, or nothing at all.
+
+The most frustrating version of this was the clipped first word. You would start a sentence with a soft lead-in, "Actually, we should," and the opening word arrived a beat before you were fully up to volume. The detector treated that soft start as silence to trim, and your sentence began in the wrong place.
+
+## What changed
+
+Two things, both working underneath without anything for you to configure.
+
+First, the app is better at recognizing soft speech as speech. The detection that decides what to keep no longer assumes you are talking at a normal volume, so faint and far-away words make it through instead of being thrown out as noise.
+
+Second, there is a safeguard for that soft opening word. When the app is about to trim what looks like silence from the very start of a recording, it checks whether it is actually about to discard a real, quiet word. If it is, it keeps it. A gentle "Overall" or "Actually" at the top of a thought stays where you said it.
+
+Together, that means the things that used to vanish (a whispered sentence, a soft start, a word spoken while you leaned back in your chair) now stay in your transcript.
+
+## Nothing to turn on
+
+This is worth saying plainly: there is no whisper mode and no sensitivity dial to find. We deliberately did not add one. A slider that asks you to guess the right setting for your room is a setting that is usually wrong, and we would rather the app just handle it.
+
+So the answer to "how do I turn on quiet capture" is simple: you do not. Hold your hotkey, speak as softly as the room asks for, and release.
+
+## Where this helps
+
+- **Late at night, with people asleep.** Draft the email or the message in a near-whisper without waking anyone.
+- **In a shared office or open plan.** Keep your voice down so your neighbor is not pulled into your train of thought, and still get clean text.
+- **On a quiet train or in a waiting room.** Speak at the volume the space expects rather than the volume the software used to demand.
+- **When you simply do not feel like projecting.** Some days you do not want to talk loudly. Now you do not have to.
+
+Because all of this runs [on-device on your Mac](/how-it-works/), the quiet stays quiet in the other sense too. Your audio is captured, analyzed, and transcribed locally. Whispering at midnight does not send anything to a server.
+
+## A note on honesty
+
+We will be candid: this is the kind of improvement that should have been the behavior all along, and for a while it was not. Quiet speech getting dropped was a real gap, and the fix was less about adding a feature and more about the app finally hearing you the way you expected it to. If you tried dictating softly in the past and it let you down, it is worth another try.
+
+## What changes for you
+
+Nothing in the steps. Hold the hotkey, speak, release, and the polished text lands in your clipboard or pastes where you are working. What changed is the volume floor. The soft, the distant, and the whispered now make it in.
+
+## Related posts
+
+- [How EnviousWispr works, end to end](/how-it-works/). Where your audio goes, and why it never leaves your Mac.
+- [Why Mac dictation keeps stopping, and how to fix it](/blog/mac-dictation-keeps-stopping/). The other reason dictation cuts out, and what to do about it.
+- [macOS dictation that works offline and stays private](/blog/macos-dictation-offline-private/). The fully-local setup.
+
+If you have not tried it yet, [download EnviousWispr free](/#download). Then turn your voice down as far as the room asks, and see what stays.

--- a/website/src/content/blog/speak-emoji-dictation.md
+++ b/website/src/content/blog/speak-emoji-dictation.md
@@ -1,0 +1,81 @@
+---
+title: "Say 'Fire Emoji,' Get 🔥: Speaking Emoji in Your Dictation"
+description: "Say 'thumbs up emoji' in EnviousWispr and you get 👍. It is on by default, covers more than 1,500 emoji by name, runs on your Mac, and never converts a bare word by accident."
+pubDate: 2026-06-10
+tags: ["dictation", "macos", "productivity"]
+draft: false
+author: "Saurabh Vaish"
+keywords:
+  - "dictate emoji mac"
+  - "speak emoji voice to text"
+  - "say emoji name"
+  - "voice dictation emoji"
+faqs:
+  - question: "How do I dictate an emoji?"
+    answer: "Say the emoji's name followed by the word 'emoji'. Say 'thumbs up emoji' and you get 👍, or 'fire emoji' and you get 🔥. The trailing word 'emoji' (or 'emoticon') is what tells the app you want the glyph rather than the words. The feature is on by default, so there is nothing to set up first."
+  - question: "Will it turn normal words into emoji by mistake?"
+    answer: "No. A bare word never converts. 'I got fired today' stays as text because there is no 'emoji' cue after it. Only the explicit 'name plus emoji' pattern triggers a conversion, which keeps your ordinary writing safe."
+  - question: "How many emoji does it know?"
+    answer: "More than 1,500, drawn from the standard Unicode short names, plus a set of hand-picked everyday synonyms like 'happy face'. If two names are too close to call, it leaves the text alone rather than guessing."
+  - question: "Does this need AI polish or an internet connection?"
+    answer: "Neither. Spoken emoji is a rule-based step that runs entirely on your Mac, before any AI polish, and works offline. It is on by default, and you can turn it off in settings if you would rather not have it."
+---
+
+Some messages want an emoji. A thumbs up on the plan, a fire on the launch, a soft smile on the note to a friend. When you are dictating, reaching for the emoji picker breaks the exact flow you were trying to keep.
+
+EnviousWispr lets you just say it. Say "thumbs up emoji," and you get 👍. The glyph lands inline, in the right spot, and your hands never leave what they were doing.
+
+## How it works
+
+You say the emoji's name, then the word "emoji." That trailing word is the trick: it signals that you want the picture, not the words.
+
+- "thumbs up emoji" becomes 👍
+- "send a fire emoji" becomes "send a 🔥"
+- "rocket emoji we shipped it" becomes "🚀 we shipped it"
+- "happy face emoji thanks for picking up the kids" becomes "🙂 thanks for picking up the kids"
+
+The word "emoticon" works as the cue too, if that is how you think of them. And the app is forgiving about the little stumbles dictation introduces, so "thumbs up, emoji" with a stray comma still gives you 👍.
+
+## The part we care about most: it leaves your words alone
+
+The obvious risk with a feature like this is that it gets greedy. You write "I got fired today" and suddenly there is a flame in your sentence. That specific failure would make the feature not worth having.
+
+So the rule is strict and simple: a bare word never converts. Without the "emoji" cue right after it, "fire" is just the word fire, "heart" is just the word heart, "rocket" is just the word rocket. The conversion only happens when you explicitly ask for it by saying the name and then "emoji."
+
+There is one more guard. If you are clearly talking about emoji rather than using one, the app stays out of the way. Say "the fire emoji feature is great" or "the red heart emoji category is confusing" and it recognizes you are discussing the thing, not requesting it, and leaves your sentence intact.
+
+## More than 1,500 by name
+
+The vocabulary comes from the standard Unicode list of emoji short names, so the coverage is broad: faces, hands, animals, food, weather, symbols, flags. On top of that we added a set of everyday spoken synonyms for the ones people reach for most, so "happy face" works as well as the official name.
+
+It also tolerates a mishearing or two. If dictation renders something slightly off, the app can still recognize a close match by sound, so a slightly garbled "sad face emoji" can still land 😢. When two names are genuinely too close to tell apart, it declines rather than guessing, because a wrong emoji is worse than none.
+
+## On your Mac, before the AI step
+
+Spoken emoji is a rule-based step that runs entirely on your Mac. It does not need AI polish turned on, it does not call out to any server, and it works offline. Because it runs before any polishing, the glyph is already in place by the time the rest of the pipeline sees your text.
+
+That also means it is fast and predictable. There is no model interpreting your intent and occasionally surprising you. You said a name and the word "emoji," so you get that emoji.
+
+## It is already on
+
+Spoken emoji is on by default, and it is safe to be. Because it only fires on the explicit "name plus emoji" cue and never guesses based on the mood of your sentence, it will not put surprise glyphs in your writing. You simply have the capability when you want it.
+
+If you would rather not have it, you can turn it off. Open EnviousWispr's settings, find the speech engine options, and switch off the setting described as converting spoken emoji, the one with the "thumbs up emoji → 👍" example next to it. With it on, the cue works in any app you dictate into.
+
+## Where it fits
+
+- **Quick replies with a human touch.** A 👍 or a 🙂 without opening a picker.
+- **Team chat while your hands are busy.** Say the reaction as part of the sentence.
+- **Notes to family.** The little warmth that a plain sentence sometimes misses.
+
+## What changes for you
+
+When you want an emoji, you say it, and it appears where you said it. When you do not, nothing changes, because a bare word is left exactly as you spoke it.
+
+## Related posts
+
+- [How EnviousWispr works, end to end](/how-it-works/). The on-device pipeline that runs this step.
+- [Say it, get it formatted: dates, numbers, emails, and more](/blog/spoken-text-formatting-dates-numbers-emails/). The other on-device formatting that happens before polish.
+- [Getting started with EnviousWispr in under 2 minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
+
+Want to try it? [Download EnviousWispr free](/#download), then say "rocket emoji."

--- a/website/src/content/blog/spoken-text-formatting-dates-numbers-emails.md
+++ b/website/src/content/blog/spoken-text-formatting-dates-numbers-emails.md
@@ -1,0 +1,124 @@
+---
+title: "Say It, Get It Formatted: Dates, Numbers, Emails, and More"
+description: "EnviousWispr formats spoken numbers, dates, times, money, percentages, phone numbers, emails, and web addresses into the way you would actually type them. It runs on your Mac, before any AI step, on every dictation."
+pubDate: 2026-06-08
+tags: ["dictation", "macos", "productivity", "ai-polish"]
+draft: false
+author: "Saurabh Vaish"
+keywords:
+  - "voice to text formatting"
+  - "dictate numbers and dates"
+  - "dictate email address"
+  - "dictate phone number"
+  - "spoken numbers to digits"
+faqs:
+  - question: "Does EnviousWispr turn spoken numbers into digits?"
+    answer: "Yes. Say 'seventy eight thousand five hundred forty seven' and you get '78,547', with the thousands separator placed for you. The same applies to decimals, ordinals like 'seventy third' becoming '73rd', percentages, and currency such as 'fifty dollars and thirty cents' becoming '$50.30'."
+  - question: "Can I dictate an email address or a website?"
+    answer: "Yes. Say 'casey at proton dot me' and you get 'casey@proton.me'. Say 'stackoverflow dot io slash blog' and you get 'stackoverflow.io/blog'. The app recognizes the spoken 'at', 'dot', and 'slash' markers and assembles the address."
+  - question: "Do I need AI polish turned on for this?"
+    answer: "No. This formatting is a separate, on-device step that runs before AI polish on every dictation. It works whether polish is on or off, and whether you use on-device or cloud polish. There is no setting to enable; it is always on for English."
+  - question: "What if a number is ambiguous?"
+    answer: "When a phrase could mean more than one thing, the formatter leaves it alone rather than guessing wrong. Idiomatic times like 'quarter past five' stay as words, and a loose phrase like 'one twenty people' is left untouched so the AI step or your own edit can decide. The goal is to never corrupt your text."
+---
+
+You say "march fifteenth twenty twenty six," and what you usually get is exactly that: the words, spelled out, waiting for you to turn them into "March 15, 2026." Dictation handles the talking and leaves you the cleanup.
+
+EnviousWispr does the cleanup for you. When you speak a number, a date, a price, an email, or a web address, it writes it the way you would have typed it. This happens on your Mac, before any AI step, on every dictation, in English.
+
+Here is the full list of what it converts.
+
+## Numbers
+
+Spoken numbers become digits, with separators placed correctly.
+
+- "ninety four" becomes "94"
+- "seventy eight thousand five hundred forty seven" becomes "78,547"
+- "three point one four" becomes "3.14", and "thirty point six zero" keeps its trailing zero as "30.60"
+
+## Ordinals
+
+- "seventy third" becomes "73rd", with the correct ending (st, nd, rd, or th) chosen for you
+- Ordinal days inside dates are handled too, so "march fifteenth" becomes "March 15"
+
+## Dates
+
+- "march fifteenth twenty twenty six" becomes "March 15, 2026"
+- "january twenty eighth two thousand twenty one" becomes "January 28, 2021"
+- Spoken numeric dates work as well: "four slash six slash twenty twenty one" becomes "4/6/2021"
+
+## Years
+
+- "nineteen eighty seven" becomes "1987"
+- "twenty twenty six" becomes "2026"
+- Leading zeros are handled: "twenty oh six" becomes "2006"
+
+## Times
+
+- "ten thirty a m" becomes "10:30 AM"
+- "six fifty p m" becomes "6:50 PM"
+- "ten o'clock" becomes "10:00"
+
+Idiomatic times are left as you said them on purpose. "Quarter past five" and "half past three" stay in words, because writing them as "5:15" and "3:30" changes the register of how you were speaking.
+
+## Money
+
+- "six thousand two hundred thirty nine dollars" becomes "$6,239"
+- "fifty dollars and thirty cents" becomes "$50.30", always with two decimal places
+- Large amounts keep their magnitude word: "eighty million dollars" becomes "$80 million", not "$80,000,000"
+
+## Percentages
+
+- "twenty one percent" becomes "21%"
+- "nine percent" becomes "9%"
+
+## Phone numbers
+
+- "eight two four six one nine six one seven five" becomes "824-619-6175"
+- A spoken "oh" is treated as a zero, the way people actually read numbers aloud
+- It even handles a mix of already-spoken digits and number words in the same breath: "call me at 203 nine five four eight eight seven nine" becomes "call me at 203-954-8879"
+
+## Email addresses
+
+- "casey at proton dot me" becomes "casey@proton.me"
+- "riley at gmail dot com" becomes "riley@gmail.com"
+
+It only fires on the clear "name at domain dot something" shape, so an ordinary sentence like "meet me at noon" is never turned into an address by mistake.
+
+## Web addresses
+
+- "github dot io" becomes "github.io"
+- "stackoverflow dot io slash blog" becomes "stackoverflow.io/blog"
+- Spoken "w w w dot example dot com" becomes "www.example.com"
+
+## Spoken punctuation and breaks
+
+- "hello comma world period" becomes "hello, world."
+- "are you free question mark" becomes "are you free?"
+- "new paragraph" and "new line" insert the breaks for you
+
+## How it decides what to leave alone
+
+The most important rule in all of this is the one about restraint. An overly eager formatter is worse than none at all, because it quietly corrupts your words before you notice.
+
+So when a phrase is genuinely ambiguous, the app does nothing. "There were one twenty people there" stays exactly as spoken, because "one twenty" could be a count, a time, or a price, and guessing wrong would be worse than leaving it. The idiomatic times above stay in words for the same reason. The design goal is simple: plain prose comes through untouched.
+
+## Where this runs
+
+This is not the AI step. It is a separate, rule-based pass that runs entirely on your Mac, before any polishing, on every dictation in English. That has three practical consequences.
+
+It is fast, it is predictable, and it works even when you turn AI polish off. If you prefer fully [offline, on-device dictation](/blog/macos-dictation-offline-private/) with no polishing model at all, your "78,547" and "March 15, 2026" still come out formatted. And because it runs before polish, the AI step receives clean, formatted text to work with rather than a wall of spelled-out numbers.
+
+There is nothing to switch on. It is on by default for everyone.
+
+## What changes for you
+
+You stop doing the second pass. Numbers, dates, prices, and addresses arrive already typed the way you meant them. Your dictated text is closer to ready the moment it lands.
+
+## Related posts
+
+- [How EnviousWispr works, end to end](/how-it-works/). The on-device pipeline, step by step.
+- [Dictate emails at the speed of thought](/blog/dictate-emails-speed-of-thought/). Where formatted numbers and addresses earn their keep.
+- [On-device dictation and the small models that polish it](/blog/on-device-dictation-polishing-small-models/). What the AI step does after formatting.
+
+Want to try it? [Download EnviousWispr free](/#download), then dictate a sentence with a date and a dollar amount and watch them format themselves.

--- a/website/src/content/blog/whisperkit-neural-engine-to-gpu.md
+++ b/website/src/content/blog/whisperkit-neural-engine-to-gpu.md
@@ -1,0 +1,85 @@
+---
+title: "Moving Whisper Off the Neural Engine: What We Found"
+description: "We switched our Whisper-based engine from the Neural Engine to the GPU and watched a 109-second cold start fall to about 13 seconds, with no hit to transcription speed. Here is the measurement, and why the Neural Engine was the wrong place for this job."
+pubDate: 2026-06-09
+tags: ["engineering", "macos", "apple-silicon", "performance", "whisper"]
+draft: false
+author: "Saurabh Vaish"
+keywords:
+  - "whisperkit gpu vs neural engine"
+  - "coreml compute units"
+  - "apple neural engine cold start"
+  - "on-device speech recognition performance"
+  - "whisper apple silicon"
+faqs:
+  - question: "Did moving Whisper to the GPU make transcription faster?"
+    answer: "Transcription speed stayed essentially the same: about 0.70 seconds on the GPU versus about 0.75 seconds on the Neural Engine for the same clip. The large win was in cold start. The first-launch model compile dropped from roughly 109 seconds on the Neural Engine to about 13 seconds on the GPU on a current Apple Silicon Mac."
+  - question: "Why was the Neural Engine slow to start?"
+    answer: "The Neural Engine needs an ahead-of-time compile of the model the first time it runs on a given system, and that compiled cache does not survive a macOS update. Every update wipes it, forcing a fresh compile. On our test machine that compile took around 109 seconds, during which the engine was not ready."
+  - question: "Does the GPU version use more disk space?"
+    answer: "No. Both paths build the same compiled-model cache. The GPU does not avoid that cost. It simply produces the cache far faster, so the not-ready window is much shorter."
+  - question: "Does this affect the default engine?"
+    answer: "No. This change is specific to the optional Whisper-based engine you can switch to. The default engine was already starting quickly and was left as it was."
+---
+
+EnviousWispr ships with two transcription engines. Most people stay on the default one. The other is a Whisper-based engine you can switch to, and it had a problem that was easy to miss in normal use and impossible to miss at the worst possible moment.
+
+The first time you ran it, or right after a macOS update, you would press the dictation key and wait. Not for a couple of seconds. For closer to two minutes, staring at a "preparing" state with no way to know it would eventually work.
+
+We moved that engine off the Apple Neural Engine and onto the GPU. The cold start went from about 109 seconds to about 13. Transcription speed did not change. This post is the measurement and the reasoning, because the result was more interesting than "we flipped a setting."
+
+## What we actually changed
+
+On Apple Silicon, a Core ML model can be told which hardware to run on: the CPU, the GPU, the Neural Engine, or some combination. Our Whisper-based engine was asking for the Neural Engine for both halves of the model, the audio encoder and the text decoder.
+
+The change was to ask for the CPU-and-GPU combination instead. That is a small edit in the model configuration. The effect was not small.
+
+## The cold-start problem
+
+The Neural Engine is wonderful at running a model once the model is ready for it. Getting it ready is the catch. The first time a given model runs on a given machine, the system performs an ahead-of-time compile, translating the model into the form the Neural Engine executes, and caches the result.
+
+Two facts make that cache fragile. It is large. And it does not survive a macOS update, which throws it away. So the slow compile is not a one-time new-install cost. It comes back every time you update your operating system, which is exactly when you are least expecting your tools to misbehave.
+
+On our test machine, a current M-series Mac, that compile took roughly 109 seconds. For that whole window the engine was not ready, and a dictation press in that window went nowhere.
+
+## What the GPU did
+
+The GPU path needs its own compile, and it builds the same cache. The difference is how long that takes. The GPU produced its cache in about 13 seconds, against the Neural Engine's 109. That is about an eight-fold reduction in the not-ready window for the same work and the same disk footprint.
+
+To be completely honest, the GPU does not escape the cost. It pays it far faster. Thirteen seconds is short enough that the app's startup warm-up usually finishes before you make your first press, so on a modern Mac the wait you used to hit becomes something most people never see.
+
+## The result we expected to lose, and did not
+
+The reason this was not an obvious change is the conventional wisdom: the Neural Engine is the efficient, fast place to run inference, and the GPU is the fallback. We expected to trade some steady-state transcription speed for the faster start, and we measured carefully to see how much.
+
+There was nothing to trade. For the same audio, the GPU transcribed in about 0.70 seconds where the Neural Engine took about 0.75. Within the margin of error, it was the same speed.
+
+We also looked for a first-inference penalty, the common pattern where the very first transcription after a model loads is slow because the hardware is still warming up. On the GPU there was not one. The first transcription ran at full speed, the same as the ones after it. Once the engine reports ready, your first press is as quick as any later press, so there was no need for a throwaway warm-up transcription to hide a penalty that was not there.
+
+## What we took away from it
+
+A few things worth keeping.
+
+**The compile, not the inference, was the bottleneck.** It is tempting to optimize the part of a system that runs constantly. Here, the part that ran once (the cold compile) was the entire user-facing problem, hiding behind a "preparing" spinner where it was easy to ignore.
+
+**A cache a macOS update wipes is a recurring cost, not a setup cost.** We had been reasoning about cold start as a fresh-install event. It is really an after-every-update event. That reframing is what made the 109 seconds unacceptable rather than tolerable.
+
+**The "right" accelerator depends on which cost you are paying.** The Neural Engine is the textbook choice for running a model. For this model, on this product, where the felt cost was the wait before the first word, the GPU was simply better, and it cost us nothing on the part the Neural Engine is supposed to win.
+
+## Honest limits
+
+This measurement is from a current Apple Silicon Mac. Older Macs will compile more slowly, and the configuration we used falls back gracefully on hardware without a usable GPU, so nobody ends up worse off than the Neural Engine path. We did not measure battery draw; the GPU likely draws more during the compile, but over a far shorter window. And this is one engine, the optional Whisper-based one. The default engine was already quick to start and we left it alone.
+
+You can read the engine configuration yourself. EnviousWispr is source-available, and the compute-unit choice lives in the Whisper backend in [the repository](https://github.com/saurabhav88/EnviousWispr).
+
+## What changes for you
+
+If you use the Whisper-based engine, the long wait after a fresh install or a macOS update is largely gone. Transcription feels the same as it always did once you are going. The difference is at the start, where there used to be a wall.
+
+## Related posts
+
+- [How EnviousWispr works, end to end](/how-it-works/). The full on-device pipeline.
+- [Building commercial software solo with Claude Code](/blog/building-commercial-software-solo-with-claude-code/). More notes from the build.
+- [macOS dictation that works offline and stays private](/blog/macos-dictation-offline-private/). Why on-device matters in the first place.
+
+Curious to try the local engines on your own Mac? [Download EnviousWispr free](/#download).


### PR DESCRIPTION
## What

Four feature-grounded blog posts, queued to publish one per day (Jun 7–10) via future `pubDate`, plus re-enabling the daily Cloudflare deploy cron so they go live automatically without a local push.

| Date | Post | Feature |
|---|---|---|
| Sun Jun 7 | Dictating in a whisper | quiet/whispered speech capture + soft-onset recovery |
| Mon Jun 8 | Say it, get it formatted | full inverse-text-normalization capability list |
| Tue Jun 9 | Moving Whisper off the Neural Engine | compute units ANE → GPU (#937 / #879 Phase C) |
| Wed Jun 10 | Say "fire emoji," get 🔥 | trigger-word spoken emoji (#341 / #760) |

## Release mechanism (laptop-independent)

`deploy-blog.yml` schedule cron `'7 14 * * *'` (was commented out) is re-enabled. A daily GitHub-hosted rebuild reveals each future-dated post on its `pubDate` because `isPublishedPost` (`website/src/utils/posts.ts`) recomputes "today" in America/New_York at build time. No dependency on any local machine. Manual `workflow_dispatch` remains as a backfill.

## Validation

- **Codex fact-check** against source: caught and fixed 3 real errors — emoji default is ON not OFF (#923), standalone ordinals don't convert, and removed GPU figures (1.6 GB, 0.698/0.755s) not traceable to a source. All remaining claims verified to `file:line`.
- **Gemini** readability/engagement pass applied (surgical line edits only).
- **Codex release-structure validation**: all TRUE, no must-fix; DST/visibility math verified empirically.
- Astro build green (48 pages); no em/en-dashes; no banned words; "source-available" (not "open source").