### PR TITLE
docs(blog): trim four post meta descriptions to SERP length

### DIFF
--- a/website/src/content/blog/dictate-in-a-whisper-soft-speech.md
+++ b/website/src/content/blog/dictate-in-a-whisper-soft-speech.md
@@ -1,6 +1,6 @@
 ---
 title: "Dictate in a Whisper: Capturing Soft and Quiet Speech"
-description: "EnviousWispr now reliably captures quiet, whispered, and far-from-the-mic speech, including the soft first word that used to get clipped. Dictate at midnight or in an open office without raising your voice."
+description: "EnviousWispr now captures quiet, whispered, and far-from-the-mic speech, so you can dictate at midnight or in a shared office without raising your voice."
 pubDate: 2026-06-07
 tags: ["dictation", "macos", "privacy", "accessibility"]
 draft: false

--- a/website/src/content/blog/speak-emoji-dictation.md
+++ b/website/src/content/blog/speak-emoji-dictation.md
@@ -1,6 +1,6 @@
 ---
 title: "Say 'Fire Emoji,' Get 🔥: Speaking Emoji in Your Dictation"
-description: "Say 'thumbs up emoji' in EnviousWispr and you get 👍. It is on by default, covers more than 1,500 emoji by name, runs on your Mac, and never converts a bare word by accident."
+description: "Say 'thumbs up emoji' in EnviousWispr and you get 👍. It covers more than 1,500 emoji by name, runs on your Mac, and never converts a bare word by accident."
 pubDate: 2026-06-10
 tags: ["dictation", "macos", "productivity"]
 draft: false

--- a/website/src/content/blog/spoken-text-formatting-dates-numbers-emails.md
+++ b/website/src/content/blog/spoken-text-formatting-dates-numbers-emails.md
@@ -1,6 +1,6 @@
 ---
 title: "Say It, Get It Formatted: Dates, Numbers, Emails, and More"
-description: "EnviousWispr formats spoken numbers, dates, times, money, percentages, phone numbers, emails, and web addresses into the way you would actually type them. It runs on your Mac, before any AI step, on every dictation."
+description: "EnviousWispr formats spoken numbers, dates, times, money, phone numbers, emails, and web addresses the way you would actually type them, right on your Mac."
 pubDate: 2026-06-08
 tags: ["dictation", "macos", "productivity", "ai-polish"]
 draft: false

--- a/website/src/content/blog/whisperkit-neural-engine-to-gpu.md
+++ b/website/src/content/blog/whisperkit-neural-engine-to-gpu.md
@@ -1,6 +1,6 @@
 ---
 title: "Moving Whisper Off the Neural Engine: What We Found"
-description: "We switched our Whisper-based engine from the Neural Engine to the GPU and watched a 109-second cold start fall to about 13 seconds, with no hit to transcription speed. Here is the measurement, and why the Neural Engine was the wrong place for this job."
+description: "We moved our Whisper-based engine from the Neural Engine to the GPU and watched a 109-second cold start fall to about 13, with no hit to transcription speed."
 pubDate: 2026-06-09
 tags: ["engineering", "macos", "apple-silicon", "performance", "whisper"]
 draft: false


### PR DESCRIPTION
Follow-up to #1001. The four feature posts shipped with meta descriptions of 173-253 chars, over the ~145-160 norm in `seo-guidelines.md` and every existing post; Google truncates around 155-160. Trimmed all four to 153-157 chars, preserving the primary benefit and CTA. No body/factual changes.

Rendered-HTML SEO audit confirmed everything else is correctly wired (BlogPosting + FAQPage + BreadcrumbList schema, canonical, OG/Twitter, single H1, sitemap, RSS); description length was the only miss.