### PR TITLE
docs(seo): bump llms.txt Last-updated date

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -5,7 +5,7 @@
 Maker: Envious Labs LLC (Connecticut, USA). Founder: Saurabh Vaish.
 License: Business Source License 1.1 (source-available on GitHub).
 Platform: macOS 14 (Sonoma) or later, Apple Silicon only.
-Last-updated: 2026-05-15
+Last-updated: 2026-06-06
 
 ## Product
 


### PR DESCRIPTION
One-line correctness fix: the four feature posts were added to `llms.txt` in #1003, but the `Last-updated` field still read 2026-05-15. Synced to 2026-06-06.

Surfaced while researching current llms.txt best practices (May 2026 sources) — our file already follows the canonical format (H1, blockquote summary, curated H2 sections with specific per-link descriptions); the stale date was the only gap.