### PR TITLE
fix(build): add Contacts entitlement so the hardened app can request address-book access (#636)

### DIFF
--- a/Sources/EnviousWispr/Resources/EnviousWispr-Dev.entitlements
+++ b/Sources/EnviousWispr/Resources/EnviousWispr-Dev.entitlements
@@ -12,9 +12,13 @@
       data-protection keychain and never needs the team-prefixed group. The
       self-signed "EnviousWispr Dev" cert has no team, so carrying the group would
       force a provisioning profile. Keep the privacy entitlements (mic +
-      apple-events) — those sign fine with a self-signed cert and no profile.
+      contacts + apple-events) — those sign fine with a self-signed cert and no
+      profile. #636: contacts (addressbook) added in parallel with prod so the
+      dev build mirrors the release resource-access set.
     -->
     <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>

--- a/Sources/EnviousWispr/Resources/EnviousWispr.entitlements
+++ b/Sources/EnviousWispr/Resources/EnviousWispr.entitlements
@@ -4,6 +4,16 @@
 <dict>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <!--
+      #636 follow-up: Contacts (Import from Contacts). Hardened Runtime requires
+      a per-resource entitlement to access Contacts — the parallel of audio-input
+      above for the microphone. Non-sandboxed does NOT exempt this; without it the
+      notarized hardened app's CNContactStore access is blocked and the permission
+      prompt never appears. NSContactsUsageDescription is necessary but not
+      sufficient on hardened runtime.
+    -->
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
     <!--


### PR DESCRIPTION
## Problem
"Import from Contacts" (#636, shipped in #1000) failed instantly on-device: tapping Import jumped straight to the denied/"Open Settings" state, and System Settings > Privacy > Contacts was empty — no prompt, no entry.

## Root cause
The notarized Release app runs under **Hardened Runtime**, which requires a per-resource entitlement to reach protected data. Microphone already declares `com.apple.security.device.audio-input`; Contacts needs `com.apple.security.personal-information.addressbook`. Without it, `CNContactStore` access is blocked **before** the system permission prompt can appear. `NSContactsUsageDescription` is necessary but **not sufficient** under Hardened Runtime, and non-sandboxed does not exempt this.

## Fix
Add `com.apple.security.personal-information.addressbook` to both entitlements files:
- `EnviousWispr.entitlements` (Release: Developer-ID signed, notarized, Hardened Runtime)
- `EnviousWispr-Dev.entitlements` (self-signed dev — inert there, kept for parity)

## Validation
- **On-device (dev build):** permission prompt now appears; names import and tag as people. ✅
- **Codex grounded review (read-only): PROCEED, no issues.** Confirmed against Apple docs that this is the canonical Contacts key; it's a **standard** Hardened Runtime resource entitlement (TN3125), **not** a restricted one like `keychain-access-groups`, so it needs **no** provisioning-profile entry and carries **no** notarization/amfid risk (unlike #913); nothing else required beyond the usage-description string already present in `Info.plist`.

council-skip: zero-blast-radius (config)

Follow-up to #636 (Import from Contacts).