### PR TITLE
feat(settings): per-name contact import + auto sound-alike aliases (#636 follow-up)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
@@ -1,5 +1,6 @@
 import EnviousWisprContacts
 import EnviousWisprCore
+import EnviousWisprPostProcessing
 import EnviousWisprServices
 import Foundation
 import Observation
@@ -14,7 +15,7 @@ import Observation
 /// the App layer and is injected by `WisprBootstrapper`.
 ///
 /// Counts shown to the user are in PEOPLE, not correction terms: one contact
-/// yields a full-name canonical plus any distinctive lone tokens (1-3 terms),
+/// yields its distinctive first and/or last name as separate tokens (0-2 terms),
 /// but the confirm sheet and the pill speak in contacts ("42 names").
 @MainActor @Observable
 final class ContactsImportCoordinator {
@@ -29,10 +30,17 @@ final class ContactsImportCoordinator {
 
   /// Honest preview surfaced to the confirm sheet before any write.
   struct ImportPreview: Equatable {
-    let newWords: [CustomWord]  // terms to add (full names + distinctive tokens)
+    let newWords: [CustomWord]  // distinctive first/last tokens to add
     let newContactIDs: [String]  // distinct contacts contributing those terms
     let newContactCount: Int  // = newContactIDs.count, the "N names" shown
     let alreadyPresentCount: Int  // contacts already in the list / already imported
+  }
+
+  /// Background alias-generation progress. `done` counts words attempted (some
+  /// yield no usable aliases), `total` the words targeted at job start. UI-only.
+  struct EnrichmentProgress: Equatable {
+    var done: Int
+    var total: Int
   }
 
   private(set) var phase: ImportPhase = .idle
@@ -40,10 +48,21 @@ final class ContactsImportCoordinator {
   private(set) var importedCount: Int
   /// Non-nil while the confirm sheet should be shown.
   private(set) var pendingPreview: ImportPreview?
+  /// Live background alias-generation progress (nil when idle). Drives the
+  /// "Finding spoken variants…" line. UI-only, never persisted.
+  private(set) var enrichmentProgress: EnrichmentProgress?
 
   private let provider: any ContactNameProvider
   private let customWords: CustomWordsCoordinator
   private let stateStore: ImportedContactsStateStore
+  /// On-device alias generator, reused from the custom-words coordinator at the
+  /// composition root. nil in tests that don't exercise enrichment; production
+  /// always injects it. nil here means enrichment is disabled (clean no-op).
+  private let aliasSuggester: (any AliasSuggesting)?
+  private var enrichmentTask: Task<Void, Never>?
+  /// Identity token: a superseded task whose generation no longer matches must
+  /// not clear a newer task's state. Bumped by every start and every cancel.
+  private var enrichmentGeneration = 0
 
   /// Priority for imported names: sorts AFTER user-typed terms (priority 0) in
   /// the 50-term polish cap, so a large import never crowds out hand-typed
@@ -51,14 +70,20 @@ final class ContactsImportCoordinator {
   /// polish-prompt quality lever only, never a correction lever.
   private let importedPriority = 10
 
+  /// Flush generated aliases to disk every N words so the corrector rebuilds at
+  /// most ceil(count/N) times rather than once per word (heart-path mitigation).
+  private static let enrichmentFlushChunk = 25
+
   init(
     provider: any ContactNameProvider = CNContactStoreProvider(),
     customWords: CustomWordsCoordinator,
-    stateStore: ImportedContactsStateStore = ImportedContactsStateStore()
+    stateStore: ImportedContactsStateStore = ImportedContactsStateStore(),
+    aliasSuggester: (any AliasSuggesting)? = nil
   ) {
     self.provider = provider
     self.customWords = customWords
     self.stateStore = stateStore
+    self.aliasSuggester = aliasSuggester
     self.importedCount = stateStore.load().importedContactIDs.count
   }
 
@@ -97,7 +122,12 @@ final class ContactsImportCoordinator {
     guard let preview = pendingPreview else { return }
     pendingPreview = nil
     guard !preview.newWords.isEmpty else {
+      // Nothing new to add, but a re-scan should still recover: clean up dead
+      // combined entries from earlier builds and fill in any missing aliases on
+      // names already imported.
       phase = .idle
+      cleanupLegacyCombinedEntries()
+      startEnrichment()
       return
     }
     phase = .importing
@@ -116,12 +146,17 @@ final class ContactsImportCoordinator {
     }
     TelemetryService.shared.contactsImported(count: preview.newContactCount, trigger: "manual")
     phase = .imported(count: preview.newContactCount)
+    cleanupLegacyCombinedEntries()
+    startEnrichment()
   }
 
-  /// User dismisses the confirm sheet without importing.
+  /// User dismisses the confirm sheet without importing. Also stops any running
+  /// enrichment (the user backed out of this import action); a later confirm or
+  /// re-scan re-runs it over the import-logged words that still need aliases.
   func cancelImport() {
     pendingPreview = nil
     phase = .idle
+    cancelEnrichment()
   }
 
   /// Opt-in launch sync: add-only, no UI, safe off the launch path. Adds only
@@ -137,6 +172,8 @@ final class ContactsImportCoordinator {
       try persistLog(contactIDs: preview.newContactIDs, wordIDs: createdIDs)
       TelemetryService.shared.contactsImported(
         count: preview.newContactCount, trigger: "launch_sync")
+      cleanupLegacyCombinedEntries()
+      startEnrichment()
     } catch {
       // Limb: stay silent on failure (incl. a log-save failure from persistLog);
       // the existing word list is untouched and telemetry does not fire.
@@ -148,6 +185,8 @@ final class ContactsImportCoordinator {
   func bulkRemoveImported() {
     let state = stateStore.load()
     guard !state.importedWordIDs.isEmpty else { return }
+    // Stop enriching words we are about to delete; the canceller owns the clear.
+    cancelEnrichment()
     // Only erase ownership if BOTH the removal and the log reset succeed —
     // otherwise words could remain while the pill loses track of them.
     if let error = customWords.removeBatch(ids: state.importedWordIDs) {
@@ -208,5 +247,136 @@ final class ContactsImportCoordinator {
     state.record(contactIDs: contactIDs, wordIDs: wordIDs, at: Date())
     try stateStore.save(state)
     importedCount = state.importedContactIDs.count
+  }
+
+  // MARK: - Alias enrichment (#636 follow-up)
+
+  /// Remove the dead combined "First Last" entries earlier builds wrote. Strictly
+  /// ID-scoped: only import-logged word IDs whose current canonical contains a
+  /// space are touched, so a user's hand-typed multi-word term is never removed.
+  /// Removed IDs are dropped from the log so enrichment never re-targets them.
+  /// The contact stays imported (its per-name tokens remain), so `importedCount`
+  /// is unchanged. Best-effort: a removal/log-save failure leaves state as-is.
+  private func cleanupLegacyCombinedEntries() {
+    var state = stateStore.load()
+    guard !state.importedWordIDs.isEmpty else { return }
+    let loggedIDs = Set(state.importedWordIDs)
+    let staleIDs =
+      customWords.customWords
+      .filter { loggedIDs.contains($0.id) && $0.canonical.contains(" ") }
+      .map(\.id)
+    guard !staleIDs.isEmpty else { return }
+    guard customWords.removeBatch(ids: staleIDs) == nil else { return }
+    let removed = Set(staleIDs)
+    state.importedWordIDs.removeAll { removed.contains($0) }
+    try? stateStore.save(state)
+  }
+
+  /// Start background alias generation for import-logged person names that still
+  /// have no aliases (recovers mid-job-quit / model-unavailable stragglers on a
+  /// re-scan, not just freshly added words). Low priority, never blocks the heart
+  /// path; persists in batches so the corrector rebuilds at most ceil(count/25)
+  /// times. Cancels and supersedes any prior run via the generation token.
+  private func startEnrichment() {
+    enrichmentTask?.cancel()
+    enrichmentGeneration += 1
+    let gen = enrichmentGeneration
+    guard let suggester = aliasSuggester, suggester.isAvailable else {
+      enrichmentProgress = nil
+      enrichmentTask = nil
+      return
+    }
+    let loggedIDs = Set(stateStore.load().importedWordIDs)
+    let targetIDs =
+      customWords.customWords
+      .filter { loggedIDs.contains($0.id) && $0.category == .person && $0.aliases.isEmpty }
+      .map(\.id)
+    guard !targetIDs.isEmpty else {
+      enrichmentProgress = nil
+      enrichmentTask = nil
+      return
+    }
+    enrichmentProgress = EnrichmentProgress(done: 0, total: targetIDs.count)
+    enrichmentTask = Task(priority: .utility) { [weak self] in
+      await self?.runEnrichment(targetIDs: targetIDs, suggester: suggester, generation: gen)
+    }
+  }
+
+  /// The enrichment loop. Runs on the main actor (the coordinator is
+  /// `@MainActor`); each on-device call hops off and resumes here, so all
+  /// custom-word reads/writes stay serialized. Honors cancellation before AND
+  /// after every await, and re-reads each word after the await (actor
+  /// reentrancy) so a word the user removed or edited mid-job is never clobbered.
+  private func runEnrichment(
+    targetIDs: [UUID], suggester: any AliasSuggesting, generation gen: Int
+  ) async {
+    var buffer: [CustomWord] = []
+    var attempted = 0
+
+    func flush() {
+      guard !buffer.isEmpty else { return }
+      _ = customWords.updateBatch(buffer)
+      buffer.removeAll(keepingCapacity: true)
+    }
+
+    defer {
+      // Only the current generation clears shared state. A superseded task (a
+      // newer start replaced it, or a canceller already cleared) must not null
+      // the newer/cleared state.
+      if gen == enrichmentGeneration {
+        enrichmentProgress = nil
+        enrichmentTask = nil
+      }
+    }
+
+    for id in targetIDs {
+      if Task.isCancelled { return }
+      // Skip a word that vanished or already gained aliases since job start.
+      guard
+        let current = customWords.customWords.first(where: { $0.id == id }),
+        current.aliases.isEmpty
+      else {
+        attempted += 1
+        enrichmentProgress?.done = attempted
+        continue
+      }
+      let raw = await suggester.suggestAliases(for: current.canonical, category: .person)
+      if Task.isCancelled { return }  // post-await: never write for a cancelled job
+      attempted += 1
+      enrichmentProgress?.done = attempted
+      // Re-read after the await: the user may have removed or edited the word.
+      guard
+        let fresh = customWords.customWords.first(where: { $0.id == id }),
+        fresh.aliases.isEmpty
+      else { continue }
+      // Drop any generated alias that is itself a common word — an alias enters
+      // WordCorrector's unconditional single-alias self-map, so a common-word
+      // alias would rewrite ordinary speech.
+      let safe = (raw ?? []).filter { !ContactNameShaper.isCommonWord($0) }
+      guard !safe.isEmpty else { continue }
+      var updated = fresh
+      updated.aliases = safe
+      buffer.append(updated)
+      if buffer.count >= Self.enrichmentFlushChunk { flush() }
+    }
+    flush()
+  }
+
+  /// Stop any running enrichment and clear its UI state. The canceller owns the
+  /// clear: the in-task generation guard blocks a superseded task from nulling
+  /// state, so on an explicit cancel (no successor task) the progress line would
+  /// otherwise stick. Bumping the generation also makes the cancelled task's own
+  /// end-of-run clear a no-op (gen mismatch).
+  private func cancelEnrichment() {
+    enrichmentTask?.cancel()
+    enrichmentGeneration += 1
+    enrichmentTask = nil
+    enrichmentProgress = nil
+  }
+
+  /// Test seam: await the current enrichment task to completion (no sleeps).
+  /// Returns immediately when no job is running.
+  package func awaitEnrichmentForTesting() async {
+    await enrichmentTask?.value
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -9,6 +9,10 @@ final class CustomWordsCoordinator {
   var customWords: [CustomWord] = []
   var customWordError: String?
   let suggestionService = WordSuggestionService()
+  /// The reused on-device alias generator, exposed as the narrow protocol so the
+  /// composition root can wire it into the contacts-import coordinator without
+  /// naming a PostProcessing type (keeps the root's import surface minimal).
+  var aliasSuggester: any AliasSuggesting { suggestionService }
 
   /// Called after any mutation so the former root state can sync words to pipelines.
   var onWordsChanged: (([CustomWord]) -> Void)?
@@ -98,6 +102,22 @@ final class CustomWordsCoordinator {
   func update(_ word: CustomWord) -> String? {
     do {
       try manager.update(word: word, in: &customWords)
+      onWordsChanged?(customWords)
+      customWordError = nil
+      return nil
+    } catch {
+      customWordError = error.localizedDescription
+      return customWordError
+    }
+  }
+
+  /// Bulk-update existing words (contacts-import alias enrichment, #636
+  /// follow-up). One `onWordsChanged` for the whole batch so the corrector
+  /// rebuilds once per flush, not once per word.
+  @discardableResult
+  func updateBatch(_ words: [CustomWord]) -> String? {
+    do {
+      try manager.updateBatch(words, to: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
       return nil

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -75,10 +75,11 @@ public final class WisprBootstrapper {
     let audioDeviceList = AudioDeviceList()
     let captureTelemetry = CaptureTelemetryState()
     let customWordsCoordinator = CustomWordsCoordinator()
-    // #636: contacts-import orchestrator. Reads only the tiny import-log file at
-    // construction (no Contacts framework call until the user acts).
+    // #636: contacts-import orchestrator (opt-in import + bulk-remove + background
+    // alias enrichment via the reused on-device suggester). #636 follow-up.
     let contactsImportCoordinator = ContactsImportCoordinator(
-      customWords: customWordsCoordinator)
+      customWords: customWordsCoordinator,
+      aliasSuggester: customWordsCoordinator.aliasSuggester)
     let customWordsPropagator = CustomWordsPropagator()
     // #633 Phase 9: owns enabled vocabulary-pack state; merges pack terms into
     // the corrector lane (default OFF). Wired into `wireCustomWords` below.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -61,6 +61,14 @@ struct LearningSection: View {
               .font(.stHelper)
               .foregroundStyle(.green)
           }
+          if let progress = contactsImport.enrichmentProgress {
+            Label(
+              "Finding spoken variants… \(progress.done) of \(progress.total)",
+              systemImage: "sparkles"
+            )
+            .font(.stHelper)
+            .foregroundStyle(.stTextTertiary)
+          }
           if case .failed(let message) = contactsImport.phase {
             Text(message)
               .font(.stHelper)

--- a/Sources/EnviousWisprContacts/ContactNameShaper.swift
+++ b/Sources/EnviousWisprContacts/ContactNameShaper.swift
@@ -13,24 +13,21 @@ public struct ShapedName: Sendable, Equatable {
 }
 
 /// Pure logic that turns raw contact names into the exact set of canonical terms
-/// to import. This is the §3.4 design hinge in code.
+/// to import: each distinctive name becomes its OWN single-token canonical.
 ///
 /// `WordCorrector` registers every space-free (single-token) canonical as an
-/// EXACT self-entry that rewrites the spoken word unconditionally on Pass 3 —
-/// no fuzzy/threshold/stopword guard. So a lone common word like "Will" or
-/// "May" imported as a single-token canonical would capitalize that word every
-/// time the user dictates it. Multi-word canonicals get NO exact self-entry
-/// (they fire only on the full phrase). The shaping rules below exploit that:
+/// EXACT self-entry that rewrites the spoken word unconditionally on Pass 3, with
+/// no fuzzy/threshold/stopword guard. A space-containing canonical gets NO such
+/// self-entry, so a combined "First Last" entry corrected nothing; we no longer
+/// emit one. The per-name rules below exploit the single-token behavior:
 ///
-/// - When both names are present, always emit the full `"First Last"` canonical
-///   (safe: multi-word, phrase-only) — this covers the name in context even when
-///   neither part survives as a lone token.
-/// - Additionally emit `given` or `family` ALONE only when that token is
-///   distinctive (not a common English word, length ≥ 2, letters-only) so
-///   "Ramachandran" / "Vasquez" still correct when said alone.
-/// - A lone common-word name (in the stoplist) is skipped as a single token; the
-///   full-name entry still covers it. A single-field contact whose only name is a
-///   common word produces nothing (better than corrupting speech).
+/// - Emit `given` and/or `family` ALONE, each only when that token is distinctive
+///   (not a common English word, length >= 2, letters-only) so "Ramachandran" /
+///   "Vasquez" still correct when said.
+/// - A lone common-word name (in the stoplist) is skipped: importing "Will" or
+///   "May" as a single-token canonical would capitalize that ordinary word on
+///   every dictation. A contact whose only names are common words yields nothing
+///   (better than corrupting speech).
 public enum ContactNameShaper {
   /// Lone tokens shorter than this are not imported on their own (still covered
   /// by the full-name entry). Guards single letters / initials.
@@ -39,23 +36,14 @@ public enum ContactNameShaper {
   public static func shape(_ candidates: [CandidateName]) -> [ShapedName] {
     var out: [ShapedName] = []
     for candidate in candidates {
-      let given = candidate.given
-      let family = candidate.family
-      let givenValid = isNameLike(given)
-      let familyValid = isNameLike(family)
-
+      // Per-name shaping: each distinctive name becomes its own single-token
+      // canonical. No combined "First Last" entry (a space-containing canonical
+      // gets no exact self-entry in WordCorrector, so it corrected nothing).
       var canonicals: [String] = []
-      if givenValid && familyValid {
-        canonicals.append("\(given) \(family)")
-        if isDistinctiveLoneToken(given) { canonicals.append(given) }
-        if isDistinctiveLoneToken(family) { canonicals.append(family) }
-      } else if givenValid {
-        if isDistinctiveLoneToken(given) { canonicals.append(given) }
-      } else if familyValid {
-        if isDistinctiveLoneToken(family) { canonicals.append(family) }
-      }
+      if isDistinctiveLoneToken(candidate.given) { canonicals.append(candidate.given) }
+      if isDistinctiveLoneToken(candidate.family) { canonicals.append(candidate.family) }
 
-      // De-dupe within one contact (e.g. given == family) — case-insensitive.
+      // De-dupe within one contact (e.g. given == family), case-insensitive.
       var seen = Set<String>()
       for canonical in canonicals where seen.insert(canonical.lowercased()).inserted {
         out.append(ShapedName(contactID: candidate.contactID, canonical: canonical))
@@ -81,6 +69,16 @@ public enum ContactNameShaper {
     guard isNameLike(token) else { return false }
     guard token.count >= minLoneTokenLength else { return false }
     return !commonWordStoplist.contains(token.lowercased())
+  }
+
+  /// Whether `token` is in the common-word stoplist (case-insensitive). Exposed
+  /// `package` so the import-side alias enrichment can drop any generated alias
+  /// that is itself a common word: an alias DOES enter `WordCorrector`'s
+  /// unconditional single-alias self-map, so a common-word alias would rewrite
+  /// ordinary speech. PostProcessing cannot import this module, so the filter
+  /// lives at the AppKit enrichment call site (#636 follow-up).
+  package static func isCommonWord(_ token: String) -> Bool {
+    commonWordStoplist.contains(token.lowercased())
   }
 
   /// Common English words that are also common given/family names. A lone token

--- a/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
+++ b/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
@@ -1,0 +1,16 @@
+import EnviousWisprCore
+
+/// Narrow, on-device alias generator seam. Declared `package` (same-package
+/// consumers only — EnviousWisprAppKit's contacts-import enrichment), mirroring
+/// Core's package narrow protocols. The sole production conformer is
+/// `WordSuggestionService`; tests use a fake. (#636 follow-up.)
+package protocol AliasSuggesting: Sendable {
+  /// Whether on-device generation is available right now (Apple Intelligence on
+  /// macOS 26+). When false, callers skip enrichment entirely.
+  var isAvailable: Bool { get }
+
+  /// Generate spoken-variant aliases for `word`, with the category already known
+  /// so no classification call is made. Returns nil when unavailable, timed out,
+  /// or the model degenerated to self-echoes (mirrors `suggest(for:)`).
+  func suggestAliases(for word: String, category: WordCategory) async -> [String]?
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -425,6 +425,37 @@ public final class CustomWordsManager {
     words = updated
   }
 
+  /// Bulk-update existing words by ID with a single file read + write. Mirrors
+  /// `update(word:)` per word — canonical trim, reject-empty, alias sanitize —
+  /// but collapses the per-word `loadFile`/`saveFile` into one of each so the
+  /// contacts-import alias enrichment can flush a batch of generated aliases
+  /// without an O(n) per-word rewrite (#636 follow-up).
+  ///
+  /// An ID not present in the file is skipped (no-op), NOT appended — unlike
+  /// `update(word:)`, which appends a missing id as a built-in override.
+  /// Enrichment must never resurrect a word the user deleted mid-job. Returns
+  /// with `words` untouched if nothing matched.
+  public func updateBatch(_ updates: [CustomWord], to words: inout [CustomWord]) throws {
+    guard !updates.isEmpty else { return }
+    var file = loadFile() ?? CustomWordsFile()
+    var changed = false
+    for word in updates {
+      let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { continue }
+      guard let idx = file.words.firstIndex(where: { $0.id == word.id }) else { continue }
+      var sanitized = word
+      sanitized.canonical = trimmed
+      sanitized.aliases = sanitized.aliases
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+      file.words[idx] = sanitized
+      changed = true
+    }
+    guard changed else { return }
+    try saveFile(file)
+    words = mergedWords(file: file)
+  }
+
   // MARK: - Private File I/O
 
   /// Single read path — normalizes legacy formats to CustomWordsFile.

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -439,14 +439,19 @@ public final class WordSuggestionService: Sendable {
 
     @available(macOS 26, *)
     private func runRawSuggestion(
-      for word: String
+      for word: String,
+      knownCategory: WordCategory? = nil
     ) async throws -> (category: WordCategory, aliases: [String]) {
-      // Heuristic classification first — skips one AFM call for clear-cut
-      // cases (all-caps short = acronym; mixed-case or digits/dots = domain).
-      // The AFM classifier has been observed to misclassify obvious acronyms
-      // like CRM, JSON, SQL, API as brand/general/domain.
+      // A caller that already knows the category (contacts import pins .person)
+      // skips both the heuristic and the AFM classifier call. Otherwise:
+      // heuristic classification first — skips one AFM call for clear-cut cases
+      // (all-caps short = acronym; mixed-case or digits/dots = domain). The AFM
+      // classifier has been observed to misclassify obvious acronyms like CRM,
+      // JSON, SQL, API as brand/general/domain.
       let category: WordCategory
-      if let heuristic = Self.classifyByHeuristic(word) {
+      if let knownCategory {
+        category = knownCategory
+      } else if let heuristic = Self.classifyByHeuristic(word) {
         category = heuristic
       } else {
         let classificationSession = LanguageModelSession(
@@ -523,11 +528,16 @@ public final class WordSuggestionService: Sendable {
   #elseif canImport(FoundationModels)
     @available(macOS 26, *)
     private func runRawSuggestion(
-      for word: String
+      for word: String,
+      knownCategory: WordCategory? = nil
     ) async throws -> (category: WordCategory, aliases: [String]) {
-      // Step 1 — heuristic classification first, AFM as fallback.
+      // Step 1 — classification. A caller that already knows the category
+      // (contacts import pins .person) skips it; otherwise heuristic first, AFM
+      // as fallback.
       let category: WordCategory
-      if let heuristic = Self.classifyByHeuristic(word) {
+      if let knownCategory {
+        category = knownCategory
+      } else if let heuristic = Self.classifyByHeuristic(word) {
         category = heuristic
       } else {
         let classificationSession = LanguageModelSession(
@@ -604,6 +614,34 @@ public final class WordSuggestionService: Sendable {
       }
     }
   #endif
+}
+
+// MARK: - AliasSuggesting (contacts-import enrichment, #636 follow-up)
+
+extension WordSuggestionService: AliasSuggesting {
+  /// On-device alias generation for an already-classified word. Mirrors
+  /// `suggest(for:)`'s availability gate, 5-second timeout, and degeneration
+  /// filter, but skips classification (the caller pins the category) and returns
+  /// the bare alias list. nil when unavailable, timed out, or the model
+  /// degenerated to self-echoes.
+  package func suggestAliases(for word: String, category: WordCategory) async -> [String]? {
+    #if canImport(FoundationModels)
+      guard #available(macOS 26, *),
+        case .available = SystemLanguageModel.default.availability
+      else { return nil }
+      do {
+        return try await withThrowingTimeout(seconds: 5) {
+          let raw = try await self.runRawSuggestion(for: word, knownCategory: category)
+          let filtered = Self.filterDegeneratedAliases(raw.aliases, canonical: word)
+          return filtered.isEmpty ? nil : filtered
+        }
+      } catch {
+        return nil
+      }
+    #else
+      return nil
+    #endif
+  }
 }
 
 public struct WordSuggestions: Sendable {

--- a/Tests/EnviousWisprTests/Contacts/ContactNameShaperTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactNameShaperTests.swift
@@ -1,10 +1,11 @@
 import EnviousWisprContacts
 import Testing
 
-/// #636 — the §3.4 design hinge: shaping contact names so a lone common word
-/// never becomes a single-token canonical (which `WordCorrector` would rewrite
-/// unconditionally on its exact pass).
-@Suite("ContactNameShaper — import shaping (#636)")
+/// #636 follow-up — per-name shaping: each distinctive name becomes its OWN
+/// single-token canonical (no combined "First Last"), and a lone common word is
+/// never imported as a single token (WordCorrector would rewrite it on its exact
+/// pass, and there is no longer a combined entry to absorb it).
+@Suite("ContactNameShaper — per-name shaping (#636 follow-up)")
 struct ContactNameShaperTests {
   private func canonicals(_ candidates: [CandidateName]) -> [String] {
     ContactNameShaper.shape(candidates).map(\.canonical)
@@ -14,32 +15,29 @@ struct ContactNameShaperTests {
     CandidateName(contactID: id, given: given, family: family)
   }
 
-  @Test("Distinctive full name yields the full canonical plus both lone tokens")
-  func distinctiveFullName() {
-    let out = canonicals([contact("Rajesh", "Ramachandran")])
-    #expect(out.contains("Rajesh Ramachandran"))
-    #expect(out.contains("Rajesh"))
-    #expect(out.contains("Ramachandran"))
+  @Test("Distinctive first and last become two separate tokens, no combined entry")
+  func distinctiveFullNameSplits() {
+    #expect(canonicals([contact("Malavika", "Chander")]) == ["Malavika", "Chander"])
+    #expect(canonicals([contact("Rajesh", "Ramachandran")]) == ["Rajesh", "Ramachandran"])
   }
 
-  // matcher-set-adversarial-tests: the common-word first name "Will" must NEVER
-  // become a lone single-token canonical — that would capitalize the spoken
-  // verb "will" on every dictation via the corrector's exact pass.
-  @Test("Common-word first name kept only in the full name, never as a lone token")
-  func commonWordFirstNameNotLone() {
-    let out = canonicals([contact("Will", "Vasquez")])
-    #expect(out.contains("Will Vasquez"))  // full phrase is safe (multi-word)
-    #expect(out.contains("Vasquez"))  // distinctive surname lone is fine
-    #expect(!out.contains("Will"))  // lone common word is NEVER imported
+  // matcher-set-adversarial-tests: a common-word first name must NEVER become a
+  // lone single-token canonical, and there is no longer a combined entry to fall
+  // back on — only the distinctive surname survives.
+  @Test("Common-word first name dropped; distinctive surname kept alone")
+  func commonWordFirstNameDropped() {
+    #expect(canonicals([contact("Will", "Vasquez")]) == ["Vasquez"])
   }
 
-  @Test("Common-word surname also excluded as a lone token")
-  func commonWordSurnameNotLone() {
+  @Test("Common-word surname dropped; distinctive first name kept alone")
+  func commonWordSurnameDropped() {
     // "cook" is an occupational common word in the stoplist.
-    let out = canonicals([contact("Aisha", "Cook")])
-    #expect(out.contains("Aisha Cook"))
-    #expect(out.contains("Aisha"))
-    #expect(!out.contains("Cook"))
+    #expect(canonicals([contact("Aisha", "Cook")]) == ["Aisha"])
+  }
+
+  @Test("Both names common words yields nothing")
+  func bothCommonWordsYieldNothing() {
+    #expect(canonicals([contact("Will", "May")]).isEmpty)
   }
 
   @Test("Single-field contact whose only name is a common word yields nothing")
@@ -54,6 +52,18 @@ struct ContactNameShaperTests {
     #expect(canonicals([contact("Ramachandran", "")]) == ["Ramachandran"])
   }
 
+  @Test("Common-word match is case-insensitive")
+  func commonWordCaseInsensitive() {
+    // Lower/upper variants of stoplisted "will" are still dropped.
+    #expect(canonicals([contact("will", "Vasquez")]) == ["Vasquez"])
+    #expect(canonicals([contact("WILL", "Vasquez")]) == ["Vasquez"])
+  }
+
+  @Test("Hyphenated and apostrophe names are distinctive tokens")
+  func hyphenAndApostropheKept() {
+    #expect(canonicals([contact("Anne-Marie", "O'Connor")]) == ["Anne-Marie", "O'Connor"])
+  }
+
   @Test("Names containing digits are treated as junk")
   func digitsAreJunk() {
     // Family field is a phone fragment → dropped; distinctive given kept.
@@ -64,10 +74,8 @@ struct ContactNameShaperTests {
 
   @Test("Single-letter initials are not captured as lone tokens")
   func initialsNotLone() {
-    let out = canonicals([contact("J", "Okafor")])
-    #expect(out.contains("J Okafor"))
-    #expect(out.contains("Okafor"))
-    #expect(!out.contains("J"))
+    // No combined "J Okafor" either — only the distinctive surname survives.
+    #expect(canonicals([contact("J", "Okafor")]) == ["Okafor"])
   }
 
   @Test("Two-character distinctive surname is kept")
@@ -77,9 +85,7 @@ struct ContactNameShaperTests {
 
   @Test("Identical given and family dedupe within one contact")
   func intraContactDedupe() {
-    let out = canonicals([contact("Aaron", "Aaron")])
-    #expect(out.contains("Aaron Aaron"))
-    #expect(out.filter { $0 == "Aaron" }.count == 1)
+    #expect(canonicals([contact("Aaron", "Aaron")]) == ["Aaron"])
   }
 
   @Test("Both-empty contact yields nothing")
@@ -87,10 +93,23 @@ struct ContactNameShaperTests {
     #expect(canonicals([contact("", "")]).isEmpty)
   }
 
+  @Test(
+    "A surname shared across contacts is emitted per contact (cross-contact dedupe is the importer's job)"
+  )
+  func duplicateSurnameAcrossContactsNotDedupedByShaper() {
+    let out = ContactNameShaper.shape([
+      contact("Arvind", "Vaish", id: "c1"),
+      contact("Saurabh", "Vaish", id: "c2"),
+    ])
+    #expect(out.map(\.canonical) == ["Arvind", "Vaish", "Saurabh", "Vaish"])
+    // Provenance distinguishes the two "Vaish" entries.
+    #expect(out.filter { $0.canonical == "Vaish" }.map(\.contactID) == ["c1", "c2"])
+  }
+
   @Test("Per-contact provenance is preserved on every shaped term")
   func provenancePreserved() {
     let shaped = ContactNameShaper.shape([contact("Rajesh", "Ramachandran", id: "abc")])
-    #expect(!shaped.isEmpty)
+    #expect(shaped.map(\.canonical) == ["Rajesh", "Ramachandran"])
     #expect(shaped.allSatisfy { $0.contactID == "abc" })
   }
 }

--- a/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
@@ -35,6 +35,27 @@ private final class FakeContactProvider: ContactNameProvider, @unchecked Sendabl
   }
 }
 
+/// Test double for the on-device alias generator (#636 follow-up).
+/// `@unchecked Sendable` mirrors `FakeContactProvider`: the coordinator calls it
+/// sequentially behind `await`, so `calls` never races.
+private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
+  let available: Bool
+  let aliasesByWord: [String: [String]]
+  private(set) var calls: [String] = []
+
+  init(available: Bool, aliasesByWord: [String: [String]] = [:]) {
+    self.available = available
+    self.aliasesByWord = aliasesByWord
+  }
+
+  var isAvailable: Bool { available }
+
+  func suggestAliases(for word: String, category: WordCategory) async -> [String]? {
+    calls.append(word)
+    return aliasesByWord[word]
+  }
+}
+
 @MainActor
 @Suite("ContactsImportCoordinator — orchestration (#636)")
 struct ContactsImportCoordinatorTests {
@@ -46,7 +67,8 @@ struct ContactsImportCoordinatorTests {
   }
 
   private func make(
-    provider: FakeContactProvider
+    provider: FakeContactProvider,
+    suggester: (any AliasSuggesting)? = nil
   ) -> (ContactsImportCoordinator, ImportedContactsStateStore, CustomWordsCoordinator, URL) {
     let dir = Self.tempDir()
     let cwCoord = CustomWordsCoordinator(
@@ -54,7 +76,7 @@ struct ContactsImportCoordinatorTests {
     let store = ImportedContactsStateStore(
       fileURL: dir.appendingPathComponent("imported-contacts-state.json"))
     let coord = ContactsImportCoordinator(
-      provider: provider, customWords: cwCoord, stateStore: store)
+      provider: provider, customWords: cwCoord, stateStore: store, aliasSuggester: suggester)
     return (coord, store, cwCoord, dir)
   }
 
@@ -99,7 +121,10 @@ struct ContactsImportCoordinatorTests {
     #expect(coord.phase == .imported(count: 1))
     #expect(store.load().importedContactIDs == ["c1"])
     #expect(!store.load().importedWordIDs.isEmpty)
-    #expect(cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
+    // Per-name: two separate tokens, never the combined "First Last".
+    #expect(cw.customWords.contains { $0.canonical == "Rajesh" })
+    #expect(cw.customWords.contains { $0.canonical == "Ramachandran" })
+    #expect(!cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
     #expect(coord.importedCount == 1)
   }
 
@@ -163,7 +188,8 @@ struct ContactsImportCoordinatorTests {
     coord.bulkRemoveImported()
     #expect(coord.importedCount == 0)
     #expect(store.load().importedWordIDs.isEmpty)
-    #expect(!cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
+    #expect(!cw.customWords.contains { $0.canonical == "Rajesh" })
+    #expect(!cw.customWords.contains { $0.canonical == "Ramachandran" })
   }
 
   @Test("syncNewContacts no-ops when not authorized (fetch never called)")
@@ -187,5 +213,175 @@ struct ContactsImportCoordinatorTests {
     let countAfterFirst = store.load().importedWordIDs.count
     await coord.syncNewContacts()
     #expect(store.load().importedWordIDs.count == countAfterFirst)
+  }
+
+  // MARK: - Alias enrichment (#636 follow-up)
+
+  @Test("Enrichment fills aliases for imported names")
+  func enrichmentHappy() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(
+      available: true,
+      aliasesByWord: ["Rajesh": ["rah jesh", "raj esh"], "Vasquez": ["vaskez", "vah skez"]])
+    let (coord, _, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.awaitEnrichmentForTesting()
+    #expect(cw.customWords.first { $0.canonical == "Rajesh" }?.aliases == ["rah jesh", "raj esh"])
+    #expect(cw.customWords.first { $0.canonical == "Vasquez" }?.aliases == ["vaskez", "vah skez"])
+  }
+
+  @Test("Enrichment clears its progress line on completion")
+  func enrichmentClearsProgressOnCompletion() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Rajesh": ["r"], "Vasquez": ["v"]])
+    let (coord, _, _, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.awaitEnrichmentForTesting()
+    #expect(coord.enrichmentProgress == nil)
+  }
+
+  @Test("Enrichment is a clean no-op when the model is unavailable")
+  func enrichmentUnavailable() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(available: false)
+    let (coord, _, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.awaitEnrichmentForTesting()
+    #expect(coord.enrichmentProgress == nil)
+    #expect(cw.customWords.first { $0.canonical == "Rajesh" }?.aliases.isEmpty == true)
+    #expect(fake.calls.isEmpty)  // the model was never queried
+  }
+
+  @Test("A generated alias that is itself a common word is dropped before persisting")
+  func enrichmentDropsCommonWordAlias() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Ramachandran", "", id: "c1")])
+    // "will" and "may" are stoplisted common words; "ram uh" is a clean variant.
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Ramachandran": ["will", "ram uh", "may"]])
+    let (coord, _, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.awaitEnrichmentForTesting()
+    #expect(cw.customWords.first { $0.canonical == "Ramachandran" }?.aliases == ["ram uh"])
+  }
+
+  @Test("Re-scan enriches only import-logged empty-alias words, never one already aliased")
+  func enrichmentRecoversLoggedEmptiesOnly() async throws {
+    // No new contacts: this is the recovery path (mid-job-quit / model-was-off).
+    let provider = FakeContactProvider(status: .authorized, candidates: [])
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Empty": ["em tee"], "Filled": ["should not apply"]])
+    let (coord, store, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    // Seed two logged person words: one empty, one already aliased.
+    let empty = CustomWord(canonical: "Empty", category: .person, priority: 10)
+    let filled = CustomWord(
+      canonical: "Filled", aliases: ["preset"], category: .person, priority: 10)
+    let ids = try #require(cw.addBatch([empty, filled]))
+    var state = store.load()
+    state.record(contactIDs: ["c0"], wordIDs: ids, at: Date())
+    try? store.save(state)
+
+    await coord.prepareImport()
+    coord.confirmImport()  // 0 new → recovery enrichment over logged empties
+    await coord.awaitEnrichmentForTesting()
+
+    #expect(cw.customWords.first { $0.canonical == "Empty" }?.aliases == ["em tee"])
+    #expect(cw.customWords.first { $0.canonical == "Filled" }?.aliases == ["preset"])
+    #expect(fake.calls == ["Empty"])  // the already-aliased word is never queried
+  }
+
+  @Test("Legacy cleanup removes logged combined entries, keeps lone tokens")
+  func legacyCleanupRemovesCombinedEntries() async throws {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Ramachandran", id: "c1")])
+    let (coord, store, cw, dir) = make(provider: provider)
+    defer { cleanup(dir) }
+    // Simulate an earlier build: a combined entry + a lone entry, both logged.
+    let combined = CustomWord(canonical: "Rajesh Ramachandran", category: .person, priority: 10)
+    let lone = CustomWord(canonical: "Ramachandran", category: .person, priority: 10)
+    let ids = try #require(cw.addBatch([combined, lone]))
+    var state = store.load()
+    state.record(contactIDs: ["c1"], wordIDs: ids, at: Date())
+    try? store.save(state)
+
+    await coord.prepareImport()
+    coord.confirmImport()  // c1 already imported → 0 new → cleanup runs
+    await coord.awaitEnrichmentForTesting()
+
+    #expect(!cw.customWords.contains { $0.canonical == "Rajesh Ramachandran" })
+    #expect(cw.customWords.contains { $0.canonical == "Ramachandran" })
+    #expect(!store.load().importedWordIDs.contains(ids[0]))  // combined ID dropped from log
+    #expect(store.load().importedWordIDs.contains(ids[1]))  // lone ID kept
+  }
+
+  @Test("syncNewContacts enriches the contacts it adds")
+  func syncEnriches() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Rajesh": ["r1"], "Vasquez": ["v1"]])
+    let (coord, _, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.syncNewContacts()
+    await coord.awaitEnrichmentForTesting()
+    #expect(cw.customWords.first { $0.canonical == "Rajesh" }?.aliases == ["r1"])
+    #expect(cw.customWords.first { $0.canonical == "Vasquez" }?.aliases == ["v1"])
+  }
+
+  @Test("bulkRemoveImported cancels enrichment and clears its progress")
+  func bulkRemoveCancelsEnrichment() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Rajesh": ["r"], "Vasquez": ["v"]])
+    let (coord, store, _, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()  // starts enrichment (task queued)
+    coord.bulkRemoveImported()  // synchronously cancels + clears before the task runs
+    await coord.awaitEnrichmentForTesting()
+    #expect(coord.enrichmentProgress == nil)
+    #expect(coord.importedCount == 0)
+    #expect(store.load().importedWordIDs.isEmpty)
+  }
+
+  @Test("Enrichment persists every word across the 25-flush boundary (>25)")
+  func enrichmentFlushesAcrossChunkBoundary() async throws {
+    // 30 logged empty-alias person words exercise the every-25 flush plus the
+    // final flush; the trailing 5 must not be dropped. No new contacts: the
+    // 0-new recovery path drives enrichment over the whole logged set.
+    let provider = FakeContactProvider(status: .authorized, candidates: [])
+    let names = (0..<30).map { "Coworker\($0)" }
+    let aliasMap = Dictionary(uniqueKeysWithValues: names.map { ($0, ["v-\($0)"]) })
+    let fake = FakeAliasSuggester(available: true, aliasesByWord: aliasMap)
+    let (coord, store, cw, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    let seeded = names.map { CustomWord(canonical: $0, category: .person, priority: 10) }
+    let ids = try #require(cw.addBatch(seeded))
+    var state = store.load()
+    state.record(contactIDs: ["c0"], wordIDs: ids, at: Date())
+    try? store.save(state)
+
+    await coord.prepareImport()
+    coord.confirmImport()  // 0 new → recovery enrichment over all 30 logged empties
+    await coord.awaitEnrichmentForTesting()
+
+    for name in names {
+      #expect(cw.customWords.first { $0.canonical == name }?.aliases == ["v-\(name)"])
+    }
+    #expect(coord.enrichmentProgress == nil)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBatchTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBatchTests.swift
@@ -107,4 +107,53 @@ struct CustomWordsBatchTests {
     try mgr.removeBatch(ids: [], from: &words)
     #expect(words.count == before)
   }
+
+  // #636 follow-up — updateBatch: single-save bulk alias update used by the
+  // contacts-import enrichment flush.
+
+  @Test("updateBatch updates aliases for existing words and persists across reload")
+  func updateBatchPersists() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let a = person("Ramachandran Test")
+    let b = person("Vasquez Test")
+    _ = try mgr.addBatch([a, b], to: &words)
+
+    var aUpd = try #require(words.first { $0.canonical == "Ramachandran Test" })
+    aUpd.aliases = ["rama", "ram uh"]
+    try mgr.updateBatch([aUpd], to: &words)
+
+    #expect(words.first { $0.canonical == "Ramachandran Test" }?.aliases == ["rama", "ram uh"])
+    let reloaded = CustomWordsManager(fileURL: url).load() ?? []
+    #expect(reloaded.first { $0.canonical == "Ramachandran Test" }?.aliases == ["rama", "ram uh"])
+    // The untouched word keeps its empty alias list.
+    #expect(reloaded.first { $0.canonical == "Vasquez Test" }?.aliases.isEmpty == true)
+  }
+
+  @Test("updateBatch skips a missing id — never resurrects a removed word")
+  func updateBatchMissingIdNoOp() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    _ = try mgr.addBatch([person("Ramachandran Test")], to: &words)
+
+    var ghost = person("Ghost Test")  // never added to the file
+    ghost.aliases = ["boo"]
+    try mgr.updateBatch([ghost], to: &words)
+
+    #expect(!words.contains { $0.canonical == "Ghost Test" })
+    let reloaded = CustomWordsManager(fileURL: url).load() ?? []
+    #expect(!reloaded.contains { $0.canonical == "Ghost Test" })
+  }
+
+  @Test("updateBatch with empty input is a no-op")
+  func updateBatchEmpty() throws {
+    let (mgr, url) = Self.tempManager()
+    defer { Self.cleanup(url) }
+    var words = mgr.load() ?? []
+    let before = words.count
+    try mgr.updateBatch([], to: &words)
+    #expect(words.count == before)
+  }
 }


### PR DESCRIPTION
## Summary
Follow-up to #636 (Import from Contacts, shipped via #1000). Two issues the founder found on-device:

1. **Per-name entries.** Imported names landed as a useless combined `"First Last"` entry. `WordCorrector` only registers single-token canonicals as exact self-entries, so a space-containing canonical corrected nothing. The shaper now emits only the distinctive first/last tokens (no combined entry); a contact yields 0-2 tokens. Common-word names stay skipped as lone tokens (case-insensitive).

2. **Auto sound-alike aliases.** Imported names got no aliases (the misspelling variants the manual add path auto-fills). After an import, a low-priority background job generates aliases per imported name via the on-device model (category pinned to `.person`, skipping the classifier call), filtered so no generated alias is itself a common word, persisted in batches of 25 so the corrector rebuilds at most ceil(count/25) times. A "Finding spoken variants..." progress line shows while it runs. Never blocks the heart path.

Plus a safe, ID-scoped cleanup of the dead combined entries earlier builds wrote (only import-logged word IDs whose canonical contains a space; dropped from the import log; the contact stays imported so the count is unchanged).

## Design notes
- `aliasSuggester` reuses the existing `WordSuggestionService` (no second instance), exposed via `CustomWordsCoordinator.aliasSuggester` so the composition root stays within its import ceiling (no PostProcessing import added to the root).
- Concurrency: one enrichment task + a generation token; `Task.isCancelled` checked before AND after every await; the word is re-read post-await (actor reentrancy) so a removed/edited word is never clobbered; cancellers clear progress immediately; a superseded task's gen-guarded clear can't null newer state. Partial buffer discarded on cancel, flushed on normal completion.
- A 0-new Re-scan still runs cleanup + enrichment recovery (recovers stragglers + cleans legacy entries on an already-imported list).
- Privacy: zero logging in the contacts files (`check-contacts-data-flow.sh` treats `AppLogger`/`os_log`/`print` as hard sinks there); observability is the live progress line + `custom-words.json`.
- `suggest(for:)` / `benchmarkSuggest(...)` are byte-identical (alias-eval baseline frozen); `runRawSuggestion`'s new `knownCategory` only short-circuits classification when non-nil.

## Validation
- Full Xcode test gate green: **1701 tests**, incl. 4 architecture ceiling tests + new per-name shaper (adversarial), enrichment (happy / unavailable / recovery / pre-aliased-skip), common-word alias filter, legacy cleanup, cancel, and 25-flush-boundary tests.
- `check-contacts-data-flow.sh` (privacy) + `check-dependency-direction.sh` green.
- Codex code-diff review: **SHIP** (no P0-P3 defects; concurrency / privacy / eval-baseline / updateBatch / dep-direction all confirmed).
- Heart-path dictation smoke on the dev build: **PASS** (clean transcript, pipeline 1.869s: ASR 0.11s, polish 1.40s, paste 0.27s, no crash/stuck overlay).

## Note for existing imports
For names already imported, Re-scan cleans the dead combined entries and fills aliases on the lone tokens, but does not re-add a first name that was never created at original import. To get first AND last as fresh separate entries on an existing import, tap the pill's "x" (remove all imported) then Import once. Fresh imports get per-name automatically.