### PR TITLE
test(pipeline): gate sweep drain on unconsumed recording-exit signal (fixes recurring interleavingSweep flake)

### DIFF
--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -379,6 +379,21 @@ final class RecordingSessionKernel {
   private var pendingRecordingExit: RecordingExit?
   private var recordingExitLatched = false
 
+  /// Test-observation signal for the simulator's drain (companion to
+  /// `workEpoch`). `true` only in the window between `deliverRecordingExit`
+  /// latching an exit from `.recording` and the forward path consuming it and
+  /// transitioning out of `.recording`. The exit delivery bumps `workEpoch`
+  /// and resumes the forward-path continuation synchronously inside the
+  /// triggering call — *before* the simulator's `drainReadyWork` starts — so
+  /// that bump is absorbed and epoch-stability alone can falsely report
+  /// quiescence while the resumed-but-not-yet-scheduled forward path still sits
+  /// at `.recording`. The drain gates on this signal so it never settles mid
+  /// hand-off (the recurring `interleavingSweep` `got recording` flake). No
+  /// production reader — observation only.
+  var hasUnconsumedRecordingExit: Bool {
+    recordingExitLatched && state == .recording
+  }
+
   /// Buffers handed to the adapter this session — the sub-minimum-duration
   /// proxy (PR-1 §B.1.2 `recording → discarded`): zero buffers ⇒ `discarded`.
   private var bufferCountThisSession = 0

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/DrainReadyWorkSettleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/DrainReadyWorkSettleTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - drainReadyWork settle race (recurring interleavingSweep flake)
+//
+// The 64-schedule sweep (`RecordingSessionKernelScenarioTests`) flaked on CI
+// under full-suite MainActor contention with the same signature every time:
+// `step N: expected <terminal>, got recording`, then a stale terminal. It
+// recurred across #875 / #912 / #958 / #984 and main-post-merge `a4902ea`
+// (scenario A8) and was repeatedly dismissed as a rerun-to-green contention
+// flake (child of #881).
+//
+// Root cause (2026-06-06): a recording-exit delivered by a `stop` / `cancel`
+// step bumps `workEpoch` and resumes the forward-path continuation
+// synchronously inside that step — *before* `drainReadyWork` starts — so the
+// lone bump is absorbed into the drain's initial `last`. Under contention the
+// resumed-but-unscheduled forward-path task can lose the scheduler lottery for
+// the whole 64-yield stability window, so the drain returns while the FSM is
+// still observably `.recording`. The next step's `cancel` is then swallowed by
+// the already-latched stop and the scenario flakes.
+//
+// Fix: `drainReadyWork` gates its return on `kernel.hasUnconsumedRecordingExit`
+// — it never settles while a delivered exit is still unconsumed.
+
+@MainActor
+@Suite("drainReadyWork settle — recording-exit hand-off")
+struct DrainReadyWorkSettleTests {
+
+  private func makeContext(
+    behavior: FakeEngineBehavior
+  ) -> (wrapper: KernelRecordingSession, context: SimulatorContext, capture: FakeAudioCapture) {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: behavior, clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    let context = SimulatorContext(
+      sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return (wrapper, context, capture)
+  }
+
+  /// Deterministic lock on the hand-off signal: immediately after a `stop` from
+  /// `.recording`, the exit is delivered and the forward-path continuation is
+  /// resumed, but the forward-path task has NOT run yet — so the FSM is still
+  /// `.recording` while `workEpoch` already carries the single (absorbed) bump.
+  /// This is exactly the moment epoch-stability alone would falsely declare
+  /// quiescence; `hasUnconsumedRecordingExit` flags it, and the signal-gated
+  /// drain waits it out.
+  @Test("a delivered recording-exit reads as unconsumed before the forward path runs")
+  func unconsumedExitWindowIsFlagged() async {
+    let (wrapper, _, capture) = makeContext(
+      behavior: .slowFinalize(ticksToFinal: 3, text: "in flight"))
+    let kernel = wrapper.testKernel
+
+    // Drive to a settled `.recording`.
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    capture.deliverBuffer()
+    await wrapper.drainReadyWork()
+    #expect(kernel.state == .recording)
+    #expect(kernel.hasUnconsumedRecordingExit == false)
+
+    // Stop synchronously delivers the exit + resumes the forward path, but does
+    // not run it (no suspension between `requestStop()` returning and these
+    // reads). The lone `bump()` is already in `workEpoch`, so epoch-stability
+    // would settle here — but the exit is unconsumed.
+    let epochBeforeStop = kernel.workEpoch
+    kernel.requestStop()
+    #expect(kernel.state == .recording)
+    #expect(kernel.hasUnconsumedRecordingExit == true)
+    #expect(kernel.workEpoch == epochBeforeStop + 1)
+
+    // The signal-gated drain refuses to settle until the forward path consumes
+    // the exit and transitions out of `.recording`.
+    await wrapper.drainReadyWork()
+    #expect(kernel.hasUnconsumedRecordingExit == false)
+    #expect(kernel.state != .recording)
+  }
+
+  /// A7 shape: a lone `cancel` from `.recording` latches the exit the same way.
+  /// The signal must flag it and the drain must wait for the `→ cancelled`
+  /// transition.
+  @Test("a cancel-delivered exit reads as unconsumed before the forward path runs")
+  func cancelExitWindowIsFlagged() async {
+    let (wrapper, _, capture) = makeContext(behavior: .batchSuccess(text: "x"))
+    let kernel = wrapper.testKernel
+
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    capture.deliverBuffer()
+    await wrapper.drainReadyWork()
+    #expect(kernel.state == .recording)
+
+    kernel.cancel()
+    #expect(kernel.state == .recording)
+    #expect(kernel.hasUnconsumedRecordingExit == true)
+
+    await wrapper.drainReadyWork()
+    #expect(kernel.hasUnconsumedRecordingExit == false)
+    #expect(kernel.state == .cancelled)
+  }
+
+  /// Load-robustness check (NOT a guaranteed red-without-fix discriminator):
+  /// runs the full A8 sweep while 128 cooperative noise tasks compete for the
+  /// MainActor, approximating the full-suite contention that triggered the CI
+  /// flake. The deterministic locks above are the regression guarantee for the
+  /// signal the gate depends on; this test cannot prove "fails without the gate"
+  /// because Swift's cooperative executor ordering is not controllable from test
+  /// code (a starve-the-forward-path interleaving is probabilistic, and on an
+  /// idle local machine the forward path usually still gets its turn). Its value
+  /// is the positive direction: with the gate, every schedule lands `.cancelled`
+  /// even under sustained contention.
+  @Test("A8 survives the 64-schedule sweep under heavy MainActor contention")
+  func a8SurvivesSweepUnderContention() async {
+    let noise = (0..<128).map { _ in
+      Task { @MainActor in
+        for _ in 0..<20000 {
+          if Task.isCancelled { return }
+          await Task.yield()
+        }
+      }
+    }
+    defer { for task in noise { task.cancel() } }
+
+    guard let a8 = ScenarioInventory.all.first(where: { $0.id == "A8" }) else {
+      Issue.record("A8 missing from inventory")
+      return
+    }
+
+    for schedule in interleavingSweepSchedules {
+      let (_, context, _) = makeContext(
+        behavior: .slowFinalize(ticksToFinal: 3, text: "in flight"))
+      let result = await ScenarioRunner().run(a8.applying(schedule), context: context)
+      #expect(
+        result.passed,
+        "A8 seed \(String(schedule.seed, radix: 16)) under contention: \(result.failures)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -241,19 +241,42 @@ final class KernelRecordingSession: RecordingSessionDriving {
     }
   }
 
-  /// Yield until the kernel's `workEpoch` stops advancing — every ready task
-  /// has run and the FSM has settled. `workEpoch` is the signal: the kernel
-  /// bumps it on every transition, task resumption, and progress tick. The
-  /// 64-yield stability requirement is margin for a ready kernel task that
-  /// loses the scheduler lottery to unrelated parallel tests across several
-  /// yields under MainActor contention — not a deadline. The 20000-iteration
-  /// cap is a safety net against a kernel livelock (it surfaces as a
-  /// stuck-state assertion failure, not a hang).
+  /// Yield until the kernel's `workEpoch` stops advancing — the FSM has settled
+  /// for everything `workEpoch` covers (the kernel bumps it on every transition,
+  /// task resumption, and progress tick). The 64-yield stability requirement is
+  /// margin for a ready kernel task that loses the scheduler lottery to
+  /// unrelated parallel tests across several yields under MainActor contention —
+  /// not a deadline. The 20000-iteration cap is a safety net against a kernel
+  /// livelock (it surfaces as a stuck-state assertion failure, not a hang).
+  ///
+  /// Epoch-stability ALONE is not sufficient for the recording-exit hand-off: a
+  /// recording-exit delivered by the previous step (`stop` / `cancel` from
+  /// `.recording`) bumps `workEpoch` and resumes the forward-path continuation
+  /// synchronously inside that step — *before* this drain starts — so the bump
+  /// is absorbed into the initial `last` and offers no protection. Under
+  /// full-suite MainActor contention the resumed forward-path task can then lose
+  /// the scheduler lottery for the whole 64-yield window, and the drain would
+  /// return while the FSM is still observably `.recording`. The next step's
+  /// `cancel` is then swallowed by the already-latched stop and the scenario
+  /// flakes (the recurring `interleavingSweep` `got recording` failure). So gate
+  /// the return on the kernel's own hand-off signal: never declare quiescence
+  /// while a delivered recording-exit is still unconsumed. The forward path is a
+  /// ready task on a cooperative serial executor, so it cannot be starved
+  /// forever — the signal clears within a bounded number of yields, well under
+  /// the livelock cap.
+  ///
+  /// Scope: this gate addresses the recording-exit hand-off, the only window the
+  /// observed flakes hit (every recurrence was `got recording`). The same
+  /// bump-absorption shape exists in principle at other continuations resumed
+  /// inside a step's `apply` — `FakeClock.advance(by:)` resuming a `slowLoad` /
+  /// `slowFinalize` sleep, a VAD `AsyncStream.yield` — but none has manifested.
+  /// If a future flake reports a stale `transcribing` / `warmingUp` after an
+  /// `advanceClock` or VAD step, those are the next signals to gate the same way.
   func drainReadyWork() async {
     var last = kernel.workEpoch
     var stable = 0
     var iterations = 0
-    while stable < 64, iterations < 20000 {
+    while iterations < 20000 {
       await Task.yield()
       iterations += 1
       let now = kernel.workEpoch
@@ -263,6 +286,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
         stable = 0
         last = now
       }
+      if stable >= 64, !kernel.hasUnconsumedRecordingExit { return }
     }
   }
 


### PR DESCRIPTION
## What
Roots out the recurring `interleavingSweep` CI flake — `RecordingSessionKernelScenarioTests."concurrency-sensitive scenarios survive the 64-schedule sweep"`. Same signature every recurrence: `step N: expected <terminal>, got recording`, then a stale terminal (A8 ended completed/pasted instead of cancelled). Recurred since #875 (#912 / #958 / #984 / main-post-merge `a4902ea`), each time reran-to-green and flagged for #881.

## Root cause (test-harness settle race, NOT a kernel bug)
`KernelRecordingSession.drainReadyWork()` declares quiescence after `kernel.workEpoch` is stable for 64 `Task.yield()`s. A `stop`/`cancel` from `.recording` calls `deliverRecordingExit(...)`, which bumps `workEpoch` **once** and resumes the forward-path continuation **synchronously inside that step — before the drain starts**. The bump is absorbed into the drain's initial `last`, so under full-suite MainActor contention the resumed-but-unscheduled forward-path task can lose the scheduler lottery for the whole 64-yield window. The drain returns while the FSM is still `.recording`; the next `cancel` is swallowed by the already-latched stop; the stop finalizes → completed/pasted.

The seed is non-causal: A8 has no `advanceClock` step and `Scenario.applying(_:)` only rewrites `advanceClock`, so all 64 A8 iterations are byte-identical.

## Fix (test-only)
- `RecordingSessionKernel.hasUnconsumedRecordingExit` = `recordingExitLatched && state == .recording` — a kernel-owned test-observation signal (companion to `workEpoch`), true only in the deliver→consume window. No production reader, no app behavior change.
- `drainReadyWork` gates its return on `stable >= 64 && !kernel.hasUnconsumedRecordingExit`. The 20000-yield cap stays as the livelock backstop, so a genuine wedge still surfaces as a stuck-state assertion failure rather than being masked.

Founder-scoped to test-only: a same-instant cancel-after-stop letting the stop win is acceptable product behavior; product hardening explicitly out of scope.

## Tests
- Two deterministic regression locks pin the signal window (stop/cancel from recording → state stays `.recording` with the signal true until the forward path consumes it).
- A contention stress test runs the full A8 sweep under 128 competing MainActor tasks as a robustness check (honestly documented as non-discriminating — Swift's cooperative executor ordering isn't controllable from test code).

## Validation
- Full logic suite green: **1704 tests** (incl. the real sweep + new suite), under full-suite parallel contention.
- Codex grounded review: verified diagnosis 1–5 with file:line, confirmed direction/completeness/termination; **PROCEED** with comment-only revisions (applied).
- Phase 3 — Lane: Code. Logic tests ✓; smoke = dev build ✓; **Live UAT N/A** (test-observation accessor with no production reader + a test-harness change — no runtime/UI surface to exercise); Codex diff review covered by the grounded review (read the exact committed lines).

`council-skip: codex-grounded-review settled the only structural fork (kernel-owned signal vs wrapper policy); test-harness settle logic, no CI gate/hook/plan-template change; coverage questions answered with grounded file:line evidence.`

Part of #881.