### PR TITLE
chore(cleanup): remove dead foundation symbols, mark test seams (#822)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -167,7 +167,6 @@ extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate
     let available = UpdateAvailabilityService.AvailableUpdate(
       versionString: update.versionString,
       displayVersion: update.displayVersionString,
-      buildString: update.versionString,
       isCriticalUpdate: update.isCriticalUpdate
     )
     updateCoordinator?.service.noteAvailable(available)

--- a/Sources/EnviousWisprContacts/ImportedContactsStateStore.swift
+++ b/Sources/EnviousWisprContacts/ImportedContactsStateStore.swift
@@ -78,6 +78,7 @@ public struct ImportedContactsStateStore: Sendable {
 
   /// Test seam: inject an explicit file URL so unit tests hit a per-test temp
   /// file instead of the production path. Production uses the zero-arg `init()`.
+  // periphery:ignore - test seam
   package init(fileURL: URL) {
     self.fileURL = fileURL
     Self.prepareDirectory(at: fileURL.deletingLastPathComponent())

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -93,10 +93,6 @@ public enum TimingConstants {
   /// Accessibility permission polling interval (seconds).
   public static let accessibilityPollIntervalSec: Double = 5.0
 
-  /// Minimum recording duration before transcription (seconds).
-  /// Recordings shorter than this are silently discarded (accidental taps).
-  public static let minimumRecordingDuration: TimeInterval = 0.5
-
   /// Maximum recording duration before graceful auto-stop (seconds).
   /// Prevents runaway recordings from consuming unbounded memory/CPU.
   /// AudioCaptureManager has a hard emergency limit at 600s; this fires earlier and gracefully.

--- a/Sources/EnviousWisprCore/LanguageTypes.swift
+++ b/Sources/EnviousWisprCore/LanguageTypes.swift
@@ -269,10 +269,10 @@ public enum LanguageDetectorThresholds {
 
 /// Script classification helper. The set of non-Latin-script Whisper languages
 /// is fixed per spec § Layer 4.
-public enum LanguageScriptGuardrail {
+enum LanguageScriptGuardrail {
   /// ISO 639-1 codes whose dominant script is non-Latin.
   /// Sourced verbatim from the spec.
-  public static let nonLatinScriptLanguages: Set<String> = [
+  static let nonLatinScriptLanguages: Set<String> = [
     "ar", "bg", "bn", "el", "gu", "he", "hi", "ja", "ka", "km", "kn",
     "ko", "lo", "ml", "mr", "my", "ne", "pa", "ru", "sa", "si", "sr",
     "ta", "te", "th", "uk", "ur", "yi", "yue", "zh",
@@ -280,7 +280,7 @@ public enum LanguageScriptGuardrail {
 
   /// True if the ISO 639-1 language code's dominant script is not Latin.
   /// Used by the prompt layer to decide whether to strip untagged Latin terms.
-  public static func isNonLatinScript(_ lang: String) -> Bool {
+  static func isNonLatinScript(_ lang: String) -> Bool {
     nonLatinScriptLanguages.contains(lang.lowercased())
   }
 
@@ -289,13 +289,13 @@ public enum LanguageScriptGuardrail {
   /// switch to character-count for these. Note: Korean DOES use whitespace
   /// between Eojeol word units, so it stays on the word-count path. Arabic,
   /// Hebrew, Cyrillic, and Indic scripts also use whitespace.
-  public static let unsegmentedScriptLanguages: Set<String> = [
+  static let unsegmentedScriptLanguages: Set<String> = [
     "ja", "zh", "yue", "th", "lo", "my", "km",
   ]
 
   /// True if the language uses a script that does not separate words with
   /// whitespace. See `unsegmentedScriptLanguages`.
-  public static func isUnsegmentedScript(_ lang: String) -> Bool {
+  static func isUnsegmentedScript(_ lang: String) -> Bool {
     unsegmentedScriptLanguages.contains(lang.lowercased())
   }
 }

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -211,6 +211,7 @@ public final class LoadProgressWatcher {
   /// resets the watcher. Useful for deterministic assertions in tests
   /// (instead of awaiting `wedged()` and hoping the scheduler resumes it
   /// within the test runner's deadline).
+  // periphery:ignore - test seam
   public var hasFired: Bool { fired }
 
   /// Snapshot of the watcher's per-attempt state. Used by the pipeline to

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -173,8 +173,8 @@ final class RecordingSessionKernel {
   /// the simulator's logical-tick time base — not a wall-clock deadline.
   private let wedgeStallTicks: Int
 
-  /// Minimum logical-tick duration of a visible recording (PR-4.5 #4 — parity
-  /// with `TimingConstants.minimumRecordingDuration` = 500 ms). A recording
+  /// Minimum logical-tick duration of a visible recording (PR-4.5 #4 — a
+  /// 500 ms floor). A recording
   /// terminating in less than this many ticks since `→ recording` is silently
   /// discarded as an accidental tap (`discardReason = .tooShort`). Measured
   /// from VISIBLE recording start, NOT from pre-roll capture (PR-4.5 §5b — so

--- a/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
+++ b/Sources/EnviousWisprServices/PasteCompletionRegistry.swift
@@ -77,6 +77,7 @@ public final class PasteCompletionRegistry {
   }
 
   /// Test-only — current observer count (after pruning dead weak refs).
+  // periphery:ignore - test seam
   public var observerCount: Int {
     observers.removeAll { $0.value == nil }
     return observers.count

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -289,6 +289,7 @@ extension SentryBreadcrumb {
   /// query Core Audio, await work, or take locks on the Sentry capture path.
   public nonisolated(unsafe) static var audioEnvironmentProvider: AudioEnvironmentProvider?
 
+  // periphery:ignore - test seam
   public static func withAudioEnvironmentProvider<T>(
     _ provider: AudioEnvironmentProvider?,
     _ body: () throws -> T

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -54,7 +54,6 @@ enum SettingsDefaultValues {
   static let useExtendedThinking = false
 
   static let whisperKitLanguage = "en"
-  static let languageMode: LanguageMode = .auto
 
   static let selectedInputDeviceUID = ""
   static let noiseSuppression = false

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -13,18 +13,15 @@ public final class UpdateAvailabilityService {
   public struct AvailableUpdate: Sendable, Equatable {
     public let versionString: String  // CFBundleVersion (canonical compare key)
     public let displayVersion: String  // CFBundleShortVersionString (UI copy)
-    public let buildString: String?
     public let isCriticalUpdate: Bool
 
     public init(
       versionString: String,
       displayVersion: String,
-      buildString: String?,
       isCriticalUpdate: Bool
     ) {
       self.versionString = versionString
       self.displayVersion = displayVersion
-      self.buildString = buildString
       self.isCriticalUpdate = isCriticalUpdate
     }
   }
@@ -113,6 +110,7 @@ public final class UpdateAvailabilityService {
   /// Public API retained for tests; no in-app caller post-#739. Sparkle's
   /// cycle-finish callback no longer invokes this — widget state is cleared by
   /// `rehydratePendingIfNewer` when the bundle version catches up to pending.
+  // periphery:ignore - test seam
   public func noteResolved(installedVersion: String?) {
     state = .none
     dismissedForSession = false
@@ -123,6 +121,7 @@ public final class UpdateAvailabilityService {
 
   // MARK: - User-driven mutations
 
+  // periphery:ignore - test seam
   public func dismissForSession() {
     dismissedForSession = true
     if case .available(let u) = state {
@@ -168,7 +167,6 @@ public final class UpdateAvailabilityService {
     return AvailableUpdate(
       versionString: v,
       displayVersion: display,
-      buildString: v,
       isCriticalUpdate: isCritical
     )
   }

--- a/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
@@ -23,7 +23,6 @@ struct UpdateAvailabilityServiceTests {
     UpdateAvailabilityService.AvailableUpdate(
       versionString: version,
       displayVersion: display,
-      buildString: version,
       isCriticalUpdate: critical
     )
   }


### PR DESCRIPTION
Part of #822 (dead-code sweep tier 1) · epic #821.

First batch of the Periphery cleanup — foundation/support modules (Core / Services / Contacts). Driven by the fresh Xcode-mode scan (2026-06-06, `docs/periphery-findings-2026-06-06.txt`), **not** the stale 2026-05-20 #821 triage. Every candidate re-validated against current code by Codex.

## Removed (validated unreferenced in prod AND tests)
- `TimingConstants.minimumRecordingDuration` — only a stale doc reference remained; `RecordingSessionKernel` owns its own tick-based 500 ms floor.
- `SettingsDefaultValues.languageMode` — orphaned; `SettingsManager` resolves its own `.auto` default via `resolvedLanguageMode`.
- `AvailableUpdate.buildString` — always `== versionString`, never read by UI. All 3 construction sites updated (Sparkle controller, persisted rehydrate, test).

## Downgraded public → internal
- `LanguageScriptGuardrail` enum + members — reached only via the public `LanguageTypes` wrapper (same module).

## Marked test-only seams (`// periphery:ignore - test seam`)
`ImportedContactsStateStore.init(fileURL:)`, `LoadProgressWatcher.hasFired`, `PasteCompletionRegistry.observerCount`, `SentryBreadcrumb.withAudioEnvironmentProvider`, `UpdateAvailabilityService.noteResolved` / `dismissForSession`.

## Kept (Codex KEEP-API — confirmed live, NOT dead)
PasteCompletionRegistry observer chain (emits on every paste), `FocusSnapshot`, `SentryBreadcrumb.reportAIFailure`, `TelemetryService` planned-schema events.

## Deferred to heart-path batches (need dictation UAT)
`XPCErrorContext.timestampNs` (Audio), `ClipboardSnapshot.changeCount` (Paste).

## Validation
- Dev build (Xcode, `EnviousWispr-Dev`/Dev): green.
- Logic tests (`scripts/xcode-test.sh`): **1704 tests passed**.
- Codex diff review: **SHIP** — no remaining references, all construction sites updated, downgrade has no cross-module callers, annotations correctly placed.

`council-skip: codex-grounded-review settled — pure dead-code removal, no user surface, no new symbols, no design ambiguity (#822 tier 1)`