### PR TITLE
chore(cleanup): remove dead PostProcessing symbols, mark test seams (#822)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -42,6 +42,7 @@ public final class CustomWordsManager {
   /// per-test temp file instead of the production Application Support path.
   /// Production code always uses the zero-arg `init()`. Bible §9.3 disk
   /// round-trip coverage was missing from Phase 3b; this seam closes it.
+  // periphery:ignore - test seam
   package init(fileURL: URL) {
     self.fileURL = fileURL
     let directory = fileURL.deletingLastPathComponent()
@@ -209,6 +210,7 @@ public final class CustomWordsManager {
   /// Phase 3b (#631): test seam — synchronously flush any pending increments.
   /// Production code never calls this; tests use it to validate the writer
   /// without waiting for the 30s debounce timer.
+  // periphery:ignore - test seam
   package func flushPendingIncrementsForTesting() {
     flushPendingIncrements()
   }

--- a/Sources/EnviousWisprPostProcessing/EmojiFormatter.swift
+++ b/Sources/EnviousWisprPostProcessing/EmojiFormatter.swift
@@ -15,6 +15,7 @@ public struct EmojiFormatter: Sendable {
     public let emoji: String  // "👍"
     public let synonyms: [String]  // ["thumb up", "thumbs-up"]
 
+    // periphery:ignore - test seam
     public init(phrase: String, emoji: String, synonyms: [String] = []) {
       self.phrase = phrase
       self.emoji = emoji
@@ -196,12 +197,14 @@ public struct EmojiFormatter: Sendable {
   /// resource bundle did not ship. Exposes the SAME `Bundle.module` lookup the
   /// production `load()` path uses — not a fallback — so a test can assert the
   /// shipped resource resolves at runtime under the Xcode build.
+  // periphery:ignore - test seam (resource-resolution diagnostic)
   public static var bundledDictionaryURLForDiagnostics: URL? {
     Bundle.module.url(forResource: "emoji-dictionary", withExtension: "json")
   }
 
   /// The `Bundle.module` bundle URL, for asserting where the resource bundle
   /// physically resolves (e.g. inside a signed app's `Contents/Resources`).
+  // periphery:ignore - test seam (resource-resolution diagnostic)
   public static var moduleBundleURLForDiagnostics: URL {
     Bundle.module.bundleURL
   }
@@ -255,7 +258,6 @@ public struct EmojiFormatter: Sendable {
   struct CandidateMatch: Equatable {
     let range: NSRange
     let emoji: String
-    let phrase: String
   }
 
   /// Tier A (exact canonical) + Tier B (synonym). Returns non-overlapping
@@ -276,7 +278,7 @@ public struct EmojiFormatter: Sendable {
         for m in results {
           if !overlaps(m.range) {
             taken.append(m.range)
-            out.append(CandidateMatch(range: m.range, emoji: entry.emoji, phrase: entry.phrase))
+            out.append(CandidateMatch(range: m.range, emoji: entry.emoji))
           }
         }
       }
@@ -368,7 +370,7 @@ public struct EmojiFormatter: Sendable {
           continue
         }
         newlyCovered.append(matchRange)
-        out.append(CandidateMatch(range: matchRange, emoji: chosen.emoji, phrase: chosen.phrase))
+        out.append(CandidateMatch(range: matchRange, emoji: chosen.emoji))
         break  // only longest matching span per trigger
       }
     }

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -95,7 +95,6 @@ public struct InverseTextNormalizer: Sendable {
     words.sorted { $0.count != $1.count ? $0.count > $1.count : $0 < $1 }.joined(separator: "|")
   }
   static func alt(_ words: Set<String>) -> String { alt(Array(words)) }
-  static func alt(_ words: [String.SubSequence]) -> String { alt(words.map(String.init)) }
 
   static let numwordAlt = alt(numword)
   // A number token: a number-WORD or an already-digit token ('20', '1,234') for mixed-state.

--- a/Sources/EnviousWisprPostProcessing/VocabularyPackStore.swift
+++ b/Sources/EnviousWisprPostProcessing/VocabularyPackStore.swift
@@ -44,7 +44,6 @@ public enum VocabularyPackID: String, CaseIterable, Sendable, Codable, Identifia
 }
 
 public struct VocabularyPack: Sendable {
-  public let id: VocabularyPackID
   public let terms: [CustomWord]
 }
 
@@ -55,11 +54,6 @@ public final class VocabularyPackStore: Sendable {
   /// Production: loads from this module's `Bundle.module`.
   public init() {
     self.bundle = .module
-  }
-
-  /// Test seam: inject a fixture bundle.
-  package init(bundle: Bundle) {
-    self.bundle = bundle
   }
 
   /// Pack IDs whose JSON resolves in the bundle. Fail-open: unresolved packs
@@ -80,7 +74,7 @@ public final class VocabularyPackStore: Sendable {
         source: .pack
       )
     }
-    return VocabularyPack(id: id, terms: terms)
+    return VocabularyPack(terms: terms)
   }
 
   /// Flattened terms for every enabled pack (deterministic order). Missing

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -353,6 +353,7 @@ public struct WordCorrector: Sendable {
 
   /// Convenience overload — builds lookups inline. Use this when you only
   /// call `correct` once per vocabulary (legacy callers, tests).
+  // periphery:ignore - test seam
   public func correct(_ text: String, against words: [CustomWord]) -> (
     corrected: String, replacements: [Replacement]
   ) {

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -46,6 +46,7 @@ public final class WordSuggestionService: Sendable {
   /// NEVER call from production code. Production reads `suggest(for:)`,
   /// which shares the same `runRawSuggestion` core but wraps a 5s timeout
   /// and returns `WordSuggestions?` after running the degeneration filter.
+  // periphery:ignore - eval harness API (scripts/eval/alias_runner)
   public func benchmarkSuggest(
     for word: String,
     disableTimeout: Bool = false


### PR DESCRIPTION
Part of #822 (dead-code sweep tier 1) · epic #821.

Second batch of the Periphery cleanup — PostProcessing module. Driven by the fresh Xcode-mode scan (2026-06-06); every candidate re-validated against current code by Codex.

## Removed (validated unreferenced in prod AND tests)
- `InverseTextNormalizer.alt([String.SubSequence])` overload — callers convert via `.map(String.init)` and use the `[String]` / `Set` overloads.
- `VocabularyPackStore.init(bundle:)` — no references anywhere; prod uses default `init()`.
- `EmojiFormatter.CandidateMatch.phrase` — assign-only; consumers read `range` + `emoji`.
- `VocabularyPack.id` — assign-only; consumers read `.terms`.

## Marked test-only / eval seams (`// periphery:ignore`)
`CustomWordsManager.init(fileURL:)` / `flushPendingIncrementsForTesting`, `EmojiFormatter.Entry.init` + both `*ForDiagnostics` URLs, `WordCorrector.correct(_:against:)` (prod uses `correct(_:using:)`), `WordSuggestionService.benchmarkSuggest` (eval harness `scripts/eval/alias_runner`; retains `elapsedMs` + `WordSuggestionBenchmarkRecord`).

## Kept (Codex — NOT dead)
`CustomWordsManager.add(canonical:to:)` is now live via the contacts-import path (a 2026-05-20-plan verdict that's since gone stale).

## Validation
- Dev build (Xcode `EnviousWispr-Dev`/Dev): green.
- Logic tests (`scripts/xcode-test.sh`): **1704 tests passed**.
- Codex diff review: **SHIP** — no remaining references; `VocabularyPack(`/`CandidateMatch(` sites updated; annotations correctly placed.
- No `acceptance_gate.py` polish mirror touched (Codex-confirmed).

`council-skip: codex-grounded-review settled — pure dead-code removal, no user surface, no new symbols, no design ambiguity (#822 tier 1)`