### PR TITLE
chore(cleanup): dead heart-path symbols — Audio/ASR/recording wiring (#822 part 1)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -176,6 +176,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// for the #586 regression test that exercises the polling lifecycle without
   /// going through the (XPC-coupled) `loadModel` happy path. Tests reach it
   /// via `@testable import EnviousWisprASR`.
+  // periphery:ignore - test seam
   internal var isProgressPollingActiveForTesting: Bool { progressPollTimer != nil }
 
   /// Read-only handle to the live polling timer, for the #586 leak-regression
@@ -183,6 +184,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// assert it was invalidated (a leak is invisible through the `!= nil` flag
   /// above, which only ever sees the newest timer). Read-only window onto the
   /// existing private state — adds no behavior and no new stored property.
+  // periphery:ignore - test seam
   internal var progressPollTimerForTesting: Timer? { progressPollTimer }
 
   internal func startProgressPolling() {

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -51,7 +51,7 @@ public protocol ASRBackend: Actor {
 extension ASRBackend {
   public var supportsStreaming: Bool { false }
 
-  public func startStreaming(options: TranscriptionOptions) async throws {
+  public func startStreaming(options _: TranscriptionOptions) async throws {
     throw ASRError.streamingNotSupported
   }
 

--- a/Sources/EnviousWisprASR/LanguageDetector.swift
+++ b/Sources/EnviousWisprASR/LanguageDetector.swift
@@ -448,11 +448,13 @@ public actor LanguageDetector {
   public func peekMemory() -> SessionLanguageMemory { memory }
   /// Testing-only: seed memory (e.g., for anti-flap setups without replaying
   /// full history).
+  // periphery:ignore - test seam
   public func setMemoryForTesting(_ memory: SessionLanguageMemory) {
     self.memory = memory
   }
   /// Testing seam: run Layer 3 logic over a pre-computed probability dict.
   /// Skips the WhisperKit call so tests do not need a real model.
+  // periphery:ignore - test seam
   public func evaluateForTesting(
     windowProbs: [String: Double],
     voicedDuration: TimeInterval,

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -104,7 +104,7 @@ public actor ParakeetBackend: ASRBackend {
 
   // MARK: - Streaming ASR
 
-  public func startStreaming(options: TranscriptionOptions) async throws {
+  public func startStreaming(options _: TranscriptionOptions) async throws {
     guard isReady, let models = fluidModels else { throw ASRError.notReady }
 
     // Cancel any existing streaming session before starting a new one.

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -59,17 +59,6 @@ public actor WhisperKitBackend: ASRBackend {
     "openai_whisper-large-v3-v20240930_turbo"
   }
 
-  /// Issue #445 / Codex pass 3: drop the held `loadTask` reference so the
-  /// next `prepare()` starts a fresh task instead of awaiting the wedged
-  /// one. The wedged task itself cannot be cancelled (CoreML's `MLModel.load`
-  /// is synchronous and ignores cooperative cancel) — it leaks until it
-  /// returns. But the `isReady` flag stays false, so the next call enters the
-  /// new-task branch and the user gets a clean retry.
-  public func resetLoadState() {
-    loadTask?.cancel()
-    loadTask = nil
-  }
-
   public func prepare() async throws {
     guard !isReady else { return }  // Idempotent — skip if already loaded
 

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
@@ -8,7 +8,6 @@ import Foundation
 /// resolver-helper closure needed.
 @MainActor
 final class ASREventRouter {
-  let asrManager: any ASRManagerInterface
   let kernelDriver: KernelDictationDriver
   let whisperKitKernelDriver: KernelDictationDriver
 
@@ -17,7 +16,6 @@ final class ASREventRouter {
     kernelDriver: KernelDictationDriver,
     whisperKitKernelDriver: KernelDictationDriver
   ) {
-    self.asrManager = asrManager
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
 

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -1,9 +1,7 @@
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprPipeline
 import EnviousWisprServices
-import EnviousWisprStorage
 import Foundation
 
 /// PR9 of #763 — Lifecycle home for pipeline state-change side effects plus the

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -32,9 +32,13 @@ import Foundation
 @MainActor
 @Observable
 final class DictationRuntime {
+  // periphery:ignore - retain anchor: owns the lifecycle coordinator (installs weak-self driver callbacks)
   private let dictationLifecycleCoordinator: DictationLifecycleCoordinator
+  // periphery:ignore - retain anchor: owns the audio event router (AVAudio observer + weak-self callbacks)
   private let audioEventRouter: AudioEventRouter
+  // periphery:ignore - retain anchor: owns the ASR event router (asrManager.onServiceInterrupted weak-self callback)
   private let asrEventRouter: ASREventRouter
+  // periphery:ignore - retain anchor: owns the wedge-recovery router (audioCapture weak-self callbacks)
   private let wedgeRecoveryRouter: WedgeRecoveryRouter
   private let hotkeyController: HotkeyController
   private let starter: RecordingStarter

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -25,7 +25,6 @@ final class RecordingStarter {
   let kernelDriver: KernelDictationDriver
   let whisperKitKernelDriver: KernelDictationDriver
   let settings: SettingsManager
-  let permissions: PermissionsService
   let recordingOverlay: RecordingOverlayPanel
   /// #904 test seam — the accessibility re-arm step `start()`/`toggle()` run.
   /// Default (bound in init capturing `permissions`, since a default arg can't
@@ -80,7 +79,6 @@ final class RecordingStarter {
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
     self.settings = settings
-    self.permissions = permissions
     self.recordingOverlay = recordingOverlay
     self.heartControlRecovery = heartControlRecovery
     self.recordingLockedAccess = recordingLockedAccess

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/WedgeRecoveryRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/WedgeRecoveryRouter.swift
@@ -1,7 +1,6 @@
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprPipeline
-import EnviousWisprServices
 import Foundation
 
 /// PR8 of #763 — routes capture-stall, XPC reply timeout, and capture-session
@@ -9,23 +8,16 @@ import Foundation
 /// stale callbacks via `isCurrentSession` before dispatching.
 @MainActor
 final class WedgeRecoveryRouter {
-  let audioCapture: any AudioCaptureInterface
-  let kernelDriver: KernelDictationDriver
-  let whisperKitKernelDriver: KernelDictationDriver
-
   let isCurrentSession: @MainActor (UInt64) -> Bool
   let resolveActiveTelemetryTarget: @MainActor () -> (any HeartPathTelemetryTarget)?
 
   init(
     audioCapture: any AudioCaptureInterface,
-    kernelDriver: KernelDictationDriver,
-    whisperKitKernelDriver: KernelDictationDriver,
+    kernelDriver _: KernelDictationDriver,
+    whisperKitKernelDriver _: KernelDictationDriver,
     isCurrentSession: @escaping @MainActor (UInt64) -> Bool,
     resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?
   ) {
-    self.audioCapture = audioCapture
-    self.kernelDriver = kernelDriver
-    self.whisperKitKernelDriver = whisperKitKernelDriver
     self.isCurrentSession = isCurrentSession
     self.resolveActiveTelemetryTarget = resolveActiveTelemetryTarget
 

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -115,9 +115,6 @@ final class AVAudioEngineSource: AudioInputSource {
   )
   /// Pending watchdog; cancelled on stop / deactivate / new session.
   private var stallWorkItem: DispatchWorkItem?
-  /// Uptime nanoseconds captured when the current watchdog was armed —
-  /// passed into `CaptureStallContext` for latency diagnostics.
-  private var stallArmedAtUptimeNs: UInt64 = 0
 
   // MARK: - State
 
@@ -361,7 +358,6 @@ final class AVAudioEngineSource: AudioInputSource {
     stallWorkItem?.cancel()
     let armedSession = captureGeneration
     let armedAtNs = DispatchTime.now().uptimeNanoseconds
-    stallArmedAtUptimeNs = armedAtNs
     let item = Self.makeStallWorkItem(
       armedSession: armedSession, armedAtNs: armedAtNs, source: self)
     stallWorkItem = item

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -26,10 +26,6 @@ private final class SessionLifecycleSignal<T: Sendable>: @unchecked Sendable {
     self.continuation = continuation
   }
 
-  func observe(name: Notification.Name, object: Any?, returning value: T) {
-    observe(name: name, object: object, returning: value, onSignal: nil)
-  }
-
   func observe(
     name: Notification.Name,
     object: Any?,

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -6,6 +6,7 @@ import EnviousWisprCore
 @MainActor
 public protocol AudioCaptureInterface: AnyObject {
   // Observable state (read-only externally)
+  // periphery:ignore - protocol requirement; prod reads concrete impls
   var isCapturing: Bool { get }
   var audioLevel: Float { get }
   var capturedSamples: [Float] { get }
@@ -52,6 +53,7 @@ public protocol AudioCaptureInterface: AnyObject {
   /// Fires on the first route resolution and on every subsequent resolution
   /// where sourceType or reason differs from the prior call. No-op on
   /// warm-reuse resolutions that produce the same decision.
+  // periphery:ignore - planned route telemetry API (producers wired, consumer pending)
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)? { get set }
 
   /// Monotonic per-source identifier for the active capture session.
@@ -92,6 +94,8 @@ public protocol AudioCaptureInterface: AnyObject {
 
   // VAD (Step 5)
   func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)
+  // periphery:ignore - XPC capture contract (invoked via NSXPC proxy)
   func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int)
+  // periphery:ignore - XPC capture contract (invoked via NSXPC proxy)
   func getVADSegments() async -> [SpeechSegment]
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -587,6 +587,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Returns empty — in-process VAD segments are owned by the pipeline's SilenceDetector,
   /// not by the capture manager. Only meaningful for the XPC path.
+  // periphery:ignore - XPC capture contract (invoked via NSXPC proxy)
   public func getVADSegments() async -> [SpeechSegment] {
     return []
   }

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -706,6 +706,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
   }
 
+  // periphery:ignore - XPC capture contract (invoked via NSXPC proxy)
   public func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) {
     // Use OneShotContinuation to guarantee exactly one resume — XPC error handler and
     // reply handler can race, and double-resume is undefined behavior.
@@ -729,6 +730,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
   }
 
+  // periphery:ignore - XPC capture contract (invoked via NSXPC proxy)
   public func getVADSegments() async -> [SpeechSegment] {
     // Use OneShotContinuation to guarantee exactly one resume.
     let sessionID = activeCaptureGeneration

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -3,7 +3,7 @@ import CoreAudio
 /// Policy for selecting the audio capture source.
 /// `.automatic` decides based on output route + input intent.
 /// `.forceEngine` / `.forceCaptureSession` are for debugging/testing.
-public enum CaptureSourcePolicy: Sendable {
+enum CaptureSourcePolicy: Sendable {
   case automatic
   case forceEngine
   case forceCaptureSession

--- a/Sources/EnviousWisprAudio/RotatingFileSink.swift
+++ b/Sources/EnviousWisprAudio/RotatingFileSink.swift
@@ -45,14 +45,14 @@ import os
 /// Callers must NOT invoke `append` while holding the RT audio lock — see
 /// `architecture-rules.md` Audio/ASR Danger Zones. Capture the message
 /// outside the RT lock and emit afterwards.
-public final class RotatingFileSink: @unchecked Sendable {
+final class RotatingFileSink: @unchecked Sendable {
   private let path: URL
   private let lockFilePath: URL
   private let maxSize: Int
   private let maxFiles: Int
   private let lock = OSAllocatedUnfairLock()
 
-  public init(path: URL, maxSize: Int = 5 * 1_024 * 1_024, maxFiles: Int = 3) {
+  init(path: URL, maxSize: Int = 5 * 1_024 * 1_024, maxFiles: Int = 3) {
     self.path = path
     // Stable companion file for cross-process flock. Never renamed, never
     // touched by rotation logic — its only role is to host an OS file lock
@@ -65,7 +65,7 @@ public final class RotatingFileSink: @unchecked Sendable {
 
   /// Append a single message to the sink. Synchronous and nonisolated; safe to
   /// call from non-RT audio paths. Failures are silent (best-effort logging).
-  public func append(_ message: String) {
+  func append(_ message: String) {
     let data = Data(message.utf8)
     lock.withLock {
       Self.atomicAppendWithRotation(

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -334,32 +334,6 @@ public actor SilenceDetector {
     }
   }
 
-  public func filterSamples(from allSamples: [Float], padding: Int = 1600) -> [Float] {
-    guard !speechSegments.isEmpty else { return allSamples }
-
-    let totalVoiced = speechSegments.reduce(0) { $0 + ($1.endSample - $1.startSample) }
-    guard totalVoiced >= 4800 else { return allSamples }
-
-    // Build padded ranges and merge overlaps
-    var merged: [(start: Int, end: Int)] = []
-    for segment in speechSegments {
-      let start = max(0, segment.startSample - padding)
-      let end = min(allSamples.count, segment.endSample + padding)
-      if let last = merged.last, start <= last.end {
-        merged[merged.count - 1].end = max(last.end, end)
-      } else {
-        merged.append((start, end))
-      }
-    }
-
-    var result: [Float] = []
-    for range in merged {
-      guard range.start < range.end else { continue }
-      result.append(contentsOf: allSamples[range.start..<range.end])
-    }
-    return result.isEmpty ? allSamples : result
-  }
-
   // MARK: - Private Helpers
 
   /// Applies a FluidAudio streaming VAD boundary event to `speechSegments`.


### PR DESCRIPTION
Part of #822 (dead-code sweep tier 1) · epic #821.

Heart-path batch **part 1** — Audio capture, ASR backends, and the recording-orchestration routers. Every candidate re-validated against current code by Codex (per-module read-only passes run from this worktree, not a stale plan). Pipeline + LLM follow in part 2 / part 3 so each heart-path PR stays small and gets its own dual-engine UAT.

## Removed (validated unreferenced in prod AND tests)
- `AVAudioEngineSource.stallArmedAtUptimeNs` — assign-only; the watchdog uses the local `armedAtNs`
- `AVCaptureSessionSource.SessionLifecycleSignal.observe(name:object:returning:)` — the no-`onSignal` overload (callers use the `onSignal` one)
- `SilenceDetector.filterSamples(from:padding:)` — no caller (the pipeline owns sample filtering)
- `WhisperKitBackend.resetLoadState()` — no caller (#445 recovery runs at the manager/XPC level)
- Assign-only stored references on the recording routers (collaborators are App-owned, retained elsewhere): `ASREventRouter.asrManager`, `RecordingStarter.permissions`, `WedgeRecoveryRouter.audioCapture/kernelDriver/whisperKitKernelDriver`
- Unused imports: `EnviousWisprServices` (WedgeRecoveryRouter), `EnviousWisprASR` + `EnviousWisprStorage` (DictationLifecycleCoordinator)

## Downgraded public → internal (no app-target / cross-module use)
- `CaptureSourcePolicy`; `RotatingFileSink` class + `init` + `append(_:)`

## Renamed unused contract params → `_` (label preserved, call sites unaffected)
- `ASRBackend` default `startStreaming(options:)`, `ParakeetBackend.startStreaming(options:)`

## Annotated `// periphery:ignore` (intentional keeps, documented at the site)
- **retain anchors**: `DictationRuntime`'s 4 router fields (it owns the routers; callbacks capture weak self)
- **XPC capture contract** (invoked via NSXPC, periphery can't trace): `AudioCaptureInterface.getSamplesSnapshot/getVADSegments` + concrete impls
- **planned route telemetry API**: `AudioCaptureInterface.onRouteResolved`
- **protocol requirement read via concrete impls**: `AudioCaptureInterface.isCapturing`
- **test seams**: `ASRManagerProxy.isProgressPollingActiveForTesting/progressPollTimerForTesting`, `LanguageDetector.setMemoryForTesting/evaluateForTesting`

## Deferred to a follow-up (bigger than dead-code removal; need their own validation)
- ASR `download*` progress mirror removal (protocol surface + 2 conformers + 8 test doubles; onboarding flow not covered by recording UAT)
- `ModelDownloadManager` vestigial instance-method cluster (keep static `verifyChecksum` + `StallTracker`)
- `WedgeRecoveryRouter` vestigial driver params (removal touches 3 test-double sites; currently `_`-named)
- `LanguageDetector.detect(samples:)` + `ASRProtocol` requirement `options` param (documented API params)

## Validation
- Dev build (Xcode `EnviousWispr-Dev`/Dev): **green**.
- Logic tests (`scripts/xcode-test.sh`): **1704 passed, 0 failures** (1617 + 87 across the two bundles).
- Dual-engine ambient UAT (no TTS; ambient room audio, verdicts read from app.log):
  - **WhisperKit: full path PASS** — capture → ASR → WordCorrection → Filler → Emoji → ITN → polish → paste via cgevent; "Pipeline timing TOTAL: 1.394s".
  - **Parakeet: capture + VAD + ASR ran, graceful `terminal noSpeech`** (×3) — ambient was below the speech-energy floor (peak ~0.01), so the ASR correctly found no speech and returned to idle. Capture/VAD/conditioner/ASR/kernel orchestration all exercised; no hang, no crash. The shared post-ASR pipeline is covered by the WhisperKit run.
- Codex diff review: **SHIP** — deletions, assign-only stored-field drops (retention not load-bearing), retain anchors, downgrades, import removals, param renames, and annotation format all verified against current code with `rg`.

`council-skip: codex-grounded-review settled — pure heart-path dead-code removal + visibility/annotation, no user surface, no design ambiguity (#822 tier 1)`