### PR TITLE
chore(cleanup): dead Pipeline symbols, visibility, seams (#822 part 2)

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -198,7 +198,7 @@ public struct AudioBufferHandoff: @unchecked Sendable {
 /// MUST / MUST NOT clauses in PR-1 §B.2.2 define the behavior every conformer
 /// (`FakeEngine`, and the PR-4 / PR-5 real adapters) must implement.
 @MainActor
-public protocol ASREngineAdapter: AnyObject {
+package protocol ASREngineAdapter: AnyObject {
   // MARK: Identity & capability
 
   /// Self-declared engine identity. The kernel and factory read identity from

--- a/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
+++ b/Sources/EnviousWisprPipeline/CapturedAudioConditioner.swift
@@ -79,7 +79,7 @@ public struct ConditionedAudio: Equatable, Sendable {
 /// Apply VAD-segment filtering, too-aggressive-filter raw fallback, and
 /// short-utterance padding in the order the old pipeline did (PR-4.5 plan
 /// §3 #5 + §5b). Pure function; safe to call from any actor.
-public enum CapturedAudioConditioner {
+enum CapturedAudioConditioner {
 
   /// Condition `rawSamples` for ASR batch rescue. When `vadSegments` is empty
   /// the VAD-filter step is a no-op (the kernel passes empty segments when no
@@ -87,7 +87,7 @@ public enum CapturedAudioConditioner {
   ///
   /// `minimumSamples` defaults to `AudioConstants.minimumTranscriptionSamples`
   /// — both ASR backends require ≥1 s of audio. Tests may override.
-  public static func condition(
+  static func condition(
     rawSamples: [Float],
     vadSegments: [SpeechSegment],
     minimumSamples: Int = AudioConstants.minimumTranscriptionSamples

--- a/Sources/EnviousWisprPipeline/EmojiFormatterStep.swift
+++ b/Sources/EnviousWisprPipeline/EmojiFormatterStep.swift
@@ -34,6 +34,7 @@ public final class EmojiFormatterStep: TextProcessingStep {
   }
 
   /// Test seam — inject a custom formatter (used by `EmojiFormatterStepTests`).
+  // periphery:ignore - test seam
   init(formatter: EmojiFormatter?) {
     self.formatter = formatter
   }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -1,4 +1,3 @@
-import EnviousWisprAudio
 import Foundation
 
 /// Per-call context for `HeartPathTelemetryEmitter.noAudioCaptured(...)`.

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -1,4 +1,3 @@
-import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -19,54 +19,54 @@ import Foundation
 /// so it runs OFF the main actor (the `WordCorrectionStep` pattern) and a no-op returns
 /// the input context untouched. Founder Gate-1 (2026-06-02): always ON, no user toggle.
 @MainActor
-public final class InverseTextNormalizationStep: TextProcessingStep {
-  public let name = "Inverse Text Normalization"
+final class InverseTextNormalizationStep: TextProcessingStep {
+  let name = "Inverse Text Normalization"
 
   /// Always-on safety floor (#145, founder Gate-1 2026-06-02: ON for all, no toggle).
-  public var isEnabled: Bool { true }
+  var isEnabled: Bool { true }
 
   /// Runner-level runaway BACKSTOP only. The real cap is the step's own 0.5s
   /// `withDeadline` in `process(...)` — a TRUE wall-clock bound that abandons a
   /// pathological `normalize` so the heart path's paste is never held. This outer
   /// bound sits comfortably above 0.5s so the runner never preempts the step's
   /// own deadline (which also owns the anomaly breadcrumb).
-  public var maxDuration: Duration { .seconds(2) }
+  var maxDuration: Duration { .seconds(2) }
 
   /// Per-session capability hint wired by `KernelFinalizationWiring` from
   /// `adapter.capabilities.supportsLanguageDetection` — NOT an engine-identity
   /// literal (`EngineIdentityFreezeTests` bans identity reads at non-factory sites).
   /// Default `false` = legacy / Parakeet-class (run on English-or-unknown), the
   /// always-on intent for steps constructed in isolation (tests).
-  public var backendSupportsLID: Bool = false
+  var backendSupportsLID: Bool = false
 
   /// Per-run outcome the wiring reads after the chain runs to thread ITN fields onto
   /// `dictation.completed`. Metadata only (counts/lengths/latency/skip-reason) — never
   /// transcript text (`telemetry-privacy-boundary`).
-  public struct RunOutcome: Sendable {
+  struct RunOutcome: Sendable {
     /// True when the engine actually ran (not gated out by language).
-    public let ran: Bool
+    let ran: Bool
     /// True when the engine changed the text.
-    public let changed: Bool
+    let changed: Bool
     /// `nil` when it ran; otherwise the skip bucket (`non_english` / `lid_backend_nil`).
-    public let skipReason: String?
+    let skipReason: String?
     /// Wall-clock of the engine call in milliseconds (0 on skip).
-    public let latencyMs: Double
+    let latencyMs: Double
     /// Character length before / after (edit size is allowed; #253 precedent).
-    public let lenBefore: Int
-    public let lenAfter: Int
+    let lenBefore: Int
+    let lenAfter: Int
   }
 
   /// The most recent `process(...)` outcome. Read by `KernelFinalizationWiring`
   /// immediately after the chain runs (same actor, no race).
-  public private(set) var lastRun: RunOutcome?
+  private(set) var lastRun: RunOutcome?
 
   private let normalizer: InverseTextNormalizer
 
-  public init(normalizer: InverseTextNormalizer = InverseTextNormalizer()) {
+  init(normalizer: InverseTextNormalizer = InverseTextNormalizer()) {
     self.normalizer = normalizer
   }
 
-  public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+  func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     let input = context.text
     let lenBefore = input.count
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -693,12 +693,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     /// a specific FSM state (e.g. force `.finalizing` to assert `.polishing`
     /// state mapping or to pin a safe-point invariant) reach `testForceTransition`
     /// through this accessor.
+    // periphery:ignore - test seam
     var kernelForTesting: RecordingSessionKernel { kernel }
 
     /// Test-only session-context handle. Used to verify the terminal-state
     /// cleanup clears `targetApp` + `targetElement` (Div 8 of seam audit /
     /// TP:998-1000, 1128-1129, 1221-1223). The context's properties are not
     /// otherwise observable from outside the driver.
+    // periphery:ignore - test seam
     var contextForTesting: KernelSessionContext { context }
   #endif
 

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -1,6 +1,5 @@
 import EnviousWisprAudio
 import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 // MARK: - KernelHeartPathTelemetryObserver (epic #827, PR-4 §3.9)

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -552,6 +552,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// that a queued feed saw the terminated session and skipped — instead of
   /// yield-polling `feedAudioCount`. Each task always returns (it guards on the
   /// session check and returns), so the await is bounded.
+  // periphery:ignore - test seam
   internal var feedTasksForUnitTests: [Task<Void, Never>] { feedTasks }
 }
 

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -9,8 +9,8 @@ import Foundation
 // App consumes it directly. `KernelOwnershipFreezeTests` keeps it deleted.
 
 /// Known interruption message strings used to route .error state to .interruption overlay intent.
-public enum InterruptionMessages {
-  public static let micDisconnected = "Microphone disconnected"
+enum InterruptionMessages {
+  static let micDisconnected = "Microphone disconnected"
 }
 
 /// Events the recording driver handles.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -71,20 +71,21 @@ public enum RecordingSessionState: Equatable, Sendable {
 
 /// The `finalizing` sub-status surfaced for the overlay string (PR-1 §B.4,
 /// PR-3 plan §3.5). The kernel owns the observation point; a limb only emits.
-public enum FinalizingSubStatus: Equatable, Sendable {
+enum FinalizingSubStatus: Equatable, Sendable {
   case transcribing
   case polishing
 }
 
 /// How the transcript reached the user (PR-1 §B.1.3). The kernel records this
 /// from the `deliver` seam's return value.
-public enum KernelDeliveryOutcome: Equatable, Sendable {
+enum KernelDeliveryOutcome: Equatable, Sendable {
   case pasted
   case clipboardOnly
 }
 
 /// The user-visible error surface a terminal state renders (PR-1 §B.1.3).
-public enum KernelErrorCategory: Equatable, Sendable {
+// periphery:ignore - test seam (read only via the test-only userVisibleError)
+enum KernelErrorCategory: Equatable, Sendable {
   case recoverableError
   case interruption
 }
@@ -93,7 +94,7 @@ public enum KernelErrorCategory: Equatable, Sendable {
 /// PR-1 §B.7.4 telemetry event (PR-4 plan §3.8a). A sibling observable to
 /// `state`, the same shape as `deliveredTranscript`; the `discarded` FSM case
 /// stays plain (no state-enum payload).
-public enum DiscardReason: Equatable, Sendable {
+enum DiscardReason: Equatable, Sendable {
   /// Stop latched before the session ever reached `recording` — PTT released
   /// during prepare / warm-up. No transcribable audio.
   case releasedBeforeRecording
@@ -107,7 +108,7 @@ public enum DiscardReason: Equatable, Sendable {
 /// observer can route the source-appropriate breadcrumb without losing the
 /// old VAD-gate vs ASR-empty no-speech distinction (PR-1 §B.7.2; old
 /// the old Parakeet pipeline vs `:902`).
-public enum NoSpeechSource: Equatable, Sendable {
+enum NoSpeechSource: Equatable, Sendable {
   /// VAD gate fired pre-ASR — raw samples had no speech evidence
   /// (`TP:787` — "VAD gate: no speech detected, skipping ASR").
   case vadGate
@@ -130,7 +131,8 @@ struct KernelModelLoadWedgeTelemetry: Equatable, Sendable {
 
 /// A typed limb-seam failure the kernel maps to a `failed` terminal reason
 /// (PR-3 plan §14a). The `processText` / `store` seams throw these.
-public enum KernelLimbError: Error, Sendable {
+// periphery:ignore - test seam (thrown only by the test simulator)
+enum KernelLimbError: Error, Sendable {
   /// Text processing produced empty output (PR-1 §B.1.2 `emptyAfterProcessing`).
   case emptyAfterProcessing
   /// Transcript disk-save threw (epic §3.8 caveat b, deferred #830).
@@ -276,6 +278,7 @@ final class RecordingSessionKernel {
 
   /// The user-visible error category for the current terminal state, derived
   /// from the FSM state (PR-1 §B.1.3). `nil` for non-error terminals.
+  // periphery:ignore - test seam (read only by the simulator)
   var userVisibleError: KernelErrorCategory? {
     switch state {
     case .audioInterrupted:
@@ -390,6 +393,7 @@ final class RecordingSessionKernel {
   /// at `.recording`. The drain gates on this signal so it never settles mid
   /// hand-off (the recurring `interleavingSweep` `got recording` flake). No
   /// production reader — observation only.
+  // periphery:ignore - test seam (simulator drain gate; no production reader)
   var hasUnconsumedRecordingExit: Bool {
     recordingExitLatched && state == .recording
   }

--- a/Sources/EnviousWisprPipeline/SampleFilter.swift
+++ b/Sources/EnviousWisprPipeline/SampleFilter.swift
@@ -75,13 +75,3 @@ internal enum SampleFilter {
     return result.isEmpty ? allSamples : result
   }
 }
-
-/// Shared pipeline utilities.
-internal enum PipelineUtils {
-
-  /// Convert Duration to milliseconds for logging.
-  static func durationMs(_ d: Duration) -> Int {
-    let (seconds, attoseconds) = d.components
-    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
-  }
-}

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -5,6 +5,7 @@ import EnviousWisprStorage
 import Foundation
 
 /// Input for post-ASR finalization.
+// periphery:ignore - test seam (production finalization is KernelFinalizationWiring)
 @MainActor
 internal struct FinalizationRequest {
   let asrText: String
@@ -21,6 +22,7 @@ internal struct FinalizationRequest {
 }
 
 /// Output from post-ASR finalization.
+// periphery:ignore - test seam (production finalization is KernelFinalizationWiring)
 @MainActor
 internal struct FinalizationResult {
   let transcript: Transcript
@@ -42,6 +44,7 @@ internal struct FinalizationResult {
 /// Typed errors so pipelines can decide the right fallback per category.
 /// GPT Desktop review: a single generic throw path blurs storage failures
 /// with polish failures, creating misleading Sentry data and wrong fallbacks.
+// periphery:ignore - test seam (production finalization is KernelFinalizationWiring)
 internal enum FinalizationError: Error {
   /// Text processing ran but produced empty output
   case emptyAfterProcessing
@@ -55,6 +58,7 @@ internal enum FinalizationError: Error {
 /// .polishing, .complete, .error based on the result.
 /// Does NOT own step instances. Steps are passed in via the request.
 /// Does NOT emit pipeline-specific telemetry (ASR mode, backend, etc.).
+// periphery:ignore - test seam (production finalization is KernelFinalizationWiring)
 @MainActor
 internal final class TranscriptFinalizer {
   private let save: @MainActor (Transcript) throws -> Void

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -206,12 +206,6 @@ public final class TranscriptPolishService {
     return updated
   }
 
-  /// Clear enhancement state. The in-flight LLM call will check Task.checkCancellation()
-  /// and exit without saving if the parent Task was cancelled.
-  public func cancel() {
-    polishingTranscriptID = nil
-  }
-
   // MARK: - Private Helpers
 
   /// Record an enhancement error scoped to a transcript.

--- a/Sources/EnviousWisprPipeline/VADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/VADSignalSource.swift
@@ -59,7 +59,7 @@ public enum VADSpeechEvidence: Equatable, Sendable {
 /// (PR-1 §B.6). The kernel does not know whether the conformer is the
 /// in-process detector or the XPC service-side one.
 @MainActor
-public protocol VADSignalSource: AnyObject {
+protocol VADSignalSource: AnyObject {
   /// Open a fresh per-subscriber stream of stop-driving signals (auto-stop,
   /// max-duration). The kernel latches a stop on each delivered signal.
   ///

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1129,8 +1129,10 @@ extension WhisperKitEngineAdapter {
   /// Test-only read of the retained PCM. The production read site is the
   /// incremental worker's provider closure, which captures `self` weakly and
   /// reads `retainedPCM` on `@MainActor`.
+  // periphery:ignore - test seam
   internal var retainedPCMForUnitTests: [Float] { retainedPCM }
   /// Test-only read of the kernel-supplied speech segments.
+  // periphery:ignore - test seam
   internal var observedSpeechSegmentsForUnitTests: [SpeechSegment] { observedSpeechSegments }
   /// Test-only handle to the armed model-unload task. Tests `await
   /// adapter.modelUnloadTaskForUnitTests?.value` to wait for an armed
@@ -1138,6 +1140,7 @@ extension WhisperKitEngineAdapter {
   /// task always completes (it returns whether or not it fires `unload()`),
   /// so the await is bounded. Avoids the release-config flake where the
   /// scheduled unload had not run within a fixed `Task.yield()` budget.
+  // periphery:ignore - test seam
   internal var modelUnloadTaskForUnitTests: Task<Void, Never>? { modelUnloadTask }
 }
 
@@ -1158,6 +1161,7 @@ package protocol WhisperKitBackendDriving: Actor {
   var isReady: Bool { get }
   var modelVariantName: String { get }
   func prepare() async throws
+  // periphery:ignore - protocol requirement (witnessed by WhisperKitBackend)
   func prepareIfCached() async throws -> Bool
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
   func observeLID(samples: [Float], maxWindows: Int) async -> LIDObservationBatch

--- a/Sources/EnviousWisprPipeline/WhisperKitPipelineSpeechRouting.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitPipelineSpeechRouting.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import Foundation
 
 internal enum WhisperKitPipelineSpeechRouting {
+  // periphery:ignore - test seam
   static func hasSpeechEvidence(vadSegments: [SpeechSegment]?) -> Bool {
     vadSegments.map { !$0.isEmpty } ?? true
   }


### PR DESCRIPTION
Part of #822 (dead-code sweep tier 1) · epic #821.

Heart-path batch **part 2** — the Pipeline module (kernel orchestration, ASR adapters, text-processing steps, telemetry). Builds on part 1 (#1013). Every candidate re-validated against current code by Codex; the record → transcribe → polish → paste path is exercised by dual-engine ambient UAT.

## Removed (validated unreferenced in prod AND tests)
- `PipelineUtils` enum (SampleFilter) — unused `durationMs` helper, no caller
- `TranscriptPolishService.cancel()` — no caller
- Unused imports: `EnviousWisprAudio` (HeartPathTelemetryContexts, HeartPathTelemetryEmitter), `EnviousWisprServices` (KernelHeartPathTelemetryObserver)

## Downgraded visibility (no app-target / cross-module use)
- → `internal`: `CapturedAudioConditioner` + `condition`, `InverseTextNormalizationStep` (class + 13 members), `InterruptionMessages` + `micDisconnected`, `VADSignalSource`, and RecordingSessionKernel `FinalizingSubStatus` / `KernelDeliveryOutcome` / `DiscardReason` / `NoSpeechSource` / `KernelErrorCategory` / `KernelLimbError`
- → `package`: `ASREngineAdapter` protocol (the `KernelAdapterFactory.make*Adapter` package factories return `any ASREngineAdapter`, so `internal` won't compile — caught at build, fixed to `package`)

## Annotated `// periphery:ignore` (intentional keeps, documented at the site)
- **test seams**: `EmojiFormatterStep.init`, `KernelDictationDriver` kernelForTesting/contextForTesting, `ParakeetEngineAdapter.feedTasksForUnitTests`, `WhisperKitEngineAdapter` unit-test inspectors (×3), `WhisperKitPipelineSpeechRouting.hasSpeechEvidence`, `TranscriptFinalizer` types/class (production finalization is `KernelFinalizationWiring`), RecordingSessionKernel `userVisibleError` / `hasUnconsumedRecordingExit` / `KernelErrorCategory` / `KernelLimbError`
- **protocol requirement** (witnessed by `WhisperKitBackend`): `WhisperKitBackendDriving.prepareIfCached()`

## Deferred to a follow-up (bigger than dead-code removal; need their own validation)
- `ASREngineAdapter` tick/handoff contract fields (`ASRLoadProgressTick.marker`, `ASRFinalizeProgressTick.marker`/`init`, `AudioBufferHandoff.frameCount`/`sequence`) — young #827 kernel-adapter contract (`sequence` documented for future streaming adapters); drop cascades to producers + tests
- `RecordingSessionKernel.captureStallTelemetry` seam (superseded by the router stall path; removal touches the kernel init + all construction sites + the simulator)
- `KernelLifecycleTelemetrySink` unused convenience init (large block)
- The 9 `RecordingSessionKernel` `#if DEBUG` test* seams — cohesive labeled block, absorbed by the regenerated baseline rather than 9 inline annotations
- KEEP-API (baseline): `ASREngineError.loadFailed/engineCrashed`, `KernelTelemetryState.rawSampleCount`

## Validation
- Dev build (Xcode `EnviousWispr-Dev`/Dev): **green** (after the `ASREngineAdapter` package fix — caught by the build).
- Logic tests (`scripts/xcode-test.sh`): **1704 passed, 0 failures**.
- Dual-engine ambient UAT (no TTS; verdicts from app.log):
  - **WhisperKit: full path PASS** — capture → ASR → post-ASR steps → paste via cgevent; "Pipeline timing TOTAL: 1.242s".
  - **Parakeet: capture (4.88s) + VAD + ASR ran → graceful `terminal noSpeech`** (ambient below the speech-energy floor). Kernel orchestration + the touched Pipeline types all exercised; no hang/crash.
- Codex diff review: **SHIP** — deletions, import removals, access-control downgrades (incl. the `package` fix), ITN conformance, annotations, and `prepareIfCached` witness all verified against current code; deferred items confirmed untouched.

`council-skip: codex-grounded-review settled — pure Pipeline dead-code removal + visibility/annotation, no user surface, no design ambiguity (#822 tier 1)`