### PR TITLE
chore(cleanup): dead LLM symbols, visibility, seam (#822 part 3)

### DIFF
--- a/Sources/EnviousWisprLLM/ApplePolishRouter.swift
+++ b/Sources/EnviousWisprLLM/ApplePolishRouter.swift
@@ -94,16 +94,16 @@ public enum RouterBasis: Sendable, Equatable {
 ///
 /// Tunability: every threshold, noun list, and weight lives in one file so
 /// later telemetry-driven adjustments are a single PR.
-public enum ApplePolishRouter {
+enum ApplePolishRouter {
 
   /// A routing decision with the mode and the signals that produced it.
-  public struct Decision: Equatable, Sendable {
-    public let mode: ApplePolishMode
-    public let score: Int
-    public let basis: RouterBasis
-    public let signals: [RouterSignal]
+  struct Decision: Equatable, Sendable {
+    let mode: ApplePolishMode
+    let score: Int
+    let basis: RouterBasis
+    let signals: [RouterSignal]
 
-    public init(
+    init(
       mode: ApplePolishMode, score: Int, basis: RouterBasis, signals: [RouterSignal]
     ) {
       self.mode = mode
@@ -116,12 +116,13 @@ public enum ApplePolishRouter {
   // MARK: - Public entry points
 
   /// Classify a post-ASR transcript and return `natural` or `technical`.
-  public static func classify(_ text: String) -> ApplePolishMode {
+  // periphery:ignore - test seam
+  static func classify(_ text: String) -> ApplePolishMode {
     decide(text).mode
   }
 
   /// Classify and return the full decision with signals (for logging / tests).
-  public static func decide(_ text: String) -> Decision {
+  static func decide(_ text: String) -> Decision {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
       return Decision(mode: .natural, score: 0, basis: .empty, signals: [.emptyInput])

--- a/Sources/EnviousWisprLLM/EnviousOutputFilter.swift
+++ b/Sources/EnviousWisprLLM/EnviousOutputFilter.swift
@@ -17,15 +17,15 @@ import Foundation
 ///      input didn't, AFM executed instead of cleaned. Fall back to raw input.
 ///   3. Length backstop — if stripped body is > 1.5x input + 50 chars, assume
 ///      AFM generated a novel/essay. Fall back to raw input.
-public enum EnviousOutputFilter {
+enum EnviousOutputFilter {
 
-  public struct Result: Equatable, Sendable {
-    public let polished: String
-    public let fellBackToRaw: Bool
-    public let tripped: String?
+  struct Result: Equatable, Sendable {
+    let polished: String
+    let fellBackToRaw: Bool
+    let tripped: String?
   }
 
-  public static func filter(input: String, output: String) -> Result {
+  static func filter(input: String, output: String) -> Result {
     let rawInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
     let rawOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -86,7 +86,7 @@ public enum EnviousOutputFilter {
   /// Fail-open: a nil classifier, timeout, throw, NaN, or any disable reason
   /// returns the synchronous result unchanged. Never blocks dictation. Telemetry
   /// logs score/decision/latency only — never raw text or tokens.
-  public static func filterWithClassifier(
+  static func filterWithClassifier(
     input: String,
     output: String,
     classifier: OutputClassifierProtocol?

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -291,13 +291,6 @@ public final class OllamaSetupService {
     return thinkingCapableFamilyPrefixes.contains(where: { lower.hasPrefix($0) })
   }
 
-  /// Convenience: check if a model name is weak using downloaded model metadata.
-  public func isWeakModel(_ name: String) -> Bool {
-    let canonical = Self.canonicalModelName(name)
-    let downloaded = downloadedModels.first(where: { $0.canonicalName == canonical })
-    return Self.isWeakModel(name, parameterBillions: downloaded?.parameterBillions)
-  }
-
   // MARK: - Private
 
   private var ollamaProcess: Process?

--- a/Sources/EnviousWisprLLM/PairEncodingAdapter.swift
+++ b/Sources/EnviousWisprLLM/PairEncodingAdapter.swift
@@ -21,12 +21,12 @@ public struct EncodedClassifierInput: Equatable, Sendable {
 ///   6. assemble specials by walking `pairTemplate.sequence`
 ///   7. segment ids by the same walk (`bert_segments` / `none`)
 ///   8. attention mask 1=real 0=pad; right-pad ids/mask/segments to maxLength
-public struct PairEncodingAdapter: Sendable {
-  public let contract: TokenizerContract
+struct PairEncodingAdapter: Sendable {
+  let contract: TokenizerContract
   /// Tokenize one side as a single text WITHOUT special tokens.
   private let encode: @Sendable (String) -> [Int]
 
-  public init(contract: TokenizerContract, encode: @escaping @Sendable (String) -> [Int]) {
+  init(contract: TokenizerContract, encode: @escaping @Sendable (String) -> [Int]) {
     self.contract = contract
     self.encode = encode
   }
@@ -41,7 +41,7 @@ public struct PairEncodingAdapter: Sendable {
   /// requires positive budgets, a sane maxLength, and that every template
   /// special resolves. Any violation throws `.disabled(.unsupportedFamily)` so
   /// the classifier disables and fails open (Codex P2). Call once at load.
-  public func validate() throws {
+  func validate() throws {
     func require(_ condition: Bool) throws {
       if !condition { throw OutputClassifierError.disabled(.unsupportedFamily) }
     }
@@ -60,7 +60,7 @@ public struct PairEncodingAdapter: Sendable {
     }
   }
 
-  public func encodePair(input: String, output: String) -> EncodedClassifierInput {
+  func encodePair(input: String, output: String) -> EncodedClassifierInput {
     var inIDs = encode(contract.inputPrefix + input)
     var outIDs = encode(contract.outputPrefix + output)
 

--- a/Sources/EnviousWisprLLM/Prompting/CustomVocabularyFormatter.swift
+++ b/Sources/EnviousWisprLLM/Prompting/CustomVocabularyFormatter.swift
@@ -51,58 +51,6 @@ public struct CustomVocabularyFormatter: Sendable {
     return "Preferred spellings: \(names)"
   }
 
-  // MARK: - Multilingual v1 (W3): PromptVocabulary entry points
-
-  /// Render a `PromptVocabulary` to a full-format prompt block, applying the
-  /// confidence-tiered + script-guardrail policy for the detected language.
-  /// Returns nil if no terms survive the filter (caller should emit a
-  /// formatting-only prompt in that case).
-  public static func render(
-    vocabulary: PromptVocabulary,
-    detectedLang: String?,
-    tier: LanguageConfidenceTier
-  ) -> String? {
-    let terms = vocabulary.effectiveTerms(detectedLang: detectedLang, tier: tier)
-    return renderStrings(terms)
-  }
-
-  /// Render a `PromptVocabulary` to a simplified comma-separated block (for
-  /// Gemma). Applies the same tier + script-guardrail policy.
-  public static func renderSimplified(
-    vocabulary: PromptVocabulary,
-    detectedLang: String?,
-    tier: LanguageConfidenceTier
-  ) -> String? {
-    let terms = vocabulary.effectiveTerms(detectedLang: detectedLang, tier: tier)
-    return renderStringsSimplified(terms)
-  }
-
-  /// Render a raw flat `[String]` list in full format. Used when a callsite
-  /// already has a pre-filtered list of terms.
-  public static func renderStrings(_ terms: [String]) -> String? {
-    guard !terms.isEmpty else { return nil }
-    let capped = Array(terms.prefix(maxWords))
-    var lines: [String] = []
-    var charCount = fullHeader.count
-    for term in capped {
-      let clean = sanitize(term)
-      let line = "- \(clean)"
-      if charCount + line.count > maxChars { break }
-      lines.append(line)
-      charCount += line.count
-    }
-    guard !lines.isEmpty else { return nil }
-    return fullHeader + "\n" + lines.joined(separator: "\n")
-  }
-
-  /// Render a raw flat `[String]` list in simplified (comma-separated) form.
-  public static func renderStringsSimplified(_ terms: [String]) -> String? {
-    guard !terms.isEmpty else { return nil }
-    let capped = Array(terms.prefix(maxWords))
-    let names = capped.map { sanitize($0) }.joined(separator: ", ")
-    return "Preferred spellings: \(names)"
-  }
-
   /// Strip injection-risky characters from custom word text.
   static func sanitize(_ text: String) -> String {
     text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
+++ b/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
@@ -105,7 +105,6 @@ public struct DefaultPromptPlanner: PromptPlanning {
     let filteredCustomWords = Self.filterCustomWords(
       input.polishVocabulary.terms,
       tier: detection.tier,
-      detectedLang: detection.lang,
       allowedStrings: Set(effectiveStrings)
     )
     return input.withPolishVocabulary(
@@ -122,7 +121,6 @@ public struct DefaultPromptPlanner: PromptPlanning {
   static func filterCustomWords(
     _ customWords: [CustomWord],
     tier: LanguageConfidenceTier,
-    detectedLang: String?,
     allowedStrings: Set<String>
   ) -> [CustomWord] {
     switch tier {

--- a/Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/GeminiPromptBuilder.swift
@@ -4,10 +4,10 @@ import EnviousWisprCore
 /// System prompt defines the editor role and allowed edits; user message wraps the transcript
 /// in <transcript> tags with an anti-instruction clause. Resists injection and jailbreak shapes.
 /// Retains mode-specific formatting, appName context, short-text guard, and custom vocabulary.
-public struct GeminiPromptBuilder: PromptBuilder {
-  public init() {}
+struct GeminiPromptBuilder: PromptBuilder {
+  init() {}
 
-  public func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
+  func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
     var system = V2SystemBase
 
     // Context block

--- a/Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/GemmaPromptBuilder.swift
@@ -4,10 +4,10 @@ import EnviousWisprCore
 /// Uses few-shot examples to teach formatting (Gemma mirrors demonstrated format).
 /// No context block (eval showed no quality difference for Gemma).
 /// No separate ASR clause (few-shot examples implicitly teach correction).
-public struct GemmaPromptBuilder: PromptBuilder {
-  public init() {}
+struct GemmaPromptBuilder: PromptBuilder {
+  init() {}
 
-  public func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
+  func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
     // Weak model override: simplified prompt, no formatting, no few-shot
     if OllamaSetupService.isWeakModel(input.modelID) {
       return buildWeakModel(transcript: input.transcript)

--- a/Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift
+++ b/Sources/EnviousWisprLLM/Prompting/OpenAIPromptBuilder.swift
@@ -6,10 +6,10 @@ import EnviousWisprCore
 /// ASR-awareness clause, appName context block, language override prefix, short-text
 /// guard, and custom vocabulary rendering. Gemini-specific system text (`V2SystemBase`)
 /// and mode clauses (`formattingClause`) are NOT used by this builder.
-public struct OpenAIPromptBuilder: PromptBuilder {
-  public init() {}
+struct OpenAIPromptBuilder: PromptBuilder {
+  init() {}
 
-  public func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
+  func build(input: PromptBuildInput, mode: PolishMode) -> PromptEnvelope {
     var system = ""
 
     // Language override (prepended for non-English transcripts).

--- a/Sources/EnviousWisprLLM/Prompting/TranscriptAnalyzer.swift
+++ b/Sources/EnviousWisprLLM/Prompting/TranscriptAnalyzer.swift
@@ -2,7 +2,7 @@ import EnviousWisprCore
 
 /// Analyzes a transcript to determine the appropriate PolishMode.
 /// Pure function. Deterministic heuristics, never delegated to the LLM.
-public struct TranscriptAnalyzer: Sendable {
+struct TranscriptAnalyzer: Sendable {
 
   /// Analyze transcript text and return the appropriate polish mode.
   ///
@@ -15,7 +15,7 @@ public struct TranscriptAnalyzer: Sendable {
   ///
   /// Conservative nil-app routing: when appName is nil, bias toward .message,
   /// never produce .structured without strong signals.
-  public static func analyzeMode(
+  static func analyzeMode(
     transcript: String,
     appName: String?
   ) -> PolishMode {

--- a/Sources/EnviousWisprLLM/TokenizerContract.swift
+++ b/Sources/EnviousWisprLLM/TokenizerContract.swift
@@ -121,7 +121,7 @@ public struct TokenizerContract: Codable, Sendable, Equatable {
 /// Supports the JSON subset the contract uses: object / array / String / Bool /
 /// integer NSNumber. Throws on an unsupported type (e.g. a float).
 enum CanonicalJSON {
-  struct UnsupportedValue: Error { let typeDescription: String }
+  struct UnsupportedValue: Error {}
 
   static func encode(_ value: Any) throws -> Data {
     var out = String()
@@ -157,14 +157,14 @@ enum CanonicalJSON {
         // Contract values are integers only; reject a non-integral number
         // rather than silently emitting a format Python wouldn't match.
         guard Double(number.intValue) == number.doubleValue else {
-          throw UnsupportedValue(typeDescription: "non-integer number \(number)")
+          throw UnsupportedValue()
         }
         out.append(String(number.intValue))
       }
     case is NSNull:
       out.append("null")
     default:
-      throw UnsupportedValue(typeDescription: String(describing: type(of: value)))
+      throw UnsupportedValue()
     }
   }
 

--- a/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LanguageAwarePromptInjectionTests.swift
@@ -70,7 +70,6 @@ struct LanguageAwarePromptInjectionTests {
     let result = DefaultPromptPlanner.filterCustomWords(
       [],
       tier: .locked,
-      detectedLang: "ja",
       allowedStrings: Set(vocab.effectiveTerms(detectedLang: "ja", tier: .locked))
     )
     let canonicals = Set(result.map(\.canonical))

--- a/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
@@ -1,9 +1,9 @@
 import EnviousWisprCore
-import EnviousWisprLLM
 import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprLLM
 @testable import EnviousWisprPipeline
 
 /// Tests for dual-mode polish telemetry plumbing (#429).


### PR DESCRIPTION
Part of #822 (dead-code sweep tier 1) · epic #821.

Heart-path batch **part 3** — the LLM module (polish routing, output filtering, prompt builders, classifier tokenizer). Final heart-path batch, after part 1 (#1013) and part 2 (#1014). Every candidate re-validated against current code by Codex.

## Removed (validated unreferenced in prod AND tests)
- `CustomVocabularyFormatter` PromptVocabulary entry points — `render(vocabulary:)`, `renderSimplified(vocabulary:)`, `renderStrings(_:)`, `renderStringsSimplified(_:)` (dead cluster; prod uses the legacy `render(_:)` / `renderSimplified(_:)`)
- `OllamaSetupService` instance `isWeakModel(_:)` (callers use the static overload)
- `DefaultPromptPlanner.filterCustomWords(… detectedLang:)` parameter — unused in the body; removed param + both call sites (prod + test)
- `TokenizerContract…UnsupportedValue.typeDescription` — assigned at two throw sites, never read; dropped the field, simplified the throws

## Downgraded public → internal (no cross-module / app-target use)
- `ApplePolishRouter` enum + `Decision` + members/init + `decide(…)`
- `EnviousOutputFilter` enum + `Result` + members + `filter(…)` + `filterWithClassifier(…)`
- `PairEncodingAdapter` struct + `contract` + init + `validate()` + `encodePair(…)`
- `GeminiPromptBuilder` / `GemmaPromptBuilder` / `OpenAIPromptBuilder` (struct + init + build — still conform to the public `PromptBuilder`, returned as `any PromptBuilder`)
- `TranscriptAnalyzer` struct + `analyzeMode(…)`

## Annotated `// periphery:ignore`
- test seam: `ApplePolishRouter.classify(_:)` (`decide(…)` is the prod entry point)

## KEEP-API / FALSE-POSITIVE (baseline, no change)
- `OutputClassifierManifest` + schema constants (classifier contract)
- `OllamaSetupService.downloadedModelNames` (backward-compat API)
- `KeychainManager.productionKeychainBundleIDs` (release `#else`; debug scan blind)

Cross-module note: `EnviousOutputFilter` and `TranscriptAnalyzer` appear in Core/Pipeline only as doc-comment references (not code), so the internal downgrade is safe.

## Test alignment
`DualModePolishTelemetryTests` switched to `@testable import EnviousWisprLLM` — it directly tests the now-internal `EnviousOutputFilter`, and every other LLM test already used `@testable`. The test build (and Codex) caught the plain-import; this is Codex's recommended fix.

## Validation
- Dev build (Xcode `EnviousWispr-Dev`/Dev): **green**.
- Logic tests (`scripts/xcode-test.sh`): **1704 passed, 0 failures**.
- Dual-engine ambient UAT (no TTS; verdicts from app.log):
  - **WhisperKit: full path PASS** — Transcribing → **Polishing** → paste; "Pipeline timing TOTAL: 1.531s (ASR=1.215s, polish=0.022s, paste=0.263s)". The polish step (this module) ran and completed.
  - **Parakeet: capture + VAD + ASR ran → graceful no-speech** (faint ambient).
- Codex diff review: **SHIP** — the only blocker was the test plain-import (now fixed per Codex's own recommendation); all removals/downgrades/annotations verified, KEEP items untouched.

`council-skip: codex-grounded-review settled — pure LLM dead-code removal + visibility/annotation, no user surface, no design ambiguity (#822 tier 1)`