### PR TITLE
chore(release): bump version to 2.1.3

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -26,6 +26,45 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.1.3
+
+    Entry(
+      id: "import-names-from-contacts",
+      icon: "person.crop.circle.badge.plus",
+      title: "Bring in the names of people you know",
+      description:
+        "One tap on \"Import from Contacts\" adds the people in your address book to your custom words, so a coworker's or friend's hard-to-spell name comes out right the first time. Everything stays on your Mac. Your contacts are never uploaded. EnviousWispr also quietly learns the common ways each name gets misheard, so it catches those too.",
+      category: .newFeatures,
+      version: "2.1.3"
+    ),
+    Entry(
+      id: "vocabulary-packs",
+      icon: "books.vertical",
+      title: "Vocabulary packs for brands and jargon",
+      description:
+        "Turn on a pack and EnviousWispr recognizes those words and capitalizes them the way they're meant to be written (AngularJS, Nivea, Acosta). Each pack has a searchable list, so you can see every word it covers and the spoken variants it catches.",
+      category: .newFeatures,
+      version: "2.1.3"
+    ),
+    Entry(
+      id: "no-swallowed-press-after-idle",
+      icon: "clock.arrow.circlepath",
+      title: "No more swallowed first press after a break",
+      description:
+        "If you left the app idle for a while, your next recording could get eaten while it flashed a \"warming up\" notice, even though it was basically ready. It now quietly re-wakes in a fraction of a second and captures your words, including the very first one.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.3"
+    ),
+    Entry(
+      id: "simpler-settings-performance",
+      icon: "slider.horizontal.3",
+      title: "One less Settings tab to hunt through",
+      description:
+        "The \"Performance\" tab held just one control: how long to keep the engine loaded between recordings. It now sits at the bottom of the Transcription screen, right where it belongs, so Settings has one less place to look.",
+      category: .qualityOfLife,
+      version: "2.1.3"
+    ),
+
     // MARK: - v2.1.2
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.1.2"
+  public static let currentContentVersion = "2.1.3"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.1.3 with What's New entries for user-visible changes shipped since v2.1.2.

User-facing highlights:
- **Import from Contacts** — add people's names to custom words on-device (#636, #1000, #1007)
- **Vocabulary packs** — searchable brand/jargon packs with correct casing (#992, #994)
- **Idle warm-respawn** — no swallowed first press / false "warming up" after idle reap (#959, #990)
- **Settings tidy** — Performance tab merged into Transcription (#1016)

## Test plan

- [x] scripts/build-dev-app.sh — built + launched locally from the release worktree
- [ ] build-check CI passes on this PR
- [ ] Tag v2.1.3 after merge triggers release pipeline