### PR TITLE
fix(paste): drive Edit>Paste menu for container-role apps (#729)

### DIFF
--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -124,6 +124,10 @@ internal final class PasteCascadeExecutor {
     // attempted, can also be recorded. Populated only on failure paths;
     // attached to the `.clipboardOnly` Sentry payload as `paste.tier_failures`.
     var tierFailures: [String: String] = [:]
+    // #729 Tier 2c menu-paste probe outcome, used to compute `paste.focus_class`.
+    // nil = the menu probe never ran (not a `.nonText` path, or activation
+    // timed out before probing) → no `focus_class` value is emitted.
+    var menuProbe: MenuPasteProbe? = nil
 
     // Three-way classification of the focused element (PR #220 design intent,
     // restored for Chromium/Electron contenteditable inputs — see #277).
@@ -190,26 +194,9 @@ internal final class PasteCascadeExecutor {
     if tier == .clipboardOnly, canAttemptKeyPaste,
       let app = request.targetApp, !app.isTerminated
     {
-      let pollInterval = TimingConstants.activationPollIntervalMs
-      let timeout = TimingConstants.activationTimeoutMs
-
-      _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-      app.activate()
-      var elapsed = 0
-      while elapsed < timeout {
-        try? await Task.sleep(for: .milliseconds(pollInterval))
-        elapsed += pollInterval
-        if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
-          break
-        }
-        if elapsed % 300 < pollInterval {
-          _ = PasteService.forceActivateApp(pid: app.processIdentifier)
-          app.activate()
-        }
-      }
-
-      let activated =
-        NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+      let activation = await activate(app)
+      let activated = activation.activated
+      let elapsed = activation.elapsed
 
       if activated {
         tiersAttempted.append(.cgEvent)
@@ -266,6 +253,58 @@ internal final class PasteCascadeExecutor {
       }
     }
 
+    // Tier 2c: Language-agnostic Edit > Paste for non-text container roles (#729).
+    // Word/Excel/Numbers/OneNote expose their editor as a container AX role, so
+    // Tier 2's blind Cmd+V is skipped (canAttemptKeyPaste == false) to avoid
+    // firing into a void. Instead we activate the app (snap-back), put our text
+    // on the clipboard, then drive the app's OWN Edit > Paste command, found by
+    // its ⌘V shortcut. The command's enabled-state separates a real editor
+    // (Scenario B — paste it) from no-field-focused (Scenario A — overlay).
+    if tier == .clipboardOnly, classification == .nonText, axTrusted,
+      let app = request.targetApp, !app.isTerminated
+    {
+      let activation = await activate(app)
+      if activation.activated {
+        // Put our text on the clipboard BEFORE probing enabled-state: apps grey
+        // out Paste when the clipboard is empty/incompatible (#729 Codex r1).
+        let snapshot: ClipboardSnapshot? =
+          request.restoreClipboardAfterPaste ? PasteService.saveClipboard() : nil
+        let changeCount = PasteService.copyToClipboardReturningChangeCount(request.text)
+        if let menuItem = PasteService.findPasteMenuItem(pid: app.processIdentifier),
+          PasteService.isMenuItemEnabled(menuItem)
+        {
+          // Scenario B: a real paste target. Enabled item found.
+          menuProbe = .targetEnabled
+          tiersAttempted.append(.menuPaste)
+          if PasteService.pressMenuItem(menuItem) {
+            tier = .menuPaste
+            // Restore the user's prior clipboard after the paste lands.
+            if let snapshot {
+              try? await Task.sleep(for: .milliseconds(TimingConstants.clipboardRestoreDelayMs))
+              PasteService.restoreClipboard(snapshot, changeCountAfterPaste: changeCount)
+            }
+          } else {
+            // Enabled but AXPress failed. Leave request.text on the clipboard
+            // (do NOT restore) so the user's manual Cmd+V still works.
+            tierFailures["menu_paste"] = "press_failed"
+            emitTierFailureBreadcrumb(
+              stage: "menu_paste", reason: "press_failed", bundleId: bundleId)
+          }
+        } else {
+          // Scenario A (or item disabled/absent): no paste target. Leave
+          // request.text on the clipboard; Tier 3 overlay follows.
+          menuProbe = .noTarget
+        }
+      } else {
+        // Activation timed out for .nonText: do NOT route to the English-only
+        // Tier 2b AppleScript path (that fallback is for the key-paste-eligible
+        // branch). Fall to clipboard-only; the probe never ran, so no focus_class.
+        tierFailures["activation"] = "timeout_ms=\(activation.elapsed)"
+        emitTierFailureBreadcrumb(
+          stage: "activation", reason: "timeout_ms=\(activation.elapsed)", bundleId: bundleId)
+      }
+    }
+
     // Tier 3: Clipboard fallback.
     // The "non-text element focused" log fires only when we deliberately skipped
     // Tier 2 because a non-text element was focused (PR #220's void-protection
@@ -311,15 +350,58 @@ internal final class PasteCascadeExecutor {
       )
     }
 
-    emitPasteTelemetry(outcome: outcome, tierFailures: tierFailures)
+    emitPasteTelemetry(
+      outcome: outcome, tierFailures: tierFailures, focusClass: menuProbe?.focusClassLabel)
 
     return PasteDeliveryResult(tier: tier, durationMs: durationMs, outcome: outcome)
+  }
+
+  /// #729 Tier 2c menu-paste probe outcome. Drives `paste.focus_class`.
+  enum MenuPasteProbe {
+    /// An enabled Edit > Paste item was found (Scenario B — real paste target).
+    case targetEnabled
+    /// The item was absent or disabled (Scenario A — no paste target).
+    case noTarget
+
+    var focusClassLabel: String {
+      switch self {
+      case .targetEnabled: return "non_text_with_paste_target"
+      case .noTarget: return "no_paste_target"
+      }
+    }
+  }
+
+  /// Activate `app` and poll until it is frontmost or the activation timeout
+  /// elapses. Re-issues activation every ~300ms. Returns whether the app became
+  /// frontmost and how long we waited. Shared by Tier 2 (Cmd+V) and Tier 2c
+  /// (menu paste).
+  private func activate(_ app: NSRunningApplication) async -> (activated: Bool, elapsed: Int) {
+    let pollInterval = TimingConstants.activationPollIntervalMs
+    let timeout = TimingConstants.activationTimeoutMs
+
+    _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+    app.activate()
+    var elapsed = 0
+    while elapsed < timeout {
+      try? await Task.sleep(for: .milliseconds(pollInterval))
+      elapsed += pollInterval
+      if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
+        break
+      }
+      if elapsed % 300 < pollInterval {
+        _ = PasteService.forceActivateApp(pid: app.processIdentifier)
+        app.activate()
+      }
+    }
+    let activated =
+      NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+    return (activated, elapsed)
   }
 
   /// Fires Sentry captureError for non-delivered outcomes. Owned by the cascade
   /// so overlay UI and telemetry both derive from the same typed outcome.
   private func emitPasteTelemetry(
-    outcome: PasteDeliveryOutcome, tierFailures: [String: String]
+    outcome: PasteDeliveryOutcome, tierFailures: [String: String], focusClass: String?
   ) {
     switch outcome {
     case .delivered:
@@ -341,7 +423,8 @@ internal final class PasteCascadeExecutor {
           targetBundleID: bundle,
           accessibilityTrusted: accessibilityTrusted,
           targetDiagnostics: diagnostics,
-          tierFailures: tierFailures
+          tierFailures: tierFailures,
+          focusClass: focusClass
         )
       )
     case .cgEventCreationFailed(let accessibilityTrusted):
@@ -377,9 +460,10 @@ internal final class PasteCascadeExecutor {
     targetBundleID: String?,
     accessibilityTrusted: Bool,
     targetDiagnostics: PasteElementDiagnostics,
-    tierFailures: [String: String]
+    tierFailures: [String: String],
+    focusClass: String? = nil
   ) -> [String: Any] {
-    [
+    var extra: [String: Any] = [
       "paste.tiers_attempted": tiersAttempted,
       "paste.focus_classification": focus.telemetryLabel,
       "paste.target_bundle_id": targetBundleID ?? NSNull(),
@@ -391,6 +475,13 @@ internal final class PasteCascadeExecutor {
       "paste.target_element_role_source": targetDiagnostics.roleSource,
       "paste.target_element_subrole_status": targetDiagnostics.subroleStatus,
     ]
+    // #729: present only when the Tier 2c menu probe actually ran (Scenario
+    // A/B discriminator). Absent on .textField/.missing and on activation
+    // timeout before probing.
+    if let focusClass {
+      extra["paste.focus_class"] = focusClass
+    }
+    return extra
   }
 
   /// Emit a non-blocking Sentry breadcrumb for a single tier failure. The

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -21,6 +21,10 @@ public enum PasteTier: String, Sendable {
   case axDirect = "ax_direct"
   case cgEvent = "cgevent"
   case appleScript = "applescript"
+  /// Language-agnostic Edit > Paste menu command driven via Accessibility
+  /// (#729). Used for non-text container roles (Word/Excel/Numbers/OneNote)
+  /// where Cmd+V can't be aimed at a writable element.
+  case menuPaste = "menu_paste"
   case clipboardOnly = "clipboard_only"
 }
 
@@ -82,7 +86,8 @@ public enum PasteService {
 
   /// Reads privacy-safe role metadata from the captured AX element handle.
   /// This is queried at paste time, not snapshotted at recording start.
-  public static func capturedElementDiagnostics(_ element: AXUIElement?) -> PasteElementDiagnostics {
+  public static func capturedElementDiagnostics(_ element: AXUIElement?) -> PasteElementDiagnostics
+  {
     guard let element else { return .missing }
 
     var roleRef: CFTypeRef?
@@ -100,10 +105,12 @@ public enum PasteService {
     let subroleErr = AXUIElementCopyAttributeValue(
       element, kAXSubroleAttribute as CFString, &subroleRef
     )
-    let subrole = subroleErr == .success
+    let subrole =
+      subroleErr == .success
       ? PasteElementDiagnostics.sanitizedAXAttribute(subroleRef as? String)
       : nil
-    let subroleStatus: String = subroleErr == .success
+    let subroleStatus: String =
+      subroleErr == .success
       ? (subrole == nil ? "missing" : "present")
       : "unavailable"
 
@@ -170,8 +177,12 @@ public enum PasteService {
       return
     }
 
-    // Nothing to restore (clipboard was already empty).
-    guard !snapshot.items.isEmpty else { return }
+    // Prior clipboard was empty — restore to empty by clearing our own paste
+    // text off the board, rather than leaving it behind (#729 Codex diff review).
+    guard !snapshot.items.isEmpty else {
+      pasteboard.clearContents()
+      return
+    }
 
     pasteboard.clearContents()
     let pbItems: [NSPasteboardItem] = snapshot.items.map { itemDict in
@@ -400,6 +411,95 @@ public enum PasteService {
   /// Simulate Cmd+V keystroke to paste from clipboard into the active app.
   public static func simulatePaste() {
     dispatchCmdV()
+  }
+
+  // MARK: - Tier 2c: Language-agnostic Edit > Paste via Accessibility menu (#729)
+
+  /// True when an AX menu item's command-key equivalent is exactly ⌘V (no
+  /// extra modifiers). Pure, language-agnostic predicate: it matches the
+  /// keyboard shortcut, never the localized menu title.
+  ///
+  /// - `cmdChar` is `AXMenuItemCmdChar` (the shortcut character; "v" / "V").
+  /// - `modifiers` is `AXMenuItemCmdModifiers`, where `0` ==
+  ///   `kAXMenuItemModifierNone` (Command only). `1<<3` ==
+  ///   `kAXMenuItemModifierNoCommand` denotes the ABSENCE of ⌘ and must not
+  ///   match; Shift/Option/Control bits (`1<<0`/`1<<1`/`1<<2`) also exclude.
+  ///   So a plain ⌘V item has `modifiers == 0`.
+  public static func isPasteShortcut(cmdChar: String?, modifiers: Int) -> Bool {
+    guard let cmdChar else { return false }
+    return cmdChar.lowercased() == "v" && modifiers == 0
+  }
+
+  /// Walk the app's menu bar to find the Edit > Paste item, identified by its
+  /// ⌘V shortcut rather than its (localized) title. Returns the menu-item
+  /// element or nil. Bounded traversal depth (menu bar → top menus → items).
+  /// Live-only (like `captureFocusedElement` / `forceActivateApp`); the pure
+  /// matching logic is covered by `isPasteShortcut` unit tests.
+  @MainActor
+  public static func findPasteMenuItem(pid: pid_t) -> AXUIElement? {
+    let app = AXUIElementCreateApplication(pid)
+    // Cap AX round-trips so a misbehaving app can't hang the paste path.
+    AXUIElementSetAttributeValue(app, "AXTimeout" as CFString, Float(1.0) as CFTypeRef)
+    var menuBarRef: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
+      let menuBar = menuBarRef
+    else { return nil }
+    let menuBarElement = menuBar as! AXUIElement
+    return firstPasteItem(in: menuBarElement, depth: 0)
+  }
+
+  /// Depth-bounded search for the first ⌘V menu item under `element`.
+  @MainActor
+  private static func firstPasteItem(in element: AXUIElement, depth: Int) -> AXUIElement? {
+    // menu bar(0) → menu-bar-item(1) → menu(2) → menu-item(3); allow a little
+    // slack for apps that nest an extra group, but stay bounded.
+    guard depth <= 4 else { return nil }
+    var childrenRef: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+        == .success,
+      let children = childrenRef as? [AXUIElement]
+    else { return nil }
+
+    for child in children {
+      var cmdCharRef: CFTypeRef?
+      let hasShortcut =
+        AXUIElementCopyAttributeValue(child, "AXMenuItemCmdChar" as CFString, &cmdCharRef)
+        == .success
+      if hasShortcut {
+        var modRef: CFTypeRef?
+        _ = AXUIElementCopyAttributeValue(child, "AXMenuItemCmdModifiers" as CFString, &modRef)
+        let modifiers = (modRef as? Int) ?? -1
+        if isPasteShortcut(cmdChar: cmdCharRef as? String, modifiers: modifiers) {
+          return child
+        }
+      }
+      if let found = firstPasteItem(in: child, depth: depth + 1) {
+        return found
+      }
+    }
+    return nil
+  }
+
+  /// Whether an AX menu item is currently enabled. Apps disable Edit > Paste
+  /// when there is no paste target focused or the clipboard is empty — this is
+  /// the Scenario-A-vs-B discriminator, so it MUST be read AFTER our text is on
+  /// the clipboard. Fails closed (returns false) on any AX error.
+  @MainActor
+  public static func isMenuItemEnabled(_ item: AXUIElement) -> Bool {
+    var ref: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(item, kAXEnabledAttribute as CFString, &ref) == .success
+    else { return false }
+    return (ref as? Bool) ?? false
+  }
+
+  /// Trigger a menu item's default action (AXPress) — equivalent to the user
+  /// clicking it. Returns true on success.
+  @MainActor
+  public static func pressMenuItem(_ item: AXUIElement) -> Bool {
+    AXUIElementPerformAction(item, kAXPressAction as CFString) == .success
   }
 
   // MARK: - App Activation via Accessibility

--- a/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteDeliveryResultLabelTests.swift
@@ -37,6 +37,11 @@ struct PasteDeliveryResultLabelTests {
         outcome: .delivered(tier: .appleScript, durationMs: 3)
       ),
       PasteDeliveryResult(
+        tier: .menuPaste,
+        durationMs: 3,
+        outcome: .delivered(tier: .menuPaste, durationMs: 3)
+      ),
+      PasteDeliveryResult(
         tier: .clipboardOnly,
         durationMs: 4,
         outcome: .delivered(tier: .clipboardOnly, durationMs: 4)

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -100,6 +100,33 @@ struct PasteTelemetryPayloadTests {
     assertNoContentLikeKeys(extra)
   }
 
+  @Test("#729: focus_class present only when the menu probe ran")
+  func focusClassPresentOnlyWhenProbed() {
+    // No probe (default nil) -> key absent.
+    let noProbe = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [],
+      focus: .nonText,
+      targetBundleID: "com.microsoft.Word",
+      accessibilityTrusted: true,
+      targetDiagnostics: .missing,
+      tierFailures: [:]
+    )
+    #expect(noProbe["paste.focus_class"] == nil)
+
+    // Scenario A: probe ran, no paste target.
+    let noTarget = PasteCascadeExecutor.clipboardOnlyTelemetryExtra(
+      tiersAttempted: [],
+      focus: .nonText,
+      targetBundleID: "com.microsoft.Word",
+      accessibilityTrusted: true,
+      targetDiagnostics: .missing,
+      tierFailures: [:],
+      focusClass: "no_paste_target"
+    )
+    #expect(noTarget["paste.focus_class"] as? String == "no_paste_target")
+    assertNoContentLikeKeys(noTarget)
+  }
+
   private func assertNoContentLikeKeys(_ extra: [String: Any]) {
     for key in extra.keys {
       let lower = key.lowercased()

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -136,6 +136,27 @@ struct PipelineStateChangeHandlerTests {
     #expect(calls.completedCalls.count == 1)
   }
 
+  @Test("#729: menu_paste tier is a successful delivery, not a clipboard fallback")
+  func completeMenuPasteRoutesAsSuccess() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "menu_paste")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: transcript
+    )
+
+    // Must NOT show the clipboard-fallback or accessibility-toast overlay —
+    // menu_paste delivered the text, same as any other success tier.
+    #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
+    #expect(calls.completedCalls.count == 1)
+    #expect(calls.failedCalls.isEmpty)
+  }
+
   @Test("complete + AX-denied paste tier routes to accessibilityToast overlay")
   func completeAccessibilityDeniedRoutesToToast() {
     let spy = OverlaySpy()

--- a/Tests/EnviousWisprTests/Services/PasteMenuProbeTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteMenuProbeTests.swift
@@ -1,0 +1,61 @@
+import Testing
+
+@testable import EnviousWisprServices
+
+// #729 Tier 2c: the language-agnostic Edit > Paste matcher. The AX menu-bar
+// traversal (`findPasteMenuItem`) is live-only like the other AX primitives
+// (`captureFocusedElement`, `forceActivateApp`) and is exercised by Live UAT;
+// the pure matching predicate is unit-tested here.
+@Suite("PasteService.isPasteShortcut")
+struct PasteMenuProbeTests {
+
+  @Test("⌘V (cmdChar v, no extra modifiers) matches")
+  func commandVMatches() {
+    #expect(PasteService.isPasteShortcut(cmdChar: "v", modifiers: 0))
+  }
+
+  @Test("uppercase V from AXMenuItemCmdChar still matches (case-insensitive)")
+  func uppercaseVMatches() {
+    #expect(PasteService.isPasteShortcut(cmdChar: "V", modifiers: 0))
+  }
+
+  @Test("⇧⌘V (Shift bit set) does NOT match — that's Paste and Match Style")
+  func shiftCommandVRejected() {
+    // kAXMenuItemModifierShift = 1 << 0
+    #expect(!PasteService.isPasteShortcut(cmdChar: "v", modifiers: 1))
+  }
+
+  @Test("⌥⌘V (Option bit set) does NOT match")
+  func optionCommandVRejected() {
+    // kAXMenuItemModifierOption = 1 << 1
+    #expect(!PasteService.isPasteShortcut(cmdChar: "v", modifiers: 2))
+  }
+
+  @Test("NoCommand bit set (1<<3) does NOT match — that shortcut has no ⌘")
+  func noCommandRejected() {
+    // kAXMenuItemModifierNoCommand = 1 << 3 = 8
+    #expect(!PasteService.isPasteShortcut(cmdChar: "v", modifiers: 8))
+  }
+
+  @Test("a different command key (⌘C) does NOT match")
+  func commandCRejected() {
+    #expect(!PasteService.isPasteShortcut(cmdChar: "c", modifiers: 0))
+  }
+
+  @Test("nil cmdChar (item has no shortcut) does NOT match")
+  func nilCmdCharRejected() {
+    #expect(!PasteService.isPasteShortcut(cmdChar: nil, modifiers: 0))
+  }
+
+  @Test("missing-modifiers sentinel (-1) does NOT match")
+  func missingModifiersRejected() {
+    #expect(!PasteService.isPasteShortcut(cmdChar: "v", modifiers: -1))
+  }
+
+  @Test("matches on shortcut alone — title is never consulted (localization-proof)")
+  func matchesRegardlessOfLocale() {
+    // A localized menu would title this "Coller" / "貼り付け" etc.; the matcher
+    // never sees the title, only the ⌘V shortcut, so it matches identically.
+    #expect(PasteService.isPasteShortcut(cmdChar: "v", modifiers: 0))
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceClipboardTests.swift
@@ -38,6 +38,27 @@ struct PasteServiceClipboardTests {
     #expect(NSPasteboard.general.string(forType: .string) == originalText)
   }
 
+  @Test("#729: restoreClipboard restores an empty prior clipboard to empty (clears our paste text)")
+  func restoreClipboardRestoresEmptyToEmpty() {
+    let initial = PasteService.saveClipboard()
+    defer { Self.restoreExactly(initial) }
+
+    // Prior clipboard is empty.
+    NSPasteboard.general.clearContents()
+    let emptySnapshot = PasteService.saveClipboard()
+    #expect(emptySnapshot.items.isEmpty)
+
+    // Our paste writes text onto the board.
+    let pastedText = "dictated-\(UUID().uuidString)"
+    let changeCountAfterPaste = PasteService.copyToClipboardReturningChangeCount(pastedText)
+    #expect(NSPasteboard.general.string(forType: .string) == pastedText)
+
+    PasteService.restoreClipboard(emptySnapshot, changeCountAfterPaste: changeCountAfterPaste)
+
+    // The board must be cleared back to empty, not left holding our paste text.
+    #expect(NSPasteboard.general.string(forType: .string) == nil)
+  }
+
   @Test("restoreClipboard skips restore when clipboard changed after our paste write")
   func restoreClipboardSkipsWhenClipboardAdvanced() {
     let initial = PasteService.saveClipboard()


### PR DESCRIPTION
Closes #729.

## Problem
Apps that expose their editor as a **container** AX role — Word, Excel, Numbers, Pages, OneNote, Sublime, Firefox/LibreWolf (`AXScrollArea` / `AXSplitGroup` / `AXLayoutArea` / `AXGroup` / `AXWindow`) — were classified `.nonText`, which short-circuited the entire paste cascade (including app re-activation / snap-back) straight to clipboard-only at 0ms. Users saw "Copied" but nothing pasted. P1, 5 users on Sentry ENVIOUSWISPR-V. (PR #758 already shipped the web-wrapper bundle-hint half; this completes the native-container half.)

## Fix
New **Tier 2c**: for `.nonText` + Accessibility-trusted, re-activate the target app, put the text on the clipboard, then drive the app's **own Edit→Paste command** — located language-agnostically by its ⌘V shortcut (`AXMenuItemCmdChar=="v"` + `AXMenuItemModifierNone`) and pressed via `AXPress`. The menu command's **enabled-state is the Scenario-A/B discriminator**: enabled ⇒ real editor, paste it (`tier=menu_paste`); absent/disabled ⇒ no paste target ⇒ clipboard-only overlay (unchanged). On menu-path failure the dictated text is left on the clipboard so manual Cmd+V works; on success the prior clipboard is restored. Also fixes a pre-existing gap where an empty prior clipboard wasn't restored to empty.

Adds `paste.focus_class` telemetry (`non_text_with_paste_target` / `no_paste_target`), present only when the probe ran, so dashboards separate the real bug from genuinely-no-field-focused. `.textField` and `.missing` flows untouched; activation loop extracted into a shared `activate()` helper.

## Validation
- **Logic tests:** 1716 green (`scripts/xcode-test.sh`), incl. new `isPasteShortcut`, `focus_class`, `menu_paste`-is-success, label, and empty-clipboard-restore tests.
- **Live UAT (founder, real mic + clipboard):** `menu_paste` confirmed in **Excel, Pages, Numbers (cell editing), Sublime, LibreWolf, WhatsApp search**; correct clipboard-only **refusal** in **Finder** and **idle Numbers** (no misfire); **clipboard preservation** and **snap-back** (tab-away-and-back) both verified; every real text field + Chromium app unchanged (`ax_direct`/`cgevent`).
- **Review gates:** Council skipped per founder direction; Codex grounded review r1→r4 PROCEED-AS-PLANNED; Codex code-diff review SHIP (one should-fix found + fixed).

## Out of scope (follow-up issues to file)
Pasteboard-read landing verification; secure-input detection/messaging; HID-tap evaluation; awareness overlay. (Founder asked for the full paste-mechanism upgrade as staggered PRs — this is PR-1.)