### PR TITLE
feat(ui): surface waiting updates for always-on users (#1019, PR-A app)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -75,13 +75,25 @@ final class MenuBarController: NSObject {
     // was the sole assigner of this single-slot closure — a verified 1:1
     // transfer. The owner of the icon owns the trigger.
     permissions.onAccessibilityChange = { [weak self] in self?.updateIcon() }
+
+    // #1019: flip the icon to / from the "update waiting" gold-wave cue the
+    // moment availability changes, even with no window or menu open. The
+    // coordinator exists by now (startUpdater() ran in
+    // applicationWillFinishLaunching, before this didFinishLaunching call).
+    sparkleUpdateController.updateCoordinator?.onAvailabilityChange = { [weak self] in
+      self?.updateIcon()
+    }
+    updateIcon()
   }
 
   // MARK: - Icon
 
   /// Update the status item icon for the current pipeline / permission state.
   func updateIcon() {
-    iconAnimator.transition(to: Self.iconState(currentViewState()))
+    let state = currentViewState()
+    iconAnimator.transition(to: Self.iconState(state))
+    // #1019: non-color accessibility affordance for the gold-wave cue.
+    statusItem?.button?.setAccessibilityValue(state.updateAvailable ? "Update available" : nil)
   }
 
   /// Pure icon-state mapping. Logic byte-identical to the pre-PR-B.3
@@ -101,7 +113,10 @@ final class MenuBarController: NSObject {
     {
       return .processing
     } else {
-      return .idle
+      // #1019: idle-with-update variant. Chosen ONLY here, after onboarding /
+      // warning / error / recording / processing — so the update cue never
+      // overrides a higher-priority state.
+      return state.updateAvailable ? .updatePending : .idle
     }
   }
 
@@ -124,6 +139,26 @@ final class MenuBarController: NSObject {
         systemSymbolName: "exclamationmark.circle.fill", accessibilityDescription: "Setup required")
       setupItem.target = self
       menu.addItem(setupItem)
+      menu.addItem(.separator())
+    }
+
+    // #1019: prominent "update waiting" item near the top. Disabled (with a
+    // "finish dictating" hint) while dictation is active; the coordinator's
+    // install path is guarded too, so this is defense-in-depth, not the sole
+    // gate.
+    if state.updateAvailable {
+      let installTitle: String = {
+        guard state.installEnabled else { return "Update ready: finish dictating to install" }
+        if let v = state.updateDisplayVersion, !v.isEmpty { return "Update ready: Install v\(v)" }
+        return "Update ready: Install"
+      }()
+      let updateItem = NSMenuItem(
+        title: installTitle, action: #selector(installUpdateAction), keyEquivalent: "")
+      updateItem.image = NSImage(
+        systemSymbolName: "arrow.down.circle.fill", accessibilityDescription: "Install update")
+      updateItem.target = self
+      updateItem.isEnabled = state.installEnabled
+      menu.addItem(updateItem)
       menu.addItem(.separator())
     }
 
@@ -220,7 +255,19 @@ final class MenuBarController: NSObject {
   /// Reads are byte-identical to the pre-PR-B.3 `AppDelegate.populateMenu` /
   /// `updateIcon` reads.
   private func currentViewState() -> MenuBarViewState {
-    MenuBarViewState(
+    // #1019: read the pending-update state (non-critical only — critical routes
+    // to Sparkle's own UX) and the active-dictation guard.
+    let pending: UpdateAvailabilityService.AvailableUpdate? = {
+      if case .available(let u) = sparkleUpdateController.updateCoordinator?.service.state ?? .none,
+        !u.isCriticalUpdate
+      {
+        return u
+      }
+      return nil
+    }()
+    let dictationActive = liveRecordingState.isDictationActive
+
+    return MenuBarViewState(
       pipelineState: liveRecordingState.pipelineState,
       asrLabel: backendMetadata.modelLabel,
       llmLabel: backendMetadata.llmLabel,
@@ -228,7 +275,10 @@ final class MenuBarController: NSObject {
       vadAutoStop: settings.vadAutoStop,
       vadSilenceTimeout: settings.vadSilenceTimeout,
       showAccessibilityWarning: permissions.shouldShowAccessibilityWarning,
-      hasUpdater: sparkleUpdateController.hasUpdater
+      hasUpdater: sparkleUpdateController.hasUpdater,
+      updateAvailable: pending != nil,
+      updateDisplayVersion: pending?.displayVersion,
+      installEnabled: pending != nil && !dictationActive
     )
   }
 
@@ -255,6 +305,13 @@ final class MenuBarController: NSObject {
 
   @objc private func quitAction() {
     actions.quit()
+  }
+
+  /// #1019: install the waiting update from the menu item. The coordinator
+  /// re-checks active dictation before relaunching, so a stale-enabled item
+  /// still cannot kill in-flight work.
+  @objc private func installUpdateAction() {
+    sparkleUpdateController.updateCoordinator?.installFromMenu()
   }
 }
 
@@ -300,4 +357,13 @@ struct MenuBarViewState: Equatable {
   let vadSilenceTimeout: Double
   let showAccessibilityWarning: Bool
   let hasUpdater: Bool
+  /// #1019: a non-critical update is waiting to install.
+  var updateAvailable: Bool = false
+  /// #1019: the pending update's display version (e.g. "2.1.4"), for the
+  /// dropdown item copy.
+  var updateDisplayVersion: String? = nil
+  /// #1019: whether install is permitted right now — false whenever dictation
+  /// is active (record / load / transcribe / polish), so a relaunch never kills
+  /// in-flight work.
+  var installEnabled: Bool = false
 }

--- a/Sources/EnviousWisprAppKit/App/MenuBarIconAnimator.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarIconAnimator.swift
@@ -2,8 +2,10 @@ import AppKit
 
 /// Manages animated menu bar icon states using Core Graphics rendering.
 ///
-/// Four states: idle (static grey lips), recording (rainbow lips reacting to audio),
-/// processing (rotating rainbow spectrum wheel), error (static red lips).
+/// Five states: idle (static grey lips), recording (rainbow lips reacting to
+/// audio), processing (rotating rainbow spectrum wheel), error (static red
+/// lips), updatePending (grey lips with a gold wave travelling outward — the
+/// "update waiting" cue, #1019).
 @MainActor
 final class MenuBarIconAnimator {
 
@@ -12,6 +14,11 @@ final class MenuBarIconAnimator {
     case recording
     case processing
     case error
+    /// #1019: an update is downloaded/available and waiting to install. An
+    /// idle-with-update display variant — the controller selects it only inside
+    /// the idle branch of its icon-state mapping, so it never overrides
+    /// recording / processing / error / warning.
+    case updatePending
   }
 
   private weak var button: NSStatusBarButton?
@@ -26,6 +33,15 @@ final class MenuBarIconAnimator {
   // Processing rotation angle (degrees)
   private var rotationAngle: Double = 0
 
+  // #1019: update-pending gold-wave phase (0…1 per loop).
+  private var wavePhase: Double = 0
+  private var reduceMotionObserver: NSObjectProtocol?
+
+  /// #ffd700 — the "pending" semantic gold.
+  private static let goldColor = (r: CGFloat(1.0), g: CGFloat(0.843), b: CGFloat(0.0))
+  /// Mid-grey base the gold washes through.
+  private static let greyColor = (r: CGFloat(0.5), g: CGFloat(0.5), b: CGFloat(0.5))
+
   // MARK: - Configuration
 
   /// Call once from setupStatusItem() after creating the button.
@@ -34,6 +50,19 @@ final class MenuBarIconAnimator {
     self.idleImage = renderIdleLips()
     self.errorImage = renderErrorLips()
     button.image = self.idleImage
+
+    // #1019: re-render the update-pending cue when the system reduce-motion
+    // setting changes live (AppKit-native — the SwiftUI `@Environment` key does
+    // not reach this AppKit class).
+    reduceMotionObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+      object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        guard let self, self.currentState == .updatePending else { return }
+        self.restartUpdatePendingForReduceMotionChange()
+      }
+    }
   }
 
   // MARK: - State Transitions
@@ -54,7 +83,19 @@ final class MenuBarIconAnimator {
       startProcessingAnimation()
     case .error:
       button?.image = errorImage
+    case .updatePending:
+      wavePhase = 0
+      startUpdatePendingAnimation()
     }
+  }
+
+  /// Re-apply the update-pending cue when reduce-motion toggles while it is the
+  /// current state (the new transition guard would otherwise no-op a same-state
+  /// re-entry).
+  private func restartUpdatePendingForReduceMotionChange() {
+    stopTimer()
+    wavePhase = 0
+    startUpdatePendingAnimation()
   }
 
   // MARK: - Timer Management
@@ -92,6 +133,30 @@ final class MenuBarIconAnimator {
         self.rotationAngle += 3.0  // 360° / 8s / 15fps = 3° per frame
         if self.rotationAngle >= 360 { self.rotationAngle -= 360 }
         button.image = self.renderProcessingWheel()
+      }
+    }
+  }
+
+  // MARK: - Update-pending Animation (gold wave through grey lips, ~20fps)
+
+  /// #1019: grey lips with a fast, near-together gold wave sweeping outward from
+  /// the center column. Reduce-motion users get a static gold-tinted frame
+  /// instead of the loop.
+  private func startUpdatePendingAnimation() {
+    guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else {
+      button?.image = renderUpdatePendingStatic()
+      return
+    }
+    button?.image = renderUpdatePendingLips(phase: wavePhase)
+
+    animationTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 20.0, repeats: true) {
+      [weak self] _ in
+      MainActor.assumeIsolated {
+        guard let self, let button = self.button else { return }
+        // ~1.3s loop at 20fps → 26 frames per loop.
+        self.wavePhase += 1.0 / 26.0
+        if self.wavePhase >= 1.0 { self.wavePhase -= 1.0 }
+        button.image = self.renderUpdatePendingLips(phase: self.wavePhase)
       }
     }
   }
@@ -327,6 +392,92 @@ final class MenuBarIconAnimator {
         ctx.restoreGState()
       }
 
+      return true
+    }
+  }
+
+  // Shared 9+9 lip geometry (viewBox 0 0 64 64), column index 0…8.
+  private static let upperLipBars: [(x: CGFloat, y: CGFloat, h: CGFloat)] = [
+    (4, 22.25, 5), (10, 17.6375, 8), (16, 12.04, 12),
+    (22, 16.96, 9), (28, 21.5575, 6), (34, 16.96, 9),
+    (40, 12.04, 12), (46, 17.6375, 8), (52, 22.25, 5),
+  ]
+  private static let lowerLipBars: [(x: CGFloat, y: CGFloat, h: CGFloat)] = [
+    (4, 30.25, 5), (10, 28.6375, 9), (16, 27.04, 12),
+    (22, 28.96, 15), (28, 30.5575, 17), (34, 28.96, 15),
+    (40, 27.04, 12), (46, 28.6375, 9), (52, 30.25, 5),
+  ]
+
+  /// Gold intensity (0…1) for a bar at column index `i` of `count` columns,
+  /// given the wave front position. Distance is normalized (0 center, 1 edge);
+  /// a narrow band → "near-together" wave; the front overshoots to 1.25 so
+  /// there is a brief all-grey gap before the next sweep ("fast").
+  private static func waveIntensity(columnIndex i: Int, of count: Int, phase: Double) -> CGFloat {
+    let center = CGFloat(count - 1) / 2.0  // 4.0 for 9 columns
+    let distance = abs(CGFloat(i) - center) / center
+    let front = CGFloat(phase) * 1.25
+    let band: CGFloat = 0.22
+    return max(0, 1 - abs(distance - front) / band)
+  }
+
+  /// Render the gold-wave frame for `phase`. Grey lips with gold washing
+  /// outward from the center column.
+  private func renderUpdatePendingLips(phase: Double) -> NSImage {
+    let upper = Self.upperLipBars.indices.map {
+      Self.waveIntensity(columnIndex: $0, of: Self.upperLipBars.count, phase: phase)
+    }
+    let lower = Self.lowerLipBars.indices.map {
+      Self.waveIntensity(columnIndex: $0, of: Self.lowerLipBars.count, phase: phase)
+    }
+    return renderLips(upperIntensities: upper, lowerIntensities: lower)
+  }
+
+  /// Reduce-motion fallback: a static, clearly-gold lips (uniform mid blend) so
+  /// the "update waiting" meaning still reads without any animation.
+  private func renderUpdatePendingStatic() -> NSImage {
+    let upper = Self.upperLipBars.map { _ in CGFloat(0.6) }
+    let lower = Self.lowerLipBars.map { _ in CGFloat(0.6) }
+    return renderLips(upperIntensities: upper, lowerIntensities: lower)
+  }
+
+  private static func blendGoldOverGrey(_ t: CGFloat) -> CGColor {
+    let r = greyColor.r + (goldColor.r - greyColor.r) * t
+    let g = greyColor.g + (goldColor.g - greyColor.g) * t
+    let b = greyColor.b + (goldColor.b - greyColor.b) * t
+    return CGColor(red: r, green: g, blue: b, alpha: 0.95)
+  }
+
+  /// Shared lips renderer: fills the 9+9 bar geometry, coloring each bar by its
+  /// precomputed gold intensity. Only `[CGFloat]` (Sendable) crosses into the
+  /// drawing block — colors are built inside it.
+  private func renderLips(upperIntensities: [CGFloat], lowerIntensities: [CGFloat]) -> NSImage {
+    let size = NSSize(width: 18, height: 18)
+    return NSImage(size: size, flipped: true) { rect in
+      guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
+      let scale = rect.width / 64.0
+      let barWidth: CGFloat = 4.5 * scale
+      let cornerRadius: CGFloat = 1.5 * scale
+
+      for (i, bar) in Self.upperLipBars.enumerated() {
+        ctx.setFillColor(Self.blendGoldOverGrey(upperIntensities[i]))
+        let barRect = CGRect(
+          x: bar.x * scale, y: bar.y * scale, width: barWidth, height: bar.h * scale)
+        ctx.addPath(
+          CGPath(
+            roundedRect: barRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius,
+            transform: nil))
+        ctx.fillPath()
+      }
+      for (i, bar) in Self.lowerLipBars.enumerated() {
+        ctx.setFillColor(Self.blendGoldOverGrey(lowerIntensities[i]))
+        let barRect = CGRect(
+          x: bar.x * scale, y: bar.y * scale, width: barWidth, height: bar.h * scale)
+        ctx.addPath(
+          CGPath(
+            roundedRect: barRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius,
+            transform: nil))
+        ctx.fillPath()
+      }
       return true
     }
   }

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -147,11 +147,14 @@ extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate
     _ update: SUAppcastItem,
     andInImmediateFocus immediateFocus: Bool
   ) -> Bool {
-    let hasMainWindow = NSApp.windows.contains { $0.isVisible && $0.canBecomeMain }
-    if !hasMainWindow { return true }  // no banner mount → Sparkle handles
+    // #1019: the no-window non-critical case no longer hands off to Sparkle's
+    // focus-stealing modal. Our menu-bar gold-wave cue + once-per-version
+    // notification own that surface now (both land from `noteAvailable` in
+    // `standardUserDriverWillHandleShowingUpdate` below). Critical or
+    // immediate-focus updates still route to Sparkle's full UX.
     if update.isCriticalUpdate { return true }  // critical → Sparkle's full UX
     if immediateFocus { return true }  // Sparkle wants front-and-center
-    return false  // we own the gentle UX via the banner
+    return false  // we own the gentle UX (banner when windowed; menu-bar + notification otherwise)
   }
 
   /// Issue #343: side-effect callback that fires after the yes/no decision.
@@ -371,5 +374,19 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     // triggerInstall restores .available if the user clicked the widget but
     // did not complete an install.
     updateCoordinator?.lastInstallSource = nil
+
+    // #1019: feed the cycle OUTCOME to the proactive-check cooldown. A genuine
+    // network/parse failure does NOT consume the event-driven cooldown (so the
+    // next wake/network trigger re-checks); a benign Sparkle terminal code
+    // (no-update / user-cancel / install-later) means the feed WAS reached and
+    // the cooldown is earned.
+    let reachedFeed: Bool = {
+      guard let nsError = error as NSError? else { return true }
+      if nsError.domain == "SUSparkleErrorDomain", [1001, 4007, 4008].contains(nsError.code) {
+        return true
+      }
+      return false
+    }()
+    updateCoordinator?.recordUpdateCheckOutcome(success: reachedFeed)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -41,15 +41,42 @@ final class UpdateCoordinator {
   private static let kLastAttemptTimestamp = "com.enviouswispr.updateBanner.lastAttemptTimestamp"
   private static let kLastAttemptSource = "com.enviouswispr.updateBanner.lastAttemptSource"
 
+  /// #1019: persisted "we already fired the macOS notification for this version"
+  /// marker, so the notification is once-per-version across relaunch.
+  private static let kLastNotifiedVersion = "com.enviouswispr.updateBanner.lastNotifiedVersion"
+
   // In-memory dedup for `update.banner_shown` (per app launch, per version).
   private var bannerShownReportedVersions: Set<String> = []
 
   private weak var updaterController: SPUStandardUpdaterController?
   private let defaults: UserDefaults
+  private let notifier: any UpdateNotifying
 
-  init(updaterController: SPUStandardUpdaterController?, defaults: UserDefaults = .standard) {
+  /// #1019: refresh hook for the menu-bar surface. The menu-bar home sets this
+  /// so the status-item icon flips to / from the "update waiting" cue the
+  /// moment availability changes, even with no window or menu open.
+  var onAvailabilityChange: (() -> Void)?
+
+  /// #1019: reads whether dictation is currently active (recording / loading /
+  /// transcribing / polishing) so the install affordances never relaunch the
+  /// app mid-capture. Wired in `WisprBootstrapper` to `LiveRecordingState`.
+  var dictationActiveProvider: (() -> Bool)?
+
+  /// #1019: when the last update-check cycle FINISHED having reached the feed
+  /// (update found, none found, or user-cancelled install). Nil until the first
+  /// such outcome. A genuine network/parse failure does NOT update this, so the
+  /// event-driven cooldown is not consumed and the next wake/network trigger
+  /// re-checks.
+  private(set) var lastCheckOutcomeAt: Date?
+
+  init(
+    updaterController: SPUStandardUpdaterController?,
+    defaults: UserDefaults = .standard,
+    notifier: (any UpdateNotifying)? = nil
+  ) {
     self.updaterController = updaterController
     self.defaults = defaults
+    self.notifier = notifier ?? UpdateNotificationPresenter()
     self.service = UpdateAvailabilityService(
       installAction: { [weak updaterController] in
         updaterController?.checkForUpdates(nil)
@@ -57,14 +84,47 @@ final class UpdateCoordinator {
       defaults: defaults,
       currentBundleVersion: AppConstants.appVersion
     )
+    // #1019: react to every availability change — fire the once-per-version
+    // notification and refresh the menu-bar icon.
+    self.service.onAvailabilityChange = { [weak self] in
+      self?.handleAvailabilityChanged()
+    }
+    // Route a notification tap through the active-dictation guard.
+    self.notifier.onInstallTapped = { [weak self] in
+      self?.handleNotificationInstallTapped()
+    }
+    // #1019 (Codex P1): `rehydratePendingIfNewer()` runs INSIDE the service
+    // initializer above — before this hook is installed. So a persisted-pending
+    // update newer than the current bundle would set `.available` with the hook
+    // still nil and miss its once-per-version notification (and a later
+    // same-version `noteAvailable` returns early). Replay the current
+    // availability now that the hook is live; the per-version marker keeps this
+    // idempotent across relaunch.
+    if case .available = service.state {
+      handleAvailabilityChanged()
+    }
   }
 
   // MARK: - Proactive update checks (issue #958)
 
-  /// Cooldown between proactive background checks, anchored on Sparkle's own
+  /// Cooldown for the `launch` trigger, anchored on Sparkle's own
   /// `lastUpdateCheckDate`. 1h matches the scheduled cadence (`SUScheduledCheckInterval`),
-  /// which is also Sparkle's enforced minimum interval.
+  /// which is also Sparkle's enforced minimum interval. Launch coalesces with
+  /// Sparkle's scheduled background checks across relaunch.
   static let proactiveCheckCooldown: TimeInterval = 3600
+
+  /// #1019: cooldown for the event-driven triggers (`foreground`/`wake`/
+  /// `network`). Anchored on `UpdateCoordinator`'s OWN outcome timestamp
+  /// (`lastCheckOutcomeAt`), NOT Sparkle's `lastUpdateCheckDate` — Sparkle
+  /// stamps its date when the driver *starts* (before the outcome is known), so
+  /// it cannot distinguish a failed check from a successful one. 30 min gives an
+  /// always-on user near-current freshness on wake/reconnect without hammering
+  /// the feed; Sparkle's hourly scheduled check remains the floor.
+  static let foregroundCheckCooldown: TimeInterval = 1800
+
+  /// Triggers gated on the local outcome-aware cooldown (vs `launch`, which
+  /// stays on Sparkle's check-date).
+  private static let outcomeAwareTriggers: Set<String> = ["foreground", "wake", "network"]
 
   /// Issue #958: proactive, cooldown-gated background update check. Fires
   /// Sparkle's BACKGROUND driver (→ gentle banner via the user-driver delegate
@@ -99,15 +159,38 @@ final class UpdateCoordinator {
       reportProactive(trigger: trigger, fired: false, reason: "session_in_progress")
       return false
     }
-    let elapsed =
-      updater.lastUpdateCheckDate.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
-    guard elapsed >= Self.proactiveCheckCooldown else {
+    // #1019: event-driven triggers gate on the local outcome-aware timestamp;
+    // `launch` keeps Sparkle's check-date anchor (coalesces with scheduled
+    // background checks across relaunch).
+    let elapsed: TimeInterval
+    let cooldown: TimeInterval
+    if Self.outcomeAwareTriggers.contains(trigger) {
+      elapsed = lastCheckOutcomeAt.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+      cooldown = Self.foregroundCheckCooldown
+    } else {
+      elapsed =
+        updater.lastUpdateCheckDate.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+      cooldown = Self.proactiveCheckCooldown
+    }
+    guard elapsed >= cooldown else {
       reportProactive(trigger: trigger, fired: false, reason: "cooldown")
       return false
     }
     reportProactive(trigger: trigger, fired: true, reason: "fired")
     updater.checkForUpdatesInBackground()
     return true
+  }
+
+  /// #1019: records the outcome of an update-check cycle (called from
+  /// `SparkleUpdateController.didFinishUpdateCycleFor`). `success` means the
+  /// cycle reached the feed — update found, none found, or user-cancelled
+  /// install — vs a genuine network/parse failure. Only a successful outcome
+  /// consumes the event-driven cooldown; a failure leaves `lastCheckOutcomeAt`
+  /// untouched so the next wake/network trigger re-checks instead of waiting
+  /// out a cooldown that was never earned.
+  func recordUpdateCheckOutcome(success: Bool, at date: Date = Date()) {
+    guard success else { return }
+    lastCheckOutcomeAt = date
   }
 
   /// Emits telemetry on EVERY proactive-check return path (bounded `reason`:
@@ -135,6 +218,49 @@ final class UpdateCoordinator {
   func checkForUpdatesFromSettings() {
     lastInstallSource = "settings"
     updaterController?.checkForUpdates(nil)
+  }
+
+  // MARK: - Availability surfaces (#1019)
+
+  /// Fired on every `UpdateAvailabilityService.state` mutation. Fires the
+  /// once-per-version macOS notification (non-critical only) and re-publishes
+  /// to the menu-bar icon-refresh hook.
+  private func handleAvailabilityChanged() {
+    fireUpdateNotificationIfNeeded()
+    onAvailabilityChange?()
+  }
+
+  /// Posts exactly one macOS notification per newly-available non-critical
+  /// version. Critical updates route to Sparkle's own UX, so they get no gentle
+  /// notification. The per-version marker persists across relaunch so a
+  /// rehydrated pending state does not re-fire.
+  private func fireUpdateNotificationIfNeeded() {
+    guard case .available(let update) = service.state, !update.isCriticalUpdate else { return }
+    guard defaults.string(forKey: Self.kLastNotifiedVersion) != update.versionString else { return }
+    defaults.set(update.versionString, forKey: Self.kLastNotifiedVersion)
+    notifier.post(displayVersion: update.displayVersion)
+  }
+
+  /// Install entry from the menu-bar "update ready" item. Guarded on active
+  /// dictation (defense-in-depth — the item is also disabled in that state).
+  func installFromMenu() {
+    triggerGuardedInstall(source: "menu_update_item")
+  }
+
+  /// Install entry from a notification tap. Guarded on active dictation so a
+  /// tap mid-dictation never relaunches the app and destroys in-flight work;
+  /// the user can tap again once dictation ends.
+  private func handleNotificationInstallTapped() {
+    triggerGuardedInstall(source: "notification")
+  }
+
+  private func triggerGuardedInstall(source: String) {
+    guard !(dictationActiveProvider?() ?? false) else { return }
+    lastInstallSource = source
+    if case .available(let update) = service.state {
+      recordInstallAttempt(version: update.versionString, source: source)
+    }
+    service.triggerInstall()
   }
 
   // MARK: - Install-attempt persistence (cross-launch correlation)

--- a/Sources/EnviousWisprAppKit/App/UpdateNotificationPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateNotificationPresenter.swift
@@ -1,0 +1,107 @@
+import EnviousWisprCore
+import Foundation
+import UserNotifications
+
+/// #1019 — narrow seam over the local-notification mechanics so
+/// `UpdateCoordinator` can own the *policy* (when to fire, once-per-version,
+/// install guard) while the `UNUserNotificationCenter` *mechanics* (permission
+/// request, posting, tap delegate) stay injectable and out of unit tests.
+@MainActor
+protocol UpdateNotifying: AnyObject {
+  /// Invoked when the user taps the notification (or its Install action).
+  /// `UpdateCoordinator` sets this and routes it through the active-dictation
+  /// guard before triggering an install.
+  var onInstallTapped: (() -> Void)? { get set }
+
+  /// Lazily request authorization (first time only) and post a single
+  /// "update ready" notification. A no-op if the user denied permission.
+  func post(displayVersion: String)
+}
+
+/// Production `UNUserNotificationCenter` implementation. Construction is inert
+/// (no `UNUserNotificationCenter.current()` touch) so unit tests that build an
+/// `UpdateCoordinator` with the default notifier never reach into the
+/// notification subsystem — only `post(displayVersion:)` does, and that path is
+/// exercised only in the running app / Live UAT.
+@MainActor
+final class UpdateNotificationPresenter: NSObject, UpdateNotifying {
+  var onInstallTapped: (() -> Void)?
+
+  /// Category + action identifiers for the "Install" affordance on the banner.
+  private static let categoryIdentifier = "com.enviouswispr.updateReady"
+  private static let installActionIdentifier = "com.enviouswispr.updateReady.install"
+
+  private var delegateInstalled = false
+
+  func post(displayVersion: String) {
+    let center = UNUserNotificationCenter.current()
+    installDelegateIfNeeded(center)
+    // `requestAuthorization` is idempotent: after the user's first decision it
+    // returns the existing grant without re-prompting. So this both lazily
+    // requests permission the first time and gates on it thereafter. The
+    // completion captures only Sendable values (`self`, `displayVersion`) — it
+    // does NOT capture `center`, which is non-Sendable and would otherwise race.
+    center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+      guard granted else { return }  // denied → limb degrades silently
+      Task { @MainActor in self.deliver(displayVersion: displayVersion) }
+    }
+  }
+
+  private func deliver(displayVersion: String) {
+    let content = UNMutableNotificationContent()
+    content.title = AppConstants.appName
+    // No em/en-dashes in user-facing copy (brand rule).
+    content.body = "Version \(displayVersion) is ready. Click to install."
+    content.sound = nil
+    content.categoryIdentifier = Self.categoryIdentifier
+
+    let request = UNNotificationRequest(
+      identifier: "\(Self.categoryIdentifier).\(displayVersion)",
+      content: content,
+      trigger: nil
+    )
+    UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+  }
+
+  private func installDelegateIfNeeded(_ center: UNUserNotificationCenter) {
+    guard !delegateInstalled else { return }
+    delegateInstalled = true
+    let installAction = UNNotificationAction(
+      identifier: Self.installActionIdentifier,
+      title: "Install",
+      options: [.foreground]
+    )
+    let category = UNNotificationCategory(
+      identifier: Self.categoryIdentifier,
+      actions: [installAction],
+      intentIdentifiers: [],
+      options: []
+    )
+    center.setNotificationCategories([category])
+    center.delegate = self
+  }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension UpdateNotificationPresenter: UNUserNotificationCenterDelegate {
+  /// Surface the banner even when the app is foregrounded.
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner])
+  }
+
+  /// Tap (body or Install action) → route through the install handler, which
+  /// `UpdateCoordinator` guards on active dictation.
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void
+  ) {
+    Task { @MainActor in self.onInstallTapped?() }
+    completionHandler()
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/UpdateTriggerCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateTriggerCoordinator.swift
@@ -1,0 +1,121 @@
+import AppKit
+import Foundation
+import Network
+
+/// #1019 — App-owned home whose single responsibility is to translate OS
+/// wake/network signals into proactive update checks for an always-on,
+/// never-foregrounded user. Holds NO update data: it owns only the
+/// `NWPathMonitor` + the wake one-shot latch, and forwards a trigger label to
+/// the `onTrigger` closure (wired in `WisprBootstrapper` to
+/// `UpdateCoordinator.checkForUpdatesProactively`). The cooldown/outcome policy
+/// lives on `UpdateCoordinator` (where the gate is); this home never decides
+/// whether a check actually fires.
+///
+/// Event-driven, not timer-driven: an idle laptop that never quits the app
+/// still discovers updates on wake-from-sleep and network-reconnect without
+/// any per-minute polling (founder + council constraint — no repeating timer).
+@MainActor
+final class UpdateTriggerCoordinator {
+  /// Forwards a bounded trigger label (`"wake"` / `"network"`) to the proactive
+  /// check funnel. Reads `updateCoordinator` lazily so it tolerates being
+  /// constructed before `startUpdater()` runs.
+  private let onTrigger: (String) -> Void
+
+  private let pathMonitor: NWPathMonitor
+  private let monitorQueue = DispatchQueue(label: "com.enviouswispr.updateTrigger.path")
+
+  private var wakeObserver: NSObjectProtocol?
+  private var lastPathSatisfied = false
+  private var receivedInitialPath = false
+  private var wakeArmed = false
+  private var settleTask: Task<Void, Never>?
+  private var started = false
+
+  /// Settle delay after a path becomes `.satisfied` before firing a check.
+  /// DNS / captive-portal resolution can lag the `.satisfied` transition, so a
+  /// check fired the instant the path flips would hit an unreachable feed. This
+  /// is a debounce (a newer `.satisfied` edge cancels a pending fire), NOT a
+  /// failure-detection deadline.
+  static let settleDelay: TimeInterval = 2.0
+
+  init(onTrigger: @escaping (String) -> Void) {
+    self.onTrigger = onTrigger
+    self.pathMonitor = NWPathMonitor()
+  }
+
+  /// Begin observing wake + network. Idempotent.
+  func start() {
+    guard !started else { return }
+    started = true
+
+    wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.handleWake() }
+    }
+
+    pathMonitor.pathUpdateHandler = { [weak self] path in
+      let satisfied = path.status == .satisfied
+      Task { @MainActor in self?.handlePathChange(satisfied: satisfied) }
+    }
+    pathMonitor.start(queue: monitorQueue)
+  }
+
+  /// Tear down on app terminate. Idempotent.
+  func stop() {
+    if let wakeObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
+    }
+    wakeObserver = nil
+    settleTask?.cancel()
+    settleTask = nil
+    pathMonitor.cancel()
+    started = false
+  }
+
+  // MARK: - Signal handlers
+
+  /// Wake does NOT fire a check directly (council's wake-before-network catch:
+  /// the network stack is often not yet reachable on wake). It arms a one-shot
+  /// that fires on the next satisfied path; if the path is already satisfied,
+  /// schedule the wake check now (after the settle delay).
+  private func handleWake() {
+    wakeArmed = true
+    if lastPathSatisfied {
+      scheduleCheck(trigger: "wake")
+    }
+  }
+
+  /// Fire on the rising edge into `.satisfied`: a wake-armed check takes
+  /// priority and labels `"wake"`; an unarmed reconnect labels `"network"`.
+  /// The very first path update is a baseline (the launch check already covers
+  /// startup), so it never fires.
+  private func handlePathChange(satisfied: Bool) {
+    let wasSatisfied = lastPathSatisfied
+    lastPathSatisfied = satisfied
+
+    if !receivedInitialPath {
+      receivedInitialPath = true
+      return
+    }
+    guard satisfied else { return }
+
+    if wakeArmed {
+      scheduleCheck(trigger: "wake")
+    } else if !wasSatisfied {
+      scheduleCheck(trigger: "network")
+    }
+  }
+
+  /// Debounced fire: a newer satisfied edge cancels the pending check, so a
+  /// flapping network coalesces into a single check after it settles.
+  private func scheduleCheck(trigger: String) {
+    wakeArmed = false
+    settleTask?.cancel()
+    settleTask = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(Self.settleDelay))
+      guard !Task.isCancelled else { return }
+      self?.onTrigger(trigger)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -26,6 +26,7 @@ public final class WisprBootstrapper {
   let languageSuggestionPresenter: LanguageSuggestionPresenter
   let updateCoordinatorHolder: UpdateCoordinatorHolder
   let sparkleUpdateController: SparkleUpdateController
+  let updateTriggerCoordinator: UpdateTriggerCoordinator
   let transcriptWorkflowCoordinator: TranscriptWorkflowCoordinator
   let liveRecordingState: LiveRecordingState
   let lastRecordingResult: LastRecordingResult
@@ -328,6 +329,14 @@ public final class WisprBootstrapper {
     let updateCoordinatorHolder = UpdateCoordinatorHolder()
     let sparkleUpdateController = SparkleUpdateController(holder: updateCoordinatorHolder)
 
+    // #1019: event-driven update-discovery triggers (wake / network). Data-free
+    // — it reads `updateCoordinator` lazily (nil until `startUpdater()`), so it
+    // tolerates being constructed before Sparkle boots.
+    let updateTriggerCoordinator = UpdateTriggerCoordinator(
+      onTrigger: { [weak sparkleUpdateController] trigger in
+        sparkleUpdateController?.updateCoordinator?.checkForUpdatesProactively(trigger: trigger)
+      })
+
     let transcriptWorkflowCoordinator = TranscriptWorkflowCoordinator(
       transcriptCoordinator: transcriptCoordinator,
       polishService: polishService
@@ -458,6 +467,7 @@ public final class WisprBootstrapper {
     self.languageSuggestionPresenter = languageSuggestionPresenter
     self.updateCoordinatorHolder = updateCoordinatorHolder
     self.sparkleUpdateController = sparkleUpdateController
+    self.updateTriggerCoordinator = updateTriggerCoordinator
     self.transcriptWorkflowCoordinator = transcriptWorkflowCoordinator
     self.liveRecordingState = liveRecordingState
     self.lastRecordingResult = lastRecordingResult
@@ -544,8 +554,15 @@ public final class WisprBootstrapper {
 
   public func applicationWillFinishLaunching() {
     sparkleUpdateController.startUpdater()
+    // #1019: wire the active-dictation guard so the new install affordances
+    // (menu item / notification) never relaunch the app mid-capture.
+    sparkleUpdateController.updateCoordinator?.dictationActiveProvider = { [weak self] in
+      self?.liveRecordingState.isDictationActive ?? false
+    }
     // #958: proactive launch check, right after startUpdater per Sparkle guidance.
     sparkleUpdateController.updateCoordinator?.checkForUpdatesProactively(trigger: "launch")
+    // #1019: begin observing wake / network for an always-on, windowless user.
+    updateTriggerCoordinator.start()
   }
 
   public func applicationDidFinishLaunching() {
@@ -559,6 +576,8 @@ public final class WisprBootstrapper {
   }
 
   public func applicationWillTerminate() {
+    // #1019: tear down the network path monitor + wake observer.
+    updateTriggerCoordinator.stop()
     appLifecycleCoordinator.runWillTerminate()
   }
 

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -59,6 +59,13 @@ public final class UpdateAvailabilityService {
   @ObservationIgnored private let defaults: UserDefaults
   @ObservationIgnored private let currentBundleVersion: String
 
+  /// #1019: AppKit-facing change hook (the `@Observable` macro only notifies
+  /// SwiftUI dependency tracking; AppKit consumers — the menu-bar icon, the
+  /// once-per-version notification — get no callback from it). Mirrors the
+  /// `SettingsManager.onChange` / `PermissionsService.onAccessibilityChange`
+  /// single-slot pattern. Fired from every `state` mutation.
+  @ObservationIgnored public var onAvailabilityChange: (() -> Void)?
+
   // MARK: - Init
 
   public init(
@@ -105,6 +112,7 @@ public final class UpdateAvailabilityService {
     state = .available(update)
     dismissedForSession = (defaults.string(forKey: Self.kDismissedVersion) == update.versionString)
     persist(update)
+    onAvailabilityChange?()
   }
 
   /// Public API retained for tests; no in-app caller post-#739. Sparkle's
@@ -117,6 +125,7 @@ public final class UpdateAvailabilityService {
     resolvingWatchdog?.cancel()
     resolvingWatchdog = nil
     clearPersisted()
+    onAvailabilityChange?()
   }
 
   // MARK: - User-driven mutations
@@ -131,6 +140,7 @@ public final class UpdateAvailabilityService {
 
   public func triggerInstall() {
     state = .resolving
+    onAvailabilityChange?()
     installAction()
     // Watchdog: if no terminal signal arrives within 5s, restore .available so
     // the user can retry. Keeps the banner from getting stuck if Sparkle no-ops.
@@ -142,6 +152,7 @@ public final class UpdateAvailabilityService {
         guard let self else { return }
         if case .resolving = self.state, let pending = self.persistedPending() {
           self.state = .available(pending)
+          self.onAvailabilityChange?()
         }
       }
     }
@@ -190,6 +201,7 @@ public final class UpdateAvailabilityService {
       // is not silently suppressed by historical state.
       defaults.removeObject(forKey: Self.kDismissedVersion)
       dismissedForSession = false
+      onAvailabilityChange?()
     } else {
       // Bundle has caught up to or surpassed pending — user installed by some path.
       clearPersisted()

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -6,8 +6,8 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage
@@ -72,6 +72,32 @@ struct MenuBarControllerTests {
   @Test("iconState: idle + onboarding incomplete → error")
   func iconStateOnboardingIncomplete() {
     let s = fixture(pipelineState: .idle, onboardingComplete: false)
+    #expect(MenuBarController.iconState(s) == .error)
+  }
+
+  // MARK: - iconState update cue (#1019)
+
+  @Test("iconState: idle + update available → updatePending")
+  func iconStateUpdatePending() {
+    let s = fixture(pipelineState: .idle, updateAvailable: true)
+    #expect(MenuBarController.iconState(s) == .updatePending)
+  }
+
+  @Test("iconState: update cue never overrides recording")
+  func iconStateUpdateIgnoredWhileRecording() {
+    let s = fixture(pipelineState: .recording, updateAvailable: true)
+    #expect(MenuBarController.iconState(s) == .recording)
+  }
+
+  @Test("iconState: update cue never overrides processing")
+  func iconStateUpdateIgnoredWhileProcessing() {
+    let s = fixture(pipelineState: .transcribing, updateAvailable: true)
+    #expect(MenuBarController.iconState(s) == .processing)
+  }
+
+  @Test("iconState: update cue never overrides accessibility warning")
+  func iconStateUpdateIgnoredWithWarning() {
+    let s = fixture(pipelineState: .idle, showAccessibilityWarning: true, updateAvailable: true)
     #expect(MenuBarController.iconState(s) == .error)
   }
 
@@ -176,6 +202,48 @@ struct MenuBarControllerTests {
       updateItem?.action == #selector(SparkleUpdateController.openUpdateCheckFromMenu(_:)))
   }
 
+  @Test(
+    "renderMenu: update available + install enabled → versioned Install item targets controller")
+  func renderMenuUpdateInstallEnabled() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu,
+      state: fixture(
+        pipelineState: .idle, updateAvailable: true, updateDisplayVersion: "2.1.4",
+        installEnabled: true))
+
+    let installItem = item(menu, "Update ready: Install v2.1.4")
+    #expect(installItem != nil, "Enabled update item must show the version")
+    #expect(installItem?.isEnabled == true)
+    #expect(installItem?.target as AnyObject? === controller)
+  }
+
+  @Test("renderMenu: update available but dictation active → disabled finish-dictating item")
+  func renderMenuUpdateInstallDisabledWhileDictating() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu,
+      state: fixture(
+        pipelineState: .recording, updateAvailable: true, updateDisplayVersion: "2.1.4",
+        installEnabled: false))
+
+    #expect(item(menu, "Update ready: Install v2.1.4") == nil)
+    let blocked = item(menu, "Update ready: finish dictating to install")
+    #expect(blocked != nil, "Disabled item must explain why install is blocked")
+    #expect(blocked?.isEnabled == false)
+  }
+
+  @Test("renderMenu: no update → no install item")
+  func renderMenuNoUpdateNoItem() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(into: menu, state: fixture(pipelineState: .idle))
+    #expect(item(menu, "Update ready: Install") == nil)
+    #expect(menu.items.allSatisfy { !$0.title.hasPrefix("Update ready") })
+  }
+
   @Test("renderMenu: auto-stop indicator appears when vadAutoStop is on")
   func renderMenuAutoStop() {
     let controller = makeController()
@@ -228,7 +296,10 @@ struct MenuBarControllerTests {
     onboardingComplete: Bool = true,
     vadAutoStop: Bool = false,
     showAccessibilityWarning: Bool = false,
-    hasUpdater: Bool = false
+    hasUpdater: Bool = false,
+    updateAvailable: Bool = false,
+    updateDisplayVersion: String? = nil,
+    installEnabled: Bool = false
   ) -> MenuBarViewState {
     MenuBarViewState(
       pipelineState: pipelineState,
@@ -238,7 +309,10 @@ struct MenuBarControllerTests {
       vadAutoStop: vadAutoStop,
       vadSilenceTimeout: 2.0,
       showAccessibilityWarning: showAccessibilityWarning,
-      hasUpdater: hasUpdater
+      hasUpdater: hasUpdater,
+      updateAvailable: updateAvailable,
+      updateDisplayVersion: updateDisplayVersion,
+      installEnabled: installEnabled
     )
   }
 

--- a/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
+++ b/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
@@ -35,16 +35,44 @@ struct UpdateCoordinatorProactiveCheckTests {
     func checkForUpdatesInBackground() { backgroundCheckCount += 1 }
   }
 
+  /// #1019 — fake `UpdateNotifying` so the once-per-version notification path is
+  /// observable without touching `UNUserNotificationCenter`.
+  @MainActor
+  final class FakeNotifier: UpdateNotifying {
+    var onInstallTapped: (() -> Void)?
+    private(set) var posted: [String] = []
+    func post(displayVersion: String) { posted.append(displayVersion) }
+  }
+
   private func makeCoordinator() -> UpdateCoordinator {
     // No real Sparkle controller; the proactive path uses the injected probe,
     // and `checkForUpdatesFromSettings` is a no-op call against a nil updater
-    // (we only assert the source tag it sets).
-    UpdateCoordinator(updaterController: nil)
+    // (we only assert the source tag it sets). Ephemeral defaults so the
+    // once-per-version notification marker never leaks across tests.
+    UpdateCoordinator(updaterController: nil, defaults: ephemeralDefaults())
   }
 
-  // MARK: - Cooldown gate
+  private func makeCoordinator(notifier: FakeNotifier) -> UpdateCoordinator {
+    UpdateCoordinator(updaterController: nil, defaults: ephemeralDefaults(), notifier: notifier)
+  }
 
-  @Test("fires when the updater has never checked (lastUpdateCheckDate nil)")
+  private func ephemeralDefaults() -> UserDefaults {
+    let suite = "issue1019-tests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    return defaults
+  }
+
+  private func availableUpdate(_ version: String, critical: Bool = false)
+    -> UpdateAvailabilityService.AvailableUpdate
+  {
+    UpdateAvailabilityService.AvailableUpdate(
+      versionString: version, displayVersion: version, isCriticalUpdate: critical)
+  }
+
+  // MARK: - Cooldown gate (launch — Sparkle check-date anchored)
+
+  @Test("launch fires when the updater has never checked (lastUpdateCheckDate nil)")
   func firesWhenNeverChecked() {
     let coordinator = makeCoordinator()
     let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
@@ -55,32 +83,89 @@ struct UpdateCoordinatorProactiveCheckTests {
     #expect(fake.backgroundCheckCount == 1)
   }
 
-  @Test("fires at exactly the cooldown boundary (elapsed == 3600)")
-  func firesAtCooldownBoundary() {
+  @Test("launch fires at exactly the Sparkle cooldown boundary (elapsed == 3600)")
+  func launchFiresAtCooldownBoundary() {
     let coordinator = makeCoordinator()
     let now = Date(timeIntervalSince1970: 1_000_000)
     let fake = FakeProactiveUpdater(
       autoChecks: true,
       lastCheck: now.addingTimeInterval(-UpdateCoordinator.proactiveCheckCooldown))
 
-    let fired = coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
+    let fired = coordinator.checkForUpdatesProactively(trigger: "launch", now: now, probe: fake)
 
     #expect(fired == true)
     #expect(fake.backgroundCheckCount == 1)
   }
 
-  @Test("skips just below the cooldown boundary (elapsed == 3599)")
-  func skipsJustBelowCooldown() {
+  @Test("launch skips just below the Sparkle cooldown boundary (elapsed == 3599)")
+  func launchSkipsJustBelowCooldown() {
     let coordinator = makeCoordinator()
     let now = Date(timeIntervalSince1970: 1_000_000)
     let fake = FakeProactiveUpdater(
       autoChecks: true,
       lastCheck: now.addingTimeInterval(-(UpdateCoordinator.proactiveCheckCooldown - 1)))
 
+    let fired = coordinator.checkForUpdatesProactively(trigger: "launch", now: now, probe: fake)
+
+    #expect(fired == false)
+    #expect(fake.backgroundCheckCount == 0)
+  }
+
+  // MARK: - Outcome-aware cooldown (#1019 — foreground / wake / network)
+
+  @Test("event-driven trigger fires when no successful outcome recorded yet")
+  func eventTriggerFiresWithNoOutcome() {
+    let coordinator = makeCoordinator()
+    // Sparkle's check-date is recent, but event-driven triggers ignore it.
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: now.addingTimeInterval(-60))
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "wake", now: now, probe: fake)
+
+    #expect(fired == true)
+    #expect(fake.backgroundCheckCount == 1)
+  }
+
+  @Test("event-driven trigger fires at the 30-min outcome boundary")
+  func eventTriggerFiresAtOutcomeBoundary() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    coordinator.recordUpdateCheckOutcome(
+      success: true, at: now.addingTimeInterval(-UpdateCoordinator.foregroundCheckCooldown))
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "network", now: now, probe: fake)
+
+    #expect(fired == true)
+    #expect(fake.backgroundCheckCount == 1)
+  }
+
+  @Test("event-driven trigger skips just below the 30-min outcome boundary")
+  func eventTriggerSkipsJustBelowOutcomeBoundary() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    coordinator.recordUpdateCheckOutcome(
+      success: true, at: now.addingTimeInterval(-(UpdateCoordinator.foregroundCheckCooldown - 1)))
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
+
     let fired = coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
 
     #expect(fired == false)
     #expect(fake.backgroundCheckCount == 0)
+  }
+
+  @Test("a failed outcome does NOT consume the event-driven cooldown")
+  func failedOutcomeDoesNotConsumeCooldown() {
+    let coordinator = makeCoordinator()
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    // A check just failed — must not block the next wake/network re-check.
+    coordinator.recordUpdateCheckOutcome(success: false, at: now.addingTimeInterval(-1))
+    let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
+
+    let fired = coordinator.checkForUpdatesProactively(trigger: "wake", now: now, probe: fake)
+
+    #expect(fired == true)
+    #expect(fake.backgroundCheckCount == 1)
   }
 
   // MARK: - Auto-checks opt-out guard (product choice)
@@ -175,7 +260,10 @@ struct UpdateCoordinatorProactiveCheckTests {
 
       let coordinator = makeCoordinator()
       let now = Date(timeIntervalSince1970: 1_000_000)
-      let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: now.addingTimeInterval(-60))
+      // #1019: foreground is outcome-aware — seed a recent successful outcome so
+      // the gate skips on cooldown.
+      coordinator.recordUpdateCheckOutcome(success: true, at: now.addingTimeInterval(-60))
+      let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
       coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
 
       await Task.yield()
@@ -189,4 +277,91 @@ struct UpdateCoordinatorProactiveCheckTests {
     }
 
   #endif  // DEBUG
+
+  // MARK: - Once-per-version notification (#1019)
+
+  @Test("posts one notification per newly-available non-critical version")
+  func notifiesOncePerVersion() {
+    let notifier = FakeNotifier()
+    let coordinator = makeCoordinator(notifier: notifier)
+
+    coordinator.service.noteAvailable(availableUpdate("2.1.4"))
+    coordinator.service.noteAvailable(availableUpdate("2.1.4"))  // same version → no re-fire
+    #expect(notifier.posted == ["2.1.4"])
+
+    coordinator.service.noteAvailable(availableUpdate("2.1.5"))  // newer → fires again
+    #expect(notifier.posted == ["2.1.4", "2.1.5"])
+  }
+
+  @Test("rehydrated pending update fires the notification once on construction")
+  func rehydratedPendingNotifiesOnce() {
+    let defaults = ephemeralDefaults()
+    // Persisted by a prior session, newer than the (test-bundle) current
+    // version → rehydrate sets `.available` inside the service initializer,
+    // before the coordinator's hook is wired.
+    defaults.set("99.0.0", forKey: UpdateAvailabilityService.kPendingVersion)
+    defaults.set("99.0.0", forKey: UpdateAvailabilityService.kPendingBuild)
+    defaults.set(Date().timeIntervalSince1970, forKey: UpdateAvailabilityService.kPendingTimestamp)
+    defaults.set(false, forKey: UpdateAvailabilityService.kPendingCritical)
+
+    let notifier = FakeNotifier()
+    let coordinator = UpdateCoordinator(
+      updaterController: nil, defaults: defaults, notifier: notifier)
+
+    #expect(coordinator.service.state == .available(availableUpdate("99.0.0")))
+    #expect(notifier.posted == ["99.0.0"])
+  }
+
+  @Test("critical updates do not post a gentle notification")
+  func criticalUpdatesDoNotNotify() {
+    let notifier = FakeNotifier()
+    let coordinator = makeCoordinator(notifier: notifier)
+
+    coordinator.service.noteAvailable(availableUpdate("2.1.4", critical: true))
+
+    #expect(notifier.posted.isEmpty)
+  }
+
+  // MARK: - Notification tap install guard (#1019 heart-path)
+
+  @Test("notification tap installs when dictation is idle")
+  func notificationTapInstallsWhenIdle() {
+    let notifier = FakeNotifier()
+    let coordinator = makeCoordinator(notifier: notifier)
+    coordinator.dictationActiveProvider = { false }
+    coordinator.service.noteAvailable(availableUpdate("2.1.4"))
+
+    notifier.onInstallTapped?()
+
+    #expect(coordinator.service.state == .resolving)
+  }
+
+  @Test("notification tap is a no-op while dictation is active")
+  func notificationTapBlockedWhileDictating() {
+    let notifier = FakeNotifier()
+    let coordinator = makeCoordinator(notifier: notifier)
+    coordinator.dictationActiveProvider = { true }
+    coordinator.service.noteAvailable(availableUpdate("2.1.4"))
+
+    notifier.onInstallTapped?()
+
+    // State stays available — no install kicked off mid-dictation.
+    #expect(coordinator.service.state == .available(availableUpdate("2.1.4")))
+  }
+
+  // MARK: - Menu install guard (#1019 heart-path)
+
+  @Test("installFromMenu is a no-op while dictation is active")
+  func menuInstallBlockedWhileDictating() {
+    // Inject a fake notifier — `noteAvailable` fires the notification path, and
+    // the real presenter would touch `UNUserNotificationCenter` in the test
+    // bundle.
+    let coordinator = makeCoordinator(notifier: FakeNotifier())
+    coordinator.dictationActiveProvider = { true }
+    coordinator.service.noteAvailable(availableUpdate("2.1.4"))
+
+    coordinator.installFromMenu()
+
+    #expect(coordinator.service.state == .available(availableUpdate("2.1.4")))
+  }
 }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -95,13 +95,18 @@ import Testing
   ///   Import-from-Contacts — orchestrates the opt-in import + bulk-remove,
   ///   injected into the main Window scene and read by AppLifecycleCoordinator
   ///   for the opt-in launch sync. A narrow new coordinator (issue-636 §3b).
+  /// - 29 → 30 in #1019 (2026-06-09): App-owned `updateTriggerCoordinator` for
+  ///   always-on update discovery — translates OS wake/network signals into
+  ///   proactive update checks for a never-foregrounded user. Data-free; holds
+  ///   only the path monitor + wake latch (issue-1019 §3b). A narrow new home
+  ///   keeping the composition root thin per `no-appcontainer`.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 29,
+      count <= 30,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 29. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 30. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -182,14 +187,19 @@ import Testing
   /// constructs `vocabularyPackManager`, passes it into `wireCustomWords`, and
   /// injects it into the main Window scene. Cap set by the deterministic rule
   /// (post-change actual 693 + 10, rounded up to nearest 5 = 705).
+  /// Ratcheted 705→735 in #1019 (2026-06-09): the composition root constructs
+  /// `updateTriggerCoordinator`, wires the dictation-active guard provider +
+  /// launch start in `applicationWillFinishLaunching`, and tears the monitor
+  /// down in `applicationWillTerminate`. Cap set by the deterministic rule
+  /// (post-change actual 721 + 10, rounded up to nearest 5 = 735).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 705,
+      lineCount <= 735,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 705. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 735. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }


### PR DESCRIPTION
Part of #1019. **PR-A (Code lane)** of the staggered v2.1.4 update-delivery work; PR-B (feed cache + release-pipeline purge/verify) follows.

## What this does
Makes a waiting update reach an always-on, never-foregrounded user without restart or foreground:

- **Event-driven discovery** (`UpdateTriggerCoordinator`, new App-owned home): wake-from-sleep arms a one-shot that fires on the next satisfied network path; network-reconnect fires directly. No per-minute timer.
- **Outcome-aware cooldown** on `UpdateCoordinator`: foreground/wake/network gate on a local last-successful-outcome timestamp (30 min), not Sparkle's pre-outcome check-date; `launch` keeps the Sparkle anchor (1 h). A failed cycle does not consume the cooldown (fed by `didFinishUpdateCycleFor`).
- **Menu-bar cue**: `MenuBarIconAnimator.updatePending` = grey lips with a gold wave; reduce-motion → static gold tint (AppKit-native). Dropdown "Update ready: Install vX.Y.Z" item; **install is blocked mid-dictation** (guard on `isDictationActive`, covering record/load/transcribe/polish).
- **One macOS notification per version** on detection (`UNUserNotificationCenter`), lazy permission, degrades if denied; tap routed through the same dictation guard.
- **No-window handoff**: non-critical no-window updates no longer trigger Sparkle's focus-stealing modal; the menu-bar cue + notification own that surface. Critical/immediate still route to Sparkle.

## Excluded this round (founder decision)
Silent auto-install, push channel, escalation/acknowledgment timer.

## Validation
- Logic tests green via `scripts/xcode-test.sh` (outcome-aware cooldown boundaries, failure-not-consumed, once-per-version + rehydrate replay, notification/menu install guards, `updatePending` mapping + priority, install-item rendering). Ceiling bumps documented for the new home.
- **Codex code-diff review: no P0 heart-path issue; one P1 (rehydrate could miss the once-per-version notification) fixed + regression-tested; re-review CLEAN.**
- **Live UAT** (windowless dev app, real rehydrate-on-launch path): status-item AX value flips to "Update available", menu renders "Update ready: Install v99.0.0" enabled at top, app launches without crash (notification + gold-wave render + reduce-motion observer all execute). Heart path untouched (audio/ASR/paste/pipeline files unchanged).

Plan: `docs/feature-requests/issue-1019-2026-06-09-always-on-update-delivery.md` (council coverage-approved, Codex grounded review PROCEED-AS-PLANNED ×3).