### PR TITLE
chore(release): instantly-fresh appcast feed at the edge (#1019, PR-B)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,7 +505,9 @@ jobs:
         needs.build-release-artifacts.result == 'skipped'
       )
     runs-on: [self-hosted, enviouswispr-release]
-    timeout-minutes: 10
+    # #1019: bumped 10→20 to accommodate the wait-for-Pages-deploy poll before
+    # the edge purge + verify (the deploy + edge refresh can take several min).
+    timeout-minutes: 20
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -597,6 +599,71 @@ jobs:
             git push origin main
             echo "==> Appcast pushed to main"
           fi
+
+      # ----------------------------------------------------------------------
+      # #1019 C2 — instantly-fresh feed at the edge.
+      # The appcast push above triggers deploy-blog.yml (paths: website/**) →
+      # Cloudflare Pages redeploy. Cloudflare's edge was observed serving the
+      # stale appcast well past its TTL (#948), so after the deploy is live we
+      # purge the edge for appcast.xml and verify the canonical URL serves the
+      # new version. All three steps are limbs (continue-on-error): on failure
+      # the release still ships and the feed self-refreshes at max-age=60.
+      # ----------------------------------------------------------------------
+      - name: Wait for Cloudflare Pages deploy of new appcast
+        id: wait-pages
+        if: steps.check-appcast.outputs.exists == 'false' && steps.push-appcast.outcome == 'success'
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          # Cache-bypassing poll: a unique query string misses the Cloudflare
+          # edge cache and hits the Pages origin, so this observes the deploy
+          # going live (independent of the edge cache state).
+          URL="https://enviouswispr.com/appcast.xml?cb=${{ github.run_id }}-${{ github.run_attempt }}"
+          for i in $(seq 1 30); do
+            if curl -fsS "$URL" | grep -qF "<sparkle:version>${VERSION}</sparkle:version>"; then
+              echo "==> Pages origin live with v${VERSION} (attempt ${i})"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::warning::Pages deploy did not surface v${VERSION} within ~7.5m; edge self-refreshes at max-age=60."
+          exit 1
+
+      - name: Purge Cloudflare edge cache for appcast
+        id: purge-edge
+        if: steps.check-appcast.outputs.exists == 'false' && steps.push-appcast.outcome == 'success' && steps.wait-pages.outcome == 'success'
+        continue-on-error: true
+        env:
+          CF_PURGE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}
+        run: |
+          # Scoped cache-purge token (single zone: enviouswispr.com). Bearer auth.
+          curl -fsS -X POST \
+            "https://api.cloudflare.com/client/v4/zones/b4416a0f0ebd699e96969a331c7ad7ff/purge_cache" \
+            -H "Authorization: Bearer ${CF_PURGE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"files":["https://enviouswispr.com/appcast.xml"]}'
+          echo ""
+          echo "==> Requested edge purge for appcast.xml"
+
+      - name: Verify canonical appcast serves new version
+        if: steps.check-appcast.outputs.exists == 'false' && steps.push-appcast.outcome == 'success' && steps.wait-pages.outcome == 'success'
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          # The canonical (cacheable) URL must serve the new version after purge.
+          for i in $(seq 1 6); do
+            if curl -fsS "https://enviouswispr.com/appcast.xml" | grep -qF "<sparkle:version>${VERSION}</sparkle:version>"; then
+              echo "==> Canonical appcast.xml now serves v${VERSION} (attempt ${i})"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::warning::Canonical appcast.xml still stale after purge; edge self-refreshes at max-age=60."
+          # Surface as a failed-but-nonblocking limb (continue-on-error) so a
+          # stale-after-purge is visible in the run, not a silent green.
+          exit 1
 
       - name: Fallback — open appcast PR
         id: fallback-pr

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -14,5 +14,5 @@
   Cache-Control: public, max-age=2592000
 
 /appcast.xml
-  Cache-Control: public, max-age=300
+  Cache-Control: public, max-age=60
   X-Robots-Tag: noindex


### PR DESCRIPTION
Closes #1019. **PR-B (feed lane)** of the v2.1.4 update-delivery work; follows merged PR-A (#1020, app surfaces).

## What this does
Makes the Sparkle update feed reflect a new release at the edge immediately after publish, instead of relying on Cloudflare to self-expire a stale copy.

- **`website/public/_headers`**: appcast.xml `Cache-Control` max-age **300 → 60**.
- **`release.yml` `publish-appcast`**: after the appcast push to main (which triggers the Pages redeploy via `deploy-blog.yml` `paths: ['website/**']`), three limb steps (all `continue-on-error`):
  1. **Wait for the Pages deploy** to go live — observed via a cache-bypassing `?cb=` query-string poll (hits origin, not the edge).
  2. **Purge** the Cloudflare edge cache for `appcast.xml` (scoped `CLOUDFLARE_PURGE_TOKEN`, single zone). Cloudflare was observed serving the stale feed past its TTL (#948), so an explicit purge is the reliable fix.
  3. **Verify** the canonical URL now serves the new `<sparkle:version>` (fails-but-nonblocking if still stale, so it's visible — not a silent green).
  - On any failure the release still ships and the feed self-refreshes at max-age=60. Job `timeout-minutes` 10 → 20 for the deploy wait.

## New credential
`CLOUDFLARE_PURGE_TOKEN` — a Cloudflare API token scoped to **exactly Cache Purge on the enviouswispr.com zone** (least-privilege, revocable). Verified: token scope correct + the purge endpoint returns `success: true`.

## Validation
- `actionlint` clean on `release.yml` (only the pre-existing custom self-hosted runner-label warnings).
- **Codex review: one MEDIUM (verify step couldn't surface failure) fixed; re-checked.**
- Folds the edge-cache half of #948. (#948's push-permission half is already handled by the job's GitHub App token.)
- Note: no inert Swift trigger added — this PR changes no app build/cache/test logic (release-time workflow + a passthrough header), so `build-check` greens via step-skip; `release.yml` was validated locally with actionlint.