### PR TITLE
fix(llm): short-dictation skip is a true bypass, no phantom AI badge

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -278,12 +278,12 @@ struct KernelFinalizationWiring {
 
   /// #145: did the user actually GET the ITN floor? True when ITN changed the
   /// text AND polish did not deliver a DISTINCT polished result — disabled /
-  /// unavailable (no polished text), ran-and-rejected (fell back to raw), OR
-  /// short-circuited (e.g. "too short" returns its input verbatim, so polished
-  /// == the post-ITN text; that path does NOT set `pipelineFellBackToRaw` —
-  /// Codex r1 #2). In all cases the pasted text is the post-ITN text. `rawText`
-  /// is the final chain text (post-ITN), set in `processText`. Internal for a
-  /// direct parametric test.
+  /// unavailable / too-short bypass (no polished text — since #1022 the
+  /// "too short" skip leaves `polishedText` nil), ran-and-rejected (fell back
+  /// to raw), OR ran-but-identical (polished == the post-ITN text; that path
+  /// does NOT set `pipelineFellBackToRaw` — Codex r1 #2). In all cases the
+  /// pasted text is the post-ITN text. `rawText` is the final chain text
+  /// (post-ITN), set in `processText`. Internal for a direct parametric test.
   static func itnFloorDelivered(
     itnChanged: Bool,
     polishedText: String?,

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -133,6 +133,15 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// gate for non-whitespace-segmented scripts. 10 chars ≈ a short utterance.
   private static let minCharsForCJKPolish = 10
 
+  /// The too-short skip's return value: text untouched, AI fields nil (#1022).
+  private static func bypassedContext(_ context: TextProcessingContext) -> TextProcessingContext {
+    var ctx = context
+    ctx.polishedText = nil
+    ctx.llmProvider = nil
+    ctx.llmModel = nil
+    return ctx
+  }
+
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     onWillProcess?()
     // #827 PR-8: snapshot the mutable provider/model at entry. process()
@@ -155,6 +164,12 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     // Language-aware: CJK/Thai/Lao scripts use char-count since they don't
     // segment words with whitespace (a 31-char Japanese utterance is 1-2
     // "words" by split, which would wrongly skip polish).
+    //
+    // The skip is a Bypass (llm-contract): no polish output, no provider
+    // stamp — `polishedText != nil` is the UI's "AI was applied" signal
+    // (history badge, Enhance visibility), so the bypass must leave it nil
+    // (#1022). Fields cleared explicitly so the contract holds even for a
+    // caller entering with stale AI fields set.
     let lang = languageDetection?.lang ?? context.language
     let useCharCount = lang.map(LanguageTypes.isUnsegmentedScript) ?? false
     if useCharCount {
@@ -166,9 +181,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
             level: .info, category: "LLM"
           )
         }
-        var ctx = context
-        ctx.polishedText = context.text
-        return ctx
+        return Self.bypassedContext(context)
       }
     } else {
       let wordCount = context.text.split(whereSeparator: \.isWhitespace).count
@@ -179,9 +192,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
             level: .info, category: "LLM"
           )
         }
-        var ctx = context
-        ctx.polishedText = context.text
-        return ctx
+        return Self.bypassedContext(context)
       }
     }
 

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -126,14 +126,14 @@ public final class TranscriptPolishService {
     // .whisperKit + nil detection as formatting-only (safe, no lexical bias).
     llmPolishStep.languageDetection = nil
 
-    let polishedText: String
+    let stepOutput: String?
     do {
       var context = TextProcessingContext(
         text: transcript.text,
         language: transcript.language
       )
       context = try await llmPolishStep.process(context)
-      polishedText = context.polishedText ?? context.text
+      stepOutput = context.polishedText
     } catch {
       recordError(for: transcript.id, message: error.localizedDescription)
       Task {
@@ -145,8 +145,17 @@ public final class TranscriptPolishService {
       throw error
     }
 
-    // Check for cancellation after LLM work completes
+    // Check for cancellation after LLM work completes — before the bypass
+    // guard, so a cancelled enhancement never records a fresh user message.
     try Task.checkCancellation()
+
+    // Bypass (too-short skip) returns no polish output (#1022). Surface it
+    // instead of saving a raw copy stamped as polished (llm-contract:
+    // "Re-polish must surface live silent-skips").
+    guard let polishedText = stepOutput else {
+      recordError(for: transcript.id, message: "This dictation is too short for AI polish.")
+      throw LLMError.requestFailed("Transcript too short for polish")
+    }
 
     // Validate: don't save empty or identical text
     if polishedText.isEmpty {

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -173,9 +173,9 @@ import Testing
     arguments: [
       // (itnChanged, polished, raw, fellBack, expected)
       (false, String?.none, String?.some("203"), false, false),  // ITN didn't change → never
-      (true, String?.none, String?.some("203"), false, true),  // polish disabled → floor
+      (true, String?.none, String?.some("203"), false, true),  // disabled or too-short bypass → floor
       (true, String?.some("203"), String?.some("203"), true, true),  // rejected → floor
-      (true, String?.some("203"), String?.some("203"), false, true),  // short-circuit (==) → floor
+      (true, String?.some("203"), String?.some("203"), false, true),  // ran-but-identical (==) → floor
       (true, String?.some("Two oh three"), String?.some("203"), false, false),  // distinct polish → not floor
     ])
   func floorDeliveredLogic(
@@ -188,6 +188,35 @@ import Testing
   }
 
   // MARK: store
+
+  @Test(
+    "short dictation through the real chain persists no polish output and no provider stamp",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1022",
+      "AI badge on short dictations AI never touched"
+    )
+  )
+  func shortDictationStoresBypass() async throws {
+    let outcome = KernelFinalizationOutcome()
+    let saved = SavedTranscriptBox()
+    let steps = makeSteps()
+    // Polish ON (provider + mocked polisher) so the nil comes from the
+    // too-short gate, not from the disabled-step path the other tests use.
+    steps.llmPolish.llmProvider = .openAI
+    steps.llmPolish.llmModel = "gpt-4o-mini"
+    steps.llmPolish.makePolisher = { _, _, _ in CannedPolisher() }
+    let wiring = makeWiring(outcome: outcome, steps: steps, save: { saved.transcript = $0 })
+
+    let result = try await wiring.processText("Other apps") {}
+    try await wiring.store(result)
+
+    // The unit-level proxy for "history row shows no AI badge" (#1022).
+    let transcript = try #require(saved.transcript)
+    #expect(transcript.text == "Other apps")
+    #expect(transcript.polishedText == nil)
+    #expect(transcript.llmProvider == nil)
+    #expect(transcript.llmModel == nil)
+  }
 
   @Test("store builds the Transcript from the side-channel and persists it")
   func storeBuildsAndSaves() async throws {
@@ -297,6 +326,21 @@ private final class ManualClock {
 }
 
 private enum WiringTestError: Error { case storage }
+
+/// Deterministic polisher for the #1022 short-dictation test: enables the
+/// polish step (provider set, connector mocked) so the persisted nil can only
+/// come from the too-short gate. If the gate ever let the short input through,
+/// the test would see "canned polish output" persisted instead of nil.
+private struct CannedPolisher: TranscriptPolisher {
+  func polish(
+    text: String,
+    instructions: PolishInstructions,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    LLMResult(polishedText: "canned polish output")
+  }
+}
 
 @MainActor
 private final class SignalFlag {

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepShortCircuitTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepShortCircuitTests.swift
@@ -1,0 +1,152 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1022: the too-short skip is a Bypass — it must leave NO polish output and
+/// NO provider attribution, because `polishedText != nil` is the UI's signal
+/// for "AI was applied" (history badge, Enhance visibility) and `llmProvider`
+/// is its attribution (llm-contract FACT: llm-contract-signals).
+///
+/// Before the fix, both skip branches copied the raw text into `polishedText`,
+/// so 1-3 word dictations showed the AI badge though AI never ran.
+@MainActor
+@Suite("LLMPolishStep short-circuit bypass")
+struct LLMPolishStepShortCircuitTests {
+
+  /// Counts polisher invocations on an actor so the read after `process()`
+  /// returns is race-free (the polish call completes before process returns).
+  private actor InvocationCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+  }
+
+  /// Deterministic polisher: records the call, returns a fixed result.
+  /// Implements the legacy `text:` method; the planner path reaches it via
+  /// the protocol's default `envelope:` bridge.
+  private struct SpyPolisher: TranscriptPolisher {
+    let counter: InvocationCounter
+    let result: String
+
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      await counter.increment()
+      return LLMResult(polishedText: result)
+    }
+  }
+
+  private func makeStep(
+    counter: InvocationCounter,
+    result: String = "unused"
+  ) -> LLMPolishStep {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .openAI
+    step.llmModel = "gpt-4o-mini"
+    step.makePolisher = { _, _, _ in SpyPolisher(counter: counter, result: result) }
+    return step
+  }
+
+  private func expectBypass(
+    _ ctx: TextProcessingContext,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) {
+    #expect(ctx.polishedText == nil, sourceLocation: sourceLocation)
+    #expect(ctx.llmProvider == nil, sourceLocation: sourceLocation)
+    #expect(ctx.llmModel == nil, sourceLocation: sourceLocation)
+  }
+
+  // MARK: English word-count gate (skip at <= 3 words, polish at 4+)
+
+  @Test(
+    "3-word English input bypasses: no polish output, no provider stamp, no LLM call",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1022",
+      "AI badge on short dictations AI never touched"
+    )
+  )
+  func threeWordEnglishBypasses() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter)
+    let ctx = try await step.process(
+      TextProcessingContext(text: "hey running late", language: "en"))
+    expectBypass(ctx)
+    #expect(ctx.text == "hey running late")
+    #expect(await counter.count == 0)
+  }
+
+  @Test("founder repro: \"Other apps.\" (2 words, punctuation kept) bypasses")
+  func founderReproBypasses() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter)
+    let ctx = try await step.process(TextProcessingContext(text: "Other apps.", language: "en"))
+    expectBypass(ctx)
+    #expect(await counter.count == 0)
+  }
+
+  @Test("4-word English input polishes: output set, provider stamped (no over-suppression)")
+  func fourWordEnglishPolishes() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter, result: "Hey, I am late.")
+    let ctx = try await step.process(TextProcessingContext(text: "hey i am late", language: "en"))
+    #expect(ctx.polishedText == "Hey, I am late.")
+    #expect(ctx.llmProvider == LLMProvider.openAI.rawValue)
+    #expect(ctx.llmModel == "gpt-4o-mini")
+    #expect(await counter.count == 1)
+  }
+
+  // MARK: Unsegmented-script char-count gate (skip at < 10 chars, polish at 10+)
+
+  @Test("9-char Japanese input bypasses via the char-count branch")
+  func nineCharJapaneseBypasses() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter)
+    // 9 non-whitespace scalars.
+    let ctx = try await step.process(TextProcessingContext(text: "こんにちは元気です", language: "ja"))
+    expectBypass(ctx)
+    #expect(await counter.count == 0)
+  }
+
+  @Test("10-char Japanese input polishes")
+  func tenCharJapanesePolishes() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter, result: "こんにちは、元気ですか。")
+    // 10 non-whitespace scalars.
+    let ctx = try await step.process(TextProcessingContext(text: "こんにちは元気ですか", language: "ja"))
+    #expect(ctx.polishedText == "こんにちは、元気ですか。")
+    #expect(ctx.llmProvider == LLMProvider.openAI.rawValue)
+    #expect(await counter.count == 1)
+  }
+
+  @Test("short Thai input routes to the char-count branch and bypasses")
+  func shortThaiBypasses() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter)
+    // 6 non-whitespace scalars — would be 1 "word" by whitespace split either
+    // way; the char-count branch is what makes the gate honest for Thai.
+    let ctx = try await step.process(TextProcessingContext(text: "สวัสดี", language: "th"))
+    expectBypass(ctx)
+    #expect(await counter.count == 0)
+  }
+
+  // MARK: Stale-field defense
+
+  @Test("bypass clears pre-set AI fields: the Bypass contract holds even for a stale context")
+  func bypassClearsStaleFields() async throws {
+    let counter = InvocationCounter()
+    let step = makeStep(counter: counter)
+    var stale = TextProcessingContext(text: "Other apps.", language: "en")
+    stale.polishedText = "stale polished"
+    stale.llmProvider = "openai"
+    stale.llmModel = "gpt-4o-mini"
+    let ctx = try await step.process(stale)
+    expectBypass(ctx)
+    #expect(await counter.count == 0)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptPolishServiceBypassTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptPolishServiceBypassTests.swift
@@ -1,0 +1,85 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprStorage
+
+/// #1022: manual Enhance on a too-short transcript hits the same quality gate
+/// as live polish (the gate exists because LLMs answer 1-3 word inputs instead
+/// of cleaning them). The service must surface that bypass — record a
+/// plain-English enhancement error and throw — instead of saving a raw copy
+/// stamped as polished (llm-contract: "Re-polish must surface live
+/// silent-skips, or transcripts get mislabeled as polished").
+@MainActor
+@Suite("TranscriptPolishService bypass surfacing")
+struct TranscriptPolishServiceBypassTests {
+
+  @MainActor
+  private final class IdleDictationActivity: DictationActivityProviding {
+    var isDictationActive: Bool { false }
+  }
+
+  /// A polisher that fails the test if the gate ever lets a short input through.
+  private struct ForbiddenPolisher: TranscriptPolisher {
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      Issue.record("polisher must not be invoked for a too-short transcript")
+      return LLMResult(polishedText: "should never happen")
+    }
+  }
+
+  private func makeTempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tps-bypass-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  @Test(
+    "Enhance on a 2-word transcript: throws, records a too-short message, saves nothing",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1022",
+      "manual Enhance would save a raw copy stamped as polished"
+    )
+  )
+  func enhanceOnShortTranscriptSurfacesBypass() async throws {
+    let dir = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let activity = IdleDictationActivity()
+    let service = TranscriptPolishService(
+      keychainManager: KeychainManager(),
+      transcriptStore: store,
+      dictationActivity: activity
+    )
+    service.llmPolishStep.llmProvider = .openAI
+    service.llmPolishStep.llmModel = "gpt-4o-mini"
+    service.llmPolishStep.makePolisher = { _, _, _ in ForbiddenPolisher() }
+
+    let transcript = Transcript(text: "Other apps.", language: "en")
+    try store.save(transcript)
+
+    await #expect(throws: LLMError.self) {
+      _ = try await service.polish(transcript)
+    }
+
+    let message = try #require(service.lastEnhancementError?.message)
+    #expect(message.localizedCaseInsensitiveContains("too short"))
+    #expect(service.lastEnhancementError?.transcriptID == transcript.id)
+    #expect(service.polishingTranscriptID == nil, "in-flight guard resets via defer")
+
+    // The persisted transcript is untouched: no fake polished copy, no stamp.
+    let onDisk = try await store.loadAll()
+    let reloaded = try #require(onDisk.first { $0.id == transcript.id })
+    #expect(reloaded.polishedText == nil)
+    #expect(reloaded.llmProvider == nil)
+    #expect(reloaded.llmModel == nil)
+  }
+}


### PR DESCRIPTION
Closes #1022

## What

The too-short polish skip (<=3 words English, <10 chars unsegmented scripts) copied raw text into `polishedText`, so history rows showed the purple AI badge on dictations AI never touched, and the detail view hid the Enhance button behind a fake polished/original split. The skip now clears `polishedText`/`llmProvider`/`llmModel` (a true Bypass per the llm-contract), and manual Enhance on a still-too-short transcript surfaces "This dictation is too short for AI polish." instead of saving a raw copy stamped with a provider.

Pre-fix rows on disk are left as-is (new dictations only, declared non-goal).

## Process

- Plan: `docs/feature-requests/issue-1022-2026-06-10-short-dictation-ai-badge.md` (local), Gate 2 approved.
- Council 1 round (GPT + Gemini) + Codex grounded review 4 rounds → PROCEED-AS-PLANNED. Design fork resolved with code evidence: manual Enhance keeps the length gate (no force flag) because `.inline` validators cannot reliably reject a short chatty LLM answer.
- Failing-first tests: 5 red on pre-fix code, green after.

## Validation

Run dir: `.validation/runs/2026-06-10T16-13-56Z-691f57e`
- Logic tests: full suite, 1742 tests green.
- Smoke: dev bundle built, signed, launched.
- Live UAT (wispr-eyes, main thread): "Other apps" dictation → clipboard PASS, app.log shows "LLM polish skipped: transcript too short", persisted transcript has `polishedText=null`, no provider stamp. Over-suppression control: 14-word dictation polished and stamped (`appleIntelligence`). Founder visual confirm.
- Codex code-diff review: clean, no findings.

## Async edge classes (SMALL tier, noted for completeness)

Cancelled mid-flight: cancellation check now precedes the bypass guard, so no stale message. Concurrent enhance: existing `polishingTranscriptID` guard unchanged. Deleted-during-enhancement: existing guard unchanged, bypass throws before it. Stale settings: gate reads only `context.text`, no settings dependency.