### PR TITLE
fix(ui): History columns compress gracefully; window can't crush them

### DIFF
--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -614,7 +614,10 @@ private struct MainWindowRoot: View {
 
   var body: some View {
     UnifiedWindowView()
-      .frame(minWidth: 580, minHeight: 400)
+      // 710 covers the pinned sidebar (200) + the NavigationSplitView divider
+      // (~8, AX-measured) + the History pane floors (230 + 8 + 260 = 498), so
+      // the window can never crush any column (#1024).
+      .frame(minWidth: 710, minHeight: 400)
       .environment(b.navigationCoordinator)
       .environment(b.diagnosticsCoordinator)
       .environment(b.languageSuggestionPresenter)

--- a/Sources/EnviousWisprAppKit/Views/Main/HistoryContentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/HistoryContentView.swift
@@ -3,11 +3,23 @@ import EnviousWisprServices
 import SwiftUI
 
 /// Inner content for the History tab: transcript list (left) + detail/status (right).
+///
+/// #1024: a custom width-tracking split replaces `HSplitView`, which never
+/// renegotiates pane widths when its container shrinks (the content canvas kept
+/// its old total and clipped under the sidebar / off the window edge). Here the
+/// effective list width is re-clamped against the live container width on every
+/// render, so window shrink compresses the detail pane first, then the list down
+/// to its readable floor; the root window minimum in WisprBootstrapper covers
+/// sidebar + both floors so neither column can ever render broken.
 struct HistoryContentView: View {
   @Environment(PermissionsService.self) private var permissions
   @Environment(TranscriptWorkflowCoordinator.self) private var transcriptWorkflowCoordinator
   // PR7 of #763: live-recording fallback transcript comes from LiveRecordingState.
   @Environment(LiveRecordingState.self) private var liveRecordingState
+
+  /// User's preferred list width from divider drags; the effective width shown
+  /// is this value re-clamped to the live container (see `effectiveListWidth`).
+  @State private var preferredListWidth: CGFloat = HistorySplitMetrics.listIdeal
 
   /// PR7 of #763: compose the displayed transcript inline. History selection
   /// from `TranscriptCoordinator` wins over the in-flight live fallback —
@@ -28,18 +40,27 @@ struct HistoryContentView: View {
         AccessibilityWarningBanner()
       }
 
-      HSplitView {
-        TranscriptHistoryView()
-          .frame(minWidth: 120, idealWidth: 200, maxWidth: 280)
+      GeometryReader { geo in
+        let listWidth = HistorySplitMetrics.effectiveListWidth(
+          preferred: preferredListWidth, available: geo.size.width)
 
-        Group {
-          if let transcript = displayedTranscript {
-            TranscriptDetailView(transcript: transcript)
-          } else {
-            StatusView()
+        HStack(spacing: 0) {
+          TranscriptHistoryView()
+            .frame(width: listWidth)
+
+          HistorySplitDivider(
+            preferredListWidth: $preferredListWidth, currentListWidth: listWidth)
+
+          Group {
+            if let transcript = displayedTranscript {
+              TranscriptDetailView(transcript: transcript)
+            } else {
+              StatusView()
+            }
           }
+          .frame(
+            width: max(0, geo.size.width - listWidth - HistorySplitMetrics.dividerWidth))
         }
-        .frame(minWidth: 260, idealWidth: 420, maxWidth: .infinity)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -47,5 +68,78 @@ struct HistoryContentView: View {
     .task {
       transcriptWorkflowCoordinator.transcriptCoordinator.load()
     }
+  }
+}
+
+/// Width allocation for the History split (#1024). Pure so the clamp
+/// boundaries are unit-testable.
+enum HistorySplitMetrics {
+  static let listMin: CGFloat = 230
+  static let listIdeal: CGFloat = 260
+  static let listMax: CGFloat = 340
+  static let detailMin: CGFloat = 260
+  static let dividerWidth: CGFloat = 8
+
+  /// Clamp the preferred list width to what the container can host: the list
+  /// holds its preferred width until the detail pane would drop below its
+  /// floor, then compresses to `listMin`. Containers too small for both floors
+  /// degrade without negative frames (list keeps up to its floor, detail gets
+  /// the non-negative remainder); the root window minimum prevents that state
+  /// outside transient live-resize.
+  static func effectiveListWidth(preferred: CGFloat, available: CGFloat) -> CGFloat {
+    let maxHostable = min(listMax, available - detailMin - dividerWidth)
+    guard maxHostable >= listMin else {
+      return min(listMin, max(0, available - dividerWidth))
+    }
+    return min(max(preferred, listMin), maxHostable)
+  }
+}
+
+/// Draggable boundary between the transcript list and the detail pane:
+/// 1pt separator line inside an 8pt hit target.
+private struct HistorySplitDivider: View {
+  @Binding var preferredListWidth: CGFloat
+  let currentListWidth: CGFloat
+
+  @State private var dragBaseWidth: CGFloat?
+  @State private var isHovering = false
+
+  var body: some View {
+    ZStack {
+      Color.clear
+      Rectangle()
+        .fill(Color(nsColor: .separatorColor))
+        .frame(width: 1)
+    }
+    .frame(width: HistorySplitMetrics.dividerWidth)
+    .contentShape(Rectangle())
+    .onHover { inside in
+      if inside, !isHovering {
+        NSCursor.resizeLeftRight.push()
+        isHovering = true
+      } else if !inside, isHovering {
+        NSCursor.pop()
+        isHovering = false
+      }
+    }
+    .onDisappear {
+      if isHovering {
+        NSCursor.pop()
+        isHovering = false
+      }
+    }
+    .gesture(
+      DragGesture(minimumDistance: 1)
+        .onChanged { value in
+          let base = dragBaseWidth ?? currentListWidth
+          if dragBaseWidth == nil { dragBaseWidth = base }
+          preferredListWidth = base + value.translation.width
+        }
+        .onEnded { _ in
+          preferredListWidth = min(
+            max(preferredListWidth, HistorySplitMetrics.listMin), HistorySplitMetrics.listMax)
+          dragBaseWidth = nil
+        }
+    )
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -57,7 +57,9 @@ struct UnifiedWindowView: View {
         }
       }
       .background(Color.stSidebarBg)
-      .navigationSplitViewColumnWidth(min: 200, ideal: 230, max: 260)
+      // Fixed at 200 (#1024): the root window minimum (700) guarantees the
+      // History pane floors (498) only when the sidebar cannot grow past 200.
+      .navigationSplitViewColumnWidth(200)
     } detail: {
       detailContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Tests/EnviousWisprTests/Views/HistorySplitMetricsTests.swift
+++ b/Tests/EnviousWisprTests/Views/HistorySplitMetricsTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Boundary tests for the History split width clamp (#1024).
+@Suite struct HistorySplitMetricsTests {
+  // listMin 230 + dividerWidth 8 + detailMin 260 = 498 is the smallest
+  // container that hosts both floors.
+  private let bothFloors: Double = 498
+
+  @Test func preferredWidthHeldWhenDetailHasRoom() {
+    // 1000 - 260 - 8 = 732 hostable; preferred 260 within [230, 340].
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 260, available: 1000) == 260)
+  }
+
+  @Test func preferredClampedToListMax() {
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 900, available: 1000) == 340)
+  }
+
+  @Test func preferredClampedToListMin() {
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 10, available: 1000) == 230)
+  }
+
+  @Test func detailCompressesFirstThenListGivesWidth() {
+    // available 520: maxHostable = 520 - 268 = 252 >= 230, so a 340 preference
+    // compresses the list to 252 — the detail floor wins over preference.
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 340, available: 520) == 252)
+  }
+
+  @Test func justAboveBothFloorsListSitsAtItsMin() {
+    #expect(
+      HistorySplitMetrics.effectiveListWidth(preferred: 340, available: bothFloors + 1) == 231)
+  }
+
+  @Test func exactlyBothFloorsListSitsAtItsMin() {
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 340, available: bothFloors) == 230)
+  }
+
+  @Test func justBelowBothFloorsDegradesToListFloor() {
+    // Below both floors the list keeps (at most) its floor; never negative.
+    #expect(
+      HistorySplitMetrics.effectiveListWidth(preferred: 340, available: bothFloors - 1) == 230)
+  }
+
+  @Test func degenerateTinyContainerNeverGoesNegative() {
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 340, available: 100) == 92)
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 340, available: 0) == 0)
+    #expect(HistorySplitMetrics.effectiveListWidth(preferred: 340, available: 5) == 0)
+  }
+}


### PR DESCRIPTION
Closes #1024.

## What
The History tab's split could render every column broken: the transcript list crushable to 120pt (3-line dates, vertical badge pills), window-shrink sliding content under the sidebar and off the right edge, and split-screen windows unusable.

## Why (root cause, AX-measured)
`HSplitView` never renegotiates pane widths when its container shrinks: content stayed 907pt wide inside a 700pt window, so the outer `NavigationSplitView` overflowed and clipped (list pane measured at x = -54).

## How
- Replace `HSplitView` with a width-tracking split local to `HistoryContentView`: `GeometryReader` reclamps the list width every render. Window shrink compresses the detail pane first (floor 260), then the list to its readable floor (230). 8pt draggable divider with cursor feedback; divider preference is view-local `@State`.
- Pin the sidebar at 200 and raise the root window minimum 580 → 710 so sidebar + outer divider + both pane floors always fit.
- `HistorySplitMetrics.effectiveListWidth` is pure; 8 boundary tests cover both floors, preference clamps, and degenerate live-resize widths.

## Validation
Run dir: `.validation/runs/2026-06-10T17-51-20Z-a9361c0`. 1750 logic tests green; smoke green; Live UAT = AX resize staircase (content width == window width at 1000/900/800/750/700; min-clamp 600→710; list 234 / detail 260 exactly at minimum) + founder manual divider/split-screen UAT ("it's perf") + heart-path `test_recording` PASS (pipeline 1.997s). Codex: grounded review 5 rounds to PROCEED-AS-PLANNED + direction consult on the pivot + 3 diff-review rounds (caught the resizable-sidebar gap and the outer-divider 6pt gap; final round clean).

Plan: `docs/feature-requests/issue-1024-2026-06-10-history-split-min-width.md` (local).