### PR TITLE
feat(ui): sidebar status card labels Engine and shows configured AI Polish (#1026)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -28,6 +28,20 @@ final class BackendMetadata {
     settings.selectedBackend == .parakeet ? "Parakeet v3" : "WhisperKit"
   }
 
+  /// Sidebar AI Polish row label. Reads the CONFIGURED polish target
+  /// (a settings readout), not runtime availability or last-polish
+  /// success — a configured-but-unreachable provider still shows its
+  /// model name; per-dictation outcomes surface on the transcript.
+  /// Apple Intelligence is named directly: its model id never varies
+  /// and discovery only runs when the settings pane is visited.
+  var polishLabel: String {
+    switch settings.llmProvider {
+    case .none: "Off"
+    case .appleIntelligence: "Apple Intelligence"
+    default: llmLabel
+    }
+  }
+
   var llmLabel: String {
     guard settings.llmProvider != .none else { return "LLM Deactivated" }
     let model = settings.llmProvider == .ollama ? settings.ollamaModel : settings.llmModel

--- a/Sources/EnviousWisprAppKit/Views/Main/SidebarStatsHeader.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/SidebarStatsHeader.swift
@@ -46,6 +46,7 @@ struct SidebarStatsHeader: View {
       ModelStatusBar(
         modelName: backendMetadata.modelLabel,
         statusText: backendMetadata.statusText(for: liveRecordingState.pipelineState),
+        polishLabel: backendMetadata.polishLabel,
         isRecording: isRecording,
         isLoaded: asrManager.isModelLoaded,
         hasError: {
@@ -60,33 +61,68 @@ struct SidebarStatsHeader: View {
   }
 }
 
-/// Compact status bar showing model name and state.
+/// Compact two-row status card: transcription engine + configured AI polish.
+/// `polishLabel` is a settings readout (configured target), not a runtime
+/// health signal — see `BackendMetadata.polishLabel`.
 struct ModelStatusBar: View {
   let modelName: String
   let statusText: String
+  let polishLabel: String
   let isRecording: Bool
   let isLoaded: Bool
   let hasError: Bool
 
   var body: some View {
-    HStack(spacing: 6) {
-      Circle()
-        .fill(dotColor)
-        .frame(width: 8, height: 8)
-        .accessibilityHidden(true)
+    VStack(alignment: .leading, spacing: 5) {
+      HStack(spacing: 6) {
+        Circle()
+          .fill(dotColor)
+          .frame(width: 8, height: 8)
+          .accessibilityHidden(true)
 
-      Text(modelName)
-        .font(.caption)
-        .fontWeight(.medium)
+        Text("Engine")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .layoutPriority(1)
 
-      Text("·")
-        .foregroundStyle(.tertiary)
+        Spacer(minLength: 8)
 
-      Text(statusText)
-        .font(.caption)
-        .foregroundStyle(.secondary)
+        Text(modelName)
+          .font(.caption)
+          .fontWeight(.medium)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .help(modelName)
 
-      Spacer()
+        Text("·")
+          .foregroundStyle(.tertiary)
+
+        Text(statusText)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .layoutPriority(1)
+      }
+
+      HStack(spacing: 6) {
+        Color.clear
+          .frame(width: 8, height: 8)
+          .accessibilityHidden(true)
+
+        Text("AI Polish")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .layoutPriority(1)
+
+        Spacer(minLength: 8)
+
+        Text(polishLabel)
+          .font(.caption)
+          .fontWeight(.medium)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .help(polishLabel)
+      }
     }
     .padding(.horizontal, 10)
     .padding(.vertical, 6)
@@ -95,6 +131,7 @@ struct ModelStatusBar: View {
         .fill(
           isRecording ? AnyShapeStyle(Color.stError.opacity(0.1)) : AnyShapeStyle(.fill.quinary))
     )
+    .accessibilityElement(children: .combine)
   }
 
   private var dotColor: Color {

--- a/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
+++ b/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
@@ -4,8 +4,8 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 
 /// Unit tests for `BackendMetadata` (PR7 of epic #763). Covers the three
 /// display surfaces exposed to views/AppDelegate: `modelLabel`,
@@ -79,6 +79,59 @@ struct BackendMetadataTests {
     bm.settings.ollamaModel = "llama3.2"
     bm.llmDiscovery.discoveredModels = []
     #expect(bm.llmLabel == "llama3.2")
+  }
+
+  // MARK: - polishLabel
+
+  @Test("polishLabel: provider .none returns 'Off' even with stale model fields populated")
+  func polishLabelOffIgnoresStaleModels() {
+    let bm = makeBackendMetadata()
+    bm.settings.llmProvider = LLMProvider.none
+    bm.settings.llmModel = "gpt-4o-mini"
+    bm.settings.ollamaModel = "llama3.2"
+    #expect(bm.polishLabel == "Off")
+  }
+
+  @Test("polishLabel: discovered cloud model returns its displayName")
+  func polishLabelDiscoveredModelReturnsDisplayName() {
+    let bm = makeBackendMetadata()
+    bm.settings.llmProvider = .openAI
+    bm.settings.llmModel = "gpt-4o-mini"
+    bm.llmDiscovery.discoveredModels = [
+      LLMModelInfo(
+        id: "gpt-4o-mini",
+        displayName: "GPT-4o Mini",
+        provider: .openAI,
+        isAvailable: true)
+    ]
+    #expect(bm.polishLabel == "GPT-4o Mini")
+  }
+
+  @Test("polishLabel: cloud model before discovery returns the raw ID")
+  func polishLabelPreDiscoveryReturnsRawID() {
+    let bm = makeBackendMetadata()
+    bm.settings.llmProvider = .gemini
+    bm.settings.llmModel = "gemini-2.0-flash"
+    bm.llmDiscovery.discoveredModels = []
+    #expect(bm.polishLabel == "gemini-2.0-flash")
+  }
+
+  @Test("polishLabel: Apple Intelligence is named directly, never the raw model id")
+  func polishLabelAppleIntelligenceNamedDirectly() {
+    let bm = makeBackendMetadata()
+    bm.settings.llmProvider = .appleIntelligence
+    bm.settings.llmModel = "apple-intelligence"
+    bm.llmDiscovery.discoveredModels = []
+    #expect(bm.polishLabel == "Apple Intelligence")
+  }
+
+  @Test("polishLabel: Ollama provider reads ollamaModel")
+  func polishLabelOllamaReadsOllamaModel() {
+    let bm = makeBackendMetadata()
+    bm.settings.llmProvider = .ollama
+    bm.settings.ollamaModel = "llama3.2"
+    bm.llmDiscovery.discoveredModels = []
+    #expect(bm.polishLabel == "llama3.2")
   }
 
   // MARK: - statusText(for:) — Parakeet branch

--- a/Tests/EnviousWisprTests/Architecture/BackendMetadataCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/BackendMetadataCeilingsTests.swift
@@ -6,14 +6,22 @@ import Testing
 /// Locks the home as the canonical "backend/model display labels" surface:
 /// - 3 stored properties (`settings`, `asrManager`, `llmDiscovery`)
 /// - 1 non-private method (`statusText(for:)`)
-/// - ≤65 lines
+/// - ≤75 lines
 /// - imports ⊆ {EnviousWisprASR, EnviousWisprCore, EnviousWisprServices, Observation}
 ///
-/// Computed properties (`modelLabel`, `llmLabel`) are NOT counted by the
-/// shared parser; only `func` declarations are. `LLMModelDiscoveryCoordinator`
-/// is App-local (same target, no Services import needed for it).
+/// Computed properties (`modelLabel`, `llmLabel`, `polishLabel`) are NOT
+/// counted by the shared parser; only `func` declarations are.
+/// `LLMModelDiscoveryCoordinator` is App-local (same target, no Services
+/// import needed for it).
 ///
 /// Lowering any cap is free; raising requires a Bible §30 changelog entry.
+///
+/// Bible §30 entry (#1026, 2026-06-10): line cap 65→75. Reason: fourth
+/// display label `polishLabel` (sidebar AI Polish row) — a provider
+/// switch ("Off" / "Apple Intelligence" / llmLabel chain) in the
+/// ceiling's explicitly uncounted category (computed display label);
+/// stored-property, method, and import caps unchanged. The home
+/// remains display-only.
 @Suite struct BackendMetadataCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/BackendMetadata.swift"
@@ -51,9 +59,9 @@ import Testing
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let count = CeilingsTestSupport.lineCount(in: source)
     #expect(
-      count <= 65,
+      count <= 75,
       """
-      BackendMetadata line count exceeded: \(count) > 65. \
+      BackendMetadata line count exceeded: \(count) > 75. \
       Ratchet down if implementation came in lower; raise only via Bible §30.
       """)
   }


### PR DESCRIPTION
## What
The sidebar status strip under the search box becomes a two-row status card:
- **Engine** — existing dot + backend name + live status word, unchanged logic (Parakeet v3 / WhisperKit / future engines).
- **AI Polish** — the configured polish target: discovered cloud model display name, Ollama model name, "Apple Intelligence" (named directly), or "Off" when polish is disabled.

Closes #1026

## Semantics
The AI Polish value is a settings readout (configured target), NOT runtime availability or last-polish success; per-dictation outcomes keep their existing surfaces (AI badge, polish-failed banner). Provider `.none` is the sole off-switch (same definition the kernel telemetry uses, `RecordingSessionKernel.swift:503`).

## Details
- New computed `BackendMetadata.polishLabel` (the designated display-label home; ceiling-safe category) + 5 unit tests including the stale-model leakage guard and Apple Intelligence direct naming (Live UAT caught the raw "apple-intelligence" id showing pre-discovery).
- Values middle-truncate with hover help for narrow sidebars (post-#1024); labels keep layout priority.
- Card is one combined accessibility element, so VoiceOver/AX read coherent label-value pairs.
- **Ceiling ratchet:** BackendMetadata line cap 65→75 with Bible §30 entry in the ceilings test header (4th display label; stored-property/method/import caps unchanged).

## Validation
Run dir: `.validation/runs/2026-06-10T20-47-55Z-b96260b`
- Logic tests: 1668/1668 green (incl. ceilings suite).
- Smoke: dev build + signed launch green.
- Live UAT: heart-path dictation PASS (pipeline 2.27s, expected token found, app-log corroborated); combined AX value proves row association; Settings flip Off↔Apple Intelligence updates the card live without relaunch; window-floor (710pt) screenshot clean; settings + window restored.
- Codex grounded review: PROCEED-AS-PLANNED round 1 (`docs/audits/2026-06-10-issue-1026-grounded-review.txt`).
- Codex diff review: clean, no actionable findings.
- Council: coverage round + persona roleplay (Priya, Frank), findings folded into plan and contract.