### PR TITLE
chore(release): bump version to 2.1.4

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -26,6 +26,27 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.1.4
+
+    Entry(
+      id: "paste-works-in-word-excel-pages",
+      icon: "doc.richtext",
+      title: "Pasting now lands in Word, Excel, and more",
+      description:
+        "We fixed an issue where in some apps (Word, Excel, Pages, Numbers, OneNote, Sublime Text, Firefox) your dictation would say \"Copied\" but never actually paste. Your words now land in the document like everywhere else.",
+      category: .fasterAndMoreReliable,
+      version: "2.1.4"
+    ),
+    Entry(
+      id: "small-ui-tweaks",
+      icon: "sparkles",
+      title: "Small UI tweaks for a cleaner experience",
+      description:
+        "A tidier sidebar status card, History columns that stay readable in small windows, more reliable update delivery, and an AI badge that only appears when AI actually ran.",
+      category: .qualityOfLife,
+      version: "2.1.4"
+    ),
+
     // MARK: - v2.1.3
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.1.3"
+  public static let currentContentVersion = "2.1.4"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.1.4 with What's New entries for changes shipped since v2.1.3:
- Paste fix for container-role apps (Word, Excel, Pages, Numbers, OneNote, Sublime, Firefox) (#729)
- Small UI tweaks: sidebar status card (#1026), History column resilience (#1024), update delivery for always-on users (#1019), no phantom AI badge (#1022)

## Test plan

- [x] scripts/build-dev-app.sh — built locally
- [ ] build-check CI passes on this PR
- [ ] Tag v2.1.4 after merge triggers release pipeline