### PR TITLE
chore(build): ignore local artifacts/ research workbench dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ routine-session-logs-*/
 
 # Codex scratch artifacts (local-only review prompts/outputs)
 .codex/
+
+# Local research workbenches (classifier retraining data, eval corpora) — never tracked
+/artifacts/


### PR DESCRIPTION
## Summary

Adds `/artifacts/` to .gitignore so the local research workbench (classifier retraining data from #832, ITN selection corpus from #145, ~21GB) can live inside the repo root instead of a sibling `EnviousWispr-artifacts/` folder. Local-only material; never tracked.

council-skip: zero-blast-radius (single-value config)

## Test plan

- [x] `git check-ignore artifacts/` matches after merge
- [ ] build-check CI passes