### PR TITLE
fix(ui): homepage no longer advertises removed custom-prompt polish

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -432,7 +432,7 @@ const jsonLdFaq = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#0099aa" stroke-width="2" stroke-linecap="round"><path d="M12 2L15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2z"/></svg>
           </div>
           <h3>Cleans Up Your Words</h3>
-          <p>Removes ums, fixes grammar, and polishes your text automatically. Or write a custom prompt to control exactly how it shapes your output.</p>
+          <p>Removes ums, fixes grammar, and polishes your text automatically. Add your own names and jargon as Custom Words so they come out right.</p>
         </div>
         <div class="benefit-card reveal" style="--i:3">
           <div class="benefit-icon amber" aria-hidden="true">


### PR DESCRIPTION
## Summary
- The custom-prompt polish feature was removed in #614; the README was corrected in #938, but the homepage benefit card still promised "write a custom prompt to control exactly how it shapes your output."
- Replaced with the Custom Words capability the app actually ships: "Add your own names and jargon as Custom Words so they come out right."

## Lane
Content (website/src/pages/ copy-only, no logic). Lightweight PR: build-check + visual confirm.

## Validation
- Astro build green locally (52 pages).
- Grep swept ALL customer-facing content for remaining "custom prompt" promises: workers/crisp-kb and content-engine are clean; **5 blog posts still teach the removed feature** — that is real content surgery (SEO posts with woven-in narrative) and is filed as a follow-up issue rather than rushed here.

Closes #944