### PR TITLE
fix(pipeline): ASR interruption during polishing is not an idle reap

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ASREventRouter.swift
@@ -33,6 +33,16 @@ final class ASREventRouter {
         self.kernelDriver.handleASRServiceInterruption()
       } else if wkState == .recording || wkState == .transcribing {
         self.whisperKitKernelDriver.handleASRServiceInterruption()
+      } else if pState == .polishing || wkState == .polishing {
+        // Codex PR #990 P2 (#959): a crash/reap during the post-ASR polishing
+        // window is NOT an idle reap — a session is still finalizing. The
+        // kernel deliberately treats `.finalizing` as a safe point (see the
+        // WONTFIX note in `KernelDictationDriver.pipelineState(for:)`), and
+        // the marker is part of that safe-point contract: setting it here
+        // would let the next not-ready press consume a stale marker, bypass
+        // the #879 cold pill after a genuine mid-session crash, and pollute
+        // `coldstart.service_reclaimed` telemetry. Log-only (the line above
+        // already records both driver states).
       } else {
         // #959: the Parakeet ASR service (this `asrManager`) was reaped while
         // idle — `onServiceInterrupted` only fires when a resident model was

--- a/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
@@ -110,6 +110,12 @@ struct ASREventRouterTests {
       await Task.yield()
 
       #expect(driver.state == .polishing)
+      // Codex PR #990 P2 (#959): the safe point includes the marker side
+      // effect, not just the FSM state — a crash during polishing is not an
+      // idle reap. A stale marker would route the NEXT not-ready press
+      // through warm-respawn (skipping the cold pill) and pollute
+      // `coldstart.service_reclaimed` telemetry.
+      #expect(driver.residentModelLostWhileIdle == false)
       withExtendedLifetime(router) {}
     }
   #endif
@@ -149,6 +155,10 @@ struct ASREventRouterTests {
       await Task.yield()
 
       #expect(whisperKit.state == .polishing)
+      // Codex PR #990 P2 (#959): same marker discipline as the Parakeet
+      // polishing test above — a WhisperKit session mid-polish means the
+      // system is not idle, so the Parakeet driver must not be marked.
+      #expect(driver.residentModelLostWhileIdle == false)
       withExtendedLifetime(router) {}
     }
   #endif


### PR DESCRIPTION
## Summary
Closes the Codex post-merge P2 on PR #990 (#959): when either driver sits at `.polishing` (kernel `.finalizing`), the `ASREventRouter` else-branch treated an ASR service interruption as a reap-while-idle — setting `residentModelLostWhileIdle` and emitting `coldstart.service_reclaimed`. The stale marker let the next not-ready press bypass the #879 cold pill after a genuine mid-session crash, and polluted reclaim telemetry.

The polishing window is a kernel safe point (the kernel deliberately takes no action on ASR interruption during `.finalizing`); the marker side effect now honors the same contract: log-only, no marker, no reclaim telemetry.

## Validation
- Failing-first: both existing polishing safe-point tests extended with marker assertions; both reproduced the bug before the fix (`residentModelLostWhileIdle → true`), green after.
- Full logic suite: 1,755 tests green (Xcode debug lane).
- Dev app rebuilt.
- Codex code-diff review: "No actionable correctness issues found... consistently prevent the idle-reap marker from being set during polishing."

## Tier / lane
SMALL, Code lane. Guard-fix on shipped routing; no new symbols, no new dependencies.

Closes #959 (the headline mechanism shipped in v2.1.2 via PR #961; the second mechanism shipped in PR #990 awaiting release; this closes the last flagged hole)