### PR TITLE
test(pipeline): deterministic timeout executor in finalization-wiring suite

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -308,7 +308,15 @@ import Testing
       context: context,
       adapter: ParakeetEngineAdapter(asrManager: StubParakeetASRManager()),
       steps: steps ?? makeSteps(),
-      textProcessingRunner: TextProcessingRunner(),
+      // #989: deterministic executor — this suite asserts chain SEMANTICS
+      // (ordering, side channels, delivery), never step timing. The
+      // production `withThrowingTimeout` executor let full-suite MainActor
+      // contention starve a short-budget limb (FillerRemoval, 50ms) past its
+      // deadline, silently discarding its output and flaking the chain-order
+      // test. Timeout behavior itself is covered by TextProcessingRunnerTests
+      // and HeartPathIntegrationTests with the same fake.
+      textProcessingRunner: TextProcessingRunner(
+        timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
       save: save,
       deliverPaste: deliverPaste,
       pasteCompletionRegistry: nil,


### PR DESCRIPTION
## Summary
Fixes the #989 flake: `build-debug` failed on release PR #988 with the chain-order test seeing un-stripped filler (`itnLenBefore` 29 vs 26) — on a SHA where main-post-merge had passed.

**Root cause (traced, not the issue's original hypothesis):** the suite's fixture used the production `withThrowingTimeout` executor. Under full-suite parallelism, MainActor contention can starve `FillerRemovalStep` (50ms limb budget) past its deadline; the runner then discards the step's output by design (heart-and-limbs passthrough), so ITN sees raw text. Not shared state — the issue's suspected state-clobbering doesn't exist (the flag is per-instance).

**Fix:** inject `FakeTimeoutExecutor(throwBelowSeconds: 0)` (established in-repo pattern) so no step can wall-clock out in a suite that asserts chain semantics, never timing. Real timeout behavior stays covered by `TextProcessingRunnerTests` + `HeartPathIntegrationTests`.

## Validation
- Wiring suite green (16 tests).
- Codex code-diff review: "no actionable bugs... fits the stated test scope."
- Dev app rebuilt (test-only change; build freshness gate).

Closes #989