### PR TITLE
fix(ui): recording-mode control shows both modes as a segmented picker

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import EnviousWisprServices
 import SwiftUI
 
@@ -21,11 +22,17 @@ struct ShortcutsSettingsView: View {
         }
         BrandedRow {
           VStack(alignment: .leading, spacing: 4) {
-            Toggle(
-              settings.isPushToTalk ? "Push to Talk" : "Toggle",
-              isOn: $settings.isPushToTalk
+            // #917: both modes visible side by side. The old single Toggle
+            // labeled itself with the ACTIVE mode, so switching it "off" to
+            // leave toggle mode kept you in toggle mode — observed live as
+            // "the switch is broken."
+            BrandedSegmentedPicker(
+              options: [
+                ("Push to Talk", RecordingMode.pushToTalk),
+                ("Toggle", RecordingMode.toggle),
+              ],
+              selection: $settings.recordingMode
             )
-            .toggleStyle(BrandedToggleStyle())
             Text(
               settings.isPushToTalk
                 ? "Hold the hotkey to record, release to stop."


### PR DESCRIPTION
## Summary
The recording-mode control was a single Toggle that labeled itself with the ACTIVE mode and bound `isOn` to `isPushToTalk` — so switching it "off" to leave toggle mode kept you in toggle mode. Observed live: founder turned "Toggle" off expecting hold-to-talk, kept getting toggle behavior, and reasonably concluded the switch was broken (#917).

Replaced with the house `BrandedSegmentedPicker` (same pattern as the engine picker in Speech Engine settings): both modes visible side by side, selection binds `recordingMode` directly. Per-mode helper text unchanged, hands-free hint still shows only for Push to Talk.

## Validation
- Dev app rebuilt; AX verification on the running app: picker renders as two segments, tapping "Toggle" switched the helper text and cleared the hands-free hint, tapping "Push to Talk" switched back; `defaults read` confirmed the persisted value flipped and was restored.
- Codex code-diff review: "no actionable correctness issues... matches the app's existing settings pattern."
- Tier SMALL, UI-only; no logic-test obligation (runtime-only UI module).

Closes #917