### PR TITLE
feat(pipeline): DEBUG-only audio dump on empty-ASR-despite-evidence

### DIFF
--- a/Sources/EnviousWisprPipeline/ASREmptyCaptureDump.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyCaptureDump.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+#if DEBUG
+  /// #979 diagnostic instrument — DEBUG builds only (founder dogfood machine).
+  ///
+  /// Production telemetry shows the asr_empty_result class (ENVIOUSWISPR-14:
+  /// VAD found a single short speech segment, the engine returned empty) but
+  /// metadata cannot answer THE fork: was the audio a real short word the
+  /// pipeline lost, or a non-speech transient (cough/door/keyboard) that fooled
+  /// the voice detector? This dumper saves the audio pair for exactly that
+  /// terminal so the next local occurrence is fully diagnosable offline
+  /// (listen + re-decode via fluidaudiocli, per docs/vad-investigation-2026-06-03.md).
+  ///
+  /// Privacy: never compiled into release builds; audio never leaves the local
+  /// disk; the directory rides the same `~/Library/Logs/EnviousWispr/` home as
+  /// the (also DEBUG-gated) app.log.
+  enum ASREmptyCaptureDump {
+    static let directoryURL = FileManager.default
+      .homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/Logs/EnviousWispr/asr-empty-captures", isDirectory: true)
+
+    /// Keep the newest N files (raw+fed pairs count as 2). ~1 occurrence/day
+    /// locally, so 40 files = ~3 weeks of evidence with bounded disk use.
+    static let maxRetainedFiles = 40
+
+    /// Write the raw capture and the engine-fed (conditioned) buffers as
+    /// 16 kHz mono WAVs. Returns the pair's shared path prefix for logging,
+    /// or nil on any failure (diagnostic limb: never throws past itself).
+    @discardableResult
+    static func dump(
+      raw: [Float],
+      fed: [Float],
+      sessionID: String,
+      now: Date = Date(),
+      directory: URL? = nil
+    ) -> String? {
+      // Kernel tests exercise the real .failed(.asrEmpty) path, so without
+      // this gate every full-suite run writes synthetic buffers into the
+      // dogfood evidence directory and contaminates the corpus this
+      // instrument exists to collect (caught live: first "organic" dump was
+      // the 15:17 test run). Unit tests pass `directory:` explicitly and are
+      // unaffected.
+      if directory == nil,
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+          || ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil
+      {
+        return nil
+      }
+      let dir = directory ?? directoryURL
+      let fm = FileManager.default
+      do {
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let stamp = Self.timestampFormatter.string(from: now)
+        let sid8 = String(sessionID.replacingOccurrences(of: "-", with: "").prefix(8))
+        let prefix = "\(stamp)-\(sid8)"
+        try wavData(samples: raw).write(to: dir.appendingPathComponent("\(prefix)-raw.wav"))
+        try wavData(samples: fed).write(to: dir.appendingPathComponent("\(prefix)-fed.wav"))
+        prune(directory: dir)
+        return dir.appendingPathComponent(prefix).path
+      } catch {
+        return nil
+      }
+    }
+
+    /// 16 kHz mono 16-bit PCM WAV container around Float32 samples in [-1, 1].
+    static func wavData(samples: [Float], sampleRate: Int = 16000) -> Data {
+      var pcm = Data(capacity: samples.count * 2)
+      for s in samples {
+        let clamped = max(-1.0, min(1.0, s))
+        var i = Int16(clamped * Float(Int16.max))
+        withUnsafeBytes(of: &i) { pcm.append(contentsOf: $0) }
+      }
+      let byteRate = sampleRate * 2
+      var header = Data()
+      header.append(contentsOf: Array("RIFF".utf8))
+      header.append(uint32: UInt32(36 + pcm.count))
+      header.append(contentsOf: Array("WAVE".utf8))
+      header.append(contentsOf: Array("fmt ".utf8))
+      header.append(uint32: 16)  // PCM fmt chunk size
+      header.append(uint16: 1)  // PCM
+      header.append(uint16: 1)  // mono
+      header.append(uint32: UInt32(sampleRate))
+      header.append(uint32: UInt32(byteRate))
+      header.append(uint16: 2)  // block align
+      header.append(uint16: 16)  // bits per sample
+      header.append(contentsOf: Array("data".utf8))
+      header.append(uint32: UInt32(pcm.count))
+      return header + pcm
+    }
+
+    /// Delete the oldest files beyond `maxRetainedFiles` (by name — the
+    /// timestamp prefix sorts lexicographically).
+    static func prune(directory: URL) {
+      let fm = FileManager.default
+      guard
+        let names = try? fm.contentsOfDirectory(atPath: directory.path)
+          .filter({ $0.hasSuffix(".wav") })
+          .sorted()
+      else { return }
+      guard names.count > maxRetainedFiles else { return }
+      for name in names.prefix(names.count - maxRetainedFiles) {
+        try? fm.removeItem(at: directory.appendingPathComponent(name))
+      }
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+      let f = DateFormatter()
+      f.dateFormat = "yyyyMMdd'T'HHmmss"
+      f.locale = Locale(identifier: "en_US_POSIX")
+      f.timeZone = TimeZone.current
+      return f
+    }()
+  }
+
+  extension Data {
+    fileprivate mutating func append(uint32 v: UInt32) {
+      var le = v.littleEndian
+      Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+    fileprivate mutating func append(uint16 v: UInt16) {
+      var le = v.littleEndian
+      Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+  }
+#endif

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1297,6 +1297,37 @@ final class RecordingSessionKernel {
             level: .info, category: "Pipeline"
           )
         }
+        #if DEBUG
+          // #979 diagnostic: dogfood builds save the audio pair for this
+          // terminal so the next local occurrence answers the production
+          // fork (real short word lost vs non-speech transient that fooled
+          // the voice detector). DEBUG-only; local disk; bounded retention.
+          let rawSamples = captureResult.samples
+          // Codex P2 (r1+r2): dump what the engine ACTUALLY decoded.
+          // WhisperKit ignores the conditioned buffer and decodes the raw
+          // capture padded to the transcription minimum — reuse the SAME
+          // routing helper the adapter calls so the fed WAV matches the
+          // failing decode byte-for-byte.
+          let fedSamples =
+            adapter.capabilities.decodesConditionedBatchSamples
+            ? conditioned.samples
+            : WhisperKitPipelineSpeechRouting.paddedASRSamples(
+              rawSamples: captureResult.samples,
+              minimumSamples: AudioConstants.minimumTranscriptionSamples)
+          let sidRaw = sid.raw.uuidString
+          Task.detached(priority: .utility) {
+            // Task.detached (not Task): file IO off the kernel's actor; no
+            // cancellation or ordering relationship with the session — the
+            // dump must survive the session reaching its terminal state.
+            let prefix = ASREmptyCaptureDump.dump(
+              raw: rawSamples, fed: fedSamples, sessionID: sidRaw)
+            await AppLogger.shared.log(
+              prefix.map { "ASR-empty capture dumped: \($0)-{raw,fed}.wav" }
+                ?? "ASR-empty capture dump FAILED (diagnostic limb, ignored)",
+              level: .info, category: "Pipeline"
+            )
+          }
+        #endif
       }
       finishTerminal(
         effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech, sid: sid)

--- a/Tests/EnviousWisprTests/Pipeline/ASREmptyCaptureDumpTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREmptyCaptureDumpTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+#if DEBUG
+  /// #979 — the DEBUG-only diagnostic dumper for empty-ASR-despite-evidence
+  /// terminals. Pure file IO + WAV encoding; tests run against a temp dir.
+  @Suite("ASREmptyCaptureDump")
+  struct ASREmptyCaptureDumpTests {
+
+    private func tempDir() throws -> URL {
+      let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("asr-empty-dump-tests-\(UUID().uuidString)")
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+      return url
+    }
+
+    @Test("WAV container: header fields and payload size are correct for 16kHz mono 16-bit")
+    func wavHeader() {
+      let samples: [Float] = [0.0, 0.5, -0.5, 1.0, -1.0, 2.0, -2.0]  // incl. out-of-range
+      let data = ASREmptyCaptureDump.wavData(samples: samples)
+
+      #expect(data.count == 44 + samples.count * 2)
+      #expect(String(data: data[0..<4], encoding: .ascii) == "RIFF")
+      #expect(String(data: data[8..<12], encoding: .ascii) == "WAVE")
+      #expect(String(data: data[36..<40], encoding: .ascii) == "data")
+      let sampleRate = data[24..<28].withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+      #expect(UInt32(littleEndian: sampleRate) == 16000)
+      let channels = data[22..<24].withUnsafeBytes { $0.loadUnaligned(as: UInt16.self) }
+      #expect(UInt16(littleEndian: channels) == 1)
+      let dataLen = data[40..<44].withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+      #expect(UInt32(littleEndian: dataLen) == UInt32(samples.count * 2))
+      // Out-of-range floats clamp instead of wrapping (no Int16 overflow trap).
+      let lastTwo = data.suffix(4)
+      let positives = lastTwo.prefix(2).withUnsafeBytes { $0.loadUnaligned(as: Int16.self) }
+      #expect(Int16(littleEndian: positives) == Int16.max)
+    }
+
+    @Test("dump writes a raw+fed pair and returns the shared prefix")
+    func dumpWritesPair() throws {
+      let dir = try tempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+
+      let prefix = ASREmptyCaptureDump.dump(
+        raw: [0.1, 0.2, 0.3], fed: [0.1], sessionID: "ABCD-1234-EF",
+        now: Date(timeIntervalSince1970: 1_750_000_000), directory: dir)
+
+      let written = try #require(prefix)
+      #expect(FileManager.default.fileExists(atPath: written + "-raw.wav"))
+      #expect(FileManager.default.fileExists(atPath: written + "-fed.wav"))
+      // sid embeds dash-stripped 8-char prefix.
+      #expect(written.contains("ABCD1234"))
+    }
+
+    @Test("real-path writes are gated off under the test harness")
+    func realPathGatedUnderTests() {
+      // This suite runs under xctest, so the no-explicit-directory call must
+      // refuse — otherwise kernel tests exercising .failed(.asrEmpty) would
+      // write synthetic buffers into the dogfood evidence directory.
+      let result = ASREmptyCaptureDump.dump(
+        raw: [0.1], fed: [0.1], sessionID: "GATE-TEST")
+      #expect(result == nil)
+    }
+
+    @Test("prune keeps only the newest maxRetainedFiles WAVs by name order")
+    func pruneRetention() throws {
+      let dir = try tempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let fm = FileManager.default
+      let total = ASREmptyCaptureDump.maxRetainedFiles + 6
+      for i in 0..<total {
+        let name = String(format: "20260601T%06d-aaaa-raw.wav", i)
+        fm.createFile(atPath: dir.appendingPathComponent(name).path, contents: Data([1]))
+      }
+
+      ASREmptyCaptureDump.prune(directory: dir)
+
+      let remaining = try fm.contentsOfDirectory(atPath: dir.path).sorted()
+      #expect(remaining.count == ASREmptyCaptureDump.maxRetainedFiles)
+      // The oldest 6 (lowest-sorting names) are the ones deleted.
+      #expect(remaining.first == String(format: "20260601T%06d-aaaa-raw.wav", 6))
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary
Diagnostic instrument for #979 (production: 7 users / 19 events on 2.1.x, escalating). All events share one signature — a single short VAD speech segment (256ms-2s) where the engine returns empty via batch, streaming, AND rescue. Metadata cannot answer the decisive fork: real short word lost (heart-path data loss) vs non-speech transient that fooled the voice detector (we alarm Sentry and show "Couldn't catch that" for a non-event). The clincher local case had FULL raw audio fed (no trim/pad) at peak 0.67 and still came back empty — so the fork is upstream of conditioning and only the audio itself can answer it.

`ASREmptyCaptureDump` (DEBUG builds only): on the `.failed(.asrEmpty)` terminal, save the raw capture + engine-fed buffer as 16kHz WAVs to `~/Library/Logs/EnviousWispr/asr-empty-captures/`, bounded retention (newest 40 files). Audio never leaves disk; the type and call site compile only into dogfood builds. At the local ~1/day rate, a few days yields enough pairs to classify by ear + fluidaudiocli re-decode (same offline method as docs/vad-investigation-2026-06-03.md).

## Codex findings incorporated (3 rounds)
- r1: WhisperKit decodes the RAW capture, not the conditioned buffer — fed WAV now selected by `decodesConditionedBatchSamples`.
- r2: WhisperKit pads short captures before decode — fed WAV now uses the SAME `paddedASRSamples` routing helper the adapter calls, byte-for-byte.
- r3: clean.
- Self-caught live during validation: the kernel tests exercise the real empty terminal, and the first "organic" dump turned out to be the test suite writing synthetic buffers into the evidence directory. Real-path writes are now gated off under the test harness (proved empirically: full suite → zero files), with a pinning test; unit tests use explicit temp directories.

## Validation
- 1,774 logic tests green (4 new: WAV header/clamping, pair write, retention prune, test-harness gate).
- Negative live smoke on the instrumented dev build: normal dictation transcribed perfectly, no dump written.
- Positive trigger is inherently stochastic (~1/day organic on the dogfood machine) — the instrument's first real capture is the next investigation step, not a pre-merge gate.

## Tier / lane
SMALL, Code lane. DEBUG-only diagnostic; no release-build surface, no user-facing change. Council skipped: no user surface, no design ambiguity (instrument pattern precedent: #991 tail telemetry, 06-03 VADCaptureDump); Codex grounded the design via the consult + 3 diff rounds.

Updates #979