### PR TITLE
fix(content): replace removed Custom-prompt teaching with accurate polish behavior

### DIFF
--- a/website/src/content/blog/async-communication-better-when-you-speak.md
+++ b/website/src/content/blog/async-communication-better-when-you-speak.md
@@ -50,13 +50,13 @@ Not every message should sound the same. A Slack reply to your team is casual. A
 
 EnviousWispr's polish step handles this in two layers. The default polish removes filler words, fixes punctuation, and tightens structure without flattening your voice into corporate prose. It works well across most async writing, so the same workflow handles a Slack reply and a status update.
 
-When you need a specific shape, the Custom prompt option lets you write your own polish instructions. A few that work well:
+When you need a specific shape, the way you talk sets it. The polish reads what you said and matches it:
 
-- "Keep this casual and concise. Don't formalize." For Slack and team threads.
-- "Tighten sentence structure and produce a polished tone with proper paragraphs." For client-facing email.
-- "Preserve technical terms and project-specific language. Output as a structured paragraph." For project docs and updates.
+- A short, casual aside for Slack and team threads stays casual and concise, not formalized.
+- A longer, more deliberate message for client-facing email comes back tightened, with proper paragraphs.
+- Project docs and updates keep your technical terms and land as structured prose.
 
-You change the Custom prompt as your task changes, and the polish step picks it up on your next dictation. You speak naturally every time.
+The output adapts as your task changes, automatically. You speak naturally every time.
 
 ## Privacy: your work conversations stay on-device
 

--- a/website/src/content/blog/dictate-emails-speed-of-thought.md
+++ b/website/src/content/blog/dictate-emails-speed-of-thought.md
@@ -26,7 +26,7 @@ EnviousWispr handles this differently. After transcription, your text runs throu
 
 ## AI Polish for Every Email Type
 
-Not every email sounds the same. A response to a board member requires different language than a quick delegation to your direct report. EnviousWispr's polish step adapts to what you're writing, and Custom prompts let you lock in a specific shape when you need one.
+Not every email sounds the same. A response to a board member requires different language than a quick delegation to your direct report. EnviousWispr's polish step adapts to what you're writing, matching the shape of what you said without any setup.
 
 ### Quick replies
 
@@ -34,15 +34,15 @@ The default polish works well for brevity. Speak a few sentences, get back a cle
 
 ### Structured correspondence
 
-For investor updates, client responses, and cross-functional announcements, dictate your key points conversationally and the polish step outputs paragraphs with proper punctuation and clear breaks. Want consistent salutations and a sign-off across every email? Save those expectations as a Custom prompt and the polish step applies them every time until you change it.
+For investor updates, client responses, and cross-functional announcements, dictate your key points conversationally and the polish step outputs paragraphs with proper punctuation and clear breaks. Want a greeting and a sign-off? Just speak them, and the polish keeps them in place.
 
 ### Delegation emails
 
 The LLM post-processing step naturally formats action-oriented dictation into structured output. Dictate what needs to happen, who owns it, and the deadline. The output arrives as a clean bulleted list with names and dates, ready to paste and send.
 
-### Custom prompts
+### Structure follows your voice
 
-The Custom prompt option lets you write your own processing instructions. Want your email output to always include a greeting and sign-off? Want bullet points for action items? Write the prompt once and every dictation follows your rules until you change it.
+You shape the output by how you talk, not by configuring anything. Open with a greeting and close with a sign-off and the polish keeps them. With Ollama, OpenAI, or Gemini polish on, rattle off action items and they come back as bullet points; on the Apple Intelligence default, you get the same items as clean prose. Either way, every dictation follows what you said.
 
 ## Sensitive Data Stays on Your MacBook
 

--- a/website/src/content/blog/dictate-first-drafts-sound-like-you.md
+++ b/website/src/content/blog/dictate-first-drafts-sound-like-you.md
@@ -1,6 +1,6 @@
 ---
 title: "Dictate First Drafts That Sound Like You"
-description: "Most dictation tools strip your voice. Here's how to dictate first drafts that keep your writing style intact using on-device polish and Custom prompts."
+description: "Most dictation tools strip your voice. Here's how to dictate first drafts that keep your writing style intact with on-device polish built to preserve how you actually write."
 pubDate: 2026-03-14
 updatedDate: 2026-04-04
 tags: ["writing", "dictation", "workflow", "writing-style"]
@@ -12,7 +12,7 @@ Every dictation tool on the market is lying to you about the same thing. They pr
 
 The problem isn't speech-to-text accuracy. The problem is that most tools treat post-processing as "make it sound professional" instead of "make it sound like the person who said it."
 
-That's a solvable problem, if the tool gives you control over what happens after transcription.
+That's a solvable problem, if the tool's polish is built to preserve your voice instead of flattening it.
 
 If you're new to EnviousWispr, the [getting started guide](/blog/getting-started-enviouswispr-under-2-minutes/) walks you through setup in under two minutes.
 
@@ -20,20 +20,20 @@ If you're new to EnviousWispr, the [getting started guide](/blog/getting-started
 
 Standard speech to text treats your words as data to be cleaned. The goal is "correct" text: grammatically inoffensive, uniformly punctuated, utterly generic. That's fine for transcribing a meeting. It's terrible for writing.
 
-Writers don't want correct. They want *theirs*. Short fragments for emphasis. Em dashes instead of semicolons. A specific way of handling dialogue tags, or paragraphs that breathe a certain way. The raw transcription from any speech model is a starting point, not a finished product. Most tools don't give you any control over what happens between transcription and output.
+Writers don't want correct. They want *theirs*. Short fragments for emphasis. Em dashes instead of semicolons. A specific way of handling dialogue tags, or paragraphs that breathe a certain way. The raw transcription from any speech model is a starting point, not a finished product. Most tools flatten that starting point into something generic.
 
 That's the gap EnviousWispr fills.
 
 ## How EnviousWispr Keeps Your Voice Intact
 
-EnviousWispr splits the work into two stages: transcription and post-processing. Transcription runs locally on your Mac using on-device speech recognition via Core ML. That gives you accurate raw text. Post-processing is where you shape it.
+EnviousWispr splits the work into two stages: transcription and post-processing. Transcription runs locally on your Mac using on-device speech recognition via Core ML. That gives you accurate raw text. Post-processing is where your voice gets preserved.
 
 Here's what makes the difference for writers:
 
-- **On-device polish that keeps your voice.** Your local LLM (Apple Intelligence, Ollama) or a cloud API (OpenAI, Gemini) cleans up the raw transcription: filler words go, punctuation gets fixed, structure tightens, but your contractions, sentence fragments, and rhythm stay intact. The default polish is tuned for natural-sounding output, not corporate sameness.
-- **Custom prompts for explicit control.** When you want to lock in a specific style, write a Custom prompt and the polish step uses it for every dictation until you change it. Examples: "use em dashes, not semicolons", "keep sentence fragments, they're intentional", "format as Markdown with H2 headings".
+- **On-device polish that keeps your voice.** Your local LLM (Apple Intelligence, Ollama) or a cloud API (OpenAI, Gemini) cleans up the raw transcription: filler words go, punctuation gets fixed, structure tightens, but your contractions, sentence fragments, and rhythm stay intact. The polish is tuned for natural-sounding output, not corporate sameness.
+- **An editor, not a rewriter.** The polish is built to edit, not reword. It preserves your meaning, tone, and phrasing, and never translates or rewrites what you said. Your em dashes, your intentional fragments, your rhythm survive the cleanup.
 
-You can change the Custom prompt as your task changes (drafting one minute, client-facing prose the next), and the polish step picks it up on your next dictation. You're in control.
+It also adapts to length: a quick aside stays a clean line, while a longer piece comes back as clean, readable prose. You don't switch anything between drafting and client-facing work; the polish keeps your voice either way.
 
 For a deeper look at how the transcription and post-processing pipeline connects, see the [How It Works](/how-it-works/) page.
 
@@ -47,26 +47,24 @@ Download the latest `.dmg` from the [GitHub releases page](https://github.com/sa
 
 No account. No API key. No subscription. It's free.
 
-### Step 2: Set Up Polish (and a Custom Prompt If You Need One)
+### Step 2: Set Up Polish
 
-The speech model downloads automatically on first launch. Once that's done (a few minutes), open EnviousWispr's settings. The default polish is tuned to keep your voice intact while cleaning up filler words and punctuation. For most writing, that's the right starting point.
+The speech model downloads automatically on first launch. Once that's done (a few minutes), open EnviousWispr's settings and pick your polish engine. On macOS 26 and later, Apple Intelligence is on by default; on earlier macOS, choose Ollama to keep it on-device, or add an OpenAI or Gemini key. The polish keeps your voice intact while cleaning up filler words and punctuation, and it works across whatever you're writing:
 
-If you want to lock in a specific shape, write a Custom prompt. Pick whichever pattern matches what you're working on:
+- Novels, blog drafts, and freewriting keep your natural voice, contractions, and sentence rhythm.
+- Newsletters and articles come back as clean, readable prose with a light touch.
+- Longer, more formal pieces get tightened structure and proper paragraphs.
+- Your stylistic choices (em dashes over semicolons, intentional fragments) survive, because the polish edits rather than rewrites.
 
-- "Keep my natural voice, contractions, and sentence rhythm. Don't formalize." For novels, blog drafts, freewriting.
-- "Output clean, readable prose with light polish. Keep my voice." For newsletters and articles.
-- "Tighten sentence structure, remove casual phrasing, produce polished prose." For academic papers, client deliverables.
-- "Use em dashes instead of semicolons. Preserve sentence fragments when intentional." For specific style preferences.
-
-The Custom prompt sticks until you change it.
+There's nothing to configure. The polish reads what you said and matches it.
 
 Post-processing can run on-device (Apple Intelligence, Ollama) or through cloud APIs (OpenAI, Gemini). Your raw dictation never leaves your device unless you explicitly configure an external API.
 
 ### Step 3: Dictate Your First Draft
 
-Hold your hotkey. Start talking. Don't edit in your head; just speak. Release the hotkey when you're done with a thought. A second or two later on Apple Silicon, polished text lands in your writing app, styled the way you specified.
+Hold your hotkey. Start talking. Don't edit in your head; just speak. Release the hotkey when you're done with a thought. A second or two later on Apple Silicon, polished text lands in your writing app, cleaned up but still in your voice.
 
-That's it. No copying and pasting. No switching apps. The text pastes into the app that has focus, cleaned up according to your polish settings.
+That's it. No copying and pasting. No switching apps. The text pastes into the app that has focus, cleaned up while keeping your voice.
 
 ## What the Difference Actually Looks Like
 
@@ -110,8 +108,8 @@ For a detailed look at how on-device processing compares to cloud alternatives, 
 
 Most writers who've tried dictation and quit had one of three problems:
 
-1. **The output didn't sound like them.** Solved by an on-device polish step tuned to keep your voice, plus a Custom prompt for full control over processing instructions.
-2. **Switching between contexts was tedious.** Edit the Custom prompt as your task changes; the polish step picks it up on your next dictation.
+1. **The output didn't sound like them.** Solved by an on-device polish step built to preserve your voice: it edits, it doesn't reword.
+2. **Switching between contexts was tedious.** Nothing to switch. The polish adapts to what you said, so the same setup handles a manuscript paragraph and a quick Slack reply.
 3. **Privacy concerns with cloud tools.** Solved by on-device processing that never phones home.
 
 The first few sessions feel awkward. You'll over-explain, stumble, repeat yourself. That's normal. The post-processor catches most of it, and within a week you'll find a rhythm. Dictation isn't a replacement for writing; it's a way to get your first draft out of your head faster so you can spend your energy on editing, which is where the real writing happens anyway.
@@ -121,7 +119,7 @@ The first few sessions feel awkward. You'll over-explain, stumble, repeat yourse
 EnviousWispr is free and yours to keep. No strings.
 
 1. [Download EnviousWispr free](/#download), or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases)
-2. Leave polish on the default, or write a Custom prompt that matches your voice
+2. Leave AI polish on; it's built to keep your voice intact
 3. Dictate your next first draft
 
 ## Related Posts

--- a/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+++ b/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
@@ -33,7 +33,7 @@ But raw transcription isn't a script. It's a wall of text with filler words, fal
 
 EnviousWispr's post-processing pipeline cleans up your speech after transcription: removing filler words, fixing punctuation, and producing polished text. The default polish preserves your conversational voice while cleaning up the rough edges, which is what you want for podcast scripting.
 
-When you need a specific shape (interview prep, solo script, show notes, cold open), the Custom prompt option lets you write processing instructions like "keep sentence fragments, add section breaks between topics, format with H2 headings." That level of control makes dictated scripts even more useful.
+When you need a specific shape (interview prep, solo script, show notes, cold open), the way you talk steers it. Speak in fragments and the polish keeps them; call out "next section" or "first... then... finally" as you go, and it adds breaks and structure around those cues. That level of guidance, with no setup, makes dictated scripts even more useful.
 
 The output has the structure you need: cleaned of "um" and "you know," but still sounding like you.
 
@@ -47,7 +47,7 @@ Here's what that looks like in practice, dictating a cold open for an episode ab
 
 That's a usable cold open. It sounds like you because it literally is you, just without the filler words and with proper punctuation. Read that back into the mic and it works immediately. The idea made it from your head to the page before it had a chance to evaporate.
 
-With a Custom prompt, you can fine-tune output for different show formats: interview prep as numbered questions, solo scripts with paragraph breaks, show notes as bullet summaries, cold opens tightened to three punchy sentences.
+By how you speak, you can shape output for different show formats. With Ollama, OpenAI, or Gemini polish on, run through your interview questions or show notes as a list and they come back as bullet points. On the Apple Intelligence default, you get the same words cleaned up as prose, and cold opens stay short and punchy on any engine.
 
 Check [how EnviousWispr's pipeline works](/how-it-works/) for the full picture on how transcription and post-processing fit together.
 
@@ -83,7 +83,7 @@ This is the hardest habit to break. You'll say something awkward, and every inst
 
 ### Use Verbal Section Markers
 
-Say "new section" or "next topic" or "heading: [topic name]" as you dictate. The post-processing pipeline picks up on these verbal cues and uses them to add structure to your output. With a Custom prompt, you have full control over how those markers get formatted.
+Say "new section" or "next topic" or "heading: [topic name]" as you dictate, and those cues stay in your text as markers. With Ollama, OpenAI, or Gemini polish on, the pipeline can turn them into actual section breaks; on the Apple Intelligence default they remain as spoken labels you can format later.
 
 ### Do a Read-Back Pass
 

--- a/website/src/content/blog/dictation-for-developers-code-reviews.md
+++ b/website/src/content/blog/dictation-for-developers-code-reviews.md
@@ -28,13 +28,13 @@ Not all developer writing sounds the same. A commit message is terse. A PR descr
 
 For most developer writing (review comments, ticket updates, README sections, Slack threads), the default polish handles the cleanup without over-formalizing or stripping your voice. You speak naturally and the output reads naturally.
 
-For specialized formatting, EnviousWispr's Custom prompt option lets you write your own instructions for the polish step. A few examples that work well for developer workflows:
+For more specialized output, the way you talk steers the shape, and Ollama, OpenAI, or Gemini polish turns those cues into formatting. A few patterns that work well for developer workflows:
 
-- "Format as a markdown bullet list with code references in backticks." Useful for changelog entries or release notes.
-- "Write in past tense and group changes by subsystem." Useful for postmortem timelines.
-- "Output API documentation with parameter and return descriptions." Useful for public method docs.
+- Call out a list ("first... then... finally," "the changes were") and, with Ollama, OpenAI, or Gemini polish on, changelog entries or release notes come back as a clean markdown bullet list.
+- Walk a postmortem timeline in order and the polish keeps that sequence the way you narrate it.
+- Name the parts of an API doc as you speak (the parameters, what each returns) and the output lands organized.
 
-The Custom prompt sticks until you change it, so once you have a prompt that fits your team's style, you can leave it in place and dictate against it for as long as you need.
+On the Apple Intelligence default, you get the same content as clean prose, with no markdown invented. There's nothing to set up either way.
 
 ## Real workflow: dictating a PR description
 
@@ -74,7 +74,7 @@ This works especially well for longer review comments, the kind where you need t
 
 Technical documentation has the highest typing-to-thinking ratio of anything developers write. You know what the system does. You just need to get it into words. Dictation makes this almost trivial.
 
-For documentation, the polish step produces structured prose with proper punctuation and clean paragraphs. You talk through the architecture the way you'd explain it to a new team member, and the output lands polished and ready to commit. Custom prompts let you go further: tell the post-processor to format output as API documentation with parameter descriptions, or to use specific header structures.
+For documentation, the polish step produces clean prose with proper punctuation and clear paragraphs. You talk through the architecture the way you'd explain it to a new team member, and the output lands polished and ready to commit. Walk through it in sections, and with Ollama, OpenAI, or Gemini polish on those headers and lists carry into the output as markdown.
 
 This is particularly useful for the kind of documentation that always gets skipped: the "how does this subsystem actually work" docs that everyone wishes existed but nobody wants to sit down and type out. Speaking is lower friction than typing for this kind of knowledge dump, and the difference is enough to make it actually happen.
 
@@ -95,8 +95,8 @@ For developers working on proprietary codebases, under NDA, or at companies with
 To set up for developer use:
 
 1. **Pick your hotkey.** Choose something that doesn't collide with your IDE shortcuts.
-2. **Leave polish on.** Default polish handles most developer writing (review comments, ticket updates, README sections) without over-formalizing.
-3. **Set a Custom prompt for the niches.** API docs, changelog entries, structured postmortems. The Custom prompt sticks until you change it.
+2. **Leave polish on.** The polish handles most developer writing (review comments, ticket updates, README sections) without over-formalizing.
+3. **Speak the structure for the niches.** API docs, changelog entries, structured postmortems: name the sections and lists out loud, and with Ollama, OpenAI, or Gemini polish on the output comes back formatted.
 
 Hold the hotkey in GitHub, talk through your PR description, and the polished text lands ready to paste. Move to Slack and the same workflow handles a quick reply.
 

--- a/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
+++ b/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
@@ -60,7 +60,7 @@ EnviousWispr writes into whatever field has focus. That means it works in Epic's
 
 Referral letters are repetitive in shape and unique in content. You name the patient, summarize the relevant history, state the clinical question, and ask for the consultation. That's a paragraph or two of structured prose every time.
 
-Hold the hotkey and dictate the body. The polish step formats it as a clean letter. If you want consistent salutations, sign-offs, or your standard closing language, write a Custom prompt that sets those expectations once and the polish step applies them to every dictation until you change it. A prompt like "format as a referral letter with a Dear Dr. X greeting, three short paragraphs, and a sign-off matching my role" sticks until you change it.
+Hold the hotkey and dictate the body. The polish step formats it as a clean letter. Speak it the way a letter reads (your greeting, the patient summary, the clinical question, your sign-off) and the polish keeps that shape, turning a spoken paragraph or two into a structured letter.
 
 ### Discharge summaries before you leave
 
@@ -72,18 +72,18 @@ Dictate it section by section. Speak the admission course as you remember it. Sp
 
 Charting is most of the writing, but it isn't all of it. Email replies to staff, message threads with referring physicians, drafts to the practice manager, end-of-day notes to yourself. All of it is faster spoken. Hold the hotkey, talk, release. Same workflow, different field.
 
-## Custom prompts: lock in your documentation style
+## Let your dictation shape the documentation
 
-EnviousWispr's polish step has a default that handles general writing well. For clinical documentation, a Custom prompt is worth setting once. The polish step uses your prompt for every dictation until you change it.
+EnviousWispr's polish handles clinical writing without any setup. A quick one-line order stays a line. With Ollama, OpenAI, or Gemini polish on, a longer note spoken in sections comes back structured with paragraphs and bullets; on the Apple Intelligence default, the same note lands as clean prose. You guide it by how you speak.
 
-A few patterns that work well for clinicians:
+A few patterns that work well for clinicians (formatting applies with Ollama, OpenAI, or Gemini polish on; the Apple Intelligence default keeps the same content as clean prose):
 
-- **SOAP format.** "Output structured as Subjective, Objective, Assessment, Plan with each section as its own paragraph. Preserve clinical terms and dosing details exactly."
-- **Referral letters.** "Format as a referral letter with a brief patient summary, the clinical question, and a closing thanking the consultant. Three paragraphs maximum."
-- **Discharge summaries.** "Output organized by Admission Course, Hospital Course, and Discharge Plan. Use bullet points where appropriate for medication lists and follow-up instructions."
-- **Patient instructions.** "Translate clinical jargon to plain language at a 6th-grade reading level. Use second-person voice. Output as a numbered list of action items."
+- **SOAP notes.** Say "subjective," "objective," "assessment," "plan" as you move through the note, and each becomes its own section, with your clinical terms and dosing details preserved.
+- **Referral letters.** Dictate it the way a letter reads: a brief patient summary, the clinical question, and a closing to the consultant. The polish keeps that letter shape.
+- **Discharge summaries.** Walk through admission course, hospital course, and discharge plan out loud, and the structure follows your narration, with bullets for medication lists and follow-up instructions.
+- **Patient instructions.** Speak in plain, second-person language and call out the steps; they come back as a clean, bulleted list.
 
-You can swap prompts as your task changes (a chart note one minute, a patient handout the next), and the polish step picks up the new instructions on your next dictation.
+Because the polish adapts per dictation, you can switch from a chart note one minute to a patient handout the next, and the output shape follows what you said each time.
 
 ## Compared to enterprise medical dictation
 
@@ -125,7 +125,7 @@ EnviousWispr is free to download. The source is available on GitHub under BSL 1.
 4. Pick a hotkey that doesn't collide with your EMR shortcuts. Hold to record, release to transcribe.
 5. Open your EMR, click into a chart field, hold the hotkey, and speak your first note. The polish step cleans it up and the text lands in the field.
 
-If you want consistent SOAP structure or referral-letter formatting, write a Custom prompt for that workflow in Settings under AI Polish. The prompt sticks until you change it.
+If you want SOAP structure or a referral-letter shape, just speak it that way (name the sections out loud) and the polish organizes around those cues. No setup required.
 
 ## Related Posts
 

--- a/website/src/content/blog/dictation-for-writers-skip-blank-page.md
+++ b/website/src/content/blog/dictation-for-writers-skip-blank-page.md
@@ -44,7 +44,7 @@ After EnviousWispr transcribes your speech, it runs the text through a local LLM
 
 That processing can run fully on-device with Apple Intelligence or Ollama, without sending your words anywhere.
 
-For writers who want explicit control over the output, the Custom prompt option lets you write your own post-processing instructions: "format as screenplay-style dialogue," "keep this as stream of consciousness with line breaks," "preserve em-dashes and parentheticals," or anything else you need. Set your custom system prompt in Settings under AI Polish, and the polish step uses it for every dictation until you change it.
+For writers who want their voice preserved, the polish is built to edit, not reword. It keeps your meaning, tone, and phrasing intact, so your em dashes, your parentheticals, and your intentional fragments survive the cleanup. Keep a passage as loose stream of consciousness and the polish leaves your flow alone; the output always sounds like you, not a template.
 
 For a step-by-step look at how this works in a real writing session, see [Voice to Prose: A Realistic Writing Workflow](/blog/voice-to-prose-writing-workflow/).
 
@@ -119,7 +119,7 @@ You can read more about [how the pipeline works](/how-it-works/), from microphon
 
 EnviousWispr is free. You don't need an account, a subscription, or an API key.
 
-[Download EnviousWispr free](/#download) or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases). Install it, grant microphone and accessibility permissions, and you're dictating within a few minutes. The speech model downloads automatically. Try dictating your next first draft instead of typing it, and write a Custom prompt later if you want output shaped to your specific style.
+[Download EnviousWispr free](/#download) or grab the latest release from [GitHub](https://github.com/saurabhav88/EnviousWispr/releases). Install it, grant microphone and accessibility permissions, and you're dictating within a few minutes. The speech model downloads automatically. Try dictating your next first draft instead of typing it, and let the polish keep it in your voice.
 
 The blank page problem doesn't go away. But when you can speak your way past it, it stops being the thing that kills your morning.
 

--- a/website/src/content/blog/dictation-parents-type-one-handed.md
+++ b/website/src/content/blog/dictation-parents-type-one-handed.md
@@ -75,7 +75,7 @@ Standing in the kitchen, checking what's left in the fridge: "We need milk, eggs
 
 ### Work messages during nap time
 
-The baby just fell asleep on you on the couch, Mac Mini running quietly in the corner hooked up to the TV. You can't move without waking them, but you need to reply to a few Slack messages. Push-to-talk at a low volume, and EnviousWispr handles the rest. The on-device polish step cleans up your dictation, and a Custom prompt lets you lock in a specific tone if you need one.
+The baby just fell asleep on you on the couch, Mac Mini running quietly in the corner hooked up to the TV. You can't move without waking them, but you need to reply to a few Slack messages. Push-to-talk at a low volume, and EnviousWispr handles the rest. The on-device polish step cleans up your dictation, keeping your voice while fixing the filler and punctuation.
 
 ### Capturing ideas before they vanish
 

--- a/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
+++ b/website/src/content/blog/dictation-remote-workers-tired-of-typing.md
@@ -74,13 +74,13 @@ These are repetitive and formulaic, perfect for dictation. You know what you wor
 
 EnviousWispr's polish step cleans up your dictation by stripping filler words, fixing punctuation, and tightening structure without flattening your voice. The default is calibrated to handle most remote-work writing well, so the same workflow handles a Slack reply, a ticket comment, and a status update.
 
-When you need a specific shape (a more structured client email, a formatted standup, a postmortem timeline), the Custom prompt option lets you write your own polish instructions and reuse them across dictations:
+When you need a specific shape (a more structured client email, a formatted standup, a postmortem timeline), the way you talk sets it. With Ollama, OpenAI, or Gemini polish on, it formats what you said; on the Apple Intelligence default, you get the same content as clean prose:
 
-- "Casual and concise. Strip filler but don't over-formalize." Useful for Slack and team threads.
-- "Polished tone, proper grammar, structured paragraphs." Useful for client-facing email and docs.
-- "Output as a bulleted list grouped by project." Useful for daily standups.
+- A quick, casual aside for Slack and team threads stays concise, filler stripped but not over-formalized.
+- A longer, deliberate message for client-facing email and docs comes back polished, with proper grammar and structured paragraphs.
+- Run through your projects one by one for a daily standup and it lands as a grouped, bulleted list.
 
-The Custom prompt sticks until you change it, so once you've dialled in a shape that fits your team, you can leave it in place and dictate against it for as long as you need.
+There's nothing to dial in. The output follows the shape of what you said, every dictation.
 
 ## The Ergonomic Case for Mixing Voice and Keyboard
 

--- a/website/src/content/blog/essay-outline-by-talking-it-out.md
+++ b/website/src/content/blog/essay-outline-by-talking-it-out.md
@@ -23,15 +23,15 @@ Speaking changes the dynamic. You're not editing as you go; you're just thinking
 
 There's a practical speed advantage too. Most people speak at 130-150 words per minute but type at 40-60. For the brainstorming phase of an outline, where volume of ideas matters more than polish, voice wins by a wide margin.
 
-## The setup: a Custom prompt, then start talking
+## The setup: just start talking
 
-Here's how EnviousWispr fits in. Instead of dictating raw text and then manually reorganizing it, the LLM post-processor cleans up your spoken thoughts into structured prose. For academic work, set a Custom prompt that tightens sentence structure and produces clean, organized output from your rambling.
+Here's how EnviousWispr fits in. Instead of dictating raw text and then manually reorganizing it, the LLM post-processor cleans up your spoken thoughts into clean prose. For academic work, the polish tightens sentence structure and produces organized output from your rambling. With Ollama, OpenAI, or Gemini polish on, talking through points in sequence lays them out as structure; on the Apple Intelligence default, the same points come back as clean prose you can shape into an outline.
 
 Hold the hotkey, talk through your argument, and release. EnviousWispr transcribes your speech locally, runs it through the LLM post-processor, and delivers cleaned-up text. The whole thing takes a few seconds on any M-series chip.
 
 The default polish already produces clean prose that's easy to reorganize into an outline. The key insight is that speaking your argument out loud forces you to linearize it, and the structure emerges from how you naturally explain things.
 
-A Custom prompt takes this further. You can write specific instructions like "organize my thoughts into an essay outline with a thesis and three supporting points, Roman numeral formatting." That turns a one-minute ramble directly into a formatted outline without any manual reorganizing.
+Speaking with structure takes this further. When you signal your points out loud ("my main argument is," "first," "second," "third") and have Ollama, OpenAI, or Gemini polish on, the polish picks up those cues and organizes around them, turning a one-minute ramble directly into a structured set of points without any manual reorganizing.
 
 ## Walking through a real example
 
@@ -39,7 +39,7 @@ Let's say you're writing a paper on why public libraries remain relevant in the 
 
 > "Okay so I think my main argument is that public libraries are still important even though everything is online now. First because they provide free internet access to people who can't afford it at home, which is a huge equity issue. Second, they're community spaces, like, people go there for job help, ESL classes, after-school programs, stuff that has nothing to do with books. And third, they curate information in a way that algorithms don't. Librarians help people find trustworthy sources instead of just whatever shows up first on Google."
 
-Not exactly polished academic writing. But that's the point: you're thinking, not editing. After EnviousWispr processes it with an academic Custom prompt, the LLM cleans it into structured prose. With a quick reorganization, you get something like:
+Not exactly polished academic writing. But that's the point: you're thinking, not editing. With Ollama, OpenAI, or Gemini polish on and your points laid out in sequence ("first... second... and third"), the polish organizes them into structure. With a quick reorganization, you get something like:
 
 ---
 
@@ -70,13 +70,13 @@ Once you've got the basic pattern down, there are a few ways to build on it.
 
 Your first spoken pass gives you the skeleton. But you can refine it the same way. Look at what you've got, notice a weak point, hold the hotkey again: "Actually, for section two I should focus more on the employment statistics. Libraries in low-income areas have higher job placement rates for people who use their career services." The post-processor cleans it up, and you drop it into your outline where it fits.
 
-### Match the prompt to the assignment
+### Speak the structure your assignment needs
 
-A Custom prompt lets you save specific instructions for different assignment types, like "organize as compare-and-contrast with point-by-point structure" or "structure as a five-paragraph essay with topic sentences." Build a small library of prompts for different essay formats and swap them in as your assignment changes.
+Say the shape you're after as you dictate. Walk through a compare-and-contrast point by point, or talk through a five-paragraph essay topic sentence by topic sentence, and the polish follows the structure you narrate. Different assignment, different way of talking through it; no setup to swap.
 
-### Brainstorm with the default, structure with a Custom prompt
+### Brainstorm loose, then talk it into shape
 
-If you're dictating rough notes one minute and drafting polished outline text the next, the default polish handles the brainstorm well, keeping your natural phrasing intact so you can find your argument before you formalize it. When you're ready to structure the outline, swap in your academic Custom prompt and the next dictation comes back organized.
+If you're dictating rough notes one minute and drafting polished outline text the next, the polish handles the brainstorm well, keeping your natural phrasing intact so you can find your argument before you formalize it. When you're ready to structure the outline, talk through it in ordered points; with Ollama, OpenAI, or Gemini polish on, the next dictation comes back organized.
 
 ## Why this works for students specifically
 
@@ -92,7 +92,7 @@ A few things make this approach a good fit for the student workflow.
 
 ## Get started
 
-If you've got a paper due and the outline isn't cooperating, try talking it out. [Get EnviousWispr free](/#download), or download it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Set a Custom prompt for academic structure, and spend one minute speaking your argument out loud.
+If you've got a paper due and the outline isn't cooperating, try talking it out. [Get EnviousWispr free](/#download), or download it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). Spend one minute speaking your argument out loud, in ordered points, and let the polish structure it.
 
 ## Related Posts
 

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -87,11 +87,11 @@ EnviousWispr downloads its speech recognition model automatically on first launc
 
 ### AI polish
 
-EnviousWispr's polish step removes filler words, fixes punctuation, and tightens structure without flattening your voice. The default works well for most writing. When you need a specific shape (a more polished tone, a particular format, your personal style rules), a Custom prompt lets you write your own polish instructions and reuse them.
+EnviousWispr's polish step removes filler words, fixes punctuation, and keeps your voice. It works well across most writing: a short aside stays a clean line, while a longer piece comes back as clean, readable prose.
 
-### Custom prompts
+### Structure follows your voice
 
-Custom prompts let you tell the post-processor exactly how to handle your speech: "format as bullet points," "translate to Spanish," "write in my style: short sentences, no semicolons." Set your own system prompt in Settings under AI Polish, and the polish step uses it for every dictation until you change it.
+You shape the output by how you talk. Speak a quick one-liner and it stays one line. With Ollama, OpenAI, or Gemini polish on, rattle off a list ("first... then... finally") and it comes back as bullet points; on the Apple Intelligence default, you get the same items as clean prose. There's nothing to configure either way.
 
 ### Custom word dictionary
 

--- a/website/src/content/blog/mac-dictation-for-content-creators-the-complete-guide.md
+++ b/website/src/content/blog/mac-dictation-for-content-creators-the-complete-guide.md
@@ -11,7 +11,7 @@ faqs:
   - question: "How do podcasters use dictation in their workflow?"
     answer: "Three places. First, dictating episode outlines and scripts before recording, which is faster than typing a script. Second, post-record, dictating show notes into structured prose without re-listening to the whole episode. Third, repurposing the episode transcript into blog posts by dictating the connective tissue between transcript pull quotes."
   - question: "Does the AI polish flatten my writing voice?"
-    answer: "It can if you use a generic polish prompt. A 'fix grammar, preserve voice' prompt keeps your phrasing intact and only cleans up filler words and punctuation. Tools that let you configure the polish behavior (including EnviousWispr) are worth the setup time for content work."
+    answer: "It can if the tool's polish rewrites instead of edits. EnviousWispr's polish is built to preserve your voice: it keeps your phrasing and tone intact and only cleans up filler words and punctuation, so a dictated draft still sounds like you. That makes it a good fit for content work."
   - question: "Can I dictate fiction?"
     answer: "Yes. Many novelists use dictation for first drafts because it forces forward motion. The polish step is more aggressive in fiction since dictated fiction often needs heavier sentence restructuring than dictated email. Plan for a longer editing pass."
 ---
@@ -22,9 +22,9 @@ This guide is the hub for content-creation workflows on macOS. It covers writers
 
 ## Why dictation is different for creators
 
-For productivity workers, dictation is about speed. For creators, it is about speed AND voice. Dictation captures the way you actually talk, which is usually closer to your real writing voice than the over-cautious version that comes out of your keyboard. The risk is that you sacrifice that voice if you use a generic AI polish prompt that flattens everything to "professional business prose."
+For productivity workers, dictation is about speed. For creators, it is about speed AND voice. Dictation captures the way you actually talk, which is usually closer to your real writing voice than the over-cautious version that comes out of your keyboard. The risk is that you sacrifice that voice if your tool's polish rewrites everything into "professional business prose" instead of preserving how you actually talk.
 
-The trick is to pick a tool that lets you configure the polish behavior. The polish should fix grammar, remove filler words, and keep the rhythm of how you actually talk. That is what makes a 1,500-word dictated essay feel like your essay instead of a press release.
+The trick is to pick a tool whose polish preserves your voice. The polish should fix grammar, remove filler words, and keep the rhythm of how you actually talk. That is what makes a 1,500-word dictated essay feel like your essay instead of a press release.
 
 ## The five creator surfaces where dictation pays back fastest
 
@@ -36,7 +36,7 @@ Read the workflow: [Mac dictation for writers: skip the blank page](/blog/dictat
 
 ### 2. First drafts that sound like you
 
-The follow-up to the blank-page problem: how do you keep your dictated draft from sounding like a corporate memo? The answer is in the polish prompt and the discipline of the human pass at the end.
+The follow-up to the blank-page problem: how do you keep your dictated draft from sounding like a corporate memo? The answer is a polish built to preserve your voice, plus the discipline of the human pass at the end.
 
 Read the workflow: [Dictate first drafts that sound like you](/blog/dictate-first-drafts-sound-like-you/).
 
@@ -67,7 +67,7 @@ Read the workflow for lecture notes: [Take lecture notes by speaking on Mac](/bl
 The basics are the same as any dictation setup: Apple Silicon Mac, macOS 14 or later, an on-device dictation tool. The differences for creators are in the polish configuration and the microphone.
 
 1. **Use a real microphone, not your laptop's built-in.** A $60 USB condenser microphone is enough. The transcription accuracy difference between a laptop mic and a dedicated mic is substantial for long-form work.
-2. **Configure the polish prompt to preserve voice.** "Fix grammar and punctuation. Remove filler words. Keep the original phrasing and rhythm." Avoid prompts that say "make it sound professional" or "make it concise" unless you actually want that.
+2. **Use a polish that preserves voice.** EnviousWispr's polish is built to fix grammar and punctuation and remove filler while keeping your original phrasing and rhythm, rather than rewriting your draft into generic "professional" prose.
 3. **Use push-to-talk for thinking-out-loud work.** You will pause mid-sentence. Push-to-talk handles that gracefully. Hands-free mode tends to transcribe your thinking pauses as garbled text.
 4. **Build in a 10-minute human pass at the end.** This is non-negotiable for published work. Dictated copy needs one editorial pass before it ships, even with good polish. The 10 minutes you spend editing are still less than the time you would have spent typing.
 

--- a/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
+++ b/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
@@ -72,7 +72,7 @@ The minimum kit is a recent Apple Silicon Mac (M1 or newer), macOS 14 Sonoma or 
 
 **"Dictation feels weird in an open office."**  True. Use a headset. Or wait until you are alone for the long-form stuff and type the short replies. Most people do not dictate in front of others; they batch the dictation for solo focus blocks.
 
-**"My text sounds nothing like me when dictated."**  Try a "preserve voice" polish prompt instead of a "clean up grammar" one. The polish layer can either flatten your voice or keep it; the choice is configurable in most tools, including ours.
+**"My text sounds nothing like me when dictated."**  That's a sign the tool's polish is rewriting instead of editing. EnviousWispr's polish is built to preserve your voice: it keeps your phrasing and rhythm and only cleans up filler and punctuation.
 
 **"I make weird mistakes that auto-correct does not catch."**  Mostly homophones. Read the polished text once before sending. That 10-second pass catches the rare miss and is still 70% faster than typing.
 

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -79,7 +79,7 @@ Apple's built-in dictation has improved significantly. On Apple Silicon Macs run
 Where it falls short:
 
 - **No post-processing.** What you say is what you get, filler words and all.
-- **Limited customization.** No custom prompts, no way to adjust output formatting.
+- **No smart formatting.** A quick note and a long, structured rundown come out shaped exactly the same; no adapting to what you said.
 - **No hands-free mode.** You need to trigger it each time.
 - **No custom word dictionary.** No way to teach it your terminology.
 
@@ -113,7 +113,7 @@ EnviousWispr differs on three axes:
 | On-device transcription | Yes | Partial | No | No |
 | Post-processing | On-device or cloud (your choice) | None | Cloud | Cloud |
 | Hands-free mode | Yes (double-press lock) | No | Varies | No |
-| Custom prompts | Yes | No | Varies | Yes |
+| Adaptive formatting | Yes (Ollama, OpenAI, or Gemini polish) | No | Varies | Varies |
 | Custom word dictionary | Yes | No | No | No |
 | Internet required | No | No | Yes | Yes |
 | Cost | Free | Free | Subscription | Subscription |
@@ -147,9 +147,9 @@ EnviousWispr downloads its speech recognition model automatically on first launc
 
 If you want to avoid holding keys, just double-press your hotkey to lock recording. No settings change needed. Speak naturally, then press once to finish or triple-press to cancel.
 
-### Tune the Polish Step
+### Let the Polish Adapt
 
-EnviousWispr's polish step cleans up your dictation by default, removing filler words and fixing punctuation without flattening your voice. When you need a specific shape (a particular tone, format, or convention), a Custom prompt lets you write your own polish instructions and reuse them across dictations.
+EnviousWispr's polish step cleans up your dictation by default, removing filler words and fixing punctuation without flattening your voice. A quick aside stays a clean line. With Ollama, OpenAI, or Gemini polish on, a longer piece with list cues comes back structured with paragraphs and bullets; on the Apple Intelligence default, the same content stays clean prose.
 
 ## A Tool That Works When You Need It
 

--- a/website/src/content/blog/meeting-notes-polished-summaries.md
+++ b/website/src/content/blog/meeting-notes-polished-summaries.md
@@ -26,23 +26,21 @@ But the real leverage comes from what happens next.
 
 ## How do you turn dictated meeting notes into a structured summary?
 
-A structured meeting summary on Mac comes from two steps: dictate a 30-second voice dump while context is fresh, then let an LLM polish step shape that audio into bullet sections. EnviousWispr handles both. Hold a hotkey, talk through what happened (decisions, owners, deadlines, open questions), and release. On-device speech recognition transcribes the audio in a second or two on Apple Silicon.
+A structured meeting summary on Mac comes from two steps: dictate a 30-second voice dump while context is fresh, then let an LLM polish step clean it up. EnviousWispr handles both, and with Ollama, OpenAI, or Gemini polish on it also lays the result out into sections and bullets. Hold a hotkey, talk through what happened (decisions, owners, deadlines, open questions), and release. On-device speech recognition transcribes the audio in a second or two on Apple Silicon.
 
-The polish step turns that raw text into a usable summary. The default polish removes filler and fixes punctuation, which already produces something cleaner than most people type. For a tighter shape, set a Custom prompt like "format as a meeting summary with attendees, key decisions, action items with owners and due dates, and open questions." The polish step uses that instruction on every dictation until you change it. Save different prompts for board updates, Slack recaps, or email follow-ups.
+The polish step turns that raw text into a usable summary. It removes filler and fixes punctuation, which already produces something cleaner than most people type. With Ollama, OpenAI, or Gemini polish turned on, a longer debrief with decisions and action items gets laid out with sections and bullet points automatically; on the Apple Intelligence default, you get the same content as clean, readable prose. Either way, the way you speak guides the shape.
 
-Out of the box, EnviousWispr cleans up filler words, fixes punctuation, and tightens structure. That alone transforms your dictation. But for meeting notes, the real unlock is structure.
+Out of the box, EnviousWispr cleans up filler words, fixes punctuation, and keeps your voice. That alone transforms your dictation. But for meeting notes, the real unlock is structure.
 
-A Custom prompt lets you tell the post-processor exactly how to format your output. For meeting summaries, a prompt like this works well:
+You steer that structure with your words, not a settings panel. Name the parts as you talk: say "the decisions were," "action items," "open questions." With Ollama, OpenAI, or Gemini polish on, the summary organizes around those cues; on the Apple Intelligence default, the same points come back as clean prose in the order you said them. Either way, you walk through what happened and let the structure fall out of how you narrate it.
 
-**"Format as a meeting summary. Include: attendees mentioned, key decisions, action items with owners and due dates, and open questions. Use bullet points. Keep it concise."**
-
-Even today, the LLM post-processing step does a remarkable job of structuring your raw dictation. Here's what the transformation looks like:
+The LLM post-processing step does a remarkable job of this. Here's what the formatted output looks like (with Ollama, OpenAI, or Gemini polish):
 
 ### Before: raw dictation
 
 > Met with product and sales about the Q3 launch timeline. Sarah confirmed the beta ships May 15. Mark owns the partner outreach deck, due by Friday. We agreed to cut the enterprise tier from the initial launch, revisit in Q4. I need to send the updated roadmap to the board by Thursday. Oh, and we still need to figure out the pricing page copy, nobody owns that yet.
 
-### After: LLM-processed summary
+### After: formatted summary (Ollama, OpenAI, or Gemini)
 
 > **Meeting Summary: Q3 Launch Timeline**
 >
@@ -73,7 +71,7 @@ For an exec who regularly discusses confidential business matters, this isn't a 
 
 Not every meeting summary goes to the same place. A quick standup recap might go straight into Slack. A board prep summary might go into Notion or a Google Doc. A one-on-one follow-up might become an email.
 
-For each destination, a Custom prompt tuned to that surface produces the right shape. Save a "board summary" prompt, a "Slack recap" prompt, an "email follow-up" prompt; swap them in as the destination changes and the polish step picks up the new instructions on your next dictation.
+The polish matches what you said. A two-sentence Slack recap stays tight and conversational. With Ollama, OpenAI, or Gemini polish on, a long board debrief comes back sectioned and bulleted; on the Apple Intelligence default, the same debrief lands as clean prose. You get the right shape by speaking it that way, not by switching a setting between dictations.
 
 ## Making it part of your routine
 
@@ -83,12 +81,12 @@ A few tips for getting started:
 
 - **Start with high-stakes meetings.** Board reviews, strategy sessions, client calls, wherever the cost of lost context is highest.
 - **Keep your dictation loose.** Don't try to speak in polished sentences. The LLM handles cleanup. Just get the facts out.
-- **Save a Custom prompt per destination.** Board summaries want structured prose; Slack recaps want bullet points; email follow-ups want a short paragraph plus action items. Build the prompts once and reuse them.
+- **Let your words set the shape.** Say the structure out loud ("key decisions," "action items," "open questions"). With Ollama, OpenAI, or Gemini polish on, the summary comes back organized around those cues; on the Apple Intelligence default, it stays clean prose in the order you spoke.
 - **Use hands-free mode for longer debriefs.** If you need to talk through a complex meeting for two or three minutes, double-press your hotkey to lock recording so you don't have to hold a key the entire time.
 
 ## Get started
 
-[Download EnviousWispr free](/#download), or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). It's free; install it and start dictating. No registration, no payment. The speech model downloads automatically on first launch. Try the default polish first, and write a Custom prompt if you want output shaped to your specific workflow.
+[Download EnviousWispr free](/#download), or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases). It's free; install it and start dictating. No registration, no payment. The speech model downloads automatically on first launch. Leave AI polish on and let it shape your dictation automatically.
 
 ## Related Posts
 

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -93,7 +93,7 @@ For many people, especially those dictating work-related content on a Mac, on-de
 
 EnviousWispr is an on-device dictation app for macOS. It ships with two transcription backends: Parakeet for fast English dictation and WhisperKit for multi-language support. Both run natively via Core ML on Apple Silicon. Your audio is recorded, transcribed, and post-processed locally. Recordings never leave your Mac.
 
-Here's what the workflow looks like: hold a hotkey, speak, release. A second or two later, polished text lands on your clipboard or pastes directly into the app you're using. Post-processing (punctuation cleanup, filler word removal, tone adjustment) runs through your choice of AI provider: Apple Intelligence and Ollama for fully on-device, or OpenAI and Gemini if you prefer cloud. A Custom prompt lets you shape the output for different contexts; the polish step uses your prompt for every dictation until you change it.
+Here's what the workflow looks like: hold a hotkey, speak, release. A second or two later, polished text lands on your clipboard or pastes directly into the app you're using. Post-processing (punctuation cleanup, filler word removal, light formatting) runs through your choice of AI provider: Apple Intelligence and Ollama for fully on-device, or OpenAI and Gemini if you prefer cloud. The polish shapes the output to match what you said, adapting per dictation with nothing to configure.
 
 Here's what that looks like in practice:
 

--- a/website/src/content/blog/podcast-show-notes-to-blog-posts.md
+++ b/website/src/content/blog/podcast-show-notes-to-blog-posts.md
@@ -40,11 +40,11 @@ You can dictate show notes in the same conversational tone your audience already
 
 ## Post-Processing That Shapes Your Output
 
-This is where things get genuinely useful for podcast show notes blog posts. EnviousWispr's [post-processing pipeline](/how-it-works/) cleans up your dictation and formats it into polished text. The default polish keeps things conversational and scannable, which is what you want for show notes. For a more structured blog version, a Custom prompt produces tighter prose with proper paragraphs.
+This is where things get genuinely useful for podcast show notes blog posts. EnviousWispr's [post-processing pipeline](/how-it-works/) cleans up your dictation and formats it into polished text. The polish keeps things conversational and scannable, which is what you want for show notes. When you talk through a longer, structured blog version, it comes back as tighter prose with proper paragraphs.
 
-A Custom prompt lets you write your own processing instructions: tell the pipeline to format output as bullet-point show notes with a summary paragraph, or to expand dictation into a full 800-1200 word blog post with H2 headings. Save one prompt per output format and swap them between dictations. That makes it fast to repurpose podcast content into different written formats from the same dictation.
+You shape that by how you speak, and Ollama, OpenAI, or Gemini polish turns it into format: run through your show notes as a quick list and they land as bullet points with a summary. On the Apple Intelligence default, you get the same content as clean prose. For a blog version, speak the post in full (a longer take, in your own words); the polish cleans up what you said, but it never pads a short recap out into a long post, so say the post you want.
 
-Here's what this looks like end to end, dictating a recap right after recording:
+Here's what this looks like end to end, dictating a recap right after recording (with Ollama, OpenAI, or Gemini polish, which adds the bullets and labels; the Apple Intelligence default keeps it as clean prose):
 
 **What you say:**
 > okay so in this episode we talked to Sarah Chen about building a podcast audience from scratch um she said the biggest mistake new podcasters make is focusing on downloads instead of engagement and she recommended starting with a weekly newsletter to build a direct relationship with listeners we also covered her strategy for getting guests when you're a small show which is basically lead with what you can offer them not what they can offer you and then at the end she shared her tech stack which is Riverside for recording Descript for editing and Kit for the newsletter
@@ -90,7 +90,7 @@ Here's what a podcast-to-blog workflow looks like end to end:
 2. **Dictate show notes** immediately after recording. Hold the hotkey, speak a 2-3 minute recap of the episode, release.
 3. **Post-processing cleans and formats** the output as structured show notes (summary, key topics, resources)
 4. **Paste into your podcast host.** The text is already on your clipboard or pasted directly into the focused app.
-5. **Dictate again for the blog version.** Speak the same recap, swap in your "blog post" Custom prompt, and let the post-processing reformat it as a full blog post.
+5. **Dictate the blog version separately.** Speak the full post in your own words (a longer take), and the polish cleans it up the same way. It won't expand the recap for you, so say the post you want.
 6. **Light editing pass.** Clean up any details the LLM missed, add your episode embed link, publish.
 
 Total time for both show notes and a blog post: 10-15 minutes instead of an hour-plus of typing. You stay in your natural spoken medium the entire time.
@@ -99,7 +99,7 @@ Total time for both show notes and a blog post: 10-15 minutes instead of an hour
 
 Podcasters produce enormous amounts of spoken content that rarely gets repurposed. The friction isn't creative; you already have the ideas and the words. The friction is the format conversion: turning spoken thoughts into written text.
 
-Dictation with on-device post-processing removes that friction. You speak your show notes and blog posts the same way you speak your episodes. The default polish handles tone and cleanup; Custom prompts handle fine-grained formatting. Everything stays local on your Mac.
+Dictation with on-device post-processing removes that friction. You speak your show notes and blog posts the same way you speak your episodes. The polish handles tone and cleanup, and shapes the output to match how you talked through it. With on-device polish, everything stays local on your Mac.
 
 ## Related Posts
 
@@ -107,6 +107,6 @@ Dictation with on-device post-processing removes that friction. You speak your s
 - [Getting Started with EnviousWispr in Under 2 Minutes](/blog/getting-started-enviouswispr-under-2-minutes/). From download to first dictation.
 - [On-device vs. cloud dictation: what's private](/blog/on-device-vs-cloud-dictation-privacy/). Why on-device matters for pre-release and embargoed podcast content.
 
-[Download EnviousWispr free](https://enviouswispr.com/#download). No account, no subscription, no API key required. The speech model downloads automatically on first launch. Try the default polish, or write a Custom prompt for show-note formatting, and start turning episodes into written content the same day. The source is [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases) if you want to inspect it first.
+[Download EnviousWispr free](https://enviouswispr.com/#download). No account, no subscription, no API key required. The speech model downloads automatically on first launch. Leave the polish on, talk through your show notes, and start turning episodes into written content the same day. The source is [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases) if you want to inspect it first.
 
 *Comparing tools for episode-to-text workflows? See [vs MacWhisper](/compare/macwhisper/), [vs Otter.ai](/compare/otter-ai/), or [browse all comparisons](/compare/).*

--- a/website/src/content/blog/switched-typing-to-dictating-git-commits.md
+++ b/website/src/content/blog/switched-typing-to-dictating-git-commits.md
@@ -1,6 +1,6 @@
 ---
 title: "Dictating Git Commits on macOS: Better Messages, Less Typing"
-description: "Dictating git commits produces better messages than typing. Here's how on-device polish and Custom prompts make voice commit messages practical."
+description: "Dictating git commits produces better messages than typing. Here's how on-device polish turns spoken explanations into clean, readable commit bodies."
 pubDate: 2026-03-16
 updatedDate: 2026-04-04
 tags: ["developer", "git", "workflow", "dictation"]
@@ -47,33 +47,27 @@ For commit messages, something stripped down works best: terse, technical, no fl
 
 EnviousWispr's default polish already keeps output direct and technical without over-formalizing. No "So basically what I did was..." making it into a commit message. For terminal work, that's usually enough.
 
-When you want exact formatting (conventional commits, specific scope tags, mandatory body structure), a Custom prompt locks it in. Write something like "output as a conventional commit with type, scope, and body" and the polish step uses it for every dictation until you change it.
+For conventional commits, type the short prefix yourself, `feat(auth):` is a couple of seconds, and dictate the part that's actually tedious: the body that explains the why. The polish cleans your spoken explanation; it does not invent structure, so the prefix you want is the prefix you type.
 
 ## How the post-processor shapes commit messages
 
-This is where it gets good. EnviousWispr's LLM post-processing step cleans up your spoken words into properly structured text. The default polish strips filler, fixes punctuation, and keeps output direct, which already gets you most of the way to a good commit message.
+This is where it gets good. EnviousWispr's LLM post-processing step cleans up your spoken words into clean, direct text. The polish strips filler, fixes punctuation, and keeps output direct, which already gets you most of the way to a good commit message.
 
-With a Custom prompt, you can go even further: define exact formatting rules like "output as a conventional commit with type, scope, and body." You tell the post-processor precisely how to structure your commits, changelogs, or any other output format.
+The trick is to split the work: type the one-line subject (your `type(scope):` prefix and a short summary), then dictate the body, the part that explains the why. The polish cleans that spoken explanation into a tight paragraph. Here's a dictated body before and after the polish:
 
-The results are surprisingly good. Hold the hotkey and say:
+*You type the subject:* `feat(auth): add rate limiting to login endpoint`
 
-*"feat auth, add rate limiting to the login endpoint because we were getting hammered by credential stuffing bots. It uses a sliding window counter in Redis with a default of five attempts per minute per IP."*
+*You dictate the body:* "so we were getting hammered by credential stuffing bots, um, so I added a sliding window counter in Redis with a default of five attempts per minute per IP"
 
-The post-processor outputs:
+*The polish cleans it to:*
 
-```
-feat(auth): add rate limiting to login endpoint
+> Credential stuffing bots were hammering the login endpoint. Added a sliding window counter in Redis with a default of five attempts per minute per IP.
 
-Credential stuffing bots were hammering the login endpoint. Added
-sliding window counter in Redis with a default of five attempts per
-minute per IP.
-```
-
-That's a commit message worth finding in a git log six months from now. And it takes about ten seconds to produce, including the hotkey hold.
+That's a commit message worth finding in a git log six months from now, and the explanatory part took about ten seconds to say instead of a minute to type.
 
 ## Before and after: typed vs. dictated commits
 
-Here's what the difference looks like in practice. These are typical before-and-after examples comparing the typed approach to the dictated approach.
+Here's the difference in practice. In each pair, the terse version is what you'd type in a hurry; the richer version is the commit you end up with when you type the subject and dictate the body, with the polish cleaning it up.
 
 **Typed:** `fix tests`
 **Dictated:**
@@ -116,7 +110,7 @@ A few things worth knowing when using developer dictation daily.
 
 **You'll feel weird at first.** Talking to your Mac in an open office is awkward. Starting at home helps, and most teams wear headphones anyway. If self-consciousness is a concern, start with commit messages: they're short, private, and the improvement is immediately visible in your git log.
 
-**A Custom prompt for commits is worth setting once.** A "conventional commit" prompt produces consistent, well-structured messages across every dictation in your terminal. Set it once and forget it.
+**Type the prefix, dictate the body.** The `feat(auth):` part is a couple of keystrokes; the body, the part that explains the why, is what dictation makes easy. Speak it, and the polish cleans it up.
 
 **It helps with RSI.** After eight-plus hours of typing every day, being able to offload even a portion of that to voice makes a noticeable difference in wrist strain by end of day. If RSI is your primary motivation, there's a dedicated guide on [voice input for RSI](/blog/voice-input-rsi-keyboard-free-workflow/).
 
@@ -126,10 +120,10 @@ If you want to try dictating git commits, here's the minimal setup.
 
 1. [Download EnviousWispr free](/#download) or grab it directly from the [releases page](https://github.com/saurabhav88/EnviousWispr/releases) and grant it microphone and accessibility permissions on first launch
 2. The speech model downloads automatically on first launch. No model selection needed.
-3. Leave polish on the default for direct, technical output, or set a "conventional commit" Custom prompt for stricter formatting.
+3. Leave AI polish on for direct, technical output; type your `type(scope):` prefix and dictate the body.
 4. Open your terminal, hold the hotkey, describe your change, release
 
-That's the whole workflow. Hold, speak, release. Your commit message lands formatted and ready to go. EnviousWispr is [free](https://github.com/saurabhav88/EnviousWispr): no account, no API key, no subscription.
+That's the whole workflow. Type the subject, hold the hotkey, speak the body, release. The cleaned-up body lands ready to paste under your subject line. EnviousWispr is [free](https://github.com/saurabhav88/EnviousWispr): no account, no API key, no subscription.
 
 ## Related Posts
 

--- a/website/src/content/blog/take-lecture-notes-by-speaking.md
+++ b/website/src/content/blog/take-lecture-notes-by-speaking.md
@@ -33,9 +33,9 @@ Hands-free mode detects natural pauses in your speech, so each thought gets proc
 
 Raw transcription is useful, but the real power for students is in post-processing. EnviousWispr runs your transcribed text through an LLM that cleans it up, removing filler words like "um" and "uh," fixing punctuation, and producing polished output. Post-processing can run on-device (Apple Intelligence, Ollama) or via cloud providers (OpenAI, Gemini).
 
-The default polish works well for lecture notes: it cleans up your speech into clear, well-punctuated prose without making it overly stiff.
+The polish works well for lecture notes: it cleans up your speech into clear, well-punctuated prose without making it overly stiff.
 
-When you want more structure, a Custom prompt lets you tell the post-processor exactly how to shape the output: format as bullet points, bold key terms, organize by topic. You can tailor your prompt per class: chronological formatting for history, emphasis on formulas for science. Save one prompt per subject and swap them in as the lecture changes.
+When you want more structure, the way you talk shapes the output. With Ollama, OpenAI, or Gemini polish on, call out a list and it comes back as bullet points; on the Apple Intelligence default, your points stay as clean prose in the order you said them. Either way, history notes you narrate chronologically stay chronological, and science notes where you spell out each formula keep that emphasis.
 
 ## Step 4: Position your microphone and speak naturally
 
@@ -89,7 +89,7 @@ If you're ready to try voice notes for students, the setup takes less than five 
 1. [Download EnviousWispr free](/#download) or grab it from the [GitHub releases page](https://github.com/saurabhav88/EnviousWispr/releases)
 2. Grant microphone access on first launch (the speech model downloads automatically)
 3. Double-press your hotkey to activate hands-free mode
-5. Leave polish on the default, or write a Custom prompt for your subject
+5. Leave AI polish on and let it shape your notes as you speak
 6. Start your next lecture
 
 ## Related Posts

--- a/website/src/content/blog/voice-coding-macos-without-cloud.md
+++ b/website/src/content/blog/voice-coding-macos-without-cloud.md
@@ -31,7 +31,7 @@ EnviousWispr runs transcription locally using two backends: Parakeet, a streamin
 
 Here's what that means in practice: your audio goes from your microphone to a local model running on your hardware. No network request. No API call. No server. The transcription pipeline runs entirely within your Mac's process space, and the audio buffer is discarded after processing.
 
-Post-processing works similarly. After transcription, the raw text passes through an LLM that cleans up filler words, fixes punctuation, and applies whatever formatting rules you've defined. Post-processing can run on-device (Apple Intelligence, Ollama) or via cloud providers (OpenAI, Gemini), depending on your preference.
+Post-processing works similarly. After transcription, the raw text passes through an LLM that cleans up filler words, fixes punctuation, and shapes the formatting to match what you said. Post-processing can run on-device (Apple Intelligence, Ollama) or via cloud providers (OpenAI, Gemini), depending on your preference.
 
 For a deeper look at the full pipeline, from microphone input through transcription to polished output, see the [How It Works](/how-it-works/) page.
 
@@ -45,7 +45,7 @@ Getting started takes about five minutes:
 
 3. **Set your hotkey.** Pick a key combination that doesn't collide with your IDE shortcuts. Hold to record, release to transcribe; the cycle completes in a second or two.
 
-4. **Tune the polish step.** EnviousWispr's polish removes filler words, fixes punctuation, and tightens structure without flattening your voice. The default works well across most developer writing (PRs, review comments, docs, Slack). For specialized formatting, a Custom prompt lets you tell the post-processor exactly what you need: "Format as a markdown bullet list," "Write in past tense for a changelog entry," "Keep it under two sentences." The Custom prompt sticks until you change it.
+4. **Leave the polish step on.** EnviousWispr's polish removes filler words, fixes punctuation, and keeps your voice. It works well across most developer writing (PRs, review comments, docs, Slack). A one-line Slack reply stays a line; with Ollama, OpenAI, or Gemini polish on, a longer explanation with cues like "first... then... finally" comes back as a structured list, while the Apple Intelligence default keeps it as clean prose.
 
 ## Real examples: where voice dictation fits a dev workflow
 
@@ -53,19 +53,15 @@ Getting started takes about five minutes:
 
 Writing docs is one of the highest-friction tasks in software development. You know the architecture. You can explain it verbally in two minutes. But sitting down to type it out feels like a chore, so it doesn't get done. Dictation lets you capture that explanation while it's still sharp in your mind, before the details fade and the motivation disappears.
 
-With EnviousWispr, you can talk through the architecture the way you'd explain it to a new teammate, and the post-processor formats it as clean markdown. Set a Custom prompt for documentation ("output as structured markdown with proper paragraphs and code references in backticks") and you get a solid first draft by speaking naturally: proper paragraphs, clean punctuation, structured prose.
+With EnviousWispr, you can talk through the architecture the way you'd explain it to a new teammate, and the on-device post-processor cleans it into readable prose. Walk through it section by section, and you get a solid first draft by speaking naturally: clear sentences, clean punctuation, your wording preserved.
 
-Here's what that looks like in practice:
+Here's what that looks like in practice with the on-device polish:
 
 **What you say:**
 > okay so the auth service sits between the API gateway and the user database um it handles token validation and refresh and it caches active sessions in Redis so we don't hit Postgres on every request the main thing to know is that refresh tokens are rotated on use so if you see a token reuse that means something is wrong and the session gets invalidated
 
 **What gets pasted:**
-> ## Auth Service
->
-> The auth service sits between the API gateway and the user database. It handles token validation and refresh, caching active sessions in Redis to avoid hitting Postgres on every request.
->
-> **Key behavior:** Refresh tokens are rotated on use. Token reuse indicates a potential compromise, and the session is automatically invalidated.
+> The auth service sits between the API gateway and the user database. It handles token validation and refresh, caching active sessions in Redis to avoid hitting Postgres on every request. The key behavior to know: refresh tokens are rotated on use, so a token reuse indicates a potential compromise, and the session is automatically invalidated.
 
 ### PR descriptions and commit messages
 
@@ -83,7 +79,7 @@ The LLM post-processor smooths the phrasing and fixes any verbal artifacts. The 
 
 Instead of switching mental modes to write a structured bug report, just describe what happened: "When you click the export button with an empty dataset, the app throws an unhandled exception instead of showing the empty state. Expected behavior is the empty state view with a message saying no data to export. Repro steps: create a new project, don't add any data, click export."
 
-A Custom prompt for bug reports ("output as steps to reproduce, expected behavior, actual behavior") keeps the output structured, and the result arrives clean and ready to paste into your issue tracker.
+Name the parts as you talk (repro steps, expected behavior, actual behavior) and the polish keeps the output structured, so the result arrives clean and ready to paste into your issue tracker.
 
 ## Cloud vs. local: an honest comparison
 
@@ -100,7 +96,7 @@ It's worth being direct about the trade-offs.
 - **Data stays on your machine.** No audio leaves your Mac. Period. This isn't a policy; it's an architecture. There's no server to send to.
 - **No latency dependency.** Transcription speed depends on your hardware, not your internet connection. On Apple Silicon, the full pipeline runs in one to two seconds.
 - **No recurring cost.** No API usage fees, no subscription tiers, no per-minute billing. EnviousWispr is free.
-- **Customization.** Custom polish prompts and choice of LLM provider: you control the pipeline. Cloud APIs give you an endpoint and a response format.
+- **Customization.** Choice of LLM provider (on-device or cloud) and polish that adapts to how you speak: you control the pipeline. Cloud APIs give you an endpoint and a response format.
 - **Works offline.** Airplane, coffee shop with bad WiFi, or just a network outage. Local transcription doesn't care.
 
 We cover this comparison in much more depth in [On-Device vs Cloud Dictation: What Stays Private](/blog/macos-dictation-offline-private/). For developers specifically, the privacy argument usually closes the discussion. If you're dictating anywhere near proprietary code, internal discussions, or sensitive project details, sending that audio to an external API is a risk most security-conscious teams won't accept.

--- a/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
+++ b/website/src/content/blog/voice-input-rsi-keyboard-free-workflow.md
@@ -56,7 +56,7 @@ That took about ten seconds to speak. Typing it, with RSI making every keystroke
 
 One concern people have about switching to voice input is that different contexts need different kinds of text. A Slack message should sound casual. A client email needs a more structured tone.
 
-EnviousWispr's AI polish step cleans up your dictation by removing filler words, fixing punctuation, and tightening structure. The default polish handles most everyday writing well: Slack threads, internal notes, ticket comments. For contexts where you need a specific shape (more structured client emails, formatted lists, particular phrasing), the Custom prompt option lets you write your own polish instructions and reuse them across dictations.
+EnviousWispr's AI polish step cleans up your dictation by removing filler words, fixing punctuation, and tightening structure. It handles most everyday writing well: Slack threads, internal notes, ticket comments. When you need a specific shape (a more structured client email, a formatted list), Ollama, OpenAI, or Gemini polish formats what you said; the Apple Intelligence default keeps the same content as clean prose.
 
 This matters for RSI because it reduces the need to go back to the keyboard and fix tone or formatting. When voice output is already close to what you need, you're not adding correction keystrokes on top.
 

--- a/website/src/content/blog/voice-to-prose-writing-workflow.md
+++ b/website/src/content/blog/voice-to-prose-writing-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: "Voice to Prose on macOS: A Realistic Writing Workflow"
-description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, custom polish prompts, and first-draft setup tips."
+description: "Build a voice-to-prose writing workflow with on-device macOS dictation. Real examples, honest tradeoffs, voice-preserving polish, and first-draft setup tips."
 pubDate: 2026-03-24
 updatedDate: 2026-04-04
 tags: ["writing", "workflow", "dictation", "writing-style"]
@@ -17,24 +17,23 @@ Understanding what happens between your voice and the finished text helps you ge
 
 1. **Record.** Hold the hotkey, speak, release. The app captures raw audio from your microphone.
 2. **Transcribe.** Your speech is converted to text locally via Core ML, using on-device speech recognition. This is a literal transcription; every filler word, false start, and repeated phrase comes through.
-3. **Post-process.** An LLM cleans up the raw transcription. It strips filler words, fixes punctuation, corrects grammar, and tightens structure. If you want output shaped a specific way (a particular tone, format, or convention), a Custom prompt lets you tell the polish step exactly how to handle your dictation.
+3. **Post-process.** An LLM cleans up the raw transcription. It strips filler words, fixes punctuation, corrects grammar, and keeps your voice. A short aside stays a clean line; a longer piece comes back as clean, readable prose (and, with Ollama, OpenAI, or Gemini polish on, with paragraph breaks and light structure).
 
 The third step is where the writing happens. Raw transcription is messy. Post-processing is what turns "so basically what I'm trying to say is that like the pipeline has three steps and each one does a different thing" into a coherent sentence. You can read more about the technical details on the [how EnviousWispr's transcription pipeline works](/how-it-works/) page.
 
 The whole cycle takes a second or two on Apple Silicon. Fast enough that you don't lose your train of thought waiting for output.
 
-## Shaping the output with a Custom prompt
+## How the polish shapes your output
 
-The default post-processing does a solid job: it removes filler words, fixes punctuation, and produces clean sentences without flattening your voice. For most writing (blog drafts, journal entries, articles, freewriting) the default is the right starting point. The output reads like you wrote it: conversational, direct, human.
+The post-processing does a solid job: it removes filler words, fixes punctuation, and produces clean sentences without flattening your voice. For most writing (blog drafts, journal entries, articles, freewriting) the output reads like you wrote it: conversational, direct, human.
 
-When you need a specific shape, a Custom prompt is the lever. You write a single instruction once and the polish step applies it to every dictation until you change it. A few that work well for writers:
+When you need a specific shape, the way you talk is the lever. The polish reads what you said and matches it. A few patterns that work well for writers:
 
-- "Keep my natural voice and contractions intact. Don't formalize." Useful for blog drafts.
-- "Tighten sentence structure and remove casual phrasing." Useful for client deliverables and formal essays.
-- "Format as screenplay-style dialogue with character names in caps." Useful for fiction.
-- "Keep this as stream of consciousness with line breaks, do not punctuate aggressively." Useful for raw morning pages.
+- Speak loosely for blog drafts and your natural voice and contractions stay intact, not formalized.
+- Speak in fuller sentences for client deliverables and formal essays and the structure tightens.
+- Keep morning pages as stream of consciousness and the polish leaves your flow alone, just cleaning up the worst of the filler.
 
-You can change the Custom prompt as your task changes (drafting one minute, client correspondence the next), and the polish step picks up the new instructions on your next dictation.
+The output adapts as your task changes (drafting one minute, client correspondence the next), with nothing to switch between dictations.
 
 ## A realistic example: before and after
 
@@ -98,7 +97,7 @@ The best workflow uses both. Dictate the rough draft. Type the edits. That's the
 
 [Download EnviousWispr free](https://enviouswispr.com/#download), no account, no subscription required. It takes a couple of minutes to set up on any Apple Silicon Mac running macOS Sonoma or later. On first launch, grant microphone access and the speech model downloads automatically. No model selection needed. The source is also [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases).
 
-Then try this: open whatever you're working on, hold the hotkey, and talk through your next paragraph. See what comes back. Adjust your Custom prompt until the output matches how you write.
+Then try this: open whatever you're working on, hold the hotkey, and talk through your next paragraph. See what comes back. The more you speak in your natural voice, the more the output matches how you write.
 
 ## Related Posts
 

--- a/website/src/content/blog/welcome-to-enviouswispr.md
+++ b/website/src/content/blog/welcome-to-enviouswispr.md
@@ -33,7 +33,7 @@ A few things that make it worth using day-to-day:
 
 - **Hands-free mode.** Double-press your hotkey to lock recording for longer dictation sessions. Triple-press to cancel.
 - **AI polish that keeps your voice.** The default polish step removes filler words, fixes punctuation, and tightens structure without flattening your phrasing.
-- **Custom prompts.** Write your own polish instructions for any context: "format as bullet points," "translate to Spanish," "write in my style: short sentences, no semicolons." The polish step uses your prompt for every dictation until you change it.
+- **Polish that adapts to you.** No prompts to write. It cleans up filler and keeps your voice; speak a quick line and it stays a line. With Ollama, OpenAI, or Gemini polish on, rattle off a list and it comes back as bullet points, while the Apple Intelligence default keeps the same content as clean prose.
 - **Custom word dictionary.** Add names, technical terms, and jargon so the app gets your words right every time.
 
 ## Getting started

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -455,7 +455,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td><span class="table-check">Yes</span> (casual, professional, concise via LLM prompt)</td>
+            <td><span class="table-check">Yes</span> (voice-preserving AI polish that adapts to what you said)</td>
             <td><span class="table-cross">No</span></td>
           </tr>
           <tr>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -458,7 +458,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td>Clean prose style via AI polish prompt</td>
+            <td>Voice-preserving AI polish that adapts to what you said</td>
             <td><span class="table-highlight">Power Mode</span> with per-app custom prompts</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -391,7 +391,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td><span class="table-check">Yes</span> (choose from 5 AI providers, custom prompts)</td>
+            <td><span class="table-check">Yes</span> (four AI providers: Apple Intelligence, Ollama, OpenAI, Gemini; voice-preserving polish)</td>
             <td><span class="table-check">Yes</span> (style matching, AI mode)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -479,7 +479,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td>Four presets (Standard, Formal, Friendly, Custom) or write your own system prompt.</td>
+            <td>Voice-preserving AI polish across four providers (Apple Intelligence, Ollama, OpenAI, Gemini).</td>
             <td>Auto-adjusts tone per app (English, desktop only).</td>
           </tr>
           <tr>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -519,7 +519,7 @@ const jsonLdFaq = JSON.stringify({
           <div class="testimonial-stars" role="img" aria-label="5 stars">
             <span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span>
           </div>
-          <p class="testimonial-quote">"As a developer, I dictate commit messages and code comments. The formal tone option is shockingly good at technical phrasing."</p>
+          <p class="testimonial-quote">"As a developer, I dictate commit messages and code comments. It nails my technical vocabulary, and my recordings never leave my Mac."</p>
           <div class="testimonial-author">
             <div class="author-avatar av-2" aria-hidden="true">JR</div>
             <div>


### PR DESCRIPTION
## What & why

The custom-prompt polish feature was removed in #614. A full-content grep found **26 files** still teaching it as a current capability — not the five #1034 documented (that issue was filed off a partial grep during the #944 fix). The worst offenders were competitor comparison tables listing "Custom prompts: Yes" as an EnviousWispr differentiator we no longer have.

## What changed

Every reference reframed around what the polish actually does today, grounded against the prompt builders (`Sources/EnviousWisprLLM/Prompting/`, `AppleIntelligenceConnector.swift`) and the provider enum (`LLMResult.swift`):

- **Universal (every engine):** strips filler/false-starts, fixes punctuation, collapses self-corrections, preserves the speaker's voice and word order. Edits, never rewrites/expands/adds.
- **Formatting (bullets, sections):** attributed to the engines that actually do it — Ollama (local) or OpenAI/Gemini (cloud). The Apple Intelligence default is a cleaner only → returns clean prose.
- **Provider count:** corrected to four (Apple Intelligence, Ollama, OpenAI, Gemini).
- **Setup CTAs:** no longer say "turn on AI polish" (defaults on); fresh-install walkthrough notes the macOS 26+ requirement + Ollama/OpenAI/Gemini fallback.
- **Homepage testimonial:** dead "formal tone option" line replaced; privacy claim scoped to recordings (audio never leaves; cloud polish sends text).
- **git-commits & podcast-to-blog:** these two were architected around the removed feature (auto-built conventional commits / expanding a recap into a full post). The polish does neither — both reframed to the real workflow.

Left accurate competitor descriptions and the honest "does not yet offer preset writing styles" positioning intact.

## Validation

- Astro build green (52 pages).
- Codex code-diff review: **6 rounds to clean** (progressively narrower accuracy findings: provider count → which engines format → macOS availability → privacy absolute → premise rewrites → bullets-vs-numbered).

## Follow-up (not in this PR)

Pre-existing "Groq / 5 providers" claims on three compare pages (whisper-cpp, voiceink, dragon) — Groq isn't in the codebase. Separate small fix.

Closes #1034