### PR TITLE
fix(content): correct provider count to four, remove unsupported Groq claim

### DIFF
--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -458,7 +458,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish / LLM providers</td>
-            <td><span class="table-highlight">5 providers:</span> Apple Intelligence, Ollama, OpenAI, Gemini, Groq</td>
+            <td><span class="table-highlight">4 providers:</span> Apple Intelligence, Ollama, OpenAI, Gemini</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -675,7 +675,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-title">Modern AI polish, not just raw transcript</div>
         <div class="deep-dive-body">
           <p>Dragon gives you a transcript and expects you to fix it. It has no concept of LLM-based post-processing. Dragon was built in an era before large language models existed, and Nuance has not retrofitted this capability.</p>
-          <p>EnviousWispr integrates five LLM providers for Smart Polish: Apple Intelligence (fully on-device), Ollama (local models like Llama or Mistral), and cloud options via OpenAI, Gemini, or Groq if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
+          <p>EnviousWispr integrates four LLM providers for Smart Polish: Apple Intelligence (fully on-device), Ollama (local models like Llama or Mistral), and cloud options via OpenAI or Gemini if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
           <p>The system is context-aware. Dictating into Slack? The polish keeps it conversational. Writing an email? It formalizes. And all cloud providers only receive the text transcript, never your audio.</p>
           <div class="deep-dive-detail">
             <strong>Technical detail:</strong> Smart Polish uses sandwich prompt framing with XML-tagged transcript boundaries to prevent hallucination. Output validation rejects responses longer than 3x the input. Short transcripts (3 words or fewer) bypass the LLM entirely. Preamble stripping removes "Certainly!" artifacts automatically.

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -135,7 +135,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does VoiceInk have AI text enhancement?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), and cloud providers with your own API key, plus built-in hallucination safeguards."
+        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 4 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), and cloud providers with your own API key, plus built-in hallucination safeguards."
       }
     }
   ]
@@ -443,7 +443,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">5 providers:</span> Apple Intelligence, Ollama (both on-device), OpenAI, Gemini, Groq (BYO key)</td>
+            <td><span class="table-highlight">4 providers:</span> Apple Intelligence, Ollama (both on-device), OpenAI, Gemini (BYO key)</td>
             <td>AI formatting via system prompts with LLM providers</td>
           </tr>
           <tr>
@@ -565,8 +565,8 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#129504;</div>
-        <div class="advantage-title">5 AI polish providers</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run fully on-device with no API key. Or bring your own OpenAI, Gemini, or Groq key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
+        <div class="advantage-title">4 AI polish providers</div>
+        <p class="advantage-desc">Apple Intelligence and Ollama run fully on-device with no API key. Or bring your own OpenAI or Gemini key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#128295;</div>
@@ -788,7 +788,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does VoiceInk have AI text enhancement?</div>
-        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), OpenAI, Gemini, and Groq, plus built-in hallucination safeguards that reject fabricated output.</p>
+        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 4 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), OpenAI, and Gemini, plus built-in hallucination safeguards that reject fabricated output.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from VoiceInk easily?</div>
@@ -800,7 +800,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is there a free alternative to VoiceInk?</div>
-        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 5 providers. No account or payment required.</p>
+        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 4 providers. No account or payment required.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -371,7 +371,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">5 providers</span>: Apple Intelligence, Ollama, OpenAI, Gemini, Groq</td>
+            <td><span class="table-highlight">4 providers</span>: Apple Intelligence, Ollama, OpenAI, Gemini</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>


### PR DESCRIPTION
## What & why

Three comparison pages claimed EnviousWispr supports **five** AI polish providers including **Groq**. Groq is not in the codebase — the `LLMProvider` enum (`Sources/EnviousWisprCore/LLMResult.swift`) exposes only `openAI`, `gemini`, `ollama`, `appleIntelligence` (with `none` disabled), and there is no Groq connector anywhere in `Sources/`.

Corrected all nine mentions across `whisper-cpp.astro`, `dragon.astro`, and `voiceink.astro` to **four providers** (Apple Intelligence, Ollama, OpenAI, Gemini) and dropped Groq from the tables, advantage blurbs, and FAQ answers.

Surfaced during the #1034 provider-count audit (kept out of that PR to stay focused).

## Validation

- Astro build green.
- Copy-only; single-commit revert.