### PR TITLE
fix(post-processing): restore apostrophes/accents in brand canonicals (#998)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/Resources/Packs/brands.json
+++ b/Sources/EnviousWisprPostProcessing/Resources/Packs/brands.json
@@ -54,15 +54,17 @@
     "eperol",
     "operol"
   ],
-  "Applebees": [
+  "Applebee's": [
     "applewis",
     "opelbees",
-    "oppelbees"
+    "oppelbees",
+    "applebees"
   ],
-  "Arbys": [
+  "Arby's": [
     "arbish",
     "herbis",
-    "irvies"
+    "irvies",
+    "arbys"
   ],
   "ASUS": [
     "asush"
@@ -107,11 +109,12 @@
     "sempuri",
     "simpari"
   ],
-  "Campbells": [
+  "Campbell's": [
     "campbellsch",
     "campbelsh",
     "compils",
-    "cumpels"
+    "cumpels",
+    "campbells"
   ],
   "CareerBuilder": [
     "careerbuildeer",
@@ -123,11 +126,12 @@
     "serive",
     "syrafu"
   ],
-  "Citroen": [
+  "Citroën": [
     "cetron",
     "citram",
     "citraun",
-    "sitroon"
+    "sitroon",
+    "citroen"
   ],
   "Conagra": [
     "canader",
@@ -152,7 +156,7 @@
     "dipand",
     "dipond"
   ],
-  "Dominos": [
+  "Domino's": [
     "dawmines",
     "dominoche"
   ],
@@ -197,9 +201,10 @@
     "folgish",
     "volgish"
   ],
-  "Frenchs": [
+  "French's": [
     "fronch",
-    "frunchs"
+    "frunchs",
+    "frenchs"
   ],
   "Gevalia": [
     "cuvalia",
@@ -262,14 +267,15 @@
     "anvision",
     "infison"
   ],
-  "Kahlua": [
+  "Kahlúa": [
     "caluo",
     "colra",
     "kerlua",
     "kihua",
     "kolua",
     "koolua",
-    "kulua"
+    "kulua",
+    "kahlua"
   ],
   "Kellogg": [
     "kellag",
@@ -301,8 +307,9 @@
     "kleenix",
     "kleinox"
   ],
-  "Kohls": [
-    "kitles"
+  "Kohl's": [
+    "kitles",
+    "kohls"
   ],
   "Komatsu": [
     "cometsa",
@@ -328,21 +335,25 @@
   "Lindt": [
     "linth"
   ],
-  "Loreal": [
+  "L'Oréal": [
     "lyrial",
     "lyrol",
-    "lyural"
+    "lyural",
+    "loreal",
+    "l'oreal"
   ],
-  "Lowes": [
+  "Lowe's": [
     "loish",
-    "lowiz"
+    "lowiz",
+    "lowes"
   ],
   "Lysol": [
     "lyself"
   ],
-  "Macys": [
+  "Macy's": [
     "masish",
-    "massish"
+    "massish",
+    "macys"
   ],
   "Marlboro": [
     "malbori",
@@ -350,16 +361,18 @@
     "merlborough",
     "mulbore"
   ],
-  "McCafe": [
+  "McCafé": [
     "macafo",
     "makafu",
     "mccaffre",
     "mccof",
     "mccugh",
-    "mckefe"
+    "mckefe",
+    "mccafe"
   ],
-  "McDonalds": [
-    "mcdennalls"
+  "McDonald's": [
+    "mcdennalls",
+    "mcdonalds"
   ],
   "Mentos": [
     "mentosh"
@@ -405,19 +418,21 @@
     "monclear",
     "monklar"
   ],
-  "Mondelez": [
+  "Mondelēz": [
     "mandalus",
     "mendelas",
     "mendelis",
     "mindelis",
     "mondalaz",
     "mondolis",
-    "mondulus"
+    "mondulus",
+    "mondelez"
   ],
-  "Moodys": [
+  "Moody's": [
     "maudis",
     "moities",
-    "moudis"
+    "moudis",
+    "moodys"
   ],
   "Motrin": [
     "mephrin",
@@ -427,10 +442,11 @@
     "motron",
     "mutrin"
   ],
-  "Nathans": [
+  "Nathan's": [
     "nafons",
     "nathensh",
-    "nothens"
+    "nothens",
+    "nathans"
   ],
   "Nestea": [
     "nesteo",
@@ -477,7 +493,7 @@
     "pantonet",
     "pintin"
   ],
-  "Patron": [
+  "Patrón": [
     "pecron",
     "pewtron",
     "pitrom",
@@ -513,9 +529,10 @@
     "recat",
     "recith"
   ],
-  "Reeses": [
+  "Reese's": [
     "reisos",
-    "revese"
+    "revese",
+    "reeses"
   ],
   "Regeneron": [
     "ragenern",
@@ -588,8 +605,9 @@
     "todol",
     "tudle"
   ],
-  "Titos": [
-    "tartos"
+  "Tito's": [
+    "tartos",
+    "titos"
   ],
   "Tripadvisor": [
     "trepadvisor",
@@ -633,8 +651,9 @@
     "wetchut",
     "witchat"
   ],
-  "Wendys": [
-    "wondis"
+  "Wendy's": [
+    "wondis",
+    "wendys"
   ],
   "Zeplin": [
     "sipplin",

--- a/Tests/EnviousWisprTests/PostProcessing/BrandApostropheTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/BrandApostropheTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprPostProcessing
+
+/// #998 — brand canonicals restored to their correct apostrophe/accent spelling
+/// in `brands.json`, with the plain (apostrophe-/accent-less) ASR form added as
+/// an alias so the everyday spoken token still corrects to the proper glyphs.
+///
+/// These tests run against the REAL bundled brands pack (not a synthetic
+/// fixture), so they lock both the shipped data and the corrector's paste path.
+/// Adversarial per `matcher-set-adversarial-tests`: each new plain alias is
+/// exercised in its intended class AND a non-intended (no-false-positive) class.
+@Suite("Brand apostrophes/accents (#998)")
+struct BrandApostropheTests {
+
+  private func brandsPackTerms() -> [CustomWord] {
+    guard let pack = VocabularyPackStore().load(.brands) else {
+      Issue.record("brands pack failed to load from bundle")
+      return []
+    }
+    return pack.terms
+  }
+
+  private func corrected(_ input: String, _ terms: [CustomWord]) -> String {
+    WordCorrector().correct(input, against: terms).corrected
+  }
+
+  // MARK: Forward — plain ASR token corrects to the apostrophe'd/accented canonical
+
+  @Test("apostrophe brands: plain spoken form corrects to the apostrophe'd canonical")
+  func apostropheForward() {
+    let terms = brandsPackTerms()
+    let cases: [(String, String)] = [
+      ("applebees", "Applebee's"),
+      ("campbells", "Campbell's"),
+      ("mcdonalds", "McDonald's"),
+      ("wendys", "Wendy's"),
+      ("reeses", "Reese's"),
+      ("nathans", "Nathan's"),
+    ]
+    for (input, expected) in cases {
+      #expect(
+        corrected(input, terms) == expected,
+        "'\(input)' should correct to '\(expected)', got '\(corrected(input, terms))'")
+    }
+  }
+
+  /// Short brands (5-char cores) sit below `packFuzzyMinLength` (7), so the pack
+  /// fuzzy tier is gated off and the plain alias is the ONLY path that can carry
+  /// them. This proves the alias add is mandatory, not redundant with fuzzy.
+  @Test("short brands (below fuzzy gate) correct only because the plain alias exists")
+  func shortBrandMandatoryAlias() {
+    let terms = brandsPackTerms()
+    let cases: [(String, String)] = [
+      ("arbys", "Arby's"),
+      ("lowes", "Lowe's"),
+      ("macys", "Macy's"),
+      ("kohls", "Kohl's"),
+      ("titos", "Tito's"),
+    ]
+    for (input, expected) in cases {
+      #expect(
+        corrected(input, terms) == expected,
+        "'\(input)' should correct to '\(expected)', got '\(corrected(input, terms))'")
+    }
+  }
+
+  @Test("accent brands: plain spoken form corrects to the accented canonical, glyphs intact")
+  func accentForward() {
+    let terms = brandsPackTerms()
+    let cases: [(String, String)] = [
+      ("loreal", "L'Oréal"),
+      ("l'oreal", "L'Oréal"),  // real ASR rendering (apostrophe kept, accent dropped) — live-UAT verified
+      ("kahlua", "Kahlúa"),
+      ("mccafe", "McCafé"),
+      ("citroen", "Citroën"),
+      ("mondelez", "Mondelēz"),
+    ]
+    for (input, expected) in cases {
+      let out = corrected(input, terms)
+      #expect(out == expected, "'\(input)' should correct to '\(expected)', got '\(out)'")
+      // Defend against silent ASCII-folding on the paste path.
+      #expect(out == expected, "accent glyphs must survive verbatim in '\(out)'")
+    }
+  }
+
+  // MARK: Punctuation-wrapper preservation (prefix/suffix reattach)
+
+  @Test("trailing punctuation is preserved around the corrected apostrophe'd canonical")
+  func punctuationWrapperPreserved() {
+    let terms = brandsPackTerms()
+    #expect(corrected("applebees,", terms) == "Applebee's,")
+    #expect(corrected("(loreal)", terms) == "(L'Oréal)")
+  }
+
+  // MARK: Kellogg disambiguation
+
+  /// Kellogg's is DEFERRED from #998. It is the only brand with an adjacent
+  /// sibling entry — the standalone company/surname `Kellogg` sits one character
+  /// from the cereal `Kellogg's`. Empirically, renaming `Kelloggs`→`Kellogg's`
+  /// and adding the plain `kelloggs` alias made the bare word `Kellogg` (the
+  /// company / Kellogg School / a person) fuzzy-coerce to `Kellogg's` (verified
+  /// against old vs new data: old `Kellogg`→`Kellogg`, post-change
+  /// `Kellogg`→`Kellogg's`). Data alone can't resolve that boundary, so the
+  /// entry is left untouched here. This test locks the safe (unchanged) state so
+  /// a future Kellogg's fix can't silently re-introduce the regression.
+  @Test("Kellogg's deferred: the company word stays Kellogg, no false coercion")
+  func kelloggDeferredSafeState() {
+    let terms = brandsPackTerms()
+    #expect(corrected("Kellogg", terms) == "Kellogg")
+    #expect(corrected("kellag", terms) == "Kellogg")  // company alias still resolves
+  }
+
+  // MARK: User precedence — a user term beats the pack alias
+
+  @Test("a user term whose alias equals a brand plain form wins over the pack")
+  func userTermBeatsPackAlias() {
+    var terms = brandsPackTerms()
+    let userWord = CustomWord(
+      canonical: "Applebee's Neighborhood Grill", aliases: ["applebees"], source: .user)
+    terms.insert(userWord, at: 0)
+    #expect(corrected("applebees", terms) == "Applebee's Neighborhood Grill")
+  }
+
+  // MARK: Negative class — no new false positives from the short plain aliases
+
+  @Test("common words near short brand aliases are not coerced into a brand")
+  func noFalsePositiveFromShortAliases() {
+    let terms = brandsPackTerms()
+    // Short brands are exact-only (fuzzy gated off), so near-neighbors must pass through.
+    for word in ["lower", "lowed", "maces", "moes", "kohl"] {
+      #expect(
+        corrected(word, terms) == word,
+        "'\(word)' must stay unchanged, got '\(corrected(word, terms))'")
+    }
+  }
+
+  /// Common-word brands (`Patron`, `Dominos`) keep the corrected canonical
+  /// spelling but DO NOT get the plain form as an exact alias — adding it would
+  /// rewrite the everyday word ("the museum patron arrived", "we played
+  /// dominos"). The canonical rename still benefits real mishears. This locks
+  /// the common-word safety (Codex code-diff finding).
+  @Test("common-word brands do not rewrite the everyday word, but mishears still map")
+  func commonWordProtection() {
+    let terms = brandsPackTerms()
+    // The everyday words pass through untouched.
+    #expect(corrected("patron", terms) == "patron")
+    #expect(corrected("the museum patron arrived", terms) == "the museum patron arrived")
+    #expect(corrected("dominos", terms) == "dominos")
+    #expect(corrected("we played dominos", terms) == "we played dominos")
+    // But a real mishear still corrects to the proper spelling.
+    #expect(corrected("pecron", terms) == "Patrón")
+    #expect(corrected("dawmines", terms) == "Domino's")
+  }
+
+  // MARK: Existing-alias regression — pre-existing misspellings still map
+
+  @Test("pre-existing misspelling aliases still correct to the now-apostrophe'd canonical")
+  func existingAliasesStillMap() {
+    let terms = brandsPackTerms()
+    #expect(corrected("opelbees", terms) == "Applebee's")
+    #expect(corrected("lyrial", terms) == "L'Oréal")
+    #expect(corrected("mcdennalls", terms) == "McDonald's")
+  }
+}


### PR DESCRIPTION
## What & why

The #992 recapitalization was deliberately case-only, so brand canonicals still pasted the wrong glyphs (`Applebees`, `Loreal`). This restores the correct spelling in `brands.json` so the corrector pastes the proper brand name.

## Approach (data-only)

The canonical key becomes the apostrophe/accent form; for most brands the plain ASR form is added as an alias so the everyday spoken token corrects to the proper glyphs. No matcher change — grounded against the prompt builders / provider enum over **3 Codex grounded-review rounds** (→ PROCEED-AS-PLANNED).

- **18 brands fully fixed** (rename + plain alias): Applebee's, Arby's, Campbell's, French's, Kohl's, Lowe's, Macy's, McDonald's, Moody's, Nathan's, Reese's, Tito's, Wendy's, Citroën, Kahlúa, **L'Oréal**, McCafé, Mondelēz. L'Oréal also carries `l'oreal` (apostrophe kept, accent dropped) — the exact form the speech engine produces, discovered via live UAT.
- **2 common-word brands** (Patrón, Domino's): canonical renamed so real mishears paste correctly, but the plain form is **not** added as an alias — `patron` / `dominos` are everyday words and an exact alias would rewrite them ("the museum patron arrived"). Verified the bare words pass through untouched.
- **Kellogg's DEFERRED**: the only brand with an adjacent sibling entry (company `Kellogg` sits one character from cereal `Kellogg's`). An old-vs-new probe showed the rename + plain alias coerced the bare word `Kellogg` → `Kellogg's`. A 1-char-edit collision sweep confirmed no other brand has this adjacency. Follow-up tracked.

## Validation

- **3 Codex grounded-review rounds** on the plan → PROCEED-AS-PLANNED.
- **3 Codex code-diff rounds** → clean. Caught two real regressions mid-build: the Kellogg sibling coercion and an exact-alias rewriting the common word `patron`; both resolved.
- **9 adversarial unit tests** (`BrandApostropheTests`, real bundled pack): forward exact, short-brand mandatory alias, accent glyph fidelity, punctuation-wrapper preservation, user precedence, common-word protection, Kellogg deferred-safe guard, existing-alias regression. Green via `scripts/xcode-test.sh`.
- **Live dictation UAT**: human dictation transcribed "McDonalds" (no apostrophe) and "L'Oreal" (no accent); the correction step restored both → "McDonald's" and "L'Oréal" in the paste. Confirmed in `CORRECTION_DEBUG` trace.

## Follow-ups
- Kellogg/Kellogg's company-vs-brand disambiguation.
- Live-verify the remaining accent brands' ASR renderings (McCafé/Citroën/Mondelēz carry accent-stripped triggers; unit-tested, not yet live-confirmed) — overlaps #997 ASR-variant research.

Closes #998