### PR TITLE
fix(pipeline): recover energetic trailing speech the VAD trim drops (#950)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -41,6 +41,18 @@ public struct ExecutionMetrics: Codable, Sendable {
   /// nil when `tailDroppedMs == 0` (no tail slice). Metadata only.
   public var tailDroppedMs: Int?
   public var tailHadEnergy: Bool?
+  /// #950 tail-preserve recovery + tuning signals. Populated only for eligible
+  /// Parakeet batch; nil for streaming / WhisperKit / non-success / pre-#950
+  /// transcripts on disk (additive optional Codable, back-compatible).
+  /// `usedTailPreservation`: nil=ineligible, false=eligible-not-preserved,
+  /// true=recovered a sustained-voice dropped tail. `recoveredTailMs`: ms appended
+  /// back on a fire. `tailVoicedFraction`: sustained-voice ratio [0,1] of the
+  /// dropped tail. `tailRefusedReason`: why an eligible tail was refused
+  /// (too_short/too_long/low_voiced_fraction/not_filtered/no_tail). Metadata only.
+  public var usedTailPreservation: Bool?
+  public var recoveredTailMs: Int?
+  public var tailVoicedFraction: Double?
+  public var tailRefusedReason: String?
 
   public init(
     asrLatencySeconds: Double? = nil,
@@ -65,7 +77,11 @@ public struct ExecutionMetrics: Codable, Sendable {
     itnLenBefore: Int? = nil,
     itnLenAfter: Int? = nil,
     tailDroppedMs: Int? = nil,
-    tailHadEnergy: Bool? = nil
+    tailHadEnergy: Bool? = nil,
+    usedTailPreservation: Bool? = nil,
+    recoveredTailMs: Int? = nil,
+    tailVoicedFraction: Double? = nil,
+    tailRefusedReason: String? = nil
   ) {
     self.asrLatencySeconds = asrLatencySeconds
     self.llmLatencySeconds = llmLatencySeconds
@@ -90,6 +106,10 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.itnLenAfter = itnLenAfter
     self.tailDroppedMs = tailDroppedMs
     self.tailHadEnergy = tailHadEnergy
+    self.usedTailPreservation = usedTailPreservation
+    self.recoveredTailMs = recoveredTailMs
+    self.tailVoicedFraction = tailVoicedFraction
+    self.tailRefusedReason = tailRefusedReason
   }
 }
 

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -339,7 +339,12 @@ struct KernelFinalizationWiring {
       // telemetry state (eligible Parakeet batch only; nil for streaming /
       // WhisperKit / non-success). Carried onto `asr.completed`.
       tailDroppedMs: telemetryState.asrCompletedTelemetry?.droppedTailMs,
-      tailHadEnergy: telemetryState.asrCompletedTelemetry?.tailHadEnergy
+      tailHadEnergy: telemetryState.asrCompletedTelemetry?.tailHadEnergy,
+      // #950 tail-preserve recovery + tuning signals.
+      usedTailPreservation: telemetryState.asrCompletedTelemetry?.usedTailPreservation,
+      recoveredTailMs: telemetryState.asrCompletedTelemetry?.recoveredTailMs,
+      tailVoicedFraction: telemetryState.asrCompletedTelemetry?.tailVoicedFraction,
+      tailRefusedReason: telemetryState.asrCompletedTelemetry?.tailRefusedReason
     )
     outcome.transcript = transcript
   }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -402,6 +402,19 @@ final class KernelLifecycleTelemetrySink {
     if let hadEnergy = telemetryState.asrCompletedTelemetry?.tailHadEnergy {
       payload["tail_had_energy"] = hadEnergy
     }
+    // #950 tail-preserve recovery + tuning signals (omit-on-nil, metadata only).
+    if let preserved = telemetryState.asrCompletedTelemetry?.usedTailPreservation {
+      payload["tail_preserved"] = preserved
+    }
+    if let recoveredMs = telemetryState.asrCompletedTelemetry?.recoveredTailMs {
+      payload["tail_preserved_ms"] = recoveredMs
+    }
+    if let voicedFraction = telemetryState.asrCompletedTelemetry?.tailVoicedFraction {
+      payload["tail_voiced_fraction"] = voicedFraction
+    }
+    if let refusedReason = telemetryState.asrCompletedTelemetry?.tailRefusedReason {
+      payload["tail_refused_reason"] = refusedReason
+    }
     return payload
   }
 

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -64,6 +64,15 @@ struct KernelASRCompletedTelemetry {
   // slice otherwise). nil → sink omits the key.
   var droppedTailMs: Int? = nil
   var tailHadEnergy: Bool? = nil
+  // #950 tail-preserve recovery + tuning signals (eligible Parakeet batch only).
+  // `usedTailPreservation`: nil=ineligible, false=eligible-not-preserved,
+  // true=recovered a sustained-voice dropped tail. `recoveredTailMs`: ms appended
+  // back on a fire. `tailVoicedFraction`: sustained-voice ratio of the dropped
+  // tail. `tailRefusedReason`: why an eligible tail was refused. nil → sink omits.
+  var usedTailPreservation: Bool? = nil
+  var recoveredTailMs: Int? = nil
+  var tailVoicedFraction: Double? = nil
+  var tailRefusedReason: String? = nil
 }
 
 struct KernelASRAdapterDiagnostics {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1155,14 +1155,53 @@ final class RecordingSessionKernel {
     let tailDroppedMs: Int? = tailEligible ? droppedTailSamples / 16 : nil
     var tailHadEnergy: Bool? = nil
     var tailPeak: Float = 0
+    // #950 tail-preserve: hoist the dropped-tail slice to outer scope — the
+    // energy check (below), the sustained-voice gate, and the recovery append all
+    // read it. `Array(...)` rebases the slice to the 0-based indexing the window
+    // scans assume; materialized ONCE on the cold stop path (not the RT audio
+    // thread); sync, cannot throw; empty when nothing was dropped.
+    let tailSlice: [Float] =
+      droppedTailSamples > 0
+      ? Array(captureResult.samples.suffix(droppedTailSamples)) : []
     if droppedTailSamples > 0 {
-      // Intentional copy: `rawAudioIsDeadAir` takes `[Float]`, and `Array(...)`
-      // also rebases the slice to the 0-based indexing its window scan assumes.
-      // Bounded by `droppedTailSamples`, materialized ONCE on the cold stop path
-      // (not the RT audio thread); sync, cannot throw.
-      let tailSlice = Array(captureResult.samples.suffix(droppedTailSamples))
       tailPeak = tailSlice.reduce(Float(0)) { Swift.max($0, Swift.abs($1)) }
       tailHadEnergy = !Self.rawAudioIsDeadAir(tailSlice, peak: tailPeak)
+    }
+    // #950 tail-preserve. Decide once; the outcome carries the refusal reason for
+    // tuning telemetry. The heart path is byte-identical to before unless a
+    // sustained-voice dropped tail (eligible "filtered" path, in [400,8000]ms,
+    // >= 50% voiced) fires the recovery branch. `tailVoicedFraction` is the
+    // hallucination guard: a single desk-thump / keyboard transient tiles to a
+    // low fraction and is refused before it ever reaches ASR.
+    let tailFraction = droppedTailSamples > 0 ? Self.tailVoicedFraction(tailSlice) : 0
+    let tailDecision = Self.tailPreserveDecision(
+      tailEligible: tailEligible,
+      conditioningReason: conditioned.conditioningReason,
+      droppedTailSamples: droppedTailSamples,
+      droppedTailMs: tailDroppedMs ?? 0,
+      voicedFraction: tailFraction)
+    let asrSamples: [Float]
+    var recoveredTailMs: Int? = nil
+    // nil when ineligible (engine/streaming); a real Bool on the eligible path so
+    // `false` is a valid false-fire-rate denominator.
+    var usedTailPreservation: Bool? = tailEligible ? false : nil
+    // Tuning signals (#950 founder upgrade): voiced fraction surfaced whenever a
+    // tail was measured; refusal reason set only on the eligible-but-refused path.
+    let tailVoicedFractionForTelemetry: Double? =
+      (tailEligible && droppedTailSamples > 0) ? tailFraction : nil
+    var tailRefusedReason: String? = nil
+    switch tailDecision {
+    case .preserve:
+      // Contiguous: `tailSlice == raw[keptThrough..<rawCount]`, the exact region
+      // the trim discarded, appended immediately after the filtered buffer.
+      asrSamples = conditioned.samples + tailSlice
+      recoveredTailMs = tailDroppedMs
+      usedTailPreservation = true
+    case .refuse(let reason):
+      asrSamples = conditioned.samples
+      tailRefusedReason = reason
+    case .notEvaluated:
+      asrSamples = conditioned.samples
     }
     // GAP 3 app.log parity: VAD filter ratio log (TP:772-776).
     let rawCount = captureResult.samples.count
@@ -1202,7 +1241,10 @@ final class RecordingSessionKernel {
       vadSpeechDurationMs: vadSpeechDurationMs,
       peakAudioLevel: rawPeakAudioLevel,
       vadFilteredSampleCount: conditioned.filteredSampleCount,
-      finalSampleCount: conditioned.finalSampleCount,
+      // #950: report the buffer ACTUALLY fed to ASR (filtered + recovered tail
+      // when preservation fired), so an asr-empty diagnostic matches the decode.
+      // `vadFilteredSampleCount` above stays the conditioner's own count.
+      finalSampleCount: asrSamples.count,
       samplesPaddedToMinimum: conditioned.samplesPaddedToMinimum,
       usedRawFallbackAfterVAD: conditioned.usedRawFallbackAfterVAD,
       usedRawSoftOnsetPreservation: conditioned.usedRawSoftOnsetPreservation,
@@ -1224,13 +1266,19 @@ final class RecordingSessionKernel {
         + "sid=\(sid.raw) capturedMs=\(captureResult.samples.count / 16) "
         + "droppedTailMs=\(tailDroppedMs.map(String.init) ?? "n/a") "
         + "tailEnergy=\(tailHadEnergy.map(String.init) ?? "n/a") "
-        + "tailPeak=\(String(format: "%.4f", tailPeak))")
+        + "tailPeak=\(String(format: "%.4f", tailPeak)) "
+        // #950 tail-preserve outcome: did the recovery fire, how much it rescued,
+        // the sustained-voice fraction, and (when refused) why. Debug-log only.
+        + "tailPreserved=\(usedTailPreservation.map(String.init) ?? "n/a") "
+        + "recoveredTailMs=\(recoveredTailMs.map(String.init) ?? "n/a") "
+        + "voicedFraction=\(tailVoicedFractionForTelemetry.map { String(format: "%.2f", $0) } ?? "n/a") "
+        + "refusedReason=\(tailRefusedReason ?? "n/a")")
 
     // Transcribing.
     let asrStart = CFAbsoluteTimeGetCurrent()
     markASRTimingStart(isStreamingSession)
     transition(to: .transcribing)
-    let outcome = await finalize(sid, batchSamples: conditioned.samples)
+    let outcome = await finalize(sid, batchSamples: asrSamples)
     guard isCurrent(sid), !state.isTerminal else { return }
     let asrEnd = CFAbsoluteTimeGetCurrent()
     markASRTimingEnd()
@@ -1256,7 +1304,12 @@ final class RecordingSessionKernel {
           .lastASRDiagnostics?.incrementalAccepted,
         // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
         droppedTailMs: tailDroppedMs,
-        tailHadEnergy: tailHadEnergy
+        tailHadEnergy: tailHadEnergy,
+        // #950 tail-preserve recovery + tuning signals.
+        usedTailPreservation: usedTailPreservation,
+        recoveredTailMs: recoveredTailMs,
+        tailVoicedFraction: tailVoicedFractionForTelemetry,
+        tailRefusedReason: tailRefusedReason
       )
       await runFinalizing(sid, asrText: result.text)
     case .empty(let hadSpeechEvidence):
@@ -1310,7 +1363,7 @@ final class RecordingSessionKernel {
           // failing decode byte-for-byte.
           let fedSamples =
             adapter.capabilities.decodesConditionedBatchSamples
-            ? conditioned.samples
+            ? asrSamples
             : WhisperKitPipelineSpeechRouting.paddedASRSamples(
               rawSamples: captureResult.samples,
               minimumSamples: AudioConstants.minimumTranscriptionSamples)
@@ -2133,6 +2186,74 @@ final class RecordingSessionKernel {
       i += window
     }
     return maxWindowRms < DeadAirFloor.windowRms
+  }
+
+  /// Fraction of non-overlapping 40 ms windows in `slice` whose RMS clears the
+  /// dead-air window floor. Continuous lost speech tiles to ~1.0; a lone
+  /// transient (desk-thump / keyboard clack) in a mostly-silent tail tiles to
+  /// ~0.04. Pure + static, O(n), reuses `DeadAirFloor` — the sustained-voice
+  /// gate that keeps energetic NON-speech tails out of ASR (#950 hallucination
+  /// guard). Returns 0 for a slice shorter than one window (too short to assess).
+  nonisolated static func tailVoicedFraction(_ slice: [Float]) -> Double {
+    let window = DeadAirFloor.windowSamples
+    guard slice.count >= window else { return 0 }
+    var voiced = 0
+    var total = 0
+    var i = 0
+    while i + window <= slice.count {
+      var ss: Float = 0
+      for j in i..<(i + window) { ss += slice[j] * slice[j] }
+      if (ss / Float(window)).squareRoot() >= DeadAirFloor.windowRms { voiced += 1 }
+      total += 1
+      i += window
+    }
+    return total == 0 ? 0 : Double(voiced) / Double(total)
+  }
+
+  /// Thresholds for the #950 tail-preserve recovery branch.
+  enum TailPreserve {
+    /// Min dropped-tail ms worth recovering (below this is pad-decay, not a word).
+    static let floorMs = 400
+    /// Hard cap — never auto-append more than this much trailing audio.
+    static let maxRecoverMs = 8000
+    /// >= half the tail's 40 ms windows must be voiced (sustained voice, not one spike).
+    static let voicedFractionFloor = 0.5
+  }
+
+  /// Outcome of the tail-preserve decision. Carries the refusal reason so
+  /// telemetry can answer "among eligible dictations with a dropped tail, why was
+  /// it NOT recovered?" without duplicating the threshold logic at the call site —
+  /// ONE source of truth for the guards.
+  enum TailPreserveDecision: Equatable {
+    case preserve
+    case refuse(reason: String)
+    case notEvaluated
+  }
+
+  /// Pure, nonisolated, total — boundary-testable like `rawAudioIsDeadAir`. Guard
+  /// ORDER defines the reason taxonomy: engine-eligibility first (`.notEvaluated`,
+  /// so `usedTailPreservation` stays nil for the denominator), then conditioner
+  /// path, then a non-empty tail, then the duration window, then sustained voice.
+  /// The first failing guard names the reason.
+  nonisolated static func tailPreserveDecision(
+    tailEligible: Bool,
+    conditioningReason: String,
+    droppedTailSamples: Int,
+    droppedTailMs: Int,
+    voicedFraction: Double,
+    floorMs: Int = TailPreserve.floorMs,
+    maxRecoverMs: Int = TailPreserve.maxRecoverMs,
+    voicedFractionFloor: Double = TailPreserve.voicedFractionFloor
+  ) -> TailPreserveDecision {
+    guard tailEligible else { return .notEvaluated }
+    guard conditioningReason == "filtered" else { return .refuse(reason: "not_filtered") }
+    guard droppedTailSamples > 0 else { return .refuse(reason: "no_tail") }
+    guard droppedTailMs >= floorMs else { return .refuse(reason: "too_short") }
+    guard droppedTailMs <= maxRecoverMs else { return .refuse(reason: "too_long") }
+    guard voicedFraction >= voicedFractionFloor else {
+      return .refuse(reason: "low_voiced_fraction")
+    }
+    return .preserve
   }
 
   private static func speechDurationMs(_ segments: [SpeechSegment]) -> Int {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -96,7 +96,9 @@ public final class TelemetryService {
       asrCompleted(
         backend: t.backendType.rawValue, result: "success", coldStart: m?.coldStart ?? false,
         latencySeconds: asrLat, charCount: t.text.count,
-        tailDroppedMs: m?.tailDroppedMs, tailHadEnergy: m?.tailHadEnergy)
+        tailDroppedMs: m?.tailDroppedMs, tailHadEnergy: m?.tailHadEnergy,
+        usedTailPreservation: m?.usedTailPreservation, recoveredTailMs: m?.recoveredTailMs,
+        tailVoicedFraction: m?.tailVoicedFraction, tailRefusedReason: m?.tailRefusedReason)
     }
     if let llmLat = m?.llmLatencySeconds, llmLat > 0, t.llmProvider != nil {
       llmPolishCompleted(
@@ -414,7 +416,13 @@ public final class TelemetryService {
     // Metadata only (Int ms + Bool); no audio/content. `tailDroppedMs` always set
     // (incl. 0) when eligible so the denominator holds; `tailHadEnergy` only when
     // a tail was actually dropped.
-    tailDroppedMs: Int? = nil, tailHadEnergy: Bool? = nil
+    tailDroppedMs: Int? = nil, tailHadEnergy: Bool? = nil,
+    // #950 tail-preserve recovery + tuning signals (omit-on-nil). `tailPreserved`
+    // nil=ineligible / false=eligible-not-preserved / true=recovered;
+    // `tailPreservedMs` = ms appended back; `tailVoicedFraction` = sustained-voice
+    // ratio; `tailRefusedReason` = why an eligible tail was refused. Metadata only.
+    usedTailPreservation: Bool? = nil, recoveredTailMs: Int? = nil,
+    tailVoicedFraction: Double? = nil, tailRefusedReason: String? = nil
   ) {
     var properties: [String: Any] = [
       "backend": backend,
@@ -426,6 +434,10 @@ public final class TelemetryService {
     ]
     if let tailDroppedMs { properties["tail_dropped_ms"] = tailDroppedMs }
     if let tailHadEnergy { properties["tail_had_energy"] = tailHadEnergy }
+    if let usedTailPreservation { properties["tail_preserved"] = usedTailPreservation }
+    if let recoveredTailMs { properties["tail_preserved_ms"] = recoveredTailMs }
+    if let tailVoicedFraction { properties["tail_voiced_fraction"] = tailVoicedFraction }
+    if let tailRefusedReason { properties["tail_refused_reason"] = tailRefusedReason }
     PostHogSDK.shared.capture("asr.completed", properties: properties)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -297,6 +297,51 @@ import Testing
       ])
   }
 
+  @Test(".asrCompleted carries preserve + tuning keys when a tail was recovered (#950)")
+  func asrCompletedCarriesPreserveKeys() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: 0.3, charCount: 5, mode: "batch", language: "en",
+      droppedTailMs: 2_500, tailHadEnergy: true,
+      usedTailPreservation: true, recoveredTailMs: 2_500, tailVoicedFraction: 0.92)
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+    sink.emit(.asrCompleted)
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "asr", message: "ASR completed",
+          dataKeys: [
+            "backend", "char_count", "duration_s", "language", "mode",
+            "tail_dropped_ms", "tail_had_energy", "tail_preserved",
+            "tail_preserved_ms", "tail_voiced_fraction",
+          ])
+      ])
+  }
+
+  @Test(".asrCompleted carries tail_refused_reason when eligible but not preserved (#950)")
+  func asrCompletedCarriesRefusedReason() {
+    let recorder = Recorder()
+    let state = KernelTelemetryState()
+    state.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: 0.3, charCount: 5, mode: "batch", language: "en",
+      droppedTailMs: 1_000, tailHadEnergy: true,
+      usedTailPreservation: false, tailVoicedFraction: 0.2,
+      tailRefusedReason: "low_voiced_fraction")
+    let sink = makeSink(recorder: recorder, telemetryState: state)
+    sink.emit(.asrCompleted)
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "asr", message: "ASR completed",
+          dataKeys: [
+            "backend", "char_count", "duration_s", "language", "mode",
+            "tail_dropped_ms", "tail_had_energy", "tail_preserved",
+            "tail_refused_reason", "tail_voiced_fraction",
+          ])
+      ])
+  }
+
   @Test(".pipelineCompleted emits the TP:1032 breadcrumb")
   func pipelineCompletedEmission() {
     let recorder = Recorder()

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTailPreserveTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTailPreserveTests.swift
@@ -1,0 +1,175 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - RecordingSessionKernelTailPreserveTests (#950)
+//
+// Boundary coverage for the tail-preserve recovery decision. Two pure statics
+// plus one conditioner-append contiguity check:
+//   - `tailVoicedFraction`: the hallucination guard. A single transient (desk
+//     thump / keyboard clack) in an otherwise-silent tail must score a LOW
+//     fraction so recovery is refused before the slice ever reaches ASR.
+//   - `tailPreserveDecision`: the gate + refusal-reason taxonomy. Per
+//     `matcher-set-adversarial-tests`, every guard is exercised at its boundary
+//     and in its NON-intended class (the transient that must be refused), and the
+//     first-failing-guard ordering is locked so the reason taxonomy can't drift.
+//   - append: filtered + dropped-tail stays contiguous with the internal VAD gap
+//     still excluded (surgical, not return-raw).
+
+@Suite("RecordingSessionKernel tail-preserve (#950)")
+struct RecordingSessionKernelTailPreserveTests {
+
+  // Reuse the production dead-air window geometry (640 samples = 40 ms @ 16 kHz).
+  private let window = RecordingSessionKernel.DeadAirFloor.windowSamples
+
+  // A voiced window clears the window RMS floor (0.002); silence does not.
+  private func voicedWindow() -> [Float] { [Float](repeating: 0.01, count: window) }
+  private func silentWindow() -> [Float] { [Float](repeating: 0.0, count: window) }
+
+  // MARK: tailVoicedFraction — the hallucination guard (tested FIRST)
+
+  @Test("single loud window in an otherwise-silent 1 s tail scores well below 0.5")
+  func singleTransientIsLowFraction() {
+    // 1 s = 25 windows; one voiced → 1/25 = 0.04. The desk-thump / keyboard-clack
+    // case the founder feared: energetic but NOT sustained voice.
+    var slice = [Float](repeating: 0.0, count: 25 * window)
+    for i in 0..<window { slice[i] = 0.01 }
+    let f = RecordingSessionKernel.tailVoicedFraction(slice)
+    #expect(f < 0.5)
+    #expect(f == 1.0 / 25.0)
+  }
+
+  @Test("a fully-voiced tail scores 1.0")
+  func allVoicedIsHighFraction() {
+    #expect(
+      RecordingSessionKernel.tailVoicedFraction([Float](repeating: 0.01, count: 10 * window)) == 1.0
+    )
+  }
+
+  @Test("a fully-silent tail scores 0")
+  func allSilentIsZero() {
+    #expect(
+      RecordingSessionKernel.tailVoicedFraction([Float](repeating: 0.0, count: 10 * window)) == 0.0)
+  }
+
+  @Test("a slice shorter than one window scores 0 (too short to assess)")
+  func subWindowIsZero() {
+    #expect(
+      RecordingSessionKernel.tailVoicedFraction([Float](repeating: 0.01, count: window - 1)) == 0.0)
+  }
+
+  @Test("exactly half the windows voiced scores 0.5 (boundary)")
+  func exactlyHalfIsBoundary() {
+    // 4 windows, 2 voiced → 0.5, which clears the >= 0.5 gate.
+    let slice = voicedWindow() + silentWindow() + voicedWindow() + silentWindow()
+    #expect(RecordingSessionKernel.tailVoicedFraction(slice) == 0.5)
+  }
+
+  // MARK: tailPreserveDecision — gate + refusal-reason taxonomy
+
+  private func decide(
+    eligible: Bool = true, reason: String = "filtered",
+    droppedSamples: Int = 6_400, droppedMs: Int = 400, fraction: Double = 0.9
+  ) -> RecordingSessionKernel.TailPreserveDecision {
+    RecordingSessionKernel.tailPreserveDecision(
+      tailEligible: eligible, conditioningReason: reason,
+      droppedTailSamples: droppedSamples, droppedTailMs: droppedMs, voicedFraction: fraction)
+  }
+
+  @Test("eligible, filtered, in-window, sustained voice → preserve")
+  func happyPathPreserves() {
+    #expect(decide(droppedMs: 400, fraction: 0.6) == .preserve)
+  }
+
+  @Test("floor boundary: 400 ms preserves, 399 ms refuses too_short")
+  func floorBoundary() {
+    #expect(decide(droppedMs: 400) == .preserve)
+    #expect(decide(droppedMs: 399) == .refuse(reason: "too_short"))
+  }
+
+  @Test("cap boundary: 8000 ms preserves, 8001 ms refuses too_long")
+  func capBoundary() {
+    #expect(decide(droppedMs: 8_000) == .preserve)
+    #expect(decide(droppedMs: 8_001) == .refuse(reason: "too_long"))
+  }
+
+  @Test("the transient case: in-window but fraction 0.3 refuses low_voiced_fraction")
+  func transientRefused() {
+    // The founder's #1 risk, at the decision layer: energetic but not sustained
+    // voice → refused, never appended.
+    #expect(decide(droppedMs: 1_000, fraction: 0.3) == .refuse(reason: "low_voiced_fraction"))
+  }
+
+  @Test("fraction boundary: exactly 0.5 preserves, just under refuses")
+  func fractionBoundary() {
+    #expect(decide(droppedMs: 1_000, fraction: 0.5) == .preserve)
+    #expect(decide(droppedMs: 1_000, fraction: 0.4999) == .refuse(reason: "low_voiced_fraction"))
+  }
+
+  @Test("zero dropped tail refuses no_tail")
+  func noTailRefused() {
+    #expect(decide(droppedSamples: 0, droppedMs: 0, fraction: 0.0) == .refuse(reason: "no_tail"))
+  }
+
+  @Test("ineligible engine → notEvaluated (keeps usedTailPreservation nil)")
+  func ineligibleNotEvaluated() {
+    #expect(decide(eligible: false) == .notEvaluated)
+  }
+
+  @Test("non-filtered conditioner paths refuse not_filtered (no double-append on raw/padded)")
+  func nonFilteredRefused() {
+    for r in ["rawSoftOnset", "rawFallbackTooAggressive", "filteredPaddedToMinimum"] {
+      #expect(decide(reason: r, droppedMs: 1_000) == .refuse(reason: "not_filtered"))
+    }
+  }
+
+  // MARK: guard ORDER (first-failing-guard names the reason)
+
+  @Test("ineligible wins over every later failure")
+  func ineligibleWinsOrder() {
+    // ineligible AND non-filtered AND zero-tail at once → notEvaluated.
+    #expect(
+      decide(
+        eligible: false, reason: "rawSoftOnset", droppedSamples: 0, droppedMs: 0, fraction: 0.0)
+        == .notEvaluated)
+  }
+
+  @Test("not_filtered wins over too_short")
+  func notFilteredWinsOrder() {
+    // eligible AND non-filtered AND too-short at once → not_filtered.
+    #expect(
+      decide(reason: "filteredPaddedToMinimum", droppedMs: 100) == .refuse(reason: "not_filtered"))
+  }
+
+  // MARK: append contiguity (surgical — internal VAD gap stays excluded)
+
+  @Test("filtered + dropped tail is contiguous and the internal VAD gap stays trimmed")
+  func appendContiguity() {
+    // Two voiced segments with a 5000-sample internal gap, plus a long trailing
+    // region the trim discards. Recovery = filtered + raw.suffix(dropped); it must
+    // append exactly the trailing region while the internal gap + leading silence
+    // stay excluded (the surgical property vs return-raw).
+    let rawCount = 200_000
+    var raw = [Float](repeating: 0, count: rawCount)
+    for i in 0..<rawCount { raw[i] = Float(i % 257) * 0.001 }  // distinguishable per index
+    let segs = [
+      SpeechSegment(startSample: 40_000, endSample: 70_000),
+      SpeechSegment(startSample: 75_000, endSample: 120_000),
+    ]
+    let cond = CapturedAudioConditioner.condition(rawSamples: raw, vadSegments: segs)
+    let dropped = cond.droppedTailSampleCount
+    #expect(dropped > 0)
+    let tailSlice = Array(raw.suffix(dropped))
+    let recovered = cond.samples + tailSlice
+    // (1) append arithmetic.
+    #expect(recovered.count == cond.samples.count + dropped)
+    // (2) internal gap + leading silence stayed excluded → recovered shorter than raw.
+    #expect(recovered.count < rawCount)
+    // (3) head unchanged: the filtered buffer is the prefix, untouched by the append.
+    #expect(Array(recovered.prefix(cond.samples.count)) == cond.samples)
+    // (4) the appended region is exactly the raw trailing slice.
+    #expect(Array(recovered.suffix(dropped)) == Array(raw[(rawCount - dropped)..<rawCount]))
+  }
+}


### PR DESCRIPTION
**Part of #950** (the VAD-trim arm; the capture/stop-boundary arm stays open as the monitoring thread, per phase-pr-closes-keyword).

## What
On the Parakeet batch path the kernel VAD trim keeps audio only in `[firstSegmentStart-100ms, lastSegmentEnd+100ms]`. When the voice detector closes the final segment early (one production user's mic/noise profile, distinct_id `019EA521...`), the trim discards 2.0-4.6s of real trailing speech before ASR. This recovers it.

## How
At the stop path, when the trim would discard a trailing region that is (a) >= 400ms, (b) <= 8000ms, and (c) sustained voice (>= 50% of its 40ms windows above the dead-air floor), append exactly that already-materialized slice to the filtered buffer before transcription. Surgical: internal-gap trimming is preserved, so no new silence reaches ASR. Parakeet-batch only; WhisperKit (decodes raw capture) and streaming are structurally excluded.

The sustained-voice fraction is the hallucination guard: a single desk-thump / keyboard transient tiles to a low fraction and is refused before it ever reaches ASR. The decision is one pure static (`tailPreserveDecision` returning `.preserve` / `.refuse(reason:)` / `.notEvaluated`); the refusal reason doubles as tuning telemetry.

## Telemetry (metadata only, no audio/content)
Adds `tail_preserved`, `tail_preserved_ms`, `tail_voiced_fraction`, `tail_refused_reason` to `asr.completed` (PostHog) + the Sentry breadcrumb + persisted `ExecutionMetrics`. Lets the 400ms floor and 0.5 gate be tuned from production data rather than guessed.

## Validation
- 1801 logic tests green (16 new boundary tests; the hallucination guard is tested first).
- Append contiguity proven against the real conditioner.
- Web-grounded council + competitor code teardown: pre-ASR VAD trimming is industry-normal (Spokenly runs the identical FluidAudio VAD and 100ms pad; no local competitor has tail recovery). Onto something, not over-engineering; ship.
- Codex grounded review: PROCEED-AS-PLANNED (5 rounds). Codex code-diff review: clean.
- Live UAT: clean dictation pass, heart path intact, recovery correctly does not fire (`refusedReason=no_tail`), all four new fields render.

## Blast radius
Non-fire path is byte-identical to today's ASR input. Single-commit revert. No VAD-config / WhisperKit / streaming / UI / paste changes.