### PR TITLE
fix(post-processing): ITN formats capitalized numbers in unit-anchored contexts

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -211,7 +211,12 @@ public struct InverseTextNormalizer: Sendable {
       return " \(comma(n)) "
     }
 
-    // generic cardinals: longest runs of number-words -> int
+    // generic cardinals: longest runs of number-words -> int. Left case-SENSITIVE on purpose: a
+    // capitalized number word here has no unit/operator anchor, so it is ambiguous between a count
+    // and prose / a proper noun ("Hundred Acre Wood", "One Million Moms"). A scale word does NOT
+    // disambiguate (proper nouns use them too), so capitalized cardinals stay untouched and that
+    // context call is left to the AI-polish layer. (Unit-anchored caps ARE handled — see currency/
+    // percent/decimals below.)
     let cardPat = #"(?:\b(?:"# + Self.numwordAlt + #")\b\s*){1,}"#
     t = reSub(cardPat, t) { m in
       let words = Self.splitWords(m.whole)
@@ -362,8 +367,14 @@ public struct InverseTextNormalizer: Sendable {
       + #"(?<d>(?:"# + Self.digitWordAlt + #")(?:\s+(?:"# + Self.digitWordAlt + #"))*)"#
       + #"(?:\s+(?<scale>million|billion|thousand))?\s"#
     return reSub(pat, t) { m in
-      guard let whole = Self.wordsToInt(Self.splitWords(m.g("w") ?? "")) else { return nil }
-      let digs = Self.splitWords(m.g("d") ?? "").map { String(Self.units[$0]!) }.joined()
+      // 'point' anchors numeric intent, so lowercasing the captured amount is corruption-safe.
+      guard let whole = Self.wordsToInt(Self.splitWords((m.g("w") ?? "").lowercased())) else {
+        return nil
+      }
+      // Lowercase the fraction words too: the case-insensitive regex can capture 'Five' in
+      // 'Three Point Five', and Self.units[$0]! would force-unwrap nil on the capitalized key.
+      let digs = Self.splitWords((m.g("d") ?? "").lowercased()).map { String(Self.units[$0]!) }
+        .joined()
       let scale = (m.g("scale") ?? "").trimmingCharacters(in: .whitespaces).lowercased()
       if !scale.isEmpty, let sv = Self.scales[scale] {
         let value = (Double("\(whole).\(digs)") ?? 0) * Double(sv)
@@ -381,9 +392,14 @@ public struct InverseTextNormalizer: Sendable {
       #"\s((?<d>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+dollars"#
       + #"(?:\s+and\s+(?<c>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok
       + #"))*)\s+cents)?)\s"#
+    // 'dollars'/'cents'/'percent' anchor numeric intent, so lowercasing the captured amount is
+    // corruption-safe: a capitalized sentence-initial 'Twenty dollars'/'Twenty percent' is a number,
+    // never prose. (Bare cardinals stay case-sensitive — see the cardinal pass above.)
     t = reSub(curPat, t) { m in
-      guard let d = Self.wordsToInt(Self.splitWords(m.g("d") ?? "")) else { return nil }
-      if let cRaw = m.g("c"), let c = Self.wordsToInt(Self.splitWords(cRaw)) {
+      guard let d = Self.wordsToInt(Self.splitWords((m.g("d") ?? "").lowercased())) else {
+        return nil
+      }
+      if let cRaw = m.g("c"), let c = Self.wordsToInt(Self.splitWords(cRaw.lowercased())) {
         return " $\(comma(d)).\(pad2(c)) "
       }
       return " $\(comma(d)) "
@@ -391,12 +407,16 @@ public struct InverseTextNormalizer: Sendable {
     let centsPat =
       #"\s((?<c>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+cents)\s"#
     t = reSub(centsPat, t) { m in
-      guard let c = Self.wordsToInt(Self.splitWords(m.g("c") ?? "")) else { return nil }
+      guard let c = Self.wordsToInt(Self.splitWords((m.g("c") ?? "").lowercased())) else {
+        return nil
+      }
       return " $\(String(format: "%.2f", Double(c) / 100.0)) "
     }
     let pctPat = #"\s((?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+percent\b"#
     t = reSub(pctPat, t) { m in
-      guard let n = Self.wordsToInt(Self.splitWords(m.g(1) ?? "")) else { return nil }
+      guard let n = Self.wordsToInt(Self.splitWords((m.g(1) ?? "").lowercased())) else {
+        return nil
+      }
       return " \(n)% "
     }
     return t

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -158,6 +158,22 @@ struct InverseTextNormalizerParityTests {
       // strict-cardinal corruption guard: a non-cardinal run is left untouched (context for
       // "one twenty" belongs to the AI-polish layer, not the deterministic floor)
       ("there were one twenty people there", "there were one twenty people there"),
+      // #145 follow-up: capitalized number words in an UNIT-ANCHORED numeric context
+      // (currency / percent / decimal point) now format — they did not before because the
+      // lexicon lookups were case-sensitive.
+      ("Twenty dollars please", "$20 please"),
+      ("Twenty percent off", "20% off"),
+      // crash guard: a title-cased decimal must format, not trap on the force-unwrapped fraction
+      // word ('Five'); the case-insensitive regex captures it, so the digit map must lowercase.
+      ("Three Point Five", "3.5"),
+      // adversarial negatives: a capitalized number word with NO unit anchor must stay a word,
+      // never corrupt into a digit — covers prose ("One thing", "Two of us") AND proper nouns
+      // that contain a scale word ("Hundred Acre Wood", "One Million Moms"). A bare/scale-only
+      // capital is ambiguous between count and name, so the deterministic floor leaves it.
+      ("One thing that I want to figure out", "One thing that I want to figure out"),
+      ("Two of us went to the store", "Two of us went to the store"),
+      ("Hundred Acre Wood", "Hundred Acre Wood"),
+      ("One Million Moms", "One Million Moms"),
     ])
   func categoryFixes(input: String, expected: String) {
     #expect(InverseTextNormalizer().normalize(input) == expected)


### PR DESCRIPTION
## What

The deterministic ITN floor (#145) looked up number words in case-sensitive lexicons, so a capitalized sentence-initial number that the case-insensitive driving regex matched ("Twenty dollars", "Twenty percent") silently failed to parse and stayed as spoken words. Codex flagged this on PR #951.

## Fix

Scoped to contexts where a unit/operator token proves numeric intent and cannot be prose: **currency** ("dollars"/"cents"), **percent**, and **decimal "point"**. There the captured number run is lowercased before the lexicon lookup:

- `Twenty dollars please` → `$20 please`
- `Twenty percent off` → `20% off`
- `Three Point Five` → `3.5`

Lowercase input is unaffected.

**Bare and scale-bearing cardinals are deliberately left case-SENSITIVE.** A capitalized number word with no unit anchor is ambiguous between a count and prose / a proper noun, and a scale word does NOT disambiguate (`Hundred Acre Wood`, `One Million Moms` are names, not numbers). That context call belongs to the AI-polish layer, not the deterministic floor (#145's design principle), so those phrases stay untouched.

## Two corruption traps caught in review (Codex, 3 rounds)

1. Naive global lowercase mangles prose: `One thing` → `1 thing`. Avoided.
2. Lowercasing the decimal whole-number without the fraction **force-unwrap-crashed** on title-cased fractions (`Three Point Five`). Fixed by lowercasing the fraction digits too.
3. A scale-word gate corrupted proper nouns (`Hundred Acre Wood` → `100 Acre Wood`). Dropped the scale path entirely.

## Validation

- Mirrored in the Python oracle (`hand_rolled.py`); parity + holdout fixtures regenerate **byte-identical** (zero existing-row drift).
- Adversarial positives, prose negatives, and proper-noun negatives added to the oracle-verified category-fixes test.
- Full Xcode logic suite green (1783 tests). Codex code-diff review: clean after 3 rounds.

Closes #145.