### PR TITLE
fix(telemetry): downgrade ASR-empty terminal from Sentry error to breadcrumb (#979)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -515,15 +515,21 @@ final class KernelLifecycleTelemetrySink {
         .audioCaptureFailed, "recording",
         captureFailureExtra(error: error, failureMode: "thrown_start"))
     case .asrEmpty:
-      emitCaptureError(
-        NSError(
-          domain: "EnviousWispr", code: -1,
-          userInfo: [
-            NSLocalizedDescriptionKey: "ASR returned empty text despite speech evidence"
-          ]),
-        .asrEmptyResult, "asr",
-        telemetryState.asrEmptyDiagnostics?.sentryExtra() ?? ["backend": backend.rawValue],
-        snapshot: recordingSnapshot())
+      // #979: ASR-empty on non-speech (ambient noise trips VAD, engine
+      // correctly returns empty) is an EXPECTED outcome, not an error.
+      // Evidence: 7 organic capture pairs all ambient non-speech (energy-mod
+      // 0.08-0.19, no inter-word pauses); founder repro "airplane, light taps";
+      // SuperWhisper logs the same condition and treats it as a soft notice.
+      // The user already sees "Couldn't catch that" from the terminal STATE
+      // (KernelDictationDriver), independent of this emit. Downgrade from a
+      // Sentry error (which flagged a non-bug AND auto-filed issues via the
+      // Sentry->GitHub triage) to a context-only breadcrumb. Frequency still
+      // lives in PostHog pipeline.failed (error_code "Couldn't catch that --
+      // try again"); engineering evidence still lives in the DEBUG
+      // ASREmptyCaptureDump. Both untouched.
+      breadcrumb(
+        "asr", "ASR returned empty text despite speech evidence",
+        telemetryState.asrEmptyDiagnostics?.sentryExtra() ?? ["backend": backend.rawValue])
     case .emptyAfterProcessing:
       emitCaptureError(
         HeartPathError.emptyAfterProcessing(

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -268,6 +268,10 @@ public enum SentryBreadcrumb {
     case audioCaptureFailed = "audio_capture_failed"
     case audioCaptureStalled = "audio_capture_stalled"
     case asrFailed = "asr_failed"
+    /// #979: retained as a historical Sentry tag — no longer emitted (ASR-empty
+    /// on non-speech downgraded to a context-only breadcrumb in
+    /// KernelLifecycleTelemetrySink). Kept so old `asr_empty_result` events stay
+    /// documented; do not re-wire to an error without revisiting #979.
     case asrEmptyResult = "asr_empty_result"
     case heartPathFinalization = "heart_path_finalization"
     case pipelineDispatchFailed = "pipeline_dispatch_failed"

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -502,14 +502,30 @@ import Testing
     #expect(recorder.captureErrors.first?.stage == "recording")
   }
 
-  @Test(".failed(.asrEmpty) emits .asrEmptyResult captureError")
-  func failedASREmptyEmission() {
+  @Test(
+    ".failed(.asrEmpty) downgrades to a breadcrumb, emits NO captureError (#979)",
+    .bug("https://github.com/saurabhav88/EnviousWispr/issues/979", "ASR-empty non-bug"))
+  func failedASREmptyDowngradedToBreadcrumb() throws {
     let recorder = Recorder()
     let sink = makeSink(recorder: recorder)
     sink.emit(.failed(.asrEmpty))
+    // #979: ASR-empty on non-speech is an expected outcome, not an error — no
+    // Sentry error means no auto-filed issue. A context-only breadcrumb instead.
+    #expect(recorder.captureErrors.isEmpty)
+    let crumb = try #require(recorder.breadcrumbs.first { $0.stage == "asr" })
+    #expect(crumb.message == "ASR returned empty text despite speech evidence")
+  }
+
+  // Adversarial control: the downgrade is scoped to `.asrEmpty` ONLY — sibling
+  // failure terminals still emit a real Sentry error (see
+  // failedModelLoadFailedEmission / failedCaptureStartFailedEmission above).
+  @Test(".failed(.asrEmpty) downgrade does NOT silence sibling failure terminals")
+  func asrEmptyDowngradeIsScoped() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+    sink.emit(.failed(.captureStartFailed))
     #expect(recorder.captureErrors.count == 1)
-    #expect(recorder.captureErrors.first?.category == .asrEmptyResult)
-    #expect(recorder.captureErrors.first?.stage == "asr")
+    #expect(recorder.captureErrors.first?.category == .audioCaptureFailed)
   }
 
   @Test(".failed(.emptyAfterProcessing) emits .heartPathFinalization captureError")


### PR DESCRIPTION
## What

When a recording in a noisy environment produces no transcribable speech, the ASR engine correctly returns empty and the user already sees the friendly **"Couldn't catch that, try again."** But the same terminal *also* emitted a Sentry **error** (`asr_empty_result`), which (a) flagged a non-bug as a crash-class error and (b) auto-filed GitHub issues via the Sentry→GitHub triage pipeline — issue #979 is literally one of those auto-filed issues (`sentry-issue-id: ENVIOUSWISPR-14`, escalated 2→7 users / 19 events across 2.1.0–2.1.3 purely as noise).

This downgrades that single terminal from a Sentry **error event** to a context-only **breadcrumb**. No user surface changes.

## Evidence it's a non-bug (not lost words)

- **7 organic capture pairs** (`~/Library/Logs/EnviousWispr/asr-empty-captures/`, PR #1040 DEBUG instrument): every one is ambient non-speech — energy-modulation 0.08–0.19 (speech is >0.4), quiet-fraction 0.00–0.02 (speech has inter-word pauses). Zero lost words.
- **Founder live repro** 2026-06-16: "lightly tapping record on an airplane with ambient noise" fired the terminal; `VAD detail: segments=1, voicedMs=256` inside a 5.68s clip = a blip in continuous noise.
- **SuperWhisper** hits the identical condition (`server VAD firing but transcribing no speech`) and treats it as a soft "silent mic" notice, never an error.

## Change (telemetry-only, one terminal)

- `KernelLifecycleTelemetrySink.emitFailed(.asrEmpty)` — replaced the `emitCaptureError(… .asrEmptyResult …)` Sentry error with the injected `breadcrumb(…)` closure (info-level session-trail crumb), carrying the same lightweight diagnostic extras (metadata only, no PII).
- `SentryBreadcrumb.ErrorCategory.asrEmptyResult` — **kept** as a historical tag (now unemitted) with a marker comment, so old `asr_empty_result` events stay documented and a future reader doesn't re-wire it.

## What is deliberately unchanged

- **UX:** "Couldn't catch that, try again" is driven by the terminal *state*, not this emit.
- **Frequency tracking:** PostHog `pipeline.failed{error_category: asr_empty_result}` still emits independently — that remains the queryable frequency home.
- **Engineering safety net:** the DEBUG `ASREmptyCaptureDump` and the `app.log` line are untouched.

## Tests

- Inverted `KernelLifecycleTelemetrySinkTests` — `.asrEmpty` now asserts **no** `captureError` and a `"asr"` breadcrumb is emitted.
- Added an adversarial scope control (`asrEmptyDowngradeIsScoped`) asserting sibling failure terminals (`.captureStartFailed`) **still** emit a real Sentry error — the downgrade is scoped to `.asrEmpty` only.

Tier: SMALL · Lane: Code · reversible in one commit.

Plan: `docs/feature-requests/issue-979-2026-06-16-asr-empty-telemetry-downgrade.md` (council coverage + Codex grounded review, 3 rounds → PROCEED-AS-PLANNED).

Closes #979