### PR TITLE
fix(content): correct residual polish-capability overclaims in blog examples (#1034)

### DIFF
--- a/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
+++ b/website/src/content/blog/dictating-episode-scripts-without-losing-flow.md
@@ -96,7 +96,7 @@ If you already have EnviousWispr installed, you can start dictating episode scri
 1. Open your writing app: whatever you use for scripts (Notion, Obsidian, Google Docs, a plain text editor)
 2. Leave polish on the default; it keeps your conversational tone intact while cleaning up filler words
 3. Hold the hotkey and talk through your next episode's cold open
-4. Look at the output. Adjust the prompt. Try again
+4. Look at the output. Adjust how you say it. Try again
 
 If you don't have EnviousWispr yet, [download it free](https://enviouswispr.com/#download). No account, no subscription, runs on macOS Sonoma or later on any Apple Silicon Mac. The source is also [on GitHub](https://github.com/saurabhav88/EnviousWispr/releases) if you want to inspect it first. For longer scripts, switch to hands-free mode and talk through the whole episode without touching the keyboard.
 

--- a/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
+++ b/website/src/content/blog/mac-dictation-for-productivity-the-complete-guide.md
@@ -37,7 +37,7 @@ Read the workflow: [Dictating emails at the speed of thought](/blog/dictate-emai
 
 ### 2. Meeting notes and polished summaries
 
-The hard part of meeting notes is not capturing them. It is turning a transcript into a summary that someone else can act on. Dictate your raw notes during or right after a meeting, then let the polish layer compress them into a structured summary with action items.
+The hard part of meeting notes is not capturing them. It is turning a raw transcript into something structured that someone else can act on. Dictate your notes during or right after a meeting, naming the decisions and action items as you say them, then let the polish layer clean them up and lay them out into clear sections.
 
 Read the workflow: [Dictating meeting notes and polished summaries](/blog/meeting-notes-polished-summaries/).
 

--- a/website/src/content/blog/meeting-notes-polished-summaries.md
+++ b/website/src/content/blog/meeting-notes-polished-summaries.md
@@ -28,7 +28,7 @@ But the real leverage comes from what happens next.
 
 A structured meeting summary on Mac comes from two steps: dictate a 30-second voice dump while context is fresh, then let an LLM polish step clean it up. EnviousWispr handles both, and with Ollama, OpenAI, or Gemini polish on it also lays the result out into sections and bullets. Hold a hotkey, talk through what happened (decisions, owners, deadlines, open questions), and release. On-device speech recognition transcribes the audio in a second or two on Apple Silicon.
 
-The polish step turns that raw text into a usable summary. It removes filler and fixes punctuation, which already produces something cleaner than most people type. With Ollama, OpenAI, or Gemini polish turned on, a longer debrief with decisions and action items gets laid out with sections and bullet points automatically; on the Apple Intelligence default, you get the same content as clean, readable prose. Either way, the way you speak guides the shape.
+The polish step turns that raw dump into clean, structured notes. It removes filler and fixes punctuation, which already produces something cleaner than most people type. With Ollama, OpenAI, or Gemini polish turned on, a longer debrief with decisions and action items gets laid out with sections and bullet points automatically; on the Apple Intelligence default, you get the same content as clean, readable prose. Either way, the way you speak guides the shape.
 
 Out of the box, EnviousWispr cleans up filler words, fixes punctuation, and keeps your voice. That alone transforms your dictation. But for meeting notes, the real unlock is structure.
 
@@ -38,24 +38,22 @@ The LLM post-processing step does a remarkable job of this. Here's what the form
 
 ### Before: raw dictation
 
-> Met with product and sales about the Q3 launch timeline. Sarah confirmed the beta ships May 15. Mark owns the partner outreach deck, due by Friday. We agreed to cut the enterprise tier from the initial launch, revisit in Q4. I need to send the updated roadmap to the board by Thursday. Oh, and we still need to figure out the pricing page copy, nobody owns that yet.
+> Met with product and sales about the Q3 launch timeline. Decisions: Sarah confirmed the beta ships May 15, and we agreed to cut the enterprise tier from the initial launch and revisit in Q4. Action items: Mark owns the partner outreach deck, due Friday, and I need to send the updated roadmap to the board by Thursday. Open question: the pricing page copy, nobody owns that yet.
 
 ### After: formatted summary (Ollama, OpenAI, or Gemini)
 
-> **Meeting Summary: Q3 Launch Timeline**
+> **Q3 Launch Timeline**
 >
-> **Attendees:** Product team, Sales team, Sarah, Mark
->
-> **Key Decisions:**
+> **Decisions:**
 > - Beta ships May 15 (confirmed)
-> - Enterprise tier cut from initial launch; revisit in Q4
+> - Enterprise tier cut from the initial launch; revisit in Q4
 >
 > **Action Items:**
-> - Mark: Partner outreach deck, due Friday
-> - [Me]: Send updated roadmap to board, due Thursday
+> - Mark: partner outreach deck, due Friday
+> - Me: send updated roadmap to the board, due Thursday
 >
-> **Open Questions:**
-> - Pricing page copy, no owner assigned
+> **Open Question:**
+> - Pricing page copy, no owner yet
 
 That's the difference between a wall of text you'll never revisit and a summary you can paste straight into Slack, email to your team, or drop into Notion. There's a real pride in sending a meeting summary that looks like you spent ten minutes on it, knowing it took thirty seconds. The whole process, from speaking to structured output, takes less time than opening a new document and typing a subject line.
 

--- a/website/src/content/blog/podcast-show-notes-to-blog-posts.md
+++ b/website/src/content/blog/podcast-show-notes-to-blog-posts.md
@@ -42,23 +42,24 @@ You can dictate show notes in the same conversational tone your audience already
 
 This is where things get genuinely useful for podcast show notes blog posts. EnviousWispr's [post-processing pipeline](/how-it-works/) cleans up your dictation and formats it into polished text. The polish keeps things conversational and scannable, which is what you want for show notes. When you talk through a longer, structured blog version, it comes back as tighter prose with proper paragraphs.
 
-You shape that by how you speak, and Ollama, OpenAI, or Gemini polish turns it into format: run through your show notes as a quick list and they land as bullet points with a summary. On the Apple Intelligence default, you get the same content as clean prose. For a blog version, speak the post in full (a longer take, in your own words); the polish cleans up what you said, but it never pads a short recap out into a long post, so say the post you want.
+You shape that by how you speak, and Ollama, OpenAI, or Gemini polish turns it into format: run through your show notes as a quick list and they land as clean bullet points. On the Apple Intelligence default, you get the same content as clean prose. For a blog version, speak the post in full (a longer take, in your own words); the polish cleans up what you said, but it never pads a short recap out into a long post, so say the post you want.
 
-Here's what this looks like end to end, dictating a recap right after recording (with Ollama, OpenAI, or Gemini polish, which adds the bullets and labels; the Apple Intelligence default keeps it as clean prose):
+Here's what this looks like end to end, dictating a recap right after recording. The structure follows the cues you speak; with Ollama, OpenAI, or Gemini polish on you get labeled bullets, and the Apple Intelligence default keeps the same content as clean prose:
 
 **What you say:**
-> okay so in this episode we talked to Sarah Chen about building a podcast audience from scratch um she said the biggest mistake new podcasters make is focusing on downloads instead of engagement and she recommended starting with a weekly newsletter to build a direct relationship with listeners we also covered her strategy for getting guests when you're a small show which is basically lead with what you can offer them not what they can offer you and then at the end she shared her tech stack which is Riverside for recording Descript for editing and Kit for the newsletter
+> okay episode recap. we talked to Sarah Chen about building a podcast audience from scratch. um the big takeaway is the biggest mistake new podcasters make is focusing on downloads instead of engagement, and she recommended starting with a weekly newsletter to build a direct relationship with listeners. we also covered her guest strategy for a small show, which is basically lead with what you can offer them not what they can offer you. and the resources she mentioned were Riverside for recording, Descript for editing, and Kit for the newsletter
 
 **What gets pasted:**
-> **Episode Summary:** Sarah Chen shares her framework for building a podcast audience from zero, focusing on engagement over downloads.
+> **Episode recap:** We talked to Sarah Chen about building a podcast audience from scratch.
 >
-> **Key Topics:**
-> - Why engagement matters more than download numbers for new podcasters
-> - Building a weekly newsletter to create direct listener relationships
-> - Guest booking strategy for small shows: lead with value you can offer
+> **The big takeaway:** The biggest mistake new podcasters make is focusing on downloads instead of engagement. She recommended starting with a weekly newsletter to build a direct relationship with listeners.
 >
-> **Resources Mentioned:**
-> - Riverside (recording), Descript (editing), Kit (newsletter)
+> **Guest strategy for a small show:** Lead with what you can offer them, not what they can offer you.
+>
+> **Resources mentioned:**
+> - Riverside (recording)
+> - Descript (editing)
+> - Kit (newsletter)
 
 Two minutes of speaking replaced forty-five minutes of typing. The show notes are structured, scannable, and ready to paste into your podcast host. That creative momentum from the recording session doesn't have to die. You capture it before the episode goes cold.
 


### PR DESCRIPTION
## What

Finishes the blog-accuracy cleanup for the removed Custom-prompt feature. **PR #1041 already did the bulk** — it swept the Custom-prompt teaching out of all five posts named in #1034 and fixed the homepage testimonial ("formal tone option" is gone). This PR fixes the **residual capability overclaims** that survived #1041, including the one Codex flagged on that PR.

The accurate model: polish **cleans filler, fixes punctuation, and formats around the cues you speak**. It never condenses, summarizes, or generates new content.

## Changes (content lane, 4 posts)

- **`podcast-show-notes-to-blog-posts.md`** — dropped "bullet points **with a summary**" (Codex P2 finding). Rewrote the worked example: the spoken input now names its own sections, and the pasted output is a faithful clean-up — no synthesized "**Episode Summary:** Sarah Chen shares her framework…" line the engine wouldn't produce.
- **`meeting-notes-polished-summaries.md`** — "raw text into a **usable summary**" → "clean, structured notes." Reworked the before/after example so the dictation names the cues (decisions / action items / open question); dropped the inferred "**Attendees:**" list and the synthesized "**Meeting Summary:**" title. Now consistent with the post's own line: "You steer that structure with your words."
- **`mac-dictation-for-productivity-the-complete-guide.md`** — "let the polish layer **compress them into a structured summary**" → clean up and lay out the items you name.
- **`dictating-episode-scripts-without-losing-flow.md`** — leftover "**Adjust the prompt.** Try again" → "Adjust how you say it" (no custom prompt has existed since #614).

## Validation

`astro build` green — 52 pages, no errors. SEO titles/links and the "summary" keyword in headings preserved (only false *capability* claims changed). No em/en dashes. Content lane: build-check + visual confirm.

Closes #1034