### PR TITLE
feat(ui): dark mode for the app window with appearance toggle (#1047)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppearanceController.swift
+++ b/Sources/EnviousWisprAppKit/App/AppearanceController.swift
@@ -1,0 +1,21 @@
+import AppKit
+import EnviousWisprCore
+
+/// Maps the user's `AppearancePreference` onto `NSApplication.appearance`.
+/// Stateless: the persisted preference lives on `SettingsManager`; this only
+/// applies it. `.system` clears the override so macOS drives appearance and
+/// repaints live when the OS setting changes.
+@MainActor
+enum AppearanceController {
+  static func apply(_ preference: AppearancePreference) {
+    // `NSApplication.shared` (not the `NSApp` global) — `NSApp` is an
+    // implicitly-unwrapped `NSApplication!` that is nil until `.shared` is first
+    // accessed, and this runs from `WisprBootstrapper.init` before that happens.
+    NSApplication.shared.appearance =
+      switch preference {
+      case .system: nil
+      case .light: NSAppearance(named: .aqua)
+      case .dark: NSAppearance(named: .darkAqua)
+      }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -226,6 +226,29 @@ final class MenuBarController: NSObject {
     settingsItem.target = self
     menu.addItem(settingsItem)
 
+    // Appearance submenu (System / Light / Dark) — checkmark on the current
+    // preference. Mirrors the Settings → Appearance picker (#1047).
+    let appearanceItem = NSMenuItem(title: "Appearance", action: nil, keyEquivalent: "")
+    appearanceItem.image = NSImage(
+      systemSymbolName: "circle.lefthalf.filled", accessibilityDescription: "Appearance")
+    let appearanceSubmenu = NSMenu()
+    for option in AppearancePreference.allCases {
+      let title =
+        switch option {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+      let item = NSMenuItem(
+        title: title, action: #selector(setAppearanceAction(_:)), keyEquivalent: "")
+      item.target = self
+      item.representedObject = option.rawValue
+      item.state = option == state.appearancePreference ? .on : .off
+      appearanceSubmenu.addItem(item)
+    }
+    appearanceItem.submenu = appearanceSubmenu
+    menu.addItem(appearanceItem)
+
     // Check for Updates — targets SparkleUpdateController so it can tag the
     // install source as "menu" for telemetry attribution (issue #343).
     // PR-B.1 of #763 retargeted target/action to the controller; PR-B.3
@@ -278,7 +301,8 @@ final class MenuBarController: NSObject {
       hasUpdater: sparkleUpdateController.hasUpdater,
       updateAvailable: pending != nil,
       updateDisplayVersion: pending?.displayVersion,
-      installEnabled: pending != nil && !dictationActive
+      installEnabled: pending != nil && !dictationActive,
+      appearancePreference: settings.appearancePreference
     )
   }
 
@@ -297,6 +321,15 @@ final class MenuBarController: NSObject {
 
   @objc private func openSettingsAction() {
     actions.openSettings()
+  }
+
+  /// #1047: set the window-appearance preference from the Appearance submenu.
+  /// The `didSet` persists it and the bootstrapper applies it to `NSApp`.
+  @objc private func setAppearanceAction(_ sender: NSMenuItem) {
+    guard let raw = sender.representedObject as? String,
+      let preference = AppearancePreference(rawValue: raw)
+    else { return }
+    settings.appearancePreference = preference
   }
 
   @objc private func openPermissionsAction() {
@@ -366,4 +399,6 @@ struct MenuBarViewState: Equatable {
   /// is active (record / load / transcribe / polish), so a relaunch never kills
   /// in-flight work.
   var installEnabled: Bool = false
+  /// #1047: current window-appearance preference, for the Appearance submenu checkmark.
+  var appearancePreference: AppearancePreference = .system
 }

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -208,6 +208,8 @@ final class PipelineSettingsSync {
     case .onboardingState, .hasCompletedOnboarding, .useXPCAudioService,
       .contactsSyncOnLaunchEnabled:
       break  // UI-only or cold flag.
+    case .appearance:
+      break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -70,6 +70,9 @@ public final class WisprBootstrapper {
     // (mutates the store it reads). Release/shipped builds no-op. See migration doc.
     SettingsDefaultsMigration.migrateIfNeeded()
     let settings = SettingsManager()
+    // #1047: apply the persisted appearance before any window is built so a
+    // pinned Dark never flashes white. `.system` clears the override (follow OS).
+    AppearanceController.apply(settings.appearancePreference)
     let permissions = PermissionsService()
     let keychainManager = KeychainManager()
     let recordingOverlay = RecordingOverlayPanel()
@@ -250,6 +253,11 @@ public final class WisprBootstrapper {
     settings.onChange = { [weak settingsSync, weak settings, outputClassifierHolder] key in
       guard let settingsSync, let settings else { return }
       settingsSync.handleSettingChanged(key, settings: settings)
+      // #1047: appearance is a view-shell concern (no pipeline sync) — apply it
+      // to NSApp here so both the menu and the Settings picker take effect live.
+      if key == .appearance {
+        AppearanceController.apply(settings.appearancePreference)
+      }
       // #832/#913 PR8: if the user switches polish to Apple Intelligence after
       // launch, prewarm the classifier then (idempotent — no-op if loaded).
       // Captures the holder (not self — self isn't fully initialized here).

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingDesignTokens.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingDesignTokens.swift
@@ -1,33 +1,65 @@
 import SwiftUI
 
 // MARK: - Onboarding Color Palette
+//
+// #1047: each token pairs the exact pre-dark light value with a dark
+// night-comfort value via `Color.stDynamic`. `obRainbow` is the brand
+// signature and stays vivid in both modes. `obButtonFill` / `obKeycapTop`
+// are new role tokens (see note below) that resolve a light/dark conflict:
+// `obTextPrimary` was doubling as both heading text AND a primary-button
+// background with white text — inverting it would make that white text
+// vanish on dark, so the button-fill role is now its own token.
 
 extension Color {
   // Backgrounds
-  static let obSurface = Color(red: 0.941, green: 0.925, blue: 0.976)
-  static let obCardBg = Color.white
+  static let obSurface = stDynamic(
+    lightRGB: (0.941, 0.925, 0.976, 1), darkRGB: (0.125, 0.106, 0.169, 1))
+  static let obCardBg = stDynamic(
+    lightRGB: (1, 1, 1, 1), darkRGB: (0.145, 0.122, 0.216, 1))
 
   // Text
-  static let obTextPrimary = Color(red: 0.059, green: 0.039, blue: 0.102)
-  static let obTextSecondary = Color(red: 0.290, green: 0.239, blue: 0.376)
-  static let obTextTertiary = Color(red: 0.490, green: 0.435, blue: 0.588)
+  static let obTextPrimary = stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 1), darkRGB: (0.910, 0.894, 0.945, 1))
+  static let obTextSecondary = stDynamic(
+    lightRGB: (0.290, 0.239, 0.376, 1), darkRGB: (0.667, 0.635, 0.749, 1))
+  static let obTextTertiary = stDynamic(
+    lightRGB: (0.490, 0.435, 0.588, 1), darkRGB: (0.478, 0.447, 0.565, 1))
+
+  // Primary button fill — dark in light mode (near-black brand fill), a rich
+  // purple in dark mode. White button text reads on both (≈5.8:1 on dark).
+  static let obButtonFill = stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 1), darkRGB: (0.420, 0.310, 0.820, 1))
+
+  // Keycap top — the raised key face; white in light, a light-violet face in
+  // dark so the key still reads as a key against the dark window.
+  static let obKeycapTop = stDynamic(
+    lightRGB: (1, 1, 1, 1), darkRGB: (0.180, 0.155, 0.255, 1))
 
   // Brand
-  static let obAccent = Color(red: 0.486, green: 0.227, blue: 0.929)
-  static let obAccentSoft = Color(red: 0.486, green: 0.227, blue: 0.929).opacity(0.1)
+  static let obAccent = stDynamic(
+    lightRGB: (0.486, 0.227, 0.929, 1), darkRGB: (0.655, 0.545, 0.980, 1))
+  static let obAccentSoft = stDynamic(
+    lightRGB: (0.486, 0.227, 0.929, 0.1), darkRGB: (0.655, 0.545, 0.980, 0.16))
 
   // Semantic
-  static let obSuccess = Color(red: 0.0, green: 0.784, blue: 0.502)
-  static let obSuccessSoft = Color(red: 0.0, green: 0.784, blue: 0.502).opacity(0.1)
-  static let obSuccessText = Color(red: 0.0, green: 0.541, blue: 0.337)
-  static let obWarning = Color(red: 0.902, green: 0.761, blue: 0.0)
-  static let obError = Color(red: 0.902, green: 0.145, blue: 0.227)
-  static let obErrorSoft = Color(red: 0.902, green: 0.145, blue: 0.227).opacity(0.1)
+  static let obSuccess = stDynamic(
+    lightRGB: (0.0, 0.784, 0.502, 1), darkRGB: (0.361, 0.788, 0.604, 1))
+  static let obSuccessSoft = stDynamic(
+    lightRGB: (0.0, 0.784, 0.502, 0.1), darkRGB: (0.361, 0.788, 0.604, 0.16))
+  static let obSuccessText = stDynamic(
+    lightRGB: (0.0, 0.541, 0.337, 1), darkRGB: (0.361, 0.788, 0.604, 1))
+  static let obWarning = stDynamic(
+    lightRGB: (0.902, 0.761, 0.0, 1), darkRGB: (0.902, 0.718, 0.400, 1))
+  static let obError = stDynamic(
+    lightRGB: (0.902, 0.145, 0.227, 1), darkRGB: (0.937, 0.486, 0.537, 1))
+  static let obErrorSoft = stDynamic(
+    lightRGB: (0.902, 0.145, 0.227, 0.1), darkRGB: (0.937, 0.486, 0.537, 0.16))
 
   // Borders
-  static let obBorder = Color(red: 0.541, green: 0.169, blue: 0.886).opacity(0.06)
+  static let obBorder = stDynamic(
+    lightRGB: (0.541, 0.169, 0.886, 0.06), darkRGB: (0.722, 0.667, 0.839, 0.14))
 
-  // Rainbow gradient (static property — used as AnyShapeStyle)
+  // Rainbow gradient (brand signature — unchanged in both modes)
   static let obRainbow = LinearGradient(
     colors: [
       Color(red: 1.0, green: 0.165, blue: 0.251),
@@ -59,7 +91,7 @@ extension Font {
 // MARK: - Button Styles
 
 struct OnboardingButtonStyle: ButtonStyle {
-  var color: Color = .obTextPrimary
+  var color: Color = .obButtonFill
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -766,7 +766,7 @@ private struct PermissionsPhaseView: View {
             .frame(maxWidth: 360)
             .padding(.vertical, 13)
             .background(
-              bothGranted ? Color.obTextPrimary : Color.obTextPrimary.opacity(0.4),
+              bothGranted ? Color.obButtonFill : Color.obButtonFill.opacity(0.4),
               in: RoundedRectangle(cornerRadius: 12)
             )
         }
@@ -948,7 +948,7 @@ private struct ReadyScreenV2: View {
             .foregroundStyle(.white)
             .frame(maxWidth: 360)
             .padding(.vertical, 13)
-            .background(Color.obTextPrimary, in: RoundedRectangle(cornerRadius: 12))
+            .background(Color.obButtonFill, in: RoundedRectangle(cornerRadius: 12))
         }
         .buttonStyle(.plain)
         .keyboardShortcut(.defaultAction)
@@ -1139,7 +1139,7 @@ private struct KeycapHotkeyView: View {
         Color.obAccent.opacity(0.10)
       } else {
         LinearGradient(
-          colors: [.white, Color.obSurface],
+          colors: [Color.obKeycapTop, Color.obSurface],
           startPoint: .top,
           endPoint: .bottom
         )

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -1,0 +1,33 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import SwiftUI
+
+/// Window appearance preference. Mirrors the menu-bar Appearance submenu — both
+/// bind `settings.appearancePreference`, so they stay in sync.
+struct AppearanceSettingsView: View {
+  @Environment(SettingsManager.self) private var settings
+
+  var body: some View {
+    @Bindable var settings = settings
+
+    SettingsContentView {
+      BrandedSection(header: "Appearance") {
+        BrandedRow(showDivider: false) {
+          VStack(alignment: .leading, spacing: 10) {
+            BrandedSegmentedPicker(
+              options: [
+                (label: "System", value: AppearancePreference.system),
+                (label: "Light", value: AppearancePreference.light),
+                (label: "Dark", value: AppearancePreference.dark),
+              ],
+              selection: $settings.appearancePreference
+            )
+            Text("System follows your Mac and switches automatically. Light and Dark pin a look.")
+              .font(.stHelper)
+              .foregroundStyle(.stTextTertiary)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
@@ -1,33 +1,73 @@
+import AppKit
 import SwiftUI
 
+// MARK: - Dynamic color helper
+
+extension Color {
+  /// A color that resolves per the effective appearance. `light` is byte-identical
+  /// to the pre-dark palette; `dark` is the night-comfort palette (#1047). The
+  /// NSColors are built inside the resolver so nothing is captured across the
+  /// Sendable boundary.
+  static func stDynamic(
+    lightRGB: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat),
+    darkRGB: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat)
+  ) -> Color {
+    Color(
+      nsColor: NSColor(name: nil) { appearance in
+        let c = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? darkRGB : lightRGB
+        return NSColor(srgbRed: c.r, green: c.g, blue: c.b, alpha: c.a)
+      }
+    )
+  }
+}
+
 // MARK: - Settings Color Palette
+//
+// Each token pairs the exact light value shipped before #1047 with a dark
+// night-comfort value (low-chroma surfaces, off-white text, desaturated lavender
+// accent, muted semantics). Consumers read these statics unchanged, so the whole
+// window adapts when `NSApp.appearance` flips.
 
 extension Color {
   // Surfaces
-  static let stPageBg = Color(red: 0.973, green: 0.961, blue: 1.0)  // #f8f5ff
-  static let stSectionBg = Color.white
-  static let stSidebarBg = Color(red: 0.910, green: 0.886, blue: 0.961)  // #e8e2f5
+  static let stPageBg = stDynamic(
+    lightRGB: (0.973, 0.961, 1.0, 1), darkRGB: (0.075, 0.063, 0.098, 1))  // #f8f5ff / #131019
+  static let stSectionBg = stDynamic(
+    lightRGB: (1, 1, 1, 1), darkRGB: (0.125, 0.106, 0.169, 1))  // #ffffff / #201b2b
+  static let stSidebarBg = stDynamic(
+    lightRGB: (0.910, 0.886, 0.961, 1), darkRGB: (0.102, 0.086, 0.137, 1))  // #e8e2f5 / #1a1623
 
   // Text
-  static let stTextSecondary = Color(red: 0.290, green: 0.239, blue: 0.376)  // #4a3d60
-  static let stTextTertiary = Color(red: 0.420, green: 0.369, blue: 0.525)  // #6b5e86
+  static let stTextSecondary = stDynamic(
+    lightRGB: (0.290, 0.239, 0.376, 1), darkRGB: (0.667, 0.635, 0.749, 1))  // #4a3d60 / #aaa2bf
+  static let stTextTertiary = stDynamic(
+    lightRGB: (0.420, 0.369, 0.525, 1), darkRGB: (0.478, 0.447, 0.565, 1))  // #6b5e86 / #7a7290
 
   // Accent
-  static let stAccent = Color(red: 0.486, green: 0.227, blue: 0.929)  // #7c3aed
-  static let stAccentLight = Color(red: 0.486, green: 0.227, blue: 0.929).opacity(0.09)
+  static let stAccent = stDynamic(
+    lightRGB: (0.486, 0.227, 0.929, 1), darkRGB: (0.655, 0.545, 0.980, 1))  // #7c3aed / #a78bfa
+  static let stAccentLight = stDynamic(
+    lightRGB: (0.486, 0.227, 0.929, 0.09), darkRGB: (0.655, 0.545, 0.980, 0.16))
 
   // Toggle
-  static let stToggleOn = Color(red: 0.0, green: 0.639, blue: 0.400)  // #00a366
-  static let stToggleOff = Color(red: 0.608, green: 0.557, blue: 0.722)  // #9b8eb8
+  static let stToggleOn = stDynamic(
+    lightRGB: (0.0, 0.639, 0.400, 1), darkRGB: (0.361, 0.788, 0.604, 1))  // #00a366 / #5cc99a
+  static let stToggleOff = stDynamic(
+    lightRGB: (0.608, 0.557, 0.722, 1), darkRGB: (0.290, 0.263, 0.376, 1))  // #9b8eb8 / #4a4360
 
   // Status (semantic — use these, not raw .red/.green/.orange)
-  static let stSuccess = Color(red: 0.0, green: 0.639, blue: 0.400)  // #00a366
-  static let stWarning = Color(red: 0.800, green: 0.439, blue: 0.0)  // #cc7000
-  static let stWarningSoft = Color(red: 0.800, green: 0.439, blue: 0.0).opacity(0.10)
-  static let stError = Color(red: 0.753, green: 0.224, blue: 0.169)  // #c0392b
+  static let stSuccess = stDynamic(
+    lightRGB: (0.0, 0.639, 0.400, 1), darkRGB: (0.361, 0.788, 0.604, 1))  // #00a366 / #5cc99a
+  static let stWarning = stDynamic(
+    lightRGB: (0.800, 0.439, 0.0, 1), darkRGB: (0.902, 0.718, 0.400, 1))  // #cc7000 / #e6b766
+  static let stWarningSoft = stDynamic(
+    lightRGB: (0.800, 0.439, 0.0, 0.10), darkRGB: (0.902, 0.718, 0.400, 0.14))
+  static let stError = stDynamic(
+    lightRGB: (0.753, 0.224, 0.169, 1), darkRGB: (0.937, 0.486, 0.537, 1))  // #c0392b / #ef7c89
 
   // Dividers
-  static let stDivider = Color(red: 0.541, green: 0.169, blue: 0.886).opacity(0.08)
+  static let stDivider = stDynamic(
+    lightRGB: (0.541, 0.169, 0.886, 0.08), darkRGB: (0.722, 0.667, 0.839, 0.14))
 }
 
 // MARK: - ShapeStyle Shorthands (enables `.stAccent` in `.foregroundStyle()`)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -4,6 +4,7 @@ import SwiftUI
 enum SettingsSection: String, CaseIterable, Identifiable {
   case history
   case whatsNew
+  case appearance
   case speechEngine
   case audio
   case shortcuts
@@ -22,6 +23,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .history: return "History"
     case .whatsNew: return "What's New"
+    case .appearance: return "Appearance"
     case .speechEngine: return "Transcription"
     case .audio: return "Microphone"
     case .shortcuts: return "Shortcuts"
@@ -40,6 +42,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .history: return "clock.arrow.circlepath"
     case .whatsNew: return "sparkle.magnifyingglass"
+    case .appearance: return "circle.lefthalf.filled"
     case .speechEngine: return "waveform"
     case .audio: return "speaker.wave.2"
     case .shortcuts: return "keyboard"
@@ -56,7 +59,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
   var group: SettingsGroup {
     switch self {
-    case .history, .whatsNew: return .app
+    case .history, .whatsNew, .appearance: return .app
     case .speechEngine, .audio, .shortcuts: return .record
     case .aiPolish, .wordCorrection: return .process
     case .clipboard: return .output

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -74,7 +74,6 @@ struct UnifiedWindowView: View {
         StatusBadge()
       }
     }
-    .preferredColorScheme(.light)
     .onChange(of: navigationCoordinator.pendingSection) { _, newSection in
       if let section = newSection {
         selectedSection = section
@@ -90,6 +89,8 @@ struct UnifiedWindowView: View {
       HistoryContentView()
     case .whatsNew:
       WhatsNewSettingsView()
+    case .appearance:
+      AppearanceSettingsView()
     case .speechEngine:
       SpeechEngineSettingsView()
     case .audio:

--- a/Sources/EnviousWisprCore/SettingsEnums.swift
+++ b/Sources/EnviousWisprCore/SettingsEnums.swift
@@ -8,3 +8,12 @@ public enum OnboardingState: String, Codable, Sendable {
   case needsPermissions = "needsCompletion"
   case completed = "completed"
 }
+
+/// User's window-appearance preference. `.system` follows the macOS setting
+/// (and repaints live when it changes); `.light`/`.dark` pin a mode.
+/// Persisted by its `rawValue`; unknown/missing values resolve to `.system`.
+public enum AppearancePreference: String, CaseIterable, Sendable {
+  case system
+  case light
+  case dark
+}

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -13,6 +13,9 @@ enum SettingsDefaultValues {
   static let selectedBackend: ASRBackendType = .parakeet
   static let recordingMode: RecordingMode = .pushToTalk
 
+  /// Default appearance follows the macOS system setting.
+  static let appearancePreference: AppearancePreference = .system
+
   // #923: AI polish is ON by default, Apple Intelligence. Previously the cold
   // fallback was `.none` and onboarding wrote `.appleIntelligence` separately,
   // which made the real default ambiguous. Apple Intelligence is on-device; on

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -41,6 +41,7 @@ public final class SettingsManager {
     case useXPCAudioService
     case useStreamingASR
     case warmEnginePolicy
+    case appearance
   }
 
   public var onChange: ((SettingKey) -> Void)?
@@ -64,7 +65,7 @@ public final class SettingsManager {
     "emojiFormatterEnabled", "contactsSyncOnLaunchEnabled", "isDebugModeEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
-    "useStreamingASR", "warmEnginePolicy",
+    "useStreamingASR", "warmEnginePolicy", "appearancePreference",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
   ]
 
@@ -271,6 +272,15 @@ public final class SettingsManager {
     didSet {
       defaults.set(warmEnginePolicy.rawValue, forKey: "warmEnginePolicy")
       onChange?(.warmEnginePolicy)
+    }
+  }
+
+  /// Window-appearance preference. UI-only — the app shell applies it to
+  /// `NSApp.appearance`; pipeline sync treats `.appearance` as a no-op.
+  public var appearancePreference: AppearancePreference {
+    didSet {
+      defaults.set(appearancePreference.rawValue, forKey: "appearancePreference")
+      onChange?(.appearance)
     }
   }
 
@@ -552,6 +562,11 @@ public final class SettingsManager {
       WarmEnginePolicy(
         rawValue: defaults.string(forKey: "warmEnginePolicy") ?? ""
       ) ?? SettingsDefaultValues.warmEnginePolicy
+
+    appearancePreference =
+      AppearancePreference(
+        rawValue: defaults.string(forKey: "appearancePreference") ?? ""
+      ) ?? SettingsDefaultValues.appearancePreference
 
     // What's New: fresh install (nil) defaults to current version so new users aren't badged.
     let storedWhatsNew =

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -118,6 +118,7 @@ struct MenuBarControllerTests {
         "Start Recording",
         "",  // separator
         "Settings...",
+        "Appearance",  // #1047 submenu parent
         "",  // separator
         "Quit \(AppConstants.appName)",
       ],
@@ -129,15 +130,49 @@ struct MenuBarControllerTests {
     // Separators are separators.
     #expect(menu.items[2].isSeparatorItem)
     #expect(menu.items[4].isSeparatorItem)
-    #expect(menu.items[6].isSeparatorItem)
+    #expect(menu.items[7].isSeparatorItem)
     // Settings carries the comma key-equivalent; Quit carries "q".
     #expect(item(menu, "Settings...")?.keyEquivalent == ",")
     #expect(item(menu, "Quit \(AppConstants.appName)")?.keyEquivalent == "q")
-    // Every actionable item targets the controller.
-    for actionable in menu.items where actionable.action != nil {
+    // Every actionable item targets the controller. Submenu parents (e.g.
+    // Appearance) are excluded: AppKit assigns them a system `submenuAction:`
+    // whose target is the submenu itself; their children's targeting is covered
+    // by `renderMenuAppearanceSubmenu`.
+    for actionable in menu.items where actionable.action != nil && actionable.submenu == nil {
       #expect(
         actionable.target as AnyObject? === controller,
         "\(actionable.title) should target the MenuBarController")
+    }
+  }
+
+  @Test(
+    "renderMenu: Appearance submenu checkmarks the current preference, clears the others",
+    arguments: [AppearancePreference.system, .light, .dark])
+  func renderMenuAppearanceSubmenu(current: AppearancePreference) {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, appearancePreference: current))
+
+    let appearance = item(menu, "Appearance")
+    #expect(appearance != nil, "Appearance item missing")
+    let submenu = appearance?.submenu
+    #expect(submenu?.items.map(\.title) == ["System", "Light", "Dark"])
+
+    // Exactly the current preference is checked; the other two are off.
+    let expectedOn: String = {
+      switch current {
+      case .system: return "System"
+      case .light: return "Light"
+      case .dark: return "Dark"
+      }
+    }()
+    for sub in submenu?.items ?? [] {
+      #expect(
+        sub.state == (sub.title == expectedOn ? .on : .off),
+        "\(sub.title) checkmark wrong for current=\(current)")
+      #expect(sub.representedObject as? String != nil, "\(sub.title) must carry its rawValue")
+      #expect(sub.target as AnyObject? === controller, "\(sub.title) should target the controller")
     }
   }
 
@@ -299,7 +334,8 @@ struct MenuBarControllerTests {
     hasUpdater: Bool = false,
     updateAvailable: Bool = false,
     updateDisplayVersion: String? = nil,
-    installEnabled: Bool = false
+    installEnabled: Bool = false,
+    appearancePreference: AppearancePreference = .system
   ) -> MenuBarViewState {
     MenuBarViewState(
       pipelineState: pipelineState,
@@ -312,7 +348,8 @@ struct MenuBarControllerTests {
       hasUpdater: hasUpdater,
       updateAvailable: updateAvailable,
       updateDisplayVersion: updateDisplayVersion,
-      installEnabled: installEnabled
+      installEnabled: installEnabled,
+      appearancePreference: appearancePreference
     )
   }
 

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -72,6 +72,32 @@ struct SettingsDefaultsRoutingTests {
     #expect(!keys.contains("sessionLanguagePriors"))
   }
 
+  // MARK: - Appearance preference (#1047)
+
+  @Test("appearance defaults to .system on a fresh install")
+  func appearanceDefaultsToSystem() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    #expect(settings.appearancePreference == .system)
+  }
+
+  @Test("appearance persists to the injected store and is in the unified key set")
+  func appearancePersists() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.appearancePreference = .dark
+    #expect(suite.string(forKey: "appearancePreference") == "dark")
+    // Reload from the same store → the choice survives.
+    #expect(SettingsManager(defaults: suite).appearancePreference == .dark)
+    #expect(SettingsManager.unifiedDefaultsKeys.contains("appearancePreference"))
+  }
+
+  @Test("an unparseable stored appearance value falls back to .system")
+  func appearanceUnparseableFallsBack() {
+    let suite = Self.freshSuite()
+    suite.set("solarized", forKey: "appearancePreference")
+    #expect(SettingsManager(defaults: suite).appearancePreference == .system)
+  }
+
   @Test("useXPCAudioService writes to .standard, never the injected store")
   func useXPCStaysPerBuild() {
     let suite = Self.freshSuite()


### PR DESCRIPTION
Closes #1047.

## What
A System/Light/Dark appearance for the app window, controlled from two synced places:
- Menu-bar **Appearance** submenu (System / Light / Dark, checkmark on current).
- New **Settings → Appearance** tab (`BrandedSegmentedPicker`).

Default is **System** (follows the OS, repaints live on OS change). Pinned choice persists across relaunch.

## How
- `SettingsDesignTokens` (`st*`) and `OnboardingDesignTokens` (`ob*`) converted to dynamic light/dark colors via `Color.stDynamic`. **Light values are byte-identical to today.**
- `AppearanceController` maps the preference to `NSApplication.shared.appearance` (`.system` → nil/follow-OS); applied in `WisprBootstrapper.init` before the SwiftUI scene (no launch flash) and on change via `settings.onChange`.
- Persisted on `SettingsManager.appearancePreference` (+ `SettingKey.appearance`, registered in `unifiedDefaultsKeys`).
- Onboarding's `obTextPrimary` button-fill role split into `obButtonFill`/`obKeycapTop` so white button text stays legible on dark.
- `PipelineSettingsSync` treats `.appearance` as a no-op (UI-only); no new `MenuBarController` stored property (ceiling-safe).

## Out of scope (unchanged)
The floating recording pill/overlay (its own palette) and the menu-bar status icon.

## Validation
- Council coverage (GPT + Gemini) + Codex grounded review (2 rounds → PROCEED-AS-PLANNED) + Codex diff review (no actionable issues).
- Canonical Xcode suite green: 1,805 tests, 0 failures (4 new: appearance default/persist/fallback + menu submenu golden).
- Live dev-app UAT: launches in each mode, switches live from both controls, recording pill identical, light mode unchanged. Caught + fixed a launch crash (`NSApp` nil-early → `NSApplication.shared`).

Plan: `docs/feature-requests/issue-1047-2026-06-16-dark-mode.md`.