### PR TITLE
fix(llm): skip on-device polish silently for genuinely-huge dictations (#1055)

### DIFF
--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -27,6 +27,30 @@ public struct AFMPolishError: Error, Sendable {
   }
 }
 
+/// Thrown when a dictation's assembled on-device prompt (instructions +
+/// transcript + reserved output) would exceed Apple Intelligence's 4,096-token
+/// context window (#1055). `.predicted` = the token-count preflight stopped it
+/// before the model call; `.caught` = the model still threw
+/// `exceededContextWindowSize` at generation (the preflight under-counted).
+///
+/// Deliberately NOT an `AFMPolishError` and NOT an `LLMError`: it propagates
+/// untyped through `LLMPolishStep.process()`, and is handled by exactly two
+/// callers — `TextProcessingRunner` treats it as a silent live-dictation skip
+/// (deterministically-cleaned text passes through), and `TranscriptPolishService`
+/// surfaces an honest "too long for on-device polish" message. A plain struct
+/// (no FoundationModels dependency) so Pipeline-side code and tests can catch /
+/// construct it without importing the framework.
+public struct AFMContextWindowExceeded: Error, Sendable {
+  public enum Stage: String, Sendable {
+    case predicted
+    case caught
+  }
+  public let stage: Stage
+  public init(stage: Stage) {
+    self.stage = stage
+  }
+}
+
 /// Normalizes language identifiers (ISO 639-1 or BCP-47) to lowercased base
 /// codes. Shared between the preflight gate and the output validator so both
 /// speak the same language vocabulary. Internal so `@testable import` can reach
@@ -132,6 +156,59 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
 
   public init(classifier: OutputClassifierProtocol? = nil) {
     self.classifier = classifier
+  }
+
+  // MARK: - AFM context-window preflight (#1055)
+
+  /// Apple Intelligence shares a 4,096-token context window across instructions
+  /// + prompt + generated output (Apple docs; measured 2026-06-17, see
+  /// `.claude/knowledge/llm-contract.md` FACT: afm-context-window-4096).
+  static let afmContextWindowTokens = 4096
+  /// Headroom kept below the hard window. Tuned by on-device validation (#1055).
+  static let afmContextSafetyMarginTokens = 128
+  /// PREFLIGHT output reserve as a multiple of input tokens. A clean transcript
+  /// polish produces output ≈ input — filler removal roughly offsets the
+  /// punctuation/capitalization it adds (measured ~1.01× on an 881-word unique
+  /// passage, 2026-06-17). So 1.0 reserves exactly enough room for a 1:1 polish,
+  /// and the preflight skips ONLY when even that can't fit the shared 4,096-token
+  /// window — i.e. genuinely-huge input (~990+ words / ~7+ min). The preflight is
+  /// a fast-path optimization, NOT the safety net: a dictation that slips through
+  /// and overflows or stalls is caught silently at generation (`.caught`, or the
+  /// runner's Apple-Intelligence-timeout skip) and the deterministic text ships.
+  /// Earlier builds used a large FIXED reserve that wrongly skipped good ~4-min
+  /// dictations; that "5-minute cliff" was a test-methodology artifact (a reused
+  /// session accumulating turns + repetitive test text), corrected 2026-06-17.
+  static let afmPreflightOutputReserveMultiplier = 1.0
+  /// Generation cap multiple (× input tokens, + floor) used to derive the
+  /// ADVISORY `GenerationOptions.maximumResponseTokens`. For most inputs this
+  /// sits above the `EnviousOutputFilter` length_guard's 1.5× ceiling, so a
+  /// legitimate cleanup (≤1.5× input) is never the binding limit while a runaway
+  /// is bounded so it does not generate for tens of seconds. Near the window
+  /// limit the call site CLAMPS the resulting cap to the room actually left in
+  /// the window (see `generateGuardingContextWindow`), which can pull it below
+  /// 1.5× — harmless because the cap is advisory (the model can exceed it,
+  /// measured 2026-06-17) and a clean polish is ~1:1 anyway. Best-effort latency
+  /// optimization only, NOT a correctness mechanism: a genuine overflow is caught
+  /// by `.caught`, a stall by the runner's Apple-Intelligence-timeout skip, and a
+  /// >1.5× runaway by the length_guard (→ raw).
+  static let afmOutputCapMultiplier = 1.7
+  static let afmOutputCapFloorTokens = 80
+
+  /// Advisory max tokens the on-device model should generate for a given input,
+  /// BEFORE the call-site clamp to remaining window room.
+  static func afmMaxOutputTokens(inputTokens: Int) -> Int {
+    Int(Double(inputTokens) * afmOutputCapMultiplier) + afmOutputCapFloorTokens
+  }
+
+  /// Conservative token estimate from character count, language-scaled. Used
+  /// only when Apple's exact `tokenCount` is unavailable (< macOS 26.4) or
+  /// throws. Over-estimates (CJK/unsegmented ~1 char/token, Latin ~3
+  /// chars/token) so it errs toward skipping rather than letting an overflow
+  /// reach the model.
+  static func heuristicAFMTokens(_ text: String, lang: String?) -> Int {
+    let unsegmented = lang.map(LanguageTypes.isUnsegmentedScript) ?? false
+    let divisor = unsegmented ? 1.0 : 3.0
+    return Int((Double(text.count) / divisor).rounded(.up))
   }
 
   /// Natural-mode instructions — v30 prompt family. Aggressive filler cleanup,
@@ -372,9 +449,14 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
         }
 
         return result
+      } catch let ctxErr as AFMContextWindowExceeded {
+        // #1055: the context-window skip must NOT be wrapped as AFMPolishError
+        // (which LLMPolishStep maps to a `generation_failed` Sentry error). Let
+        // it propagate untyped to the runner (silent live skip) /
+        // TranscriptPolishService (honest "too long" message).
+        throw ctxErr
       } catch let afmErr as AFMPolishError {
-        // Re-throw untouched if already typed (defensive — shouldn't happen
-        // since polishWithFoundationModels currently only throws plain errors).
+        // Re-throw untouched if already typed (defensive).
         throw afmErr
       } catch {
         throw AFMPolishError(underlying: error, routerMode: routerMode, routerBasis: routerBasis)
@@ -409,7 +491,7 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       mode: ApplePolishMode,
       routerBasis: String
     ) async throws -> LLMResult {
-      let session = try makeSession(
+      let prepared = try makeSession(
         instructions: instructions,
         detectedLanguage: detectedLanguage,
         mode: mode
@@ -420,11 +502,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       // performs better empirically. `<TRANSCRIPT>` tags structurally isolate
       // dictated content from the system prompt.
       let wrapped = "<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
-      let response = try await session.respond(
-        to: wrapped,
-        options: GenerationOptions(sampling: .greedy)
-      )
-      let rawContent = response.content
+      // #1055: token-count preflight + generation-time overflow guard. Throws
+      // AFMContextWindowExceeded (predicted/caught) when the dictation can't fit
+      // the 4,096-token window, instead of stalling ~10s then erroring.
+      let rawContent = try await Self.generateGuardingContextWindow(
+        prepared: prepared, wrapped: wrapped, detectedLanguage: detectedLanguage)
       let filtered = await EnviousOutputFilter.filterWithClassifier(
         input: text, output: rawContent, classifier: classifier)
       let content = filtered.polished
@@ -485,7 +567,7 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       mode: ApplePolishMode,
       routerBasis: String
     ) async throws -> LLMResult {
-      let session = try makeSession(
+      let prepared = try makeSession(
         instructions: instructions,
         detectedLanguage: detectedLanguage,
         mode: mode
@@ -494,11 +576,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       // CLT-only fallback path: same plain-string + filter design as the
       // @Generable path so behavior is consistent across build flavors.
       let wrapped = "<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
-      let response = try await session.respond(
-        to: wrapped,
-        options: GenerationOptions(sampling: .greedy)
-      )
-      let rawContent = response.content
+      // #1055: token-count preflight + generation-time overflow guard. Throws
+      // AFMContextWindowExceeded (predicted/caught) when the dictation can't fit
+      // the 4,096-token window, instead of stalling ~10s then erroring.
+      let rawContent = try await Self.generateGuardingContextWindow(
+        prepared: prepared, wrapped: wrapped, detectedLanguage: detectedLanguage)
       let filtered = await EnviousOutputFilter.filterWithClassifier(
         input: text, output: rawContent, classifier: classifier)
       let content = filtered.polished
@@ -578,12 +660,114 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       }
     }
 
+    /// Bundles the live session with the model instance and the EXACT assembled
+    /// system prompt, so the #1055 context-window preflight can `tokenCount` the
+    /// same strings that `respond(...)` will consume.
+    @available(macOS 26.0, *)
+    struct PreparedAFMSession {
+      let session: LanguageModelSession
+      let model: SystemLanguageModel
+      let systemPrompt: String
+    }
+
+    /// Exact token count via Apple's counter (macOS 26.4+); on older systems or
+    /// if the counter throws (non-cancellation), fall back to the conservative
+    /// char heuristic. Cancellation rethrows so the pipeline timeout/cancel path
+    /// is preserved.
+    @available(macOS 26.0, *)
+    private static func estimateAFMTokens(
+      model: SystemLanguageModel, text: String, lang: String?
+    ) async throws -> Int {
+      if #available(macOS 26.4, *) {
+        do {
+          return try await model.tokenCount(for: text)
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          return heuristicAFMTokens(text, lang: lang)
+        }
+      }
+      return heuristicAFMTokens(text, lang: lang)
+    }
+
+    /// #1055 preflight + generation guard. Counts instructions + wrapped
+    /// transcript + a reserved output budget; if that exceeds the window minus
+    /// the safety margin, throws `AFMContextWindowExceeded(.predicted)` WITHOUT
+    /// calling the model. Otherwise calls `respond(...)` and, if the model still
+    /// throws `exceededContextWindowSize`, reclassifies it as `.caught`. Returns
+    /// the raw generated content. All other generation errors propagate.
+    @available(macOS 26.0, *)
+    private static func generateGuardingContextWindow(
+      prepared: PreparedAFMSession, wrapped: String, detectedLanguage: String?
+    ) async throws -> String {
+      // The system prompt is always English (instructions + an English-framed
+      // language clause + the custom-words block), regardless of the dictation
+      // language. Count it with the Latin heuristic (lang: nil) so the macOS
+      // 26.0–26.3 fallback path doesn't over-count the ~2.5k-char prompt at
+      // ~1 char/token for CJK/Thai/Lao dictations and wrongly skip transcripts
+      // that actually fit. Only the transcript itself carries `detectedLanguage`.
+      // (On macOS 26.4+ the exact `tokenCount` ignores `lang` entirely.)
+      let promptTokens = try await estimateAFMTokens(
+        model: prepared.model, text: prepared.systemPrompt, lang: nil)
+      let inputTokens = try await estimateAFMTokens(
+        model: prepared.model, text: wrapped, lang: detectedLanguage)
+      // Skip decision reserves room for a 1:1 clean polish (output ≈ input) on
+      // top of the instructions + wrapped transcript, and skips ONLY when even
+      // that physically can't fit — genuinely-huge input. The model might still
+      // overflow a dictation that fits the 1:1 projection (a content-driven
+      // runaway), but that is caught silently at generation (`.caught`) rather
+      // than pre-empted here, so the preflight stays permissive and lets AFM
+      // polish long dictations it can actually handle.
+      let reservedOutputTokens = Int(
+        (Double(inputTokens) * afmPreflightOutputReserveMultiplier).rounded(.up))
+      let projected = promptTokens + inputTokens + reservedOutputTokens
+      let budget = afmContextWindowTokens - afmContextSafetyMarginTokens
+      // Advisory response cap, CLAMPED to the room actually left in the window
+      // after instructions + prompt. Empirically this SDK does not reject a call
+      // whose `maximumResponseTokens` would overrun the window (measured
+      // 2026-06-17: a 3,500-tok cap on a near-limit input still completed), and a
+      // clean ~1:1 polish stops well before the cap anyway — but clamping keeps
+      // the request coherent and future-proofs against an SDK that DOES reserve
+      // it upfront. `max(floor, …)` keeps it positive when the preflight is about
+      // to skip (the log line below reads it before the skip throw).
+      let maxOutputTokens = max(
+        afmOutputCapFloorTokens,
+        min(afmMaxOutputTokens(inputTokens: inputTokens), budget - promptTokens - inputTokens))
+      if projected > budget {
+        Task {
+          await AppLogger.shared.log(
+            "AFM context preflight: skipping on-device polish (projected ~\(projected) tok > budget \(budget); prompt=\(promptTokens) input=\(inputTokens) reservedOutput=\(reservedOutputTokens) outputCap=\(maxOutputTokens))",
+            level: .info, category: "LLM"
+          )
+        }
+        throw AFMContextWindowExceeded(stage: .predicted)
+      }
+      do {
+        let response = try await prepared.session.respond(
+          to: wrapped,
+          options: GenerationOptions(sampling: .greedy, maximumResponseTokens: maxOutputTokens)
+        )
+        return response.content
+      } catch let genErr as LanguageModelSession.GenerationError {
+        if case .exceededContextWindowSize = genErr {
+          Task {
+            await AppLogger.shared.log(
+              "AFM context overflow caught at generation (preflight under-counted); skipping on-device polish",
+              level: .info, category: "LLM"
+            )
+          }
+          throw AFMContextWindowExceeded(stage: .caught)
+        }
+        throw genErr
+      }
+    }
+
     @available(macOS 26.0, *)
     private func makeSession(
       instructions: PolishInstructions,
       detectedLanguage: String?,
       mode: ApplePolishMode
-    ) throws -> LanguageModelSession {
+    ) throws -> PreparedAFMSession {
       // Permissive content-transformation guardrails — peer-ecosystem default
       // for text-transform apps. Prevents AFM from refusing to polish benign
       // dictation that happens to mention sensitive topics.
@@ -641,10 +825,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       }
       let systemPrompt = basePrompt + suffix
 
-      return LanguageModelSession(
+      let session = LanguageModelSession(
         model: model,
         instructions: systemPrompt
       )
+      return PreparedAFMSession(session: session, model: model, systemPrompt: systemPrompt)
     }
   #endif
 }

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -88,6 +88,13 @@ internal final class TextProcessingRunner {
       let budgetSeconds =
         Double(step.maxDuration.components.seconds)
         + Double(step.maxDuration.components.attoseconds) / 1e18
+      // #1055: snapshot the polish provider BEFORE the await. `LLMPolishStep.
+      // llmProvider` is a mutable @MainActor property that PipelineSettingsSync
+      // can change while `process()` is in flight; reading it in the catch block
+      // (after the timeout suspension) would misclassify the timeout if the user
+      // switched providers mid-polish. Snapshotting here mirrors the step's own
+      // entry snapshot of `provider` and the `stepName` snapshot above.
+      let polishProviderAtStart = (step as? LLMPolishStep)?.llmProvider
       do {
         context = try await timeoutExecutor(budgetSeconds) {
           try await step.process(input)
@@ -122,7 +129,30 @@ internal final class TextProcessingRunner {
       } catch {
         let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
         let isTimeout = error is TimeoutError
-        let reason = isTimeout ? "timed out" : "failed: \(error.localizedDescription)"
+        // #1055: AFM context-window overflow is a clean skip (dictation too long
+        // for the on-device model), not a failure — raw deterministically-cleaned
+        // text passes through and no "AI polish failed" is surfaced.
+        let contextWindowSkip = error as? AFMContextWindowExceeded
+        // #1055: an Apple Intelligence polish that TIMES OUT (the on-device model
+        // stalling on a long or runaway dictation) is handled exactly like a
+        // context-window skip — silent raw fallback, not an "AI polish failed"
+        // error. On-device polish of long input is known-flaky and the clean
+        // deterministic text is the right thing to ship. Scoped to the
+        // appleIntelligence provider ONLY: cloud-provider timeouts still surface
+        // (they signal a transient network issue the user should see).
+        let isAppleIntelligencePolishTimeout =
+          isTimeout && polishProviderAtStart == .appleIntelligence
+        let reason: String
+        if isAppleIntelligencePolishTimeout {
+          reason =
+            "skipped: on-device AI polish timed out on a long dictation, using deterministic text"
+        } else if isTimeout {
+          reason = "timed out"
+        } else if let cw = contextWindowSkip {
+          reason = "skipped: too long for on-device AI polish (\(cw.stage.rawValue))"
+        } else {
+          reason = "failed: \(error.localizedDescription)"
+        }
         // Apple Intelligence language-gate skips (unsupported input
         // language, output-language drift) are expected no-ops, not
         // polish failures. Log and continue with raw text; do not
@@ -139,8 +169,24 @@ internal final class TextProcessingRunner {
         } else {
           isLanguageGateSkip = false
         }
-        if step.errorSurfacePolicy == .surface && !isLanguageGateSkip {
+        if step.errorSurfacePolicy == .surface && !isLanguageGateSkip
+          && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
+        {
           polishError = error.localizedDescription
+        }
+        // #1055: emit a dedicated skip event so we can measure how often long
+        // dictations bypass on-device polish — input the future 1-hour-recording
+        // work needs. All three reasons share the `context_window_` prefix so a
+        // single analytics query captures every AFM-long-dictation skip mode:
+        // predicted (preflight), caught (generation overflow), timeout (stall).
+        if let cw = contextWindowSkip {
+          let skipReason =
+            cw.stage == .predicted ? "context_window_predicted" : "context_window_caught"
+          TelemetryService.shared.polishSkipped(
+            provider: LLMProvider.appleIntelligence.rawValue, reason: skipReason)
+        } else if isAppleIntelligencePolishTimeout {
+          TelemetryService.shared.polishSkipped(
+            provider: LLMProvider.appleIntelligence.rawValue, reason: "context_window_timeout")
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -134,6 +134,23 @@ public final class TranscriptPolishService {
       )
       context = try await llmPolishStep.process(context)
       stepOutput = context.polishedText
+    } catch let ctxErr as AFMContextWindowExceeded {
+      // #1055: the explicit re-polish action gets an HONEST reason ("too long"),
+      // not the live-dictation silent skip and not the misleading "too short"
+      // message the nil-output guard below would otherwise show.
+      let msg = "This dictation is too long for on-device Apple Intelligence polish."
+      recordError(for: transcript.id, message: msg)
+      TelemetryService.shared.polishSkipped(
+        provider: LLMProvider.appleIntelligence.rawValue,
+        reason: ctxErr.stage == .predicted ? "context_window_predicted" : "context_window_caught"
+      )
+      Task {
+        await AppLogger.shared.log(
+          "Transcript re-polish skipped: too long for on-device AI polish (\(ctxErr.stage.rawValue))",
+          level: .info, category: "Enhancement"
+        )
+      }
+      throw LLMError.requestFailed(msg)
     } catch {
       recordError(for: transcript.id, message: error.localizedDescription)
       Task {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -479,6 +479,27 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.polish_completed", properties: props)
   }
 
+  /// #1055: AI polish was intentionally skipped (not failed). Dedicated event —
+  /// NOT `llm.polish_completed`, which requires a provider stamp and would
+  /// wrongly mark a skipped transcript as AI-polished. `reason` is one of the
+  /// AFM-long-dictation skip modes (shared `context_window_` prefix):
+  /// `context_window_predicted` (preflight), `context_window_caught` (generation
+  /// overflow), or `context_window_timeout` (the 10 s on-device budget stalled).
+  public func polishSkipped(provider: String, reason: String) {
+    let props: [String: Any] = [
+      "provider": provider,
+      "skip_reason": reason,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "llm.polish_skipped",
+          stringProps: ["provider": provider, "skip_reason": reason],
+          boolProps: [:]))
+    #endif
+    PostHogSDK.shared.capture("llm.polish_skipped", properties: props)
+  }
+
   public func pasteCompleted(tier: String, targetApp: String?, result: String, latencyMs: Int) {
     var props: [String: Any] = [
       "tier": tier,

--- a/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
+++ b/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
@@ -70,6 +70,49 @@ struct LanguageNormalizerTests {
   }
 }
 
+// MARK: - AFM token heuristic (macOS 26.0–26.3 fallback)
+
+/// #1055: the char-based token heuristic used when Apple's exact `tokenCount`
+/// is unavailable. The system prompt is ALWAYS English, so it must be counted
+/// with the Latin rate (lang: nil) regardless of the dictation language — else
+/// a CJK/Thai dictation makes the preflight count the ~2.5k-char English prompt
+/// at ~1 char/token and skip a transcript that actually fits.
+@Suite("Apple Intelligence: AFM token heuristic")
+struct AFMTokenHeuristicTests {
+
+  /// Stand-in for the always-English system prompt (Latin script).
+  private static let englishPrompt = String(
+    repeating: "You are a transcript cleaner. Fix punctuation and remove fillers. ",
+    count: 30)
+
+  @Test("Latin text scales at ~3 chars/token; unsegmented at ~1 char/token")
+  func divisorByScript() {
+    let latin = AppleIntelligenceConnector.heuristicAFMTokens(Self.englishPrompt, lang: nil)
+    let asCJK = AppleIntelligenceConnector.heuristicAFMTokens(Self.englishPrompt, lang: "zh")
+    // Latin divisor 3.0 vs unsegmented 1.0 → CJK-scaled count is ~3× larger.
+    #expect(latin == Int((Double(Self.englishPrompt.count) / 3.0).rounded(.up)))
+    #expect(asCJK == Self.englishPrompt.count)
+    #expect(asCJK > latin * 2)
+  }
+
+  @Test("English prompt as Latin leaves window room; as CJK it blows the budget (the #1055 bug)")
+  func englishPromptMustUseLatinRate() {
+    // The fix passes lang: nil for the always-English system prompt. If a caller
+    // instead threaded a CJK dictation language through, the same prompt is
+    // counted ~3× higher. Assertions are computed from the actual length so the
+    // test is robust to edits of the stand-in prompt.
+    let chars = Self.englishPrompt.count
+    let correct = AppleIntelligenceConnector.heuristicAFMTokens(Self.englishPrompt, lang: nil)
+    let buggy = AppleIntelligenceConnector.heuristicAFMTokens(Self.englishPrompt, lang: "ja")
+    #expect(correct == Int((Double(chars) / 3.0).rounded(.up)))
+    #expect(buggy == chars)
+    // The buggy CJK-scaled prompt alone would consume more than a third of the
+    // 4,096-token window before any transcript — the over-skip the fix avoids.
+    #expect(buggy > AppleIntelligenceConnector.afmContextWindowTokens / 3)
+    #expect(correct < AppleIntelligenceConnector.afmContextWindowTokens / 3)
+  }
+}
+
 // MARK: - AppleIntelligenceCapabilities
 
 @Suite("Apple Intelligence: documented allowlist")

--- a/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprLLM
 import Foundation
 import Testing
 
@@ -38,6 +39,107 @@ struct LimbFailureFallbackTests {
     // Polish-failure surface: the error message reaches the caller so the
     // overlay can show "Polish failed -- using raw text".
     #expect(result.polishError == "Polish failed -- test failure")
+  }
+
+  @Test("AFM context-window overflow (predicted) is a SILENT skip: raw text, no polishError")
+  func contextWindowPredictedIsSilentSkip() async throws {
+    let runner = TextProcessingRunner()
+    let raw = "raw asr transcript that exceeds the on-device window"
+    let skip = ContextWindowSkipStep(stage: .predicted)
+
+    let result = try await runner.run(
+      rawText: raw, language: nil, targetAppName: nil, steps: [skip])
+
+    // Heart contract: raw text survives.
+    #expect(result.context.text == raw)
+    #expect(result.context.polishedText == nil)
+    // #1055: a too-long dictation is a clean skip, NOT a failure — it must NOT
+    // surface "AI polish failed" (contrast `polishFailureFallsBackToRaw`).
+    #expect(result.polishError == nil)
+  }
+
+  @Test("AFM context-window overflow (caught) is also a silent skip")
+  func contextWindowCaughtIsSilentSkip() async throws {
+    let runner = TextProcessingRunner()
+    let raw = "raw asr transcript"
+    let skip = ContextWindowSkipStep(stage: .caught)
+
+    let result = try await runner.run(
+      rawText: raw, language: nil, targetAppName: nil, steps: [skip])
+
+    #expect(result.context.text == raw)
+    #expect(result.context.polishedText == nil)
+    #expect(result.polishError == nil)
+  }
+
+  @Test("Apple Intelligence polish TIMEOUT is a SILENT skip: raw text, no polishError")
+  func appleIntelligencePolishTimeoutIsSilentSkip() async throws {
+    // #1055: the appleIntelligence budget is 10s; `throwBelowSeconds: 999`
+    // forces the executor to throw TimeoutError without ever invoking the step,
+    // simulating the on-device model stalling on a long dictation. A real
+    // LLMPolishStep is required (not a fake) because the runner scopes the
+    // silent-timeout behavior via `as? LLMPolishStep`'s `llmProvider`.
+    let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 999)
+    let runner = TextProcessingRunner(timeoutExecutor: fakeTimeout.run)
+    let raw = "raw asr transcript from a long dictation"
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .appleIntelligence
+
+    let result = try await runner.run(
+      rawText: raw, language: nil, targetAppName: nil, steps: [step])
+
+    // The on-device model stalled, but a too-long dictation isn't a failure —
+    // raw deterministically-cleaned text ships and NO "AI polish failed"
+    // surfaces (contrast `cloudPolishTimeoutSurfacesError`).
+    #expect(result.context.text == raw)
+    #expect(result.context.polishedText == nil)
+    #expect(result.polishError == nil)
+    #expect(fakeTimeout.callCount == 1)  // op short-circuited; step never ran
+  }
+
+  @Test("A cloud-provider polish timeout STILL surfaces polishError (contrast with AFM)")
+  func cloudPolishTimeoutSurfacesError() async throws {
+    // #1055: the timeout silence is scoped to appleIntelligence ONLY. A cloud
+    // (OpenAI) timeout signals a transient network issue the user should see,
+    // so it must continue to surface as "AI polish failed".
+    let fakeTimeout = FakeTimeoutExecutor(throwBelowSeconds: 999)
+    let runner = TextProcessingRunner(timeoutExecutor: fakeTimeout.run)
+    let raw = "raw asr transcript"
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .openAI
+
+    let result = try await runner.run(
+      rawText: raw, language: nil, targetAppName: nil, steps: [step])
+
+    #expect(result.context.text == raw)
+    #expect(result.context.polishedText == nil)
+    #expect(result.polishError != nil)
+  }
+
+  @Test("AFM timeout stays silent even if the provider is switched mid-polish (torn-read guard)")
+  func afmTimeoutSilentDespiteMidFlightProviderSwitch() async throws {
+    // #1055 (Codex review): the runner must classify the timeout by the provider
+    // the polish STARTED with, not the live (possibly-mutated) `llmProvider`.
+    // PipelineSettingsSync can switch providers during an in-flight polish; that
+    // must NOT flip an Apple Intelligence timeout into a surfaced "AI polish
+    // failed". The executor here mutates the provider to a cloud value and THEN
+    // times out, simulating that race.
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .appleIntelligence
+    let runner = TextProcessingRunner(timeoutExecutor: { _, _ in
+      step.llmProvider = .openAI  // settings change during the suspended polish
+      throw TimeoutError(seconds: 10)
+    })
+    let raw = "raw asr transcript"
+
+    let result = try await runner.run(
+      rawText: raw, language: nil, targetAppName: nil, steps: [step])
+
+    // RED before the snapshot fix (catch read the now-.openAI live value →
+    // surfaced); GREEN after (snapshot-at-start is .appleIntelligence → silent).
+    #expect(result.context.text == raw)
+    #expect(result.context.polishedText == nil)
+    #expect(result.polishError == nil)
   }
 
   @Test("Polish disabled (isEnabled=false) skips the step without error")
@@ -89,4 +191,25 @@ private final class FailingPolishStep: TextProcessingStep {
 private struct FailingPolishError: LocalizedError {
   let message: String
   var errorDescription: String? { message }
+}
+
+/// #1055 test double: a polish step that throws `AFMContextWindowExceeded`
+/// (the too-long-for-on-device signal). Name matches the production step so the
+/// runner's `errorSurfacePolicy` dispatch applies; the runner must treat this
+/// throw as a SILENT skip (no `polishError`), unlike a generic limb failure.
+@MainActor
+private final class ContextWindowSkipStep: TextProcessingStep {
+  let name = "LLM Polish"
+  let isEnabled = true
+  let maxDuration: Duration = .seconds(60)
+  let errorSurfacePolicy: ErrorSurfacePolicy = .surface
+  private let stage: AFMContextWindowExceeded.Stage
+
+  init(stage: AFMContextWindowExceeded.Stage) {
+    self.stage = stage
+  }
+
+  func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+    throw AFMContextWindowExceeded(stage: stage)
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptPolishServiceBypassTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptPolishServiceBypassTests.swift
@@ -82,4 +82,55 @@ struct TranscriptPolishServiceBypassTests {
     #expect(reloaded.llmProvider == nil)
     #expect(reloaded.llmModel == nil)
   }
+
+  /// #1055: throws the too-long-for-on-device signal so the service's HONEST
+  /// "too long" path is exercised instead of the misleading "too short" message
+  /// the nil-output guard would otherwise show.
+  private struct ContextWindowThrowingPolisher: TranscriptPolisher {
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      throw AFMContextWindowExceeded(stage: .predicted)
+    }
+  }
+
+  @Test("Re-polish a too-long transcript: honest 'too long' message, not 'too short'")
+  func enhanceOnTooLongSurfacesContextWindow() async throws {
+    let dir = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let activity = IdleDictationActivity()
+    let service = TranscriptPolishService(
+      keychainManager: KeychainManager(),
+      transcriptStore: store,
+      dictationActivity: activity
+    )
+    service.llmPolishStep.llmProvider = .openAI
+    service.llmPolishStep.llmModel = "gpt-4o-mini"
+    service.llmPolishStep.makePolisher = { _, _, _ in ContextWindowThrowingPolisher() }
+
+    // Long enough to clear the too-short gate and reach the polisher.
+    let transcript = Transcript(
+      text:
+        "this is a sufficiently long dictation that clears the short-input gate and reaches the polisher",
+      language: "en")
+    try store.save(transcript)
+
+    await #expect(throws: LLMError.self) {
+      _ = try await service.polish(transcript)
+    }
+
+    let message = try #require(service.lastEnhancementError?.message)
+    #expect(message.localizedCaseInsensitiveContains("too long"))
+    #expect(!message.localizedCaseInsensitiveContains("too short"))
+    #expect(service.lastEnhancementError?.transcriptID == transcript.id)
+
+    // Persisted transcript untouched — no fake polished copy stamped as polished.
+    let onDisk = try await store.loadAll()
+    let reloaded = try #require(onDisk.first { $0.id == transcript.id })
+    #expect(reloaded.polishedText == nil)
+  }
 }


### PR DESCRIPTION
## What & why

Apple Intelligence shares a 4,096-token window across instructions, prompt, and generated output. Long dictations could stall ~10s then drop polish, or surface "AI polish failed." This makes long on-device dictations polish when they fit, and fall back **silently** to the clean deterministic text when they genuinely can't, so a user never sees an error on a long dictation.

Closes #1055 (input-token preflight + bypass-with-reason). The issue's parenthetical "(+ long-form eval cases)" is deliberately not in scope: the polish-eval gate runs on `gpt-4o-mini` in CI and AFM is untestable there (plan §10), so AFM length behavior is validated on-device instead. Bumping max recording length and improving non-AI polishing are separate, already-scheduled sessions.

## The correction that drove the final design

The original premise ("AFM fails at ~5 min / ~700 words") was a **test-methodology artifact, not real AFM behavior.** The pre-build sweep reused one `LanguageModelSession` (it accumulates turns into the shared window, so it overflowed early) and fed it repetitive text (which makes the model ramble). Re-measured the proper way (fresh session per call + genuinely unique text + Apple's exact `tokenCount`):

- Real unique dictation polishes cleanly through **~1,229 words / ~9 min** (actual generation, output ≈ input, no overflow).
- The preflight skip now fires only at **~1,600 words / ~11.5 min** (genuinely-huge), with the real production prompt.
- A 5-minute dictation projects to under half the budget, so it is never skipped.

## Changes

- **Proportional preflight** (`AppleIntelligenceConnector`): skip on-device polish only when `prompt + input + 1.0×input > 4096 − 128` (a 1:1 clean polish can't fit). Replaces the old fixed reserve that wrongly cut off at ~4 min.
- **Every AFM failure mode is silent** and routes to deterministic text:
  - preflight-predicted (`AFMContextWindowExceeded(.predicted)`),
  - runtime-caught overflow (`.caught`),
  - the 10s AFM polish **timeout**, silenced in `TextProcessingRunner` scoped to `llmProvider == .appleIntelligence` (cloud-provider timeouts still surface). The provider is **snapshotted at step start** to avoid a torn read if settings change mid-polish.
- **Telemetry**: dedicated `llm.polish_skipped` with reason `context_window_{predicted,caught,timeout}` (shared prefix, one query captures all three).
- **Saved re-polish** (`TranscriptPolishService`): honest "too long for on-device Apple Intelligence polish" message instead of the misleading "too short" one.
- **Output cap** (`maximumResponseTokens`) kept as a best-effort latency bound, clamped to remaining window room, documented as advisory (the model can exceed it; measured).
- **Fallback heuristic** (macOS 26.0–26.3, no exact `tokenCount`): the always-English system prompt is counted at the Latin rate regardless of dictation language, so a CJK/Thai dictation no longer over-counts the prompt and skips a transcript that fits.

## Validation

- **Canonical suite green** (`scripts/xcode-test.sh`): 1,727 tests / 204 suites + 87-test target.
- **New tests**: AFM-timeout silent-skip, cloud-timeout-still-surfaces contrast, a torn-read guard (proven RED before the snapshot fix and GREEN after), and two AFM-token-heuristic prompt-language tests.
- **On-device validation** on this machine with the real FoundationModels API (fresh session + unique text + Apple `tokenCount` + real generation): the numbers above. Confirmed the SDK does not reject upfront on an over-window `maximumResponseTokens` (a 3,500-tok cap on a near-limit input still completed).
- **Codex grounded review** (plan): 4 rounds → PROCEED-AS-PLANNED. **Codex diff review**: 3 rounds, each found a legitimate, contained issue (torn read; cap clamp; prompt-language heuristic), all fixed with regression tests; round 3 clean.
- **Live UAT scoped**: a separate session's dev app (a different branch without these changes) is co-running on the shared log file and global hotkey, so an attributable single-app dictation isn't possible without disturbing it. The runtime surface here is the on-device model API, which the standalone harness exercises directly (identical model, guardrails, prompt, counter, and generation); the pipeline wiring is unit-tested on the built code.

## Process

**Council waived by founder 2026-06-17** after the 4-round Codex grounded review reached PROCEED-AS-PLANNED.