### PR TITLE
feat(pipeline): 60-minute recording cap with approaching-cap warning + auto-stop pill (#1060)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -138,6 +138,12 @@ final class DictationLifecycleCoordinator {
     whisperKitKernelDriver.onOverlayIntentChange = { [weak self] intent in
       self?.showOverlayIntent(intent)
     }
+    // #1060: approaching-cap warning — display-only banner, no lifecycle authority.
+    let onApproaching: (TimeInterval) -> Void = { [weak self] r in
+      self?.showApproachingCapWarning(remainingSeconds: r)
+    }
+    kernelDriver.onApproachingMaxDuration = onApproaching
+    whisperKitKernelDriver.onApproachingMaxDuration = onApproaching
   }
 
   /// The single overlay-show seam. Every overlay push — state-handler driven
@@ -152,6 +158,17 @@ final class DictationLifecycleCoordinator {
       audioLevelProvider: { audioCapture.audioLevel },
       isRecordingLocked: recordingLockedAccess.get()
     )
+  }
+
+  /// #1060: within the last minute before the cap. Show a PERSISTENT in-panel
+  /// banner (no auto-dismiss) that stays until the recording stops; cleared by the
+  /// transition out of recording. "Under a minute" reads accurately for the whole
+  /// window, so no countdown or late-fire guard is needed. Copy lives here.
+  private func showApproachingCapWarning(remainingSeconds: TimeInterval) {
+    recordingOverlay.flashRecordingNotice("Recording auto-stops in under a minute (60-minute cap)")
+    TelemetryService.shared.recordingCapWarningShown(
+      backend: lastCapturingBackend == .whisperKit ? "whisperKit" : "parakeet",
+      capSeconds: TimingConstants.maxRecordingDuration)
   }
 
   // MARK: - Per-pipeline state-change handling
@@ -316,7 +333,9 @@ final class DictationLifecycleCoordinator {
   // MARK: - State-handler factory
 
   private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
-    PipelineStateChangeHandler(
+    // #1060: this handler's driver — completion telemetry reads its length + stop reason.
+    let driver = backendLabel == "whisperKit" ? whisperKitKernelDriver : kernelDriver
+    return PipelineStateChangeHandler(
       showOverlay: { [weak self] intent in self?.showOverlayIntent(intent) },
       cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
       schedulePolishFailedWarning: { [weak self] in
@@ -326,7 +345,9 @@ final class DictationLifecycleCoordinator {
       reportDictationCompleted: { [weak self] t in
         guard let self else { return }
         TelemetryService.shared.reportDictationCompleted(
-          transcript: t, inputMode: self.settings.recordingMode.rawValue)
+          transcript: t, inputMode: self.settings.recordingMode.rawValue,
+          recordingSeconds: driver.lastRecordingDurationSeconds,
+          stopReason: driver.lastStopReason)
       },
       reportPipelineFailed: { msg in
         TelemetryService.shared.pipelineFailed(

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -15,6 +15,17 @@ final class OverlayLockState {
   var isLocked: Bool = false
 }
 
+/// Observable holder for the transient in-panel notice banner (#1060).
+/// Shared between RecordingOverlayPanel and RecordingOverlayView so a notice can
+/// morph the live recording pill (a banner inside the same capsule) WITHOUT
+/// tearing the panel down — the existing `.warning`/`presentTransientNotice`
+/// paths all rebuild the single panel and would lose the `.recording` state.
+@MainActor
+@Observable
+final class OverlayNoticeState {
+  var message: String? = nil
+}
+
 // MARK: - RecordingOverlayPanel
 
 /// Floating overlay panel that shows recording and polishing status.
@@ -26,6 +37,12 @@ final class RecordingOverlayPanel {
 
   /// Reactive lock state shared with RecordingOverlayView.
   private let lockState = OverlayLockState()
+
+  /// Reactive transient-notice state shared with RecordingOverlayView (#1060).
+  private let noticeState = OverlayNoticeState()
+
+  /// Pending auto-clear for the transient notice banner.
+  private var noticeDismissWork: DispatchWorkItem?
 
   /// Monotonically-increasing generation token. Incremented on every show/hide
   /// call. The DispatchQueue.main.async closures capture their token at dispatch
@@ -312,14 +329,44 @@ final class RecordingOverlayPanel {
     lockState.isLocked = isRecordingLocked
     let overlayView = RecordingOverlayView(
       audioLevelProvider: audioLevelProvider,
-      lockState: lockState
+      lockState: lockState,
+      noticeState: noticeState
     )
-    // Use a generous fixed frame that accommodates both normal (185x44) and
-    // locked (120x64) sizes. The SwiftUI content inside handles its own sizing
-    // via padding and intrinsic size. This avoids needing to resize the panel
-    // window frame on lock transitions.
-    .frame(width: 185, height: 64)
-    showPanel(content: overlayView, width: 185, height: 64, y: y)
+    // Fixed frame accommodating normal (185x44), locked (120x64), and the #1060
+    // notice-banner expansion (a 2-line banner under the pill). Content is
+    // centered and the capsule self-sizes; showPanel clamps the origin so the
+    // taller frame never clips under the menu bar (Codex P2).
+    .frame(width: 185, height: 92)
+    showPanel(content: overlayView, width: 185, height: 92, y: y)
+  }
+
+  /// #1060: flash a transient banner over the LIVE recording pill (a second line
+  /// inside the same capsule), then auto-clear. No-op unless a recording panel is
+  /// live — leaves `panel`, `currentIntent`, and `generation` untouched (no
+  /// teardown → no #930 flicker). The App layer owns the copy string.
+  func flashRecordingNotice(_ message: String, dismissAfter: Double? = nil) {
+    guard panel != nil, case .recording = currentIntent else { return }
+    noticeDismissWork?.cancel()
+    noticeDismissWork = nil
+    noticeState.message = message
+    // #1060: nil dismissAfter = persist until the recording ends. The cap warning
+    // stays the whole final minute and is cleared by the transition out of
+    // recording (transitionToPolishing) or hide(). A non-nil value auto-dismisses.
+    guard let dismissAfter else { return }
+    let work = DispatchWorkItem { [weak self] in
+      self?.noticeState.message = nil
+      self?.noticeDismissWork = nil
+    }
+    noticeDismissWork = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + dismissAfter, execute: work)
+  }
+
+  /// Clear any live notice banner + its pending auto-clear. Called on hide and on
+  /// transitions away from recording so a notice never bleeds into the next session.
+  private func clearRecordingNotice() {
+    noticeDismissWork?.cancel()
+    noticeDismissWork = nil
+    noticeState.message = nil
   }
 
   /// Show a transient "Copied to clipboard" notice that auto-dismisses after 2.5s.
@@ -455,7 +502,14 @@ final class RecordingOverlayPanel {
   private func createPolishingPanel(label: String = "Polishing...") {
     guard panel == nil else { return }
 
-    showPanel(content: PolishingOverlayView(label: label).frame(width: 185, height: 44), width: 185)
+    // #1060: wider/taller frame so a wrapped 2-line label (the 60-minute end
+    // message) is not clipped; the capsule self-sizes for short labels. The
+    // window height must match the content frame (Codex P2): showPanel sizes the
+    // hosting view to its `height` arg, so omitting it leaves a 44pt window that
+    // clips the second line.
+    showPanel(
+      content: PolishingOverlayView(label: label).frame(width: 230, height: 70),
+      width: 230, height: 70)
   }
 
   /// Transition an existing panel to the Accessibility permission notice.
@@ -494,6 +548,7 @@ final class RecordingOverlayPanel {
   /// Transition an existing panel from recording to polishing mode.
   private func transitionToPolishing(label: String = "Polishing...") {
     guard let existingPanel = panel else { return }
+    clearRecordingNotice()  // #1060 (Codex P3): don't leak a cap notice into the next session.
     let y = existingPanel.frame.origin.y
 
     panel = nil
@@ -519,7 +574,8 @@ final class RecordingOverlayPanel {
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
       self.showPanel(
-        content: PolishingOverlayView(label: label).frame(width: 185, height: 44), width: 185, y: y)
+        content: PolishingOverlayView(label: label).frame(width: 230, height: 70),
+        width: 230, height: 70, y: y)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
@@ -532,6 +588,7 @@ final class RecordingOverlayPanel {
     audioLevelProvider: @escaping () -> Float, isRecordingLocked: Bool = false
   ) {
     guard let existingPanel = panel else { return }
+    clearRecordingNotice()  // #1060 (Codex P3): fresh session starts with no stale notice.
     let y = existingPanel.frame.origin.y
 
     panel = nil
@@ -587,7 +644,15 @@ final class RecordingOverlayPanel {
     p.contentView = hostingView
 
     let x = targetScreen.visibleFrame.midX - width / 2
-    let panelY = y ?? (targetScreen.visibleFrame.maxY - 60)
+    let requestedY = y ?? (targetScreen.visibleFrame.maxY - 60)
+    // #1060 (Codex P2): keep the whole panel within the visible frame. The
+    // recording pill's frame is tall enough to host the cap-warning banner, and
+    // positioning by the bottom origin would push the top above the visible
+    // frame (clipping under the menu bar) on a normal recording start. Clamp the
+    // origin so the top never exceeds the frame. Small panels (≤ the default
+    // 60 pt offset) are unaffected.
+    let maxOriginY = targetScreen.visibleFrame.maxY - height - 8
+    let panelY = min(requestedY, maxOriginY)
     p.setFrameOrigin(NSPoint(x: x, y: panelY))
 
     p.orderFrontRegardless()
@@ -676,6 +741,7 @@ final class RecordingOverlayPanel {
     currentIntent = .hidden
     isRecordingLocked = false
     lockState.isLocked = false
+    clearRecordingNotice()
     autoDismissTask?.cancel()
     autoDismissTask = nil
     generation &+= 1
@@ -984,22 +1050,38 @@ private struct DistressCapsuleBackground: View {
 struct RecordingOverlayView: View {
   let audioLevelProvider: () -> Float
   var lockState: OverlayLockState
+  /// #1060: transient notice banner shown inside the recording capsule.
+  var noticeState: OverlayNoticeState
   @State private var audioLevel: Float = 0
   @State private var elapsed: TimeInterval = 0
 
   private let startTime = Date()
 
   var body: some View {
-    HStack(spacing: 10) {
-      // Rainbow lips icon — audio-reactive during recording.
-      // Scales to 2x in hands-free (locked) mode.
-      RainbowLipsIcon(size: 24, audioLevel: audioLevel)
-        .scaleEffect(lockState.isLocked ? 2.0 : 1.0)
+    VStack(spacing: 6) {
+      HStack(spacing: 10) {
+        // Rainbow lips icon — audio-reactive during recording.
+        // Scales to 2x in hands-free (locked) mode.
+        RainbowLipsIcon(size: 24, audioLevel: audioLevel)
+          .scaleEffect(lockState.isLocked ? 2.0 : 1.0)
 
-      if !lockState.isLocked {
-        Text(FormattingConstants.formatDuration(elapsed))
-          .font(.system(size: 13, weight: .medium, design: .monospaced))
-          .foregroundStyle(.white)
+        if !lockState.isLocked {
+          Text(FormattingConstants.formatDuration(elapsed))
+            .font(.system(size: 13, weight: .medium, design: .monospaced))
+            .foregroundStyle(.white)
+            .transition(.opacity)
+        }
+      }
+
+      // #1060: approaching-cap warning banner. Appears inside the same capsule
+      // (no panel rebuild), wraps within the pill width, auto-clears.
+      if let notice = noticeState.message {
+        Text(notice)
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(.white.opacity(0.95))
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: 170)
           .transition(.opacity)
       }
     }
@@ -1007,6 +1089,7 @@ struct RecordingOverlayView: View {
     // Single container animation prevents animation stacking: N per-element
     // modifiers × update rate creates exponential state transitions (gotchas.md).
     .animation(.easeOut(duration: 0.08), value: audioLevel)
+    .animation(.easeInOut(duration: 0.25), value: noticeState.message)
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
     .background(OverlayCapsuleBackground())
@@ -1032,9 +1115,16 @@ struct PolishingOverlayView: View {
       // Spinning spectrum wheel icon — polishing/processing state
       SpectrumWheelIcon(size: 24)
 
+      // #1060: wrap long labels (e.g. "Reached the 60-minute limit. Transcribing
+      // now.") instead of clipping them in a fixed single line. Short labels
+      // ("Transcribing...", "Polishing...") render unchanged on one line; the
+      // capsule sizes to content.
       Text(label)
         .font(.system(size: 13, weight: .medium))
         .foregroundStyle(.white)
+        .multilineTextAlignment(.leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 180)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -90,8 +90,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// User override for input device. Empty string means "Auto" (smart selection enabled).
   public var preferredInputDeviceIDOverride: String = ""
 
-  /// Maximum recording duration in seconds. Prevents unbounded memory growth.
-  public nonisolated static let maxRecordingDurationSeconds: Double = 600
+  /// Hard emergency recording-duration ceiling in seconds. Prevents unbounded
+  /// memory growth. MUST stay strictly above the graceful soft cap
+  /// (`TimingConstants.maxRecordingDuration`, 3600s) so the graceful stop+transcribe
+  /// always wins; this 60s margin keeps the hard teardown a true backstop only
+  /// reached if the soft stop wedges (#1060). Raised 600→3660.
+  public nonisolated static let maxRecordingDurationSeconds: Double = 3660
   /// Maximum sample count derived from maxRecordingDurationSeconds at 16kHz.
   public nonisolated static let maxRecordingSamples: Int = Int(
     maxRecordingDurationSeconds * targetSampleRate)

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -95,8 +95,29 @@ public enum TimingConstants {
 
   /// Maximum recording duration before graceful auto-stop (seconds).
   /// Prevents runaway recordings from consuming unbounded memory/CPU.
-  /// AudioCaptureManager has a hard emergency limit at 600s; this fires earlier and gracefully.
-  public static let maxRecordingDuration: TimeInterval = 300
+  /// AudioCaptureManager has a hard emergency limit at 3660s; this fires earlier and gracefully.
+  /// Raised 300→3600 (#1060): 60-minute cap. Memory ~230 MB/copy at 16 kHz mono Float32.
+  /// In RELEASE this is always 3600. DEBUG builds honor a `EWDebugMaxRecordingSeconds`
+  /// UserDefaults override (>0) so Live UAT can drive the full warning→cap→transcribe
+  /// cycle in ~90s instead of an hour; the override cannot exist in release.
+  public static var maxRecordingDuration: TimeInterval {
+    #if DEBUG
+      let override = UserDefaults.standard.double(forKey: "EWDebugMaxRecordingSeconds")
+      if override > 0 { return override }
+    #endif
+    return 3600
+  }
+
+  /// Lead time before `maxRecordingDuration` at which the user is warned the
+  /// recording is about to auto-stop (seconds). #1060: the 59-minute nudge.
+  /// DEBUG-overridable via `EWDebugWarningLeadSeconds` (paired with the cap override).
+  public static var maxDurationWarningLeadSeconds: TimeInterval {
+    #if DEBUG
+      let override = UserDefaults.standard.double(forKey: "EWDebugWarningLeadSeconds")
+      if override > 0 { return override }
+    #endif
+    return 60
+  }
 
   /// Double-press detection window for hands-free recording mode (milliseconds).
   /// Release within this window starts a debounce timer; second press within

--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -38,6 +38,11 @@ package final class CaptureVADSignalSource: VADSignalSource {
   /// cancellation removes its own entry via `onTermination`.
   private var subscribers: [Int: AsyncStream<VADStopSignal>.Continuation] = [:]
   private var nextSubscriberID: Int = 0
+  /// Per-subscriber continuations for the separate approaching-cap warning
+  /// stream (#1060). Mirrors `subscribers` but for `VADWarningSignal` (advisory,
+  /// never stop-driving). Kept distinct so warnings can never ride the stop path.
+  private var warningSubscribers: [Int: AsyncStream<VADWarningSignal>.Continuation] = [:]
+  private var nextWarningSubscriberID: Int = 0
   private weak var audioCapture: (any AudioCaptureInterface)?
   private var monitorTask: Task<Void, Never>?
   private var silenceDetector: SilenceDetector?
@@ -80,6 +85,19 @@ package final class CaptureVADSignalSource: VADSignalSource {
       continuation.onTermination = { @Sendable [weak self] _ in
         Task { @MainActor [weak self] in
           self?.subscribers.removeValue(forKey: id)
+        }
+      }
+    }
+  }
+
+  package func subscribeWarningSignals() -> AsyncStream<VADWarningSignal> {
+    let id = nextWarningSubscriberID
+    nextWarningSubscriberID += 1
+    return AsyncStream { continuation in
+      warningSubscribers[id] = continuation
+      continuation.onTermination = { @Sendable [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.warningSubscribers.removeValue(forKey: id)
         }
       }
     }
@@ -233,9 +251,13 @@ package final class CaptureVADSignalSource: VADSignalSource {
       detector: detector,
       vadAutoStop: config.vadAutoStop,
       maxDuration: TimingConstants.maxRecordingDuration,
+      warningLead: TimingConstants.maxDurationWarningLeadSeconds,
       recordingStartTime: recordingStartTime,
       sampleProvider: { audioCapture.capturedSamples },
       isRecording: isRecording,
+      onApproachingMaxDuration: { [weak self] remainingSeconds in
+        self?.noteApproachingMaxDuration(remainingSeconds: remainingSeconds)
+      },
       onStop: { [weak self] reason in
         switch reason {
         case .silenceTimeout:
@@ -264,5 +286,17 @@ package final class CaptureVADSignalSource: VADSignalSource {
 
   private func broadcast(_ signal: VADStopSignal) {
     for continuation in subscribers.values { continuation.yield(signal) }
+  }
+
+  /// Record an approaching-cap warning (#1060). Advisory — does NOT stop the
+  /// recording. Stamped with the current session; broadcast to every live
+  /// warning subscriber. Fired at most once per recording by `VADMonitorLoop`.
+  func noteApproachingMaxDuration(remainingSeconds: TimeInterval) {
+    broadcastWarning(
+      VADWarningSignal(remainingSeconds: remainingSeconds, sessionID: currentSessionID))
+  }
+
+  private func broadcastWarning(_ signal: VADWarningSignal) {
+    for continuation in warningSubscribers.values { continuation.yield(signal) }
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -149,6 +149,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   public var onOverlayIntentChange: ((OverlayIntent) -> Void)?
 
+  /// Fired at most once per recording when the recording approaches the
+  /// max-duration cap (#1060), carrying remaining seconds. Display-only, like
+  /// `onOverlayIntentChange`: carries NO lifecycle authority; wire ONLY to the
+  /// overlay banner path, never to anything that mutates recording state. The
+  /// App layer owns the user-facing copy.
+  @ObservationIgnored
+  public var onApproachingMaxDuration: ((TimeInterval) -> Void)?
+
   /// Heart-path error sink for the driver's own direct `.asrInterrupted`
   /// captureError emit. Defaulted to the production global so the only behavior
   /// change is testability — the factory threads the same injected sink it
@@ -251,6 +259,9 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   func start() {
     observeKernelState()
     observeFinalizingSubStatus()
+    kernel.onApproachingMaxDuration = { [weak self] remaining in
+      self?.onApproachingMaxDuration?(remaining)
+    }
   }
 
   // MARK: Limb-step accessors (read by `PipelineSettingsSync` + custom-words)
@@ -478,7 +489,23 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     context.config
   }
 
+  /// #1060: stop reason + wall-clock length of the most recent recording, for
+  /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
+  /// kernel; never persisted. Reason strings only, never user content.
+  public var lastStopReason: String? { kernel.lastStopReason }
+  public var lastRecordingDurationSeconds: Double? { kernel.lastRecordingDurationSeconds }
+
   // MARK: Caller-facing event + overlay surface
+
+  /// #1060: the transcribing-pill label. After a max-duration auto-stop, make the
+  /// stop legible ("Recording ended, transcribing now"); otherwise the plain
+  /// label. Transcribing/Polishing labels already live in the driver, so this
+  /// stays consistent with that precedent.
+  private var transcribingPillLabel: String {
+    kernel.lastStopReason == "max_duration"
+      ? "Reached the 60-minute limit. Transcribing now."
+      : "Transcribing..."
+  }
 
   public var overlayIntent: OverlayIntent {
     if let lastExternalError {
@@ -525,11 +552,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // pipeline returns 0 here, exactly as the old Parakeet pipeline did.
       return .recording(audioLevel: 0)
     case .stopping, .transcribing:
-      return .processing(label: "Transcribing...")
+      return .processing(label: transcribingPillLabel)
     case .finalizing:
       switch kernel.finalizingSubStatus {
       case .transcribing:
-        return .processing(label: "Transcribing...")
+        return .processing(label: transcribingPillLabel)
       case .polishing:
         return .processing(label: "Polishing...")
       }

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -80,8 +80,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   private(set) var lastFailureError: (any Error)?
 
   /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
-  /// (300 s x 16 kHz = 4.8 M `Float` = ~19 MB). On reaching the cap the
-  /// accumulation stops growing; recording auto-stops on max-duration anyway.
+  /// (3600 s x 16 kHz = 57.6 M `Float` = ~230 MB; #1060 raised the cap 300→3600).
+  /// On reaching the cap the accumulation stops growing; recording auto-stops on
+  /// max-duration anyway.
   private static let retainedPCMCap = Int(
     TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -328,6 +328,26 @@ final class RecordingSessionKernel {
   private var stoppingStartedAtTick: UInt64?
   private var recordingStartedAtDate: Date?
 
+  /// Fired at most once per recording when the VAD seam reports the recording is
+  /// approaching `maxRecordingDuration` (#1060), carrying the remaining seconds.
+  /// ADVISORY: the kernel does NOT stop on this (that is the separate stop
+  /// stream); it forwards a semantic event the driver maps to a UI banner. No
+  /// user-facing copy lives here — copy stays in the App layer.
+  var onApproachingMaxDuration: (@MainActor (TimeInterval) -> Void)?
+
+  /// Low-cardinality reason the most recent recording stopped, set when the
+  /// recording-exit latches and cleared at session start (#1060). Read by the
+  /// driver to label the transcribing pill ("Recording ended, transcribing now"
+  /// on `"max_duration"`) and by the App layer for `dictation.completed`
+  /// telemetry (`stop_reason`). A reason string, never user content.
+  private(set) var lastStopReason: String?
+
+  /// Wall-clock length of the most recent recording in seconds (#1060), captured
+  /// when the recording-exit latches and cleared at session start. LIVE metadata
+  /// for `dictation.completed` (`recording_seconds`) — distinct from the
+  /// processing-time `e2eSeconds`. Never persisted to the transcript.
+  private(set) var lastRecordingDurationSeconds: Double?
+
   /// `true` once the polish step returned a non-empty processed transcript —
   /// the kernel-era equivalent of the point at which the old pipeline called
   /// `asrManager.noteTranscriptionComplete(policy:)` (just after polish, before
@@ -881,6 +901,8 @@ final class RecordingSessionKernel {
     // Recording.
     transition(to: .recording)
     recordingStartedAtDate = Date()
+    lastStopReason = nil  // #1060: clear prior session's stop reason.
+    lastRecordingDurationSeconds = nil
     // Stamp visible-recording start for the #4 discard gate (PR-4.5 #4, §5b).
     // Set ONLY after the transition to .recording; pre-roll buffers fed
     // earlier do not count toward minimum-duration.
@@ -1761,6 +1783,24 @@ final class RecordingSessionKernel {
         }
       }
     }
+    // Separate advisory stream (#1060): approaching-cap warnings never stop the
+    // recording. Same session-stamp / stale-drop discipline as the stop stream;
+    // a stale warning from a finished session is dropped, not forwarded.
+    spawn(sid) { [weak self] in
+      guard let self else { return }
+      for await warning in self.vad.subscribeWarningSignals() {
+        guard self.isCurrent(sid) else { return }
+        guard warning.sessionID == self.currentSessionID else {
+          self.staleVADSignalDrops += 1
+          self.log(
+            "dropped stale VAD warning from=\(warning.sessionID.raw) "
+              + "current=\(self.currentSessionID.raw) totalDrops=\(self.staleVADSignalDrops)")
+          continue
+        }
+        guard self.state == .recording else { continue }
+        self.onApproachingMaxDuration?(warning.remainingSeconds)
+      }
+    }
   }
 
   // MARK: Recording-exit channel
@@ -1778,6 +1818,20 @@ final class RecordingSessionKernel {
   private func deliverRecordingExit(_ exit: RecordingExit) {
     guard !recordingExitLatched else { return }
     recordingExitLatched = true
+    // #1060: capture wall-clock recording length (live telemetry, not persisted).
+    if let start = recordingStartedAtDate {
+      lastRecordingDurationSeconds = Date().timeIntervalSince(start)
+    }
+    // #1060: record the stop reason for the transcribing-pill label + telemetry.
+    switch exit {
+    case .userStop: lastStopReason = "user"
+    case .vadAutoStop: lastStopReason = "vad_auto_stop"
+    case .maxDuration: lastStopReason = "max_duration"
+    case .captureStall: lastStopReason = "capture_stall"
+    case .audioInterruption: lastStopReason = "audio_interruption"
+    case .asrInterruption: lastStopReason = "asr_interruption"
+    case .cancel: lastStopReason = "cancel"
+    }
     bump()
     if let continuation = recordingExitContinuation {
       recordingExitContinuation = nil

--- a/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
+++ b/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
@@ -27,17 +27,40 @@ internal enum VADMonitorLoop {
   ///   - recordingStartTime: When recording began (for max duration check)
   ///   - sampleProvider: Returns current captured samples array (called on @MainActor)
   ///   - isRecording: Returns whether recording is still active
+  ///   - warningLead: Seconds before `maxDuration` at which to fire the one-shot
+  ///     approaching-cap warning (#1060). No warning if `warningLead <= 0` or
+  ///     `maxDuration <= warningLead`.
+  ///   - now: Injectable wall clock (defaults to `Date()`); tests pass a manual
+  ///     clock so the warning/stop thresholds are exercised without real sleeps.
+  ///   - onApproachingMaxDuration: Fired at most once when elapsed crosses
+  ///     `maxDuration - warningLead`, carrying the actual remaining seconds.
+  ///     Advisory only — recording continues; never stops.
   ///   - onStop: Called when auto-stop should trigger. Runs in a new Task to avoid
   ///     cancellation propagation from the monitor task into transcription.
   static func run(
     detector: SilenceDetector?,
     vadAutoStop: Bool,
     maxDuration: TimeInterval,
+    warningLead: TimeInterval,
     recordingStartTime: Date,
     sampleProvider: @escaping @MainActor () -> [Float],
     isRecording: @escaping @MainActor () -> Bool,
+    now: @escaping @MainActor () -> Date = { Date() },
+    onApproachingMaxDuration: @escaping @MainActor (TimeInterval) -> Void,
     onStop: @escaping @MainActor (VADStopReason) -> Void
   ) async {
+    // One-shot approaching-cap warning (#1060). Fires at most once per run when
+    // elapsed crosses `maxDuration - warningLead`, only when the cap is long
+    // enough to have a lead window. Advisory — it never stops the recording.
+    var warningFired = false
+    let warningArmed = warningLead > 0 && maxDuration > warningLead
+    let warningThreshold = maxDuration - warningLead
+    func maybeWarn(elapsed: TimeInterval) {
+      guard warningArmed, !warningFired, elapsed >= warningThreshold else { return }
+      warningFired = true
+      onApproachingMaxDuration(maxDuration - elapsed)
+    }
+
     if let detector {
       // In-process mode: process chunks through SilenceDetector
       var processedSampleCount = 0
@@ -45,10 +68,12 @@ internal enum VADMonitorLoop {
 
       while isRecording() && !Task.isCancelled {
         // Max duration check
-        if Date().timeIntervalSince(recordingStartTime) >= maxDuration {
+        let elapsed = now().timeIntervalSince(recordingStartTime)
+        if elapsed >= maxDuration {
           onStop(.maxDuration)
           return
         }
+        maybeWarn(elapsed: elapsed)
 
         let samples = sampleProvider()
         let currentCount = samples.count
@@ -71,12 +96,14 @@ internal enum VADMonitorLoop {
         try? await Task.sleep(for: .milliseconds(100))
       }
     } else {
-      // XPC mode: service handles VAD. Only enforce max duration here.
+      // XPC mode: service handles VAD. Only enforce max duration + warning here.
       while isRecording() && !Task.isCancelled {
-        if Date().timeIntervalSince(recordingStartTime) >= maxDuration {
+        let elapsed = now().timeIntervalSince(recordingStartTime)
+        if elapsed >= maxDuration {
           onStop(.maxDuration)
           return
         }
+        maybeWarn(elapsed: elapsed)
         try? await Task.sleep(for: .milliseconds(500))
       }
     }

--- a/Sources/EnviousWisprPipeline/VADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/VADSignalSource.swift
@@ -40,6 +40,23 @@ public struct VADStopSignal: Equatable, Sendable {
   }
 }
 
+/// An advisory VAD signal that the recording is approaching `maxRecordingDuration`
+/// (#1060). NOT a stop — recording continues; this is a separate stream from
+/// `VADStopSignal` precisely because `VADStopKind` is stop-driving and the kernel
+/// routes every stop kind to `deliverRecordingExitIfCurrent`. Carries
+/// `remainingSeconds` so the App layer can keep "auto-stop in 1 minute" copy
+/// truthful (suppress/relabel on a late fire). Session-stamped like `VADStopSignal`
+/// so a late warning from a finished session is dropped by the kernel.
+public struct VADWarningSignal: Equatable, Sendable {
+  public let remainingSeconds: TimeInterval
+  public let sessionID: SessionID
+
+  public init(remainingSeconds: TimeInterval, sessionID: SessionID) {
+    self.remainingSeconds = remainingSeconds
+    self.sessionID = sessionID
+  }
+}
+
 /// Tri-state speech evidence read by the kernel at `stopping` (PR-1 §B.6).
 /// The no-speech gate keys on *confirmed* no-speech, not on an empty segment
 /// list per se (Codex r2 correction).
@@ -73,6 +90,13 @@ protocol VADSignalSource: AnyObject {
   /// per-subscriber continuation is removed automatically on iterator
   /// cancellation via `onTermination`.
   func subscribeStopSignals() -> AsyncStream<VADStopSignal>
+
+  /// Open a fresh per-subscriber stream of approaching-cap warning signals
+  /// (#1060). Advisory only — the kernel forwards a semantic event upward and
+  /// never stops on these. Same per-subscriber broadcast contract as
+  /// `subscribeStopSignals()` (each call returns a new stream; every yield is
+  /// broadcast to every live subscriber; `onTermination` removes the continuation).
+  func subscribeWarningSignals() -> AsyncStream<VADWarningSignal>
 
   /// The speech-evidence verdict at stop. Read once when the kernel enters
   /// `stopping`.

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -131,9 +131,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   private var observedSpeechSegments: [SpeechSegment] = []
 
   /// Cap on `retainedPCM` — `maxRecordingDuration` worth of 16 kHz mono samples
-  /// (300 s * 16 kHz = 4.8 M Float = ~19 MB). Mirrors Parakeet's cap so the
-  /// two engines size memory the same way. On reaching the cap the
-  /// accumulation stops growing; recording auto-stops on max-duration anyway.
+  /// (3600 s * 16 kHz = 57.6 M Float = ~230 MB; #1060 raised the cap 300→3600).
+  /// Mirrors Parakeet's cap so the two engines size memory the same way. On
+  /// reaching the cap the accumulation stops growing; recording auto-stops on
+  /// max-duration anyway.
   private static let retainedPCMCap = Int(
     TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -56,7 +56,10 @@ public final class TelemetryService {
   // MARK: - Observation Layer (reads domain objects)
 
   /// Called by the former root state when a pipeline completes. Reads Transcript + ExecutionMetrics.
-  public func reportDictationCompleted(transcript t: Transcript, inputMode: String) {
+  public func reportDictationCompleted(
+    transcript t: Transcript, inputMode: String,
+    recordingSeconds: Double? = nil, stopReason: String? = nil
+  ) {
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
@@ -85,7 +88,9 @@ public final class TelemetryService {
       itnSkipReason: m?.itnSkipReason,
       itnLatencyMs: m?.itnLatencyMs,
       itnLenBefore: m?.itnLenBefore,
-      itnLenAfter: m?.itnLenAfter
+      itnLenAfter: m?.itnLenAfter,
+      recordingSeconds: recordingSeconds,
+      stopReason: stopReason
     )
     if let e2e = m?.e2eSeconds {
       metricPipelineE2E(
@@ -221,7 +226,8 @@ public final class TelemetryService {
     e2eSeconds: Double, asrSeconds: Double?, llmSeconds: Double?,
     itnRan: Bool? = nil, itnChanged: Bool? = nil, itnFloorDelivered: Bool? = nil,
     itnSkipReason: String? = nil, itnLatencyMs: Double? = nil,
-    itnLenBefore: Int? = nil, itnLenAfter: Int? = nil
+    itnLenBefore: Int? = nil, itnLenAfter: Int? = nil,
+    recordingSeconds: Double? = nil, stopReason: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -231,6 +237,10 @@ public final class TelemetryService {
       "e2e_seconds": String(format: "%.3f", e2eSeconds),
       "$value": e2eSeconds,
     ]
+    // #1060: how long the user actually spoke (distinct from e2e processing time)
+    // + why the recording stopped. Metadata only (telemetry-privacy-boundary).
+    if let rec = recordingSeconds { props["recording_seconds"] = String(format: "%.3f", rec) }
+    if let sr = stopReason { props["stop_reason"] = sr }
     if let p = llmProvider { props["llm_provider"] = p }
     if let a = targetApp { props["target_app"] = a }
     if let pr = pasteResult { props["paste_result"] = pr }
@@ -254,6 +264,16 @@ public final class TelemetryService {
       props["$value"] = d
     }
     PostHogSDK.shared.capture("dictation.canceled", properties: props)
+  }
+
+  /// #1060: the approaching-cap warning was shown to the user (~1 min before the
+  /// recording-duration cap). Counts the population that records long enough to
+  /// near the cap — near-zero today; a rising count is the signal to invest in
+  /// full long-form mode (#344). Metadata only.
+  public func recordingCapWarningShown(backend: String, capSeconds: Double) {
+    PostHogSDK.shared.capture(
+      "recording.cap_warning_shown",
+      properties: ["asr_backend": backend, "cap_seconds": capSeconds])
   }
 
   // MARK: - Pipeline Steps

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -26,6 +26,16 @@ import Testing
 ///       PR10's `RecordingFinalizer` plan).
 ///   PR10 ratchets back down when `RecordingFinalizer` absorbs the
 ///   lock-state writes (the closure-pair retires).
+/// - #1060 (2026-06-17): line ceiling 350 → 365. The coordinator gained the
+///   approaching-cap warning presentation (`showApproachingCapWarning`, a PRIVATE
+///   method) + its callback wiring + completion-telemetry stop-reason/length —
+///   correctly placed here per state-ownership decision table row 8 (overlay /
+///   warning / transition behavior after start). The ENTANGLEMENT ceilings are
+///   UNCHANGED (collaborators still 11, non-private methods still 5): the feature
+///   added no collaborator and no public surface, only lines. Per
+///   `measure-entanglement-not-paper` the line ceiling is the loose/paper metric,
+///   so a modest paper bump for a correctly-placed responsibility is the honest
+///   call over comment-cramming. Comments were trimmed first to minimize it.
 ///
 /// Var-exclusion rationale (per category, locked here so a future PR cannot
 /// argue "var anything is free"):
@@ -75,9 +85,9 @@ import Testing
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      count <= 350,
+      count <= 365,
       """
-      DictationLifecycleCoordinator line count exceeded: \(count) > 350. \
+      DictationLifecycleCoordinator line count exceeded: \(count) > 365. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
@@ -34,6 +34,28 @@ import Testing
     #expect(signal == VADStopSignal(kind: .maxDurationReached, sessionID: sid))
   }
 
+  @Test("noteApproachingMaxDuration yields a warning signal stamped with the current session")
+  func warningBridging() async {
+    let source = CaptureVADSignalSource()
+    let sid = SessionID()
+    source.setCurrentSessionID(sid)
+    var iterator = source.subscribeWarningSignals().makeAsyncIterator()
+    source.noteApproachingMaxDuration(remainingSeconds: 60)
+    let signal = await iterator.next()
+    #expect(signal == VADWarningSignal(remainingSeconds: 60, sessionID: sid))
+  }
+
+  @Test("a warning never appears on the stop stream (#1060 separate streams)")
+  func warningDoesNotRideStopStream() async {
+    let source = CaptureVADSignalSource()
+    source.setCurrentSessionID(SessionID())
+    var stopIterator = source.subscribeStopSignals().makeAsyncIterator()
+    source.noteApproachingMaxDuration(remainingSeconds: 60)  // must NOT reach the stop stream
+    source.noteMaxDurationReached()
+    let signal = await stopIterator.next()
+    #expect(signal?.kind == .maxDurationReached)
+  }
+
   @Test("bind claims onVADAutoStop — the XPC callback drives a stop signal")
   func bindOwnsXPCCallback() async {
     let source = CaptureVADSignalSource()

--- a/Tests/EnviousWisprTests/Pipeline/RecordingCapInvariantTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingCapInvariantTests.swift
@@ -1,0 +1,28 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+// MARK: - RecordingCapInvariantTests (#1060)
+//
+// Locks the soft-vs-hard cap relationship: the in-process emergency ceiling
+// (`AudioCaptureManager.maxRecordingDurationSeconds`) MUST stay strictly above
+// the graceful soft cap (`TimingConstants.maxRecordingDuration`) so the graceful
+// stop+transcribe always pre-empts the hard teardown. A regression here would
+// make the hard cap fire first and tear capture down non-gracefully.
+
+@Suite struct RecordingCapInvariantTests {
+
+  @Test("hard emergency cap is strictly greater than the graceful soft cap")
+  func hardCapExceedsSoftCap() {
+    #expect(AudioCaptureManager.maxRecordingDurationSeconds > TimingConstants.maxRecordingDuration)
+  }
+
+  @Test("soft cap is the 60-minute value and leaves room for the warning lead")
+  func softCapAndLeadAreConsistent() {
+    // In release these are the shipped constants (DEBUG overrides default off).
+    #expect(TimingConstants.maxRecordingDuration == 3600)
+    #expect(TimingConstants.maxDurationWarningLeadSeconds == 60)
+    #expect(TimingConstants.maxRecordingDuration > TimingConstants.maxDurationWarningLeadSeconds)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
@@ -18,6 +18,9 @@ final class FakeVADSignalSource: VADSignalSource {
   /// auto-removes its entry via `onTermination`.
   private var subscribers: [Int: AsyncStream<VADStopSignal>.Continuation] = [:]
   private var nextSubscriberID: Int = 0
+  /// Per-subscriber continuations for the approaching-cap warning stream (#1060).
+  private var warningSubscribers: [Int: AsyncStream<VADWarningSignal>.Continuation] = [:]
+  private var nextWarningSubscriberID: Int = 0
 
   /// The verdict `speechEvidenceAtStop()` returns. Defaults to `.voiced`;
   /// scenarios set `.confirmedNoSpeech` or `.unavailable`.
@@ -57,6 +60,36 @@ final class FakeVADSignalSource: VADSignalSource {
     }
   }
 
+  func subscribeWarningSignals() -> AsyncStream<VADWarningSignal> {
+    let id = nextWarningSubscriberID
+    nextWarningSubscriberID += 1
+    return AsyncStream { continuation in
+      warningSubscribers[id] = continuation
+      continuation.onTermination = { @Sendable [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.warningSubscribers.removeValue(forKey: id)
+        }
+      }
+    }
+  }
+
+  /// Number of approaching-cap warnings emitted — for warning-path tests.
+  private(set) var emittedWarningCount = 0
+
+  /// Emit an approaching-cap warning stamped with `currentSessionID` (#1060).
+  func emitWarning(remainingSeconds: TimeInterval = 60) {
+    emittedWarningCount += 1
+    let signal = VADWarningSignal(remainingSeconds: remainingSeconds, sessionID: currentSessionID)
+    for continuation in warningSubscribers.values { continuation.yield(signal) }
+  }
+
+  /// Emit a warning stamped with a PRIOR session's id — the stale-drop case.
+  func emitStaleWarning(remainingSeconds: TimeInterval = 60) {
+    emittedWarningCount += 1
+    let signal = VADWarningSignal(remainingSeconds: remainingSeconds, sessionID: SessionID())
+    for continuation in warningSubscribers.values { continuation.yield(signal) }
+  }
+
   /// Emit one stop-driving signal, stamped with `currentSessionID` (driven by a
   /// scenario's `VADDirective`). Broadcast to every live subscriber.
   func emit(_ kind: VADStopKind) {
@@ -86,5 +119,7 @@ final class FakeVADSignalSource: VADSignalSource {
   func finish() {
     for continuation in subscribers.values { continuation.finish() }
     subscribers.removeAll()
+    for continuation in warningSubscribers.values { continuation.finish() }
+    warningSubscribers.removeAll()
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/VADMonitorLoopTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/VADMonitorLoopTests.swift
@@ -1,0 +1,112 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - VADMonitorLoopTests (#1060)
+//
+// Unit coverage for the one-shot approaching-cap warning added to the shared
+// VAD monitor loop. Drives the XPC branch (detector == nil) with an injected
+// `now` clock so threshold crossings are exercised without real-time waits in
+// the assertions (the loop's inter-poll sleep still runs, kept to ≤2 iterations).
+
+@MainActor
+@Suite struct VADMonitorLoopTests {
+
+  /// Records the loop's callbacks. `@MainActor` so the loop's `@MainActor`
+  /// closures mutate it without data races; `keepRecording` flips it off.
+  @MainActor final class Recorder {
+    var warningRemaining: [TimeInterval] = []
+    var stops: [VADStopReason] = []
+    var keepRecording = true
+    var ticks = 0
+  }
+
+  private static let start = Date(timeIntervalSince1970: 1_000_000)
+
+  @Test("warning fires exactly once when elapsed crosses maxDuration - lead")
+  func warningFiresOnceAtThreshold() async {
+    let rec = Recorder()
+    // elapsed 250s: past the 240s threshold (300 - 60), before the 300s cap.
+    await VADMonitorLoop.run(
+      detector: nil, vadAutoStop: true,
+      maxDuration: 300, warningLead: 60,
+      recordingStartTime: Self.start,
+      sampleProvider: { [] },
+      isRecording: { rec.keepRecording },
+      now: { Self.start.addingTimeInterval(250) },
+      onApproachingMaxDuration: { remaining in
+        rec.warningRemaining.append(remaining)
+        rec.keepRecording = false  // exit the loop after the warning
+      },
+      onStop: { rec.stops.append($0) }
+    )
+    #expect(rec.warningRemaining.count == 1)
+    #expect(abs((rec.warningRemaining.first ?? 0) - 50) < 0.001)  // 300 - 250
+    #expect(rec.stops.isEmpty)
+  }
+
+  @Test("no warning when recording stops before the threshold")
+  func noWarningIfStoppedEarly() async {
+    let rec = Recorder()
+    rec.keepRecording = false  // loop body never runs
+    await VADMonitorLoop.run(
+      detector: nil, vadAutoStop: true,
+      maxDuration: 300, warningLead: 60,
+      recordingStartTime: Self.start,
+      sampleProvider: { [] },
+      isRecording: { rec.keepRecording },
+      now: { Self.start.addingTimeInterval(100) },
+      onApproachingMaxDuration: { rec.warningRemaining.append($0) },
+      onStop: { rec.stops.append($0) }
+    )
+    #expect(rec.warningRemaining.isEmpty)
+    #expect(rec.stops.isEmpty)
+  }
+
+  @Test("no warning when maxDuration is not greater than the lead")
+  func noWarningWhenCapTooShort() async {
+    let rec = Recorder()
+    // maxDuration 30 <= lead 60 → warning disarmed. Run ≤2 body iterations.
+    await VADMonitorLoop.run(
+      detector: nil, vadAutoStop: true,
+      maxDuration: 30, warningLead: 60,
+      recordingStartTime: Self.start,
+      sampleProvider: { [] },
+      isRecording: {
+        rec.ticks += 1
+        return rec.ticks <= 2
+      },
+      now: { Self.start.addingTimeInterval(25) },  // past any threshold, below cap
+      onApproachingMaxDuration: { rec.warningRemaining.append($0) },
+      onStop: { rec.stops.append($0) }
+    )
+    #expect(rec.warningRemaining.isEmpty)
+    #expect(rec.stops.isEmpty)
+  }
+
+  @Test("max-duration stop fires at the cap and pre-empts the warning")
+  func stopFiresAtCapBeforeWarning() async {
+    let rec = Recorder()
+    await VADMonitorLoop.run(
+      detector: nil, vadAutoStop: true,
+      maxDuration: 300, warningLead: 60,
+      recordingStartTime: Self.start,
+      sampleProvider: { [] },
+      isRecording: { rec.keepRecording },
+      now: { Self.start.addingTimeInterval(300) },  // == cap
+      onApproachingMaxDuration: {
+        rec.warningRemaining.append($0)
+        rec.keepRecording = false
+      },
+      onStop: {
+        rec.stops.append($0)
+        rec.keepRecording = false
+      }
+    )
+    #expect(rec.stops == [.maxDuration])
+    // The cap check precedes the warning check, so no warning fires at exactly the cap.
+    #expect(rec.warningRemaining.isEmpty)
+  }
+}


### PR DESCRIPTION
## What & why
Raises the recording cap from 5 min to **60 min** and adds two safety nudges so a long continuous dictation never silently truncates. Deliberately reduced subset of #344 (long-form mode) per founder decision — just the cap bump + warnings; auto-stop stays on, so short-dictation users are unaffected and only continuous talkers reach the new cap.

Closes #1060.

## Changes
- **Cap 5 → 60 min.** `TimingConstants.maxRecordingDuration` 300 → 3600 (computed `static var`; DEBUG-only `EWDebugMaxRecordingSeconds` UserDefaults override lets Live UAT drive the full warning→cap→transcribe cycle in ~90s, never in release). Cascades to both ASR backends' retained-PCM caps. In-process emergency ceiling `AudioCaptureManager.maxRecordingDurationSeconds` 600 → 3660 so the graceful soft stop always pre-empts the hard teardown; `maxRecordingSamples` is now derived from it. Hard > soft invariant locked by `RecordingCapInvariantTests`.
- **Approaching-cap warning (one-shot).** Fired from `VADMonitorLoop` when elapsed ≥ cap − lead (`maxDurationWarningLeadSeconds` = 60), on its own `VADWarningSignal` stream (separate from the stop signal), session-stamped + stale-dropped, routed through the kernel to a semantic `onApproachingMaxDuration` callback. The coordinator shows a **persistent in-panel banner** ("Recording auto-stops in under a minute (60-minute cap)") via `RecordingOverlayPanel.flashRecordingNotice` — NOT a new overlay intent (a `.warning` intent would tear down the single recording panel; caught in Codex grounded review). The banner stays the full final minute.
- **Auto-stop pill at the cap.** When the stop reason is `max_duration`, the transcribing pill reads "Reached the 60-minute limit. Transcribing now." (`KernelDictationDriver.transcribingPillLabel`), wrapped 2-line in a content-sized panel window, so the cap stop never reads as a glitch.
- **Telemetry.** `dictation.completed` gains `recording_seconds` + `stop_reason`; new `recording.cap_warning_shown` (`asr_backend`, `cap_seconds`). The duration + stop-reason pair also serves as the production canary for any long-recording empty-result edge.

## Validation
- Build green; full logic suite **1814 tests pass, 0 failures** (new: VADMonitorLoop one-shot warning w/ injected clock, warning-never-on-stop-stream adversarial test, hard>soft cap invariant, coordinator ceiling).
- Live UAT (debug 12s cap): recording auto-stops at the cap (`capturedMs=12385` with 18.6s of continuous audio), transcribes, pastes — the soft cap pre-empts the manual/hard stop.
- 60-minute real-audio accuracy validated across all 3 decode styles (Parakeet batch, Parakeet streaming, WhisperKit) — none break or OOM at length; all chunk long audio internally.
- Codex grounded review (4 rounds → PROCEED-AS-PLANNED) + code-diff review. Two code-diff P2s resolved: (1) cap-end pill window-height clip **fixed** (window now sized to the wrapped content); (2) XPC 230 MB stop-reply "watchdog wedge" concern **refuted as a false-positive** — two independent benchmarks (incl. a same-process NSXPC reply of the full 234 MB payload) measured the post-`reply_ready` quiet window at 32-88 ms vs the watcher's 800 ms minimum floor (9-25× margin). Evidence: `docs/audits/2026-06-17-1060-xpc-largereply-grounding.txt`.

## Out of scope (deferred)
Crash-recovery / audio-to-disk spool (heart-path; follow-up issue), long-form mode toggle/forced backend (#344), long-transcript AFM polish (parallel session #1055).