### PR TITLE
feat(llm): honest fallback_reason for AFM polish telemetry (#1050)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -20,6 +20,13 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var polishRouterBasis: String?
   public var polishFilterTripped: String?
   public var polishFellBackToRaw: Bool?
+  /// #1050 honest disaggregation of `polishFellBackToRaw`. Populated only for AFM
+  /// polish (nil for cloud / pre-#1050 records); nil also when polish CHANGED the
+  /// text (not a fallback). `no_change` (benign — model returned input unchanged),
+  /// `guard_discard` (`EnviousOutputFilter` caught bad output), or
+  /// `validator_discard` (`validatePolishOutput` caught bad output — invisible to
+  /// `polishFilterTripped`). Invariant: present iff `polishFellBackToRaw == true`.
+  public var polishFallbackReason: String?
   /// Deterministic ITN telemetry (#145). Populated per dictation; nil on
   /// pre-#145 transcripts on disk (additive optional Codable, back-compatible).
   /// `itnFloorDelivered` = ITN changed the text AND polish did not deliver a
@@ -69,6 +76,7 @@ public struct ExecutionMetrics: Codable, Sendable {
     polishRouterBasis: String? = nil,
     polishFilterTripped: String? = nil,
     polishFellBackToRaw: Bool? = nil,
+    polishFallbackReason: String? = nil,
     itnRan: Bool? = nil,
     itnChanged: Bool? = nil,
     itnFloorDelivered: Bool? = nil,
@@ -97,6 +105,7 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.polishRouterBasis = polishRouterBasis
     self.polishFilterTripped = polishFilterTripped
     self.polishFellBackToRaw = polishFellBackToRaw
+    self.polishFallbackReason = polishFallbackReason
     self.itnRan = itnRan
     self.itnChanged = itnChanged
     self.itnFloorDelivered = itnFloorDelivered

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -43,6 +43,8 @@ final class KernelFinalizationOutcome {
   /// assembly (§8 polish-latency capture).
   var polishMetadata: PolishMetadata?
   var pipelineFellBackToRaw = false
+  /// #1050 honest disaggregation of `pipelineFellBackToRaw`; AFM-gated downstream.
+  var polishFallbackReason: String?
   var pipelineStartedAtSeconds: Double?
   var pipelineEndedAtSeconds: Double?
   var asrStartedAtSeconds: Double?
@@ -188,6 +190,7 @@ struct KernelFinalizationWiring {
       outcome.llmModel = ctx.llmModel
       outcome.polishMetadata = ctx.polishMetadata
       outcome.pipelineFellBackToRaw = ctx.pipelineFellBackToRaw
+      outcome.polishFallbackReason = ctx.polishFallbackReason
       outcome.polishError = result.polishError
       outcome.polishDurationSeconds = CFAbsoluteTimeGetCurrent() - start
       return ctx.polishedText ?? ctx.text
@@ -280,8 +283,12 @@ struct KernelFinalizationWiring {
   /// text AND polish did not deliver a DISTINCT polished result — disabled /
   /// unavailable / too-short bypass (no polished text — since #1022 the
   /// "too short" skip leaves `polishedText` nil), ran-and-rejected (fell back
-  /// to raw), OR ran-but-identical (polished == the post-ITN text; that path
-  /// does NOT set `pipelineFellBackToRaw` — Codex r1 #2). In all cases the
+  /// to raw), OR ran-but-identical (polished == the post-ITN text). NOTE
+  /// (corrected #1050): the ran-but-identical case ALSO sets
+  /// `pipelineFellBackToRaw` (the `validatedText == context.text` arm in
+  /// `LLMPolishStep`, surfaced as reason `no_change`); the explicit
+  /// `polishedText == rawText` clause is a redundant safety net for any path
+  /// that delivers polished == raw without the flag. In all cases the
   /// pasted text is the post-ITN text. `rawText` is the final chain text
   /// (post-ITN), set in `processText`. Internal for a direct parametric test.
   static func itnFloorDelivered(
@@ -328,6 +335,7 @@ struct KernelFinalizationWiring {
       polishRouterBasis: outcome.polishMetadata?.routerBasis,
       polishFilterTripped: outcome.polishMetadata?.filterTripped,
       polishFellBackToRaw: outcome.polishMetadata == nil ? nil : outcome.pipelineFellBackToRaw,
+      polishFallbackReason: outcome.polishMetadata == nil ? nil : outcome.polishFallbackReason,
       itnRan: outcome.itnRan,
       itnChanged: outcome.itnChanged,
       itnFloorDelivered: itnFloorDelivered,

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -308,6 +308,14 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       ctx.polishMetadata = result.polishMetadata
       ctx.pipelineFellBackToRaw =
         (result.polishMetadata?.filterFellBackToRaw ?? false) || (validatedText == context.text)
+      // #1050: honest disaggregation of the boolean above. Invariant:
+      // (reason != nil) == pipelineFellBackToRaw (the existing line is left
+      // untouched — `pipelineFellBackToRaw` also feeds `itnFloorDelivered`).
+      ctx.polishFallbackReason = Self.polishFallbackReason(
+        filterFellBackToRaw: result.polishMetadata?.filterFellBackToRaw ?? false,
+        postFilterOutput: result.polishedText,
+        validatedText: validatedText,
+        originalText: context.text)
       return ctx
     }
 
@@ -363,7 +371,48 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     ctx.polishMetadata = result.polishMetadata
     ctx.pipelineFellBackToRaw =
       (result.polishMetadata?.filterFellBackToRaw ?? false) || (validatedText == context.text)
+    // #1050: see the AFM path above. Cloud providers leave `polishMetadata` nil,
+    // so this reason is nil-degraded downstream in `KernelFinalizationWiring`
+    // exactly like `pipelineFellBackToRaw` — kept here only for path symmetry.
+    ctx.polishFallbackReason = Self.polishFallbackReason(
+      filterFellBackToRaw: result.polishMetadata?.filterFellBackToRaw ?? false,
+      postFilterOutput: result.polishedText,
+      validatedText: validatedText,
+      originalText: context.text)
     return ctx
+  }
+
+  // MARK: - Fallback Reason (#1050)
+
+  /// Disaggregate the conflated `pipelineFellBackToRaw` boolean into an honest
+  /// reason for telemetry. Pure + static so it is directly unit-testable
+  /// (mirrors the `KernelFinalizationWiring.itnFloorDelivered` precedent).
+  ///
+  /// - nil → polish CHANGED the text (NOT a fallback; `pipelineFellBackToRaw == false`).
+  /// - `guard_discard` → the connector `EnviousOutputFilter` tripped (genuine
+  ///   misbehavior caught; `polishMetadata.filterTripped` names which guard).
+  /// - `no_change` → the model returned the input unchanged (benign no-op — the
+  ///   ~75%-of-fallbacks majority that inflated the headline rate).
+  /// - `validator_discard` → the model differed but `validatePolishOutput`
+  ///   substituted the original (genuine catch the `filter_tripped` signal cannot see).
+  ///
+  /// Invariant (locked by a parametric test): `(reason != nil)` equals the real
+  /// `filterFellBackToRaw || (validatedText == originalText)`, so this NEVER
+  /// changes `pipelineFellBackToRaw` — it only labels it.
+  ///
+  /// `postFilterOutput` is `result.polishedText`: post-connector-filter,
+  /// post-leading-marker-repair, PRE-`validatePolishOutput` (not the raw model
+  /// output). On a filter trip it equals the input, so `guard_discard` MUST be
+  /// checked first.
+  static func polishFallbackReason(
+    filterFellBackToRaw: Bool,
+    postFilterOutput: String,
+    validatedText: String,
+    originalText: String
+  ) -> String? {
+    if filterFellBackToRaw { return "guard_discard" }
+    guard validatedText == originalText else { return nil }
+    return postFilterOutput == originalText ? "no_change" : "validator_discard"
   }
 
   // MARK: - Output Validation

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -23,6 +23,15 @@ public struct TextProcessingContext: Sendable {
   /// to raw input. Computed in `LLMPolishStep` after validation; the connector
   /// cannot know this. Telemetry surfaces this as `fell_back_to_raw`.
   public var pipelineFellBackToRaw: Bool
+  /// Honest reason the pipeline fell back to raw, disaggregating the single
+  /// `pipelineFellBackToRaw` boolean (#1050). Nil when polish changed the text
+  /// (not a fallback). One of `no_change` (model returned the input unchanged —
+  /// benign), `guard_discard` (connector `EnviousOutputFilter` tripped — genuine
+  /// misbehavior caught; `polishMetadata.filterTripped` names which), or
+  /// `validator_discard` (model differed but `validatePolishOutput` substituted
+  /// the original — genuine catch the `filter_tripped` signal cannot see).
+  /// Invariant: `(polishFallbackReason != nil) == pipelineFellBackToRaw`.
+  public var polishFallbackReason: String?
 
   public init(text: String, language: String?) {
     self.text = text

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -39,6 +39,9 @@ internal struct FinalizationResult {
   /// Final pipeline-level fallback flag (filter OR validator). See
   /// `TextProcessingContext.pipelineFellBackToRaw`.
   let pipelineFellBackToRaw: Bool
+  /// #1050 honest disaggregation of `pipelineFellBackToRaw`. Carried for parity
+  /// with the production fold; this test-seam finalizer emits no telemetry.
+  let polishFallbackReason: String?
 }
 
 /// Typed errors so pipelines can decide the right fallback per category.
@@ -184,7 +187,8 @@ internal final class TranscriptFinalizer {
       polishDurationSeconds: polishEnd - polishStart,
       pasteDurationSeconds: pasteEnd - pasteStart,
       polishMetadata: context.polishMetadata,
-      pipelineFellBackToRaw: context.pipelineFellBackToRaw
+      pipelineFellBackToRaw: context.pipelineFellBackToRaw,
+      polishFallbackReason: context.polishFallbackReason
     )
   }
 }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -112,7 +112,8 @@ public final class TelemetryService {
         routerMode: m?.polishRouterMode,
         routerBasis: m?.polishRouterBasis,
         filterTripped: m?.polishFilterTripped,
-        fellBackToRaw: m?.polishFellBackToRaw
+        fellBackToRaw: m?.polishFellBackToRaw,
+        fallbackReason: m?.polishFallbackReason
       )
     }
     if let tier = m?.pasteTier, let ms = m?.pasteLatencyMs {
@@ -467,7 +468,8 @@ public final class TelemetryService {
     routerMode: String? = nil,
     routerBasis: String? = nil,
     filterTripped: String? = nil,
-    fellBackToRaw: Bool? = nil
+    fellBackToRaw: Bool? = nil,
+    fallbackReason: String? = nil
   ) {
     var props: [String: Any] = [
       "provider": provider,
@@ -480,6 +482,7 @@ public final class TelemetryService {
     if let rb = routerBasis { props["router_basis"] = rb }
     if let ft = filterTripped { props["filter_tripped"] = ft }
     if let fb = fellBackToRaw { props["fell_back_to_raw"] = fb }
+    if let fr = fallbackReason { props["fallback_reason"] = fr }
     #if DEBUG
       var stringProps: [String: String] = [
         "provider": provider, "result": result,
@@ -488,6 +491,7 @@ public final class TelemetryService {
       if let rm = routerMode { stringProps["router_mode"] = rm }
       if let rb = routerBasis { stringProps["router_basis"] = rb }
       if let ft = filterTripped { stringProps["filter_tripped"] = ft }
+      if let fr = fallbackReason { stringProps["fallback_reason"] = fr }
       var boolProps: [String: Bool] = [:]
       if let fb = fellBackToRaw { boolProps["fell_back_to_raw"] = fb }
       testEventHook?(

--- a/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
@@ -244,11 +244,11 @@ struct DualModePolishTelemetryTests {
 
   // MARK: - 4b. PipelineFellBackToRaw OR semantics (LLMPolishStep §3.5)
 
-  /// `LLMPolishStep` computes `pipelineFellBackToRaw = filterFellBackToRaw ||
-  /// (validatedText == context.text)`. That OR is too small to inject through
-  /// the existing LLMPolishStep surface (the polisher is built per-call from
-  /// `llmProvider`), so we verify the formula directly here. Production sites:
-  /// `LLMPolishStep.swift:248` (AFM path) and `LLMPolishStep.swift:312` (cloud).
+  /// `LLMPolishStep.process()` computes `pipelineFellBackToRaw =
+  /// filterFellBackToRaw || (validatedText == context.text)` on both the AFM and
+  /// cloud paths. The OR is conceptually verified here; the production formula is
+  /// now also locked against the new `#1050` reason helper by
+  /// `fallbackReasonInvariantMatchesOR` below (section 7).
   @Test("pipelineFellBackToRaw is OR of filter outcome and validator outcome")
   func pipelineFellBackToRawIsOR() {
     func computeOR(filterFellBack: Bool, validatorFellBack: Bool) -> Bool {
@@ -265,8 +265,9 @@ struct DualModePolishTelemetryTests {
   /// Pipelines build `polishFellBackToRaw: metadata == nil ? nil : pipelineFellBackToRaw`.
   /// When no AFM polish ran (cloud provider, or polish skipped), the field
   /// must be NIL — not `false` — so PostHog filtering on `fell_back_to_raw IS
-  /// NOT NULL` correctly excludes non-AFM events. Production sites:
-  /// the old Parakeet pipeline and `KernelDictationDriver.swift:1050`.
+  /// NOT NULL` correctly excludes non-AFM events. Production site:
+  /// `KernelFinalizationWiring.updateTranscriptMetrics` (the `polishMetadata ==
+  /// nil ? nil : …` gate, which `#1050` `polishFallbackReason` now mirrors).
   @Test("ExecutionMetrics.polishFellBackToRaw is nil when polishMetadata is absent")
   func executionMetricsFellBackIsNilWithoutMetadata() {
     let metadata: PolishMetadata? = nil
@@ -306,6 +307,172 @@ struct DualModePolishTelemetryTests {
     #expect(metrics.polishRouterMode == "natural")
     #expect(metrics.polishFellBackToRaw == false)
   }
+
+  // MARK: - 7. #1050 polishFallbackReason — honest disaggregation
+
+  /// The real production helper (`LLMPolishStep.polishFallbackReason`) is pure +
+  /// static, so we exercise it directly rather than re-implementing the logic.
+
+  @Test("polishFallbackReason: nil when polish CHANGED the text (not a fallback)")
+  func fallbackReasonNilWhenChanged() {
+    // Obviously-distinct strings: filler removed + capitalized + punctuated, so
+    // validatedText != originalText → polish applied → not a fallback.
+    let reason = LLMPolishStep.polishFallbackReason(
+      filterFellBackToRaw: false,
+      postFilterOutput: "This is the clean text.",
+      validatedText: "This is the clean text.",
+      originalText: "um so this is the clean text")
+    #expect(reason == nil)
+  }
+
+  @Test("polishFallbackReason: guard_discard when the connector filter tripped")
+  func fallbackReasonGuardDiscard() {
+    // filter trip → postFilterOutput is raw input, validated == original.
+    let reason = LLMPolishStep.polishFallbackReason(
+      filterFellBackToRaw: true,
+      postFilterOutput: "raw input",
+      validatedText: "raw input",
+      originalText: "raw input")
+    #expect(reason == "guard_discard")
+  }
+
+  @Test("polishFallbackReason: guard_discard takes PRECEDENCE even if output differs")
+  func fallbackReasonGuardDiscardPrecedence() {
+    // Defensive: a filter trip must win before the no_change/validator branch,
+    // since on a real trip postFilterOutput == input anyway.
+    let reason = LLMPolishStep.polishFallbackReason(
+      filterFellBackToRaw: true,
+      postFilterOutput: "something else",
+      validatedText: "raw input",
+      originalText: "raw input")
+    #expect(reason == "guard_discard")
+  }
+
+  @Test("polishFallbackReason: no_change when the model returned the input unchanged")
+  func fallbackReasonNoChange() {
+    let reason = LLMPolishStep.polishFallbackReason(
+      filterFellBackToRaw: false,
+      postFilterOutput: "already clean text",
+      validatedText: "already clean text",
+      originalText: "already clean text")
+    #expect(reason == "no_change")
+  }
+
+  @Test("polishFallbackReason: validator_discard when the validator substituted the original")
+  func fallbackReasonValidatorDiscard() {
+    // Model produced DIFFERENT output, but validatePolishOutput rejected it and
+    // returned the original — invisible to filter_tripped.
+    let reason = LLMPolishStep.polishFallbackReason(
+      filterFellBackToRaw: false,
+      postFilterOutput: "a wildly hallucinated expansion",
+      validatedText: "original",
+      originalText: "original")
+    #expect(reason == "validator_discard")
+  }
+
+  @Test("polishFallbackReason invariant: (reason != nil) == the real pipelineFellBackToRaw OR")
+  func fallbackReasonInvariantMatchesOR() {
+    // Lock the equivalence to the production formula
+    // `filterFellBackToRaw || (validatedText == originalText)` so the new reason
+    // can never drift from the boolean it disaggregates.
+    let original = "the original text"
+    let differing = "a different polished text"
+    for filterFellBack in [false, true] {
+      for validatedEqualsOriginal in [false, true] {
+        let validated = validatedEqualsOriginal ? original : differing
+        // postFilterOutput varied so both no_change and validator_discard arise.
+        for postFilter in [original, differing] {
+          let reason = LLMPolishStep.polishFallbackReason(
+            filterFellBackToRaw: filterFellBack,
+            postFilterOutput: postFilter,
+            validatedText: validated,
+            originalText: original)
+          let expectedFellBack = filterFellBack || (validated == original)
+          #expect((reason != nil) == expectedFellBack)
+        }
+      }
+    }
+  }
+
+  @Test("ExecutionMetrics roundtrips polishFallbackReason through Codable")
+  func executionMetricsRoundtripsFallbackReason() throws {
+    let original = ExecutionMetrics(
+      llmLatencySeconds: 0.5,
+      polishRouterMode: "natural",
+      polishRouterBasis: "scored",
+      polishFilterTripped: nil,
+      polishFellBackToRaw: true,
+      polishFallbackReason: "no_change")
+    let decoded = try JSONDecoder().decode(
+      ExecutionMetrics.self, from: try JSONEncoder().encode(original))
+    #expect(decoded.polishFallbackReason == "no_change")
+    #expect(decoded.polishFellBackToRaw == true)
+  }
+
+  @Test("ExecutionMetrics decodes pre-#1050 records (no polishFallbackReason) cleanly")
+  func executionMetricsDecodesWithoutFallbackReason() throws {
+    let oldShape = """
+      {
+        "coldStart": false,
+        "streamingMode": false,
+        "polishFellBackToRaw": true
+      }
+      """
+    let metrics = try JSONDecoder().decode(
+      ExecutionMetrics.self, from: oldShape.data(using: .utf8)!)
+    #expect(metrics.polishFellBackToRaw == true)
+    #expect(metrics.polishFallbackReason == nil)
+  }
+
+  #if DEBUG
+
+    @Test("TelemetryService emits fallback_reason when passed")
+    func telemetryServiceEmitsFallbackReason() async {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in
+          if event.name == "llm.polish_completed" { box.value = event }
+        }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.llmPolishCompleted(
+        provider: "appleIntelligence", model: "apple-intelligence",
+        result: "success", latencySeconds: 0.4,
+        routerMode: "natural", routerBasis: "scored",
+        filterTripped: nil, fellBackToRaw: true,
+        fallbackReason: "no_change")
+
+      await Task.yield()
+      try? await Task.sleep(nanoseconds: 5_000_000)
+
+      let event = try? #require(box.value)
+      #expect(event?.stringProps["fallback_reason"] == "no_change")
+      #expect(event?.boolProps["fell_back_to_raw"] == true)
+    }
+
+    @Test("TelemetryService omits fallback_reason when nil (cloud / not a fallback)")
+    func telemetryServiceOmitsFallbackReasonWhenNil() async {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in
+          if event.name == "llm.polish_completed" { box.value = event }
+        }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.llmPolishCompleted(
+        provider: "openai", model: "gpt-4o-mini",
+        result: "success", latencySeconds: 1.0)
+
+      await Task.yield()
+      try? await Task.sleep(nanoseconds: 5_000_000)
+
+      let event = try? #require(box.value)
+      #expect(event?.stringProps["fallback_reason"] == nil)
+    }
+
+  #endif  // DEBUG
 
   // MARK: - 5. AFMPolishError shape
 


### PR DESCRIPTION
Closes #1050.

## Problem
The `llm.polish_completed` boolean `fell_back_to_raw` conflated a **benign no-op** (Apple Intelligence returned already-clean input unchanged) with a **genuine "model misbehaved, safety net caught it" discard**. Production (30d): ~40% "fell back," but ~75% of those were no-ops — the real misbehavior rate is ~10%. The headline 40% chased a phantom.

## Change
Add a parallel `fallback_reason` string to `llm.polish_completed` (AFM-only; absent when polish changed the text), derived by a pure static helper at the one site that can see both the model's post-filter output and the post-validator text:

| `fallback_reason` | meaning |
|---|---|
| (absent) | polish changed the text — not a fallback |
| `no_change` | model returned the input unchanged (benign majority) |
| `guard_discard` | `EnviousOutputFilter` caught bad output (`filter_tripped` names which guard) |
| `validator_discard` | `validatePolishOutput` caught bad output — a genuine catch **invisible** to `filter_tripped` |

Genuine-misbehavior rate = `fallback_reason IN (guard_discard, validator_discard)`. Dashboards/alerts should key off `fallback_reason`, not raw `fell_back_to_raw`.

### Why `validator_discard` (refinement of the issue's proposal)
The issue proposed `no_change` / `guard_discard` / `genuine_fallback`. Grounding found **two** safety nets: the connector `EnviousOutputFilter` (sets `filter_tripped`) and the pipeline `validatePolishOutput` (substitutes the original on hallucination / content-drop / question-to-answer **without** a `filter_tripped` fingerprint). Folding validator rejections into `no_change` would *under*-count misbehavior, so they get their own reason. `genuine_fallback` (provider error) is intentionally **not** a value here — those throw and emit no `llm.polish_completed` (tracked by `llm.polish_skipped` / `pipeline.failed`).

## Safety
- The existing `pipelineFellBackToRaw` boolean is left **byte-for-byte unchanged** (it also feeds `itnFloorDelivered`). A parametric test locks the invariant `(reason != nil) == pipelineFellBackToRaw` so the two can never drift.
- AFM-gated end to end (nil for cloud providers, exactly like the boolean).
- Metadata-only (fixed enum string) — telemetry privacy boundary respected.
- Additive optional Codable — backward-compatible with on-disk transcript records.

## Validation
- Logic tests: debug lane 1832 + release lane 1727 — both green. 11 new tests (4 outcomes + guard precedence + drift-locking invariant + Codable roundtrip/back-compat + emit/omit).
- Grounded review (Codex) + code-diff review (Codex): direction confirmed; all substantive claims verified TRUE.
- No Live UAT / heart-path / UI / runtime-behavior change (telemetry shape only).

Also rolled in from review: corrected a wrong `itnFloorDelivered` docstring, added `TranscriptFinalizer` parity, refreshed stale test-comment line refs.