### PR TITLE
feat(website): on-page SEO refinements (#538)

### DIFF
--- a/website/src/pages/authors/saurabh-vaish.astro
+++ b/website/src/pages/authors/saurabh-vaish.astro
@@ -70,7 +70,7 @@ const breadcrumbJsonLd = JSON.stringify({
 
       <header class="author-header">
         <h1 class="author-name">{authorName}</h1>
-        <p class="author-bio">Founder of Envious Labs and creator of EnviousWispr, a free, source-available AI dictation app for macOS. He writes about on-device speech-to-text, privacy, Apple Silicon, and accessibility.</p>
+        <p class="author-bio">Saurabh didn't set out to build a dictation app. He kept seeing people online swear by voice-to-text tools for the Mac, tried them himself, and was struck by two things: how much they cost, and how much of your voice they send off to the cloud. Fast, accurate dictation shouldn't require a subscription or hand your audio to someone else's servers. So he built EnviousWispr to show it could work differently: free, private by design, and run entirely on your Mac. Your voice is transcribed on-device and never leaves your machine, and the app works fully offline. Optional AI polish can clean up the text on-device too, or through a cloud provider you connect yourself, so you stay in control of where your words go. He builds and maintains it in the open: the code is source-available on GitHub, so anyone can check exactly how it handles your audio and text. He writes here about on-device speech-to-text, privacy, Apple Silicon, and making dictation reliable enough to use all day.</p>
         <div class="author-links">
           <a href="https://github.com/saurabhav88" rel="me noopener" target="_blank">GitHub</a>
           <a href="https://www.linkedin.com/in/saurabh-a-vaish-568253a6/" rel="me noopener" target="_blank">LinkedIn</a>

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr vs Apple Dictation on speed, AI polish, custom words, and timeout limits. Both free, both on-device, but EnviousWispr goes further.",
   "url": `${siteUrl}/compare/apple-dictation/`,
   "image": `${siteUrl}/images/og/apple-dictation.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-06-13T01:09:39Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr vs Dragon (Nuance) on price, privacy, platform support, and speed. Free on-device dictation for Apple Silicon Macs. No $700 license fee.",
   "url": `${siteUrl}/compare/dragon/`,
   "image": `${siteUrl}/images/og/dragon.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-06-13T01:39:38Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and Google Docs Voice Typing. Both free, but EnviousWispr works system-wide, offline, and on-device. No browser or Google account required.",
   "url": `${siteUrl}/compare/google-docs-voice-typing/`,
   "image": `${siteUrl}/images/og/google-docs-voice-typing.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and MacWhisper for Mac dictation. EnviousWispr is purpose-built for real-time voice-to-text with sub-second latency. MacWhisper excels at file transcription and subtitle export.",
   "url": `${siteUrl}/compare/macwhisper/`,
   "image": `${siteUrl}/images/og/macwhisper.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and Notta.ai. One is real-time dictation for typing on Mac. The other is meeting transcription across platforms. See which fits your workflow.",
   "url": `${siteUrl}/compare/notta/`,
   "image": `${siteUrl}/images/og/notta.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and Otter.ai. One is real-time dictation for typing by voice. The other is meeting transcription. See which fits your workflow.",
   "url": `${siteUrl}/compare/otter-ai/`,
   "image": `${siteUrl}/images/og/otter-ai.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and Superwhisper on price, speech engines, offline support, and speed. Free on-device dictation with Parakeet for Apple Silicon Macs.",
   "url": `${siteUrl}/compare/superwhisper/`,
   "image": `${siteUrl}/images/og/superwhisper.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and VoiceInk on speed, pricing, speech engines, and AI polish. Two on-device Mac dictation apps, one is free.",
   "url": `${siteUrl}/compare/voiceink/`,
   "image": `${siteUrl}/images/og/voiceink.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-06-13T01:39:38Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and whisper.cpp for Mac dictation. Same on-device philosophy, but EnviousWispr gives you a hold-to-talk workflow, AI polish, and custom words without touching a terminal.",
   "url": `${siteUrl}/compare/whisper-cpp/`,
   "image": `${siteUrl}/images/og/whisper-cpp.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-06-13T01:39:38Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Compare EnviousWispr and Willow Voice on privacy, pricing, offline support, and speed. Free on-device dictation for Apple Silicon Macs vs cloud-first subscription.",
   "url": `${siteUrl}/compare/willow-voice/`,
   "image": `${siteUrl}/images/og/willow-voice.png`,
-  "datePublished": "2026-04-04",
-  "dateModified": "2026-04-04",
+  "datePublished": "2026-04-04T21:41:19Z",
+  "dateModified": "2026-06-13T01:09:39Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/wisprflow-alternatives.astro
+++ b/website/src/pages/compare/wisprflow-alternatives.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "Looking for a WisprFlow alternative on Mac? Nine options compared on price, privacy, offline support, and use case. Free and on-device picks lead the list.",
   "url": `${siteUrl}/compare/wisprflow-alternatives/`,
   "image": `${siteUrl}/images/og/wisprflow.png`,
-  "datePublished": "2026-05-15",
-  "dateModified": "2026-05-15",
+  "datePublished": "2026-05-15T18:30:48Z",
+  "dateModified": "2026-05-15T18:30:48Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -10,8 +10,8 @@ const articleJsonLd = JSON.stringify({
   "description": "See how EnviousWispr and WisprFlow compare on privacy, speed, pricing, and architecture. Free on-device dictation vs. cloud subscription.",
   "url": `${siteUrl}/compare/wisprflow/`,
   "image": `${siteUrl}/images/og/wisprflow.png`,
-  "datePublished": "2026-04-03",
-  "dateModified": "2026-04-03",
+  "datePublished": "2026-04-04T01:54:09Z",
+  "dateModified": "2026-06-13T01:09:39Z",
   "author": {
     "@type": "Person",
     "name": "Saurabh Vaish",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -231,6 +231,15 @@ const jsonLdFaq = JSON.stringify({
   </section>
 
   <!-- ═══════════════════════════════════════════════════════
+       What EnviousWispr is — AI-citable definition
+       ═══════════════════════════════════════════════════════ -->
+  <section class="intro-def" aria-label="What EnviousWispr is">
+    <div class="container">
+      <p class="intro-def-text reveal">EnviousWispr is a free dictation app for macOS. Hold a hotkey, speak, and your words land as clean, polished text in whatever app you're using. Transcription runs entirely on your Mac, so your audio never leaves your device. Optional AI polish can tidy the text on-device too, or through a cloud provider you choose.</p>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════
        How It Works — Video Demo
        ═══════════════════════════════════════════════════════ -->
   <section class="video-section section" id="how-it-works" aria-labelledby="video-heading">
@@ -639,6 +648,13 @@ const jsonLdFaq = JSON.stringify({
 </BaseLayout>
 
 <style>
+/* What EnviousWispr is — AI-citable definition block (#538) */
+.intro-def { padding: 8px 0 56px; text-align: center; }
+.intro-def-text {
+  max-width: 680px; margin: 0 auto; padding: 0 24px;
+  font-size: 19px; line-height: 1.65; color: var(--text-2);
+}
+
 /* ═══════════════════════════════════════════════════════
    Hero
    ═══════════════════════════════════════════════════════ */

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -217,3 +217,23 @@ body::after {
   *,*::before,*::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
   .reveal { opacity: 1; transform: none; }
 }
+
+/* #538 on-page SEO: pin the first (feature-label) column of compare tables on phones
+   so labels stay visible while swiping to the competitor column. Adds only NEW sticky
+   properties on the first cell; does not override the per-page scoped wrapper rules.
+   Applies to all .compare-table users (11 /compare/<competitor>/ pages + the /compare/ hub). */
+@media (max-width: 600px) {
+  .compare-table thead th:first-child,
+  .compare-table tbody td:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    /* Opaque so the scrolling competitor column doesn't ghost through the pinned
+       first column. Some pages set a translucent scoped bg on these first cells
+       (header `thead th` on competitor pages; body `td:first-child` on the /compare/ hub),
+       and Astro boosts scoped-selector specificity, so a targeted !important is the
+       correct tool to keep a sticky-overlay background opaque everywhere. */
+    background: #fff !important;
+  }
+  .compare-table thead th:first-child { z-index: 3; }
+}


### PR DESCRIPTION
On-page SEO "bucket A" from the 2026-06-18 claude-seo audit, trimmed to what current (2026) Google/GEO guidance still rewards.

## Changes (15 files, website code lane, zero new logic)
- **Freshness:** 12 compare pages now carry full ISO 8601 datetimes; `dateModified` set to each page's real last-substantive-edit commit timestamp (#1041/#1042 = June 13; #732 = May 15). Hardcoded, not build-dynamic.
- **AI-citability:** a ~55-word, front-loaded "what EnviousWispr is" definition block on the homepage. Privacy-accurate (verified vs `pipeline-mechanics.md` + `llm-contract.md`): audio is transcribed on-device and never leaves the Mac; only opt-in cloud polish (OpenAI/Gemini) sends transcribed text.
- **Mobile UX:** sticky first (feature-label) column on the comparison tables so labels stay visible while swiping to the competitor column. Applies to the 11 `/compare/<competitor>/` pages (verified in-browser). The `/compare/` hub uses `overflow:hidden` on its table, so sticky is a harmless no-op there — no regression.
- **E-E-A-T:** author bio expanded into a trust narrative (true origin story; no competitor naming, no parity/open-source claims).

## Dropped during review (process working)
`offers` (already shipped at `index.astro:14`), `publisher.logo`/`mainEntityOfPage` (Google removed from Article recommended set 2025-12-10), Organization-logo ImageObject (string accepted), softwareVersion/featureList (no SERP value).

## Validation
- `astro build` green (52 pages); rendered Article JSON-LD valid (recommended props present; missing-`aggregateRating` Warning expected/accepted).
- Indexability: canonical intact, no accidental noindex, pages in sitemap.
- Mobile sticky column empirically verified at phone width in Chrome (opaque pinned labels, no page-level overflow, no ghosting).
- Zero em/en-dashes in new customer-facing copy.

## Reviews
- Council (GPT-5.5 + Gemini 3.1 Pro) coverage.
- Codex grounded review: 6 rounds → PROCEED-AS-PLANNED.
- Codex code-diff review: clean (found + fixed one hub-CSS opacity issue first).
- Founder sign-off on the homepage paragraph + author bio copy.

Plan: `docs/feature-requests/issue-538-2026-06-18-onpage-seo-refinements.md`

Part of #538.