### PR TITLE
feat(website): "best dictation app for Mac" comparison hub

### DIFF
--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -1,0 +1,314 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const siteUrl = 'https://enviouswispr.com';
+
+const articleJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Best Dictation App for Mac in 2026: Honest Picks by Use Case",
+  "description": "An honest, by-use-case guide to the best Mac dictation and transcription apps in 2026. Free and private, built-in, file transcription, cross-device, and meetings, compared.",
+  "url": `${siteUrl}/compare/best-dictation-apps-for-mac/`,
+  "image": `${siteUrl}/og-image.png`,
+  "datePublished": "2026-06-18T12:00:00Z",
+  "dateModified": "2026-06-18T12:00:00Z",
+  "author": {
+    "@type": "Person",
+    "name": "Saurabh Vaish",
+    "url": `${siteUrl}/authors/saurabh-vaish/`,
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Envious Labs",
+    "url": siteUrl,
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "url": siteUrl,
+    "name": "EnviousWispr",
+  },
+});
+
+const breadcrumbJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": "Comparisons", "item": `${siteUrl}/compare/` },
+    { "@type": "ListItem", "position": 3, "name": "Best Dictation Apps for Mac", "item": `${siteUrl}/compare/best-dictation-apps-for-mac/` },
+  ],
+});
+
+// At-a-glance rows. Facts verified from each tool's official site (see table note).
+const tableRows = [
+  {
+    feature: "Price",
+    ew: "Free",
+    cells: ["$12/mo Pro (free 2k words/wk)", "$8.49/mo (free trial)", "~$30 one-time or $99.99 lifetime", "$8.49/mo Pro (free 300 min/mo)", "Free (built in)"],
+  },
+  {
+    feature: "Audio stays on your Mac",
+    ew: "Yes, fully on-device",
+    cells: ["No, cloud", "Yes", "Yes", "No, cloud only", "Mostly (enhanced uses cloud)"],
+  },
+  {
+    feature: "Works offline",
+    ew: "Yes",
+    cells: ["No", "Yes", "Yes", "No", "Partial (enhanced needs internet)"],
+  },
+  {
+    feature: "Account",
+    ew: "No account for core use",
+    cells: ["Email signup required", "No", "No", "Account required", "No"],
+  },
+  {
+    feature: "Polish / cleanup",
+    ew: "Yes, on-device Apple Intelligence default; optional cloud via your own key",
+    cells: ["Yes, cloud", "Optional, your own key", "Optional add-on", "AI summaries (cloud)", "No"],
+  },
+  {
+    feature: "Languages",
+    ew: "English (Parakeet) + 90+ (WhisperKit)",
+    cells: ["100+", "100+", "100+", "~100", "~60"],
+  },
+  {
+    feature: "Best for",
+    ew: "Free, private, on-device dictation",
+    cells: ["Polished cross-device dictation", "Customisable on-device modes", "Transcribing existing audio files", "Meetings and long transcripts", "Built-in, zero-install short bursts"],
+  },
+];
+const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple Dictation"];
+---
+
+<BaseLayout
+  title="Best Dictation App for Mac in 2026: Honest Picks by Use Case"
+  description="An honest, by-use-case guide to the best Mac dictation apps in 2026. Free and private, built-in, file transcription, cross-device, and meetings, compared by the EnviousWispr team."
+  activePage="compare"
+  canonicalPath="/compare/best-dictation-apps-for-mac/"
+  ogType="article"
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={articleJsonLd}></script>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+  </Fragment>
+
+<style>
+.page-header { padding: 100px 0 32px; text-align: center; position: relative; z-index: 1; }
+.page-header h1 { font-size: 46px; font-weight: 800; letter-spacing: -2px; line-height: 1.12; color: var(--text); margin-bottom: 14px; max-width: 760px; margin-left: auto; margin-right: auto; }
+.page-header-sub { font-size: 18px; font-weight: 400; color: var(--text-2); max-width: 620px; margin: 0 auto; line-height: 1.6; }
+.hero-meta { font-size: 13px; color: var(--text-3); margin-top: 18px; }
+.hero-meta a { color: var(--text-3); text-decoration: underline; }
+
+.intro-block { max-width: 760px; margin: 0 auto; }
+.disclosure {
+  background: var(--accent-soft); border: 1px solid rgba(124,58,237,0.18);
+  border-radius: var(--radius-card); padding: 18px 22px; margin: 8px 0 28px;
+  font-size: 15px; color: var(--text-2); line-height: 1.6;
+}
+.disclosure strong { color: var(--text); font-weight: 700; }
+.method { margin-bottom: 28px; }
+.method h2 { font-size: 20px; font-weight: 700; letter-spacing: -0.5px; color: var(--text); margin-bottom: 10px; }
+.method p { font-size: 15px; color: var(--text-2); line-height: 1.65; }
+.short-answer {
+  border-left: 3px solid var(--accent); padding: 4px 0 4px 20px; margin: 0 0 8px;
+  font-size: 17px; color: var(--text); line-height: 1.6;
+}
+.short-answer strong { font-weight: 700; }
+
+.compare-table-wrap {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius-card); border: 1px solid var(--border-hover); background: #fff;
+}
+.compare-table { width: 100%; border-collapse: collapse; font-size: 14px; min-width: 880px; }
+.compare-table thead th {
+  padding: 16px 16px; font-size: 14px; font-weight: 700; text-align: left;
+  border-bottom: 2px solid var(--border-hover); background: rgba(248,245,255,0.6);
+  white-space: nowrap;
+}
+.compare-table thead th:nth-child(2) { background: rgba(124,58,237,0.06); color: var(--accent); }
+.compare-table tbody td { padding: 14px 16px; border-bottom: 1px solid var(--border); vertical-align: top; line-height: 1.5; color: var(--text-2); }
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody td:first-child { font-weight: 600; color: var(--text); }
+.compare-table tbody td:nth-child(2) { background: rgba(124,58,237,0.03); color: var(--text); font-weight: 500; }
+.table-note { font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center; line-height: 1.5; }
+.scroll-hint { display: none; }
+
+.pick { padding: 38px 0 10px; border-bottom: 1px solid var(--border); }
+.pick:last-of-type { border-bottom: none; }
+.pick-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: var(--accent); margin-bottom: 6px; }
+.pick h2 { font-size: 26px; font-weight: 800; letter-spacing: -1px; color: var(--text); margin-bottom: 12px; }
+.pick p { font-size: 16px; color: var(--text-2); line-height: 1.7; margin-bottom: 14px; max-width: 760px; }
+.pick-links { display: flex; gap: 18px; flex-wrap: wrap; font-size: 14px; font-weight: 600; }
+.pick-links a { color: var(--accent); text-decoration: none; }
+.pick-links a:hover { text-decoration: underline; }
+
+.honesty { background: #fff; border: 1px solid var(--border-hover); border-radius: var(--radius-card); padding: 28px 28px 8px; margin-top: 12px; }
+.honesty h2 { font-size: 22px; font-weight: 800; letter-spacing: -0.5px; color: var(--text); margin-bottom: 14px; }
+.honesty li { font-size: 15px; color: var(--text-2); line-height: 1.6; margin-bottom: 12px; list-style: none; padding-left: 22px; position: relative; }
+.honesty li::before { content: '→'; position: absolute; left: 0; color: var(--accent); font-weight: 700; }
+.honesty a { color: var(--accent); text-decoration: none; font-weight: 600; }
+
+.cta-section { padding: var(--section-pad) 0 64px; text-align: center; position: relative; z-index: 1; }
+.cta-section h2 { font-size: 34px; font-weight: 800; letter-spacing: -1.5px; margin-bottom: 12px; }
+.cta-section p { font-size: 16px; color: var(--text-2); margin-bottom: 28px; }
+.cta-actions { display: flex; gap: 16px; align-items: center; justify-content: center; flex-wrap: wrap; }
+.directory-line { text-align: center; font-size: 15px; color: var(--text-2); padding: 0 0 8px; }
+.directory-line a { color: var(--accent); text-decoration: none; font-weight: 600; }
+
+@media (max-width: 760px) {
+  .page-header h1 { font-size: 34px; letter-spacing: -1px; }
+  .scroll-hint { display: block; text-align: center; font-size: 11px; color: var(--text-3); padding: 6px 0; }
+}
+</style>
+
+<!-- Page Header -->
+<header class="page-header">
+  <div class="container">
+    <h1 class="reveal">Best dictation app for Mac in 2026: honest picks by use case</h1>
+    <p class="page-header-sub reveal">There is no single best Mac dictation app. There is a best one for what you actually do. Here is the honest pick for each kind of person.</p>
+    <p class="hero-meta reveal">By <a href="/authors/saurabh-vaish/">Saurabh Vaish</a> · Last updated: June 2026</p>
+  </div>
+</header>
+
+<section class="section" style="padding-top: 0;">
+  <div class="container">
+    <div class="intro-block">
+      <div class="disclosure reveal">
+        <strong>Published by the team behind EnviousWispr.</strong> We make one of the apps below, so we have been explicit about when a different tool is the better choice. Every competitor pick links to a full head-to-head comparison.
+      </div>
+
+      <div class="method reveal">
+        <h2>How we chose</h2>
+        <p>We compared the main Mac dictation and transcription tools on the things that actually change the decision: Mac support, whether your audio stays on your device, offline support, price, whether an account is required, built-in cleanup or AI polish, and whether the app is built for live dictation or for transcribing recorded files. Picks are by use case, not a single universal ranking. Competitor prices and features are verified from each tool's official site (dates in the table note below) and reflect public documentation rather than a hands-on test of every product.</p>
+      </div>
+
+      <p class="short-answer reveal">The best Mac dictation app depends on what you need. For <strong>free, fully private, on-device dictation</strong>, EnviousWispr is the pick. For <strong>built-in, zero-install</strong> use, Apple Dictation. For <strong>transcribing existing audio files</strong>, MacWhisper. For <strong>customisable on-device modes</strong>, SuperWhisper. For a <strong>polished cross-device</strong> experience, WisprFlow. For <strong>meetings and long transcripts</strong>, Otter.ai.</p>
+    </div>
+  </div>
+</section>
+
+<!-- At-a-glance table -->
+<section class="section" style="padding-top: 16px;" aria-label="At a glance comparison">
+  <div class="container">
+    <div class="compare-table-wrap">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th scope="col">At a glance</th>
+            <th scope="col">EnviousWispr</th>
+            {tableCols.map(col => <th scope="col">{col}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {tableRows.map(row => (
+            <tr>
+              <td>{row.feature}</td>
+              <td>{row.ew}</td>
+              {row.cells.map(cell => <td>{cell}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p class="scroll-hint">Scroll the table sideways to see every app.</p>
+    <p class="table-note">Competitor prices and features verified from each tool's official site, April to June 2026. EnviousWispr details reflect the current app. Claims are source-verified from public documentation, not a hands-on test of every product.</p>
+  </div>
+</section>
+
+<!-- Picks by use case -->
+<section class="section" style="padding-top: 8px;">
+  <div class="container">
+
+    <div class="pick reveal" id="best-free-private-mac-dictation">
+      <div class="pick-label">Best for free, private, on-device dictation</div>
+      <h2>EnviousWispr</h2>
+      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a hotkey, speak, and polished text lands where your cursor is, usually in about a second. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. The default cleanup uses Apple Intelligence on-device, so even the polish step can stay local; you can bring your own OpenAI or Gemini key if you prefer a cloud model. English runs on the fast Parakeet engine by default, and you can switch to WhisperKit for 90+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
+      <div class="pick-links">
+        <a href="https://www.youtube.com/watch?v=srS5OgTj3O4" target="_blank" rel="noopener">Watch the 30-second demo</a>
+        <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-built-in-mac-dictation">
+      <div class="pick-label">Best built-in, nothing to install</div>
+      <h2>Apple Dictation</h2>
+      <p>If you just need to dictate a sentence or two now and then and do not want to install anything, the dictation already built into macOS is the simplest option. It is free, it is on by default, and on Apple Silicon Macs it runs on-device for supported languages. For a quick note, a search box, or a short message, it is perfectly adequate. The limits show up when you lean on it: it tends to stop after roughly 30 seconds of silence, even mid-thought, so it is awkward for longer dictation, and it does no cleanup, so filler words and missing punctuation stay in. There are no writing styles and no system-wide workflow beyond the basics. For occasional short bursts it is the right call; for anything you do many times a day, a dedicated app pulls ahead.</p>
+      <div class="pick-links">
+        <a href="/compare/apple-dictation/">Full EnviousWispr vs Apple Dictation comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-for-audio-files">
+      <div class="pick-label">Best for transcribing existing audio files</div>
+      <h2>MacWhisper</h2>
+      <p>Dictation apps turn your live voice into text. If instead you already have recorded audio, an interview, a lecture, a podcast, a meeting capture, and you need a transcript or subtitles, that is a different job, and MacWhisper is built for it. It imports audio and video files and transcribes them locally using Whisper models, so the files stay on your Mac, and it can export subtitles and batch-process a folder of recordings. Pricing is a one-time purchase (around $30 on Gumroad, with a $99.99 lifetime tier and an optional AI add-on on the App Store), so there is no subscription for the core tool. It has a live mode too, but its strength is file transcription rather than sub-second push-to-talk dictation. If your need is recordings rather than real-time typing, start here.</p>
+      <div class="pick-links">
+        <a href="/compare/macwhisper/">Full EnviousWispr vs MacWhisper comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-customisable-on-device">
+      <div class="pick-label">Best for customisable on-device modes</div>
+      <h2>SuperWhisper</h2>
+      <p>SuperWhisper is the closest on-device alternative to EnviousWispr, and the better fit if you want to tune how the output is formatted per context. It runs Whisper models locally, so audio stays on your Mac and it works offline, and its standout feature is custom modes: pre-built workflows that format the result differently for an email, a code comment, meeting notes, and so on. You can pick from several model sizes to trade speed against accuracy, and connect a cloud model for cleanup if you bring your own key. It is a paid app after a free trial (about $8.49 a month, with a lifetime option), so it is the right pick if per-context formatting and model choice are worth a subscription to you. If you mainly want free, fast, private dictation without the configuration, EnviousWispr covers that.</p>
+      <div class="pick-links">
+        <a href="/compare/superwhisper/">Full EnviousWispr vs SuperWhisper comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-cross-device">
+      <div class="pick-label">Best polished cross-device dictation</div>
+      <h2>WisprFlow</h2>
+      <p>WisprFlow is the most polished commercial dictation tool, and the right choice if you work across more than just a Mac. It runs on macOS and iOS, so your setup follows you between devices, and it is more feature-rich than the free options today: snippets, backtrack, per-app tones, command mode, and syntax awareness. The trade-off is architecture and cost: transcription happens in the cloud, so your audio is uploaded to its servers, it needs an internet connection, and it is a subscription (around $12 a month after a limited free tier, with an email account required). If cross-device support and the deepest feature set matter more to you than keeping audio on your machine or avoiding a subscription, WisprFlow earns the pick. If privacy and price are the priorities, the free on-device options close most of the everyday gap.</p>
+      <div class="pick-links">
+        <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>
+      </div>
+    </div>
+
+    <div class="pick reveal" id="best-for-meetings">
+      <div class="pick-label">Best for meetings and long transcripts</div>
+      <h2>Otter.ai</h2>
+      <p>Dictation and meeting transcription look similar but solve different problems. If you need to record a call, separate who said what, and get a summary, that is meeting transcription, and Otter.ai is built for it, with speaker identification, AI summaries, and Zoom, Meet, and Teams integration. It is cloud-based (audio is uploaded), needs an account, and has a free tier of 300 minutes a month with a 30-minute per-conversation cap before its paid plans (Pro around $8.49 a month). Notta is a close alternative with a similar meeting focus and a smaller 120-minute free tier. Neither is meant for typing by voice into your everyday apps; for that, a dictation tool pastes text straight where your cursor is. Many people run one of these for meetings and a dictation app for everything else.</p>
+      <div class="pick-links">
+        <a href="/compare/otter-ai/">EnviousWispr vs Otter.ai</a>
+        <a href="/compare/notta/">EnviousWispr vs Notta</a>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- Choose a competitor instead -->
+<section class="section" style="padding-top: 8px;" aria-label="When to choose a different tool">
+  <div class="container">
+    <div class="intro-block">
+      <div class="honesty reveal">
+        <h2>Choose a different tool instead if&hellip;</h2>
+        <ul>
+          <li>You need snippets, backtrack, per-app tones, cross-platform support, or command-mode features today: choose <a href="/compare/wisprflow/">WisprFlow</a>.</li>
+          <li>You record and summarise meetings with multiple speakers: choose <a href="/compare/otter-ai/">Otter.ai</a> or <a href="/compare/notta/">Notta</a>.</li>
+          <li>You want per-context output modes and do not mind a subscription: choose <a href="/compare/superwhisper/">SuperWhisper</a>.</li>
+          <li>You mainly transcribe already-recorded audio or video files: choose <a href="/compare/macwhisper/">MacWhisper</a>.</li>
+          <li>You need hands-free Mac control or system commands, not just text dictation: start with Apple's built-in Voice Control accessibility tools.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section" aria-label="Download CTA">
+  <div class="container">
+    <h2 class="reveal">Want the free, private, on-device option?</h2>
+    <p class="reveal">No account. No cloud transcription. No subscription. macOS 14+, Apple Silicon.</p>
+    <div class="cta-actions reveal">
+      <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="best-apps-hub">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download EnviousWispr Free
+      </a>
+    </div>
+    <p class="directory-line reveal" style="margin-top: 28px;">Want every head-to-head? See all <a href="/compare/">11 Mac dictation app comparisons</a>.</p>
+  </div>
+</section>
+
+</BaseLayout>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -189,6 +189,7 @@ const itemListJsonLd = JSON.stringify({
     </a>
     <span class="compare-hero-cta-sub">macOS 14+, Apple Silicon. No account. Works offline.</span>
     <p class="compare-intro">Mac dictation tools split into three groups: cloud-based services that send your audio to a server (<a href="/compare/wisprflow/">WisprFlow</a>, <a href="/compare/otter-ai/">Otter.ai</a>, <a href="/compare/notta/">Notta</a>, <a href="/compare/google-docs-voice-typing/">Google Docs Voice Typing</a>), on-device apps that keep audio local (<a href="/compare/superwhisper/">Superwhisper</a>, <a href="/compare/macwhisper/">MacWhisper</a>, <a href="/compare/voiceink/">VoiceInk</a>, <a href="/compare/willow-voice/">Willow Voice</a>), and legacy or developer-focused tools (<a href="/compare/dragon/">Dragon</a>, <a href="/compare/apple-dictation/">Apple Dictation</a>, <a href="/compare/whisper-cpp/">whisper.cpp</a>). Pricing ranges from free to $144 a year. Each comparison below covers price, accuracy, latency, privacy architecture, and the specific use case the tool fits best, so you can pick the right one without trying all 11.</p>
+    <p class="compare-intro" style="margin-top: 16px;">Want a recommendation rather than a directory? See our guide to the <a href="/compare/best-dictation-apps-for-mac/">best dictation apps for Mac by use case</a>.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## What

New first-party, by-use-case comparison page at **`/compare/best-dictation-apps-for-mac/`** targeting the "best dictation app for Mac" recommendation intent, plus one inbound link from the `/compare/` index.

## Why

The "best dictation app for mac" SERP and AI Overview are 100% editorial listicles, most of them competitor-owned content farms that crown their own app #1. EnviousWispr is absent. This is a fixable page-type gap, not pure authority. The page is built to be genuinely useful and honest so it can earn citations the listicles can't.

## How it stays honest (and dodges the Dec-2025 self-promotion demotion)

- Visible **first-party disclosure** + a **"How we chose" methodology** placed *before* the picks.
- Six **"best for X"** segments, each pointing to whichever app genuinely wins it; EnviousWispr leads **only** the free/private/on-device slot. No "#1 overall", no ranked numbering, no stars.
- Substantive "choose a competitor instead if…" block (WisprFlow / Otter / Notta / SuperWhisper / MacWhisper, plus an Apple Voice Control accessibility note).
- All competitor facts mirrored from the already-verified `/compare/*` spokes; "source-verified, not all firsthand-tested" footnote.

## Technical

- `Article` + `BreadcrumbList` JSON-LD (no new FAQPage, retired 2026-05-07). Author byline + "Last updated June 2026".
- Reuses the spokes' page-scoped table styles; mobile sticky first column via the existing global rule. Nuanced cells (not blunt yes/no).
- `data-download-source="best-apps-hub"` for PostHog attribution. Sitemap inclusion automatic.

## Validation

- Plan + council (GPT-5.5 + Gemini-3.1 coverage) + 2 Codex grounded rounds → PROCEED-AS-PLANNED.
- `npm run build` green; browser UAT desktop + mobile (sticky column, reveal, all links 200); zero em/en dashes; Codex code-diff review clean.

Part of #538.