### PR TITLE
feat(llm): drop on-device custom-words prompt block (#1084)

### DIFF
--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -610,8 +610,8 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       prepared: PreparedAFMSession, wrapped: String, detectedLanguage: String?
     ) async throws -> String {
       // The system prompt is always English (instructions + an English-framed
-      // language clause + the custom-words block), regardless of the dictation
-      // language. Count it with the Latin heuristic (lang: nil) so the macOS
+      // language clause), regardless of the dictation language. Count it with
+      // the Latin heuristic (lang: nil) so the macOS
       // 26.0–26.3 fallback path doesn't over-count the ~2.5k-char prompt at
       // ~1 char/token for CJK/Thai/Lao dictations and wrongly skip transcripts
       // that actually fit. Only the transcript itself carries `detectedLanguage`.
@@ -711,7 +711,8 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       // Issue #616, 2026-05-04: extract the suffix that
       // `LLMPolishStep.appleIntelligenceInstructions` appended on top of
       // `PolishInstructions.default.systemPrompt` (the speech-to-text-awareness
-      // clause and, when non-empty, the user's Custom Words block) and
+      // clause; the user's custom-words block was dropped from this on-device
+      // path in #1084 — the corrector lane applies those terms pre-polish) and
       // concatenate it onto `basePrompt`. Production callers always pass a
       // default-prefixed prompt (verified `SettingsManager.activePolishInstructions`
       // hardcoded to `.default`). The defensive `else` branch is forward-safety

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -538,12 +538,21 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     return indirectPreambles.contains { joined.hasPrefix($0) }
   }
 
-  // MARK: - Apple Intelligence Prompt (Compressed Enrichment + Custom Vocab)
+  // MARK: - Apple Intelligence Prompt (Compressed Enrichment)
 
   /// Apple Intelligence uses a simplified on-device prompt (set in makeSession()).
-  /// We append compressed enrichment (ASR awareness, tone preservation) and custom
-  /// vocabulary. Full cloud-style enrichment is too verbose for the small on-device model.
-  private func appleIntelligenceInstructions(
+  /// We append compressed enrichment (ASR awareness, tone preservation); full
+  /// cloud-style enrichment is too verbose for the small on-device model.
+  ///
+  /// Custom words are deliberately NOT injected here (#1084). The deterministic
+  /// `WordCorrector` lane runs BEFORE polish and already applies the user's terms,
+  /// and an eval (ci151 tier-bench, reps=3) showed the on-device vocab block was
+  /// net-negative — it distracted the small model into dropping sentence openers
+  /// and capitalization for no reliable gain. The cloud planner path (see
+  /// `process()` building `PromptBuildInput.polishVocabulary`) still injects vocab;
+  /// this drop is on-device only. `internal` (not `private`) so the regression test
+  /// can assert the assembled prompt stays vocab-free.
+  func appleIntelligenceInstructions(
     _ base: PolishInstructions
   ) -> PolishInstructions {
     var systemPrompt = base.systemPrompt
@@ -553,34 +562,6 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     systemPrompt +=
       "\nThis is speech-to-text output. Remove false starts. "
       + "Preserve the speaker's tone and formality level. If unsure about a correction, leave unchanged."
-
-    let termsCount = polishVocabulary.terms.count
-    Task {
-      await AppLogger.shared.log(
-        "AFM polish vocab inject: termsCount=\(termsCount)",
-        level: .info, category: "LLM"
-      )
-    }
-    if !polishVocabulary.terms.isEmpty {
-      if let vocab = CustomVocabularyFormatter.render(polishVocabulary.terms) {
-        let renderedChars = vocab.count
-        let preview = String(vocab.prefix(180))
-        Task {
-          await AppLogger.shared.log(
-            "AFM polish vocab rendered: chars=\(renderedChars) preview=\"\(preview)\"",
-            level: .info, category: "LLM"
-          )
-        }
-        systemPrompt += "\n\n" + vocab
-      } else {
-        Task {
-          await AppLogger.shared.log(
-            "AFM polish vocab render returned nil despite termsCount=\(termsCount)",
-            level: .info, category: "LLM"
-          )
-        }
-      }
-    }
 
     return PolishInstructions(systemPrompt: systemPrompt)
   }

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepAppleVocabTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepAppleVocabTests.swift
@@ -1,0 +1,52 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1084: the on-device (Apple Intelligence) polish prompt must NOT carry the
+/// custom-words block. The deterministic `WordCorrector` lane applies the user's
+/// terms BEFORE polish, and an eval (ci151 tier-bench, reps=3) showed the
+/// on-device vocab block was net-negative — it distracted the small model into
+/// dropping sentence openers and capitalization for no reliable gain.
+///
+/// This regression test locks the removal: even with a NON-empty polish
+/// vocabulary, the assembled Apple prompt stays vocab-free while keeping the
+/// speech-awareness enrichment clause. The cloud planner path is untouched and
+/// still injects vocab (verified separately by the cloud prompt-builder tests).
+/// It is the proof of correct prompt assembly — the absence of the old
+/// "AFM polish vocab inject" log line alone is not.
+@MainActor
+@Suite("LLMPolishStep Apple Intelligence prompt omits custom vocab (#1084)")
+struct LLMPolishStepAppleVocabTests {
+
+  @Test(
+    "Apple prompt excludes the custom-vocab block even when vocab is non-empty",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1084",
+      "Drop on-device custom-words prompt block")
+  )
+  func applePromptOmitsCustomVocabBlock() {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    // A non-empty polish vocabulary. Pre-#1084 this would have rendered into a
+    // "CUSTOM VOCABULARY:" block appended onto the Apple prompt.
+    step.polishVocabulary = PolishVocabulary(
+      terms: [
+        CustomWord(canonical: "EnviousWispr", aliases: ["envious whisper"]),
+        CustomWord(canonical: "ChatGPT", aliases: ["chat gpt"]),
+      ],
+      generation: 1
+    )
+
+    let system = step.appleIntelligenceInstructions(.default).systemPrompt
+
+    // The vocab block is gone — neither the header nor a listed canonical leaks
+    // into the on-device prompt.
+    #expect(system.contains("CUSTOM VOCABULARY") == false)
+    #expect(system.contains("EnviousWispr") == false)
+    // ...but the speech-awareness enrichment clause is kept (it is not vocab).
+    #expect(system.contains("This is speech-to-text output."))
+  }
+}

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -48,7 +48,9 @@ APPLE_RUNNER_BIN = APPLE_RUNNER_DIR / ".build/release/AppleIntelligenceRunner"
 
 # Mirror of Sources/EnviousWisprCore/LLMResult.swift:115-127. Keep byte-identical.
 # The Apple path in production passes instructions built from this default +
-# compressed enrichment (false-start + tone) + CustomVocabularyFormatter.render.
+# compressed enrichment (false-start + tone). Custom words are NOT injected on
+# the Apple path (#1084 — the corrector lane applies them pre-polish); only the
+# cloud HTTP mirror appends CustomVocabularyFormatter.render (see render_custom_vocab).
 # We replicate the exact prompt here so --mode bench measures what users see.
 POLISH_INSTRUCTIONS_DEFAULT = (
     "Clean up this speech-to-text transcript. Make minimal changes:\n"
@@ -977,13 +979,21 @@ def _apply_validator(candidates_by_id: dict, cases: list, provider: str) -> tupl
 
 def _build_afm_system_prompt() -> str:
     """Compose the exact system prompt the shipped LLMPolishStep passes to the
-    Apple connector in production: default + enrichment + custom vocab."""
-    return (
-        POLISH_INSTRUCTIONS_DEFAULT
-        + APPLE_ENRICHMENT_SUFFIX
-        + "\n\n"
-        + render_custom_vocab()
-    )
+    Apple connector in production: default + enrichment. Custom vocab is NOT
+    appended on the Apple path (#1084 — the deterministic corrector lane applies
+    the user's terms pre-polish, and the on-device vocab block was eval-proven
+    net-negative); the cloud HTTP mirror still appends it via render_custom_vocab().
+
+    Bench scope caveat: this harness measures each provider's POLISH PROMPT in
+    isolation — it does NOT run the pre-polish WordCorrector lane for ANY provider
+    (live dictation does; saved re-polish currently does not). So `custom_vocabulary`
+    corpus cases are scored prompt-only: after #1084 the AFM path shows them with no
+    vocab support at all, and cloud shows them with the prompt block only. Neither
+    reflects the production live-dictation pipeline (corrector + polish); treat
+    custom-vocab as deterministic_owned and discount it (polish-eval.md
+    afm-prompt-iteration-learnings). Pre-correcting bench inputs for all providers
+    is the cleaner long-term fix (tracked with the saved-re-polish corrector gap)."""
+    return POLISH_INSTRUCTIONS_DEFAULT + APPLE_ENRICHMENT_SUFFIX
 
 
 def _apple_polish_subprocess(
@@ -1518,9 +1528,10 @@ def mode_bench(out_name: str | None, corpus_path: Path | None, sleep_seconds: fl
         }
 
     # 1b: AFM via Swift sub-package. Prompt is built to mirror
-    # LLMPolishStep.appleIntelligenceInstructions (default + enrichment + vocab)
-    # so the benchmark measures what production users see. The prompt file is
-    # saved as a run artifact so future audits can see exactly what we asked.
+    # LLMPolishStep.appleIntelligenceInstructions (default + enrichment; AFM
+    # custom-vocab dropped #1084) so the benchmark measures what production users
+    # see. The prompt file is saved as a run artifact so future audits can see
+    # exactly what we asked.
     print(f"\n[bench] Phase 1: polishing {len(cases)} cases via apple-intelligence")
     afm_prompt_path = run_dir / "afm-system-prompt.txt"
     afm_prompt_path.write_text(_build_afm_system_prompt(), encoding="utf-8")

--- a/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
+++ b/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
@@ -153,8 +153,9 @@ struct RunnerMain {
     )
     // System prompt resolution: explicit --system-prompt > --system-prompt-file
     // > built-in enrichment fallback. Python bench driver normally passes the
-    // full enriched prompt (default + false-start + vocab) via --system-prompt-file
-    // so the runner mirrors LLMPolishStep.appleIntelligenceInstructions exactly.
+    // full enriched prompt (default + false-start) via --system-prompt-file so
+    // the runner mirrors LLMPolishStep.appleIntelligenceInstructions exactly
+    // (custom vocab dropped from the Apple path in #1084).
     let systemPrompt: String
     if let explicit = args.systemPrompt {
       systemPrompt = explicit


### PR DESCRIPTION
## What
Removes the custom-words vocabulary block from the **on-device (Apple Intelligence)** polish system prompt only. Cloud providers (OpenAI/Gemini/Ollama) are untouched.

## Why
Eval-validated this session (#1084): the block is **redundant + net-negative** on the small on-device model.
- Custom terms already flow through the deterministic `WordCorrector` lane, which runs **before** polish in live dictation.
- ci151 tier-bench (reps=3): no-vocab **82.1%** vs +vocab 81.5%; the 270-token block cost ~-2 tier1 / -4 tier3 (dropped sentence openers + capitalization) for no reliable gain.

## Scope
- `LLMPolishStep.appleIntelligenceInstructions` drops the vocab injection; speech-awareness clause kept; method opened to `internal` for the test seam.
- Cloud path (planner → `CustomVocabularyFormatter`) and `PolishVocabularyConsumer` conformance unchanged.
- Python eval mirror `_build_afm_system_prompt` drops the vocab tail; `render_custom_vocab` stays live for the cloud HTTP mirror.
- Stale comments (connector, eval harness, apple_runner) corrected.

## Validation
- ✅ 1768 logic tests green incl. new `LLMPolishStepAppleVocabTests` (Apple prompt stays vocab-free with non-empty vocabulary).
- ✅ AFM tier-bench post-change: tier1 **91%** (matches the no-vocab arm; no regression).
- ✅ Live UAT: on-device polish runs with **zero** vocab injection while custom words (GitHub, VS Code) and openers (Honestly, Literally) survive end to end; heart path clean.
- ✅ Codex grounded review (4 rounds → PROCEED-AS-PLANNED) + code-diff review.

## Known limitation (deferred — separate design pass)
Codex code-diff review [P2] surfaced that saved-transcript re-polish (`TranscriptPolishService`) calls LLM polish **without** the corrector lane. So on-device re-polish of an **older** note containing a **newly-added** custom word no longer applies that word. Narrow (deliberate re-do action; saved text is already post-correction for words existing at creation; the dropped prompt block was itself unreliable; cloud re-polish unaffected). The proper fix — run the corrector in the re-polish path for all providers — is a separate change under design. Documented in the bench docstring + commit body.

Closes #1084