### PR TITLE
fix(website): qualify speed superlatives, correct WisprFlow price, soften retention claim

### DIFF
--- a/website/src/content/blog/cloud-ai-polish-not-stored.md
+++ b/website/src/content/blog/cloud-ai-polish-not-stored.md
@@ -10,7 +10,7 @@ faqs:
   - question: "What does store=false actually do at OpenAI and Gemini?"
     answer: "It tells the provider not to retain that specific request and its response in their server-side history. OpenAI documents this as a per-request flag on the Chat Completions API. Google added an equivalent per-request flag to Gemini's generateContent endpoint. Both are independent of any project-level setting, so the request opts out even if your account defaults are different."
   - question: "Does this mean my dictation is private end to end?"
-    answer: "When you use a fully on-device polish provider like Apple Intelligence or Ollama, the audio and text never leave your Mac. When you use cloud polish with OpenAI or Gemini, the polished text segment travels to the provider so the model can rewrite it. EnviousWispr never sees or stores any of it. With store=false, the provider does not keep it either after answering."
+    answer: "When you use a fully on-device polish provider like Apple Intelligence or Ollama, the audio and text never leave your Mac. When you use cloud polish with OpenAI or Gemini, the polished text segment travels to the provider so the model can rewrite it. EnviousWispr never sees or stores any of it. With store=false, we ask the provider not to retain it after answering, and the provider's data policy governs what they actually keep."
   - question: "Why use cloud polish at all if on-device polish exists?"
     answer: "On-device polish is the default for a reason: nothing leaves your Mac. Cloud polish is there for people who want the rewriting quality of a larger model, or who already have an OpenAI or Gemini key for other work and want the same model handling their dictation. The choice is yours, and EnviousWispr makes the privacy posture explicit either way."
   - question: "Does store=false stop the provider from training on my data?"
@@ -33,7 +33,7 @@ This was added in two passes. The OpenAI flag landed first. The Gemini equivalen
 
 ## What it means at OpenAI
 
-OpenAI's `store` parameter tells the Chat Completions endpoint not to keep the prompt or completion in their request history. The Conversations dashboard reflects only requests that were stored. With `store: false`, the request transcribes, the model answers, and the provider does not retain a copy of the input or output for later viewing or reuse.
+OpenAI's `store` parameter tells the Chat Completions endpoint not to keep the prompt or completion in their request history. The Conversations dashboard reflects only requests that were stored. With `store: false`, the request transcribes, the model answers, and it stays out of your account history for later viewing or reuse. That last part is a request to the provider, not a guarantee about their systems: their published data policy governs actual retention.
 
 OpenAI separately states that API traffic is not used to train their models for customers paying through the API. The `store: false` flag is a per-request reinforcement of that posture: it removes the data path that retention would have used.
 

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -44,7 +44,7 @@ const tableRows = [
   {
     feature: "Price",
     ew: "Free",
-    cells: ["$12/mo Pro (free 2k words/wk)", "$8.49/mo (free trial)", "~$30 one-time or $99.99 lifetime", "$8.49/mo Pro (free 300 min/mo)", "Free (built in)"],
+    cells: ["$12-15/mo Pro (free 2k words/wk)", "$8.49/mo (free trial)", "~$30 one-time or $99.99 lifetime", "$8.49/mo Pro (free 300 min/mo)", "Free (built in)"],
   },
   {
     feature: "Audio stays on your Mac",
@@ -259,7 +259,7 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
     <div class="pick reveal" id="best-cross-device">
       <div class="pick-label">Best polished cross-device dictation</div>
       <h2>WisprFlow</h2>
-      <p>WisprFlow is the most polished commercial dictation tool, and the right choice if you work across more than just a Mac. It runs on macOS and iOS, so your setup follows you between devices, and it is more feature-rich than the free options today: snippets, backtrack, per-app tones, command mode, and syntax awareness. The trade-off is architecture and cost: transcription happens in the cloud, so your audio is uploaded to its servers, it needs an internet connection, and it is a subscription (around $12 a month after a limited free tier, with an email account required). If cross-device support and the deepest feature set matter more to you than keeping audio on your machine or avoiding a subscription, WisprFlow earns the pick. If privacy and price are the priorities, the free on-device options close most of the everyday gap.</p>
+      <p>WisprFlow is the most polished commercial dictation tool, and the right choice if you work across more than just a Mac. It runs on macOS and iOS, so your setup follows you between devices, and it is more feature-rich than the free options today: snippets, backtrack, per-app tones, command mode, and syntax awareness. The trade-off is architecture and cost: transcription happens in the cloud, so your audio is uploaded to its servers, it needs an internet connection, and it is a subscription ($15 a month, or $12 a month billed annually, after a limited free tier, with an email account required). If cross-device support and the deepest feature set matter more to you than keeping audio on your machine or avoiding a subscription, WisprFlow earns the pick. If privacy and price are the priorities, the free on-device options close most of the everyday gap.</p>
       <div class="pick-links">
         <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>
       </div>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -342,7 +342,7 @@ const itemListJsonLd = JSON.stringify({
 
 <div class="compare-cta">
   <div class="container">
-    <p>Ready to try the fastest free dictation on Mac?</p>
+    <p>Ready to try the fastest free, private dictation on Mac?</p>
     <a href="/#download" class="btn-primary">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
       Download Free

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -207,7 +207,7 @@ const jsonLdFaq = JSON.stringify({
       </div>
 
       <h1>Talk naturally. <br/>Paste perfectly.</h1>
-      <p class="hero-sub">Free private AI dictation for macOS. The fastest way to turn your voice into polished text on Mac. On-device, on Apple Silicon, your voice never leaves your device.</p>
+      <p class="hero-sub">Free private AI dictation for macOS. The fastest free, private way to turn your voice into polished text on Mac. On-device, on Apple Silicon, your voice never leaves your device.</p>
 
       <div class="hero-ctas reveal" style="--i:3">
         <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary">


### PR DESCRIPTION
## What & why

Three accuracy fixes to public website copy, surfaced by the 2026-06-18 adversarial review and the #1069 Codex review. Pure user-facing copy: no logic, layout, or schema changes.

### #1079 - drop the unqualified "fastest" superlative (keep selling speed)
Our own editorial standards forbid a bare "fastest" with no frame. The homepage hero and the `/compare/` closing CTA now read "the fastest **free, private** way / dictation on Mac", a defensible frame (the issue names this exact wording as the fix). Speed stays prominent; no faster-than-WisprFlow claim. Founder-approved hero wording. "Sub-second" framing left intact per the founder ruling (Feedback 4/9).
- `website/src/pages/index.astro` (hero)
- `website/src/pages/compare/index.astro` (CTA)

### #1071 - WisprFlow Pro price was understated
The "best dictation apps" guide listed WisprFlow at just "$12/mo". Real pricing is $15/mo monthly, $12/mo billed annually (verified on wisprflow.ai/pricing 2026-06-19, and consistent with our own `/compare/wisprflow` page). Now "$12-15/mo" in the at-a-glance row (matching `/compare/`) and "$15 a month, or $12 a month billed annually" in the pick paragraph.
- `website/src/pages/compare/best-dictation-apps-for-mac.astro`

### #1075 (partial) - soften cloud-polish retention overclaim
The blog post said cloud providers "do not keep / do not retain" your text with `store=false`. Softened to a request-not-guarantee framing: we ask the provider not to retain it; their published terms govern actual retention. Matches the existing "terms govern" line later in the same post and the actual `store: false` request code.
- `website/src/content/blog/cloud-ai-polish-not-stored.md`
- NOT in this PR: the privacy-policy page contradiction, tracked in #1075 for the founder + Termly regeneration.

## Also done locally (not in this PR)
Internal positioning note (`content-engine/context/positioning.md`, gitignored) one-liner qualified the same way; a pre-existing "open-source" claim there corrected to "source-available" (BSL 1.1).

## Review
- Codex grounded review (pre-implementation): PROCEED-AS-PLANNED.
- Codex code-diff review: clean (see commit history if amended).
- No em-dash/en-dash in any new string; no "open source" / no WisprFlow parity (content-brand verified).

council-skip: zero-blast-radius (user-facing copy)

Closes #1079
Closes #1071
Refs #1075