### PR TITLE
feat(ui): VoiceOver labels, traits, and keyboard activation for keycap recorders + icon buttons (#1081)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -119,6 +119,7 @@ struct HotkeyRecorderView: View {
     HStack {
       Text(label)
         .foregroundStyle(colors.label)
+        .accessibilityHidden(true)
       Spacer()
 
       // Use onTapGesture on a plain view to avoid Button stealing key events
@@ -152,6 +153,16 @@ struct HotkeyRecorderView: View {
       .onTapGesture {
         toggleRecording()
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isButton)
+      .accessibilityLabel(label)
+      .accessibilityValue(
+        isRecording
+          ? "Recording, press a key combination"
+          : KeySymbols.format(keyCode: keyCode, modifiers: modifiers)
+      )
+      .accessibilityHint("Activates recording. Then press the key combination you want.")
+      .accessibilityAction { toggleRecording() }
 
       // Reset button
       if keyCode != defaultKeyCode || modifiers != defaultModifiers {
@@ -161,6 +172,7 @@ struct HotkeyRecorderView: View {
         }
         .buttonStyle(.plain)
         .help("Reset to default")
+        .accessibilityLabel("Reset shortcut to default")
       }
     }
     .onDisappear {

--- a/Sources/EnviousWisprAppKit/Views/Components/UpdateAvailableBanner.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/UpdateAvailableBanner.swift
@@ -84,6 +84,12 @@ struct UpdateAvailableBanner: View {
       LocalizedStringResource("Update available, version \(update.displayVersion)")
     )
     .accessibilityHint(LocalizedStringResource("Activate to install and restart"))
+    .accessibilityAction {
+      coordinator?.handleBannerClicked(
+        version: update.versionString,
+        isCritical: update.isCriticalUpdate,
+        secondsVisible: secondsVisible())
+    }
   }
 
   private func secondsVisible() -> Int {

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -63,6 +63,7 @@ struct TranscriptDetailView: View {
         }
         .controlSize(.small)
         .buttonStyle(.borderless)
+        .accessibilityLabel("Delete transcript")
       }
       .padding(.horizontal, 16)
       .padding(.vertical, 10)

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1034,6 +1034,16 @@ private struct KeycapHotkeyView: View {
           )
           .contentShape(Rectangle())
           .onTapGesture { toggleRecording() }
+          .accessibilityElement(children: .combine)
+          .accessibilityAddTraits(.isButton)
+          .accessibilityLabel("Dictation hotkey")
+          .accessibilityValue(
+            isRecording
+              ? "Recording, press a key combination"
+              : displayLabel
+          )
+          .accessibilityHint("Activates recording. Then press the key combination you want.")
+          .accessibilityAction { toggleRecording() }
 
         // "Change" chip — overlaps top-right corner
         if !isRecording {

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -273,6 +273,7 @@ struct AIPolishSettingsView: View {
                 }
                 .buttonStyle(.borderless)
                 .help("Refresh available models")
+                .accessibilityLabel("Refresh available models")
               }
             }
           }
@@ -792,6 +793,7 @@ struct AIPolishSettingsView: View {
       .buttonStyle(.borderless)
       .disabled(aiAvailability.isChecking)
       .help("Check Apple Intelligence availability")
+      .accessibilityLabel("Check Apple Intelligence availability")
     }
 
     // "Why?" detail text
@@ -1071,6 +1073,7 @@ struct AIPolishSettingsView: View {
     }
     .buttonStyle(.borderless)
     .help("Re-check Ollama status")
+    .accessibilityLabel("Re-check Ollama status")
   }
 
   // MARK: - Ollama Warm-up Indicator
@@ -1096,6 +1099,7 @@ struct AIPolishSettingsView: View {
       }
       .buttonStyle(.borderless)
       .help("Couldn't prepare model. Click to retry.")
+      .accessibilityLabel("Retry preparing model")
     default:
       Button {
         guard !settings.llmModel.isEmpty else { return }
@@ -1105,6 +1109,7 @@ struct AIPolishSettingsView: View {
       }
       .buttonStyle(.borderless)
       .help("Prepare model")
+      .accessibilityLabel("Prepare model")
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -50,6 +50,7 @@ struct CustomTermsSection: View {
                 .font(.system(size: 12))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Clear search")
           }
         }
       }
@@ -97,6 +98,7 @@ struct CustomTermsSection: View {
             }
             .buttonStyle(.plain)
             .disabled(currentPage == 0)
+            .accessibilityLabel("Previous page")
             Spacer()
             Text("Page \(currentPage + 1) of \(pageCount)")
               .font(.stHelper)
@@ -109,6 +111,7 @@ struct CustomTermsSection: View {
             }
             .buttonStyle(.plain)
             .disabled(currentPage >= pageCount - 1)
+            .accessibilityLabel("Next page")
           }
         }
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -99,6 +99,7 @@ struct CustomWordEditSheet: View {
                     .font(.system(size: 8, weight: .bold))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Remove alias \(alias)")
               }
               .padding(.horizontal, 6)
               .padding(.vertical, 3)

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -135,6 +135,7 @@ struct LearningSection: View {
       }
       .buttonStyle(.plain)
       .help("Remove all imported names")
+      .accessibilityLabel("Remove all imported names")
     }
     .padding(.horizontal, 8)
     .padding(.vertical, 4)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -365,5 +365,6 @@ struct SpeechEngineSettingsView: View {
     }
     .buttonStyle(.borderless)
     .help("Re-check model status")
+    .accessibilityLabel("Re-check model status")
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -54,6 +54,7 @@ struct VocabularyPackDetailSheet: View {
               .font(.system(size: 12))
           }
           .buttonStyle(.plain)
+          .accessibilityLabel("Clear search")
         }
       }
       .padding(.horizontal, 10)


### PR DESCRIPTION
## What

Adds VoiceOver / keyboard accessibility metadata to the app's own settings + onboarding UI (issue #1081, adversarial-review Feedback 13).

- **Keycap shortcut recorders** (Settings `HotkeyRecorderView` + onboarding `KeycapHotkeyView`) were bare `.onTapGesture` shapes with zero accessibility. Now each carries `.accessibilityAddTraits(.isButton)`, a stable `.accessibilityLabel`, the current shortcut as `.accessibilityValue`, a `.accessibilityHint`, and an explicit `.accessibilityAction` so it activates from the keyboard / VoiceOver. The redundant visible label is hidden from AX so the keycap owns the spoken name.
- **14 icon-only buttons** (refresh / clear-search / pagination / delete / reset / remove / retry / prepare / remove-alias) get a meaningful `.accessibilityLabel`.
- **Update banner** had label/trait/hint but no `.accessibilityAction`; backfilled so it is keyboard / VoiceOver-activatable.

AX-metadata only: no logic, layout, new types, imports, or `Package.swift` change. Mouse / trackpad users see no difference.

## Why

The adversarial review flagged thin app accessibility. The keycap recorders were the one concrete defect (zero AX); icon-only buttons read as silence to VoiceOver. Native text buttons were already accessible, so the "7 of 58" ratio overstated it.

## Scope note (beyond the literal ticket, within its intent)

The ticket named one keycap and an icon sweep. Grounded review surfaced (a) onboarding uses a *separate* keycap control with the same defect, (b) 3 more icon-only buttons the first sweep missed (now 14), and (c) the update banner's missing keyboard action. All fixed here to complete the accessibility pass rather than leave known gaps.

## Validation

- Dev DEBUG bundle compiles + launches; release scheme builds via CI build-check.
- Logic tests: 1767 pass (`scripts/xcode-test.sh`).
- AX inspection on the running app: keycaps now report button role + label + value (`Shortcut` value `Right opt`; `Cancel recording` value `Escape`); icon buttons report labels (`Check Apple Intelligence availability`, `Remove all imported names` confirmed live; the rest are the identical modifier).
- Codex grounded review (plan): PROCEED-AS-PLANNED after 3 rounds (it caught the 3 missed buttons + the banner gap).
- Codex code-diff review: clean, no behavior-breaking findings.
- **Live TTS heart-path dictation: skipped.** Rationale: this change touches zero heart-path / pipeline / audio / paste code (view-modifier AX metadata only) and compiled clean; a concurrent sibling dev build (#1084) was holding the global hotkey + mic, making a shared-mic TTS test unreliable. AX inspection is the runtime UAT for what this change actually does.

Closes #1081