### PR TITLE
fix(llm): report real AI capability at launch, not a stale cached flag

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -169,21 +169,29 @@ final class AppLifecycleCoordinator {
       Task { await aiAvailability.checkAvailability(trigger: "app_launch") }
     }
 
-    // Fire structured app.launched event — uses cached report (loaded from
-    // UserDefaults in coordinator init). No async wait needed.
+    // Fire structured app.launched event (issue #1073). Compute the AI snapshot
+    // OFF the launch main thread: the eligibility read (SystemLanguageModel
+    // .availability) is synchronous but its cold-boot cost on the main thread is
+    // not provable-safe (council + grounded review), so it must never sit on the
+    // heart-adjacent launch path. Hop back to the @MainActor TelemetryService to
+    // emit (no second telemetry path). The event emits within ms of launch (far
+    // faster than awaiting the up-to-10s deep checkAvailability above), though as
+    // a detached emit it is best-effort and may be missed on an immediate quit.
+    // Task.detached (not Task {}): a plain Task inherits this MainActor context
+    // and would run the read on main; withTaskGroup/@concurrent do not fit a
+    // one-off fire-and-forget that must leave the actor.
     let version =
       Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
     let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
     let osVer = ProcessInfo.processInfo.operatingSystemVersion
-    let cachedReport = aiAvailability.latestReport
-    TelemetryService.shared.appLaunched(
-      version: version,
-      build: build,
-      osVersion: "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)",
-      hardware: cachedReport?.hardwareClass ?? "unknown",
-      isFreshInstall: isFreshInstall,
-      aiAvailable: cachedReport?.overallStatus == .available
-    )
+    let osVersion = "\(osVer.majorVersion).\(osVer.minorVersion).\(osVer.patchVersion)"
+    Task.detached(priority: .utility) {
+      let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()
+      await TelemetryService.shared.appLaunched(
+        version: version, build: build, osVersion: osVersion,
+        hardware: snap.hardwareClass, isFreshInstall: isFreshInstall,
+        aiCapable: snap.isCapable, aiEnabled: snap.isEnabled)
+    }
 
     // Check Accessibility permission on launch (query only — never auto-prompt).
     permissions.refreshOnLaunch()

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -109,6 +109,29 @@ public struct AIGateSet: Sendable, Codable {
   }
 }
 
+// MARK: - Launch Availability Snapshot
+
+/// Synchronous launch-time Apple Intelligence facts for the `app.launched`
+/// telemetry event. Domain facts, not telemetry-shaped: the call site maps
+/// `isCapable` -> `ai_capable` and `isEnabled` -> `ai_enabled`. Produced by
+/// `AppleIntelligenceDiagnosticsService.launchSnapshot()`.
+public struct LaunchAvailabilitySnapshot: Sendable {
+  /// `hw.machine` (e.g. "arm64"). Live sysctl, always real — never "unknown" via a missing cache.
+  public let hardwareClass: String
+  /// Framework compiled in AND macOS 26+ AND the device is hardware-eligible (NOT
+  /// `.deviceNotEligible`): the device CAN run Apple Intelligence. The user may
+  /// still have it switched off or the model may be downloading — see `isEnabled`.
+  public let isCapable: Bool
+  /// `SystemLanguageModel.default.availability == .available`: eligible + enabled + model-ready right now.
+  public let isEnabled: Bool
+
+  public init(hardwareClass: String, isCapable: Bool, isEnabled: Bool) {
+    self.hardwareClass = hardwareClass
+    self.isCapable = isCapable
+    self.isEnabled = isEnabled
+  }
+}
+
 // MARK: - Availability Report
 
 /// Structured diagnostic report for Apple Intelligence availability.

--- a/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceDiagnosticsService.swift
@@ -110,6 +110,33 @@ public enum AppleIntelligenceDiagnosticsService {
     )
   }
 
+  /// Synchronous availability snapshot for the `app.launched` telemetry event.
+  /// Runs ONLY the synchronous gates (build, OS-runtime, eligibility) + the
+  /// synchronous `sysctl` hardware read — never the async model-access (Stage 4)
+  /// or functional-probe (Stage 5) stages. Eligibility
+  /// (`SystemLanguageModel.default.availability`) is read ONLY when capable, so
+  /// the non-macOS-26 fallback path is never hit.
+  /// CALLER CONTRACT: not guaranteed fast (the eligibility read may touch a
+  /// system framework), so the launch call site computes this OFF the main thread.
+  public static func launchSnapshot() -> LaunchAvailabilitySnapshot {
+    let hardwareClass = currentHardwareClass()
+    let build = checkBuildGate()
+    let runtime = build.status == .passed ? checkOSRuntimeGate() : nil
+    let frameworkAndOS = build.status == .passed && runtime?.status == .passed
+    // Read eligibility (synchronous SystemLanguageModel.availability) only when
+    // framework + OS allow it. Its failure REASON distinguishes genuine hardware
+    // ineligibility (NOT capable) from a capable device that is merely turned off
+    // or still downloading the model (capable, not enabled).
+    let eligibility = frameworkAndOS ? checkEligibilityGate() : nil
+    let deviceIneligible =
+      eligibility?.reasons.contains(.deviceNotEligible) == true
+      || eligibility?.reasons.contains(.unsupportedHardware) == true
+    let isCapable = frameworkAndOS && !deviceIneligible
+    let isEnabled = eligibility?.status == .passed
+    return LaunchAvailabilitySnapshot(
+      hardwareClass: hardwareClass, isCapable: isCapable, isEnabled: isEnabled)
+  }
+
   // MARK: - Timeout Helpers
 
   private static func totalTimeoutMs() -> Int {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -123,7 +123,7 @@ public final class TelemetryService {
 
   public func appLaunched(
     version: String, build: String, osVersion: String, hardware: String, isFreshInstall: Bool,
-    aiAvailable: Bool
+    aiCapable: Bool, aiEnabled: Bool
   ) {
     PostHogSDK.shared.capture(
       "app.launched",
@@ -133,7 +133,8 @@ public final class TelemetryService {
         "os_version": osVersion,
         "hardware": hardware,
         "is_fresh_install": isFreshInstall,
-        "ai_available": aiAvailable,
+        "ai_capable": aiCapable,
+        "ai_enabled": aiEnabled,
       ])
   }
 

--- a/Tests/EnviousWisprTests/LLM/LaunchAvailabilitySnapshotTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LaunchAvailabilitySnapshotTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprLLM
+
+/// Issue #1073 — `app.launched` `ai_capable` / `ai_enabled` / `hardware` must be
+/// derived from a live synchronous snapshot, never a nil/stale cached
+/// availability report. These tests lock the snapshot's independence from the
+/// cache and the real hardware read.
+@Suite("Launch availability snapshot (#1073)")
+struct LaunchAvailabilitySnapshotTests {
+
+  /// The exact UserDefaults key the OLD buggy launch path read from
+  /// (`AIAvailabilityCoordinator.snapshotKey`).
+  private static let cacheKey = "aiDiagnosticsLatestReport"
+
+  @Test("hardware class is real, never \"unknown\"")
+  func hardwareClassIsReal() {
+    let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    #expect(snap.hardwareClass.isEmpty == false)
+    #expect(snap.hardwareClass != "unknown")
+    // Stable across calls (live sysctl, deterministic).
+    let again = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    #expect(again.hardwareClass == snap.hardwareClass)
+  }
+
+  @Test("snapshot ignores a poisoned cached report (independence from cache)")
+  func ignoresPoisonedCachedReport() throws {
+    let defaults = UserDefaults.standard
+    let original = defaults.data(forKey: Self.cacheKey)
+    defer {
+      if let original {
+        defaults.set(original, forKey: Self.cacheKey)
+      } else {
+        defaults.removeObject(forKey: Self.cacheKey)
+      }
+    }
+
+    // Clean-cache baseline.
+    defaults.removeObject(forKey: Self.cacheKey)
+    let clean = AppleIntelligenceDiagnosticsService.launchSnapshot()
+
+    // Poison the cache with an "available" report carrying a fake hardware class.
+    // The synchronous snapshot must ignore it entirely (it reads live gates, not
+    // this key) — that is the whole point of the #1073 fix.
+    let poisoned = AppleIntelligenceAvailabilityReport(
+      overallStatus: .available,
+      gates: AIGateSet(
+        build: .passed(summary: "fake"),
+        runtime: .passed(summary: "fake"),
+        eligibility: .passed(summary: "fake"),
+        modelAccess: .passed(summary: "fake"),
+        functionalProbe: .passed(summary: "fake")),
+      failureReasons: [],
+      osVersion: "26.0.0",
+      hardwareClass: "poisoned-fake-hw")
+    let data = try #require(try? JSONEncoder().encode(poisoned))
+    defaults.set(data, forKey: Self.cacheKey)
+
+    let afterPoison = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    #expect(afterPoison.isCapable == clean.isCapable)
+    #expect(afterPoison.isEnabled == clean.isEnabled)
+    #expect(afterPoison.hardwareClass == clean.hardwareClass)
+    #expect(afterPoison.hardwareClass != "poisoned-fake-hw")
+  }
+
+  @Test("isEnabled implies isCapable")
+  func isEnabledImpliesCapable() {
+    let snap = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    if snap.isEnabled {
+      #expect(snap.isCapable == true)
+    }
+  }
+
+  @Test("deterministic across consecutive calls")
+  func deterministicAcrossCalls() {
+    let a = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    let b = AppleIntelligenceDiagnosticsService.launchSnapshot()
+    #expect(a.isCapable == b.isCapable)
+    #expect(a.isEnabled == b.isEnabled)
+  }
+}


### PR DESCRIPTION
## What & why

`app.launched`'s `ai_available` was a systematic false negative and `hardware` over-reported `unknown`: both were read synchronously at launch from a nil/stale cached availability report (nil on fresh installs, stale otherwise). Production (90d, prod, dev excluded) showed `ai_available` false=62 / true=17 while Apple Intelligence polish ran 1,754 genuine successes across 23 users — irreconcilable unless the flag was wrong. It nearly produced a false "Apple Intelligence unavailable to ~78% of users" conclusion in the 2026-06-18 adversarial review.

## Change

- New synchronous `AppleIntelligenceDiagnosticsService.launchSnapshot()` returns domain facts: `hardwareClass` (live `sysctl`), `isCapable` (framework compiled-in + macOS 26 + hardware-eligible), `isEnabled` (`SystemLanguageModel.availability == .available` right now).
- `app.launched` drops the single ambiguous `ai_available` and emits two honest signals — `ai_capable` + `ai_enabled` — and `hardware` is now the live machine class. The adoption funnel "capable but not turned on" = `ai_capable AND NOT ai_enabled`.
- The snapshot (including the eligibility read) is computed OFF the launch main thread (`Task.detached`) and hops back to the `@MainActor` `TelemetryService` to emit, so the launch/heart path is never blocked by an ML-framework read; the event still fires within ms (best-effort). Deep availability stays on `ai_diagnostics.run_completed`.

## Telemetry boundary

Pre-fix rows carry `ai_available` (unreliable, false-negative-biased) — do not trust for AI reach. Post-fix rows carry `ai_capable` / `ai_enabled`; rows are self-identifying by property presence. Re-point/segment any saved PostHog insight that filtered on `ai_available`. (Knowledge note updated in `analytics-operations.md`.)

## Validation

- Plan: `docs/feature-requests/issue-1073-2026-06-19-ai-available-launch-snapshot.md`. Council (GPT-5.5 + Gemini-3.1) coverage review; Codex grounded review (3 rounds) → PROCEED-AS-PLANNED; Codex code-diff review (one P2 incorporated: `isCapable` now excludes genuine hardware-ineligibility).
- 1,771 logic tests green via `scripts/xcode-test.sh`, including new `LaunchAvailabilitySnapshotTests` (cache-independence, real hardware class, `isEnabled ⇒ isCapable` invariant, determinism).
- Live UAT on a DEBUG dev build: heart path completed end-to-end (record → transcribe → paste), clean launch, no regression.

Closes #1073

Lane: Code. Tier: MEDIUM.