### PR TITLE
feat(ui): surface on-device polish path in onboarding, silence pre-26 polish pill

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1,9 +1,22 @@
+import AppKit
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprPipeline
 import EnviousWisprServices
 import IOKit.pwr_mgt
 import SwiftUI
+
+// MARK: - Apple Intelligence Settings Deep Link
+
+/// System Settings deep-link for the Apple Intelligence & Siri pane. `internal`
+/// (not file-private) so the onboarding-availability test target can assert the
+/// validated URL string and catch accidental edits to it. Validated 2026-06-19
+/// on macOS 26.6: opening this lands on "Apple Intelligence & Siri". Only ever
+/// opened from the `.enableInSettings` branch, which requires macOS 26, so it
+/// never targets a missing pane on older macOS. (#1080)
+enum AppleIntelligenceSettings {
+  static let systemSettingsURL = "x-apple.systempreferences:com.apple.Siri-Settings.extension"
+}
 
 // MARK: - ViewModel
 
@@ -277,6 +290,15 @@ final class OnboardingV2ViewModel {
 
   func openAccessibilitySettings(permissions: PermissionsService) {
     _ = permissions.requestAccessibilityAccess()
+  }
+
+  /// Opens the Apple Intelligence & Siri pane in System Settings so the user
+  /// can switch Apple Intelligence on. Only invoked from the `.enableInSettings`
+  /// onboarding notice (macOS 26 + switched off). (#1080)
+  func openAppleIntelligenceSettings() {
+    if let url = URL(string: AppleIntelligenceSettings.systemSettingsURL) {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   func finishOnboarding(settings: SettingsManager) {
@@ -667,6 +689,9 @@ private struct PermissionsPhaseView: View {
   var viewModel: OnboardingV2ViewModel
   @Environment(PermissionsService.self) private var permissions
   @Environment(SettingsManager.self) private var settings
+  // #1080: read the launch availability report (already computed + injected) to
+  // optionally surface the on-device polish path. Read-only; never gates Continue.
+  @Environment(AIAvailabilityCoordinator.self) private var aiAvailability
 
   var body: some View {
     VStack(spacing: 0) {
@@ -747,6 +772,18 @@ private struct PermissionsPhaseView: View {
       .padding(.bottom, 20)
       .animation(.easeInOut(duration: 0.30), value: viewModel.accessibilityGranted)
 
+      // #1080: optional on-device polish notice. Renders ONLY when the launch
+      // report yields an actionable reason (Apple Intelligence off, or pre-26).
+      // nil report or nil notice → nothing renders (load-bearing safe default).
+      // It sits below the required rows and NEVER affects the Continue gate.
+      if let notice = aiAvailability.latestReport?.onboardingPolishNotice {
+        AIPolishNoticeSection(notice: notice) {
+          viewModel.openAppleIntelligenceSettings()
+        }
+        .padding(.bottom, 20)
+        .transition(.opacity)
+      }
+
       Spacer()
 
       // #735: gate Continue on BOTH mic AND accessibility. PostHog (60d prod)
@@ -811,6 +848,91 @@ private struct PermissionsPhaseView: View {
       // #735: showSkipLink no longer used (Skip-for-now backdoor removed); `elapsed` retained
       // so future telemetry can re-attach a "time-on-permissions-screen" event if needed.
       _ = elapsed
+    }
+  }
+}
+
+/// #1080: optional onboarding notice about the free on-device Apple Intelligence
+/// polish path. Rendered by `PermissionsPhaseView` ONLY when the launch
+/// availability report yields an actionable notice; it never gates Continue.
+/// `.enableInSettings` is an accent card with a one-tap jump to System Settings
+/// (Apple Intelligence switched off on a macOS-26 Mac); `.updateMacOS` is a
+/// neutral, button-less informational card (pre-macOS-26). The "incompatible
+/// hardware" case is impossible here — we ship Apple-Silicon-only, so an
+/// ineligible Mac never launches us, and the classifier returns nil for it.
+private struct AIPolishNoticeSection: View {
+  let notice: AppleIntelligenceAvailabilityReport.OnboardingPolishNotice
+  let onOpenSettings: () -> Void
+
+  var body: some View {
+    VStack(spacing: 12) {
+      // Eyebrow: visually separates this optional item from the two required
+      // permission rows above it.
+      HStack(spacing: 10) {
+        Rectangle().fill(Color.obTextSecondary.opacity(0.18)).frame(height: 1)
+        Text("AI POLISH · OPTIONAL")
+          .font(.obCaption)
+          .kerning(1.4)
+          .foregroundStyle(Color.obTextSecondary)
+          .fixedSize()
+        Rectangle().fill(Color.obTextSecondary.opacity(0.18)).frame(height: 1)
+      }
+
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(alignment: .top, spacing: 10) {
+          Image(systemName: iconName)
+            .foregroundStyle(accentColor)
+            .font(.system(size: 16, weight: .semibold))
+          VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+              .font(.obLabel)
+              .foregroundStyle(Color.obTextPrimary)
+            Text(message)
+              .font(.obCaption)
+              .foregroundStyle(Color.obTextSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+        }
+        if notice == .enableInSettings {
+          Button("Open System Settings", action: onOpenSettings)
+            .buttonStyle(.plain)
+            .font(.obCaption.weight(.semibold))
+            .foregroundStyle(accentColor)
+            .padding(.leading, 26)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(14)
+      .background(accentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+      .overlay(
+        RoundedRectangle(cornerRadius: 12)
+          .stroke(accentColor.opacity(0.22), lineWidth: 1)
+      )
+    }
+  }
+
+  private var accentColor: Color {
+    notice == .enableInSettings ? Color.obAccent : Color.obTextSecondary
+  }
+
+  private var iconName: String {
+    notice == .enableInSettings ? "sparkles" : "arrow.up.circle"
+  }
+
+  private var title: String {
+    switch notice {
+    case .enableInSettings: return "Apple Intelligence is turned off"
+    case .updateMacOS: return "AI polish needs macOS 26"
+    }
+  }
+
+  private var message: String {
+    switch notice {
+    case .enableInSettings:
+      return "Turn it on to enable free, on-device AI polish. Dictation works fine without it."
+    case .updateMacOS:
+      return
+        "Update your Mac to macOS 26 to unlock free, on-device Apple Intelligence polish. Dictation works fully right now without it."
     }
   }
 }

--- a/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
+++ b/Sources/EnviousWisprCore/AppleIntelligenceDiagnostics.swift
@@ -200,6 +200,29 @@ public struct AppleIntelligenceAvailabilityReport: Sendable, Codable {
     return "Apple Intelligence availability could not be determined."
   }
 
+  /// What onboarding should surface about on-device polish, or nil to stay
+  /// silent. Only the two ACTIONABLE reasons map to a notice. (#1080)
+  public enum OnboardingPolishNotice: String, Sendable, Equatable {
+    case enableInSettings  // appleIntelligenceDisabled — actionable (Open Settings)
+    case updateMacOS  // unsupportedOS — informational
+  }
+
+  /// Derived onboarding notice: non-nil ONLY when on-device Apple Intelligence
+  /// polish is unavailable for a reason the user can act on —
+  /// `.enableInSettings` (switched off → Open Settings) or `.updateMacOS`
+  /// (pre-macOS-26 → informational). Every other reason and status returns nil:
+  /// transient ones (modelNotReady, modelAccessFailed, generationFailed),
+  /// the unreachable hardware case (deviceNotEligible/unsupportedHardware — we
+  /// ship Apple-Silicon-only, so an ineligible Mac never launches us), and any
+  /// available/degraded/unknown status. Pure function of `overallStatus` +
+  /// `failureReasons`; not stored.
+  public var onboardingPolishNotice: OnboardingPolishNotice? {
+    guard overallStatus == .unavailable else { return nil }
+    if failureReasons.contains(.appleIntelligenceDisabled) { return .enableInSettings }
+    if failureReasons.contains(.unsupportedOS) { return .updateMacOS }
+    return nil
+  }
+
   /// Debug summary derived from gate results. For dev builds and support.
   public var debugSummary: String {
     gates.allGates.map { "\($0.name): \($0.result.status.rawValue) — \($0.result.summary)" }.joined(

--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -559,7 +559,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
           "Apple Intelligence is not enabled. Turn it on in System Settings > Apple Intelligence & Siri."
         )
       case .modelNotReady:
-        throw LLMError.frameworkUnavailable(
+        // #1080: TRANSIENT — keep this distinct from the permanent
+        // `frameworkUnavailable` cases so the live dictation path SURFACES it
+        // (informative "downloading / restricted" message) instead of silently
+        // degrading to raw text the way pre-26 / switched-off do.
+        throw LLMError.modelNotReady(
           "The on-device model is not ready. It may still be downloading or restricted by your organization. Try again later or use a different provider."
         )
       @unknown default:

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -152,6 +152,15 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
   case providerUnavailable
   case modelNotFound(String)
   case frameworkUnavailable(String)
+  /// The selected on-device Apple Intelligence model is enabled but not usable
+  /// right now — still downloading, or restricted by organization policy.
+  /// Distinct from `frameworkUnavailable`, which is the PERMANENT "this Mac or
+  /// build cannot run Apple Intelligence" state (pre-macOS-26, switched off,
+  /// ineligible hardware, not compiled in). `modelNotReady` is TRANSIENT and may
+  /// resolve on its own, so the live dictation path keeps surfacing it (the user
+  /// learns why polish is temporarily unavailable) instead of silently degrading
+  /// to raw text the way the permanent cases do. (#1080)
+  case modelNotReady(String)
   /// Input language is not supported by the selected provider. Distinct from
   /// `frameworkUnavailable` (global provider state): this fires per-request
   /// when a specific detected language is outside the provider's supported
@@ -175,6 +184,8 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
       return "Ollama model '\(model)' is not pulled. Run: ollama pull \(model)"
     case .frameworkUnavailable(let reason):
       return reason
+    case .modelNotReady(let reason):
+      return reason
     case .unsupportedInputLanguage(let code):
       return
         "Apple Intelligence does not support the input language '\(code)' for on-device polishing."
@@ -193,6 +204,7 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
     case (.requestFailed(let a), .requestFailed(let b)),
       (.modelNotFound(let a), .modelNotFound(let b)),
       (.frameworkUnavailable(let a), .frameworkUnavailable(let b)),
+      (.modelNotReady(let a), .modelNotReady(let b)),
       (.unsupportedInputLanguage(let a), .unsupportedInputLanguage(let b)):
       return a == b
     case (.outputLanguageDrift(let le, let la), .outputLanguageDrift(let re, let ra)):

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -153,23 +153,35 @@ internal final class TextProcessingRunner {
         } else {
           reason = "failed: \(error.localizedDescription)"
         }
-        // Apple Intelligence language-gate skips (unsupported input
-        // language, output-language drift) are expected no-ops, not
-        // polish failures. Log and continue with raw text; do not
-        // set `polishError`, which would surface as "AI polish
-        // failed" in the UI.
-        let isLanguageGateSkip: Bool
+        // Apple Intelligence skips that degrade quietly to raw text instead of
+        // an "AI polish failed" pill: per-request language gates (unsupported
+        // input language, output-language drift) AND the PERMANENT
+        // provider-incapable case (#1080 — pre-macOS-26 / Apple Intelligence
+        // switched off / ineligible hardware / not compiled in).
+        // `frameworkUnavailable` is thrown ONLY by AppleIntelligenceConnector
+        // for those permanent states and fires on EVERY dictation for such a
+        // Mac, so surfacing it nags a user who cannot fix it from the live
+        // path. Log and continue with raw text; do not set `polishError`,
+        // which would surface as "AI polish failed" in the UI.
+        // Contract: `frameworkUnavailable` is the PERMANENT "this Mac or build
+        // cannot run Apple Intelligence" state. Every TRANSIENT or actionable
+        // outage MUST keep surfacing and stays OUT of this set —
+        // `modelNotReady` (model downloading / org-restricted),
+        // `providerUnavailable` (Ollama down), `requestFailed` (cloud 5xx),
+        // `invalidAPIKey` — locked by the adversarial tests in
+        // TextProcessingRunnerTests.
+        let isSilentPolishSkip: Bool
         if let llmError = error as? LLMError {
           switch llmError {
-          case .unsupportedInputLanguage, .outputLanguageDrift:
-            isLanguageGateSkip = true
+          case .unsupportedInputLanguage, .outputLanguageDrift, .frameworkUnavailable:
+            isSilentPolishSkip = true
           default:
-            isLanguageGateSkip = false
+            isSilentPolishSkip = false
           }
         } else {
-          isLanguageGateSkip = false
+          isSilentPolishSkip = false
         }
-        if step.errorSurfacePolicy == .surface && !isLanguageGateSkip
+        if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
           && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
         {
           polishError = error.localizedDescription

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
@@ -244,6 +244,119 @@ struct TextProcessingRunnerTests {
     #expect(result.polishError == nil)
   }
 
+  @Test(
+    "suppresses polishError for frameworkUnavailable skips from LLM Polish (#1080)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1080",
+      "AI polish pill nagged every dictation on AI-unavailable Macs")
+  )
+  func suppressesPolishErrorForFrameworkUnavailable() async throws {
+    let runner = deterministicRunner()
+
+    let first = RecordingStep(name: "Word Correction") { context in
+      var next = context
+      next.text += "-A"
+      return next
+    }
+
+    // Pre-macOS-26 / Apple-Intelligence-off Macs throw this on EVERY dictation;
+    // it must degrade silently to raw text, never surface the "AI polish failed"
+    // pill the user cannot fix from the live path.
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
+      throw LLMError.frameworkUnavailable("FoundationModels not available (requires macOS 26)")
+    }
+
+    let after = RecordingStep(name: "Suffix") { context in
+      var next = context
+      next.text += "-C"
+      return next
+    }
+
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [first, llm, after]
+    )
+
+    #expect(llm.runCount == 1)
+    #expect(after.runCount == 1)
+    #expect(after.seenInputs[0].text == "start-A")
+    #expect(result.context.text == "start-A-C")
+    #expect(result.polishError == nil)
+  }
+
+  @Test(
+    "surfaces polishError for providerUnavailable, the adversarial non-skip class (#1080)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1080",
+      "genuine provider outages must keep surfacing, unlike frameworkUnavailable")
+  )
+  func surfacesPolishErrorForProviderUnavailable() async throws {
+    let runner = deterministicRunner()
+
+    // providerUnavailable is a genuine outage (Ollama down, cloud provider init
+    // failed), NOT the macOS-26 framework gate. It must keep surfacing the pill;
+    // sharing the silent-skip set with frameworkUnavailable would be a regression.
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
+      throw LLMError.providerUnavailable
+    }
+
+    let after = RecordingStep(name: "Suffix") { context in
+      var next = context
+      next.text += "-after"
+      return next
+    }
+
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [llm, after]
+    )
+
+    #expect(after.runCount == 1)
+    #expect(result.context.text == "start-after")
+    #expect(result.polishError == LLMError.providerUnavailable.localizedDescription)
+  }
+
+  @Test(
+    "surfaces polishError for modelNotReady, the transient Apple Intelligence class (#1080)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1080",
+      "model-downloading / org-restricted must stay visible, unlike the permanent frameworkUnavailable"
+    )
+  )
+  func surfacesPolishErrorForModelNotReady() async throws {
+    let runner = deterministicRunner()
+
+    // modelNotReady is TRANSIENT (model still downloading, or org-restricted) and
+    // carries an informative message. Unlike the permanent frameworkUnavailable
+    // cases (pre-26 / switched off), it must keep surfacing so the user learns
+    // why polish is temporarily unavailable instead of silent raw text.
+    let message = "The on-device model is not ready. It may still be downloading."
+    let llm = RecordingStep(name: "LLM Polish", errorSurfacePolicy: .surface) { _ in
+      throw LLMError.modelNotReady(message)
+    }
+
+    let after = RecordingStep(name: "Suffix") { context in
+      var next = context
+      next.text += "-after"
+      return next
+    }
+
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [llm, after]
+    )
+
+    #expect(after.runCount == 1)
+    #expect(result.context.text == "start-after")
+    #expect(result.polishError == LLMError.modelNotReady(message).localizedDescription)
+  }
+
   @Test("skips a timed-out non-LLM step and continues without polishError")
   func skipsTimedOutNonLLMStep() async throws {
     // #784 (2026-05-18): migrated from real `Task.sleep(300ms)` racing a

--- a/Tests/EnviousWisprTests/Settings/AppleIntelligencePolishNoticeTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AppleIntelligencePolishNoticeTests.swift
@@ -1,0 +1,126 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Issue #1080 — locks the onboarding polish-availability contract:
+/// 1. `AppleIntelligenceAvailabilityReport.onboardingPolishNotice` maps the
+///    launch availability verdict to exactly the two ACTIONABLE notices (turn
+///    it on / update macOS) and stays silent for everything else.
+/// 2. The validated System Settings deep-link string does not drift.
+///
+/// Matcher-set adversarial coverage (per workflow RULE): every failure reason
+/// is exercised, including the unreachable hardware case and the status guard,
+/// so a future-added reason defaults to silent rather than surfacing a notice.
+@Suite("Onboarding polish availability notice (#1080)")
+struct AppleIntelligencePolishNoticeTests {
+
+  /// Synthetic report with an all-passed gate set (gates are irrelevant to the
+  /// classifier, which reads only `overallStatus` + `failureReasons`).
+  private func makeReport(
+    status: AIAvailabilityStatus,
+    reasons: [AIFailureReason]
+  ) -> AppleIntelligenceAvailabilityReport {
+    let gate = AIGateResult.passed(summary: "synthetic")
+    let gates = AIGateSet(
+      build: gate, runtime: gate, eligibility: gate, modelAccess: gate, functionalProbe: gate)
+    return AppleIntelligenceAvailabilityReport(
+      overallStatus: status,
+      gates: gates,
+      failureReasons: reasons,
+      osVersion: "synthetic",
+      hardwareClass: "arm64")
+  }
+
+  // MARK: - Positives (the two actionable reasons)
+
+  @Test("Apple Intelligence switched off maps to enableInSettings")
+  func disabledMapsToEnableInSettings() {
+    let report = makeReport(status: .unavailable, reasons: [.appleIntelligenceDisabled])
+    #expect(report.onboardingPolishNotice == .enableInSettings)
+  }
+
+  @Test("Pre-macOS-26 maps to updateMacOS")
+  func unsupportedOSMapsToUpdateMacOS() {
+    let report = makeReport(status: .unavailable, reasons: [.unsupportedOS])
+    #expect(report.onboardingPolishNotice == .updateMacOS)
+  }
+
+  // MARK: - Negatives (unavailable, but not an actionable reason)
+
+  @Test("Ineligible hardware stays silent (unreachable in-app: Apple-Silicon-only)")
+  func deviceNotEligibleIsSilent() {
+    // We ship arm64-only, so an ineligible Mac never launches us. If the
+    // classifier ever saw this reason it must NOT surface a note the user
+    // cannot act on.
+    #expect(
+      makeReport(status: .unavailable, reasons: [.deviceNotEligible]).onboardingPolishNotice == nil)
+    #expect(
+      makeReport(status: .unavailable, reasons: [.unsupportedHardware]).onboardingPolishNotice
+        == nil)
+  }
+
+  @Test("Transient unavailable reasons stay silent")
+  func transientReasonsAreSilent() {
+    for reason in [
+      AIFailureReason.modelNotReady, .modelAccessFailed, .generationFailed, .notCompiledIn,
+      .unknownError,
+    ] {
+      #expect(
+        makeReport(status: .unavailable, reasons: [reason]).onboardingPolishNotice == nil,
+        "\(reason) should be silent")
+    }
+  }
+
+  @Test("Every reason except the two actionable ones is silent under .unavailable")
+  func allOtherReasonsAreSilent() {
+    for reason in AIFailureReason.allCases
+    where reason != .appleIntelligenceDisabled && reason != .unsupportedOS {
+      #expect(
+        makeReport(status: .unavailable, reasons: [reason]).onboardingPolishNotice == nil,
+        "\(reason) should be silent")
+    }
+  }
+
+  // MARK: - Status guard (only .unavailable can surface a notice)
+
+  @Test("Available status is always silent")
+  func availableIsSilent() {
+    #expect(makeReport(status: .available, reasons: []).onboardingPolishNotice == nil)
+  }
+
+  @Test("Degraded / unknown status is silent even with an otherwise-actionable reason")
+  func nonUnavailableStatusIsSilent() {
+    // The guard is `overallStatus == .unavailable`. A degraded/unknown report
+    // carrying a mapped reason must still stay silent.
+    #expect(
+      makeReport(status: .degraded, reasons: [.appleIntelligenceDisabled]).onboardingPolishNotice
+        == nil)
+    #expect(
+      makeReport(status: .unknown, reasons: [.unsupportedOS]).onboardingPolishNotice == nil)
+  }
+
+  // MARK: - Precedence (defensive: the two are mutually exclusive in practice)
+
+  @Test("When both actionable reasons co-occur, enableInSettings wins")
+  func enableInSettingsTakesPrecedence() {
+    // Unreachable in practice (the eligibility gate that yields
+    // appleIntelligenceDisabled is skipped when the OS gate fails), but the
+    // documented order checks the toggle-fixable case first.
+    let report = makeReport(
+      status: .unavailable, reasons: [.unsupportedOS, .appleIntelligenceDisabled])
+    #expect(report.onboardingPolishNotice == .enableInSettings)
+  }
+
+  // MARK: - Deep-link constant
+
+  @Test("System Settings deep-link matches the validated Apple Intelligence & Siri pane")
+  func deepLinkConstantDoesNotDrift() {
+    // Validated 2026-06-19 on macOS 26.6: opening this lands on the
+    // "Apple Intelligence & Siri" pane. Guards accidental edits.
+    #expect(
+      AppleIntelligenceSettings.systemSettingsURL
+        == "x-apple.systempreferences:com.apple.Siri-Settings.extension")
+  }
+}


### PR DESCRIPTION
## What & why

Closes #1080. On a Mac that can't run on-device Apple Intelligence polish, two things were wrong:

1. **Every live dictation surfaced an "AI polish failed" pill.** `LLMError.frameworkUnavailable` wasn't in `TextProcessingRunner`'s silent-skip set, so a user who literally cannot fix it from the live path got nagged on every dictation.
2. **Onboarding never explained the situation or offered the path.**

## Changes

- **Silence the live pill for the permanent cases.** `TextProcessingRunner` now treats `LLMError.frameworkUnavailable` as a silent skip (raw cleaned text passes through), alongside the existing language-gate skips (`isLanguageGateSkip` → `isSilentPolishSkip`). This covers the genuinely-permanent "this Mac/build cannot run Apple Intelligence" states (pre-macOS-26, switched off, ineligible hardware, not compiled in).
- **Keep the transient case visible (Codex code-diff finding).** `throwIfAppleIntelligenceUnavailable()` also threw `frameworkUnavailable` for `.modelNotReady` (model still downloading, or org-restricted) — a transient state with an informative message. Split it into a new `LLMError.modelNotReady(String)` so the live pill and the saved-transcript re-polish path keep surfacing it, instead of silently degrading to raw text.
- **Optional onboarding notice.** A new `AppleIntelligenceAvailabilityReport.onboardingPolishNotice` classifier (Core) maps the launch availability verdict to `.enableInSettings` / `.updateMacOS` / `nil`. The Permissions screen renders an optional `AIPolishNoticeSection` only when the notice is non-nil; it reads the already-computed launch report reactively, **never gates Continue**, and `.enableInSettings` offers a validated "Open System Settings" deep-link to the Apple Intelligence & Siri pane. `.updateMacOS` is informational. The incompatible-hardware case is unreachable in-app (Apple-Silicon-only build), so the classifier returns nil for it and no note shows.

## Validation

- Logic tests: `scripts/xcode-test.sh` green (1697 tests). New: runner silent-vs-surfaces trio (`frameworkUnavailable` silent; `providerUnavailable` + `modelNotReady` surface); exhaustive Core classifier (every failure reason + the `.unavailable`-only status guard); deep-link constant guard.
- Smoke + heart-path Live UAT: dev `.app` rebuilt; synthetic dictation polished + pasted clean via Apple Intelligence, no pill, pipeline ~1.7s.
- Deep-link validated standalone (2026-06-19, macOS 26.6): `x-apple.systempreferences:com.apple.Siri-Settings.extension` lands on "Apple Intelligence & Siri".
- Onboarding section's two rendered states can't be reproduced live on this AI-available Mac (the report is `.available` → section hidden); covered by the Core classifier test + deep-link test + static env-injection verification (see run-dir `skip-note.txt`).
- Codex code-diff review: clean (the `modelNotReady` finding above was its P2; addressed in this PR).
- Validation run (local, gitignored): `.validation/runs/2026-06-19T22-06-20Z-49cd803/` — `check-validation.sh --strict` PASS (Code lane: tests, smoke, live-uat, codex-review all satisfied).