### PR TITLE
fix(llm): treat first-case modelNotReady as AFM bench infra-abort

### DIFF
--- a/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
+++ b/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
@@ -96,7 +96,8 @@ func printUsage() {
     EXIT CODES:
       0  every case attempted (some may have errored — Python reads those lines)
       2  startup failure: Apple Intelligence unavailable, corpus missing/malformed,
-         or the FIRST case threw frameworkUnavailable
+         or the FIRST case reported Apple Intelligence unavailable
+         (frameworkUnavailable / modelNotReady)
     """
   FileHandle.standardError.write(Data((msg + "\n").utf8))
 }
@@ -197,13 +198,24 @@ struct RunnerMain {
         record = OutRecord(
           id: caseItem.id, candidate: result.polishedText, error: nil, latencyMs: ms)
       } catch let err as LLMError {
-        // frameworkUnavailable on the very first case means Apple Intelligence
-        // is not usable on this machine at all — no reason to keep trying.
-        // Exit 2 so the Python driver treats it as infra error, not as per-case noise.
-        if index == 0, case .frameworkUnavailable = err {
-          fail(
-            "first case threw frameworkUnavailable: \(err.errorDescription ?? String(describing: err))"
-          )
+        // frameworkUnavailable OR modelNotReady on the very first case means
+        // Apple Intelligence is not usable on this machine right now (unsupported
+        // OS, switched off, ineligible hardware, not compiled in, OR the on-device
+        // model is still downloading / org-restricted) — no reason to keep trying.
+        // Exit 2 so the Python driver treats it as an infra error, not per-case
+        // noise. #1101: `modelNotReady` was split out of `frameworkUnavailable`
+        // in #1080; before that it was the same case and already aborted here, so
+        // this restores the pre-#1080 contract (an unavailable model must abort
+        // setup, never corrupt `--mode bench` results as a per-case loss).
+        if index == 0 {
+          switch err {
+          case .frameworkUnavailable, .modelNotReady:
+            fail(
+              "first case threw \(String(describing: err)): \(err.errorDescription ?? "Apple Intelligence unavailable on this machine")"
+            )
+          default:
+            break
+          }
         }
         errorCount += 1
         record = OutRecord(id: caseItem.id, candidate: nil, error: String(describing: err))


### PR DESCRIPTION
## What & why

Closes #1101. Follow-up to the GitHub Codex review on PR #1098 (the #1080 ship), which flagged a P2.

#1080 split `LLMError.modelNotReady` out of `frameworkUnavailable`. The AFM benchmark runner (`scripts/eval/apple_runner`) only treated a **first-case** `.frameworkUnavailable` as the infra-abort exit (exit 2). After #1080, a downloading / org-restricted on-device model throws `.modelNotReady`, which fell through to a per-case error record — so `acceptance_gate.py --mode bench` would load it as a per-case provider loss instead of aborting setup, **corrupting benchmark results**.

Pre-#1080, `modelNotReady` *was* `frameworkUnavailable` and already aborted here, so this restores that contract.

## Change

In the runner's first-case classification, abort setup on `.frameworkUnavailable` **or** `.modelNotReady` (both mean Apple Intelligence is not usable on the bench machine right now). Doc comment + inline comment updated.

## Validation

- Runner package builds clean (`swift build` in `scripts/eval/apple_runner`, links against the shipped `EnviousWisprLLM` with the new case).
- Codex code-diff review: clean (verified the `case .a, .b:` or-pattern compiles).
- Eval-harness lane: the changed path fires **only** when Apple Intelligence is unavailable on the bench machine (first case throws), so it cannot affect normal scoring — no public-corpus metric delta is possible (documented; full eval run not run for that reason).