### PR TITLE
feat(settings): DEBUG-only switch to simulate the onboarding AI polish note

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AIAvailabilityCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AIAvailabilityCoordinator.swift
@@ -14,6 +14,45 @@ final class AIAvailabilityCoordinator {
   /// Latest completed diagnostics report, or nil if never checked.
   private(set) var latestReport: AppleIntelligenceAvailabilityReport?
 
+  #if DEBUG
+    /// DEBUG-only override to validate the onboarding polish notice (#1080)
+    /// without a real AI-unavailable Mac (#1100). In-memory only (not persisted);
+    /// default `.useReal`. Set from the Diagnostics debug settings picker, consumed
+    /// by the onboarding Permissions section via `onboardingPolishNoticeForDisplay`.
+    enum DebugForcedNotice: String, CaseIterable, Identifiable {
+      case useReal, forceNone, enableInSettings, updateMacOS
+      var id: String { rawValue }
+      var label: String {
+        switch self {
+        case .useReal: return "Real (use launch report)"
+        case .forceNone: return "None (hidden)"
+        case .enableInSettings: return "Turn it on (enable in Settings)"
+        case .updateMacOS: return "Needs macOS 26"
+        }
+      }
+    }
+    var debugForcedNotice: DebugForcedNotice = .useReal
+  #endif
+
+  /// The on-device polish notice the onboarding Permissions section should
+  /// display, or nil to stay hidden. In release this is exactly the launch
+  /// report's classification (the section's prior inline read, now routed through
+  /// one accessor so the view no longer reaches through `latestReport`). In DEBUG
+  /// a `debugForcedNotice` override can force a specific state for validation
+  /// (#1100) without a real AI-unavailable Mac.
+  var onboardingPolishNoticeForDisplay: AppleIntelligenceAvailabilityReport.OnboardingPolishNotice?
+  {
+    #if DEBUG
+      switch debugForcedNotice {
+      case .useReal: break
+      case .forceNone: return nil
+      case .enableInSettings: return .enableInSettings
+      case .updateMacOS: return .updateMacOS
+      }
+    #endif
+    return latestReport?.onboardingPolishNotice
+  }
+
   /// Rolling history of recent checks (in-memory, last 20).
   private(set) var history: [AppleIntelligenceAvailabilityReport.HistoryEntry] = []
 

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -776,7 +776,9 @@ private struct PermissionsPhaseView: View {
       // report yields an actionable reason (Apple Intelligence off, or pre-26).
       // nil report or nil notice → nothing renders (load-bearing safe default).
       // It sits below the required rows and NEVER affects the Continue gate.
-      if let notice = aiAvailability.latestReport?.onboardingPolishNotice {
+      // #1100: reads the coordinator's display accessor (real report in release;
+      // a DEBUG override can force a state for onboarding validation).
+      if let notice = aiAvailability.onboardingPolishNoticeForDisplay {
         AIPolishNoticeSection(notice: notice) {
           viewModel.openAppleIntelligenceSettings()
         }

--- a/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
@@ -12,6 +12,11 @@ struct DiagnosticsSettingsView: View {
   // PR-B.2 of #763: "Restart Onboarding" reaches the window coordinator
   // through the environment instead of an `NSApp.delegate` downcast.
   @Environment(AppWindowCoordinator.self) private var appWindowCoordinator
+  // #1100: drives the DEBUG-only "Simulate AI polish state" picker below.
+  // DEBUG-gated so release carries no extra environment dependency here.
+  #if DEBUG
+    @Environment(AIAvailabilityCoordinator.self) private var aiAvailability
+  #endif
 
   /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
   /// environment (see `AppEnvironmentKeys.swift`).
@@ -19,6 +24,9 @@ struct DiagnosticsSettingsView: View {
 
   var body: some View {
     @Bindable var settings = settings
+    #if DEBUG
+      @Bindable var aiAvailability = aiAvailability
+    #endif
 
     SettingsContentView {
       // ── Debug Mode ────────────────────────────────────────────────────
@@ -40,6 +48,28 @@ struct DiagnosticsSettingsView: View {
               }
             }
           }
+          #if DEBUG
+            // #1100: force the onboarding Apple Intelligence note to a given
+            // state so it can be validated on a Mac where Apple Intelligence is
+            // actually available. Pair with "Restart Onboarding…" below.
+            BrandedRow {
+              VStack(alignment: .leading, spacing: 4) {
+                Picker(
+                  "Simulate AI polish state",
+                  selection: $aiAvailability.debugForcedNotice
+                ) {
+                  ForEach(AIAvailabilityCoordinator.DebugForcedNotice.allCases) { state in
+                    Text(state.label).tag(state)
+                  }
+                }
+                Text(
+                  "Forces the onboarding Apple Intelligence note. Pair with \"Restart Onboarding…\" to see each state. Debug builds only."
+                )
+                .font(.stHelper)
+                .foregroundStyle(.stTextTertiary)
+              }
+            }
+          #endif
           BrandedRow(showDivider: false) {
             VStack(alignment: .leading, spacing: 4) {
               Button("Restart Onboarding…") {

--- a/Tests/EnviousWisprTests/Settings/OnboardingPolishNoticeDebugOverrideTests.swift
+++ b/Tests/EnviousWisprTests/Settings/OnboardingPolishNoticeDebugOverrideTests.swift
@@ -1,0 +1,57 @@
+#if DEBUG
+  import EnviousWisprCore
+  import Foundation
+  import Testing
+
+  @testable import EnviousWisprAppKit
+
+  /// Issue #1100 — locks the DEBUG-only onboarding-notice override that lets the
+  /// #1080 note be validated on a Mac where Apple Intelligence is available.
+  /// `onboardingPolishNoticeForDisplay` honors `debugForcedNotice` in DEBUG and
+  /// otherwise returns the real launch-report classification (the section's prior
+  /// inline `latestReport?.onboardingPolishNotice` read).
+  @MainActor
+  @Suite("Onboarding polish notice debug override (#1100)")
+  struct OnboardingPolishNoticeDebugOverrideTests {
+
+    /// The UserDefaults key `AIAvailabilityCoordinator.init()` loads the cached
+    /// report from (`loadCachedReport`). Cleared and restored so a dev machine's
+    /// cached report cannot make `latestReport` non-nil and flake the
+    /// `.useReal`/`.forceNone` assertions. Mirrors LaunchAvailabilitySnapshotTests.
+    private static let cacheKey = "aiDiagnosticsLatestReport"
+
+    @Test(
+      "debugForcedNotice maps to the display notice; useReal falls through to the real report",
+      .bug(
+        "https://github.com/saurabhav88/EnviousWispr/issues/1100",
+        "debug onboarding-notice override")
+    )
+    func overrideMapsToDisplayNotice() {
+      let defaults = UserDefaults.standard
+      let original = defaults.data(forKey: Self.cacheKey)
+      defer {
+        if let original {
+          defaults.set(original, forKey: Self.cacheKey)
+        } else {
+          defaults.removeObject(forKey: Self.cacheKey)
+        }
+      }
+      // Clean cache → the coordinator starts with `latestReport == nil`, so
+      // `.useReal`/`.forceNone` must both yield nil (no real notice to show).
+      defaults.removeObject(forKey: Self.cacheKey)
+      let coordinator = AIAvailabilityCoordinator()
+
+      coordinator.debugForcedNotice = .useReal
+      #expect(coordinator.onboardingPolishNoticeForDisplay == nil)
+
+      coordinator.debugForcedNotice = .forceNone
+      #expect(coordinator.onboardingPolishNoticeForDisplay == nil)
+
+      coordinator.debugForcedNotice = .enableInSettings
+      #expect(coordinator.onboardingPolishNoticeForDisplay == .enableInSettings)
+
+      coordinator.debugForcedNotice = .updateMacOS
+      #expect(coordinator.onboardingPolishNoticeForDisplay == .updateMacOS)
+    }
+  }
+#endif


### PR DESCRIPTION
## What & why

Closes #1100. The #1080 onboarding Apple Intelligence note only renders on a Mac where on-device polish is unavailable, so it couldn't be seen or validated on a capable dev machine. This adds a DEBUG-only switch to force the note state, and uses it to finally validate the #1080 note live.

## Changes

- **AIAvailabilityCoordinator:** `#if DEBUG` `DebugForcedNotice` enum + `debugForcedNotice` (in-memory, default `.useReal`) + an `onboardingPolishNoticeForDisplay` accessor. In release the accessor returns `latestReport?.onboardingPolishNotice` (the section's prior inline read); all override machinery is `#if DEBUG`.
- **OnboardingV2View:** `PermissionsPhaseView` reads the accessor instead of reaching through `latestReport` (minor encapsulation win, identical release behavior).
- **DiagnosticsSettingsView:** `#if DEBUG` "Simulate AI polish state" picker next to "Restart Onboarding…".
- **Test:** `#if DEBUG` test — each override case maps to the expected display notice, UserDefaults-isolated so a cached launch report can't flake the nil cases.

Zero release behavioral change (one new passthrough accessor; everything else is `#if DEBUG` and absent from release binaries).

## Validation

- **Tests:** `scripts/xcode-test.sh` (debug, 1698) + `scripts/xcode-test.sh --release` (1679) green; the new DEBUG test passes; the release **app** compiles clean with the `#if DEBUG` symbols stripped.
- **Live UAT (wispr-eyes AX) — closes the #1080 onboarding-note validation gap:** set the picker to each state, "Restart Onboarding", and read the Permissions screen:
  - **Turn it on** → note titled "Apple Intelligence is turned off" with body "Turn it on to enable free, on-device AI polish. Dictation works fine without it.", an "Open System Settings" button, and Continue still present (note does not block Continue). Open Settings lands on the **Apple Intelligence & Siri** pane.
  - **Needs macOS 26** → note titled "AI polish needs macOS 26", informational, **no** button.
- **Reviews:** Codex grounded review (3 rounds → PROCEED-AS-PLANNED) + Codex code-diff review clean.
- **Validation run (local, gitignored):** `.validation/runs/2026-06-20T00-14-35Z-c0eb3bd/` — `check-validation.sh --strict` PASS (Code lane: tests, smoke, live-uat, codex-review all satisfied).

`council-skip: User Rubric N/A — DEBUG-only internal validation tooling, stripped from release, no user surface; placement (override co-located with the availability report it overrides on AIAvailabilityCoordinator) was the only structural fork and was settled by Codex grounded review; no architectural ceiling, no new module dependency, no workflow/hook/lane/CI change.`