### PR TITLE
feat(recovery): crash-recovery encrypted audio spool groundwork (PR0) (#1063)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -208,6 +208,8 @@ final class PipelineSettingsSync {
     case .onboardingState, .hasCompletedOnboarding, .useXPCAudioService,
       .contactsSyncOnLaunchEnabled:
       break  // UI-only or cold flag.
+    case .crashRecoveryEnabled:
+      break  // #1063: read by the recovery wiring at capture start, not the live pipeline.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     }

--- a/Sources/EnviousWisprAudio/RecoverySpoolWriter.swift
+++ b/Sources/EnviousWisprAudio/RecoverySpoolWriter.swift
@@ -1,0 +1,244 @@
+import EnviousWisprCore
+import Foundation
+import os
+
+// MARK: - Crash-recovery spool writer (#1063 PR0)
+//
+// Runs in the audio helper process. While recording, it encrypts each chunk of
+// captured samples and appends it to a single `.ewrec` file on a DEDICATED
+// background queue — never the heart-critical `xpcSendQueue`, never the
+// real-time audio thread. It is a strict LIMB: every failure path (open fails,
+// disk full, encryption error, queue backed up) drops recovery and leaves
+// capture / transcription byte-identical. The authoritative samples it is fed
+// (PR1 wiring) are the same buffer `stopCapture` returns, so the spool equals
+// exactly what ASR would have received.
+
+/// Low-level append target. Abstracted so tests can inject a failing sink to
+/// exercise the fail-open path without a real disk-full.
+public protocol RecoverySpoolFileSink {
+  func open() throws
+  func write(_ data: Data) throws
+  /// Durably flush to stable storage (`F_FULLFSYNC` on macOS).
+  func sync() throws
+  func close()
+}
+
+public enum RecoverySpoolWriterError: Error, Equatable {
+  case openFailed(Int32)
+  case notOpen
+  case syncFailed(Int32)
+}
+
+/// Encrypts and appends captured audio to a per-session spool file, fail-open.
+///
+/// Concurrency: all file + frame-counter state is confined to the serial
+/// `writeQueue`; only the `healthy`/`pendingBytes` backpressure flags are read
+/// off-queue, behind a lock. Hence `@unchecked Sendable` — mutable state is
+/// either serial-queue-confined or lock-protected.
+public final class RecoverySpoolWriter: @unchecked Sendable {
+  private struct BackpressureState {
+    var healthy = true
+    var pendingBytes = 0
+  }
+
+  private let recoverySessionID: String
+  private let cipher: RecoverySpoolCipher
+  private let settings: RecordingSettingsSnapshot
+  private let appVersion: String
+  private let createdAt: Date
+  private let maxPendingBytes: Int
+  private let writeQueue: DispatchQueue
+  private let state = OSAllocatedUnfairLock(initialState: BackpressureState())
+
+  // Serial-queue-confined state.
+  private nonisolated(unsafe) var sink: any RecoverySpoolFileSink
+  private nonisolated(unsafe) var chunkIndex: UInt32 = 0
+  private nonisolated(unsafe) var nextStartSample: UInt64 = 0
+  private nonisolated(unsafe) var nextNonceCounter: UInt64 = RecoveryConstants
+    .firstFrameNonceCounter
+
+  /// - Parameters:
+  ///   - maxPendingBytes: backpressure cap. When more than this many bytes of
+  ///     un-written audio queue up (the disk can't keep pace), spooling stops
+  ///     so the audio path is never throttled. Default ~4 MB (~60 s at 64 KB/s).
+  public init(
+    recoverySessionID: String,
+    cipher: RecoverySpoolCipher,
+    settings: RecordingSettingsSnapshot,
+    appVersion: String = AppConstants.appVersion,
+    createdAt: Date = Date(),
+    sink: any RecoverySpoolFileSink,
+    maxPendingBytes: Int = 4_000_000,
+    queue: DispatchQueue? = nil
+  ) {
+    self.recoverySessionID = recoverySessionID
+    self.cipher = cipher
+    self.settings = settings
+    self.appVersion = appVersion
+    self.createdAt = createdAt
+    self.sink = sink
+    self.maxPendingBytes = maxPendingBytes
+    self.writeQueue =
+      queue
+      ?? DispatchQueue(label: "com.enviouswispr.recovery.spool-writer", qos: .utility)
+  }
+
+  /// Convenience initializer writing to a real file at `spoolURL` (0600).
+  public convenience init(
+    recoverySessionID: String,
+    spoolURL: URL,
+    cipher: RecoverySpoolCipher,
+    settings: RecordingSettingsSnapshot,
+    appVersion: String = AppConstants.appVersion,
+    createdAt: Date = Date(),
+    maxPendingBytes: Int = 4_000_000,
+    queue: DispatchQueue? = nil
+  ) {
+    self.init(
+      recoverySessionID: recoverySessionID,
+      cipher: cipher,
+      settings: settings,
+      appVersion: appVersion,
+      createdAt: createdAt,
+      sink: FileHandleSpoolSink(url: spoolURL),
+      maxPendingBytes: maxPendingBytes,
+      queue: queue)
+  }
+
+  /// True until the first unrecoverable failure (open/write/encrypt error or
+  /// backpressure shed). Once false, the spool stops and the prefix on disk is
+  /// final.
+  public var isHealthy: Bool { state.withLock { $0.healthy } }
+
+  /// Open the file and write the header (magic + encrypted settings block).
+  public func start() {
+    writeQueue.async { [self] in
+      do {
+        let encryptedSettings = try cipher.sealSettings(settings)
+        let header = RecoverySpoolHeader(
+          cipher: cipher.mode,
+          recoverySessionID: recoverySessionID,
+          createdAt: createdAt,
+          appVersion: appVersion,
+          encryptedSettings: encryptedSettings)
+        let headerData = try RecoverySpoolFileFormat.encodeHeader(header)
+        try sink.open()
+        try sink.write(headerData)
+      } catch {
+        markFailed()
+      }
+    }
+  }
+
+  /// Encrypt and append a chunk of captured samples. Fail-open and
+  /// load-shedding: returns immediately, never throws, never blocks the caller.
+  public func append(_ samples: [Float]) {
+    guard !samples.isEmpty else { return }
+    let size = samples.count * MemoryLayout<Float>.size
+
+    let admitted = state.withLock { backpressure -> Bool in
+      guard backpressure.healthy else { return false }
+      if backpressure.pendingBytes + size > maxPendingBytes {
+        // Disk can't keep up: drop recovery, never audio. Spool stops here.
+        backpressure.healthy = false
+        return false
+      }
+      backpressure.pendingBytes += size
+      return true
+    }
+    guard admitted else { return }
+
+    writeQueue.async { [self] in
+      defer { state.withLock { $0.pendingBytes -= size } }
+      guard isHealthy else { return }
+      do {
+        let frame = try cipher.encodeAudioFrame(
+          samples: samples,
+          chunkIndex: chunkIndex,
+          startSample: nextStartSample,
+          nonceCounter: nextNonceCounter)
+        try sink.write(frame)
+        chunkIndex += 1
+        nextStartSample += UInt64(samples.count)
+        nextNonceCounter += 1
+      } catch {
+        markFailed()
+      }
+    }
+  }
+
+  /// Durably flush the bytes written so far (the durable-checkpoint cadence in
+  /// PR1 calls this). Best-effort.
+  public func flush() {
+    writeQueue.async { [self] in
+      guard isHealthy else { return }
+      try? sink.sync()
+    }
+  }
+
+  /// Write the terminal marker frame, fsync, and close. After this the spool is
+  /// complete and the host may recover (or, on a clean stop, delete) it.
+  /// `completion` runs on the write queue after close.
+  public func finalize(
+    reason: RecoverySpoolTerminationReason, completion: (@Sendable () -> Void)? = nil
+  ) {
+    writeQueue.async { [self] in
+      if isHealthy {
+        do {
+          let marker = try cipher.encodeMarkerFrame(
+            reason: reason,
+            chunkIndex: chunkIndex,
+            startSample: nextStartSample,
+            nonceCounter: nextNonceCounter)
+          try sink.write(marker)
+          try sink.sync()
+        } catch {
+          markFailed()
+        }
+      }
+      sink.close()
+      completion?()
+    }
+  }
+
+  private func markFailed() {
+    state.withLock { $0.healthy = false }
+  }
+}
+
+/// Production sink: appends to a real file opened at 0600, flushed with
+/// `F_FULLFSYNC` (the only durable flush on macOS).
+public final class FileHandleSpoolSink: RecoverySpoolFileSink {
+  private let url: URL
+  private var handle: FileHandle?
+  private var fileDescriptor: Int32 = -1
+
+  public init(url: URL) {
+    self.url = url
+  }
+
+  public func open() throws {
+    let descriptor = Foundation.open(url.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+    guard descriptor >= 0 else { throw RecoverySpoolWriterError.openFailed(errno) }
+    fileDescriptor = descriptor
+    handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+  }
+
+  public func write(_ data: Data) throws {
+    guard let handle else { throw RecoverySpoolWriterError.notOpen }
+    try handle.write(contentsOf: data)
+  }
+
+  public func sync() throws {
+    guard fileDescriptor >= 0 else { throw RecoverySpoolWriterError.notOpen }
+    if fcntl(fileDescriptor, F_FULLFSYNC) == -1 {
+      throw RecoverySpoolWriterError.syncFailed(errno)
+    }
+  }
+
+  public func close() {
+    try? handle?.close()
+    handle = nil
+    fileDescriptor = -1
+  }
+}

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -75,6 +75,40 @@ public enum AudioConstants {
 
 }
 
+// MARK: - Crash-Recovery Constants
+
+/// Tuning + format constants for the crash-recovery audio spool (#1063). A
+/// recording is streamed to an encrypted, append-only `.ewrec` file while
+/// recording so a crash / OS memory-kill / kernel panic / power loss mid-take
+/// is recoverable on the next launch. Proposed flush/watermark values; tuned
+/// with empirical evidence in PR1/PR3.
+public enum RecoveryConstants {
+  /// Subdirectory of Application Support holding spool files.
+  public static let spoolDirectoryName = "audio_recovery"
+  /// File extension for a spool file (named `<recoverySessionID>.ewrec`).
+  public static let fileExtension = "ewrec"
+  /// On-disk format version recorded in the header.
+  public static let formatVersion = 1
+
+  /// AES-256 key length in bytes.
+  public static let aesKeyByteCount = 32
+  /// Reserved nonce counter for the header settings block; audio/marker frames
+  /// start at `firstFrameNonceCounter`, so no nonce is reused under one key.
+  public static let settingsNonceCounter: UInt64 = 0
+  /// First nonce counter used by an audio/marker frame.
+  public static let firstFrameNonceCounter: UInt64 = 1
+
+  /// Audio chunk cadence — how often captured samples are flushed to a frame.
+  public static let chunkIntervalSeconds: Double = 1.0
+  /// Durable-checkpoint cadence (fsync). Also the power-loss tail-loss bound.
+  public static let flushIntervalSeconds: Double = 3.0
+  /// Stop spooling when free space drops below this, so recovery never consumes
+  /// the last disk the heart path needs (History save / ASR temp / model cache).
+  public static let lowDiskWatermarkBytes: Int64 = 1_500_000_000
+  /// Orphan spools older than this are purged on launch (TTL backstop).
+  public static let retentionDays = 30
+}
+
 // MARK: - Timing Constants
 
 public enum TimingConstants {

--- a/Sources/EnviousWisprCore/RecoverySpool.swift
+++ b/Sources/EnviousWisprCore/RecoverySpool.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+// MARK: - Crash-recovery audio spool: shared value types (#1063 PR0)
+//
+// A recording lives only in RAM until stop, so a crash / OS memory-kill /
+// kernel panic / power loss mid-take loses everything. The crash-recovery limb
+// streams captured samples to an encrypted, append-only file while recording,
+// and replays it on the next launch. These value types are the contract shared
+// across process and module boundaries:
+//   - the directive the host hands the audio helper at capture start (XPC),
+//   - the on-disk header,
+//   - the record-time settings snapshot recovery must replay under,
+//   - the decoded frame the store yields.
+// The actual cipher + frame codec is `RecoverySpoolCipher`; the helper-side
+// writer (`EnviousWisprAudio`) and host-side store (`EnviousWisprStorage`) both
+// go through it, which is why these types and the codec live in Core (the only
+// module both depend on).
+//
+// Everything here is a LIMB: nothing in this file is reachable from the heart
+// path (capture -> ASR -> paste). A malformed directive, header, or frame is
+// discarded, never fatal.
+
+/// How a spool's frames (and its settings block) are protected at rest.
+/// `aesGcm256` is the only mode shipped writers use (encryption is live from
+/// PR1); `none` is a format affordance for a degraded writer that could not
+/// obtain a key, and keeps the on-disk frame shape identical so turning
+/// encryption on is never a format rewrite.
+public enum RecoverySpoolCipherMode: String, Codable, Sendable {
+  case none = "none"
+  case aesGcm256 = "aes-gcm-256"
+}
+
+/// What a frame carries. Audio frames hold captured samples; a single terminal
+/// marker frame records WHY writing stopped so the recovered entry can be
+/// honest ("recording cut short, disk was full").
+public enum RecoveryFrameKind: UInt8, Sendable {
+  case audio = 0
+  case marker = 1
+}
+
+/// Why a spool stopped being written. Encoded in the terminal marker frame.
+public enum RecoverySpoolTerminationReason: UInt8, Codable, Sendable {
+  /// The user stopped normally; the live transcript is being saved.
+  case cleanFinalized = 0
+  /// A write failed because the volume filled up mid-recording.
+  case diskFull = 1
+  /// Spooling stopped because free space crossed the low-disk watermark.
+  case lowDiskWatermark = 2
+  /// The helper is exiting (XPC invalidation / termination) and flushed.
+  case interrupted = 3
+}
+
+/// The record-time settings recovery must replay under, NOT whatever the user
+/// has set now. Replaying a Spanish dictation under English settings would
+/// produce 45 minutes of hallucinations; this snapshot prevents that. Captured
+/// at capture start, encrypted into the spool header, read back on recovery.
+public struct RecordingSettingsSnapshot: Codable, Sendable, Equatable {
+  /// The ASR engine the recording used (recovery replays through the neutral
+  /// engine interface; this is metadata, never an identity branch).
+  public let backendType: ASRBackendType
+  /// Whether the recording's engine could detect language, captured at record
+  /// time from `adapter.capabilities.supportsLanguageDetection` (a CAPABILITY,
+  /// never an engine-identity literal). Recovery applies it to the inverse-text-
+  /// normalization gate so a recovered take is processed exactly like the live
+  /// one — a LID engine with unknown language skips ITN instead of rewriting
+  /// possibly-non-English text.
+  public let backendSupportsLanguageDetection: Bool
+  /// The decode language the user had locked (or `.auto`).
+  public let languageMode: LanguageMode
+  public let wordCorrectionEnabled: Bool
+  public let fillerRemovalEnabled: Bool
+  public let emojiFormatterEnabled: Bool
+  /// Version/hash of the custom-words vocabulary at record time, so recovery
+  /// can note when the vocabulary has since changed. Nil when unknown.
+  public let customWordsVersion: String?
+  /// Polish provider/model identity at record time (e.g. "appleIntelligence").
+  public let llmProvider: String
+  public let llmModel: String
+  /// Whether extended-thinking polish was on at record time. Recovery applies it
+  /// so a reasoning-capable provider replays under the same setting the live
+  /// dictation used, not the default off.
+  public let useExtendedThinking: Bool
+  /// Polish prompt version at record time. Nil for providers without one.
+  public let polishPromptVersion: String?
+
+  public init(
+    backendType: ASRBackendType,
+    backendSupportsLanguageDetection: Bool,
+    languageMode: LanguageMode,
+    wordCorrectionEnabled: Bool,
+    fillerRemovalEnabled: Bool,
+    emojiFormatterEnabled: Bool,
+    customWordsVersion: String? = nil,
+    llmProvider: String,
+    llmModel: String,
+    useExtendedThinking: Bool = false,
+    polishPromptVersion: String? = nil
+  ) {
+    self.backendType = backendType
+    self.backendSupportsLanguageDetection = backendSupportsLanguageDetection
+    self.languageMode = languageMode
+    self.wordCorrectionEnabled = wordCorrectionEnabled
+    self.fillerRemovalEnabled = fillerRemovalEnabled
+    self.emojiFormatterEnabled = emojiFormatterEnabled
+    self.customWordsVersion = customWordsVersion
+    self.llmProvider = llmProvider
+    self.llmModel = llmModel
+    self.useExtendedThinking = useExtendedThinking
+    self.polishPromptVersion = polishPromptVersion
+  }
+}
+
+/// The limb configuration the host hands the audio helper at capture start.
+/// Crosses the XPC boundary as `Data` (an `@objc` protocol cannot take a Swift
+/// struct), so it is `Codable`. `enabled == false` (or a nil/garbage payload)
+/// means the helper behaves exactly as it does today — no spool, no key use.
+public struct RecoverySpoolDirective: Codable, Sendable, Equatable {
+  public let enabled: Bool
+  /// The durable session key shared by the spool and its History entry. This is
+  /// the recording kernel's `SessionID`, NOT a per-XPC-call operation id, so a
+  /// crash in the save->delete window cannot duplicate a recovered transcript.
+  public let recoverySessionID: String
+  /// Absolute path to the `.ewrec` file the writer appends to.
+  public let spoolPath: String
+  /// The 32-byte AES-256 key bytes, generated host-side and persisted in the
+  /// Keychain so it survives a crash. Nil ⇒ `cipher == .none` / disabled.
+  public let keyData: Data?
+  /// Record-time settings recovery replays under.
+  public let settingsSnapshot: RecordingSettingsSnapshot
+
+  public init(
+    enabled: Bool,
+    recoverySessionID: String,
+    spoolPath: String,
+    keyData: Data?,
+    settingsSnapshot: RecordingSettingsSnapshot
+  ) {
+    self.enabled = enabled
+    self.recoverySessionID = recoverySessionID
+    self.spoolPath = spoolPath
+    self.keyData = keyData
+    self.settingsSnapshot = settingsSnapshot
+  }
+
+  public var cipherMode: RecoverySpoolCipherMode {
+    keyData == nil ? .none : .aesGcm256
+  }
+}
+
+/// The fixed, mostly-plaintext header at the top of a `.ewrec` file. The audio
+/// format is uniform across every engine (16 kHz mono Float32), so recovery can
+/// read frames even if this header is damaged — it carries provenance plus the
+/// ENCRYPTED settings block, not anything required to decode audio. The session
+/// key is keyed in the Keychain by `recoverySessionID` (also the filename), so
+/// the header never holds key material.
+public struct RecoverySpoolHeader: Codable, Sendable, Equatable {
+  public let formatVersion: Int
+  public let cipher: RecoverySpoolCipherMode
+  public let sampleRate: Double
+  public let channels: Int
+  public let recoverySessionID: String
+  public let createdAt: Date
+  public let appVersion: String
+  /// The `RecordingSettingsSnapshot` sealed with the session key (combined
+  /// nonce||ciphertext||tag). Nil when `cipher == .none`.
+  public let encryptedSettings: Data?
+
+  public init(
+    formatVersion: Int = RecoveryConstants.formatVersion,
+    cipher: RecoverySpoolCipherMode,
+    sampleRate: Double = AudioConstants.sampleRate,
+    channels: Int = AudioConstants.channels,
+    recoverySessionID: String,
+    createdAt: Date,
+    appVersion: String,
+    encryptedSettings: Data?
+  ) {
+    self.formatVersion = formatVersion
+    self.cipher = cipher
+    self.sampleRate = sampleRate
+    self.channels = channels
+    self.recoverySessionID = recoverySessionID
+    self.createdAt = createdAt
+    self.appVersion = appVersion
+    self.encryptedSettings = encryptedSettings
+  }
+}
+
+/// A single decoded frame the store yields while reconstructing the valid
+/// continuous prefix. Audio frames carry `samples`; the terminal marker frame
+/// carries `terminationReason`.
+public struct RecoveryFrame: Sendable, Equatable {
+  public let kind: RecoveryFrameKind
+  public let chunkIndex: UInt32
+  /// Index of this chunk's first sample within the whole session.
+  public let startSample: UInt64
+  public let sampleCount: UInt32
+  public let nonceCounter: UInt64
+  /// Decoded audio samples for an `.audio` frame; empty for a marker.
+  public let samples: [Float]
+  /// Termination reason for a `.marker` frame; nil for audio.
+  public let terminationReason: RecoverySpoolTerminationReason?
+
+  public init(
+    kind: RecoveryFrameKind,
+    chunkIndex: UInt32,
+    startSample: UInt64,
+    sampleCount: UInt32,
+    nonceCounter: UInt64,
+    samples: [Float],
+    terminationReason: RecoverySpoolTerminationReason?
+  ) {
+    self.kind = kind
+    self.chunkIndex = chunkIndex
+    self.startSample = startSample
+    self.sampleCount = sampleCount
+    self.nonceCounter = nonceCounter
+    self.samples = samples
+    self.terminationReason = terminationReason
+  }
+}

--- a/Sources/EnviousWisprCore/RecoverySpoolCipher.swift
+++ b/Sources/EnviousWisprCore/RecoverySpoolCipher.swift
@@ -1,0 +1,340 @@
+import CryptoKit
+import Foundation
+
+// MARK: - Crash-recovery spool cipher + frame codec (#1063 PR0)
+//
+// The on-disk `.ewrec` format is an append-only sequence of self-delimiting,
+// self-identifying frames. Recovery can rebuild the valid continuous prefix
+// from the FRAMES ALONE even if the header/index is damaged: each frame carries
+// its own length, ordering metadata, nonce, and auth tag. Any torn tail frame,
+// or any frame failing AES-GCM authentication, ends the valid prefix and is
+// discarded.
+//
+// Frame layout (big-endian fixed fields; ciphertext is the encrypted payload):
+//
+//   [payloadLength : UInt32]   bytes that follow this field = 25 + 16 + N
+//   [kind          : UInt8 ]   ┐
+//   [chunkIndex    : UInt32]   │ 25-byte fixed metadata block, authenticated
+//   [startSample   : UInt64]   │ as AES-GCM Additional Authenticated Data so
+//   [sampleCount   : UInt32]   │ reordering or tampering fails decryption
+//   [nonceCounter  : UInt64]   ┘
+//   [tag           : 16    ]   AES-GCM auth tag (zeros when cipher == .none)
+//   [ciphertext    : N     ]   encrypted payload (== plaintext when .none)
+//
+// Audio payload = little-endian Float32 samples (4 * sampleCount bytes).
+// Marker payload = one byte: `RecoverySpoolTerminationReason.rawValue`.
+//
+// Nonce uniqueness: each frame's 96-bit GCM nonce is derived from a per-session
+// monotonic `nonceCounter`, never reused under the session key (GCM nonce reuse
+// under one key is catastrophic). The header's settings block reserves
+// counter 0; audio/marker frames start at 1.
+
+/// Failure modes the writer and store map onto "drop recovery, never audio" /
+/// "discard this frame and end the valid prefix".
+public enum RecoverySpoolCipherError: Error, Equatable {
+  case missingKey
+  case invalidKeySize(Int)
+  case truncatedFrame
+  case malformedFrame
+  case authenticationFailed
+  case unsupportedFrameKind(UInt8)
+}
+
+/// Encrypts/decrypts spool frames and the header settings block. Value type so
+/// it can cross to the writer's dedicated queue and the store's background task
+/// freely; it holds only the raw key bytes and rebuilds the `SymmetricKey` per
+/// call (cheap), which keeps it unconditionally `Sendable`.
+public struct RecoverySpoolCipher: Sendable {
+  public let mode: RecoverySpoolCipherMode
+  private let keyData: Data?
+
+  /// Fixed metadata block size: kind(1) + chunkIndex(4) + startSample(8)
+  /// + sampleCount(4) + nonceCounter(8).
+  private static let metaSize = 25
+  private static let tagSize = 16
+  /// Minimum on-disk payload (empty audio frame): meta + tag + zero ciphertext.
+  private static let minPayloadLength = metaSize + tagSize
+
+  /// AAD label binding the header settings block to this format/purpose.
+  private static let settingsAAD = Data("ewrec-settings-v1".utf8)
+
+  public init(mode: RecoverySpoolCipherMode, keyData: Data?) {
+    self.mode = mode
+    self.keyData = keyData
+  }
+
+  /// Build a cipher from a directive (mode follows whether a key is present).
+  public init(directive: RecoverySpoolDirective) {
+    self.init(mode: directive.cipherMode, keyData: directive.keyData)
+  }
+
+  private func symmetricKey() throws -> SymmetricKey {
+    guard let keyData else { throw RecoverySpoolCipherError.missingKey }
+    guard keyData.count == RecoveryConstants.aesKeyByteCount else {
+      throw RecoverySpoolCipherError.invalidKeySize(keyData.count)
+    }
+    return SymmetricKey(data: keyData)
+  }
+
+  // MARK: Frame encoding
+
+  /// Encode an audio chunk into a complete on-disk frame.
+  public func encodeAudioFrame(
+    samples: [Float],
+    chunkIndex: UInt32,
+    startSample: UInt64,
+    nonceCounter: UInt64
+  ) throws -> Data {
+    try encodeFrame(
+      kind: .audio,
+      chunkIndex: chunkIndex,
+      startSample: startSample,
+      sampleCount: UInt32(samples.count),
+      nonceCounter: nonceCounter,
+      plaintext: Self.serializeSamples(samples))
+  }
+
+  /// Encode the terminal marker frame recording why writing stopped.
+  public func encodeMarkerFrame(
+    reason: RecoverySpoolTerminationReason,
+    chunkIndex: UInt32,
+    startSample: UInt64,
+    nonceCounter: UInt64
+  ) throws -> Data {
+    try encodeFrame(
+      kind: .marker,
+      chunkIndex: chunkIndex,
+      startSample: startSample,
+      sampleCount: 0,
+      nonceCounter: nonceCounter,
+      plaintext: Data([reason.rawValue]))
+  }
+
+  private func encodeFrame(
+    kind: RecoveryFrameKind,
+    chunkIndex: UInt32,
+    startSample: UInt64,
+    sampleCount: UInt32,
+    nonceCounter: UInt64,
+    plaintext: Data
+  ) throws -> Data {
+    var meta = Data(capacity: Self.metaSize)
+    meta.append(kind.rawValue)
+    meta.appendBigEndian(chunkIndex)
+    meta.appendBigEndian(startSample)
+    meta.appendBigEndian(sampleCount)
+    meta.appendBigEndian(nonceCounter)
+
+    let tag: Data
+    let ciphertext: Data
+    switch mode {
+    case .none:
+      tag = Data(repeating: 0, count: Self.tagSize)
+      ciphertext = plaintext
+    case .aesGcm256:
+      let key = try symmetricKey()
+      let sealed = try AES.GCM.seal(
+        plaintext, using: key, nonce: Self.nonce(nonceCounter), authenticating: meta)
+      tag = sealed.tag
+      ciphertext = sealed.ciphertext
+    }
+
+    let payloadLength = UInt32(Self.metaSize + Self.tagSize + ciphertext.count)
+    var frame = Data(capacity: 4 + Int(payloadLength))
+    frame.appendBigEndian(payloadLength)
+    frame.append(meta)
+    frame.append(tag)
+    frame.append(ciphertext)
+    return frame
+  }
+
+  // MARK: Frame decoding
+
+  /// Decode the frame beginning at `offset`. Returns the decoded frame and the
+  /// offset of the next frame, or `nil` when the remaining bytes are a torn
+  /// tail (the valid prefix ends here). Throws `authenticationFailed` /
+  /// `malformedFrame` for a present-but-corrupt frame, which also ends the
+  /// valid prefix.
+  public func decodeFrame(from data: Data, at offset: Int) throws -> (
+    frame: RecoveryFrame, nextOffset: Int
+  )? {
+    // `Data` slices keep their parent's indices; normalize to a 0-based view.
+    let base = data.startIndex
+    let absolute = base + offset
+    guard absolute <= data.endIndex else { return nil }
+    let remaining = data.distance(from: absolute, to: data.endIndex)
+    if remaining < 4 { return nil }  // not even a length prefix: torn tail
+
+    let payloadLength = Int(data.readBigEndianUInt32(at: absolute))
+    if payloadLength < Self.minPayloadLength { throw RecoverySpoolCipherError.malformedFrame }
+    if remaining - 4 < payloadLength { return nil }  // partial frame: torn tail
+
+    let payloadStart = absolute + 4
+    let meta = data.subdata(in: payloadStart..<payloadStart + Self.metaSize)
+    let tagStart = payloadStart + Self.metaSize
+    let tag = data.subdata(in: tagStart..<tagStart + Self.tagSize)
+    let cipherStart = tagStart + Self.tagSize
+    let ciphertext = data.subdata(in: cipherStart..<payloadStart + payloadLength)
+
+    // Parse the fixed metadata block (also the AAD).
+    let kindRaw = meta[meta.startIndex]
+    guard let kind = RecoveryFrameKind(rawValue: kindRaw) else {
+      throw RecoverySpoolCipherError.unsupportedFrameKind(kindRaw)
+    }
+    let chunkIndex = meta.readBigEndianUInt32(at: meta.startIndex + 1)
+    let startSample = meta.readBigEndianUInt64(at: meta.startIndex + 5)
+    let sampleCount = meta.readBigEndianUInt32(at: meta.startIndex + 13)
+    let nonceCounter = meta.readBigEndianUInt64(at: meta.startIndex + 17)
+
+    let plaintext: Data
+    switch mode {
+    case .none:
+      // A `.none` frame is written with an all-zero tag. A nonzero tag means
+      // this is actually an ENCRYPTED frame being decoded without its key (e.g.
+      // a damaged-header spool the store could not cipher-match) — fail closed
+      // rather than reinterpret ciphertext as raw samples (Codex PR0 P2).
+      guard tag.allSatisfy({ $0 == 0 }) else {
+        throw RecoverySpoolCipherError.authenticationFailed
+      }
+      plaintext = ciphertext
+    case .aesGcm256:
+      let key = try symmetricKey()
+      do {
+        let box = try AES.GCM.SealedBox(
+          nonce: Self.nonce(nonceCounter), ciphertext: ciphertext, tag: tag)
+        plaintext = try AES.GCM.open(box, using: key, authenticating: meta)
+      } catch {
+        // Any GCM failure (bad tag, tampered metadata, wrong key) ends the
+        // valid prefix; recovery discards this frame and everything after.
+        throw RecoverySpoolCipherError.authenticationFailed
+      }
+    }
+
+    let frame: RecoveryFrame
+    switch kind {
+    case .audio:
+      let samples = Self.deserializeSamples(plaintext, expectedCount: Int(sampleCount))
+      frame = RecoveryFrame(
+        kind: .audio, chunkIndex: chunkIndex, startSample: startSample,
+        sampleCount: sampleCount, nonceCounter: nonceCounter, samples: samples,
+        terminationReason: nil)
+    case .marker:
+      let reason = plaintext.first.flatMap(RecoverySpoolTerminationReason.init(rawValue:))
+      frame = RecoveryFrame(
+        kind: .marker, chunkIndex: chunkIndex, startSample: startSample,
+        sampleCount: 0, nonceCounter: nonceCounter, samples: [],
+        terminationReason: reason)
+    }
+    return (frame, offset + 4 + payloadLength)
+  }
+
+  // MARK: Settings block (header)
+
+  /// Seal the record-time settings snapshot for the header. Returns nil for
+  /// `.none` (the header carries no settings block when unencrypted).
+  public func sealSettings(_ snapshot: RecordingSettingsSnapshot) throws -> Data? {
+    switch mode {
+    case .none:
+      return nil
+    case .aesGcm256:
+      let key = try symmetricKey()
+      let json = try JSONEncoder().encode(snapshot)
+      let sealed = try AES.GCM.seal(
+        json, using: key,
+        nonce: Self.nonce(RecoveryConstants.settingsNonceCounter),
+        authenticating: Self.settingsAAD)
+      // `combined` is nonce || ciphertext || tag.
+      guard let combined = sealed.combined else {
+        throw RecoverySpoolCipherError.authenticationFailed
+      }
+      return combined
+    }
+  }
+
+  /// Open the header settings block. Throws on auth failure / decode failure so
+  /// recovery can fall back to current settings.
+  public func openSettings(_ data: Data) throws -> RecordingSettingsSnapshot {
+    let key = try symmetricKey()
+    let box: AES.GCM.SealedBox
+    let plaintext: Data
+    do {
+      box = try AES.GCM.SealedBox(combined: data)
+      plaintext = try AES.GCM.open(box, using: key, authenticating: Self.settingsAAD)
+    } catch {
+      throw RecoverySpoolCipherError.authenticationFailed
+    }
+    return try JSONDecoder().decode(RecordingSettingsSnapshot.self, from: plaintext)
+  }
+
+  // MARK: Primitives
+
+  /// 96-bit GCM nonce derived from a monotonic counter: four zero bytes then
+  /// the 64-bit big-endian counter. Deterministic + unique under a fresh
+  /// per-session key.
+  private static func nonce(_ counter: UInt64) -> AES.GCM.Nonce {
+    var bytes = Data(repeating: 0, count: 4)
+    bytes.appendBigEndian(counter)
+    // Exactly 12 bytes by construction (4 + 8); AES.GCM.Nonce(data:) only
+    // throws on a wrong size, so this cannot fail.
+    return try! AES.GCM.Nonce(data: bytes)
+  }
+
+  static func serializeSamples(_ samples: [Float]) -> Data {
+    var data = Data(capacity: samples.count * 4)
+    for sample in samples {
+      data.appendLittleEndian(sample.bitPattern)
+    }
+    return data
+  }
+
+  static func deserializeSamples(_ data: Data, expectedCount: Int) -> [Float] {
+    let available = data.count / 4
+    let count = min(expectedCount, available)
+    guard count > 0 else { return [] }
+    var samples = [Float]()
+    samples.reserveCapacity(count)
+    var index = data.startIndex
+    for _ in 0..<count {
+      let bits = data.readLittleEndianUInt32(at: index)
+      samples.append(Float(bitPattern: bits))
+      index += 4
+    }
+    return samples
+  }
+}
+
+// MARK: - Big/little-endian Data helpers (private to the spool codec)
+
+extension Data {
+  fileprivate mutating func appendBigEndian(_ value: UInt32) {
+    Swift.withUnsafeBytes(of: value.bigEndian) { append(contentsOf: $0) }
+  }
+  fileprivate mutating func appendBigEndian(_ value: UInt64) {
+    Swift.withUnsafeBytes(of: value.bigEndian) { append(contentsOf: $0) }
+  }
+  fileprivate mutating func appendLittleEndian(_ value: UInt32) {
+    Swift.withUnsafeBytes(of: value.littleEndian) { append(contentsOf: $0) }
+  }
+
+  fileprivate func readBigEndianUInt32(at index: Index) -> UInt32 {
+    var value: UInt32 = 0
+    for offset in 0..<4 {
+      value = (value << 8) | UInt32(self[index + offset])
+    }
+    return value
+  }
+  fileprivate func readBigEndianUInt64(at index: Index) -> UInt64 {
+    var value: UInt64 = 0
+    for offset in 0..<8 {
+      value = (value << 8) | UInt64(self[index + offset])
+    }
+    return value
+  }
+  fileprivate func readLittleEndianUInt32(at index: Index) -> UInt32 {
+    var value: UInt32 = 0
+    for offset in 0..<4 {
+      value |= UInt32(self[index + offset]) << (8 * offset)
+    }
+    return value
+  }
+}

--- a/Sources/EnviousWisprCore/RecoverySpoolFileFormat.swift
+++ b/Sources/EnviousWisprCore/RecoverySpoolFileFormat.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+// MARK: - Crash-recovery spool file framing (#1063 PR0)
+//
+// A `.ewrec` file is:
+//
+//   [magic        : 6 bytes "EWREC1"]
+//   [headerLength : UInt32 big-endian]
+//   [header JSON  : headerLength bytes]   (RecoverySpoolHeader)
+//   [frame][frame]...                     (RecoverySpoolCipher frames)
+//
+// The header carries provenance + the ENCRYPTED settings block; it is NOT a
+// required index. As long as the 10-byte magic+length prefix is intact, frames
+// are locatable even if the header JSON itself is unreadable (a damaged or
+// undecryptable settings block still yields audio — recovery then replays under
+// current settings). Both the helper-side writer and the host-side store share
+// this framing, which is why it lives in Core.
+
+/// File-level (not frame-level) framing errors.
+public enum RecoverySpoolFileError: Error, Equatable {
+  /// The file does not begin with the spool magic — not a spool file.
+  case notASpool
+  /// The header length prefix is unreadable or claims more bytes than exist.
+  case malformedHeader
+}
+
+public enum RecoverySpoolFileFormat {
+  /// 6-byte format identifier (also encodes the format generation).
+  public static let magic = Data("EWREC1".utf8)
+
+  /// Serialize the file's leading bytes: magic + length-prefixed header JSON.
+  /// Frames are appended after this by the writer.
+  public static func encodeHeader(_ header: RecoverySpoolHeader) throws -> Data {
+    let json = try JSONEncoder().encode(header)
+    var data = Data(capacity: magic.count + 4 + json.count)
+    data.append(magic)
+    let length = UInt32(json.count)
+    var bigEndian = length.bigEndian
+    withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+    data.append(json)
+    return data
+  }
+
+  /// Locate the frames and (best-effort) decode the header. A readable
+  /// magic+length prefix yields `framesOffset` even when the header JSON fails
+  /// to decode (in which case `header` is nil and recovery uses current
+  /// settings). Throws only when the file is not a spool or the prefix itself
+  /// is corrupt.
+  public static func decodeHeader(from data: Data) throws -> (
+    header: RecoverySpoolHeader?, framesOffset: Int
+  ) {
+    let base = data.startIndex
+    guard data.count >= magic.count + 4 else { throw RecoverySpoolFileError.notASpool }
+    guard data.subdata(in: base..<base + magic.count) == magic else {
+      throw RecoverySpoolFileError.notASpool
+    }
+
+    let lengthStart = base + magic.count
+    var headerLength: UInt32 = 0
+    for offset in 0..<4 {
+      headerLength = (headerLength << 8) | UInt32(data[lengthStart + offset])
+    }
+
+    let jsonStart = lengthStart + 4
+    let framesOffset = magic.count + 4 + Int(headerLength)
+    guard jsonStart + Int(headerLength) <= data.endIndex else {
+      throw RecoverySpoolFileError.malformedHeader
+    }
+
+    let json = data.subdata(in: jsonStart..<jsonStart + Int(headerLength))
+    let header = try? JSONDecoder().decode(RecoverySpoolHeader.self, from: json)
+    return (header, framesOffset)
+  }
+}

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -130,6 +130,17 @@ public struct Transcript: Codable, Identifiable, Sendable {
   public let llmProvider: String?
   public let llmModel: String?
   public var metrics: ExecutionMetrics?
+  /// Links a transcript to its crash-recovery spool (the durable kernel
+  /// `SessionID`). On a live transcript it lets the recovery scan dedup — a
+  /// spool whose id already appears in History is deleted, never re-transcribed.
+  /// On a recovered transcript it records which spool produced it. Optional for
+  /// decode-safety: pre-#1063 JSON has no key and decodes to nil (synthesized
+  /// Codable, no custom decode). #1063.
+  public let recoverySessionID: String?
+  /// True when this transcript was reconstructed from a recovered recording
+  /// after an abnormal exit — drives the History "Recovered" badge. Optional so
+  /// legacy JSON decodes to nil (treated as not-recovered). #1063.
+  public let isRecovered: Bool?
 
   public init(
     id: UUID = UUID(),
@@ -142,7 +153,9 @@ public struct Transcript: Codable, Identifiable, Sendable {
     createdAt: Date = Date(),
     llmProvider: String? = nil,
     llmModel: String? = nil,
-    metrics: ExecutionMetrics? = nil
+    metrics: ExecutionMetrics? = nil,
+    recoverySessionID: String? = nil,
+    isRecovered: Bool? = nil
   ) {
     self.id = id
     self.text = text
@@ -155,6 +168,8 @@ public struct Transcript: Codable, Identifiable, Sendable {
     self.llmProvider = llmProvider
     self.llmModel = llmModel
     self.metrics = metrics
+    self.recoverySessionID = recoverySessionID
+    self.isRecovered = isRecovered
   }
 
   /// The text to display — polished if available, otherwise raw.

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -1,0 +1,129 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import Foundation
+
+// MARK: - Recovery text-processing seam (#1063 PR0)
+//
+// Recovery must run the SAME post-ASR text chain a live dictation runs
+// (word correction -> filler removal -> emoji -> inverse text normalization ->
+// LLM polish), but OUTSIDE the live kernel. The chain's runner and steps are
+// internal to Pipeline and `TranscriptPolishService` only runs the polish step,
+// so neither is reusable from the App layer. This is the small PUBLIC seam that
+// reuses the internal `TextProcessingRunner` + the same five step instances.
+//
+// It is a limb of a limb: a recovered transcript that fails to polish lands as
+// raw text (the raw-fallback contract), exactly like a live dictation whose
+// polish limb fails.
+
+/// The outcome of running the recovery text chain on a recovered transcript.
+public struct RecoveryTextOutcome: Sendable {
+  /// The deterministic text after the non-polish steps (the raw-fallback floor).
+  public let text: String
+  /// The polished text, or nil when polish was disabled / failed / skipped.
+  public let polishedText: String?
+  /// A user-surfacable polish error, or nil. Recovery still saves `text`.
+  public let polishError: String?
+
+  public init(text: String, polishedText: String?, polishError: String?) {
+    self.text = text
+    self.polishedText = polishedText
+    self.polishError = polishError
+  }
+
+  /// What History should show — polished if available, else the raw floor.
+  public var displayText: String { polishedText ?? text }
+}
+
+/// Runs the standard five-step post-ASR text chain on a recovered transcript.
+@MainActor
+public final class RecoveryTextProcessor {
+  private let steps: LimbSteps
+  private let runner: TextProcessingRunner
+  /// The recording's locked decode language (or nil for auto), applied from the
+  /// snapshot. Recovery replays under the ORIGINAL language exactly as the live
+  /// path derives the runner language from the frozen session config — never a
+  /// caller-supplied or re-detected language (Codex PR0 P2).
+  private var recordedLanguage: String?
+
+  public init(
+    keychainManager: KeychainManager, outputClassifierHolder: OutputClassifierHolder? = nil
+  ) {
+    let llmPolish = LLMPolishStep(keychainManager: keychainManager)
+    // Standalone, like TranscriptPolishService: no live-pipeline callbacks.
+    llmPolish.onWillProcess = nil
+    llmPolish.onToken = nil
+    llmPolish.outputClassifierHolder = outputClassifierHolder
+    self.steps = LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: llmPolish)
+    self.runner = TextProcessingRunner()
+  }
+
+  /// Apply the recording's record-time settings snapshot so recovery replays
+  /// under the ORIGINAL settings (engine, language, polish provider/model, limb
+  /// toggles), NOT the user's current ones — preventing the "recorded in
+  /// Spanish, recovered under English" failure. The custom-words VOCABULARY is
+  /// not in the snapshot (only its version); PR2 reconstructs and assigns it via
+  /// `wordCorrectionStep.correctorVocabulary` separately.
+  public func applySettings(_ snapshot: RecordingSettingsSnapshot) {
+    steps.wordCorrection.wordCorrectionEnabled = snapshot.wordCorrectionEnabled
+    steps.fillerRemoval.fillerRemovalEnabled = snapshot.fillerRemovalEnabled
+    steps.emojiFormatter.emojiFormatterEnabled = snapshot.emojiFormatterEnabled
+    // Match the live ITN language gate: a LID engine with unknown language skips
+    // ITN rather than rewriting possibly-non-English text. Sourced from the
+    // record-time capability, never an engine-identity literal (Codex PR0 P2).
+    steps.inverseTextNormalization.backendSupportsLID = snapshot.backendSupportsLanguageDetection
+    steps.llmPolish.llmProvider = LLMProvider(rawValue: snapshot.llmProvider) ?? .none
+    steps.llmPolish.llmModel = snapshot.llmModel
+    steps.llmPolish.backend = snapshot.backendType
+    // Reasoning setting at record time, so a reasoning-capable provider replays
+    // under the same setting the live dictation used (Codex PR0 P2).
+    steps.llmPolish.useExtendedThinking = snapshot.useExtendedThinking
+    // No persisted language-detection result for a recovered take (mirrors
+    // TranscriptPolishService); the planner treats nil detection safely.
+    steps.llmPolish.languageDetection = nil
+    // `polishInstructions` is intentionally left at the step default: the live
+    // value (`SettingsManager.activePolishInstructions`) is the constant
+    // `.default` since the preset axis was removed (#614), so there is nothing
+    // per-recording to restore. The custom-words VOCABULARY (`correctorVocabulary`
+    // / `polishVocabulary`) is also not in the snapshot (only its version); PR2
+    // reconstructs and assigns it separately.
+    // Replay under the recording's locked decode language (or nil for auto),
+    // exactly as the live path derives the runner language from the frozen
+    // session config's languageMode. Using a caller-supplied or re-detected
+    // language instead could rewrite a locked non-English take as English
+    // (Codex PR0 P2).
+    if case .locked(let code) = snapshot.languageMode {
+      recordedLanguage = code
+    } else {
+      recordedLanguage = nil
+    }
+  }
+
+  /// Run the chain. Limb failures inside the chain (a step erroring or timing
+  /// out) are absorbed by the runner and surface as a raw-fallback outcome;
+  /// only cancellation propagates, and that too falls back to raw.
+  public func process(rawText: String, targetAppName: String? = nil) async
+    -> RecoveryTextOutcome
+  {
+    do {
+      let result = try await runner.run(
+        rawText: rawText,
+        language: recordedLanguage,
+        targetAppName: targetAppName,
+        steps: [
+          steps.wordCorrection, steps.fillerRemoval, steps.emojiFormatter,
+          steps.inverseTextNormalization, steps.llmPolish,
+        ])
+      return RecoveryTextOutcome(
+        text: result.context.text,
+        polishedText: result.context.polishedText,
+        polishError: result.polishError)
+    } catch {
+      return RecoveryTextOutcome(text: rawText, polishedText: nil, polishError: nil)
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptPolishService.swift
@@ -192,7 +192,11 @@ public final class TranscriptPolishService {
       createdAt: transcript.createdAt,
       llmProvider: provider.rawValue,
       llmModel: model,
-      metrics: transcript.metrics
+      metrics: transcript.metrics,
+      // #1063: carry the recovery metadata so re-polishing a recovered History
+      // item keeps its "Recovered" badge and its dedupe link to the spool.
+      recoverySessionID: transcript.recoverySessionID,
+      isRecovered: transcript.isRecovered
     )
 
     // Verify transcript wasn't deleted during enhancement (prevents resurrection)

--- a/Sources/EnviousWisprServices/RecoveryKeyStore.swift
+++ b/Sources/EnviousWisprServices/RecoveryKeyStore.swift
@@ -1,0 +1,244 @@
+import CryptoKit
+import EnviousWisprCore
+import Foundation
+import OSLog
+import Security
+
+// MARK: - Crash-recovery per-session key store (#1063 PR0)
+//
+// Each recording gets a fresh AES-256 key. The host generates it, persists it
+// here (so it SURVIVES a crash — an ephemeral RAM-only key could never decrypt
+// the orphan on the next launch), and hands the bytes to the helper over XPC.
+// On a clean stop or after recovery the key is destroyed.
+//
+// Distinct from `KeychainManager` (which stores customer API-key Strings and
+// rejects unknown keys): this stores raw 32-byte key Data keyed by
+// `recoverySessionID`, in its OWN keychain service.
+//
+// Two backends, mirroring `KeychainManager`: the signed release app uses the
+// data-protection keychain (`keychain-security.md`), while DEBUG, the `.dev`
+// bundle, and any unrecognized build use a 0600 file store. The file backend is
+// what unsigned `swift test` and the dev bundle exercise (DP-keychain returns
+// errSecMissingEntitlement -34018 without the signed entitlement); the
+// DP-keychain wire is proven on signed-release Live UAT.
+//
+// Off-MainActor by construction (`keychain-not-mainactor`): every method is
+// synchronous and the host calls them from a background task.
+public struct RecoveryKeyStore: Sendable {
+  enum Backend: Sendable {
+    case file
+    case keychain(service: String)
+  }
+
+  private static let productionService = "com.enviouswispr.app.recovery-keys"
+  private static let logger = Logger(subsystem: "com.enviouswispr.app", category: "RecoveryKey")
+
+  private let backend: Backend
+  private let fileDirectory: URL
+
+  public init() {
+    let directory = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".enviouswispr-recovery-keys", isDirectory: true)
+    if Self.usesFileBackendForDefaultRuntime {
+      self.init(backend: .file, fileDirectory: directory)
+    } else {
+      self.init(backend: .keychain(service: Self.productionService), fileDirectory: directory)
+    }
+  }
+
+  init(backend: Backend, fileDirectory: URL) {
+    self.backend = backend
+    self.fileDirectory = fileDirectory
+  }
+
+  /// Generate a fresh 256-bit key.
+  public static func makeKey() -> Data {
+    SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
+  }
+
+  public func store(keyData: Data, for recoverySessionID: String) throws {
+    switch backend {
+    case .file:
+      try fileStore(keyData, account: recoverySessionID)
+    case .keychain(let service):
+      try keychainStore(keyData, service: service, account: recoverySessionID)
+    }
+  }
+
+  public func retrieve(for recoverySessionID: String) throws -> Data {
+    switch backend {
+    case .file:
+      return try fileRetrieve(account: recoverySessionID)
+    case .keychain(let service):
+      return try keychainRetrieve(service: service, account: recoverySessionID)
+    }
+  }
+
+  /// Destroy a session key. Idempotent — a missing key is success.
+  public func delete(for recoverySessionID: String) throws {
+    switch backend {
+    case .file:
+      try fileDelete(account: recoverySessionID)
+    case .keychain(let service):
+      try keychainDelete(service: service, account: recoverySessionID)
+    }
+  }
+
+  // MARK: Data-protection keychain backend
+
+  private func baseQuery(service: String, account: String) -> [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+      kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+    ]
+  }
+
+  private func keychainStore(_ data: Data, service: String, account: String) throws {
+    let query = baseQuery(service: service, account: account)
+    let updateStatus = SecItemUpdate(
+      query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+    switch updateStatus {
+    case errSecSuccess:
+      return
+    case errSecItemNotFound:
+      var addQuery = query
+      addQuery[kSecValueData as String] = data
+      addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+      let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+      switch addStatus {
+      case errSecSuccess:
+        return
+      case errSecDuplicateItem:
+        // Lost an add/add race; the item now exists — overwrite it.
+        let retry = SecItemUpdate(
+          query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        guard retry == errSecSuccess else { throw RecoveryKeyStoreError.storeFailed(retry) }
+      case errSecInteractionNotAllowed:
+        throw RecoveryKeyStoreError.storeFailed(addStatus)
+      default:
+        throw RecoveryKeyStoreError.storeFailed(addStatus)
+      }
+    case errSecInteractionNotAllowed:
+      throw RecoveryKeyStoreError.storeFailed(updateStatus)
+    default:
+      throw RecoveryKeyStoreError.storeFailed(updateStatus)
+    }
+  }
+
+  private func keychainRetrieve(service: String, account: String) throws -> Data {
+    var query = baseQuery(service: service, account: account)
+    query[kSecReturnData as String] = kCFBooleanTrue
+    query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    switch status {
+    case errSecSuccess:
+      guard let data = result as? Data else { throw RecoveryKeyStoreError.invalidData }
+      return data
+    case errSecItemNotFound:
+      throw RecoveryKeyStoreError.notFound
+    case errSecInteractionNotAllowed:
+      throw RecoveryKeyStoreError.retrieveFailed(status)
+    default:
+      throw RecoveryKeyStoreError.retrieveFailed(status)
+    }
+  }
+
+  private func keychainDelete(service: String, account: String) throws {
+    let status = SecItemDelete(baseQuery(service: service, account: account) as CFDictionary)
+    switch status {
+    case errSecSuccess, errSecItemNotFound:
+      return
+    case errSecInteractionNotAllowed:
+      throw RecoveryKeyStoreError.deleteFailed(status)
+    default:
+      throw RecoveryKeyStoreError.deleteFailed(status)
+    }
+  }
+
+  // MARK: File backend (DEBUG / dev / unrecognized build)
+
+  private func fileURL(for account: String) -> URL {
+    // recoverySessionID is a UUID string; keep it filesystem-safe regardless.
+    let safe = account.replacingOccurrences(of: "/", with: "_")
+    return fileDirectory.appendingPathComponent(safe)
+  }
+
+  private func ensureFileDirectory() throws {
+    let fm = FileManager.default
+    if !fm.fileExists(atPath: fileDirectory.path) {
+      try fm.createDirectory(at: fileDirectory, withIntermediateDirectories: true)
+    }
+    try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fileDirectory.path)
+  }
+
+  private func fileStore(_ data: Data, account: String) throws {
+    try ensureFileDirectory()
+    let url = fileURL(for: account)
+    let tmpURL = fileDirectory.appendingPathComponent(".\(account).tmp")
+    let fm = FileManager.default
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      guard fd >= 0 else { throw RecoveryKeyStoreError.storeFailed(errSecIO) }
+      let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try fh.write(contentsOf: data)
+      try fh.close()
+      if fm.fileExists(atPath: url.path) {
+        _ = try fm.replaceItemAt(url, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: url)
+      }
+    } catch {
+      try? fm.removeItem(at: tmpURL)
+      throw RecoveryKeyStoreError.storeFailed(errSecIO)
+    }
+  }
+
+  private func fileRetrieve(account: String) throws -> Data {
+    let url = fileURL(for: account)
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw RecoveryKeyStoreError.notFound
+    }
+    do {
+      return try Data(contentsOf: url)
+    } catch {
+      throw RecoveryKeyStoreError.retrieveFailed(errSecIO)
+    }
+  }
+
+  private func fileDelete(account: String) throws {
+    let url = fileURL(for: account)
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else { return }
+    do {
+      try fm.removeItem(at: url)
+    } catch {
+      throw RecoveryKeyStoreError.deleteFailed(errSecIO)
+    }
+  }
+
+  // MARK: Backend selection (mirrors KeychainManager — fail closed to file)
+
+  private static let productionKeychainBundleIDs: Set<String> = ["com.enviouswispr.app"]
+
+  private static var usesFileBackendForDefaultRuntime: Bool {
+    #if DEBUG
+      return true
+    #else
+      guard let bundleID = Bundle.main.bundleIdentifier else { return true }
+      return !productionKeychainBundleIDs.contains(bundleID)
+    #endif
+  }
+}
+
+public enum RecoveryKeyStoreError: Error, Equatable {
+  case storeFailed(OSStatus)
+  case retrieveFailed(OSStatus)
+  case deleteFailed(OSStatus)
+  case notFound
+  case invalidData
+}

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -52,6 +52,11 @@ enum SettingsDefaultValues {
   // surprise emoji, just gain the explicit-trigger capability.
   static let emojiFormatterEnabled = true
 
+  // #1063: crash-recovery audio safety copy. Default ON — every recording is
+  // protected by an encrypted, auto-deleted-on-success spool. Off means never
+  // persist audio (the privacy-strict choice).
+  static let crashRecoveryEnabled = true
+
   static let isDebugModeEnabled = false
   static let debugLogLevel: DebugLogLevel = .info
   static let useExtendedThinking = false

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -29,6 +29,7 @@ public final class SettingsManager {
     case wordCorrectionEnabled
     case fillerRemovalEnabled
     case emojiFormatterEnabled
+    case crashRecoveryEnabled
     case contactsSyncOnLaunchEnabled
     case isDebugModeEnabled
     case debugLogLevel
@@ -62,7 +63,8 @@ public final class SettingsManager {
     "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
     "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
     "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
-    "emojiFormatterEnabled", "contactsSyncOnLaunchEnabled", "isDebugModeEnabled", "debugLogLevel",
+    "emojiFormatterEnabled", "crashRecoveryEnabled", "contactsSyncOnLaunchEnabled",
+    "isDebugModeEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
     "useStreamingASR", "warmEnginePolicy", "appearancePreference",
@@ -258,6 +260,17 @@ public final class SettingsManager {
     didSet {
       defaults.set(emojiFormatterEnabled, forKey: "emojiFormatterEnabled")
       onChange?(.emojiFormatterEnabled)
+    }
+  }
+
+  /// Crash-recovery audio safety copy (#1063). Default ON. When on, every
+  /// recording is streamed to an encrypted spool that is deleted on a clean
+  /// stop and replayed into History after an abnormal exit; off means audio is
+  /// never persisted.
+  public var crashRecoveryEnabled: Bool {
+    didSet {
+      defaults.set(crashRecoveryEnabled, forKey: "crashRecoveryEnabled")
+      onChange?(.crashRecoveryEnabled)
     }
   }
 
@@ -485,6 +498,9 @@ public final class SettingsManager {
     emojiFormatterEnabled =
       defaults.object(forKey: "emojiFormatterEnabled") as? Bool
       ?? SettingsDefaultValues.emojiFormatterEnabled
+    crashRecoveryEnabled =
+      defaults.object(forKey: "crashRecoveryEnabled") as? Bool
+      ?? SettingsDefaultValues.crashRecoveryEnabled
     isDebugModeEnabled =
       defaults.object(forKey: "isDebugModeEnabled") as? Bool
       ?? SettingsDefaultValues.isDebugModeEnabled

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -1,0 +1,211 @@
+import EnviousWisprCore
+import Foundation
+
+/// The host-side reader/janitor for crash-recovery audio spools (#1063).
+///
+/// The helper-side `RecoverySpoolWriter` produces encrypted, append-only
+/// `.ewrec` files while recording; this store owns the directory and the
+/// read/scan/delete side the host needs on launch: find orphans, reconstruct
+/// the valid continuous prefix from a spool, and delete a spool once its
+/// transcript is durably saved.
+///
+/// Privacy posture mirrors `TranscriptStore` (V3 audit #561/#562) and adds
+/// backup exclusion: directory 0700, `.metadata_never_index` so Spotlight does
+/// not index it, and `isExcludedFromBackup` so spools never land in Time
+/// Machine / iCloud backups.
+///
+/// Not `@MainActor`: decoding a 60-minute spool is ~230 MB of work the caller
+/// runs on a background task. Synchronous, `Sendable`, holds only a URL.
+public struct RecoverySpoolStore: Sendable {
+  private let directory: URL
+
+  public init() {
+    directory = AppConstants.appSupportURL
+      .appendingPathComponent(RecoveryConstants.spoolDirectoryName, isDirectory: true)
+    Self.prepareDirectory(at: directory)
+  }
+
+  // Tests inject a private directory. Public so `import EnviousWisprStorage`
+  // tests can point the store at a temp dir without `@testable`.
+  public init(directory: URL) {
+    self.directory = directory
+    Self.prepareDirectory(at: directory)
+  }
+
+  public var directoryURL: URL { directory }
+
+  /// Absolute path the host hands the helper for a session's spool.
+  public func spoolURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent("\(recoverySessionID).\(RecoveryConstants.fileExtension)")
+  }
+
+  /// The `recoverySessionID`s of every spool file currently on disk.
+  public func listSpoolSessionIDs() throws -> [String] {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: directory.path) else { return [] }
+    let entries = try fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+    return
+      entries
+      .filter { $0.pathExtension == RecoveryConstants.fileExtension }
+      .map { $0.deletingPathExtension().lastPathComponent }
+      .sorted()
+  }
+
+  /// Read just the provenance header without decoding frames. Returns nil when
+  /// the header JSON is unreadable but the file is still a spool (recovery can
+  /// then proceed on frames alone). Throws `notASpool` for a non-spool file.
+  public func readHeader(for recoverySessionID: String) throws -> RecoverySpoolHeader? {
+    let url = spoolURL(for: recoverySessionID)
+    let data = try Data(contentsOf: url, options: .mappedIfSafe)
+    return try RecoverySpoolFileFormat.decodeHeader(from: data).header
+  }
+
+  /// Reconstruct the valid continuous prefix of a spool. Walks frames in order,
+  /// stopping at the first torn, out-of-sequence, or authentication-failing
+  /// frame (the recovered duration is honest about where it stopped). The
+  /// `cipher` must carry the session key for an encrypted spool.
+  public func recover(recoverySessionID: String, cipher: RecoverySpoolCipher) throws
+    -> RecoveredSpool
+  {
+    let url = spoolURL(for: recoverySessionID)
+    let data = try Data(contentsOf: url, options: .mappedIfSafe)
+    let (header, framesOffset) = try RecoverySpoolFileFormat.decodeHeader(from: data)
+
+    // Fail closed on a cipher-mode mismatch. Decoding an encrypted spool with a
+    // `.none` cipher (e.g. after a failed key lookup) would read ciphertext as
+    // raw Float32 samples and emit GARBAGE audio instead of refusing. If the
+    // header declares a cipher, the caller's cipher must match it before we walk
+    // a single frame (Codex PR0 P2).
+    if let header, header.cipher != cipher.mode {
+      return RecoveredSpool(
+        recoverySessionID: recoverySessionID, header: header, settings: nil,
+        samples: [], frameCount: 0, terminationReason: nil, truncated: true)
+    }
+
+    let settings: RecordingSettingsSnapshot? = {
+      guard let encrypted = header?.encryptedSettings else { return nil }
+      return try? cipher.openSettings(encrypted)
+    }()
+
+    var samples: [Float] = []
+    var frameCount = 0
+    var expectedChunkIndex: UInt32 = 0
+    var expectedStartSample: UInt64 = 0
+    var terminationReason: RecoverySpoolTerminationReason?
+    // A spool is "complete" ONLY if it ends with a clean-finalize marker. Every
+    // other outcome — a non-clean marker, a torn/corrupt/out-of-sequence tail,
+    // or EOF with NO marker (the common crash case: the app died before
+    // `finalize`) — is truncated, so a recovered take never looks complete when
+    // it ended abnormally (Codex PR0 P2).
+    var sawCleanFinalize = false
+    var offset = framesOffset
+
+    loop: while offset < data.count {
+      let decoded: (frame: RecoveryFrame, nextOffset: Int)?
+      do {
+        decoded = try cipher.decodeFrame(from: data, at: offset)
+      } catch {
+        // A present-but-corrupt frame ends the valid prefix.
+        break loop
+      }
+      guard let (frame, nextOffset) = decoded else {
+        // Torn tail (partial frame): nothing more is trustworthy.
+        break loop
+      }
+
+      switch frame.kind {
+      case .audio:
+        // Continuity guard: a gap or reordering ends the prefix.
+        guard frame.chunkIndex == expectedChunkIndex, frame.startSample == expectedStartSample
+        else { break loop }
+        samples.append(contentsOf: frame.samples)
+        expectedStartSample += UInt64(frame.sampleCount)
+        expectedChunkIndex += 1
+        frameCount += 1
+      case .marker:
+        // Continuity guard (same as audio): a marker reached after a gap or
+        // reorder is NOT a clean ending.
+        guard frame.chunkIndex == expectedChunkIndex, frame.startSample == expectedStartSample
+        else { break loop }
+        terminationReason = frame.terminationReason
+        sawCleanFinalize = frame.terminationReason == .cleanFinalized
+        // A marker is terminal; anything after it is ignored.
+        break loop
+      }
+      offset = nextOffset
+    }
+
+    return RecoveredSpool(
+      recoverySessionID: recoverySessionID,
+      header: header,
+      settings: settings,
+      samples: samples,
+      frameCount: frameCount,
+      terminationReason: terminationReason,
+      truncated: !sawCleanFinalize)
+  }
+
+  /// Delete a spool file. Idempotent — a missing file is success.
+  public func delete(recoverySessionID: String) throws {
+    let url = spoolURL(for: recoverySessionID)
+    do {
+      try FileManager.default.removeItem(at: url)
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+      return
+    }
+  }
+
+  /// Create the directory at 0700, drop the Spotlight marker, and exclude it
+  /// from backups. Re-enforced on every init. Soft-fails on any filesystem
+  /// operation — better to lose a privacy guarantee than crash a limb.
+  private static func prepareDirectory(at directory: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+    try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    let marker = directory.appendingPathComponent(".metadata_never_index")
+    if !fm.fileExists(atPath: marker.path) {
+      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
+    }
+    var mutableDirectory = directory
+    var values = URLResourceValues()
+    values.isExcludedFromBackup = true
+    try? mutableDirectory.setResourceValues(values)
+  }
+}
+
+/// The reconstructed result of a recovery read: the valid continuous prefix of
+/// captured audio plus the provenance the recovery flow needs.
+public struct RecoveredSpool: Sendable {
+  public let recoverySessionID: String
+  /// Provenance header, or nil if its JSON was unreadable (audio still recovers).
+  public let header: RecoverySpoolHeader?
+  /// Record-time settings, decrypted from the header. Nil ⇒ replay under
+  /// current settings.
+  public let settings: RecordingSettingsSnapshot?
+  /// The recovered audio samples (16 kHz mono Float32).
+  public let samples: [Float]
+  /// Number of audio frames in the valid prefix.
+  public let frameCount: Int
+  /// Why writing stopped, if a terminal marker was present.
+  public let terminationReason: RecoverySpoolTerminationReason?
+  /// True when a torn / corrupt / out-of-sequence tail was discarded.
+  public let truncated: Bool
+
+  public init(
+    recoverySessionID: String,
+    header: RecoverySpoolHeader?,
+    settings: RecordingSettingsSnapshot?,
+    samples: [Float],
+    frameCount: Int,
+    terminationReason: RecoverySpoolTerminationReason?,
+    truncated: Bool
+  ) {
+    self.recoverySessionID = recoverySessionID
+    self.header = header
+    self.settings = settings
+    self.samples = samples
+    self.frameCount = frameCount
+    self.terminationReason = terminationReason
+    self.truncated = truncated
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryKeyStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryKeyStoreTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Security
+import Testing
+
+@testable import EnviousWisprServices
+
+/// The per-session key store (#1063 PR0). The file backend (what unsigned
+/// `swift test` and the dev bundle use) is always exercised; the data-protection
+/// keychain backend is gated behind an entitlement probe and skips honestly on
+/// an unsigned binary (`keychain-security.md` — DP keychain returns
+/// errSecMissingEntitlement -34018 without the signed entitlement). The signed
+/// wire is proven on release Live UAT.
+@Suite("Recovery key store (#1063)")
+struct RecoveryKeyStoreTests {
+
+  private func makeFileStore() -> RecoveryKeyStore {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ewrec-keys-\(UUID().uuidString)", isDirectory: true)
+    return RecoveryKeyStore(backend: .file, fileDirectory: dir)
+  }
+
+  @Test("a generated key is 256 bits")
+  func generatedKeyIs256Bits() {
+    #expect(RecoveryKeyStore.makeKey().count == 32)
+  }
+
+  @Test("file backend: store, retrieve, then destroy a session key")
+  func fileBackendLifecycle() throws {
+    let store = makeFileStore()
+    let key = RecoveryKeyStore.makeKey()
+    let sessionID = UUID().uuidString
+
+    try store.store(keyData: key, for: sessionID)
+    #expect(try store.retrieve(for: sessionID) == key)
+
+    try store.delete(for: sessionID)
+    #expect(throws: RecoveryKeyStoreError.notFound) {
+      _ = try store.retrieve(for: sessionID)
+    }
+    // Destroy is idempotent.
+    try store.delete(for: sessionID)
+  }
+
+  @Test("file backend: storing twice overwrites, never duplicates")
+  func fileBackendOverwrites() throws {
+    let store = makeFileStore()
+    let sessionID = UUID().uuidString
+    try store.store(keyData: RecoveryKeyStore.makeKey(), for: sessionID)
+    let second = RecoveryKeyStore.makeKey()
+    try store.store(keyData: second, for: sessionID)
+    #expect(try store.retrieve(for: sessionID) == second)
+  }
+
+  @Test("retrieving an unknown session key throws notFound")
+  func fileBackendUnknownKey() {
+    let store = makeFileStore()
+    #expect(throws: RecoveryKeyStoreError.notFound) {
+      _ = try store.retrieve(for: UUID().uuidString)
+    }
+  }
+
+  // MARK: Data-protection keychain (entitlement-gated)
+
+  /// One-time probe: can this (signed) binary use the DP keychain at all?
+  private static let hasDataProtectionKeychainEntitlement: Bool = {
+    let service = "ew.recovery.probe.\(UUID().uuidString)"
+    let add: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: "probe",
+      kSecValueData as String: Data([1]),
+      kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    ]
+    let status = SecItemAdd(add as CFDictionary, nil)
+    guard status == errSecSuccess else { return false }
+    SecItemDelete(
+      [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: "probe",
+        kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any,
+      ] as CFDictionary)
+    return true
+  }()
+
+  @Test(
+    "DP keychain: store, retrieve, destroy on a signed build",
+    .enabled(if: RecoveryKeyStoreTests.hasDataProtectionKeychainEntitlement))
+  func keychainBackendLifecycle() throws {
+    let service = "com.enviouswispr.app.recovery-keys.test.\(UUID().uuidString)"
+    let store = RecoveryKeyStore(
+      backend: .keychain(service: service),
+      fileDirectory: FileManager.default.temporaryDirectory)
+    let sessionID = UUID().uuidString
+    let key = RecoveryKeyStore.makeKey()
+    defer { try? store.delete(for: sessionID) }
+
+    try store.store(keyData: key, for: sessionID)
+    #expect(try store.retrieve(for: sessionID) == key)
+    try store.delete(for: sessionID)
+    #expect(throws: RecoveryKeyStoreError.notFound) {
+      _ = try store.retrieve(for: sessionID)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolCodecTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolCodecTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// The crash-recovery spool cipher + frame codec (#1063 PR0). Proves the
+/// encrypted, append-only frame format round-trips, authenticates its metadata,
+/// and degrades safely on corruption — the foundation everything else builds on.
+@Suite("Recovery spool codec (#1063)")
+struct RecoverySpoolCodecTests {
+
+  private static func key(_ byte: UInt8 = 7) -> Data {
+    Data(repeating: byte, count: RecoveryConstants.aesKeyByteCount)
+  }
+
+  private static let sampleChunk: [Float] = [0.0, 0.1, -0.25, 0.5, -1.0, 0.333_25]
+
+  private func snapshot() -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: .parakeet,
+      backendSupportsLanguageDetection: false,
+      languageMode: .auto,
+      wordCorrectionEnabled: true,
+      fillerRemovalEnabled: true,
+      emojiFormatterEnabled: false,
+      customWordsVersion: "v3",
+      llmProvider: "appleIntelligence",
+      llmModel: "apple-intelligence",
+      useExtendedThinking: true,
+      polishPromptVersion: "v38")
+  }
+
+  @Test("an audio frame round-trips bit-exact under AES-GCM")
+  func audioFrameRoundTrips() throws {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let frame = try cipher.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 3, startSample: 48_000, nonceCounter: 4)
+    let decoded = try #require(try cipher.decodeFrame(from: frame, at: 0))
+    #expect(decoded.frame.kind == .audio)
+    #expect(decoded.frame.samples == Self.sampleChunk)
+    #expect(decoded.frame.chunkIndex == 3)
+    #expect(decoded.frame.startSample == 48_000)
+    #expect(decoded.frame.sampleCount == UInt32(Self.sampleChunk.count))
+    #expect(decoded.nextOffset == frame.count)
+  }
+
+  @Test("a marker frame round-trips its termination reason")
+  func markerFrameRoundTrips() throws {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let frame = try cipher.encodeMarkerFrame(
+      reason: .diskFull, chunkIndex: 9, startSample: 1_000, nonceCounter: 10)
+    let decoded = try #require(try cipher.decodeFrame(from: frame, at: 0))
+    #expect(decoded.frame.kind == .marker)
+    #expect(decoded.frame.terminationReason == .diskFull)
+  }
+
+  @Test("the unencrypted format affordance also round-trips")
+  func noneModeRoundTrips() throws {
+    let cipher = RecoverySpoolCipher(mode: .none, keyData: nil)
+    let frame = try cipher.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    let decoded = try #require(try cipher.decodeFrame(from: frame, at: 0))
+    #expect(decoded.frame.samples == Self.sampleChunk)
+  }
+
+  @Test("tampering with authenticated metadata fails decryption")
+  func tamperedMetadataFailsAuth() throws {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    var frame = try cipher.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    // Byte 6 lies inside the metadata block (the AAD), after the 4-byte length.
+    frame[frame.startIndex + 6] ^= 0xFF
+    #expect(throws: RecoverySpoolCipherError.authenticationFailed) {
+      _ = try cipher.decodeFrame(from: frame, at: 0)
+    }
+  }
+
+  @Test("a frame written under one key does not open under another")
+  func wrongKeyFailsAuth() throws {
+    let writer = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key(1))
+    let reader = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key(2))
+    let frame = try writer.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    #expect(throws: RecoverySpoolCipherError.authenticationFailed) {
+      _ = try reader.decodeFrame(from: frame, at: 0)
+    }
+  }
+
+  @Test("a `.none` cipher refuses an encrypted (nonzero-tag) frame")
+  func noneCipherRejectsEncryptedFrame() throws {
+    // Defense-in-depth for the header-unreadable path the store cannot guard:
+    // an encrypted frame carries a real GCM tag, so a `.none` decode must fail
+    // closed instead of reinterpreting ciphertext as raw samples.
+    let aes = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let frame = try aes.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    let none = RecoverySpoolCipher(mode: .none, keyData: nil)
+    #expect(throws: RecoverySpoolCipherError.authenticationFailed) {
+      _ = try none.decodeFrame(from: frame, at: 0)
+    }
+  }
+
+  @Test("a torn tail frame decodes to nil, not an error")
+  func tornTailReturnsNil() throws {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    var frame = try cipher.encodeAudioFrame(
+      samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    frame.removeLast(3)  // a partially-flushed final frame
+    let decoded = try cipher.decodeFrame(from: frame, at: 0)
+    #expect(decoded == nil)
+  }
+
+  @Test("missing key surfaces as a typed error, never a crash")
+  func missingKeyThrows() {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: nil)
+    #expect(throws: RecoverySpoolCipherError.missingKey) {
+      _ = try cipher.encodeAudioFrame(
+        samples: Self.sampleChunk, chunkIndex: 0, startSample: 0, nonceCounter: 1)
+    }
+  }
+
+  @Test("the header settings block round-trips and is key-bound")
+  func settingsBlockRoundTrips() throws {
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let sealed = try #require(try cipher.sealSettings(snapshot()))
+    let opened = try cipher.openSettings(sealed)
+    #expect(opened == snapshot())
+
+    let wrongReader = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key(99))
+    #expect(throws: RecoverySpoolCipherError.authenticationFailed) {
+      _ = try wrongReader.openSettings(sealed)
+    }
+  }
+
+  @Test("the file header round-trips and locates the frames")
+  func fileHeaderRoundTrips() throws {
+    let header = RecoverySpoolHeader(
+      cipher: .aesGcm256,
+      recoverySessionID: "session-abc",
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+      appVersion: "1.2.3",
+      encryptedSettings: Data([1, 2, 3]))
+    let encoded = try RecoverySpoolFileFormat.encodeHeader(header)
+    let decoded = try RecoverySpoolFileFormat.decodeHeader(from: encoded)
+    #expect(decoded.header == header)
+    #expect(decoded.framesOffset == encoded.count)
+  }
+
+  @Test("a non-spool file is rejected as notASpool")
+  func nonSpoolRejected() {
+    let garbage = Data(repeating: 0xAB, count: 64)
+    #expect(throws: RecoverySpoolFileError.notASpool) {
+      _ = try RecoverySpoolFileFormat.decodeHeader(from: garbage)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -1,0 +1,205 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+/// The host-side `RecoverySpoolStore` (#1063 PR0): reading a writer-produced
+/// spool back, reconstructing the valid continuous prefix, decoding the
+/// settings block, and the scan/delete lifecycle.
+@Suite("Recovery spool store (#1063)")
+struct RecoverySpoolStoreTests {
+
+  private static func key(_ byte: UInt8 = 11) -> Data {
+    Data(repeating: byte, count: RecoveryConstants.aesKeyByteCount)
+  }
+
+  private func makeStore() -> RecoverySpoolStore {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ewrec-tests-\(UUID().uuidString)", isDirectory: true)
+    return RecoverySpoolStore(directory: dir)
+  }
+
+  private func snapshot() -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: .whisperKit,
+      backendSupportsLanguageDetection: true,
+      languageMode: .locked("es"),
+      wordCorrectionEnabled: false,
+      fillerRemovalEnabled: true,
+      emojiFormatterEnabled: false,
+      customWordsVersion: nil,
+      llmProvider: "openAI",
+      llmModel: "gpt-4o-mini",
+      polishPromptVersion: nil)
+  }
+
+  /// Drive the real writer to disk and await the serial queue draining.
+  private func writeSpool(
+    store: RecoverySpoolStore,
+    sessionID: String,
+    cipher: RecoverySpoolCipher,
+    chunks: [[Float]],
+    reason: RecoverySpoolTerminationReason
+  ) async {
+    let writer = RecoverySpoolWriter(
+      recoverySessionID: sessionID,
+      spoolURL: store.spoolURL(for: sessionID),
+      cipher: cipher,
+      settings: snapshot(),
+      appVersion: "1.0.0",
+      createdAt: Date(timeIntervalSince1970: 0))
+    writer.start()
+    for chunk in chunks { writer.append(chunk) }
+    await withCheckedContinuation { continuation in
+      writer.finalize(reason: reason) { continuation.resume() }
+    }
+  }
+
+  @Test("a writer-produced spool round-trips through the store")
+  func writerOutputRoundTrips() async throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let chunks: [[Float]] = [[0.1, 0.2], [-0.3, 0.4, 0.5], [0.6]]
+    await writeSpool(
+      store: store, sessionID: "round-trip", cipher: cipher, chunks: chunks,
+      reason: .cleanFinalized)
+
+    let recovered = try store.recover(recoverySessionID: "round-trip", cipher: cipher)
+    #expect(recovered.samples == chunks.flatMap { $0 })
+    #expect(recovered.frameCount == chunks.count)
+    #expect(recovered.terminationReason == .cleanFinalized)
+    #expect(recovered.truncated == false)
+    #expect(recovered.settings == snapshot())
+  }
+
+  @Test("recovery keeps the valid prefix when a later frame is corrupt")
+  func recoverKeepsValidPrefix() throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let c0: [Float] = [0.1, 0.2, 0.3]
+    let c1: [Float] = [0.4, 0.5]
+    let c2: [Float] = [0.6, 0.7, 0.8]
+
+    var data = try RecoverySpoolFileFormat.encodeHeader(
+      RecoverySpoolHeader(
+        cipher: .aesGcm256, recoverySessionID: "prefix",
+        createdAt: Date(timeIntervalSince1970: 0), appVersion: "1.0",
+        encryptedSettings: try cipher.sealSettings(snapshot())))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c0, chunkIndex: 0, startSample: 0, nonceCounter: 1))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c1, chunkIndex: 1, startSample: 3, nonceCounter: 2))
+    var corrupt = try cipher.encodeAudioFrame(
+      samples: c2, chunkIndex: 2, startSample: 5, nonceCounter: 3)
+    corrupt[corrupt.startIndex + 6] ^= 0xFF  // tamper a metadata byte → auth fails
+    data.append(corrupt)
+    try data.write(to: store.spoolURL(for: "prefix"))
+
+    let recovered = try store.recover(recoverySessionID: "prefix", cipher: cipher)
+    #expect(recovered.samples == c0 + c1)
+    #expect(recovered.frameCount == 2)
+    #expect(recovered.truncated)
+  }
+
+  @Test("an out-of-sequence terminal marker is truncation, not a clean stop")
+  func outOfSequenceMarkerIsTruncation() throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let c0: [Float] = [0.1, 0.2, 0.3]
+
+    var data = try RecoverySpoolFileFormat.encodeHeader(
+      RecoverySpoolHeader(
+        cipher: .aesGcm256, recoverySessionID: "gap-marker",
+        createdAt: Date(timeIntervalSince1970: 0), appVersion: "1.0",
+        encryptedSettings: try cipher.sealSettings(snapshot())))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c0, chunkIndex: 0, startSample: 0, nonceCounter: 1))
+    // A readable marker that claims a position past a missing middle frame.
+    data.append(
+      try cipher.encodeMarkerFrame(
+        reason: .cleanFinalized, chunkIndex: 5, startSample: 999, nonceCounter: 2))
+    try data.write(to: store.spoolURL(for: "gap-marker"))
+
+    let recovered = try store.recover(recoverySessionID: "gap-marker", cipher: cipher)
+    #expect(recovered.samples == c0)
+    #expect(recovered.frameCount == 1)
+    #expect(recovered.truncated)
+    #expect(recovered.terminationReason == nil)  // NOT reported as a clean finalize
+  }
+
+  @Test("the wrong key yields an empty prefix, never a crash")
+  func wrongKeyEmptyPrefix() async throws {
+    let store = makeStore()
+    let writeCipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key(1))
+    await writeSpool(
+      store: store, sessionID: "badkey", cipher: writeCipher, chunks: [[0.1, 0.2]],
+      reason: .cleanFinalized)
+
+    let readCipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key(2))
+    let recovered = try store.recover(recoverySessionID: "badkey", cipher: readCipher)
+    #expect(recovered.samples.isEmpty)
+    #expect(recovered.truncated)
+  }
+
+  @Test("a markerless crash spool is reported as truncated, not complete")
+  func markerlessCrashSpoolIsTruncated() throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let c0: [Float] = [0.1, 0.2]
+    let c1: [Float] = [0.3, 0.4]
+
+    var data = try RecoverySpoolFileFormat.encodeHeader(
+      RecoverySpoolHeader(
+        cipher: .aesGcm256, recoverySessionID: "crash",
+        createdAt: Date(timeIntervalSince1970: 0), appVersion: "1.0",
+        encryptedSettings: try cipher.sealSettings(snapshot())))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c0, chunkIndex: 0, startSample: 0, nonceCounter: 1))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c1, chunkIndex: 1, startSample: 2, nonceCounter: 2))
+    // No terminal marker: the app died before finalize ran — the common crash
+    // case this whole feature exists for.
+    try data.write(to: store.spoolURL(for: "crash"))
+
+    let recovered = try store.recover(recoverySessionID: "crash", cipher: cipher)
+    #expect(recovered.samples == c0 + c1)
+    #expect(recovered.frameCount == 2)
+    #expect(recovered.truncated)  // ended abnormally — not a clean finalize
+    #expect(recovered.terminationReason == nil)
+  }
+
+  @Test("decoding an encrypted spool with the wrong cipher mode fails closed")
+  func cipherModeMismatchFailsClosed() async throws {
+    let store = makeStore()
+    let aesCipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    await writeSpool(
+      store: store, sessionID: "mismatch", cipher: aesCipher, chunks: [[0.1, 0.2, 0.3]],
+      reason: .cleanFinalized)
+
+    // A caller that lost the key and fell back to `.none` must get NOTHING, not
+    // ciphertext reinterpreted as raw samples.
+    let noneCipher = RecoverySpoolCipher(mode: .none, keyData: nil)
+    let recovered = try store.recover(recoverySessionID: "mismatch", cipher: noneCipher)
+    #expect(recovered.samples.isEmpty)
+    #expect(recovered.truncated)
+  }
+
+  @Test("scan finds written spools; delete removes them idempotently")
+  func scanAndDelete() async throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    await writeSpool(
+      store: store, sessionID: "alpha", cipher: cipher, chunks: [[0.1]],
+      reason: .cleanFinalized)
+    await writeSpool(
+      store: store, sessionID: "beta", cipher: cipher, chunks: [[0.2]],
+      reason: .cleanFinalized)
+
+    #expect(try store.listSpoolSessionIDs() == ["alpha", "beta"])
+    try store.delete(recoverySessionID: "alpha")
+    #expect(try store.listSpoolSessionIDs() == ["beta"])
+    // Idempotent: deleting a missing spool is success.
+    try store.delete(recoverySessionID: "alpha")
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolWriterTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolWriterTests.swift
@@ -1,0 +1,107 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// The helper-side `RecoverySpoolWriter` (#1063 PR0) is a strict limb: every
+/// failure path drops recovery and leaves the caller (the audio path)
+/// untouched. These tests drive the fail-open and load-shedding behavior with
+/// controllable sinks — no real-time sleeps (`tests-no-real-time-scheduling`).
+@Suite("Recovery spool writer (#1063)")
+struct RecoverySpoolWriterTests {
+
+  private static func key() -> Data {
+    Data(repeating: 5, count: RecoveryConstants.aesKeyByteCount)
+  }
+
+  private func snapshot() -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: .parakeet, backendSupportsLanguageDetection: false, languageMode: .auto,
+      wordCorrectionEnabled: false, fillerRemovalEnabled: false,
+      emojiFormatterEnabled: false, customWordsVersion: nil,
+      llmProvider: "none", llmModel: "none", polishPromptVersion: nil)
+  }
+
+  /// Fails the Nth write (1 = header). Lets us simulate a disk-full mid-spool.
+  private final class ThrowingSink: RecoverySpoolFileSink, @unchecked Sendable {
+    private let failOnWrite: Int
+    private let lock = NSLock()
+    private var writes = 0
+    init(failOnWrite: Int) { self.failOnWrite = failOnWrite }
+    func open() throws {}
+    func write(_ data: Data) throws {
+      lock.lock()
+      writes += 1
+      let current = writes
+      lock.unlock()
+      if current == failOnWrite { throw RecoverySpoolWriterError.syncFailed(28) }
+    }
+    func sync() throws {}
+    func close() {}
+  }
+
+  /// Blocks inside `open()` until released, so the write queue stalls and
+  /// pending bytes accumulate deterministically.
+  private final class GatedSink: RecoverySpoolFileSink, @unchecked Sendable {
+    private let gate = DispatchSemaphore(value: 0)
+    func release() { gate.signal() }
+    func open() throws { gate.wait() }
+    func write(_ data: Data) throws {}
+    func sync() throws {}
+    func close() {}
+  }
+
+  private func awaitFinalize(_ writer: RecoverySpoolWriter, reason: RecoverySpoolTerminationReason)
+    async
+  {
+    await withCheckedContinuation { continuation in
+      writer.finalize(reason: reason) { continuation.resume() }
+    }
+  }
+
+  @Test("an audio write failure stops spooling without throwing to the caller")
+  func writeFailureStopsSpoolFailOpen() async {
+    let writer = RecoverySpoolWriter(
+      recoverySessionID: "fail-open",
+      cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()),
+      settings: snapshot(),
+      sink: ThrowingSink(failOnWrite: 2))  // header ok, first audio frame throws
+    writer.start()
+    writer.append([0.1, 0.2])  // triggers the failing write — must not throw
+    await awaitFinalize(writer, reason: .cleanFinalized)
+    #expect(writer.isHealthy == false)
+  }
+
+  @Test("backpressure sheds recovery when the queue backs up, never the caller")
+  func backpressureShedsLoad() async {
+    let gate = GatedSink()
+    let writer = RecoverySpoolWriter(
+      recoverySessionID: "backpressure",
+      cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()),
+      settings: snapshot(),
+      sink: gate,
+      maxPendingBytes: 8)  // one 2-sample chunk fits; a second overflows
+    writer.start()  // queue blocks inside open()
+    writer.append([0.1, 0.2])  // 8 bytes — admitted, queued behind the gate
+    writer.append([0.3])  // would push pending to 12 > 8 — dropped, spool stops
+    #expect(writer.isHealthy == false)
+    gate.release()
+    await awaitFinalize(writer, reason: .cleanFinalized)
+  }
+
+  @Test("a clean spool to a real file reports healthy")
+  func cleanSpoolStaysHealthy() async {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ewrec-writer-\(UUID().uuidString).ewrec")
+    let writer = RecoverySpoolWriter(
+      recoverySessionID: "healthy",
+      spoolURL: url,
+      cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()),
+      settings: snapshot())
+    writer.start()
+    writer.append([0.1, 0.2, 0.3])
+    await awaitFinalize(writer, reason: .cleanFinalized)
+    #expect(writer.isHealthy)
+    try? FileManager.default.removeItem(at: url)
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -1,0 +1,97 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
+import Foundation
+import Testing
+
+/// The public recovery text-processing seam (#1063 PR0) must run the SAME chain
+/// a live dictation runs, configured by the recording's settings snapshot. With
+/// polish disabled (provider `.none`) the deterministic steps are observable, so
+/// these tests prove the chain actually runs and honors the snapshot toggles.
+@MainActor
+@Suite("Recovery text processor (#1063)")
+struct RecoveryTextProcessorTests {
+
+  private func snapshot(
+    fillerRemoval: Bool, provider: String = "none",
+    backendType: ASRBackendType = .parakeet, lidCapable: Bool = false,
+    languageMode: LanguageMode = .auto
+  ) -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: backendType,
+      backendSupportsLanguageDetection: lidCapable,
+      languageMode: languageMode,
+      wordCorrectionEnabled: false,
+      fillerRemovalEnabled: fillerRemoval,
+      emojiFormatterEnabled: false,
+      customWordsVersion: nil,
+      llmProvider: provider,
+      llmModel: "none",
+      polishPromptVersion: nil)
+  }
+
+  @Test("the recovery chain runs the standard steps end to end, polish disabled")
+  func chainRunsEndToEnd() async {
+    // Inverse text normalization is the robust observable transform here (its
+    // 2s runner budget tolerates CPU-saturated parallel runs, unlike filler
+    // removal's 50ms budget — `tests-no-real-time-scheduling-precision`). A
+    // non-LID engine with auto language runs ITN. Proves the seam executes the
+    // chain and keeps polish off under provider .none.
+    let processor = RecoveryTextProcessor(keychainManager: KeychainManager())
+    processor.applySettings(snapshot(fillerRemoval: true))
+    let outcome = await processor.process(rawText: "the code is two zero three")
+    #expect(outcome.text.contains("203"))  // the chain demonstrably transformed the text
+    #expect(outcome.polishedText == nil)  // provider .none ⇒ no polish
+    #expect(outcome.polishError == nil)
+  }
+
+  @Test("disabling filler removal in the snapshot leaves the text untouched")
+  func snapshotTogglesThreadThrough() async {
+    let input = "um hello uh there world"
+    let processor = RecoveryTextProcessor(keychainManager: KeychainManager())
+    processor.applySettings(snapshot(fillerRemoval: false))
+    let outcome = await processor.process(rawText: input)
+    #expect(outcome.text == input)
+    #expect(outcome.polishedText == nil)
+  }
+
+  /// The recovered take must hit the SAME inverse-text-normalization language
+  /// gate the live pipeline does (Codex PR0 P2). For a LID engine with unknown
+  /// language, ITN must skip rather than rewrite possibly-non-English numbers.
+  @Test("the ITN language gate matches the live pipeline for the recorded engine")
+  func itnLanguageGateMatchesLiveEngine() async {
+    let spoken = "call me at two zero three"
+
+    // Non-LID engine (Parakeet-class): unknown language runs ITN → digits.
+    let parakeet = RecoveryTextProcessor(keychainManager: KeychainManager())
+    parakeet.applySettings(
+      snapshot(fillerRemoval: false, backendType: .parakeet, lidCapable: false))
+    let parakeetOut = await parakeet.process(rawText: spoken)
+    #expect(parakeetOut.text.contains("203"))
+
+    // LID engine (WhisperKit) with unknown language: ITN skips → text untouched.
+    let whisperKit = RecoveryTextProcessor(keychainManager: KeychainManager())
+    whisperKit.applySettings(
+      snapshot(fillerRemoval: false, backendType: .whisperKit, lidCapable: true))
+    let whisperKitOut = await whisperKit.process(rawText: spoken)
+    #expect(whisperKitOut.text == spoken)
+  }
+
+  /// A take recorded with a LOCKED non-English language must replay under THAT
+  /// language, derived from the snapshot — not nil/auto — so the chain never
+  /// rewrites it as English (Codex PR0 P2). With Spanish locked, the English-
+  /// only ITN must skip, leaving the spoken-form numbers intact.
+  @Test("a locked non-English snapshot replays under its own language")
+  func lockedLanguageReplaysUnderSnapshot() async {
+    let spoken = "llamame al dos cero tres two zero three"
+    let processor = RecoveryTextProcessor(keychainManager: KeychainManager())
+    // Non-LID engine: were the locked language NOT applied, language would be
+    // nil and ITN would run (non-LID + nil) and rewrite "two zero three" → 203.
+    processor.applySettings(
+      snapshot(
+        fillerRemoval: false, backendType: .parakeet, lidCapable: false,
+        languageMode: .locked("es")))
+    let outcome = await processor.process(rawText: spoken)
+    #expect(outcome.text == spoken)  // Spanish locked ⇒ English ITN skipped
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/SettingsManagerCrashRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/SettingsManagerCrashRecoveryTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// The `crashRecoveryEnabled` setting (#1063 PR0): default ON, persists to the
+/// injected store, and is part of the unified cross-build key set.
+@MainActor
+@Suite("Crash-recovery setting (#1063)")
+struct SettingsManagerCrashRecoveryTests {
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.recovery.settings.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
+  }
+
+  @Test("a fresh install defaults crash recovery ON")
+  func defaultsOn() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    #expect(settings.crashRecoveryEnabled)
+  }
+
+  @Test("turning it off persists to the injected store")
+  func persistsWhenChanged() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.crashRecoveryEnabled = false
+    #expect(SettingsManager(defaults: suite).crashRecoveryEnabled == false)
+  }
+
+  @Test("the setting is unified across builds")
+  func inUnifiedKeySet() {
+    #expect(SettingsManager.unifiedDefaultsKeys.contains("crashRecoveryEnabled"))
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/TranscriptRecoveryFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/TranscriptRecoveryFieldsTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// `Transcript` gains optional `recoverySessionID` / `isRecovered` (#1063 PR0).
+/// Both must be decode-safe: a pre-#1063 JSON file on disk (no such keys) must
+/// still decode, with the fields defaulting to nil — otherwise every existing
+/// transcript in a user's History would fail to load.
+@Suite("Transcript recovery fields (#1063)")
+struct TranscriptRecoveryFieldsTests {
+
+  @Test("a pre-#1063 JSON decodes with the new fields nil")
+  func legacyJSONDecodes() throws {
+    let id = UUID().uuidString
+    let legacy = """
+      {"id":"\(id)","text":"hello world","duration":1.5,"processingTime":0.2,\
+      "backendType":"parakeet","createdAt":12345.0}
+      """
+    let transcript = try JSONDecoder().decode(Transcript.self, from: Data(legacy.utf8))
+    #expect(transcript.text == "hello world")
+    #expect(transcript.recoverySessionID == nil)
+    #expect(transcript.isRecovered == nil)
+  }
+
+  @Test("the new fields round-trip through Codable")
+  func newFieldsRoundTrip() throws {
+    let original = Transcript(
+      text: "recovered take", recoverySessionID: "session-42", isRecovered: true)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(Transcript.self, from: data)
+    #expect(decoded.recoverySessionID == "session-42")
+    #expect(decoded.isRecovered == true)
+  }
+
+  @Test("a default transcript has nil recovery fields")
+  func defaultsAreNil() {
+    let transcript = Transcript(text: "x")
+    #expect(transcript.recoverySessionID == nil)
+    #expect(transcript.isRecovered == nil)
+  }
+}


### PR DESCRIPTION
## What

PR0 of the crash-recovery audio safety copy (#1063): the additive, fully-tested foundation. **No runtime wiring yet** — spool writing lands in PR1, recovery in PR2. The heart path (record → transcribe → paste) and all UI are byte-identical; nothing here is reachable from a live dictation.

## Why

A recording lives only in RAM until stop, so a crash / OS memory-kill / kernel panic / power loss mid-take loses everything — and the unreleased 60-minute cap (#1060) makes that up to ~50 minutes. This PR builds the encrypted on-disk format, cipher, key vault, writer, reader, and recovery text seam so PR1/PR2 are mostly wiring.

## What's in PR0

- **Encrypted format + cipher (Core).** Append-only `.ewrec` format with self-describing frames; AES-GCM-256 with frame metadata authenticated as AAD and a per-session monotonic nonce. Recovery rebuilds the valid continuous prefix from frames alone and discards any torn or authentication-failing tail.
- **Value types (Core).** `RecordingSettingsSnapshot` (the record-time settings recovery replays under), the ObjC-safe `RecoverySpoolDirective` (host → helper over XPC), and optional `Transcript.recoverySessionID` / `isRecovered` — both decode-safe for pre-#1063 transcripts.
- **Store (Storage).** `RecoverySpoolStore`: scan / read / delete + valid-prefix recovery that degrades safely on corruption or a wrong key. Directory is 0700, Spotlight-excluded, and backup-excluded.
- **Writer (Audio).** `RecoverySpoolWriter`: encrypts and appends on a dedicated queue, strictly fail-open, with backpressure that drops recovery (never audio).
- **Key vault (Services).** `RecoveryKeyStore`: a per-session AES key that survives a crash — data-protection keychain for the signed release build, 0600 file backend for DEBUG/dev so unsigned tests and the dev bundle work.
- **Recovery text seam (Pipeline).** `RecoveryTextProcessor`: a public seam reusing the live 5-step text chain outside the kernel, configured by the settings snapshot (including the inverse-text-normalization language gate, matched to the recorded engine's capability).
- **Setting (Services).** `crashRecoveryEnabled`, default on.

## Tests

7 new suites: encryption round-trips, tamper / wrong-key rejection, valid-prefix recovery, writer fail-open + backpressure, key lifecycle, legacy-data decode, settings default, and chain execution + the ITN language gate. Full `xcode-test` green (1815 tests).

## Review

Council coverage approval on the plan; Codex grounded review reached PROCEED-AS-PLANNED before Gate 2. Codex code-diff review iterated to a clean pass over seven rounds, surfacing eight correctness issues — all the same theme (recovery must faithfully mirror the live pipeline's language/settings handling and stay honest + fail-closed on a corrupted or keyless spool). Each is fixed with a locking test:

- ITN language gate matched to the recorded engine's LID capability.
- Recovered take replays under the recording's locked decode language, not nil/auto.
- `useExtendedThinking` carried into recovered polish.
- Re-polishing a recovered History item preserves its `recoverySessionID` / `isRecovered`.
- Out-of-sequence terminal marker reported as truncation, not a clean stop.
- Markerless crash spool (the common case) reported as truncated, not complete.
- Cipher-mode mismatch fails closed at the store, with codec-level nonzero-tag rejection for the damaged-header path.

Part of #1063.