### PR TITLE
feat(observability): harden Sentry/PostHog redaction so dictation can't enter diagnostics (#1095)

### DIFF
--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -142,7 +142,10 @@ final class HeartPathTelemetryEmitter {
       "capture_session.reason_label": ctx.reasonLabel ?? NSNull(),
       "capture_session.error_domain": ctx.errorDomain ?? NSNull(),
       "capture_session.error_code": ctx.errorCode.map { $0 } ?? NSNull(),
-      "capture_session.error_description": ctx.errorDescription ?? NSNull(),
+      // #1095: the raw OS `errorDescription` (a free-form `localizedDescription`)
+      // is intentionally NOT emitted — `error_domain` + `error_code` above carry
+      // the error identity content-free. The field stays on the context for the
+      // error's own `errorDescription` (HeartPathError), not for telemetry.
       "capture.is_actively_capturing": ctx.isActivelyCapturing,
       "capture_session_id": Int(ctx.sessionID),
     ]

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -44,11 +44,7 @@ public enum ObservabilityBootstrap {
     config.setBeforeSend { event in
       // PII redaction: strip transcript content, API keys, and emails from event properties.
       // This is a limb — must never throw or crash. Heart is unaffected if this fails.
-      var redactedProperties: [String: Any] = [:]
-      for (key, value) in event.properties {
-        redactedProperties[key] = ObservabilityBootstrap.redactValue(value)
-      }
-      event.properties = redactedProperties
+      event.properties = ObservabilityBootstrap.sanitizePostHogProperties(event.properties)
       return event
     }
 
@@ -90,77 +86,13 @@ public enum ObservabilityBootstrap {
       options.enableAppHangTracking = false
       options.tracesSampleRate = NSNumber(value: 0)
 
+      // PII redaction: strip transcript content, API keys, emails, and
+      // username-bearing crash paths. Extracted into `sanitizeSentryEvent`
+      // (the FINAL payload seam) so the redaction tripwire test (#1095) can
+      // assert on the exact output the SDK transmits, not a pre-`beforeSend`
+      // hook. This is a limb — `sanitizeSentryEvent` must never throw or crash.
       options.beforeSend = { event in
-        // PII redaction: strip transcript content, API keys, and emails.
-        // This is a limb — must never throw or crash. Heart is unaffected if this fails.
-
-        // Redact event message (SentryMessage wraps formatted + raw strings)
-        if let sentryMsg = event.message {
-          let redacted = ObservabilityBootstrap.redactString(sentryMsg.formatted)
-          if redacted != sentryMsg.formatted {
-            event.message = SentryMessage(formatted: redacted)
-          }
-        }
-
-        // Redact extra context values
-        if let extra = event.extra {
-          event.extra = ObservabilityBootstrap.redactDict(extra)
-        }
-
-        // Redact breadcrumb messages and data
-        if let crumbs = event.breadcrumbs {
-          for crumb in crumbs {
-            if let msg = crumb.message {
-              crumb.message = ObservabilityBootstrap.redactString(msg)
-            }
-            if let data = crumb.data {
-              crumb.data = ObservabilityBootstrap.redactDict(data)
-            }
-          }
-        }
-
-        // Redact exception value + mechanism data. Sentry's native crash
-        // handler captures the formatted exception message into
-        // `event.exceptions[].value`; without this pass, a future
-        // `fatalError("transcript=\(text)")` would leak. Verified during V3
-        // audit (#566): no current call sites interpolate transcript-typed
-        // values into fatal traps, but defense-in-depth — a regression
-        // would be invisible until users started crashing.
-        if let exceptions = event.exceptions {
-          for exception in exceptions {
-            if let value = exception.value {
-              exception.value = ObservabilityBootstrap.redactString(value)
-            }
-            if let mechData = exception.mechanism?.data {
-              exception.mechanism?.data = ObservabilityBootstrap.redactDict(mechData)
-            }
-          }
-        }
-
-        // Redact context dictionaries (arbitrary nested string values).
-        // Current contexts are diagnostic counts/statuses, but context is
-        // the natural place where future diagnostic strings would land —
-        // protect it now so a future change doesn't bypass redaction.
-        if let context = event.context {
-          var redactedContext: [String: [String: Any]] = [:]
-          for (key, inner) in context {
-            redactedContext[key] = ObservabilityBootstrap.redactDict(inner)
-          }
-          event.context = redactedContext
-        }
-
-        // Redact tag values. Current tags are low-cardinality strings
-        // (build_type, app_version), but cheap defense-in-depth against
-        // a future tag whose value bleeds transcript-shaped data.
-        if let tags = event.tags {
-          var redactedTags: [String: String] = [:]
-          for (key, value) in tags {
-            redactedTags[key] = ObservabilityBootstrap.redactString(value)
-          }
-          event.tags = redactedTags
-        }
-
-        return event
+        ObservabilityBootstrap.sanitizeSentryEvent(event)
       }
     }
 
@@ -168,6 +100,136 @@ public enum ObservabilityBootstrap {
     SentrySDK.configureScope { scope in
       scope.setTag(value: environment == "development" ? "debug" : "release", key: "app.build_type")
     }
+  }
+
+  /// Sanitize a Sentry event in place and return it. This is the EXACT body the
+  /// SDK `beforeSend` runs — the FINAL payload seam (#1095). Extracted so the
+  /// redaction tripwire test can assert on the same output the SDK transmits.
+  /// Pure, idempotent, and never throws (a limb — heart path is unaffected).
+  static func sanitizeSentryEvent(_ event: Event) -> Event {
+    // Redact event message (SentryMessage wraps formatted + raw strings)
+    if let sentryMsg = event.message {
+      let redacted = redactString(sentryMsg.formatted)
+      if redacted != sentryMsg.formatted {
+        event.message = SentryMessage(formatted: redacted)
+      }
+    }
+
+    // Redact extra context values
+    if let extra = event.extra {
+      event.extra = redactDict(extra)
+    }
+
+    // Redact breadcrumb messages and data
+    if let crumbs = event.breadcrumbs {
+      for crumb in crumbs {
+        if let msg = crumb.message {
+          crumb.message = redactString(msg)
+        }
+        if let data = crumb.data {
+          crumb.data = redactDict(data)
+        }
+      }
+    }
+
+    // Redact exception value + mechanism data. Sentry's native crash
+    // handler captures the formatted exception message into
+    // `event.exceptions[].value`; without this pass, a future
+    // `fatalError("transcript=\(text)")` would leak. Verified during V3
+    // audit (#566): no current call sites interpolate transcript-typed
+    // values into fatal traps, but defense-in-depth — a regression
+    // would be invisible until users started crashing.
+    if let exceptions = event.exceptions {
+      for exception in exceptions {
+        if let value = exception.value {
+          exception.value = redactString(value)
+        }
+        if let mechData = exception.mechanism?.data {
+          exception.mechanism?.data = redactDict(mechData)
+        }
+      }
+    }
+
+    // Redact context dictionaries (arbitrary nested string values).
+    // Current contexts are diagnostic counts/statuses, but context is
+    // the natural place where future diagnostic strings would land —
+    // protect it now so a future change doesn't bypass redaction.
+    if let context = event.context {
+      var redactedContext: [String: [String: Any]] = [:]
+      for (key, inner) in context {
+        redactedContext[key] = redactDict(inner)
+      }
+      event.context = redactedContext
+    }
+
+    // Redact tag values. Current tags are low-cardinality strings
+    // (build_type, app_version), but cheap defense-in-depth against
+    // a future tag whose value bleeds transcript-shaped data.
+    if let tags = event.tags {
+      var redactedTags: [String: String] = [:]
+      for (key, value) in tags {
+        redactedTags[key] = redactString(value)
+      }
+      event.tags = redactedTags
+    }
+
+    // #1095 Layer C — native-crash surfaces. Hard crashes (segfault /
+    // NSException) are written to disk and replayed through `beforeSend` on
+    // next launch carrying stack frames + `debugMeta` (and no `message`). These
+    // fields hold image/source paths, not dictation, but a release build's
+    // paths can embed the developer/user home directory (`/Users/<name>/…`).
+    // Clear the host identifier and scrub the username segment from every
+    // stack-frame and debug-image path so a crash report carries no identity.
+    // Frames live in three serialized surfaces — `event.stacktrace`, each
+    // `thread.stacktrace`, and each `exception.stacktrace` (the SDK sets the
+    // crashed thread's stacktrace directly on the exception for native crashes)
+    // — so cover all three, not just `threads`.
+    event.serverName = nil
+    redactUserPaths(in: event.stacktrace)
+    for thread in event.threads ?? [] {
+      redactUserPaths(in: thread.stacktrace)
+    }
+    for exception in event.exceptions ?? [] {
+      redactUserPaths(in: exception.stacktrace)
+    }
+    for meta in event.debugMeta ?? [] {
+      if let codeFile = meta.codeFile { meta.codeFile = redactUserPath(codeFile) }
+    }
+
+    return event
+  }
+
+  /// Scrub `/Users/<name>/` usernames from every frame's path fields in a
+  /// stacktrace, in place. No-op for a nil stacktrace. (#1095 Layer C helper.)
+  private static func redactUserPaths(in stacktrace: SentryStacktrace?) {
+    guard let frames = stacktrace?.frames else { return }
+    for frame in frames {
+      if let package = frame.package { frame.package = redactUserPath(package) }
+      if let fileName = frame.fileName { frame.fileName = redactUserPath(fileName) }
+    }
+  }
+
+  /// Redact every value in a PostHog event's property bag (the EXACT body the
+  /// PostHog `beforeSend` runs). Shares the same value redactor as Sentry, so
+  /// the tripwire test (#1095) covers both pipelines through one seam.
+  static func sanitizePostHogProperties(_ properties: [String: Any]) -> [String: Any] {
+    var redacted: [String: Any] = [:]
+    for (key, value) in properties {
+      redacted[key] = redactValue(value)
+    }
+    return redacted
+  }
+
+  /// Replace the username segment of a macOS home path (`/Users/<name>/…`)
+  /// with a placeholder, leaving the rest of the path intact for triage.
+  /// No-op when the string contains no such segment. Idempotent; never throws.
+  /// Mirrors the server-side "Usernames in filepaths" scrubbing rule (#1095).
+  static func redactUserPath(_ input: String) -> String {
+    input.replacingOccurrences(
+      of: #"/Users/[^/]+"#,
+      with: "/Users/[REDACTED]",
+      options: .regularExpression
+    )
   }
 
   /// Redact every String value in a `[String: Any]` dictionary recursively,

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -143,7 +143,7 @@ public enum SentryBreadcrumb {
     tags: [String: String] = [:]
   ) {
     let event = Event(level: .error)
-    event.message = SentryMessage(formatted: "\(category.rawValue): \(error.localizedDescription)")
+    event.message = SentryMessage(formatted: "\(category.rawValue): \(Self.structuredDescriptor(error))")
     var eventTags = [
       "pipeline.stage": stage,
       "error.category": category.rawValue,
@@ -177,6 +177,18 @@ public enum SentryBreadcrumb {
     } else {
       SentrySDK.capture(event: event)
     }
+  }
+
+  /// Structural, content-free descriptor for an error: `"<domain>#<code>"`.
+  /// Used in the captured event's `message` instead of `error.localizedDescription`,
+  /// which on framework errors can interpolate arbitrary OS strings. Domain and
+  /// code are framework identifiers (e.g. `AVFoundationErrorDomain#-11800`), never
+  /// user content — so dictation text can never reach the message surface, even if
+  /// a future error type interpolated a transcript into its `localizedDescription`.
+  /// See #1095. `internal` (not `private`) so the redaction tripwire can pin it.
+  nonisolated static func structuredDescriptor(_ error: any Error) -> String {
+    let ns = error as NSError
+    return "\(ns.domain)#\(ns.code)"
   }
 
   private static func mergedExtra(_ extra: [String: Any]?) -> [String: Any]? {

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -107,7 +107,7 @@ struct HeartPathTelemetryEmitterTests {
     "capture_session.reason_label",
     "capture_session.error_domain",
     "capture_session.error_code",
-    "capture_session.error_description",
+    // #1095: capture_session.error_description (raw OS string) no longer emitted.
     "capture.is_actively_capturing",
     "capture_session_id",
   ]

--- a/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
@@ -1,0 +1,293 @@
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1095 — redaction tripwire. Asserts that dictation text can never reach the
+/// FINAL diagnostic payload, by exercising the EXACT functions the SDK runs:
+/// `ObservabilityBootstrap.sanitizeSentryEvent` (the `beforeSend` body) and
+/// `sanitizePostHogProperties` (the PostHog `beforeSend` body). Asserting on
+/// these — not the pre-SDK `captureErrorDelegate`, which fires BEFORE
+/// `beforeSend` — is what makes this a real guarantee instead of theater.
+///
+/// What the B+ design guarantees, and how each is proven here:
+///  1. STRUCTURAL message — the captured `message` is `category: domain#code`,
+///     never `error.localizedDescription`, so a transcript can't enter the
+///     message surface at ANY length (Layer A; `structuralMessage*`).
+///  2. TRANSCRIPT-LENGTH content (the actual shape of dictation — long-form
+///     free text) is scrubbed from every event surface by the denylist
+///     (`denylistScrubsTranscript*`, `postHog*`).
+///  3. NATIVE-CRASH paths — host name cleared, `/Users/<name>/` usernames
+///     scrubbed from stack frames and debug images (Layer C; `nativeCrash*`).
+///  4. PRODUCERS emit counts/codes, never text — even fed a transcript, the
+///     real builder yields only counts (`realBuilder*`).
+///
+/// Explicit NON-guarantee (deferred option C, documented honestly): an
+/// arbitrary SHORT string placed in a hypothetical future rogue key is NOT
+/// scrubbed by the denylist. B+ does not claim it is — that's covered instead
+/// by guarantee 4 (producers never put transcript text in a field) and would
+/// only need the full key-allowlist rebuild if a regulator-grade claim were
+/// required. So the sentinel below is transcript-SHAPED for denylist surfaces.
+@Suite("Sentry/PostHog redaction tripwire (#1095)")
+struct SentryEventSanitizerTests {
+
+  /// Unique phrase searched for across the final payload.
+  private static let marker = "PURPLE ELEPHANT SEVENTEEN"
+  /// A realistic dictation transcript (>100 chars, the denylist threshold)
+  /// that embeds the marker — this is the shape of real leaked content.
+  private static let transcript =
+    "Reminder to self, please email the whole team about the schedule change "
+    + "for next week and mention that the code phrase is \(marker) before the call."
+  /// A path-segment marker (no spaces/slashes) for the username in crash paths.
+  private static let userMarker = "PURPLE-ELEPHANT-USER"
+
+  // MARK: - Layer A: structural message
+
+  @Test("structured descriptor is domain#code, never the localizedDescription")
+  func structuralMessageDropsLocalizedDescription() {
+    let err = NSError(
+      domain: "AVFoundationErrorDomain", code: -11800,
+      userInfo: [NSLocalizedDescriptionKey: Self.marker])
+
+    let descriptor = SentryBreadcrumb.structuredDescriptor(err)
+    #expect(descriptor == "AVFoundationErrorDomain#-11800")
+    #expect(descriptor.contains(Self.marker) == false)
+
+    // The message `captureError` composes, run through the FINAL sanitizer.
+    let event = Event(level: .error)
+    event.message = SentryMessage(
+      formatted:
+        "\(SentryBreadcrumb.ErrorCategory.audioCaptureFailed.rawValue): \(descriptor)")
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+
+    #expect(sanitized.message?.formatted == "audio_capture_failed: AVFoundationErrorDomain#-11800")
+    #expect(payloadContainsMarker(sanitized) == false)
+  }
+
+  @Test("structural message holds even for a SHORT dictated phrase")
+  func structuralMessageDropsShortPhrase() {
+    // The denylist would NOT catch this short phrase — Layer A's structural
+    // rule is what guarantees it can't enter the message at all.
+    let shortPhrase = "call mom tomorrow"
+    let err = NSError(
+      domain: "MyDomain", code: 7,
+      userInfo: [NSLocalizedDescriptionKey: shortPhrase])
+    let descriptor = SentryBreadcrumb.structuredDescriptor(err)
+    #expect(descriptor == "MyDomain#7")
+    #expect(descriptor.contains(shortPhrase) == false)
+  }
+
+  // MARK: - Layer D: denylist scrubs transcript-length content from every surface
+
+  @Test("transcript-length content is scrubbed from every Sentry surface")
+  func denylistScrubsTranscriptFromEverySurface() {
+    #expect(Self.transcript.count > 100)  // premise: it trips the >100 denylist rule
+
+    let event = Event(level: .error)
+    event.message = SentryMessage(formatted: Self.transcript)
+    event.extra = ["note": Self.transcript, "nested": ["deep": Self.transcript]]
+    event.tags = ["some_tag": Self.transcript]
+    event.context = ["diag": ["field": Self.transcript]]
+
+    let crumb = Breadcrumb(level: .info, category: "pipeline.test")
+    crumb.message = Self.transcript
+    crumb.data = ["crumb_note": Self.transcript]
+    event.breadcrumbs = [crumb]
+
+    let exc = Exception(value: Self.transcript, type: "TestError")
+    let mech = Mechanism(type: "test")
+    mech.data = ["mech_note": Self.transcript]
+    exc.mechanism = mech
+    event.exceptions = [exc]
+
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(payloadContainsMarker(sanitized) == false)
+  }
+
+  // MARK: - Layer C: native-crash field coverage
+
+  @Test("native-crash fixture: serverName nil + usernames scrubbed from paths")
+  func nativeCrashPathsAndServerNameScrubbed() {
+    // Native crash shape: no message; threads + debugMeta carrying real paths.
+    let event = Event()
+    event.serverName = "\(Self.userMarker)-MacBook-Pro.local"
+
+    // Frames live in THREE serialized surfaces — cover them all.
+    let threadFrame = Frame()
+    threadFrame.package =
+      "/Users/\(Self.userMarker)/Library/Developer/Xcode/DerivedData/EnviousWispr/Build/Products/Release/EnviousWispr.app/Contents/MacOS/EnviousWispr"
+    threadFrame.fileName = "/Users/\(Self.userMarker)/dev/EnviousWispr/Sources/Foo.swift"
+    let thread = SentryThread(threadId: NSNumber(value: 0))
+    thread.stacktrace = SentryStacktrace(frames: [threadFrame], registers: [:])
+    event.threads = [thread]
+
+    // event.stacktrace (separate top-level stacktrace).
+    let eventFrame = Frame()
+    eventFrame.package = "/Users/\(Self.userMarker)/dev/EnviousWispr/event-frame"
+    event.stacktrace = SentryStacktrace(frames: [eventFrame], registers: [:])
+
+    // exception.stacktrace (native crashes set the crashed thread's stacktrace
+    // directly on the exception — the surface Codex flagged as missed).
+    let excFrame = Frame()
+    excFrame.fileName = "/Users/\(Self.userMarker)/dev/EnviousWispr/exc-frame.swift"
+    let exc = Exception(value: "EXC_BAD_ACCESS", type: "SIGSEGV")
+    exc.stacktrace = SentryStacktrace(frames: [excFrame], registers: [:])
+    event.exceptions = [exc]
+
+    let meta = DebugMeta()
+    meta.codeFile =
+      "/Users/\(Self.userMarker)/Library/Developer/CoreSimulator/EnviousWispr.app/Contents/MacOS/EnviousWispr"
+    event.debugMeta = [meta]
+
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+
+    #expect(sanitized.serverName == nil)
+    // Username gone from every frame surface, but path STRUCTURE preserved.
+    #expect(threadFrame.package?.contains(Self.userMarker) == false)
+    #expect(threadFrame.package?.hasPrefix("/Users/[REDACTED]/Library/Developer/") == true)
+    #expect(threadFrame.fileName == "/Users/[REDACTED]/dev/EnviousWispr/Sources/Foo.swift")
+    #expect(eventFrame.package?.contains(Self.userMarker) == false)
+    #expect(excFrame.fileName?.contains(Self.userMarker) == false)
+    #expect(meta.codeFile?.contains(Self.userMarker) == false)
+    #expect(payloadContainsUserMarker(sanitized) == false)
+  }
+
+  @Test("redactUserPath replaces only the username segment, is a no-op otherwise, idempotent")
+  func redactUserPathContract() {
+    #expect(
+      ObservabilityBootstrap.redactUserPath("/Users/saurabh/dev/x.swift")
+        == "/Users/[REDACTED]/dev/x.swift")
+    // No /Users/<name> segment → unchanged.
+    #expect(
+      ObservabilityBootstrap.redactUserPath("/Library/Frameworks/Foo.framework")
+        == "/Library/Frameworks/Foo.framework")
+    // Idempotent.
+    let once = ObservabilityBootstrap.redactUserPath("/Users/saurabh/x")
+    #expect(ObservabilityBootstrap.redactUserPath(once) == once)
+  }
+
+  // MARK: - Layer D: PostHog shares the same redactor
+
+  @Test("PostHog properties: transcript scrubbed recursively, safe values survive")
+  func postHogPropertiesSanitized() {
+    let props: [String: Any] = [
+      "event_name": "dictation_completed",  // safe, low-cardinality → survives
+      "leak": Self.transcript,
+      "nested": ["deep": Self.transcript, "arr": ["ok", Self.transcript]],
+    ]
+    let sanitized = ObservabilityBootstrap.sanitizePostHogProperties(props)
+
+    #expect(sanitized["event_name"] as? String == "dictation_completed")
+    #expect(sanitized["leak"] as? String == "[REDACTED]")
+    let nested = sanitized["nested"] as? [String: Any]
+    #expect(nested?["deep"] as? String == "[REDACTED]")
+    let arr = nested?["arr"] as? [Any]
+    #expect(arr?[0] as? String == "ok")
+    #expect(arr?[1] as? String == "[REDACTED]")
+    #expect(payloadContainsMarker(sanitized) == false)
+  }
+
+  // MARK: - Producers emit counts, never text
+
+  @Test("real recording-snapshot builder emits counts only, never the transcript")
+  func realBuilderEmitsCountsNotText() {
+    // Feed a transcript containing the marker through the only transcript-aware
+    // builder. It takes COUNTS, never the text — so no value can carry it.
+    let dictation = Self.transcript
+    let charCount = dictation.count
+    let wordCount = dictation.split(separator: " ").count
+
+    let snapshot = SentryBreadcrumb.RecordingSnapshot(
+      backend: "parakeet",
+      audioRoute: "built_in_mic",
+      wasStreaming: false,
+      startTime: Date(timeIntervalSince1970: 0),
+      durationMs: 1234,
+      targetAppBundleID: "com.apple.Notes",
+      transcriptCharCount: charCount,
+      transcriptWordCount: wordCount
+    )
+    let ctx = snapshot.sentryContext
+
+    #expect(ctx["transcript_char_count"] as? Int == charCount)
+    #expect(ctx["transcript_word_count"] as? Int == wordCount)
+    for (_, value) in ctx {
+      if let s = value as? String { #expect(s.contains(Self.marker) == false) }
+    }
+
+    // And through the final sanitizer's context path.
+    let event = Event(level: .error)
+    event.context = ["recording_snapshot": ctx]
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(payloadContainsMarker(sanitized) == false)
+  }
+
+  // MARK: - Idempotency + safe values + existing denylist patterns
+
+  @Test("sanitizeSentryEvent is idempotent and preserves safe diagnostic values")
+  func idempotentAndSafeValuesSurvive() {
+    let event = Event(level: .error)
+    event.message = SentryMessage(formatted: Self.transcript)
+    event.extra = ["route": "built_in_mic", "leak": Self.transcript]
+
+    let first = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    let firstMessage = first.message?.formatted
+    let firstExtra = first.extra?["leak"] as? String
+
+    // Second pass over the already-sanitized event must not change anything.
+    let second = ObservabilityBootstrap.sanitizeSentryEvent(first)
+    #expect(second.message?.formatted == firstMessage)
+    #expect(second.extra?["leak"] as? String == firstExtra)
+    #expect((second.extra?["route"] as? String) == "built_in_mic")
+    #expect(payloadContainsMarker(second) == false)
+  }
+
+  @Test("existing denylist patterns (email, API key, long hex) still redacted")
+  func existingDenylistPatternsStillRedacted() {
+    let event = Event(level: .error)
+    event.extra = [
+      "email": "saurabh@example.com",
+      "key": "sk-abcdefghijklmnopqrstuvwxyz123456",
+      "hex": "deadbeefdeadbeefdeadbeefdeadbeef0123",
+      "safe_short": "built_in_mic",
+    ]
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(sanitized.extra?["email"] as? String == "[REDACTED]")
+    #expect(sanitized.extra?["key"] as? String == "[REDACTED]")
+    #expect(sanitized.extra?["hex"] as? String == "[REDACTED]")
+    #expect(sanitized.extra?["safe_short"] as? String == "built_in_mic")
+  }
+
+  // MARK: - Helpers
+
+  /// True if the marker appears anywhere in the event's serialized wire payload.
+  private func payloadContainsMarker(_ event: Event) -> Bool {
+    allStrings(in: event.serialize()).contains { $0.contains(Self.marker) }
+  }
+
+  private func payloadContainsUserMarker(_ event: Event) -> Bool {
+    allStrings(in: event.serialize()).contains { $0.contains(Self.userMarker) }
+  }
+
+  /// True if the marker appears anywhere in a sanitized property bag.
+  private func payloadContainsMarker(_ properties: [String: Any]) -> Bool {
+    allStrings(in: properties).contains { $0.contains(Self.marker) }
+  }
+
+  /// Recursively collect every string (keys and values) from a serialized
+  /// payload so the assertion covers the full nested structure, not just the
+  /// fields the test happened to set.
+  private func allStrings(in value: Any) -> [String] {
+    switch value {
+    case let s as String:
+      return [s]
+    case let dict as [AnyHashable: Any]:
+      return dict.keys.compactMap { $0 as? String } + dict.values.flatMap { allStrings(in: $0) }
+    case let arr as [Any]:
+      return arr.flatMap { allStrings(in: $0) }
+    default:
+      return []
+    }
+  }
+}


### PR DESCRIPTION
## What
Strengthens diagnostic-report redaction so dictation text can't ride out in a Sentry crash/error report or a PostHog event, and adds a build-failing tripwire test that proves it against the FINAL payload the SDK transmits.

- **Layer A** — handled-error messages are structural (`category: domain#code`), never `error.localizedDescription`. Holds for any error, present or future (`SentryBreadcrumb.captureError`).
- **Layer B** — drop the one raw OS-string telemetry extra (`capture_session.error_description`); `error_domain` + `error_code` already carry the identity content-free.
- **Layer C** — `event.serverName = nil` and scrub `/Users/<name>/` usernames from every stack-frame and debug-image path (`event.stacktrace`, `thread.stacktrace`, `exception.stacktrace`, `debugMeta.codeFile`), so hard native crashes are covered too.
- **Layer D** — extract the Sentry `beforeSend` body (`sanitizeSentryEvent`) and the PostHog redaction (`sanitizePostHogProperties`) into the final-payload seam; `SentryEventSanitizerTests` plants a sentinel in message/extra/breadcrumb/exception/contexts/tags + a native-crash fixture + PostHog and asserts it's gone from the serialized output.
- **Layer E** (out-of-repo) — server-side Advanced Data Scrubbing (`@userpath:remove` on `$string`) applied + read-back verified; documented in `sentry-operations.md`.

## Why
No leak exists today (empirically verified across real production events). This is future-proofing plus a durable, tested privacy guarantee that unblocks an honest privacy claim. B+ scope per the green-lit plan; the full key-allowlist rebuild is deferred (option C).

## How tested
- `scripts/xcode-test.sh` — full suite **1794 tests green** (9 new tripwire tests + updated emitter test).
- `swift build -c release` — exit 0, no new warnings.
- Codex grounded review (plan, 3 rounds) + code-diff review (2 rounds): one P2 (missed `event.stacktrace`/`exception.stacktrace`) found and fixed.
- Layer E rule live + read-back verified.

Closes #1095.