### PR TITLE
ci(release): move release pipeline to hosted macos-26 + build-only dry-run + signing hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Recovery mode'
+        description: 'Recovery / dry-run mode (build-only = build+sign+notarize, no publish)'
         required: true
         default: 'full'
         type: choice
@@ -16,6 +16,7 @@ on:
           - release-only
           - appcast-only
           - sentry-only
+          - build-only
       tag:
         description: 'Tag (e.g. v1.7.1) — required for all modes'
         required: false
@@ -55,7 +56,7 @@ jobs:
   # Preflight — fail fast before expensive work
   # ==========================================================================
   preflight:
-    runs-on: [self-hosted, enviouswispr-release]
+    runs-on: macos-26
     timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -105,7 +106,7 @@ jobs:
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
         run: |
           case "$MODE" in
-            full) ;;
+            full|build-only) ;;
             release-only|appcast-only|sentry-only)
               if [[ -z "$SOURCE_RUN_ID" ]]; then
                 echo "::error::source_run_id is required for ${MODE} recovery mode"
@@ -121,7 +122,7 @@ jobs:
           MODE: ${{ inputs.mode || 'full' }}
           INPUT_RUN_ID: ${{ inputs.source_run_id }}
         run: |
-          if [[ "$MODE" == "full" ]] || [[ -z "$INPUT_RUN_ID" ]]; then
+          if [[ "$MODE" == "full" || "$MODE" == "build-only" ]] || [[ -z "$INPUT_RUN_ID" ]]; then
             echo "run-id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
             echo "==> Source run: current (${{ github.run_id }})"
           else
@@ -141,8 +142,8 @@ jobs:
           set -euo pipefail
           FAIL=0
 
-          # Build secrets — required for full and release-only
-          if [[ "$MODE" == "full" || "$MODE" == "release-only" ]]; then
+          # Build secrets — required for full, release-only, and build-only
+          if [[ "$MODE" == "full" || "$MODE" == "release-only" || "$MODE" == "build-only" ]]; then
             [[ "$HAS_SPARKLE_PRIVATE_KEY" == "true" ]] || { echo "::error::SPARKLE_PRIVATE_KEY missing"; FAIL=1; }
             [[ "$HAS_DEVELOPER_ID_CERT" == "true" ]]    || { echo "::error::DEVELOPER_ID_CERT_BASE64 missing"; FAIL=1; }
             [[ "$HAS_APPLE_API_KEY" == "true" ]]         || { echo "::error::APPLE_API_KEY_BASE64 missing"; FAIL=1; }
@@ -183,12 +184,18 @@ jobs:
     needs: [preflight]
     if: >
       github.event_name == 'push' ||
-      inputs.mode == 'full'
-    runs-on: [self-hosted, enviouswispr-release]
+      inputs.mode == 'full' ||
+      inputs.mode == 'build-only'
+    runs-on: macos-26
     timeout-minutes: 330
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
 
       - name: Verify SDK supports FoundationModels
         run: |
@@ -233,17 +240,13 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
-      - name: Ensure Tuist available
+      - name: Install mise + Tuist
         run: |
           set -euo pipefail
-          MISE_BIN="$(command -v mise || true)"
-          [[ -z "$MISE_BIN" && -x "$HOME/.local/bin/mise" ]] && MISE_BIN="$HOME/.local/bin/mise"
-          [[ -z "$MISE_BIN" && -x /opt/homebrew/bin/mise ]] && MISE_BIN="/opt/homebrew/bin/mise"
-          if [[ -z "$MISE_BIN" ]]; then
-            echo "::error::mise not found on the release runner"; exit 1
-          fi
-          "$MISE_BIN" install tuist@4.195.11
-          "$MISE_BIN" x tuist@4.195.11 -- tuist version
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mise" install tuist@4.195.11
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
 
       - name: Import Developer ID certificate
         env:
@@ -262,6 +265,10 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: \
             -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          # Make the ephemeral keychain the default so codesign resolves the
+          # identity (signed by name in build-release-dmg.sh) unambiguously on a
+          # fresh hosted image. (#1087)
+          security default-keychain -s "$KEYCHAIN_PATH"
 
       - name: Build, sign & package release DMG
         env:
@@ -303,7 +310,9 @@ jobs:
           if echo "${SUBMIT_OUTPUT}" | grep -q "status: Accepted"; then
             echo "==> Notarization accepted. Stapling ..."
             xcrun stapler staple "${DMG_PATH}"
-            echo "==> Stapled. Done."
+            # Re-verify the stapled ticket actually stuck before we ship. (#1087)
+            xcrun stapler validate "${DMG_PATH}"
+            echo "==> Stapled + validated. Done."
             rm -f "${KEY_PATH}"
           elif echo "${SUBMIT_OUTPUT}" | grep -q "status: Invalid"; then
             echo "::error::Notarization REJECTED — fetching log for details"
@@ -430,10 +439,11 @@ jobs:
         needs.build-release-artifacts.result == 'success' ||
         needs.build-release-artifacts.result == 'skipped'
       )
-    runs-on: [self-hosted, enviouswispr-release]
+    runs-on: macos-26
     timeout-minutes: 15
     permissions:
       contents: write
+      actions: read   # cross-run download-artifact (recovery modes) (#1087)
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -464,7 +474,10 @@ jobs:
           VERSION: ${{ needs.preflight.outputs.version }}
           TAG: ${{ needs.preflight.outputs.tag }}
         run: |
+          # --repo is required on hosted runners: this job has no checkout, so a
+          # fresh hosted workspace has no .git for gh to infer the repo from. (#1087)
           gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
             --title "EnviousWispr v${VERSION}" \
             --generate-notes \
             "build/EnviousWispr-${VERSION}.dmg" \
@@ -478,7 +491,7 @@ jobs:
           TAG: ${{ needs.preflight.outputs.tag }}
         run: |
           echo "==> Recovery mode: overwriting assets on existing release $TAG"
-          gh release upload "$TAG" --clobber \
+          gh release upload "$TAG" --repo "${{ github.repository }}" --clobber \
             "build/EnviousWispr-${VERSION}.dmg" \
             "build/EnviousWispr.dmg"
 
@@ -504,10 +517,13 @@ jobs:
         needs.build-release-artifacts.result == 'success' ||
         needs.build-release-artifacts.result == 'skipped'
       )
-    runs-on: [self-hosted, enviouswispr-release]
+    runs-on: macos-26
     # #1019: bumped 10→20 to accommodate the wait-for-Pages-deploy poll before
     # the edge purge + verify (the deploy + edge refresh can take several min).
     timeout-minutes: 20
+    permissions:
+      contents: read   # checkout + cross-run download (push/PR use the App token) (#1087)
+      actions: read
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -709,8 +725,11 @@ jobs:
         needs.build-release-artifacts.result == 'success' ||
         needs.build-release-artifacts.result == 'skipped'
       )
-    runs-on: [self-hosted, enviouswispr-release]
+    runs-on: macos-26
     timeout-minutes: 15
+    permissions:
+      contents: read   # checkout + cross-run download (Sentry upload uses its own token) (#1087)
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -725,6 +744,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ needs.preflight.outputs.source-run-id }}
 
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
       - name: Upload dSYMs to Sentry
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -734,7 +756,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Expect sentry-cli pre-installed on self-hosted runner
+          # sentry-cli is installed by the prior step on the hosted runner; this guard is belt-and-suspenders
           if ! command -v sentry-cli &>/dev/null; then
             echo "::error::sentry-cli not found. Install it on the runner: curl -sL https://sentry.io/get-cli/ | bash"
             exit 1
@@ -757,7 +779,7 @@ jobs:
   release-summary:
     needs: [preflight, build-release-artifacts, publish-github-release, publish-appcast, upload-sentry-dsyms]
     if: always() && needs.preflight.result == 'success'
-    runs-on: [self-hosted, enviouswispr-release]
+    runs-on: macos-26
     timeout-minutes: 5
     steps:
       - name: Write release summary

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,6 +1,15 @@
 # Self-Hosted GitHub Actions Runner
 
-## Why
+> **DECOMMISSIONED (#1087, 2026-06-20).** The release pipeline (`release.yml`) was
+> migrated to GitHub-hosted `macos-26` runners with ephemeral-keychain signing —
+> all 6 jobs now `runs-on: macos-26`, so no machine at rest holds the signing cert.
+> The "Why" below is obsolete: hosted `macos-26` carries the macOS 26 SDK and
+> already runs our build + FoundationModels probe. The runner is unregistered only
+> AFTER the first real hosted release succeeds; until then it stays registered as a
+> one-revert fallback. The setup/recovery instructions below are retained for the
+> record (re-registration recipe if a self-hosted lane is ever needed again).
+
+## Why (obsolete — see banner)
 
 Release builds require the macOS 26 SDK for FoundationModels (Apple Intelligence).
 GitHub's hosted runners (`macos-15`) don't have it. Larger runners (`macos-26-large`)

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -71,24 +71,23 @@ test -d "$WORKSPACE"
 test -f "$ENTITLEMENTS"; test -f "$AUDIO_ENTITLEMENTS"; test -f "$ASR_ENTITLEMENTS"; test -f "$PROFILE"
 
 mkdir -p "$PROJ_ROOT/build"
-# xcconfig treats // as a comment marker; escape the Sentry DSN's :// through a
-# SLASH build setting so the DSN survives Info.plist expansion intact.
-# ${SENTRY_DSN:-} guards set -u when the secret is intentionally absent (dev/unset).
-SENTRY_DSN_RAW="${SENTRY_DSN:-}"
-SENTRY_DSN_XCCONFIG="${SENTRY_DSN_RAW//:\/\//:\$(SLASH)\/}"
-# SU_FEED_URL is NOT set here: xcconfig treats // as a comment, so a feed URL like
-# https://… would truncate to "https:". The feed is a non-secret constant, so it is
-# plutil-stamped post-archive (step 3) instead, like the SwiftPM build-dmg.sh did.
+# POSTHOG_API_KEY has no `//`, so it survives the xcconfig substitution and is
+# stamped at archive time. SENTRY_DSN and SU_FEED_URL both contain `://` — xcconfig
+# treats `//` as a comment, so both are plutil-stamped post-archive (step 3) instead.
+# The old `$(SLASH)` xcconfig escape for SENTRY_DSN was bash-version-fragile: the
+# replacement `${...//:\/\//:\$(SLASH)\/}` keeps the `\` of `\/` on some bash builds
+# (a hosted macos-26 runner's bash did, injecting a stray backslash into the DSN —
+# `https:/\/…` — which the self-hosted Mac's bash stripped). plutil is deterministic
+# and `//`-safe. (#1087)
+# ${POSTHOG_API_KEY:-} guards set -u when the secret is intentionally absent (dev/unset).
 ( umask 077; cat > "$SECRETS_XCCONFIG" <<EOF
-SLASH = /
 POSTHOG_API_KEY = ${POSTHOG_API_KEY:-}
-SENTRY_DSN = ${SENTRY_DSN_XCCONFIG:-}
 EOF
 )
 [[ -z "${POSTHOG_API_KEY:-}" ]] && echo "::warning::POSTHOG_API_KEY not set — PostHog disabled in this build"
 [[ -z "${SENTRY_DSN:-}" ]] && echo "::warning::SENTRY_DSN not set — Sentry disabled in this build"
 
-echo "==> [1/9] Archive (signing OFF; secrets+feed stamped via xcconfig at archive time)"
+echo "==> [1/9] Archive (signing OFF; PostHog stamped via xcconfig; Sentry+feed plutil-stamped post-archive)"
 rm -rf "$DERIVED_DATA" "$ARCHIVE_PATH" "$PROJ_ROOT/build/dSYMs" "$BUNDLE"
 xcodebuild archive \
     -workspace "$WORKSPACE" \
@@ -113,8 +112,13 @@ ditto "$ARCHIVED_APP" "$BUNDLE"
 echo "==> [3/9] Stamp semver + feed URL into app + XPC Info.plists"
 # Xcode names embedded XPC dirs by PRODUCT name (EnviousWispr*Service.xpc), not
 # bundle id (#913 PR4 learning) — discover by glob, route by CFBundleIdentifier.
-# SUFeedURL stamped here (not via xcconfig) to avoid the // comment truncation.
+# SUFeedURL + SentryDSN stamped here (not via xcconfig) to avoid the `//` comment
+# truncation and the bash-fragile $(SLASH) escape (#1087). plutil is `//`-safe.
+# SentryDSN is stamped UNCONDITIONALLY (empty when the secret is unset) so the
+# archive-time `$(SENTRY_DSN)` placeholder never survives into a built app and get
+# mistaken for a real DSN by ObservabilityBootstrap (#1087 Codex P2).
 plutil -replace SUFeedURL -string "$FEED_URL" "$BUNDLE/Contents/Info.plist"
+plutil -replace SentryDSN -string "${SENTRY_DSN:-}" "$BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleShortVersionString -string "$VERSION" "$BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleVersion -string "$VERSION" "$BUNDLE/Contents/Info.plist"
 for XPC_SVC in "$BUNDLE/Contents/XPCServices"/*.xpc; do
@@ -133,7 +137,7 @@ if [[ -n "${POSTHOG_API_KEY:-}" ]]; then
 fi
 if [[ -n "${SENTRY_DSN:-}" ]]; then
     SENTRY_VALUE="$(/usr/libexec/PlistBuddy -c 'Print :SentryDSN' "$APP_PLIST")"
-    # The Sentry check catches DSN truncation from an unescaped // in xcconfig.
+    # Catches a mis-stamped DSN (plutil-stamped post-archive since #1087).
     test "$SENTRY_VALUE" = "$SENTRY_DSN"
     [[ "$SENTRY_VALUE" != *'$('* ]]
     unset SENTRY_VALUE


### PR DESCRIPTION
Part of #1087.

## What this does
Moves all 6 `release.yml` jobs off the self-hosted `enviouswispr-release` runner (the founder's M4 Pro) onto GitHub-hosted `macos-26`. Removes the single-point-of-failure on the ship path (no release if the laptop is asleep/travelling/dead) and the public-repo + self-hosted-signing supply-chain anti-pattern. This is the already-documented target architecture (founder call 2026-06-19).

**The migration is mostly a `runs-on` swap:** every signing/notarization secret already lives in GitHub Actions secrets, and the build job already imports the Developer ID cert from `DEVELOPER_ID_CERT_BASE64` into a per-run ephemeral keychain destroyed on cleanup. The only tie to the laptop was the runner label.

## Changes (`.github/workflows/release.yml`)
- All 6 jobs `runs-on: macos-26` (`grep -c self-hosted` → 0).
- **Build job provisions** the laptop supplied ambiently: `Select Xcode` (latest-stable) + `Install mise + Tuist` (the old "Ensure Tuist available" required a pre-installed mise and errored otherwise).
- **`Install sentry-cli`** on the dSYM-upload job (not on hosted images).
- **New `workflow_dispatch` mode `build-only`**: preflight + build (archive, sign, notarize, staple, Sparkle-sign, dSYM, upload) with **no publish side-effects** — proves the hosted build path before any real release, and de-risks any future signing change.
- **Signing/permission hardening:** ephemeral keychain made default; `stapler validate` the notarized DMG post-staple; explicit `actions: read` on the 3 jobs that do cross-run `download-artifact` (recovery modes).
- **`docs/self-hosted-runner.md`** decommission banner (runner retired only after the first real hosted release; kept as a one-revert fallback until then).

## Review trail
- Plan: `docs/feature-requests/issue-1087-2026-06-20-hosted-release-runner.md`.
- Council (GPT-5.5 + Gemini-3.1) + Codex grounded review (2 rounds) → PROCEED-AS-PLANNED. Council/Codex steered the conservative **all-macos** choice over a hybrid ubuntu split (build-only can't validate ubuntu publish jobs pre-merge; deferred to a validated follow-up).
- Code-diff review caught a **P1**: `publish-github-release` has no checkout, so on a fresh hosted VM `gh release create/upload` couldn't infer the repo (worked self-hosted only via the persistent workspace's leftover `.git`). Fixed — both now pass `--repo`. Re-verify CLEAN.
- Cross-checked against GitHub's canonical cert-on-runner recipe + ecosystem release writeups: keychain sequence matches; notarytool API-key path + inside-out Sparkle signing exceed common practice.

## Validation
- Pre-merge: `build-only` hosted dry-run dispatched on this branch (run 27862314839) — must be green (build ✅, publish ⏭️, `stapler validate` green) before auto-merge is armed.
- Post-merge (separate session, founder-in-loop): first real `v*` tag ships end-to-end on hosted; founder confirms clean-Mac Gatekeeper launch + Sparkle auto-update; only then decommission the runner.