### PR TITLE
feat(observability): daily product-health check worker (#1092)

### DIFF
--- a/workers/product-health/README.md
+++ b/workers/product-health/README.md
@@ -1,0 +1,74 @@
+# Product-Health Worker (issue #1092)
+
+A daily Cloudflare Worker that watches product-health metrics and posts an
+advisory line to Discord. Read-only: it consumes events that already emit to
+PostHog. It gates nothing.
+
+It posts a **one-line heartbeat every run** (so a silent worker death or a
+telemetry blackout is itself visible) and a **louder alert block** only when a
+metric crosses a baseline-calibrated threshold.
+
+Plan + threshold rationale + baselines:
+`docs/feature-requests/issue-1092-2026-06-20-daily-product-health-check.md`.
+
+## Metrics + thresholds (v1)
+
+All windows are **completed** (exclude the partial current day). Production only:
+`properties.environment='production'` AND any `distinct_id` with a `-dev` build
+anywhere in its history excluded (founder-machine-tell).
+
+| Metric | What | Window | Guard | Alert when | Baseline |
+|---|---|---|---|---|---|
+| latency | per-day p50/p95 of `dictation.completed.e2e_seconds` | per complete day | day >=50 dictations | p50>2.5s OR p95>9s, 2 qualifying days | p50 ~1.5s |
+| paste fallback | clipboard fallback share (split: ax_denied vs direct-fail) | prev 7 days | >=50 pastes | share >5% | ~1.2% |
+| AFM discard | genuine Apple-polish discard share (`fallback_reason`) | prev 7 days | >=50 fr-rows AND >=10 discards | share >15% | ~10% (dark until next release) |
+| transcription | `pipeline.failed` stage=transcription family share (incl. legit no-speech) | prev 7 days | >=200 dictations | share >5% | ~0.9% |
+| volume / integrity | T-1 dictation count + co-firing check | T-1 vs trailing 7 days | trailing avg >=20/day | T-1=0 on active baseline, OR a co-firing event=0 (schema drift) | ~200/day |
+
+AFM discard reads `dark-awaiting-release` until `fallback_reason` ships in a
+release and users update (it is null on 100% of production events as of
+2026-06-20; merged in #1067 but not yet in a release).
+
+## Develop / test
+
+```bash
+cd workers/product-health
+node --test                     # pure threshold/state logic, no network
+```
+
+Pre-deploy live-query smoke (runs the real HogQL against production PostHog,
+asserts the queries resolve + denominators are non-zero, prints the heartbeat,
+posts nothing):
+
+```bash
+~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+  node workers/product-health/live-query-smoke.mjs
+```
+
+## Deploy (one-time)
+
+```bash
+cd workers/product-health
+npx wrangler deploy
+
+# secrets (never committed):
+~/.claude/bin/get-key launch posthog-personal-api-key V -- sh -c 'printf "%s" "$V" | npx wrangler secret put POSTHOG_PERSONAL_API_KEY'
+security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-session-logs | npx wrangler secret put DISCORD_WEBHOOK_URL
+# TRIGGER_SECRET gates the public manual trigger (pick any long random string):
+printf "%s" "$(openssl rand -hex 24)" | npx wrangler secret put TRIGGER_SECRET
+
+# verify (posts a real heartbeat to EnviousNotes) - needs the token:
+curl "https://enviouswispr-product-health.saurabhav.workers.dev/?token=<TRIGGER_SECRET>"
+```
+
+The daily cron path needs no token; only the public `fetch` trigger does (it
+fails closed with 401 if the token is missing or wrong, so the workers.dev URL
+cannot be crawled into spamming Discord).
+
+Cron: `0 14 * * *` (10am ET daily) - a deliberate ingestion-lag buffer so the
+prior UTC day's events from offline laptops have flushed.
+
+## Rollback
+
+`npx wrangler delete enviouswispr-product-health` stops the cron. Revert the PR
+to remove the code. A bad threshold is a one-line edit in `THRESHOLDS` + redeploy.

--- a/workers/product-health/live-query-smoke.mjs
+++ b/workers/product-health/live-query-smoke.mjs
@@ -1,0 +1,55 @@
+// Pre-deploy live-query smoke (issue #1092 plan, section 11).
+// Runs the REAL worker HogQL against production PostHog, asserts the queries
+// resolve + known-live events have non-zero denominators, then prints the
+// heartbeat WITHOUT posting to Discord. Never posts anywhere.
+//
+// Run (bridges the key, no stdout leak):
+//   ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+//     node workers/product-health/live-query-smoke.mjs
+import {
+  fetchHealth,
+  evaluateLatency,
+  evaluatePaste,
+  evaluateAFM,
+  evaluateTranscription,
+  evaluateVolume,
+  buildMessage,
+} from "./src/index.js";
+
+const env = {
+  POSTHOG_PROJECT_ID: "354235",
+  POSTHOG_PERSONAL_API_KEY: (process.env.POSTHOG_KEY || "").trim(),
+};
+if (!env.POSTHOG_PERSONAL_API_KEY) {
+  console.error("POSTHOG_KEY env not set");
+  process.exit(2);
+}
+
+const data = await fetchHealth(env);
+
+// Assertions: queries resolved with rows, known-live denominators non-zero.
+const fail = (m) => {
+  console.error("SMOKE FAIL:", m);
+  process.exit(1);
+};
+if (!data.latencyDays.length) fail("latency query returned no days");
+if (!data.volumeDays.length) fail("volume query returned no days");
+if (!(Number(data.seven.dictations_7d) > 0)) fail("7d dictations is zero - filter or window bug");
+if (!(Number(data.seven.paste_total) > 0)) fail("7d paste_total is zero - filter or window bug");
+// fallback_reason is expected all-null pre-release: afm_fr_rows may be 0.
+console.log("columns OK; denominators non-zero.");
+console.log("7d:", JSON.stringify(data.seven));
+console.log("latency days:", data.latencyDays.length, "volume days:", data.volumeDays.length);
+console.log("afm_fr_rows (expect 0 pre-release):", data.seven.afm_fr_rows);
+
+const results = {
+  latency: evaluateLatency(data.latencyDays),
+  paste: evaluatePaste(data.seven),
+  afm: evaluateAFM(data.seven),
+  transcription: evaluateTranscription(data.seven),
+  volume: evaluateVolume(data.volumeDays, data.t1ref),
+};
+console.log("t1ref (PostHog clock):", data.t1ref);
+console.log("\nstates:", Object.fromEntries(Object.entries(results).map(([k, v]) => [k, v.state])));
+console.log("\n--- heartbeat preview (NOT posted) ---");
+console.log(buildMessage(results, data.versions));

--- a/workers/product-health/package.json
+++ b/workers/product-health/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "enviouswispr-product-health",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -1,0 +1,403 @@
+/**
+ * EnviousWispr Daily Product-Health Check - Cloudflare Worker (issue #1092)
+ *
+ * Runs once a day (cron) plus a manual HTTP trigger. Reads existing product
+ * events from PostHog over COMPLETED time windows, compares each metric to a
+ * baseline-calibrated threshold with low-volume guards, and posts to Discord:
+ *   - a one-line heartbeat EVERY run (carries the day's dictation volume +
+ *     which metrics evaluated / were skipped / are dark / failed), so a silent
+ *     worker death or a telemetry blackout is itself visible;
+ *   - a louder alert block when a metric crosses.
+ *
+ * Advisory only. Gates nothing. Plan + thresholds:
+ *   docs/feature-requests/issue-1092-2026-06-20-daily-product-health-check.md
+ *
+ * Privacy: output and logs are counts / rates / version-tags only. Never an
+ * error_code string, never a raw PostHog row, never a per-user id.
+ */
+
+const POSTHOG_HOST = "https://us.posthog.com";
+const DASHBOARD = "https://us.posthog.com/project/354235/dashboard/1391797";
+
+// All thresholds in one place for easy tuning. Calibrated to production
+// baselines queried 2026-06-20 (see plan section 1).
+export const THRESHOLDS = {
+  latency: { minN: 50, p50: 2.5, p95: 9.0, sustainDays: 2, driftWindowDays: 14 },
+  paste: { minTotal: 50, share: 0.05 },
+  afm: { minFrRows: 50, minDiscards: 10, share: 0.15 },
+  transcription: { minDictations: 200, share: 0.05 },
+  volume: { activeBaselineAvg: 20 },
+};
+
+export default {
+  async scheduled(event, env) {
+    await runHealth(env);
+  },
+  async fetch(request, env) {
+    // Manual trigger is secret-gated: the workers.dev URL is public, so an
+    // unauthenticated request must NOT run the check or post to Discord (it
+    // would spam the channel + burn PostHog quota). Fail closed.
+    const url = new URL(request.url);
+    const provided = url.searchParams.get("token") || request.headers.get("x-trigger-secret");
+    if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
+      return new Response("unauthorized\n", { status: 401 });
+    }
+    try {
+      const summary = await runHealth(env);
+      return new Response(summary + "\n", { status: 200 });
+    } catch (err) {
+      return new Response("health check failed: " + err.message + "\n", { status: 500 });
+    }
+  },
+};
+
+// ----- PostHog -------------------------------------------------------------
+
+// Per-distinct_id -dev exclusion implements analytics-operations.md
+// RULE: founder-machine-tell-in-distinct-id (a dev build anywhere in an id's
+// history marks the whole id as dogfood). Bare field names do not resolve in
+// HogQL, so every property reference is prefixed `properties.`.
+const PROD = `properties.environment = 'production'
+  AND distinct_id NOT IN (
+    SELECT distinct_id FROM events
+    WHERE properties.app_version LIKE '%-dev%' )`;
+
+async function hogql(env, sql) {
+  const res = await fetch(`${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query: sql }, refresh: "blocking" }),
+  });
+  if (!res.ok) {
+    // Loud: do not let a query failure look like healthy silence.
+    throw new Error(`PostHog query HTTP ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.results) throw new Error("PostHog query returned no results array");
+  return json; // { results: [...rows], columns: [...] }
+}
+
+// Completed-window helpers: every window ends at the start of today (UTC), so
+// the partial current day (and late-flushing offline laptops) is excluded.
+const DAY = "toStartOfDay(now())"; // ClickHouse/PostHog default timezone is UTC
+
+export async function fetchHealth(env) {
+  // 1) Per-day latency for the last 14 complete days (covers the 2-qualifying-day
+  //    sustained check AND the 14d drift median).
+  const latencySql = `
+    SELECT toDate(timestamp) AS day, count() AS n,
+           round(quantile(0.5)(toFloat(properties.e2e_seconds)), 3) AS p50,
+           round(quantile(0.95)(toFloat(properties.e2e_seconds)), 3) AS p95
+    FROM events
+    WHERE event = 'dictation.completed' AND ${PROD}
+      AND properties.e2e_seconds IS NOT NULL
+      AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
+    GROUP BY day ORDER BY day DESC`;
+
+  // 2) The four 7d rate metrics in one pass (previous 7 complete days).
+  const sevenDaySql = `
+    SELECT
+      countIf(event = 'paste.completed') AS paste_total,
+      countIf(event = 'paste.completed' AND properties.tier = 'clipboard_only') AS paste_cb,
+      countIf(event = 'paste.completed' AND properties.tier = 'clipboard_only_ax_denied') AS paste_ax,
+      countIf(event = 'llm.polish_completed' AND properties.provider = 'appleIntelligence'
+              AND properties.fallback_reason IS NOT NULL) AS afm_fr_rows,
+      countIf(event = 'llm.polish_completed' AND properties.provider = 'appleIntelligence'
+              AND properties.fallback_reason IN ('guard_discard', 'validator_discard')) AS afm_disc,
+      countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS trans_fails,
+      countIf(event = 'dictation.completed') AS dictations_7d
+    FROM events
+    WHERE ${PROD}
+      AND event IN ('paste.completed', 'llm.polish_completed', 'pipeline.failed', 'dictation.completed')
+      AND timestamp >= ${DAY} - INTERVAL 7 DAY AND timestamp < ${DAY}`;
+
+  // 3) Per-day volume + co-firing counts for the last 8 complete days
+  //    (T-1 vs the 7 days before it; co-firing blackout = schema drift).
+  const volumeSql = `
+    SELECT toDate(timestamp) AS day,
+           countIf(event = 'dictation.completed') AS dictations,
+           countIf(event = 'paste.completed') AS pastes,
+           countIf(event = 'asr.completed') AS asr
+    FROM events
+    WHERE ${PROD} AND event IN ('dictation.completed', 'paste.completed', 'asr.completed')
+      AND timestamp >= ${DAY} - INTERVAL 8 DAY AND timestamp < ${DAY}
+    GROUP BY day ORDER BY day DESC`;
+
+  // 4) Top app-versions for the crossing-prone metrics (one pass, 7d).
+  const versionSql = `
+    SELECT properties.app_version AS ver,
+           countIf(event = 'paste.completed' AND properties.tier LIKE 'clipboard_only%') AS paste_fb,
+           countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS trans_fail,
+           countIf(event = 'llm.polish_completed'
+                   AND properties.fallback_reason IN ('guard_discard', 'validator_discard')) AS afm_disc
+    FROM events
+    WHERE ${PROD}
+      AND event IN ('paste.completed', 'pipeline.failed', 'llm.polish_completed')
+      AND timestamp >= ${DAY} - INTERVAL 7 DAY AND timestamp < ${DAY}
+    GROUP BY ver ORDER BY (paste_fb + trans_fail + afm_disc) DESC LIMIT 5`;
+
+  // The expected T-1 date per PostHog's own clock. Used to detect a zero-event
+  // T-1: the GROUP BY day query emits NO row for a day with zero events, so we
+  // must look T-1 up by date rather than trust the newest row.
+  const refSql = `SELECT toString(toDate(toStartOfDay(now()) - INTERVAL 1 DAY)) AS t1`;
+
+  const [latency, seven, volume, versions, ref] = await Promise.all([
+    hogql(env, latencySql),
+    hogql(env, sevenDaySql),
+    hogql(env, volumeSql),
+    hogql(env, versionSql),
+    hogql(env, refSql),
+  ]);
+
+  return {
+    latencyDays: rowsToObjects(latency),
+    seven: rowsToObjects(seven)[0] || {},
+    volumeDays: rowsToObjects(volume),
+    versions: rowsToObjects(versions),
+    t1ref: (rowsToObjects(ref)[0] || {}).t1,
+  };
+}
+
+function rowsToObjects(res) {
+  const cols = res.columns || [];
+  return (res.results || []).map((row) => {
+    const o = {};
+    cols.forEach((c, i) => (o[c] = row[i]));
+    return o;
+  });
+}
+
+// ----- Pure evaluation (unit-tested, no IO) --------------------------------
+
+function median(nums) {
+  if (!nums.length) return null;
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+export function evaluateLatency(days, TH = THRESHOLDS.latency) {
+  const qualifying = days.filter((d) => d.n >= TH.minN);
+  const driftMedian = median(qualifying.slice(0, TH.driftWindowDays).map((d) => d.p50));
+  if (qualifying.length === 0) return { state: "skipped-low-volume", driftMedian };
+  const last2 = qualifying.slice(0, TH.sustainDays);
+  const crossing =
+    last2.length === TH.sustainDays &&
+    last2.every((d) => d.p50 > TH.p50 || d.p95 > TH.p95);
+  return {
+    state: crossing ? "alerting" : "evaluated-ok",
+    latest: qualifying[0],
+    last2,
+    driftMedian,
+  };
+}
+
+export function evaluatePaste(row, TH = THRESHOLDS.paste) {
+  const total = num(row.paste_total);
+  const cb = num(row.paste_cb);
+  const ax = num(row.paste_ax);
+  const fb = cb + ax;
+  if (total < TH.minTotal) return { state: "skipped-low-volume", total };
+  const share = fb / total;
+  return { state: share > TH.share ? "alerting" : "evaluated-ok", share, fb, cb, ax, total };
+}
+
+export function evaluateAFM(row, TH = THRESHOLDS.afm) {
+  const frRows = num(row.afm_fr_rows);
+  const disc = num(row.afm_disc);
+  if (frRows === 0) return { state: "dark-awaiting-release", frRows, disc };
+  if (frRows < TH.minFrRows || disc < TH.minDiscards)
+    return { state: "skipped-low-volume", frRows, disc };
+  const share = disc / frRows;
+  return { state: share > TH.share ? "alerting" : "evaluated-ok", share, disc, frRows };
+}
+
+export function evaluateTranscription(row, TH = THRESHOLDS.transcription) {
+  const fails = num(row.trans_fails);
+  const dictations = num(row.dictations_7d);
+  if (dictations < TH.minDictations) return { state: "skipped-low-volume", dictations };
+  const denom = dictations + fails;
+  const share = denom > 0 ? fails / denom : 0;
+  return { state: share > TH.share ? "alerting" : "evaluated-ok", share, fails, denom };
+}
+
+export function evaluateVolume(days, expectedT1, TH = THRESHOLDS.volume) {
+  // Look T-1 up BY DATE: a zero-event day produces no row, so an absent T-1
+  // means zero dictations that day (the blackout case), not "use the newest row".
+  const t1Row = days.find((d) => String(d.day) === String(expectedT1));
+  const t1d = t1Row ? num(t1Row.dictations) : 0;
+  // Trailing = the 7 days before T-1 (fixed divisor 7; absent days count as 0).
+  const trailing = days.filter((d) => String(d.day) !== String(expectedT1));
+  const avg = trailing.reduce((a, d) => a + num(d.dictations), 0) / 7;
+  const zeroAlert = t1d === 0 && avg >= TH.activeBaselineAvg;
+  // Co-firing blackout (schema drift): dictations succeeded but a co-firing
+  // success event vanished. asr/paste co-fire with dictation.completed on success.
+  const driftAlert = t1Row != null && t1d > 0 && (num(t1Row.pastes) === 0 || num(t1Row.asr) === 0);
+  const ratio = avg > 0 ? t1d / avg : null;
+  return {
+    state: zeroAlert || driftAlert ? "alerting" : "evaluated-ok",
+    t1: t1Row || null, t1d, avg, ratio, zeroAlert, driftAlert,
+  };
+}
+
+function num(v) {
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return Number.isFinite(n) ? n : 0;
+}
+
+function pct(x) {
+  return (x * 100).toFixed(1) + "%";
+}
+
+function topVersionsFor(versions, key) {
+  return versions
+    .filter((v) => num(v[key]) > 0)
+    .sort((a, b) => num(b[key]) - num(a[key]))
+    .slice(0, 3)
+    .map((v) => `${v.ver || "unknown"}: ${num(v[key])}`)
+    .join(", ");
+}
+
+// ----- Message ------------------------------------------------------------
+
+export function buildMessage(r, versions = []) {
+  const alerts = [];
+  const evaluated = [];
+  const skipped = [];
+  const dark = [];
+
+  const note = (name, ev) => {
+    if (ev.state === "alerting") return; // handled as an alert
+    if (ev.state === "evaluated-ok") evaluated.push(name);
+    else if (ev.state === "dark-awaiting-release") dark.push(name);
+    else skipped.push(name);
+  };
+
+  // Latency
+  if (r.latency.state === "alerting") {
+    const d = r.latency.latest;
+    alerts.push(
+      `latency high: p50 ${d.p50}s / p95 ${d.p95}s, ${r.latency.last2.length} qualifying days, ` +
+      `thresholds p50>${THRESHOLDS.latency.p50}s or p95>${THRESHOLDS.latency.p95}s (baseline p50 ~1.5s).`
+    );
+  }
+  note("latency", r.latency);
+
+  // Paste
+  if (r.paste.state === "alerting") {
+    const tv = topVersionsFor(versions, "paste_fb");
+    alerts.push(
+      `paste fallback ${pct(r.paste.share)} (${r.paste.fb}/${r.paste.total}, prev 7d), ` +
+      `threshold >${pct(THRESHOLDS.paste.share)}, baseline ~1.2%. ` +
+      `Split: ax_denied ${r.paste.ax}, direct-paste-failed ${r.paste.cb}.` +
+      (tv ? ` Top versions ${tv}.` : "")
+    );
+  }
+  note("paste", r.paste);
+
+  // AFM discard
+  if (r.afm.state === "alerting") {
+    const tv = topVersionsFor(versions, "afm_disc");
+    alerts.push(
+      `AFM genuine discard ${pct(r.afm.share)} (${r.afm.disc}/${r.afm.frRows} fr-rows, prev 7d), ` +
+      `threshold >${pct(THRESHOLDS.afm.share)}, baseline ~10%.` + (tv ? ` Top versions ${tv}.` : "")
+    );
+  }
+  note("AFM-discard", r.afm);
+
+  // Transcription
+  if (r.transcription.state === "alerting") {
+    const tv = topVersionsFor(versions, "trans_fail");
+    alerts.push(
+      `transcription failure family ${pct(r.transcription.share)} ` +
+      `(${r.transcription.fails}/${r.transcription.denom}, prev 7d, includes legitimate no-speech), ` +
+      `threshold >${pct(THRESHOLDS.transcription.share)}, baseline ~0.9%.` + (tv ? ` Top versions ${tv}.` : "")
+    );
+  }
+  note("transcription", r.transcription);
+
+  // Volume / integrity
+  if (r.volume.state === "alerting") {
+    if (r.volume.zeroAlert) {
+      alerts.push(
+        `ZERO dictations on T-1 while trailing-7d average is ${r.volume.avg.toFixed(0)}/day ` +
+        `(possible crash-on-launch or telemetry blackout).`
+      );
+    }
+    if (r.volume.driftAlert) {
+      alerts.push(
+        `telemetry drift: T-1 had ${r.volume.t1d} dictations but a co-firing success event was 0 ` +
+        `(paste/asr should co-fire) - an event may have stopped emitting.`
+      );
+    }
+  }
+
+  // Heartbeat line (always)
+  const t1d = r.volume.t1d != null ? r.volume.t1d : "?";
+  const ratioStr =
+    r.volume.ratio != null ? ` (${r.volume.ratio.toFixed(2)}x trailing avg)` : "";
+  const driftStr =
+    r.latency.driftMedian != null && r.latency.latest
+      ? ` p50 drift: ${r.latency.latest.p50}s vs 14d ${r.latency.driftMedian.toFixed(2)}s`
+      : "";
+  const coverage =
+    `Evaluated: ${evaluated.join(", ") || "none"}.` +
+    (dark.length ? ` Dark: ${dark.join(", ")}.` : "") +
+    (skipped.length ? ` Skipped (low volume): ${skipped.join(", ")}.` : "");
+  const head = alerts.length ? "EnviousWispr health - ALERT" : "EnviousWispr health - OK";
+  const heartbeat = `${head}. T-1: ${t1d} dictations${ratioStr}. ${coverage}${driftStr}`;
+
+  let content = heartbeat;
+  if (alerts.length) {
+    content += "\n\n" + alerts.map((a) => "* " + a).join("\n") + `\n${DASHBOARD}`;
+  }
+  // Discord content cap is 2000 chars.
+  return content.length > 1990 ? content.slice(0, 1987) + "..." : content;
+}
+
+// ----- Run ----------------------------------------------------------------
+
+async function runHealth(env) {
+  let data;
+  try {
+    data = await fetchHealth(env);
+  } catch (err) {
+    // Loud failure: post a notice if Discord is reachable, then rethrow so
+    // Cloudflare logs it. A failed run must never read as "all green".
+    await safePost(env, `EnviousWispr health - CHECK FAILED TO RUN: ${err.message}`);
+    throw err;
+  }
+
+  const results = {
+    latency: evaluateLatency(data.latencyDays),
+    paste: evaluatePaste(data.seven),
+    afm: evaluateAFM(data.seven),
+    transcription: evaluateTranscription(data.seven),
+    volume: evaluateVolume(data.volumeDays, data.t1ref),
+  };
+  const message = buildMessage(results, data.versions);
+
+  const ok = await postToDiscord(env.DISCORD_WEBHOOK_URL, message);
+  if (!ok) throw new Error("Discord post failed");
+  return message;
+}
+
+async function postToDiscord(webhookUrl, content) {
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+  return res.status === 204 || res.status === 200;
+}
+
+async function safePost(env, content) {
+  try {
+    if (env.DISCORD_WEBHOOK_URL) await postToDiscord(env.DISCORD_WEBHOOK_URL, content);
+  } catch (_) {
+    // best-effort failure notice; the throw in runHealth surfaces it in logs
+  }
+}

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -1,0 +1,215 @@
+// Unit tests for the pure threshold/state logic (no network).
+// Run: node --test  (from workers/product-health/)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  THRESHOLDS,
+  evaluateLatency,
+  evaluatePaste,
+  evaluateAFM,
+  evaluateTranscription,
+  evaluateVolume,
+  buildMessage,
+} from "../src/index.js";
+
+// ---- latency ----
+test("latency: clean baseline does not alert", () => {
+  const days = [
+    { day: "2026-06-19", n: 200, p50: 1.5, p95: 4.9 },
+    { day: "2026-06-18", n: 180, p50: 1.6, p95: 5.1 },
+  ];
+  assert.equal(evaluateLatency(days).state, "evaluated-ok");
+});
+
+test("latency: 2 sustained qualifying days over p50 floor -> alert", () => {
+  const days = [
+    { day: "2026-06-19", n: 200, p50: 2.8, p95: 6.0 },
+    { day: "2026-06-18", n: 180, p50: 2.6, p95: 5.5 },
+  ];
+  assert.equal(evaluateLatency(days).state, "alerting");
+});
+
+test("latency: only 1 qualifying day over floor -> no alert", () => {
+  const days = [
+    { day: "2026-06-19", n: 200, p50: 2.8, p95: 6.0 },
+    { day: "2026-06-18", n: 30, p50: 3.0, p95: 8.0 }, // below minN, skipped
+    { day: "2026-06-17", n: 180, p50: 1.6, p95: 5.0 }, // qualifying but under floor
+  ];
+  assert.equal(evaluateLatency(days).state, "evaluated-ok");
+});
+
+test("latency: all days below minN -> skipped", () => {
+  const days = [
+    { day: "2026-06-19", n: 10, p50: 3.0, p95: 9.5 },
+    { day: "2026-06-18", n: 5, p50: 3.0, p95: 9.5 },
+  ];
+  assert.equal(evaluateLatency(days).state, "skipped-low-volume");
+});
+
+test("latency: p95 floor alone trips when sustained", () => {
+  const days = [
+    { day: "2026-06-19", n: 200, p50: 1.5, p95: 9.5 },
+    { day: "2026-06-18", n: 200, p50: 1.5, p95: 10.0 },
+  ];
+  assert.equal(evaluateLatency(days).state, "alerting");
+});
+
+// ---- paste ----
+test("paste: ~1.2% baseline does not alert", () => {
+  const row = { paste_total: 1000, paste_cb: 9, paste_ax: 3 };
+  assert.equal(evaluatePaste(row).state, "evaluated-ok");
+});
+
+test("paste: >5% fallback -> alert with split", () => {
+  const row = { paste_total: 260, paste_cb: 7, paste_ax: 10 };
+  const ev = evaluatePaste(row);
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.ax, 10);
+  assert.equal(ev.cb, 7);
+});
+
+test("paste: below 50 total -> skipped", () => {
+  assert.equal(evaluatePaste({ paste_total: 40, paste_cb: 30, paste_ax: 0 }).state, "skipped-low-volume");
+});
+
+// ---- AFM (dark / forward-looking) ----
+test("AFM: zero fr-bearing rows (pre-release) -> dark", () => {
+  const row = { afm_fr_rows: 0, afm_disc: 0 };
+  assert.equal(evaluateAFM(row).state, "dark-awaiting-release");
+});
+
+test("AFM: release seen but too few rows -> skipped (not 0%)", () => {
+  assert.equal(evaluateAFM({ afm_fr_rows: 20, afm_disc: 2 }).state, "skipped-low-volume");
+});
+
+test("AFM: genuine discard >15% with enough rows -> alert", () => {
+  const ev = evaluateAFM({ afm_fr_rows: 100, afm_disc: 20 });
+  assert.equal(ev.state, "alerting");
+});
+
+test("AFM: ~10% genuine discard -> ok", () => {
+  assert.equal(evaluateAFM({ afm_fr_rows: 100, afm_disc: 10 }).state, "evaluated-ok");
+});
+
+// ---- transcription ----
+test("transcription: ~0.9% baseline does not alert", () => {
+  const row = { trans_fails: 14, dictations_7d: 1500 };
+  assert.equal(evaluateTranscription(row).state, "evaluated-ok");
+});
+
+test("transcription: >5% family rate -> alert", () => {
+  const row = { trans_fails: 120, dictations_7d: 1500 };
+  assert.equal(evaluateTranscription(row).state, "alerting");
+});
+
+test("transcription: below 200 dictations -> skipped", () => {
+  assert.equal(evaluateTranscription({ trans_fails: 50, dictations_7d: 100 }).state, "skipped-low-volume");
+});
+
+// ---- volume / integrity ----
+test("volume: normal day -> ok", () => {
+  const days = [
+    { day: "2026-06-19", dictations: 200, pastes: 200, asr: 200 },
+    { day: "2026-06-18", dictations: 220, pastes: 220, asr: 220 },
+  ];
+  assert.equal(evaluateVolume(days, "2026-06-19").state, "evaluated-ok");
+});
+
+test("volume: zero dictations on active baseline (T-1 row present, 0) -> alert", () => {
+  const days = [
+    { day: "2026-06-19", dictations: 0, pastes: 0, asr: 0 },
+    { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
+    { day: "2026-06-17", dictations: 210, pastes: 210, asr: 210 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.zeroAlert, true);
+});
+
+test("volume: T-1 ABSENT (blackout) on active baseline -> alert (the Codex P1 fix)", () => {
+  // The grouped query emits no row for a zero-event day; T-1 must still read 0.
+  const days = [
+    { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
+    { day: "2026-06-17", dictations: 210, pastes: 210, asr: 210 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19"); // 2026-06-19 not in days
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.zeroAlert, true);
+  assert.equal(ev.t1d, 0);
+});
+
+test("volume: genuinely quiet period (zero with low baseline) -> no alert", () => {
+  const days = [
+    { day: "2026-06-19", dictations: 0, pastes: 0, asr: 0 },
+    { day: "2026-06-18", dictations: 5, pastes: 5, asr: 5 },
+    { day: "2026-06-17", dictations: 3, pastes: 3, asr: 3 },
+  ];
+  assert.equal(evaluateVolume(days, "2026-06-19").state, "evaluated-ok");
+});
+
+test("volume: weekend dip below trailing avg does NOT false-fire", () => {
+  // T-1 is a quiet Sunday far below the weekday-heavy average; must stay ok.
+  const days = [
+    { day: "2026-06-21", dictations: 40, pastes: 40, asr: 40 }, // Sunday
+    { day: "2026-06-20", dictations: 300, pastes: 300, asr: 300 },
+    { day: "2026-06-19", dictations: 320, pastes: 320, asr: 320 },
+    { day: "2026-06-18", dictations: 300, pastes: 300, asr: 300 },
+  ];
+  assert.equal(evaluateVolume(days, "2026-06-21").state, "evaluated-ok");
+});
+
+test("volume: co-firing blackout (schema drift) -> alert", () => {
+  const days = [
+    { day: "2026-06-19", dictations: 200, pastes: 0, asr: 200 }, // paste event vanished
+    { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.driftAlert, true);
+});
+
+// ---- message ----
+function results(over = {}) {
+  return Object.assign(
+    {
+      latency: { state: "evaluated-ok", latest: { p50: 1.5, p95: 4.9 }, last2: [], driftMedian: 1.4 },
+      paste: { state: "evaluated-ok" },
+      afm: { state: "dark-awaiting-release" },
+      transcription: { state: "evaluated-ok" },
+      volume: { state: "evaluated-ok", t1d: 312, avg: 280, ratio: 1.11 },
+    },
+    over
+  );
+}
+
+test("message: clean day posts a heartbeat only, no alert block", () => {
+  const msg = buildMessage(results());
+  assert.match(msg, /health - OK/);
+  assert.match(msg, /312 dictations/);
+  assert.match(msg, /Dark: AFM-discard/);
+  assert.ok(!msg.includes("\n\n*"), "no alert block on a clean day");
+});
+
+test("message: a crossing produces an ALERT header + block + dashboard link", () => {
+  const msg = buildMessage(
+    results({ paste: { state: "alerting", share: 0.065, fb: 17, cb: 7, ax: 10, total: 260 } }),
+    [{ ver: "v2.1.4", paste_fb: 12, trans_fail: 0, afm_disc: 0 }]
+  );
+  assert.match(msg, /health - ALERT/);
+  assert.match(msg, /paste fallback 6\.5%/);
+  assert.match(msg, /ax_denied 10, direct-paste-failed 7/);
+  assert.match(msg, /v2\.1\.4: 12/);
+  assert.match(msg, /dashboard/);
+});
+
+test("message: stays within Discord 2000-char cap", () => {
+  const msg = buildMessage(
+    results({
+      latency: { state: "alerting", latest: { p50: 3.0, p95: 10 }, last2: [1, 2], driftMedian: 1.4 },
+      paste: { state: "alerting", share: 0.07, fb: 20, cb: 10, ax: 10, total: 285 },
+      transcription: { state: "alerting", share: 0.06, fails: 90, denom: 1500 },
+      volume: { state: "alerting", t1d: 0, avg: 200, ratio: 0, zeroAlert: true, driftAlert: false },
+    })
+  );
+  assert.ok(msg.length <= 2000);
+});

--- a/workers/product-health/wrangler.toml
+++ b/workers/product-health/wrangler.toml
@@ -1,0 +1,17 @@
+name = "enviouswispr-product-health"
+main = "src/index.js"
+compatibility_date = "2026-06-20"
+
+# Daily at 14:00 UTC (10am ET). The late time is a deliberate ingestion-lag
+# buffer so the prior UTC day's events from sleeping/offline laptops have flushed.
+[triggers]
+crons = ["0 14 * * *"]
+
+[vars]
+POSTHOG_PROJECT_ID = "354235"
+
+# Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
+#   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
+#   DISCORD_WEBHOOK_URL       - Keychain `enviouswispr.discord-webhook-session-logs` (EnviousNotes)
+#   TRIGGER_SECRET            - gates the public manual `fetch` trigger; the cron path needs no token
+#                               (the workers.dev URL is public, so the manual trigger fails closed without it)


### PR DESCRIPTION
Part of #1092. Adds a small new Cloudflare Worker that watches product-health metrics from PostHog and posts an advisory line to Discord once a day. Read-only; gates nothing.

## What it watches (five signals, production-only)
- **e2e latency** p50/p95 per day (alert: p50>2.5s or p95>9s, 2 qualifying days)
- **paste fallback** share, split ax-denied vs direct-paste-failed (alert: >5%)
- **genuine AFM discard** rate via `fallback_reason` (alert: >15%) — currently `dark-awaiting-release` because that property is null on 100% of production events until #1067 ships in a release
- **transcription-failure family** share (alert: >5%, labeled honestly as including legitimate no-speech)
- **volume / telemetry-integrity** — the anti-masking guard: a zero-dictation day on an active baseline, or a co-firing-event blackout (schema drift), hard-alerts so a total telemetry blackout cannot read as healthy

## Key design points
- Thresholds **calibrated above real production baselines** (the issue's proposed thresholds were below baseline and would have fired every day).
- **Completed-window discipline** — every query excludes the partial current day; the cron runs at 14:00 UTC as an ingestion-lag buffer for offline laptops.
- **Daily one-line heartbeat** (always posts, carries the day's volume + per-metric evaluated/skipped/dark/query-failed states) so a silent worker death is visible. Louder alert block only on a crossing.
- **Loud failures**: query/Discord errors throw rather than read as healthy silence.
- Output and logs are **counts/rates/version-tags only** (no error strings, no raw rows, no per-user ids).
- Production filter excludes any `distinct_id` with a `-dev` build anywhere in its history (founder-machine-tell).
- Manual `fetch` trigger is **secret-gated** (fails closed) so the public workers.dev URL can't be crawled into spamming Discord.

## Validation
- 24 `node --test` unit cases green (thresholds, states, message builder, the zero-day blackout case).
- Pre-deploy **live-query smoke** run against production PostHog: queries resolve, denominators non-zero, AFM reads `dark-awaiting-release`, heartbeat well-formed, posts nothing.
- Full review chain: GPT+Gemini council coverage → 3 Codex grounded-review rounds to PROCEED-AS-PLANNED → Codex code-diff review (caught a public-trigger spam vector + the zero-day blackout bug + a dev-id window mismatch; all fixed) → clean re-review.

Plan: `docs/feature-requests/issue-1092-2026-06-20-daily-product-health-check.md`

## Deploy (founder-gated follow-up)
This PR ships the code; the worker is inert until deployed. Deploy = `wrangler deploy` + 3 secrets + a recurring cron that posts to Discord (outward-facing, free tier). Steps are in the worker README. Issue #1092 stays open until deployed.