### PR TITLE
docs(validation): sync validate-pr.sh Phase 3 order to Codex-clean-before-UAT

### DIFF
--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 # validate-pr.sh — Single-command Phase 3 runner (PR #498).
 #
-# Walks the Phase 3 sequence in order:
+# Walks the Phase 3 sequence in the canonical order (reordered 2026-06-20 per
+# founder directive — see workflow-process.md RULE: codex-clean-gates-runtime-uat):
 #   1. Logic tests
-#   2. Smoke (release build + bundle + launch)
-#   3. Live UAT (lane-specific; synthetic dictation default for Code lane)
-#   4. Codex code-diff review
-#   5. (Bug fixes return to step 1)
-#   6. (Push handled by caller)
+#   2. Codex code-diff review — iterate to a CLEAN pass (no app rebuild and no
+#      Live UAT between rounds; validate fixes with the fast inline swift harness)
+#   3. Smoke (Tuist/Xcode DEV build + signed copy + launch) + Live UAT — the
+#      SINGLE rebuild, run once on the Codex-clean code
+#   4. (Runtime-only Live UAT failure -> fix -> Codex clean again -> rebuild + re-UAT)
+#   5. (Push handled by caller)
+#
+# This script is a SCAFFOLDER, not the review sequencer: for a Code-lane change it
+# runs logic tests + the smoke build and writes `skipped:true` stubs for Live UAT
+# and Codex that the caller overwrites. The caller drives Codex code-diff to clean
+# BEFORE invoking the smoke + Live UAT portion, so the smoke build below is the
+# single post-Codex rebuild. The numbered Phase 3.x echo sections are the
+# scaffolder's internal step order, not the caller's review order.
 #
 # Writes evidence into `.validation/runs/<timestamp>-<shortsha>/`.
 # Calls `check-validation.sh` at the end as the final assertion.
@@ -200,7 +209,7 @@ elif [ "$DECLARED" = "Docs/dev-tooling" ]; then
   fi
 fi
 
-echo "==> Phase 3.2: Smoke (Tuist/Xcode DEV build + signed copy + launch)"
+echo "==> Phase 3.2: Smoke (Tuist/Xcode DEV build + signed copy + launch) — the single rebuild, expected AFTER Codex code-diff is clean"
 if [ "$DECLARED" = "Code" ]; then
   # #913 PR4: smoke runs the canonical Xcode-engine dev builder
   # scripts/build-dev-app.sh (Tuist generate → xcodebuild the EnviousWispr-Dev
@@ -224,7 +233,7 @@ if [ "$DECLARED" = "Code" ]; then
   fi
 fi
 
-echo "==> Phase 3.3: Live UAT (lane-specific)"
+echo "==> Phase 3.3: Live UAT (lane-specific) — runs on the post-Codex-clean smoke build above"
 case "$DECLARED" in
   Code)
     # Stage 1 stub: write a STRUCTURED JSON skip record. Real Code-lane
@@ -298,7 +307,7 @@ EOF
     ;;
 esac
 
-echo "==> Phase 3.4: Codex code-diff review (caller's responsibility — script not auto-invoking)"
+echo "==> Phase 3.4: Codex code-diff review (caller's responsibility; MUST be clean BEFORE the smoke + Live UAT rebuild above — script not auto-invoking)"
 if [ ! -s "$RUN_DIR/codex-review.txt" ] && [ "$DECLARED" = "Code" ]; then
   echo "Run: codex review --base origin/main -c model=gpt-5.5 -c model_reasoning_effort=medium </dev/null > $RUN_DIR/codex-review.txt" > "$RUN_DIR/codex-review-todo.txt"
   record_step "codex-review" 1 "Stage 1 stub — caller must run codex review and overwrite codex-review.txt"


### PR DESCRIPTION
## What

Syncs the `scripts/validate-pr.sh` self-documentation to the reordered Phase 3 sequence (founder directive 2026-06-20): the Codex code-diff review now runs to a **clean** pass **before** the single smoke + Live UAT rebuild, never interleaving rebuilds between Codex rounds (playbook `RULE: codex-clean-gates-runtime-uat`). A runtime-only Live UAT failure loops back through Codex-clean before the next rebuild.

The script's header comment and three progress-echo labels still described the old `smoke -> Live UAT -> Codex` order. This updates them. Also fixes a pre-existing stale header line that called smoke a "release build + bundle" — it has been the Tuist DEV build (`scripts/build-dev-app.sh`) since #913.

## Scope

**Documentation only — no logic change.** The script is a caller-driven scaffolder: for a Code-lane change it runs logic tests + the smoke build and writes `skipped:true` stubs the caller overwrites. The review order is enforced by the caller (the playbook), not the script, so only the comments/labels needed to change. Diff is the header comment block + three `echo` strings.

## Validation (Docs/dev-tooling lane)

- `shellcheck scripts/validate-pr.sh` — clean
- `scripts/validate-pr.sh --self-test` — 2/2 pass
- Codex code-diff review (`codex exec`, read-only) — **VERDICT: CLEAN** (doc-only confirmed; no old-order wording remains; DEV-build fix matches the real smoke implementation; `RULE: codex-clean-gates-runtime-uat` resolves)

`council-skip: zero-blast-radius` (doc-only sync of an already-Codex-validated, founder-directed workflow reorder; single surface = script comment/echo strings; single-commit revert).