### PR TITLE
ci(observability): schedule product-health worker via GitHub Actions (#1092)

### DIFF
--- a/.github/workflows/product-health-ping.yml
+++ b/.github/workflows/product-health-ping.yml
@@ -1,0 +1,30 @@
+name: Product Health Check
+
+# Triggers the product-health Cloudflare Worker once a day. The worker
+# (workers/product-health/) rolls up product metrics from PostHog and posts a
+# heartbeat to Discord. Scheduling lives here (GitHub Actions) rather than a
+# Cloudflare cron because the CF account is at its 5-cron free-plan limit (#1092).
+# The worker's fetch endpoint is secret-gated, so only this workflow (holding the
+# repo secret) can fire it. GitHub schedules can run a few minutes late; that is
+# fine because the worker evaluates the prior COMPLETED UTC day, not "now".
+
+on:
+  schedule:
+    - cron: "0 14 * * *"   # 10am ET daily - ingestion-lag buffer for offline laptops
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger product-health worker
+        env:
+          TRIGGER_SECRET: ${{ secrets.PRODUCT_HEALTH_TRIGGER_SECRET }}
+        run: |
+          curl -fsS --retry 3 --retry-delay 10 \
+            -H "x-trigger-secret: ${TRIGGER_SECRET}" \
+            "https://enviouswispr-product-health.saurabhav.workers.dev/" \
+            -o /dev/null -w "worker responded HTTP %{http_code}\n"

--- a/workers/product-health/README.md
+++ b/workers/product-health/README.md
@@ -54,21 +54,31 @@ npx wrangler deploy
 # secrets (never committed):
 ~/.claude/bin/get-key launch posthog-personal-api-key V -- sh -c 'printf "%s" "$V" | npx wrangler secret put POSTHOG_PERSONAL_API_KEY'
 security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-session-logs | npx wrangler secret put DISCORD_WEBHOOK_URL
-# TRIGGER_SECRET gates the public manual trigger (pick any long random string):
-printf "%s" "$(openssl rand -hex 24)" | npx wrangler secret put TRIGGER_SECRET
+# TRIGGER_SECRET gates the public trigger; stored in Keychain for the GitHub Action:
+security find-generic-password -w -a m4pro_sv -s enviouswispr.product-health-trigger-secret | npx wrangler secret put TRIGGER_SECRET
 
 # verify (posts a real heartbeat to EnviousNotes) - needs the token:
 curl "https://enviouswispr-product-health.saurabhav.workers.dev/?token=<TRIGGER_SECRET>"
 ```
 
-The daily cron path needs no token; only the public `fetch` trigger does (it
-fails closed with 401 if the token is missing or wrong, so the workers.dev URL
-cannot be crawled into spamming Discord).
+The `fetch` trigger fails closed with 401 if the token is missing or wrong, so
+the public workers.dev URL cannot be crawled into spamming Discord.
 
-Cron: `0 14 * * *` (10am ET daily) - a deliberate ingestion-lag buffer so the
-prior UTC day's events from offline laptops have flushed.
+## Scheduling (GitHub Actions, not a Cloudflare cron)
+
+The Cloudflare account is at its 5-cron free-plan limit (#1092), so the daily run
+is driven by `.github/workflows/product-health-ping.yml`, which curls the
+secret-gated endpoint at `0 14 * * *` (10am ET - ingestion-lag buffer). The same
+secret lives as repo secret `PRODUCT_HEALTH_TRIGGER_SECRET`:
+
+```bash
+security find-generic-password -w -a m4pro_sv -s enviouswispr.product-health-trigger-secret \
+  | gh secret set PRODUCT_HEALTH_TRIGGER_SECRET --repo saurabhav88/EnviousWispr
+# run on demand: gh workflow run "Product Health Check" --repo saurabhav88/EnviousWispr
+```
 
 ## Rollback
 
-`npx wrangler delete enviouswispr-product-health` stops the cron. Revert the PR
-to remove the code. A bad threshold is a one-line edit in `THRESHOLDS` + redeploy.
+Delete the GitHub workflow to stop the daily run; `npx wrangler delete
+enviouswispr-product-health` removes the worker entirely. Revert the PR to remove
+the code. A bad threshold is a one-line edit in `THRESHOLDS` + redeploy.

--- a/workers/product-health/wrangler.toml
+++ b/workers/product-health/wrangler.toml
@@ -2,10 +2,11 @@ name = "enviouswispr-product-health"
 main = "src/index.js"
 compatibility_date = "2026-06-20"
 
-# Daily at 14:00 UTC (10am ET). The late time is a deliberate ingestion-lag
-# buffer so the prior UTC day's events from sleeping/offline laptops have flushed.
-[triggers]
-crons = ["0 14 * * *"]
+# No [triggers] cron here: the Cloudflare account is at its 5-cron free-plan limit
+# (#1092), so scheduling lives in a GitHub Actions workflow
+# (.github/workflows/product-health-ping.yml) that pings the secret-gated fetch
+# endpoint daily at 14:00 UTC (10am ET) - a deliberate ingestion-lag buffer so the
+# prior UTC day's events from sleeping/offline laptops have flushed.
 
 [vars]
 POSTHOG_PROJECT_ID = "354235"
@@ -13,5 +14,6 @@ POSTHOG_PROJECT_ID = "354235"
 # Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
 #   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
 #   DISCORD_WEBHOOK_URL       - Keychain `enviouswispr.discord-webhook-session-logs` (EnviousNotes)
-#   TRIGGER_SECRET            - gates the public manual `fetch` trigger; the cron path needs no token
-#                               (the workers.dev URL is public, so the manual trigger fails closed without it)
+#   TRIGGER_SECRET            - gates the public `fetch` trigger; the GitHub Action sends it as
+#                               the `x-trigger-secret` header (the workers.dev URL is public, so
+#                               the trigger fails closed without it)


### PR DESCRIPTION
Part of #1092. The product-health worker (#1116) is deployed and verified working, but its daily **Cloudflare cron couldn't register** — the CF account is at the 5-cron free-plan limit (the Instagram poster uses 4 daily slots + the weekly digest 1, `code 10072`). This drives the daily run from a **GitHub Actions scheduled workflow** instead.

Why GitHub Actions: the repo is public, so Actions minutes are free; scheduled workflows are already a working pattern here (`ci-drift-check.yml`, `deploy-blog.yml`); default branch is `main`. No collateral to other automations, no spend.

## Changes
- **New `.github/workflows/product-health-ping.yml`** — `schedule: 0 14 * * *` (10am ET) + `workflow_dispatch`; curls the worker's secret-gated endpoint with the `x-trigger-secret` header (repo secret `PRODUCT_HEALTH_TRIGGER_SECRET`, already set); `permissions: contents: read`; `-fsS` fails the job on a non-2xx.
- **`wrangler.toml`** — removed the dead `[triggers] cron` (it returned `10072` on every deploy) and documented that scheduling lives in the Action.
- **README** — scheduling + rollback sections updated.

## Validation
- `actionlint` clean; YAML tab-free; Codex diff review clean.
- The worker itself is already deployed + secret-gated (verified: 401 unauth, heartbeat posted to EnviousNotes on authed trigger).
- Post-merge: I'll fire the workflow once via `workflow_dispatch` to confirm the scheduled path reaches the worker and posts (CI-lane evidence-of-execution).

GitHub schedules can lag a few minutes; harmless — the worker evaluates the prior COMPLETED UTC day, not "now".