### PR TITLE
feat(pipeline): crash-recovery replay flow behind a blocking pill (#1063 PR2)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -91,16 +91,18 @@ final class DictationLifecycleCoordinator {
   /// default no-op keeps recovery-off behavior. Keeps the Pipeline recovery-unaware.
   var onDurableSave: (String) -> Void = { _ in }
 
-  /// #1063 PR1 (Codex r3 P1) — fires when a recording reaches a NON-saved
-  /// terminal (`.error` / `.idle` from cancel, no-speech, too-short discard,
-  /// pipeline error, or a helper-crash-while-app-alive). `DictationRuntime` sets
-  /// it to `RecoveryCoordinator.handleRecordingEndedWithoutDurableSave` so the
-  /// armed spool + key are deleted immediately (the app is alive — not a crash —
-  /// so they have no recovery value and would otherwise accumulate until launch).
-  /// `.complete` is EXCLUDED (its save path runs `onDurableSave`); the
-  /// coordinator's armed-id guard makes a post-`.complete` `.idle` a no-op.
-  /// Another off-cap `var` closure, default no-op.
-  var onRecordingEndedWithoutDurableSave: () -> Void = {}
+  /// #1063 PR2 — fires when a recording reaches a NON-`.completed` terminal,
+  /// carrying this session's `recoverySessionID` (or nil if recovery was off) and
+  /// the terminal KIND. `DictationRuntime` sets it to `RecoveryCoordinator
+  /// .handleRecordingEndedWithoutDurableSave(recoverySessionID:terminal:)`, which
+  /// deletes a DISCARD-terminal spool now and RETAINS a FAILURE-terminal spool for
+  /// next-launch recovery. Driven by the kernel's RAW terminal transition (via the
+  /// driver's `onSessionEndedWithoutSave`), NOT the externalError-pinnable published
+  /// state — so it never fires for `.completed` (whose save path runs `onDurableSave`)
+  /// and the error pin can't trigger an early delete. Off-cap `var` closure,
+  /// default no-op keeps recovery-off behavior. (PR1's published-state cleanup
+  /// branch is replaced by this signal.)
+  var onRecordingEndedWithoutDurableSave: (String?, RecordingTerminalKind) -> Void = { _, _ in }
 
   /// Per-pipeline side-effect executors. Lazy so the closures can capture
   /// `self` after all stored properties are initialized.
@@ -146,6 +148,16 @@ final class DictationLifecycleCoordinator {
     whisperKitKernelDriver.onStateChange = { [weak self] newState in
       guard let self else { return }
       self.handleWhisperKit(newState: newState)
+    }
+    // #1063 PR2: the kernel's RAW non-`.completed` terminal signal, carrying the
+    // recovery id + terminal KIND. Routed to the recovery cleanup (discard deletes,
+    // failure retains). Distinct from `onStateChange` (the pinnable published
+    // state) — keyed off the kernel terminal so it never fires during `.finalizing`.
+    kernelDriver.onSessionEndedWithoutSave = { [weak self] id, kind in
+      self?.onRecordingEndedWithoutDurableSave(id, kind)
+    }
+    whisperKitKernelDriver.onSessionEndedWithoutSave = { [weak self] id, kind in
+      self?.onRecordingEndedWithoutDurableSave(id, kind)
     }
     // #930: the overlay-only sub-status channel. A `.transcribing` →
     // `.polishing` flip mid-`.finalizing` does NOT change the public
@@ -211,19 +223,11 @@ final class DictationLifecycleCoordinator {
       // Session ended — retry any Ollama eviction deferred because the
       // frozen session pinned the old model.
       settingsSync.retryDeferredOllamaEviction(settings: settings)
-      // #1063 PR1: a NON-saved ending (cancel / no-speech / too-short / error /
-      // helper-crash-while-alive) left a finalized recovery spool; delete it now.
-      // `.complete` owns deletion via its save path (`onDurableSave`), so skip it.
-      // KNOWN LIMITATION (Codex r4 P2 #1, routed to #1063 PR2): the published
-      // `.error` here is externalError-pinned, so it can in theory fire while the
-      // kernel is still finalizing (a transcript in hand, durable save imminent) —
-      // deleting the spool a beat early. Zero impact in PR1 (the launch purge
-      // wipes every spool regardless of deletion timing, and no current
-      // `setExternalError` caller fires during finalizing). The correct fix is to
-      // key this cleanup off the kernel's terminal transition rather than the
-      // pinnable published state; that signal redesign lands with PR2's recovery
-      // rebuild (scan → recover → save → delete).
-      if case .complete = newState {} else { onRecordingEndedWithoutDurableSave() }
+    // #1063 PR2: the recovery-spool cleanup is NO LONGER keyed off this
+    // externalError-pinnable published state. It is driven by the kernel's RAW
+    // terminal transition via `kernelDriver.onSessionEndedWithoutSave` (wired in
+    // `install()`), which carries the recovery id + terminal KIND and never
+    // fires during `.finalizing` — resolving PR1's "delete a beat early" hole.
     }
     let nowActive = newState.isActive
     if nowActive && !prevParakeetActive {
@@ -265,8 +269,9 @@ final class DictationLifecycleCoordinator {
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
       settingsSync.retryDeferredOllamaEviction(settings: settings)
-      // #1063 PR1: same non-saved recovery-spool cleanup as the Parakeet handler.
-      if case .complete = newState {} else { onRecordingEndedWithoutDurableSave() }
+    // #1063 PR2: recovery-spool cleanup is driven by the kernel terminal signal
+    // (`onSessionEndedWithoutSave`), not this published state — see the Parakeet
+    // handler. Nothing to do here.
     }
     let nowActive = newState.isActive
     if nowActive && !prevWhisperKitActive {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -129,8 +129,15 @@ final class DictationRuntime {
       },
       // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
       // the arm window mints no session, so the lifecycle coordinator sees no
-      // terminal state — the starter cleans the armed spool/key directly.
-      cleanupRecoveryArm: { recoveryCoordinator.handleRecordingEndedWithoutDurableSave() }
+      // terminal state — the starter cleans the armed spool/key directly. PR2: it
+      // passes this take's id, and a pre-start abort is always a discard.
+      cleanupRecoveryArm: { id in
+        recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
+          recoverySessionID: id, terminal: .discard)
+      },
+      // #1063 PR2: the recording gate — a press while recovery holds the shared
+      // engine mints no session (shows the "recovering" pill).
+      isRecovering: { recoveryCoordinator.isRecovering }
     )
     self.starter = starter
     // #1063 PR1: on a durable transcript save, delete that session's spool + key.
@@ -138,11 +145,12 @@ final class DictationRuntime {
     dictationLifecycleCoordinator.onDurableSave = { id in
       recoveryCoordinator.handleDurableSave(recoverySessionID: id)
     }
-    // #1063 PR1 (Codex r3): a recording that ends WITHOUT a durable save (cancel,
-    // no-speech, too-short, error, helper-crash-while-alive) deletes its armed
-    // spool/key immediately instead of accumulating until launch purge.
-    dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = {
-      recoveryCoordinator.handleRecordingEndedWithoutDurableSave()
+    // #1063 PR2: a recording that ends at a non-saved terminal routes to recovery
+    // cleanup by KIND — a discard terminal deletes the spool now; a failure
+    // terminal RETAINS it so the next launch recovers the audio.
+    dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = { id, kind in
+      recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: id, terminal: kind)
     }
     let hotkeyController = HotkeyController(
       hotkeyService: hotkeyService,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
@@ -42,7 +42,10 @@ final class RecordingFinalizer {
     try await $0.handle(event: .requestStop)
   }
   var cancelRecordingDispatch: @MainActor (KernelDictationDriver) async -> Void = {
-    await $0.cancelRecording()
+    // #1063 PR2: this is the genuine USER cancel path (the cancel button →
+    // `RecordingFinalizer.cancel()`), so a recovery spool is DELETED, not retained.
+    // The settings-rebuild system cancel uses `cancelRecording()`'s retain default.
+    await $0.cancelRecording(disposition: .discard)
   }
 
   /// Read accessor exposed to `RecordingStarter` so the start path's

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -43,10 +43,20 @@ final class RecordingStarter {
   /// recording — a PTT release or a concurrent-toggle stop landing in the arm
   /// window. Those paths mint no kernel session, so no terminal pipeline state
   /// fires to drive the lifecycle coordinator's cleanup; the start path must
-  /// trigger it directly. Bare closure (off the collaborator cap); bound to
-  /// `RecoveryCoordinator.handleRecordingEndedWithoutDurableSave`. Default no-op.
-  /// (#1063 PR1, Codex r3.)
-  let cleanupRecoveryArm: @MainActor () -> Void
+  /// trigger it directly, passing the id armed for this start (nil ⇒ recovery was
+  /// off — no-op). A pre-start abort is always a DISCARD. Bare closure (off the
+  /// collaborator cap); bound to `RecoveryCoordinator
+  /// .handleRecordingEndedWithoutDurableSave(recoverySessionID:terminal:)`.
+  /// (#1063 PR1, Codex r3; id+terminal in PR2.)
+  let cleanupRecoveryArm: @MainActor (String?) -> Void
+
+  /// Whether the crash-recovery limb is replaying a leftover recording behind the
+  /// blocking pill (#1063 PR2). A record-press while true mints NO session — the
+  /// gate shows the "recovering" pill and returns, exactly like the cold-engine
+  /// not-ready gate. Bare closure (off the collaborator cap); bound to
+  /// `RecoveryCoordinator.isRecovering`. Default `false` keeps recovery-off and
+  /// legacy/test construction unchanged.
+  let isRecovering: @MainActor () -> Bool
 
   var heartControlRecovery: HeartControlRecovery
   var recordingLockedAccess: DictationLifecycleCoordinator.RecordingLockedAccess
@@ -93,10 +103,12 @@ final class RecordingStarter {
     makeRecoveryDirective: @escaping @MainActor (SettingsManager, ASRBackendType, Bool) async -> (
       recoverySessionID: String, payload: Data
     )? = { _, _, _ in nil },
-    cleanupRecoveryArm: @escaping @MainActor () -> Void = {}
+    cleanupRecoveryArm: @escaping @MainActor (String?) -> Void = { _ in },
+    isRecovering: @escaping @MainActor () -> Bool = { false }
   ) {
     self.makeRecoveryDirective = makeRecoveryDirective
     self.cleanupRecoveryArm = cleanupRecoveryArm
+    self.isRecovering = isRecovering
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.kernelDriver = kernelDriver
@@ -131,6 +143,16 @@ final class RecordingStarter {
       guard !whisperKitKernelDriver.state.isActive else { return }
     } else {
       guard !kernelDriver.state.isActive else { return }
+    }
+    // #1063 PR2 — recovery hold. While the one leftover recording backfills behind
+    // the blocking pill, a record-press mints NO session: show the "recovering"
+    // pill (with Discard) and bail, before warming the engine the recovery is
+    // using. Takes precedence over the cold-engine gate below (same shape).
+    if isRecovering() {
+      recordingOverlay.show(intent: .recoveringLastRecording)
+      TelemetryService.shared.recoveryPressBlocked(
+        asrBackend: isWhisperKit ? "whisperkit" : "parakeet")
+      return
     }
     lastRecordingResult?.polishError = nil
     // #879 — cold-boot press safety. A press on a not-ready engine must NOT mint
@@ -217,8 +239,22 @@ final class RecordingStarter {
         audioCapture.abortPreWarm()
         // A key was armed for this take but no session will start — no terminal
         // pipeline state fires, so clean the orphan spool/key here (Codex r3).
-        cleanupRecoveryArm()
+        // Pre-start abort is always a discard (#1063 PR2: pass this take's id).
+        cleanupRecoveryArm(config.recoverySessionID)
         recordingOverlay.show(intent: .hidden)
+        recordingLockedAccess.set(false)
+        return
+      }
+      // #1063 PR2 (Codex code-diff r2 P2): the top-of-`start()` recovery gate can
+      // go STALE across the `preWarm` + recovery-arm awaits — launch recovery may
+      // have started in that window. Re-check before minting a session so a new
+      // recording can't contend with the recovery replay on the shared engine;
+      // tear down the engine + clean the just-armed id, exactly like the guards
+      // above.
+      if isRecovering() {
+        audioCapture.abortPreWarm()
+        cleanupRecoveryArm(config.recoverySessionID)
+        recordingOverlay.show(intent: .recoveringLastRecording)
         recordingLockedAccess.set(false)
         return
       }
@@ -289,6 +325,15 @@ final class RecordingStarter {
       !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive)
     var isWarmRespawn = false
     if isStartingFromIdle {
+      // #1063 PR2 — recovery hold, same as the PTT path. A toggle that would START
+      // while recovery holds the engine mints no session: show the pill and bail.
+      // A toggle that STOPS an active session is unaffected (guarded by
+      // `isStartingFromIdle`).
+      if isRecovering() {
+        recordingOverlay.show(intent: .recoveringLastRecording)
+        TelemetryService.shared.recoveryPressBlocked(asrBackend: isWK ? "whisperkit" : "parakeet")
+        return
+      }
       lastRecordingResult?.polishError = nil
       // #879 — same cold-boot press safety as the PTT path. A toggle press that
       // would START on a not-ready engine shows the pill + warms instead of
@@ -325,12 +370,21 @@ final class RecordingStarter {
       // terminal state for the lifecycle coordinator's cleanup to observe).
       if isStartingFromIdle {
         if let lastStop = lastUserStopAccess.read(), lastStop > toggleStart {
-          cleanupRecoveryArm()
+          cleanupRecoveryArm(config.recoverySessionID)
           return
         }
         if active.state.isActive {
-          cleanupRecoveryArm()
+          cleanupRecoveryArm(config.recoverySessionID)
           try await active.handle(event: .requestStop)
+          return
+        }
+        // #1063 PR2 (Codex code-diff r2 P2): re-check after the recovery-arm await
+        // — launch recovery may have started in that window. Bail before minting a
+        // session so it can't contend with the recovery replay; clean the just-
+        // armed id.
+        if isRecovering() {
+          cleanupRecoveryArm(config.recoverySessionID)
+          recordingOverlay.show(intent: .recoveringLastRecording)
           return
         }
       }

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -22,6 +22,12 @@ final class PipelineSettingsSync {
   /// preload observation without coupling this layer to the composition root.
   var onNeedsPreloadObservation: (() -> Void)?
 
+  /// #1063 PR2 — true while the crash-recovery limb is replaying behind the pill.
+  /// A backend switch then would unload/reset the model mid-recovery, throwing the
+  /// in-flight transcribe and (one-attempt) deleting the spool — data loss. Set by
+  /// the composition root to `RecoveryCoordinator.isRecovering`; default no-recovery.
+  var isRecovering: () -> Bool = { false }
+
   /// Tracks the last evictable Ollama model for #295. Independent of the
   /// kernel's polish step because SettingsManager's cascading didSet can
   /// corrupt a pre-snapshot read from the polish step.
@@ -94,13 +100,19 @@ final class PipelineSettingsSync {
   func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
     switch key {
     case .selectedBackend:
-      // Don't switch backends while a pipeline is actively recording/transcribing
+      // Don't switch backends while a pipeline is actively recording/transcribing,
+      // OR while crash recovery is replaying on the shared engine (#1063 PR2) — a
+      // switch would unload/reset the model mid-recovery and lose the spool.
+      // Like the pre-existing active-pipeline case, the switch is DROPPED (not
+      // queued): the persisted `selectedBackend` and the active engine can disagree
+      // until the next change/relaunch. Recovery is short (seconds), so the window
+      // is brief; a general deferred-apply mechanism is PR3 hardening (Codex r6 P2).
       let parakeetActive = kernelDriver.state.isActive
       let whisperKitActive = whisperKitKernelDriver.state.isActive
-      if parakeetActive || whisperKitActive {
+      if parakeetActive || whisperKitActive || isRecovering() {
         Task {
           await AppLogger.shared.log(
-            "Backend switch blocked — pipeline is active",
+            "Backend switch blocked — pipeline active or recovery in progress",
             level: .info, category: "PipelineSettingsSync"
           )
         }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -68,6 +68,9 @@ final class RecordingOverlayPanel {
   private var accessibilityToastShownThisSession: Bool = false
   private var grantHandler: (() -> Void)?
   private var accessibilityWarningDismissedProvider: () -> Bool = { false }
+  /// #1063 PR2 — invoked when the user taps Discard on the "recovering" pill.
+  /// Wired by the composition root to `RecoveryCoordinator.discardActiveRecovery`.
+  private var discardRecoveryHandler: (() -> Void)?
 
   // Passive chip handlers — installed by the former root state once at init, invoked by the
   // chip view when the user taps Lock / Dismiss or when the auto-dismiss timer
@@ -80,6 +83,11 @@ final class RecordingOverlayPanel {
 
   func setGrantHandler(_ handler: @escaping () -> Void) {
     grantHandler = handler
+  }
+
+  /// #1063 PR2 — wire the "recovering" pill's Discard action.
+  func setDiscardRecoveryHandler(_ handler: @escaping () -> Void) {
+    discardRecoveryHandler = handler
   }
 
   func setAccessibilityWarningDismissedProvider(_ provider: @escaping () -> Bool) {
@@ -227,6 +235,20 @@ final class RecordingOverlayPanel {
           icon: .ready
         ).frame(width: 240, height: 44),
         width: 240, height: 44, dismissAfter: 1.5)
+    case .recoveringLastRecording:
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: "Recovering your last recording. Press Discard to skip.",
+          .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
+        ])
+      presentTransientNotice(
+        content: RecoveryNoticeView(onDiscard: { [weak self] in
+          self?.discardRecoveryHandler?()
+          self?.hide()
+        }).frame(width: 320, height: 56),
+        width: 320, height: 56, dismissAfter: 6.0)
     }
   }
 
@@ -1397,5 +1419,49 @@ struct AccessibilityToastView: View {
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
     .background(OverlayCapsuleBackground())
+  }
+}
+
+// MARK: - RecoveryNoticeView (#1063 PR2)
+
+/// The "recovering your last recording" pill shown when a record-press lands
+/// while the crash-recovery limb holds the shared engine. Mirrors the cold-start
+/// notice shape (spinner + plain-English copy) and adds a Discard affordance for
+/// "I don't want to wait." Icon + text (never color-only); the Discard button is
+/// keyboard-activatable for VoiceOver.
+struct RecoveryNoticeView: View {
+  let onDiscard: () -> Void
+
+  var body: some View {
+    HStack(spacing: 10) {
+      ProgressView()
+        .controlSize(.small)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 1) {
+        Text("Recovering your last recording…")
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.white)
+        Text("Saved to History when it's done")
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.7))
+      }
+      Spacer(minLength: 8)
+      Button(action: onDiscard) {
+        Text("Discard")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.white)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 4)
+          .contentShape(Rectangle())
+          .background(Capsule().fill(Color.white.opacity(0.18)))
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Discard recovering recording")
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .background(OverlayCapsuleBackground())
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Recovering your last recording")
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -1,24 +1,30 @@
 import EnviousWisprCore
+import EnviousWisprPipeline
 import EnviousWisprServices
 import EnviousWisprStorage
 import Foundation
 
-/// Host-side owner of the crash-recovery limb (#1063 PR1).
+/// Host-side owner of the crash-recovery limb (#1063).
 ///
-/// Responsibilities in PR1:
+/// Responsibilities:
 /// - **Arm** a recording: mint a durable per-recording id, generate + DURABLY
 ///   store the per-session key, snapshot record-time settings, and produce the
 ///   opaque directive the audio helper writes the encrypted spool from.
 /// - **Clean up on success:** once a recording's transcript is durably saved,
 ///   delete that session's spool file + key.
-/// - **Purge on launch:** sweep every orphan spool + key (PR1 does NOT recover
-///   yet — that lands PR2; purging keeps zero recoverable audio on disk so
-///   shipping PR1 before PR2 leaks nothing).
+/// - **Clean up on a non-saved ending (PR2):** route the kernel's terminal
+///   signal — a DISCARD terminal (cancel / no-speech / too-short) deletes the
+///   spool now; a FAILURE terminal (pipeline / audio / engine fault) RETAINS it
+///   so the audio is recovered on the next launch.
+/// - **Scan + recover on launch (PR2):** find orphan spools, dedup any already
+///   in History, then — behind a blocking "recovering your last recording" pill
+///   that holds new recordings off the one shared engine — replay each orphan
+///   (decrypt → transcribe → polish → save a non-auto-pasting "Recovered" entry).
 ///
-/// It is a strict LIMB: every path fails open (returns nil / best-effort delete)
-/// and never touches the heart path. Bootstrapper-owned, a sibling of
-/// `DiagnosticsCoordinator`. Not `@Observable` in PR1 — it has no view-facing
-/// state until the PR2 recovery banner.
+/// It is a strict LIMB: every path fails open and never touches the heart path.
+/// Bootstrapper-owned, a sibling of `DiagnosticsCoordinator`. Not `@Observable`:
+/// `isRecovering` is read on demand by the recording gate (an imperative closure
+/// read at press time), not reactively observed by any view.
 @MainActor
 final class RecoveryCoordinator {
   private let keyStore: RecoveryKeyStore
@@ -26,22 +32,69 @@ final class RecoveryCoordinator {
   /// directory (0700, Spotlight/backup-excluded), so we make a fresh value at
   /// each use rather than hold one. Injectable for tests.
   private let makeSpoolStore: @Sendable () -> RecoverySpoolStore
+  /// Per-orphan replay (decrypt → transcribe → polish → save). Behind a protocol
+  /// so tests drive scan/gate/generation logic against a double.
+  private let replayer: any RecoverySpoolReplaying
+  /// The set of `recoverySessionID`s already saved to History — read once per scan
+  /// to dedup a spool whose transcript landed in a prior run's save→delete crash
+  /// window (delete it WITHOUT re-transcribing). Injectable for tests.
+  private let existingRecoveryIDs: @MainActor () async -> Set<String>
+  /// Whether a live dictation is in flight — the recovery-independent contention
+  /// guard (a recording can arm in the launch window even with recovery OFF, so
+  /// `armedSessionID` alone wouldn't catch it). Recovery never runs the shared
+  /// engine while this is true; it defers to a future launch.
+  private let isDictationActive: @MainActor () -> Bool
+
   /// The recovery session armed for the CURRENT recording, or nil. Set BEFORE
-  /// the directive's key is durably stored (so the launch purge can never delete
-  /// a key it snapshots mid-arm); cleared if that store fails, when the session's
-  /// spool + key are deleted (durable save), or when the recording ends WITHOUT a
-  /// durable save. Lets the non-saved-terminal cleanup target the live session
-  /// and lets the launch purge protect it from a concurrent-arm race. MainActor-confined
-  /// (sequential recordings — one kernel FSM — so a single slot suffices; the
-  /// rare concurrent double-arm is backstopped by the launch purge). (#1063 PR1.)
+  /// the directive's key is durably stored (so the launch scan can never delete a
+  /// key it snapshots mid-arm); cleared if that store fails, on durable save, or
+  /// when the recording ends without a durable save. Its remaining job in PR2 is
+  /// to let the launch scan PROTECT a live in-progress recording from a
+  /// concurrent-arm race. MainActor-confined.
   private var armedSessionID: String?
+
+  /// True while the launch scan is replaying orphans behind the blocking pill.
+  /// DRIVES the recording gate: a record-press while true mints no session (shows
+  /// the "recovering" pill). `private(set)` — only the scan/discard own it, and a
+  /// `defer` guarantees it clears on EVERY scan exit (a stuck `true` would brick
+  /// recording). Read by the gate via an injected closure.
+  private(set) var isRecovering = false
+
+  /// Monotonic token bumped by `discardActiveRecovery()`. The replayer captures
+  /// it per orphan and re-checks after every `await`: a mismatch means "discarded
+  /// while my uncancellable batch transcribe was in flight" → drop the result,
+  /// save nothing. The concrete mechanism behind Discard (batch transcribe has no
+  /// cancel API). MainActor-confined.
+  private var recoveryGeneration = 0
+
+  /// The orphan id currently being replayed, so Discard can delete exactly the
+  /// recording the user is waiting on. nil when the scan is between orphans.
+  private var activeRecoveryID: String?
+
+  /// Single-flight guard so a re-trigger of `scanAndRecover()` can't double-run.
+  private var scanInProgress = false
+
+  /// Hard-reset the shared engine (the #445 service-kill: kills any in-flight
+  /// load/transcribe and marks the engine for reinit). Lets Discard return the
+  /// uncancellable in-flight replay promptly and hand the user a clean engine —
+  /// so Discard is a reliable escape even if the engine wedged. Bound to
+  /// `ASRManagerInterface.cancelInFlightLoad`.
+  private let resetEngine: @MainActor () -> Void
 
   init(
     keyStore: RecoveryKeyStore = RecoveryKeyStore(),
-    makeSpoolStore: @escaping @Sendable () -> RecoverySpoolStore = { RecoverySpoolStore() }
+    makeSpoolStore: @escaping @Sendable () -> RecoverySpoolStore = { RecoverySpoolStore() },
+    replayer: any RecoverySpoolReplaying,
+    existingRecoveryIDs: @escaping @MainActor () async -> Set<String>,
+    isDictationActive: @escaping @MainActor () -> Bool,
+    resetEngine: @escaping @MainActor () -> Void = {}
   ) {
     self.keyStore = keyStore
     self.makeSpoolStore = makeSpoolStore
+    self.replayer = replayer
+    self.existingRecoveryIDs = existingRecoveryIDs
+    self.isDictationActive = isDictationActive
+    self.resetEngine = resetEngine
   }
 
   private enum RecoveryArmError: Error { case keyStoreFailed }
@@ -101,15 +154,14 @@ final class RecoveryCoordinator {
 
     guard let payload = try? JSONEncoder().encode(directive) else { return nil }
 
-    // Protect this id from the launch purge BEFORE the key can land on disk.
+    // Protect this id from the launch scan BEFORE the key can land on disk.
     // Ordering invariant: `armedSessionID` is set (synchronously, on the
-    // MainActor) no later than the key hits disk. The purge reads `armed` AFTER
-    // snapshotting the on-disk keys, so any key it could have snapshotted was
-    // stored after this assignment and is therefore already protected — closing
-    // the mid-arm gap where a purge snapshot saw the key but a nil `armed`
-    // (Codex code-diff r4 P2). Cleared below if the durable store fails.
-    // (A concurrent double-arm overwrites this; the loser's key is an orphan the
-    // launch purge sweeps — harmless in PR1, no recovery.)
+    // MainActor) no later than the key hits disk. The scan reads `armed` AFTER
+    // snapshotting the on-disk spools, so any spool it could have snapshotted was
+    // armed before this assignment and is therefore already protected — closing
+    // the mid-arm gap (Codex code-diff r4 P2). Cleared below if the durable store
+    // fails. (A concurrent double-arm overwrites this; the loser's key is an
+    // orphan a future launch scan recovers or sweeps — harmless.)
     armedSessionID = recoverySessionID
 
     // Durably store the key off the MainActor BEFORE returning an enabled
@@ -119,7 +171,7 @@ final class RecoveryCoordinator {
       (try? keyStore.store(keyData: keyData, for: recoverySessionID)) != nil
     }.value
     guard stored else {
-      // No durable key landed — un-protect so the purge isn't guarding a phantom
+      // No durable key landed — un-protect so the scan isn't guarding a phantom
       // and a later non-saved cleanup is a no-op. Guard the id in case a
       // concurrent arm overwrote the slot (won't happen with sequential
       // recordings, but keeps the clear precise).
@@ -147,59 +199,167 @@ final class RecoveryCoordinator {
     }
   }
 
-  /// A recording ended WITHOUT a durable transcript save — cancel, no-speech,
-  /// too-short discard, pipeline error, helper-crash-while-app-alive, or a
-  /// pre-session abort after the key was armed. The app is ALIVE, so this is NOT
-  /// a crash orphan (a real crash kills the app before this can run, leaving the
-  /// spool for the launch purge / PR2 recovery); delete the armed spool + key
-  /// NOW instead of letting non-saved recordings accumulate on a long-running
-  /// menu-bar app. Idempotent + best-effort; a no-op when nothing is armed.
-  /// Returns the detached work so tests can await it. (#1063 PR1, Codex r3 P1.)
+  /// A recording ended at a terminal state WITHOUT a durable transcript save
+  /// (#1063 PR2). Routes on the terminal KIND:
+  /// - `discard` (cancel / no-speech / too-short, or a pre-start abort): the app
+  ///   is alive and there is nothing worth recovering — delete the spool + key now
+  ///   instead of letting non-saved recordings accumulate on a long-running app.
+  /// - `failure` (pipeline / audio / engine fault): the captured audio is the
+  ///   user's words — RETAIN the spool so the next launch recovers it.
+  /// Idempotent + best-effort; a no-op when `id` is nil. Always clears the live-
+  /// recording protection (the recording is over). Returns the detached delete
+  /// work (discard only) so tests can await it.
   @discardableResult
-  func handleRecordingEndedWithoutDurableSave() -> Task<Void, Never>? {
-    guard let id = armedSessionID else { return nil }
-    armedSessionID = nil
-    let keyStore = self.keyStore
-    let makeSpoolStore = self.makeSpoolStore
-    return Task.detached(priority: .utility) {
-      try? makeSpoolStore().delete(recoverySessionID: id)
-      try? keyStore.delete(for: id)
+  func handleRecordingEndedWithoutDurableSave(
+    recoverySessionID id: String?, terminal: RecordingTerminalKind
+  ) -> Task<Void, Never>? {
+    guard let id else { return nil }
+    if armedSessionID == id { armedSessionID = nil }
+    switch terminal {
+    case .discard:
+      let keyStore = self.keyStore
+      let makeSpoolStore = self.makeSpoolStore
+      return Task.detached(priority: .utility) {
+        try? makeSpoolStore().delete(recoverySessionID: id)
+        try? keyStore.delete(for: id)
+      }
+    case .failure:
+      // Retain the spool + key — recovered on the next launch.
+      return nil
     }
   }
 
-  /// On launch, purge every orphan spool + key. PR1 does NOT recover — purging
-  /// guarantees no recoverable audio is left on disk. (PR2 replaces this with
-  /// scan → recover → save → delete.) Returns the detached work so tests can
-  /// await it; callers discard it.
-  @discardableResult
-  func purgeOrphansOnLaunch() -> Task<Void, Never> {
+  /// On launch, scan for orphan spools and recover them behind the blocking pill
+  /// (#1063 PR2 — replaces PR1's purge). Single-flight. Sequential. One attempt
+  /// per orphan. Strict limb: fails open at every step.
+  func scanAndRecover() async {
+    guard !scanInProgress else { return }
+    scanInProgress = true
+    defer { scanInProgress = false }
+
+    let store = makeSpoolStore()
+    // Fail CLOSED on a scan error (Codex code-diff r3 P2): a directory IO /
+    // permission failure must NOT be read as "no spools" — the key-only sweep
+    // below would then see an empty spool set and delete keys for spools that
+    // exist but weren't listed, making those recordings undecryptable. A genuine
+    // empty directory throws nothing and returns [].
+    let spoolIDs: [String]
+    do {
+      spoolIDs = try store.listSpoolSessionIDs()
+    } catch {
+      return
+    }
+    let armed = armedSessionID
+
+    // Sweep KEY-ONLY orphans first: a key whose spool was never written — a
+    // recording that armed then crashed before the helper wrote the first frame.
+    // The spool scan can't see these (no `.ewrec` file), so without this they leak
+    // a recovery key forever; the PR1 launch purge swept them via `listAccountIDs`
+    // (Codex code-diff P2). Off-MainActor (`keychain-not-mainactor`); excludes
+    // every id that DOES have a spool (deduped or recovered below, and still needs
+    // its key to decrypt). Runs even when there are zero spools.
+    //
+    // Race-safe ordering (Codex code-diff r2 + r4 P2): inside the detached task,
+    // snapshot the keys FIRST, then read the live armed id AND re-list the spools
+    // FRESH (not the scan-start `spoolIDs` snapshot). Three protections, each read
+    // as late as possible so it sees the most recent state:
+    //   - a key armed AFTER the key snapshot can't be in `keyIDs` (stored later);
+    //   - a currently-arming take is caught by the freshly-read `liveArmed`;
+    //   - a take that armed AND ENDED at a FAILURE terminal after the scan snapshot
+    //     RETAINS its spool — re-listing spools fresh sees that spool, so its key is
+    //     NOT swept (the stale scan-start snapshot would have missed it and deleted
+    //     the key, making that recording undecryptable — r4 P2).
+    // Only a key with NO spool now (and not live-armed) is a true key-only orphan.
     let keyStore = self.keyStore
     let makeSpoolStore = self.makeSpoolStore
-    return Task.detached(priority: .utility) { [weak self] in
-      let store = makeSpoolStore()
-      // Snapshot the orphan set UP FRONT — both the spool ids and the key
-      // account ids — before deleting anything. A recording that arms
-      // concurrently with this fire-and-forget purge mints a fresh UUID +
-      // stores its key; snapshotting first means the deletion can never catch
-      // a key armed AFTER the snapshot (Codex code-diff r2 P1). PR1 recovers
-      // nothing, so every spool present now is an orphan, and `keyIDs` already
-      // covers every armed key (one per spool) PLUS any orphan key with no
-      // spool — e.g. a recording that armed then aborted before the first frame.
-      let spoolIDs = (try? store.listSpoolSessionIDs()) ?? []
+    Task.detached(priority: .utility) { [weak self] in
       let keyIDs = keyStore.listAccountIDs()
-      // Hotkeys go live BEFORE this purge (it is fire-and-forget), so a recording
-      // can arm in the snapshot window with its key already in `keyIDs`. Read the
-      // live armed id (set on the MainActor in `makeDirective`) AFTER snapshotting
-      // and PROTECT it — deleting a live key would make its spool unrecoverable
-      // (Codex code-diff r3 P2). A recording armed after this read is excluded
-      // from the snapshots already.
-      let armed = await MainActor.run { self?.armedSessionID }
-      for id in spoolIDs where id != armed {
-        try? store.delete(recoverySessionID: id)
-      }
-      for id in keyIDs where id != armed {
+      let liveArmed = await MainActor.run { self?.armedSessionID }
+      // Fail CLOSED if the fresh re-list errors (Codex code-diff r5 P2): treating
+      // an IO/permission error as "no spools" would delete keys for real `.ewrec`
+      // files. Abort the sweep instead — same discipline as the scan-start list.
+      guard let currentSpoolList = try? makeSpoolStore().listSpoolSessionIDs() else { return }
+      let currentSpools = Set(currentSpoolList)
+      for id in keyIDs where id != liveArmed && !currentSpools.contains(id) {
         try? keyStore.delete(for: id)
       }
     }
+
+    guard !spoolIDs.isEmpty else { return }
+
+    // Snapshot the History dedup set. A recording that arms during the dedup
+    // `await` mints a fresh UUID not in `spoolIDs` (listed above) — already
+    // excluded; the contention guard below is the backstop.
+    let alreadySaved = await existingRecoveryIDs()
+
+    var recoverable: [String] = []
+    for id in spoolIDs where id != armed {
+      if alreadySaved.contains(id) {
+        // Saved in a prior run's save→delete crash window: delete WITHOUT
+        // re-transcribing (the dedup MUST precede any append — History forbids a
+        // duplicate id). Spool delete also clears the attempt marker.
+        try? store.delete(recoverySessionID: id)
+        Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+      } else {
+        recoverable.append(id)
+      }
+    }
+    guard !recoverable.isEmpty else { return }
+
+    // Contention guard: never run the shared engine while a live dictation is in
+    // flight (a recording can start in the launch window, including with recovery
+    // OFF). Defer the orphans to a future launch — they stay on disk.
+    guard !isDictationActive() else { return }
+
+    TelemetryService.shared.recoveryFound(count: recoverable.count)
+    isRecovering = true
+    // R1 (Codex REV-2, BLOCKER): clear the gate on EVERY exit — normal completion,
+    // a thrown error, or an early return. A stuck `isRecovering = true` would
+    // refuse every record-start and brick the heart path.
+    defer { isRecovering = false }
+
+    for id in recoverable {
+      activeRecoveryID = id
+      let generationAtStart = recoveryGeneration
+      let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in
+        // Discard bumps `recoveryGeneration`; a mismatch ⇒ abandon this in-flight
+        // replay. Coordinator gone ⇒ treat as aborted (safe).
+        self?.recoveryGeneration != generationAtStart
+      }
+      activeRecoveryID = nil
+      // A Discard ends the whole hold; remaining orphans (rare) wait for the next
+      // launch. Every other outcome continues to the next orphan.
+      if outcome == .aborted { break }
+    }
+  }
+
+  /// The user pressed Discard on the recovering pill. No-op when nothing is
+  /// actively recovering. (#1063 PR2.)
+  ///
+  /// 1. Bump `recoveryGeneration` so the in-flight replay's post-`await` check
+  ///    drops its result (no stale "Recovered" save).
+  /// 2. `resetEngine()` — hard-reset the shared engine (the #445 service-kill). For
+  ///    the default out-of-process engine this KILLS the in-flight (otherwise
+  ///    uncancellable) load/transcribe, so the replay returns `.aborted` almost
+  ///    immediately — Discard works even against a wedge (founder fix).
+  /// 3. Delete the orphan the user discarded (spool + key + marker).
+  ///
+  /// It does NOT clear `isRecovering` directly (Codex code-diff r6 P2): the gate is
+  /// released by the scan loop's `defer` when the replay RETURNS — i.e. once the
+  /// engine is genuinely free. For the out-of-process engine that is ~instant (the
+  /// reset killed the call). For the IN-PROCESS engine, `cancelInFlightLoad` cannot
+  /// stop a running Core ML transcribe, so the call finishes (a few seconds) before
+  /// the gate opens — preventing a new recording from contending with it. Either
+  /// way the gate opens exactly when the shared engine is actually free.
+  func discardActiveRecovery() {
+    guard isRecovering, let id = activeRecoveryID else { return }
+    recoveryGeneration &+= 1
+    resetEngine()
+    let store = makeSpoolStore()
+    try? store.delete(recoverySessionID: id)
+    let keyStore = self.keyStore
+    Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+    activeRecoveryID = nil
+    TelemetryService.shared.recoveryCompleted(outcome: "discarded")
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -1,0 +1,256 @@
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPipeline
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+
+/// The terminal outcome of one orphan's recovery attempt (#1063 PR2). The
+/// `discarded` outcome is owned by `RecoveryCoordinator` (it deletes + emits on
+/// Discard), never produced by the replayer.
+enum RecoveryReplayOutcome: Equatable {
+  case recovered
+  case failed
+  case abandoned
+  /// A Discard bumped the recovery generation mid-flight: drop the result, save
+  /// nothing. The coordinator already deleted the spool/key/marker.
+  case aborted
+  /// The attempt marker could not be written, so recovery was deferred WITHOUT
+  /// risking an un-guarded attempt — the spool stays for a future launch.
+  case deferred
+}
+
+/// Per-orphan recovery execution seam — lets `RecoveryCoordinator` drive scan /
+/// gate / generation / single-flight logic against a test double while the real
+/// `RecoverySpoolReplayer` owns the heavy decrypt→transcribe→polish→save chain.
+@MainActor
+protocol RecoverySpoolReplaying: AnyObject {
+  func replay(recoverySessionID: String, isAborted: @MainActor () -> Bool) async
+    -> RecoveryReplayOutcome
+}
+
+/// Per-orphan execution of the crash-recovery REPLAY flow (#1063 PR2).
+///
+/// `RecoveryCoordinator` owns the launch scan, the recording gate, dedup, and
+/// cleanup routing; this type owns the heavy per-spool chain so the coordinator
+/// stays thin (`keep-central-types-thin`): write the one-attempt marker, decrypt,
+/// transcribe on the shared engine, polish under record-time settings, and save a
+/// non-auto-pasting "Recovered" transcript to History.
+///
+/// Strict LIMB: every failure path deletes the orphan and surfaces "couldn't
+/// recover" via telemetry/breadcrumb — it never throws into the heart path. One
+/// attempt only: a per-spool marker written BEFORE the risky load/transcribe means
+/// a recovery that crashed the app is abandoned (not retried) on the next launch.
+@MainActor
+final class RecoverySpoolReplayer: RecoverySpoolReplaying {
+  private let asrManager: any ASRManagerInterface
+  private let keyStore: RecoveryKeyStore
+  private let makeSpoolStore: @Sendable () -> RecoverySpoolStore
+  private let transcriptStore: TranscriptStore
+  private let transcriptCoordinator: TranscriptCoordinator
+  private let keychainManager: KeychainManager
+  private let outputClassifierHolder: OutputClassifierHolder
+  /// Current custom-words vocabulary, best-effort (the snapshot carries only the
+  /// version, not the terms — recovery promises normal-quality, not byte-exact).
+  private let currentVocabulary:
+    @MainActor () -> (corrector: CorrectorVocabulary, polish: PolishVocabulary)
+
+  init(
+    asrManager: any ASRManagerInterface,
+    keyStore: RecoveryKeyStore,
+    makeSpoolStore: @escaping @Sendable () -> RecoverySpoolStore,
+    transcriptStore: TranscriptStore,
+    transcriptCoordinator: TranscriptCoordinator,
+    keychainManager: KeychainManager,
+    outputClassifierHolder: OutputClassifierHolder,
+    currentVocabulary: @escaping @MainActor () -> (
+      corrector: CorrectorVocabulary, polish: PolishVocabulary
+    )
+  ) {
+    self.asrManager = asrManager
+    self.keyStore = keyStore
+    self.makeSpoolStore = makeSpoolStore
+    self.transcriptStore = transcriptStore
+    self.transcriptCoordinator = transcriptCoordinator
+    self.keychainManager = keychainManager
+    self.outputClassifierHolder = outputClassifierHolder
+    self.currentVocabulary = currentVocabulary
+  }
+
+  private enum RecoveryReplayError: Error {
+    case abandonedAfterAttempt
+    case failed(String)
+  }
+
+  /// Replay one orphan end to end. `isAborted` returns true once a Discard has
+  /// bumped the recovery generation since this orphan started; it is checked
+  /// after every `await` and immediately before the synchronous save so a
+  /// discarded in-flight (uncancellable) batch transcribe can never write a stale
+  /// "Recovered" entry. Emits recovery telemetry + breadcrumbs itself (the
+  /// `discarded` outcome is the coordinator's).
+  func replay(recoverySessionID id: String, isAborted: @MainActor () -> Bool) async
+    -> RecoveryReplayOutcome
+  {
+    let spoolStore = makeSpoolStore()
+
+    // One-attempt crash-loop guard: a marker already present means a prior attempt
+    // crashed the app — abandon (delete + log), never retry.
+    if spoolStore.hasAttemptMarker(for: id) {
+      cleanUp(id, spoolStore: spoolStore)
+      SentryBreadcrumb.captureError(
+        RecoveryReplayError.abandonedAfterAttempt,
+        category: .recoveryAbandonedAfterAttempt, stage: "recovery")
+      TelemetryService.shared.recoveryCompleted(outcome: "abandoned", reason: "crash_loop")
+      return .abandoned
+    }
+    // Write the marker DURABLY before any risky load/transcribe (warm-up included).
+    // If it can't be written, defer rather than risk an un-guarded attempt.
+    do {
+      try spoolStore.writeAttemptMarker(for: id)
+    } catch {
+      SentryBreadcrumb.add(
+        stage: "recovery", message: "attempt-marker write failed — deferring recovery",
+        level: .warning, data: ["error": String(describing: error)])
+      return .deferred
+    }
+
+    // Retrieve the per-session key off the MainActor (`keychain-not-mainactor`).
+    let keyStore = self.keyStore
+    let keyData: Data? = await Task.detached(priority: .utility) {
+      try? keyStore.retrieve(for: id)
+    }.value
+    if isAborted() { return .aborted }
+    guard let keyData else {
+      return fail(id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+    }
+
+    // Decrypt + reconstruct the valid prefix off the MainActor (heavy for a long
+    // take). `recover` fails closed on a cipher-mode mismatch.
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: keyData)
+    let recovered: RecoveredSpool? = await Task.detached(priority: .utility) {
+      try? spoolStore.recover(recoverySessionID: id, cipher: cipher)
+    }.value
+    if isAborted() { return .aborted }
+    guard let recovered, !recovered.samples.isEmpty else {
+      return fail(id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+    }
+
+    // Transcribe on the shared engine (batch). The marker already covers warm-up.
+    //
+    // BEST-EFFORT BACKEND (deliberate; Codex code-diff r4 P2 → PR3): recovery uses
+    // the CURRENT active engine, not `recovered.settings?.backendType`. The audio is
+    // backend-neutral (16 kHz mono), so either engine yields valid text; the only
+    // effect is a possible quality difference for the rare user who SWITCHED engines
+    // between the recording and this crash-recovery. Switching the shared engine to
+    // the record-time backend (and restoring after, across the discard/abort paths)
+    // is heavy for a limb; record-time backend FIDELITY is routed to PR3 hardening.
+    // The saved transcript's `backendType` is `result.backendType` — the engine that
+    // actually transcribed — so the metadata stays accurate either way.
+    let options = Self.transcriptionOptions(for: recovered.settings)
+    do {
+      try await asrManager.loadModel()
+    } catch {
+      // Discard hard-resets the engine, which can throw here — that's an abort,
+      // not a recovery failure (don't delete/log; the coordinator owns cleanup).
+      if isAborted() { return .aborted }
+      return fail(
+        id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
+    }
+    // Discard during the model load: bail BEFORE the expensive batch transcribe.
+    if isAborted() { return .aborted }
+    let result: ASRResult
+    do {
+      result = try await asrManager.transcribe(audioSamples: recovered.samples, options: options)
+    } catch {
+      // A Discard-driven engine reset kills the in-flight transcribe and surfaces
+      // here as a throw — treat it as an abort (the user discarded), not a failure.
+      if isAborted() { return .aborted }
+      return fail(
+        id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
+    }
+    if isAborted() { return .aborted }
+    guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return fail(id, spoolStore: spoolStore, reason: "empty", category: .recoveryTranscribeFailed)
+    }
+
+    // Polish under the recording's record-time settings (raw-fallback floor
+    // guaranteed: a failed/skipped polish lands raw text, still saved + labeled).
+    let processor = RecoveryTextProcessor(
+      keychainManager: keychainManager, outputClassifierHolder: outputClassifierHolder)
+    if let settings = recovered.settings { processor.applySettings(settings) }
+    let vocab = currentVocabulary()
+    processor.applyCustomWordsVocabulary(corrector: vocab.corrector, polish: vocab.polish)
+    let textOutcome = await processor.process(rawText: result.text)
+    if isAborted() { return .aborted }
+
+    // Build the recovered transcript.
+    let recoveredSeconds = Double(recovered.samples.count) / AudioConstants.sampleRate
+    let transcript = Transcript(
+      text: textOutcome.text,
+      polishedText: textOutcome.polishedText,
+      language: result.language ?? Self.lockedLanguage(recovered.settings?.languageMode),
+      duration: recoveredSeconds,
+      backendType: result.backendType,
+      llmProvider: recovered.settings?.llmProvider,
+      llmModel: recovered.settings?.llmModel,
+      recoverySessionID: id,
+      isRecovered: true)
+
+    // FINAL abort check immediately before the SYNCHRONOUS save + append — there
+    // is no `await` between here and `append`, so a Discard cannot interleave a
+    // stale save (the uncancellable-transcribe stale-save guard, Codex REV-2 R2).
+    if isAborted() { return .aborted }
+    do {
+      try transcriptStore.save(transcript)
+    } catch {
+      SentryBreadcrumb.add(
+        stage: "recovery", message: "recovered transcript save failed",
+        level: .warning, data: ["error": String(describing: error)])
+      cleanUp(id, spoolStore: spoolStore)
+      TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: "save")
+      return .failed
+    }
+    transcriptCoordinator.append(transcript)
+
+    // Success: delete spool (+ marker) + key.
+    cleanUp(id, spoolStore: spoolStore)
+    TelemetryService.shared.recoveryCompleted(
+      outcome: "recovered",
+      recoveredSeconds: Int(recoveredSeconds.rounded()),
+      polishFellBack: textOutcome.polishedText == nil)
+    return .recovered
+  }
+
+  /// Delete + log a failed orphan (one attempt — no keep-for-retry in PR2).
+  private func fail(
+    _ id: String, spoolStore: RecoverySpoolStore, reason: String,
+    category: SentryBreadcrumb.ErrorCategory
+  ) -> RecoveryReplayOutcome {
+    cleanUp(id, spoolStore: spoolStore)
+    SentryBreadcrumb.captureError(
+      RecoveryReplayError.failed(reason), category: category, stage: "recovery")
+    TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: reason)
+    return .failed
+  }
+
+  /// Delete a spool (which also clears its attempt marker) and destroy its key.
+  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) {
+    try? spoolStore.delete(recoverySessionID: id)
+    let keyStore = self.keyStore
+    Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+  }
+
+  private static func transcriptionOptions(for settings: RecordingSettingsSnapshot?)
+    -> TranscriptionOptions
+  {
+    var options = TranscriptionOptions()
+    if let code = lockedLanguage(settings?.languageMode) { options.language = code }
+    return options
+  }
+
+  private static func lockedLanguage(_ mode: LanguageMode?) -> String? {
+    if case .locked(let code) = mode { return code }
+    return nil
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -283,7 +283,6 @@ public final class WisprBootstrapper {
 
     let navigationCoordinator = NavigationCoordinator()
     let diagnosticsCoordinator = DiagnosticsCoordinator()
-    let recoveryCoordinator = RecoveryCoordinator()
 
     // PR4 of #763 construction-order constraint preserved: LanguageSuggestionPresenter
     // captures `recordingOverlay` through narrow closures.
@@ -350,6 +349,51 @@ public final class WisprBootstrapper {
       audioCapture: audioCapture,
       asrManager: asrManager
     )
+    // #1063 PR2: crash-recovery owner. The per-orphan replayer (decrypt →
+    // transcribe → polish → save) is built from existing app deps; the coordinator
+    // owns the launch scan, the recording gate, dedup, and cleanup routing. The
+    // key store + spool-store factory are shared so arm/recover/cleanup agree on
+    // backend + paths.
+    let recoveryKeyStore = RecoveryKeyStore()
+    let makeRecoverySpoolStore: @Sendable () -> RecoverySpoolStore = { RecoverySpoolStore() }
+    let recoverySpoolReplayer = RecoverySpoolReplayer(
+      asrManager: asrManager,
+      keyStore: recoveryKeyStore,
+      makeSpoolStore: makeRecoverySpoolStore,
+      transcriptStore: transcriptStore,
+      transcriptCoordinator: transcriptCoordinator,
+      keychainManager: keychainManager,
+      outputClassifierHolder: outputClassifierHolder,
+      // Best-effort: the snapshot carries only the custom-words version, so recovery
+      // applies the user's CURRENT words (pack terms omitted) — normal-quality, not
+      // byte-exact. `+ 1` keeps the cache generation non-zero so terms take effect.
+      currentVocabulary: { [customWordsCoordinator] in
+        LanePartitioner.split(
+          customWordsCoordinator.customWords,
+          generation: UInt64(customWordsCoordinator.customWords.count) &+ 1)
+      })
+    let recoveryCoordinator = RecoveryCoordinator(
+      keyStore: recoveryKeyStore,
+      makeSpoolStore: makeRecoverySpoolStore,
+      replayer: recoverySpoolReplayer,
+      existingRecoveryIDs: { [transcriptStore] in
+        let all = (try? await transcriptStore.loadAll()) ?? []
+        return Set(all.compactMap(\.recoverySessionID))
+      },
+      isDictationActive: { [liveRecordingState] in liveRecordingState.isDictationActive },
+      // Discard hard-resets the shared engine (#445 service-kill) so an in-flight,
+      // otherwise-uncancellable recovery transcribe returns at once and the next
+      // recording gets a clean engine.
+      resetEngine: { [asrManager] in asrManager.cancelInFlightLoad() })
+    // #1063 PR2: the "recovering" pill's Discard action.
+    recordingOverlay.setDiscardRecoveryHandler { [weak recoveryCoordinator] in
+      recoveryCoordinator?.discardActiveRecovery()
+    }
+    // #1063 PR2: block a Speech-Engine switch while recovery replays on the shared
+    // engine (a switch mid-recovery would unload the model and lose the spool).
+    settingsSync.isRecovering = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.isRecovering ?? false
+    }
     let lastRecordingResult = LastRecordingResult()
     let backendMetadata = BackendMetadata(
       settings: settings,
@@ -563,10 +607,10 @@ public final class WisprBootstrapper {
 
   public func applicationDidFinishLaunching() {
     appLifecycleCoordinator.runDidFinishLaunching()
-    // #1063 PR1: sweep any orphan crash-recovery spools + keys left by a prior
-    // run. PR1 does not recover yet (that is PR2) — purging keeps zero
-    // recoverable audio on disk. Off-main, fire-and-forget.
-    recoveryCoordinator.purgeOrphansOnLaunch()
+    // #1063 PR2: scan for orphan crash-recovery spools and recover them behind the
+    // blocking "recovering" pill (replaces PR1's purge). Strict limb, single-flight,
+    // one attempt per orphan. No-orphan launch is byte-identical to today.
+    Task { await recoveryCoordinator.scanAndRecover() }
   }
 
   public func applicationDidBecomeActive() {

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -81,6 +81,21 @@ struct TranscriptRowView: View {
         .font(.body)
 
       HStack(spacing: 6) {
+        if transcript.isRecovered == true {
+          // #1063 PR2 — marks a transcript reconstructed from a recovered recording
+          // after an abnormal exit. Icon + text (never color-only).
+          HStack(spacing: 2) {
+            Image(systemName: "arrow.clockwise.circle")
+            Text("Recovered")
+          }
+          .font(.caption2)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 2)
+          .background(.teal.opacity(0.15), in: Capsule())
+          .foregroundStyle(.teal)
+          .accessibilityLabel("Recovered recording")
+        }
+
         if transcript.polishedText != nil {
           HStack(spacing: 2) {
             Image(systemName: "sparkles")

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -87,6 +87,12 @@ public enum RecoveryConstants {
   public static let spoolDirectoryName = "audio_recovery"
   /// File extension for a spool file (named `<recoverySessionID>.ewrec`).
   public static let fileExtension = "ewrec"
+  /// File extension for a per-spool recovery-ATTEMPT marker (#1063 PR2). Written
+  /// durably (fsync + atomic rename) BEFORE the risky load/transcribe step; its
+  /// presence on the next launch means a prior recovery attempt crashed the app,
+  /// so that spool is abandoned rather than retried (the one-attempt crash-loop
+  /// guard). Named `<recoverySessionID>.attempt`.
+  public static let attemptFileExtension = "attempt"
   /// On-disk format version recorded in the header.
   public static let formatVersion = 1
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -139,6 +139,42 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   private var lastFiredState: PipelineState
 
+  /// #1063 PR2 — fires when the kernel reaches a NON-`.completed` terminal,
+  /// carrying this session's `recoverySessionID` (captured from `context.config`
+  /// BEFORE the terminal cleanup nulls it) and the terminal KIND (discard vs
+  /// failure). The App's `DictationLifecycleCoordinator` routes it to
+  /// `RecoveryCoordinator` so a discarded recording's spool is deleted and a
+  /// failed recording's spool is RETAINED for next-launch recovery. Distinct
+  /// from `onStateChange` (which fires the externalError-pinnable public
+  /// `PipelineState`): this keys off the RAW kernel terminal, so it never fires
+  /// for `.completed` (a durable save already ran) and the error pin can't
+  /// trigger it. `@MainActor` closure, off the collaborator cap; default no-op
+  /// keeps the Pipeline recovery-unaware. The first param is the optional
+  /// `recoverySessionID` (nil when recovery was off for the take).
+  @ObservationIgnored
+  public var onSessionEndedWithoutSave: (@MainActor (String?, RecordingTerminalKind) -> Void)?
+
+  /// Fire-once latch for `onSessionEndedWithoutSave` (sibling to `lastFiredState`).
+  /// Tracks the last RAW `kernel.state` the ended-without-save check evaluated so
+  /// a re-armed observation can't double-fire for one terminal, while two
+  /// consecutive sessions ending at the SAME terminal still each fire (the
+  /// intervening `.idle`/`.preparing`/`.recording` transitions change this value).
+  @ObservationIgnored
+  private var lastEndedWithoutSaveObservedState: RecordingSessionState
+
+  /// #1063 PR2 (Codex terminal-kind matrix) — disposition for the CURRENT
+  /// session's `.cancelled` terminal. `.cancelled` is reached by BOTH a genuine
+  /// user cancel (`RecordingFinalizer.cancel()` → `cancelRecording(disposition:
+  /// .discard)`) AND fault/system cancels that route through `kernel.cancel()`
+  /// (active `reset()`, `setExternalError()`, the settings-rebuild cancel). A user
+  /// cancel should DELETE the spool; a fault cancel should RETAIN recoverable
+  /// audio. Defaults to `.failure` (RETAIN) so any cancel NOT explicitly attributed
+  /// as a user discard conservatively keeps the audio. Set at the `cancelRecording`
+  /// call site, consumed + reset at the `.cancelled` signal fire, and reset on each
+  /// new session start.
+  @ObservationIgnored
+  private var pendingCancelDisposition: RecordingTerminalKind = .failure
+
   /// Fired by the finalizing-sub-status observer (`observeFinalizingSubStatus`)
   /// whenever the overlay's intent should refresh because of a `.transcribing`
   /// → `.polishing` flip that does NOT change the public `PipelineState` (both
@@ -184,6 +220,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     self.adapter = adapter
     self.captureErrorSink = captureErrorSink
     self.lastFiredState = Self.pipelineState(for: kernel.state, externalError: nil)
+    self.lastEndedWithoutSaveObservedState = kernel.state
   }
 
   /// Cold-boot warm-up coordinator (#879). The SINGLE shared entry every warm-up
@@ -320,7 +357,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// its own is fire-and-latch: it triggers the recording-exit path or sets
   /// `cancelRequested`, but the actual transition to `.cancelled` /
   /// `.discarded` happens on the forward path's next yield.
-  public func cancelRecording() async {
+  /// `disposition` (#1063 PR2) attributes a `.cancelled` terminal for crash
+  /// recovery: `.discard` (genuine USER cancel — delete the spool) vs the
+  /// default `.failure` (a system cancel like the noise-suppression rebuild —
+  /// RETAIN recoverable audio). The user-cancel path passes `.discard`; the
+  /// settings-rebuild caller uses the retain default.
+  public func cancelRecording(disposition: RecordingTerminalKind = .failure) async {
+    pendingCancelDisposition = disposition
     kernel.cancel()
     await awaitKernelTerminal()
   }
@@ -614,6 +657,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         // closures to read at finalize time (the wiring's optional-chained
         // reads were always-nil in production until this PR — finding #6).
         lastExternalError = nil
+        // #1063 PR2: a fresh session starts with the conservative cancel
+        // disposition (RETAIN) — only a genuine user cancel during this session
+        // flips it to discard. Prevents a stale user-discard from a prior session
+        // leaking onto this session's fault-cancel.
+        pendingCancelDisposition = .failure
         outcome.transcript = nil
         outcome.polishError = nil
         outcome.rawText = nil
@@ -753,6 +801,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     } onChange: { [weak self] in
       Task { @MainActor [weak self] in
         guard let self else { return }
+        // #1063 PR2 — FIRST, before `clearContextConfigIfTerminalOrIdle()` nulls
+        // `context.config`: capture this session's recovery id off the still-live
+        // config and fire the ended-without-save signal on a fresh non-`.completed`
+        // terminal. Ordering is load-bearing — the id is gone after the clear.
+        self.fireSessionEndedWithoutSaveIfNeeded()
         self.clearContextConfigIfTerminalOrIdle()
         self.updateWarmRespawnLatch()
         self.fireStateChangeIfNeeded()
@@ -813,6 +866,55 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     guard mapped != lastFiredState else { return }
     lastFiredState = mapped
     onStateChange?(mapped)
+  }
+
+  /// #1063 PR2 — fire `onSessionEndedWithoutSave` when the kernel enters a fresh
+  /// non-`.completed` terminal. Reads `context.config?.recoverySessionID` BEFORE
+  /// the caller's `clearContextConfigIfTerminalOrIdle()` nulls it. The latch
+  /// (`lastEndedWithoutSaveObservedState`) is updated on EVERY transition so a
+  /// re-armed observation can't double-fire for one terminal, while back-to-back
+  /// sessions ending at the same terminal still each fire (intervening states
+  /// change the latch). `.completed` is never a signal here (its durable-save
+  /// callback owns cleanup); `.idle` and the transient states map to nil.
+  private func fireSessionEndedWithoutSaveIfNeeded() {
+    defer { lastEndedWithoutSaveObservedState = kernel.state }
+    guard kernel.state != lastEndedWithoutSaveObservedState else { return }
+    let kind: RecordingTerminalKind?
+    if kernel.state == .cancelled {
+      // `.cancelled` is ambiguous (Codex terminal-kind matrix): a genuine user
+      // cancel DELETES, but a fault/system cancel (active reset, external-error,
+      // settings rebuild) RETAINS recoverable audio. Resolve via the per-cancel
+      // disposition attributed at the `kernel.cancel()` call site; consume + reset
+      // to the conservative default so a stale user-discard can't leak to a later
+      // fault cancel.
+      kind = pendingCancelDisposition
+      pendingCancelDisposition = .failure
+    } else {
+      kind = Self.endedWithoutSaveKind(for: kernel.state)
+    }
+    guard let kind else { return }
+    onSessionEndedWithoutSave?(context.config?.recoverySessionID, kind)
+  }
+
+  /// Classify the UNAMBIGUOUS non-`.completed` terminals for the crash-recovery
+  /// cleanup signal. `.cancelled` is EXCLUDED (returns nil) — it is ambiguous
+  /// (user discard vs fault/system retain) and resolved at the fire site via
+  /// `pendingCancelDisposition`. Also nil for `.completed` (durable save ran),
+  /// `.idle`, and non-terminal states. Exhaustive so a new `RecordingSessionState`
+  /// forces a routing decision. Internal (not private) so the split is unit-tested
+  /// directly (`matcher-set-adversarial-tests`).
+  static func endedWithoutSaveKind(for s: RecordingSessionState)
+    -> RecordingTerminalKind?
+  {
+    switch s {
+    case .discarded, .noSpeech:
+      return .discard
+    case .failed, .audioInterrupted, .asrInterrupted:
+      return .failure
+    case .cancelled, .completed, .idle, .preparing, .warmingUp, .recording,
+      .stopping, .transcribing, .finalizing:
+      return nil
+    }
   }
 
   /// Arm a SECOND, separate `withObservationTracking` on

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -63,6 +63,27 @@ public enum OverlayIntent: Equatable, Sendable {
   /// again. Auto-dismissed after about 1.5 seconds. Never fired at launch when
   /// no cold press preceded it.
   case engineReady
+  /// Crash-recovery hold notice (#1063 PR2). Shown when the user presses to
+  /// record while the one leftover recording from a prior abnormal exit is
+  /// backfilling behind the shared engine — exactly the cold-engine
+  /// `.cachingModel` shape, plus a Discard affordance for "I don't want to
+  /// wait." No session is minted. Auto-dismissed after a few seconds; re-shown
+  /// on each blocked press.
+  case recoveringLastRecording
+}
+
+/// Why a recording ended at a terminal state WITHOUT a durable transcript save,
+/// classified for the crash-recovery cleanup signal (#1063 PR2). Derived from
+/// the kernel's terminal `RecordingSessionState` by `KernelDictationDriver`.
+///
+/// - `discard`: the user (or the absence of speech) ended it — `.cancelled`,
+///   `.discarded`, `.noSpeech`. Nothing worth recovering: delete the spool now.
+/// - `failure`: a pipeline / audio / engine fault ended it — `.failed`,
+///   `.audioInterrupted`, `.asrInterrupted`. The captured audio is the user's
+///   words they wanted: RETAIN the spool so it is recovered on the next launch.
+public enum RecordingTerminalKind: Equatable, Sendable {
+  case discard
+  case failure
 }
 
 /// Issue #285 — heart-path telemetry callbacks that the former root state routes to

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -107,6 +107,20 @@ public final class RecoveryTextProcessor {
     }
   }
 
+  /// Assign the CURRENT custom-words vocabulary, best-effort (#1063 PR2). The
+  /// snapshot carries only the custom-words VERSION, not the terms, so recovery
+  /// cannot replay the exact record-time vocabulary; it applies the user's
+  /// current words instead. Recovery promises normal-quality, not byte-exact —
+  /// without this, a power user's recovered transcript would skip word
+  /// correction the live take had. Caller builds the two vocabularies from the
+  /// live custom-words home (`CustomWordsVocabularySplit.split`).
+  public func applyCustomWordsVocabulary(
+    corrector: CorrectorVocabulary, polish: PolishVocabulary
+  ) {
+    steps.wordCorrection.correctorVocabulary = corrector
+    steps.llmPolish.polishVocabulary = polish
+  }
+
   /// Run the chain. Limb failures inside the chain (a step erroring or timing
   /// out) are absorbed by the runner and surface as a raw-fallback outcome;
   /// only cancellation propagates, and that too falls back to raw.

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -276,9 +276,20 @@ public enum SentryBreadcrumb {
     case inverseNormalizationTimeout = "inverse_normalization_timeout"
     /// #1063 PR1: the crash-recovery limb could not arm because its per-session
     /// key failed to generate/persist. Non-crash — the recording is byte-identical;
-    /// only the safety copy is absent for that take. (Recovery-side failures —
-    /// decrypt/transcribe — land in PR2 when the recovery read-flow exists.)
+    /// only the safety copy is absent for that take.
     case recoveryKeyStoreFailed = "recovery_key_store_failed"
+    /// #1063 PR2: a recovered spool failed to decrypt (missing key, cipher
+    /// mismatch, or an empty/torn prefix). Non-crash limb — the orphan is deleted
+    /// and the user sees "couldn't recover."
+    case recoveryDecryptFailed = "recovery_decrypt_failed"
+    /// #1063 PR2: transcribing a recovered spool returned empty or threw. Non-crash
+    /// limb (one attempt) — the orphan is deleted and the user sees "couldn't
+    /// recover."
+    case recoveryTranscribeFailed = "recovery_transcribe_failed"
+    /// #1063 PR2: a spool whose attempt marker was already present on launch — a
+    /// prior recovery attempt crashed the app — so it is abandoned (deleted, never
+    /// retried) by the one-attempt crash-loop guard rather than risking a loop.
+    case recoveryAbandonedAfterAttempt = "recovery_abandoned_after_attempt"
     /// #761: the deterministic post-polish emoji-restore guard re-inserted fewer
     /// glyphs than AFM dropped (`restored < dropped`). Impossible by construction
     /// — every dropped glyph is re-inserted — so this fires only on a regression.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -444,6 +444,60 @@ public final class TelemetryService {
       ])
   }
 
+  // MARK: - Crash-recovery (#1063 PR2)
+  //
+  // Privacy: state/counts/buckets only — never transcript text, audio, or
+  // filenames (telemetry-privacy boundary). Durations are bucketed, not exact.
+
+  /// At least one recoverable orphan was found on launch, so recovery ran behind
+  /// the blocking pill. `count` is how many leftover recordings will backfill.
+  public func recoveryFound(count: Int) {
+    PostHogSDK.shared.capture("recovery.found", properties: ["count": count])
+  }
+
+  /// One leftover recording finished its recovery attempt. `outcome` is one of
+  /// `recovered` / `discarded` / `failed` / `abandoned`; `reason` tags a failure
+  /// (`decrypt` / `transcribe` / `empty`); durations are bucketed; `polishFellBack`
+  /// is true when the recovered text landed raw (polish skipped/failed).
+  public func recoveryCompleted(
+    outcome: String,
+    reason: String? = nil,
+    recoveredSeconds: Int? = nil,
+    spoolSeconds: Int? = nil,
+    polishFellBack: Bool? = nil
+  ) {
+    var properties: [String: Any] = ["outcome": outcome]
+    if let reason { properties["reason"] = reason }
+    if let recoveredSeconds {
+      properties["recovered_seconds_bucket"] = Self.recoverySecondsBucket(recoveredSeconds)
+    }
+    if let spoolSeconds {
+      properties["spool_seconds_bucket"] = Self.recoverySecondsBucket(spoolSeconds)
+    }
+    if let polishFellBack { properties["polish_fell_back"] = polishFellBack }
+    PostHogSDK.shared.capture("recovery.completed", properties: properties)
+  }
+
+  /// A record-press landed while recovery held the engine, so NO session was
+  /// minted (the user saw the "recovering" pill). Mirrors `coldstart.press_blocked`.
+  public func recoveryPressBlocked(asrBackend: String) {
+    PostHogSDK.shared.capture(
+      "recovery.press_blocked", properties: ["asr_backend": asrBackend])
+  }
+
+  /// Coarse duration bucket (seconds) for recovery telemetry — keeps exact
+  /// lengths off the wire while preserving short/medium/long signal.
+  private static func recoverySecondsBucket(_ seconds: Int) -> String {
+    switch seconds {
+    case ..<10: return "0-10"
+    case ..<30: return "10-30"
+    case ..<60: return "30-60"
+    case ..<180: return "60-180"
+    case ..<600: return "180-600"
+    default: return "600+"
+    }
+  }
+
   public func asrCompleted(
     backend: String, result: String, coldStart: Bool, latencySeconds: Double, charCount: Int,
     // #950 tail-trim diagnostic — eligible Parakeet batch only; nil omitted.

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -145,9 +145,72 @@ public struct RecoverySpoolStore: Sendable {
       truncated: !sawCleanFinalize)
   }
 
-  /// Delete a spool file. Idempotent — a missing file is success.
+  /// Delete a spool file AND its recovery-attempt marker (#1063 PR2). Idempotent
+  /// — a missing file is success. Deleting the spool always clears its marker so
+  /// no stale marker outlives the spool it guarded (success and abandon paths
+  /// both route here).
   public func delete(recoverySessionID: String) throws {
     let url = spoolURL(for: recoverySessionID)
+    do {
+      try FileManager.default.removeItem(at: url)
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+      // Spool already gone — still clear any marker below.
+    }
+    try deleteAttemptMarker(for: recoverySessionID)
+  }
+
+  // MARK: - One-attempt crash-loop marker (#1063 PR2)
+
+  /// Sidecar marker path for a spool's recovery attempt (`<id>.attempt`).
+  public func attemptMarkerURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent(
+      "\(recoverySessionID).\(RecoveryConstants.attemptFileExtension)")
+  }
+
+  /// Whether a recovery-attempt marker exists for this spool. Present on the next
+  /// launch ⇒ a prior recovery attempt crashed the app ⇒ abandon, do not retry.
+  public func hasAttemptMarker(for recoverySessionID: String) -> Bool {
+    FileManager.default.fileExists(atPath: attemptMarkerURL(for: recoverySessionID).path)
+  }
+
+  /// Durably write the recovery-attempt marker BEFORE the risky load/transcribe
+  /// step: write a temp file, `F_FULLFSYNC` it, then atomically rename into place
+  /// (the same durable-write shape `RecoveryKeyStore.fileStore` uses), so a crash
+  /// the instant after we commit to recovering is reliably detected next launch.
+  public func writeAttemptMarker(for recoverySessionID: String) throws {
+    let url = attemptMarkerURL(for: recoverySessionID)
+    let tmpURL = directory.appendingPathComponent(
+      ".\(recoverySessionID).\(RecoveryConstants.attemptFileExtension).tmp")
+    let fm = FileManager.default
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      guard fd >= 0 else { throw RecoverySpoolStoreError.attemptMarkerWriteFailed(errno) }
+      // Presence is the signal; a single byte gives fsync something to flush.
+      let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try handle.write(contentsOf: Data([0x31]))
+      if fcntl(fd, F_FULLFSYNC) == -1 {
+        try? handle.close()
+        try? fm.removeItem(at: tmpURL)
+        throw RecoverySpoolStoreError.attemptMarkerWriteFailed(errno)
+      }
+      try handle.close()
+      if fm.fileExists(atPath: url.path) {
+        _ = try fm.replaceItemAt(url, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: url)
+      }
+    } catch let error as RecoverySpoolStoreError {
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    } catch {
+      try? fm.removeItem(at: tmpURL)
+      throw RecoverySpoolStoreError.attemptMarkerWriteFailed(errno)
+    }
+  }
+
+  /// Delete a spool's attempt marker. Idempotent — a missing marker is success.
+  public func deleteAttemptMarker(for recoverySessionID: String) throws {
+    let url = attemptMarkerURL(for: recoverySessionID)
     do {
       try FileManager.default.removeItem(at: url)
     } catch let error as CocoaError where error.code == .fileNoSuchFile {
@@ -208,4 +271,12 @@ public struct RecoveredSpool: Sendable {
     self.terminationReason = terminationReason
     self.truncated = truncated
   }
+}
+
+/// Errors thrown by `RecoverySpoolStore` host-side operations (#1063 PR2).
+public enum RecoverySpoolStoreError: Error, Equatable {
+  /// The one-attempt crash-loop marker could not be written durably (carries
+  /// `errno`). The caller treats this as fail-closed: skip recovering this spool
+  /// this launch rather than risk an un-guarded retry.
+  case attemptMarkerWriteFailed(Int32)
 }

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -157,21 +157,24 @@ import Testing
   /// until the next launch on a long-running menu-bar app. `.complete` must NOT
   /// fire it: its save path owns deletion via `onDurableSave`. Drives the real
   /// `install()`-wired `onStateChange` for BOTH backends.
-  @Test func nonSavedTerminalsFireRecoveryCleanupButCompleteDoesNot() {
+  /// #1063 PR2: `install()` wires the driver's kernel-terminal signal
+  /// (`onSessionEndedWithoutSave`, carrying the recovery id + terminal KIND) to the
+  /// coordinator's recovery-cleanup closure. (The "never for `.completed`" guard now
+  /// lives in the driver — it simply never fires this signal for `.completed` — so it
+  /// is covered by the driver's own terminal-kind test, not here.)
+  @Test func sessionEndedWithoutSaveSignalRoutesToRecoveryCleanup() {
     for backend in ["parakeet", "whisperKit"] {
       let fx = Self.makeCoordinator()
-      var cleanupCount = 0
-      fx.coordinator.onRecordingEndedWithoutDurableSave = { cleanupCount += 1 }
+      var calls: [(String?, RecordingTerminalKind)] = []
+      fx.coordinator.onRecordingEndedWithoutDurableSave = { id, kind in calls.append((id, kind)) }
       fx.coordinator.install()
       let driver = backend == "whisperKit" ? fx.whisperKitKernelDriver : fx.kernelDriver
 
-      driver.onStateChange?(.idle)
-      #expect(cleanupCount == 1, "\(backend): .idle (cancel/no-speech) must fire non-saved cleanup")
-      driver.onStateChange?(.error("boom"))
-      #expect(cleanupCount == 2, "\(backend): .error must fire non-saved cleanup")
-      driver.onStateChange?(.complete)
-      #expect(
-        cleanupCount == 2, "\(backend): .complete must NOT fire (its save path owns deletion)")
+      driver.onSessionEndedWithoutSave?("sid-1", .discard)
+      driver.onSessionEndedWithoutSave?(nil, .failure)
+      #expect(calls.count == 2, "\(backend): both signals routed")
+      #expect(calls[0].0 == "sid-1" && calls[0].1 == .discard)
+      #expect(calls[1].0 == nil && calls[1].1 == .failure)
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -44,7 +44,9 @@ import Testing
 
   private static func makeFixture(
     accessibilityRefresh: (@MainActor () -> Void)? = nil,
-    releaseDuringRecoveryArm: Bool = false
+    releaseDuringRecoveryArm: Bool = false,
+    isRecovering: Bool = false,
+    recoveringDuringArm: Bool = false
   ) -> Fixture {
     // `RecordingOverlayPanel.show(intent: .recording, ...)` posts an
     // `NSAccessibility` notification against `NSApp.mainWindow`. `NSApp`
@@ -87,15 +89,26 @@ import Testing
       languageSuggestionPresenter: nil
     )
     let lastRecordingResult = LastRecordingResult()
+    // `recovering` is a captured var both the arm closure (mutates) and the gate
+    // closure (reads) share — lets a test flip recovery ON during the arm await
+    // (#1063 PR2: the post-arm re-check). Both run on the MainActor.
+    var recovering = isRecovering
     // #1063 PR1: when asked, the injected recovery-arm closure simulates the
     // user RELEASING PTT while the key store is being awaited — it records a
     // user-stop on the finalizer (so `lastUserStopAccess.read() > pttStart`)
     // and returns no directive. The default closure is the recovery-off no-op.
+    // #1063 PR2: when `recoveringDuringArm`, it flips recovery ON during the arm
+    // and returns a directive (so `config.recoverySessionID` is set), simulating
+    // launch recovery starting mid-`start()`.
     let makeRecoveryDirective:
       @MainActor (SettingsManager, ASRBackendType, Bool) async -> (
         recoverySessionID: String, payload: Data
       )? = { _, _, _ in
         if releaseDuringRecoveryArm { await finalizer.userStop() }
+        if recoveringDuringArm {
+          recovering = true
+          return (UUID().uuidString, Data())
+        }
         return nil
       }
     let starter = RecordingStarter(
@@ -112,7 +125,8 @@ import Testing
       lastRecordingResult: lastRecordingResult,
       dictationLifecycleCoordinator: nil,
       accessibilityRefresh: accessibilityRefresh,
-      makeRecoveryDirective: makeRecoveryDirective
+      makeRecoveryDirective: makeRecoveryDirective,
+      isRecovering: { recovering }
     )
     return Fixture(
       starter: starter,
@@ -205,6 +219,59 @@ import Testing
     #expect(fx.kernelDriver.state == .idle)
     // The honest cold-boot pill is shown (engine-named), not a recording pill.
     #expect(fx.overlay.currentIntent == .cachingModel(engineLabel: "Parakeet v3"))
+  }
+
+  // #1063 PR2 — the recovery hold. A press (PTT or toggle) while the crash-recovery
+  // limb backfills behind the blocking pill mints NO session and shows the
+  // "recovering" pill instead, mirroring the cold-press contract.
+  @Test func pressWhileRecoveringMintsNoSessionAndShowsRecoveringPill() async {
+    // The engine is not-ready by default; the recovery gate must still win over
+    // the cold-press gate (it is checked first), so the pill is the recovery one.
+    let fx = Self.makeFixture(isRecovering: true)
+    fx.asr.activeBackendType = .parakeet
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .idle, "no session minted while recovering")
+    #expect(
+      fx.overlay.currentIntent == .recoveringLastRecording,
+      "recovery hold takes precedence over the cold-engine pill")
+  }
+
+  @Test func toggleWhileRecoveringMintsNoSessionAndShowsRecoveringPill() async {
+    let fx = Self.makeFixture(isRecovering: true)
+    fx.asr.activeBackendType = .parakeet
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.overlay.currentIntent == .recoveringLastRecording)
+  }
+
+  // #1063 PR2 (Codex code-diff r2 P2) — recovery can START during `start()`'s
+  // prewarm/arm awaits (the top-of-method gate read false). The post-arm re-check
+  // must catch it and mint no session, so a new recording can't contend with the
+  // recovery replay on the shared engine.
+  @Test func startRechecksRecoveryAfterArmAndBails() async {
+    let fx = Self.makeFixture(recoveringDuringArm: true)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true  // ready → top gate passes, recovery flips on during arm
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .idle, "no session minted — recovery started during the arm")
+    #expect(fx.overlay.currentIntent == .recoveringLastRecording)
+  }
+
+  @Test func toggleRechecksRecoveryAfterArmAndBails() async {
+    let fx = Self.makeFixture(recoveringDuringArm: true)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.overlay.currentIntent == .recoveringLastRecording)
   }
 
   @Test func coldToggleMintsNoSessionAndShowsCachingPill() async {

--- a/Tests/EnviousWisprTests/App/V2/BackendSwitchGuardTests.swift
+++ b/Tests/EnviousWisprTests/App/V2/BackendSwitchGuardTests.swift
@@ -102,6 +102,46 @@ struct BackendSwitchGuardTests {
 
     await pipeline.cancelRecording()
   }
+
+  /// #1063 PR2: a Speech-Engine switch while crash recovery is replaying on the
+  /// shared engine must be BLOCKED — otherwise the switch unloads/resets the model
+  /// mid-recovery, throws the in-flight transcribe, and (one attempt) deletes the
+  /// spool. Both pipelines are IDLE here, so ONLY the recovery guard can block it.
+  @Test("backend switch is blocked while crash recovery is replaying")
+  func testBackendSwitchBlockedDuringRecovery() async throws {
+    let audioCapture = FakeAudioCapture()
+    let asrManager = MockASRManager(
+      transcribeBehavior: .success(
+        ASRResult(
+          text: "unused", language: "en", duration: 1, processingTime: 0.01,
+          backendType: .parakeet)))
+    let store = TranscriptStore()
+    let pipeline = DictationRuntimeFixtures.makeParakeetDriver(
+      audioCapture: audioCapture, asrManager: asrManager, store: store)
+    let whisperKitKernelDriver = DictationRuntimeFixtures.makeWhisperKitPipeline(
+      audioCapture: audioCapture, store: store)
+    let sync = PipelineSettingsSync(
+      kernelDriver: pipeline,
+      whisperKitKernelDriver: whisperKitKernelDriver,
+      audioCapture: audioCapture,
+      asrManager: asrManager,
+      hotkeyService: HotkeyService(),
+      whisperKitSetup: WhisperKitSetupService()
+    )
+    #expect(!pipeline.state.isActive && !whisperKitKernelDriver.state.isActive)
+    // Simulate recovery in progress.
+    sync.isRecovering = { true }
+
+    let settings = SettingsManager()
+    settings.selectedBackend = .whisperKit
+    sync.handleSettingChanged(.selectedBackend, settings: settings)
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(
+      asrManager.activeBackendType == .parakeet,
+      "the switch must be dropped while recovery holds the engine (got \(asrManager.activeBackendType))"
+    )
+  }
 }
 
 @MainActor

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -97,10 +97,16 @@ import Testing
     // without a durable save, instead of leaking until launch). Still a `var`
     // closure (collaboratorCount stays ≤ 11); only the paper-line ceiling moves
     // (deterministic rule: actual 390 + 10 → round up to 400).
+    // #1063 PR2 (crash-recovery replay): raised 400 → 415. The published-state
+    // `.idle`/`.error` cleanup branch was REPLACED by wiring the driver's
+    // kernel-terminal signal (`onSessionEndedWithoutSave`, carrying the recovery
+    // id + terminal KIND) to the recovery-cleanup closure in `install()`; the
+    // closure type widened to `(String?, RecordingTerminalKind) -> Void`. No new
+    // collaborator (count stays ≤ 11). Deterministic rule: actual 404 + 10 → 415.
     #expect(
-      count <= 400,
+      count <= 415,
       """
-      DictationLifecycleCoordinator line count exceeded: \(count) > 400. \
+      DictationLifecycleCoordinator line count exceeded: \(count) > 415. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -196,14 +196,21 @@ import Testing
   /// launch start in `applicationWillFinishLaunching`, and tears the monitor
   /// down in `applicationWillTerminate`. Cap set by the deterministic rule
   /// (post-change actual 721 + 10, rounded up to nearest 5 = 735).
+  /// Ratcheted 735→770 in #1063 PR2 (2026-06-20, crash-recovery replay): the
+  /// composition root builds the per-orphan `RecoverySpoolReplayer` from existing
+  /// app deps + the reshaped `RecoveryCoordinator` (replayer + dedup + contention
+  /// closures), wires the "recovering" pill's Discard handler, and swaps the
+  /// launch purge for `scanAndRecover`. No new App-owned stored property (the
+  /// stored-property cap stays ≤ 30). Cap set by the deterministic rule
+  /// (post-change actual 759 + 10, rounded up to nearest 5 = 770).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 735,
+      lineCount <= 770,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 735. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 770. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -81,10 +81,24 @@ import Testing
     // so a dropped `.toggleRecording` can't lose the user's stop) and the PTT
     // abort-cleanup call. Only the paper-line ceiling moves (deterministic rule:
     // actual 375 + 10 → round up to 385).
+    // #1063 PR2 (crash-recovery replay): raised 385 → 420 for the third bare
+    // closure `isRecovering` (also excluded — a non-`async` `() -> Bool` closure
+    // is not a collaborator, collaboratorCount still ≤ 7), the recovery-hold gate
+    // branch added to BOTH `start()` and `toggle()` (a press while recovering
+    // shows the pill + returns, no session minted), and the id-carrying
+    // `cleanupRecoveryArm(config.recoverySessionID)` at the three abort sites. The
+    // recovery owner stays OFF this type; only the paper-line ceiling moves
+    // (deterministic rule: actual 407 + 10 → round up to 420).
+    // #1063 PR2 (Codex code-diff r2 P2): raised 420 → 440 for the post-arm recovery
+    // re-checks in BOTH `start()` and `toggle()` — the top-of-method `isRecovering`
+    // gate can go stale across the prewarm/arm awaits, so a second check before the
+    // kernel dispatch bails (no session) if launch recovery began mid-start. Still
+    // no new collaborator (count stays ≤ 7); only the paper-line ceiling moves
+    // (deterministic rule: actual 430 + 10 → round up to 440).
     #expect(
-      count <= 385,
+      count <= 440,
       """
-      RecordingStarter line count exceeded: \(count) > 385. \
+      RecordingStarter line count exceeded: \(count) > 440. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -1,0 +1,53 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1063 PR2 — the crash-recovery cleanup signal classifies each kernel terminal
+/// as DISCARD (delete the spool) or FAILURE (retain for next-launch recovery).
+/// `matcher-set-adversarial-tests`: every terminal is exercised in BOTH semantic
+/// classes, and the non-terminal / `.completed` / `.idle` states must map to nil
+/// so the signal never fires for a saved take or a resting kernel.
+@MainActor
+@Suite("Kernel terminal-kind split (#1063 PR2)")
+struct KernelTerminalKindTests {
+
+  @Test("unambiguous discard terminals → .discard (delete the spool)")
+  func discardTerminals() {
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .discarded) == .discard)
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .noSpeech) == .discard)
+  }
+
+  @Test("failure terminals → .failure (RETAIN the recoverable audio)")
+  func failureTerminals() {
+    #expect(
+      KernelDictationDriver.endedWithoutSaveKind(for: .failed(.storageFailed)) == .failure)
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted) == .failure)
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .asrInterrupted) == .failure)
+  }
+
+  @Test(".cancelled is excluded from the STATIC map (ambiguous — resolved dynamically)")
+  func cancelledIsDynamic() {
+    // `.cancelled` is reached by both a user cancel (delete) and a fault/system
+    // cancel (retain), so the static map returns nil and the fire site resolves it
+    // via the per-cancel disposition (Codex terminal-kind matrix).
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .cancelled) == nil)
+  }
+
+  @Test(".completed and .idle never fire the signal (saved / resting)")
+  func completedAndIdleAreNil() {
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .completed) == nil)
+    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .idle) == nil)
+  }
+
+  @Test("non-terminal states never fire the signal")
+  func nonTerminalsAreNil() {
+    for state in [
+      RecordingSessionState.preparing, .warmingUp, .recording, .stopping, .transcribing,
+      .finalizing,
+    ] {
+      #expect(KernelDictationDriver.endedWithoutSaveKind(for: state) == nil)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprPipeline
 import EnviousWisprStorage
 import Foundation
 import Testing
@@ -6,10 +7,12 @@ import Testing
 @testable import EnviousWisprAppKit
 @testable import EnviousWisprServices
 
-/// The host-side `RecoveryCoordinator` (#1063 PR1): arms a recording's encrypted
-/// spool with a DURABLY-stored key before returning an enabled payload, deletes
-/// the spool + key on a durable save, and purges every orphan on launch. All
-/// paths fail open. Temp-dir-backed stores keep the tests isolated.
+/// The host-side `RecoveryCoordinator` (#1063 PR2): arms a recording's encrypted
+/// spool with a DURABLY-stored key, deletes the spool + key on a durable save,
+/// routes a non-saved terminal by KIND (discard deletes, failure retains), and on
+/// launch scans + recovers orphans behind a blocking gate (single-flight, dedup,
+/// generation-guarded discard, `defer`-cleared gate). A fake replayer drives the
+/// scan/gate/generation logic; temp-dir stores keep the tests isolated.
 @MainActor
 @Suite("Recovery coordinator (#1063)")
 struct RecoveryCoordinatorTests {
@@ -30,22 +33,87 @@ struct RecoveryCoordinatorTests {
     return settings
   }
 
+  /// Records each replay and returns a scripted outcome. Optionally runs a hook on
+  /// each replay (e.g. to fire a Discard mid-flight) and reports whether the
+  /// coordinator's `isAborted` closure read true at that point.
+  private final class FakeReplayer: RecoverySpoolReplaying {
+    var replayedIDs: [String] = []
+    var isRecoveringDuringReplay: [Bool] = []
+    var abortedSeen: [Bool] = []
+    var outcomeByDefault: RecoveryReplayOutcome = .recovered
+    var onReplay: ((String) -> Void)?
+    /// When true, the FIRST replay suspends on a continuation until the test
+    /// resumes it — so the test can run a second scan while one is genuinely
+    /// in-flight (exercising single-flight).
+    var suspendFirstReplay = false
+    var gateContinuation: CheckedContinuation<Void, Never>?
+    private let isRecoveringProbe: () -> Bool
+
+    init(isRecoveringProbe: @escaping () -> Bool) {
+      self.isRecoveringProbe = isRecoveringProbe
+    }
+
+    func replay(recoverySessionID id: String, isAborted: @MainActor () -> Bool) async
+      -> RecoveryReplayOutcome
+    {
+      replayedIDs.append(id)
+      isRecoveringDuringReplay.append(isRecoveringProbe())
+      if suspendFirstReplay && replayedIDs.count == 1 {
+        await withCheckedContinuation { gateContinuation = $0 }
+      }
+      onReplay?(id)
+      let aborted = isAborted()
+      abortedSeen.append(aborted)
+      return aborted ? .aborted : outcomeByDefault
+    }
+  }
+
   private struct Harness {
     let coordinator: RecoveryCoordinator
     let keyStore: RecoveryKeyStore
     let spoolStore: RecoverySpoolStore
+    let replayer: FakeReplayer
+    let resetEngineCount: Box<Int>
   }
 
-  private static func makeHarness() -> Harness {
+  /// `existing` and `dictationActive` are boxed so a test can mutate them after
+  /// construction; the closures capture the boxes.
+  private final class Box<T> {
+    var value: T
+    init(_ v: T) { value = v }
+  }
+
+  private static func makeHarness(
+    existing: Set<String> = [],
+    dictationActive: Bool = false
+  ) -> Harness {
     let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: tempDir())
     let spoolDir = tempDir()
+    let existingBox = Box(existing)
+    let activeBox = Box(dictationActive)
+    let resetEngineCount = Box(0)
+    // The probe needs the coordinator, set after construction.
+    var coordinatorRef: RecoveryCoordinator?
+    let replayer = FakeReplayer(isRecoveringProbe: { coordinatorRef?.isRecovering ?? false })
     let coordinator = RecoveryCoordinator(
       keyStore: keyStore,
-      makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) })
+      makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) },
+      replayer: replayer,
+      existingRecoveryIDs: { existingBox.value },
+      isDictationActive: { activeBox.value },
+      resetEngine: { resetEngineCount.value += 1 })
+    coordinatorRef = coordinator
     return Harness(
       coordinator: coordinator, keyStore: keyStore,
-      spoolStore: RecoverySpoolStore(directory: spoolDir))
+      spoolStore: RecoverySpoolStore(directory: spoolDir), replayer: replayer,
+      resetEngineCount: resetEngineCount)
   }
+
+  private static func writeSpool(_ store: RecoverySpoolStore, _ id: String) throws {
+    try Data([1, 2, 3]).write(to: store.spoolURL(for: id))
+  }
+
+  // MARK: - Arm + durable save (PR1 behavior, unchanged)
 
   @Test("recovery off ⇒ no directive")
   func disabledReturnsNil() async {
@@ -63,16 +131,10 @@ struct RecoveryCoordinatorTests {
       settings: Self.freshSettings(crashRecoveryEnabled: true),
       backendType: .whisperKit, supportsLanguageDetection: true)
     let armed = try #require(result)
-
     let directive = try JSONDecoder().decode(RecoverySpoolDirective.self, from: armed.payload)
     #expect(directive.enabled)
     #expect(directive.recoverySessionID == armed.recoverySessionID)
-    #expect(directive.keyData != nil)
     #expect(directive.settingsSnapshot.backendType == .whisperKit)
-    #expect(directive.settingsSnapshot.backendSupportsLanguageDetection)
-
-    // R2: the key is already retrievable the instant the payload is returned —
-    // there is no crash window where the spool exists with no recoverable key.
     let storedKey = try h.keyStore.retrieve(for: armed.recoverySessionID)
     #expect(storedKey == directive.keyData)
   }
@@ -81,141 +143,279 @@ struct RecoveryCoordinatorTests {
   func durableSaveDeletes() async throws {
     let h = Self.makeHarness()
     let id = "session-\(UUID().uuidString)"
-    try Data([1, 2, 3]).write(to: h.spoolStore.spoolURL(for: id))
+    try Self.writeSpool(h.spoolStore, id)
     try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-
     await h.coordinator.handleDurableSave(recoverySessionID: id).value
-
     #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
   }
 
-  @Test("launch purge removes every orphan spool + key")
-  func purgeRemovesAllOrphans() async throws {
+  // MARK: - Non-saved terminal routing (terminal-kind split)
+
+  @Test("a DISCARD terminal deletes the spool + key")
+  func discardTerminalDeletes() async throws {
     let h = Self.makeHarness()
-    let ids = ["a-\(UUID().uuidString)", "b-\(UUID().uuidString)"]
-    for id in ids {
-      try Data([9]).write(to: h.spoolStore.spoolURL(for: id))
-      try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-    }
-
-    await h.coordinator.purgeOrphansOnLaunch().value
-
-    #expect(try h.spoolStore.listSpoolSessionIDs().isEmpty)
-    for id in ids {
-      #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
-    }
-  }
-
-  @Test("launch purge also sweeps an orphan key that has no spool")
-  func purgeRemovesOrphanKeyWithoutSpool() async throws {
-    let h = Self.makeHarness()
-    // A key armed for a recording that aborted before the helper wrote a frame:
-    // a key with NO spool. The spool-only pass can't see it (Codex code-diff P2).
-    let id = "orphan-\(UUID().uuidString)"
+    let id = "discard-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
     try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-    #expect(try h.spoolStore.listSpoolSessionIDs().isEmpty)
-
-    await h.coordinator.purgeOrphansOnLaunch().value
-
+    await h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: id, terminal: .discard)?.value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
   }
 
-  // MARK: - In-session non-saved cleanup + purge protection (Codex code-diff r3)
-
-  @Test("a non-saved terminal deletes the armed session's spool + key in-session")
-  func endedWithoutSaveDeletesArmed() async throws {
+  @Test("a FAILURE terminal RETAINS the spool + key for next-launch recovery")
+  func failureTerminalRetains() async throws {
     let h = Self.makeHarness()
-    // Arm a recording: makeDirective mints the id + durably stores the key.
-    let armed = try #require(
-      await h.coordinator.makeDirective(
-        settings: Self.freshSettings(crashRecoveryEnabled: true),
-        backendType: .parakeet, supportsLanguageDetection: false))
-    // The helper would have written + finalized the spool; simulate it on disk.
-    try Data([1, 2, 3]).write(to: h.spoolStore.spoolURL(for: armed.recoverySessionID))
-    #expect((try? h.keyStore.retrieve(for: armed.recoverySessionID)) != nil)
+    let id = "failure-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: id, terminal: .failure)
+    #expect(task == nil, "failure retains — no delete work")
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+  }
 
-    // App-alive non-saved ending (cancel / no-speech / error): delete NOW.
-    await h.coordinator.handleRecordingEndedWithoutDurableSave()?.value
-
+  @Test("non-saved cleanup is a no-op when id is nil")
+  func endedWithoutSaveNoopWhenNil() async {
+    let h = Self.makeHarness()
     #expect(
-      !FileManager.default.fileExists(
-        atPath: h.spoolStore.spoolURL(for: armed.recoverySessionID).path))
-    #expect(throws: RecoveryKeyStoreError.notFound) {
-      try h.keyStore.retrieve(for: armed.recoverySessionID)
-    }
+      h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: nil, terminal: .discard) == nil)
   }
 
-  @Test("non-saved cleanup is a no-op when nothing is armed")
-  func endedWithoutSaveNoopWhenNothingArmed() async {
+  // MARK: - Launch scan + recover
+
+  @Test("scan replays every recoverable orphan, gate ends cleared")
+  func scanReplaysOrphans() async throws {
     let h = Self.makeHarness()
-    #expect(await h.coordinator.handleRecordingEndedWithoutDurableSave() == nil)
+    let ids = ["a-\(UUID().uuidString)", "b-\(UUID().uuidString)"]
+    for id in ids { try Self.writeSpool(h.spoolStore, id) }
+    await h.coordinator.scanAndRecover()
+    #expect(Set(h.replayer.replayedIDs) == Set(ids))
+    #expect(h.replayer.isRecoveringDuringReplay.allSatisfy { $0 }, "gate held during each replay")
+    #expect(!h.coordinator.isRecovering, "defer clears the gate on completion (R1)")
   }
 
-  @Test("a durable save clears the armed id so a later non-saved cleanup is a no-op")
-  func durableSaveClearsArmed() async throws {
+  @Test("no orphans ⇒ no replay, gate never set")
+  func scanNoOrphans() async {
+    let h = Self.makeHarness()
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty)
+    #expect(!h.coordinator.isRecovering)
+  }
+
+  @Test("dedup: an orphan already in History is deleted WITHOUT re-transcribing")
+  func scanDedupsAlreadySaved() async throws {
+    let saved = "saved-\(UUID().uuidString)"
+    let fresh = "fresh-\(UUID().uuidString)"
+    let h = Self.makeHarness(existing: [saved])
+    try Self.writeSpool(h.spoolStore, saved)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: saved)
+    try Self.writeSpool(h.spoolStore, fresh)
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [fresh], "saved id deduped, not replayed")
+    #expect(
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: saved).path),
+      "deduped orphan deleted")
+  }
+
+  @Test("scan PROTECTS the live armed session (never replays it)")
+  func scanProtectsArmed() async throws {
     let h = Self.makeHarness()
     let armed = try #require(
       await h.coordinator.makeDirective(
         settings: Self.freshSettings(crashRecoveryEnabled: true),
         backendType: .parakeet, supportsLanguageDetection: false))
-    await h.coordinator.handleDurableSave(recoverySessionID: armed.recoverySessionID).value
-    // The save already deleted + cleared the armed id — nothing left to clean.
-    #expect(await h.coordinator.handleRecordingEndedWithoutDurableSave() == nil)
+    try Self.writeSpool(h.spoolStore, armed.recoverySessionID)
+    let orphan = "orphan-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, orphan)
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [orphan])
+    #expect(
+      FileManager.default.fileExists(
+        atPath: h.spoolStore.spoolURL(for: armed.recoverySessionID).path),
+      "armed live session's spool survives the scan")
   }
 
-  @Test("a key-store failure leaves nothing armed (no phantom for the purge to guard)")
+  @Test("contention guard: a live dictation defers recovery (no replay, gate stays off)")
+  func scanDefersWhenDictationActive() async throws {
+    let h = Self.makeHarness(dictationActive: true)
+    try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "never run the shared engine during a live take")
+    #expect(!h.coordinator.isRecovering)
+  }
+
+  @Test("gate ends cleared even when every orphan fails (defer backstop, R1)")
+  func scanGateClearedOnAllFailures() async throws {
+    let h = Self.makeHarness()
+    h.replayer.outcomeByDefault = .failed
+    try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
+    await h.coordinator.scanAndRecover()
+    #expect(!h.coordinator.isRecovering)
+  }
+
+  @Test("single-flight: a scan started while another is in-flight is rejected")
+  func scanSingleFlight() async throws {
+    let h = Self.makeHarness()
+    let id = "orphan-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    h.replayer.suspendFirstReplay = true
+    // Start the first scan; it suspends mid-replay (gate held), so it is genuinely
+    // in-flight when the second scan runs.
+    let first = Task { await h.coordinator.scanAndRecover() }
+    while h.replayer.gateContinuation == nil { await Task.yield() }
+    // A second scan now must be rejected by the single-flight guard.
+    await h.coordinator.scanAndRecover()
+    // Release the first scan and let it finish.
+    h.replayer.gateContinuation?.resume()
+    await first.value
+    #expect(h.replayer.replayedIDs == [id], "orphan replayed exactly once")
+  }
+
+  // MARK: - Discard
+
+  @Test("Discard mid-recovery bumps the generation, frees the gate, and deletes the orphan")
+  func discardDuringRecovery() async throws {
+    let h = Self.makeHarness()
+    let id = "orphan-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    // Simulate the user hitting Discard WHILE this orphan is mid-replay.
+    h.replayer.onReplay = { [coordinator = h.coordinator] _ in
+      coordinator.discardActiveRecovery()
+    }
+    await h.coordinator.scanAndRecover()
+    // The replay saw the post-discard generation bump → reported aborted.
+    #expect(h.replayer.abortedSeen == [true], "isAborted read true after Discard bumped generation")
+    #expect(!h.coordinator.isRecovering, "gate cleared")
+    #expect(h.resetEngineCount.value == 1, "Discard hard-reset the shared engine")
+    #expect(
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "Discard deleted the orphan the user was waiting on")
+  }
+
+  @Test("Discard resets the engine; the gate clears when the replay returns (founder fix + r6 P2)")
+  func discardResetsEngineAndClearsGateWhenReplayReturns() async throws {
+    let h = Self.makeHarness()
+    let id = "inflight-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.suspendFirstReplay = true
+    // The replay is genuinely in flight (suspended) — modelling the shared engine
+    // still busy (e.g. the in-process backend whose transcribe can't be killed).
+    let first = Task { await h.coordinator.scanAndRecover() }
+    while h.replayer.gateContinuation == nil { await Task.yield() }
+    #expect(h.coordinator.isRecovering, "gate closed while the replay holds the engine")
+
+    h.coordinator.discardActiveRecovery()
+
+    // Discard hard-resets the engine immediately. The gate stays closed until the
+    // replay returns — so a backend whose work the reset can't kill never contends
+    // (r6 P2). (For the default out-of-process engine the reset kills the call, so
+    // the replay returns almost at once and this window is ~instant in production.)
+    #expect(h.resetEngineCount.value == 1, "Discard hard-reset the engine")
+    #expect(h.coordinator.isRecovering, "gate stays closed until the engine is actually free")
+    h.replayer.gateContinuation?.resume()
+    await first.value
+    #expect(!h.coordinator.isRecovering, "gate opens once the replay returns (engine free)")
+  }
+
+  @Test("scan sweeps a key-only orphan (a key whose spool was never written, P2)")
+  func scanSweepsKeyOnlyOrphan() async throws {
+    let h = Self.makeHarness()
+    let id = "keyonly-\(UUID().uuidString)"
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    // No spool file for this id — the spool scan can't see it.
+    await h.coordinator.scanAndRecover()
+    // The sweep is detached; wait briefly for it to drain.
+    for _ in 0..<200 where (try? h.keyStore.retrieve(for: id)) != nil {
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+    #expect(h.replayer.replayedIDs.isEmpty, "no spool ⇒ nothing to replay")
+  }
+
+  @Test("the key-only sweep PROTECTS the live armed session's key (P2 race-safety)")
+  func keySweepProtectsArmedKey() async throws {
+    let h = Self.makeHarness()
+    // A live recording armed but no spool yet (the helper hasn't written a frame).
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    // A genuine key-only orphan from a prior run.
+    let orphan = "orphan-\(UUID().uuidString)"
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: orphan)
+    await h.coordinator.scanAndRecover()
+    for _ in 0..<200 where (try? h.keyStore.retrieve(for: orphan)) != nil {
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: orphan) }
+    #expect(
+      (try? h.keyStore.retrieve(for: armed.recoverySessionID)) != nil,
+      "the live armed recording's key must survive the sweep (else it's unrecoverable)")
+  }
+
+  @Test("key sweep protects a FAILURE spool that appeared AFTER the scan snapshot (r4 P2)")
+  func keySweepProtectsLateFailureSpool() async throws {
+    let h = Self.makeHarness()
+    let recoverable = "orphan-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, recoverable)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: recoverable)
+    // A key-only orphan that the sweep WILL delete — its disappearance signals the
+    // detached sweep has run, so the assertions below aren't racing it.
+    let sentinel = "sentinel-\(UUID().uuidString)"
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: sentinel)
+    // During the recoverable orphan's replay, simulate a NEW recording that armed
+    // and ended at a FAILURE terminal — its spool + key appear AFTER the scan's
+    // spool snapshot. The stale-snapshot sweep would delete its key; the fresh
+    // re-list must protect it.
+    let lateFailure = "late-failure-\(UUID().uuidString)"
+    h.replayer.onReplay = { _ in
+      try? Data([9]).write(to: h.spoolStore.spoolURL(for: lateFailure))
+      try? h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: lateFailure)
+    }
+    await h.coordinator.scanAndRecover()
+    for _ in 0..<200 where (try? h.keyStore.retrieve(for: sentinel)) != nil {
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: sentinel) }
+    #expect(
+      (try? h.keyStore.retrieve(for: lateFailure)) != nil,
+      "a failure spool retained after the scan snapshot keeps its key (else undecryptable)")
+  }
+
+  @Test("Discard is a no-op when nothing is recovering")
+  func discardNoopWhenIdle() {
+    let h = Self.makeHarness()
+    h.coordinator.discardActiveRecovery()
+    #expect(!h.coordinator.isRecovering)
+  }
+
+  @Test("a key-store failure leaves nothing armed")
   func storeFailureLeavesNothingArmed() async throws {
-    // A file key store whose directory can never be created: its parent is a
-    // regular file, so `createDirectory` throws and every `store` fails. This
-    // exercises makeDirective's fail-open guard — armedSessionID is set BEFORE
-    // the store (to close the purge race, Codex r4 P2) and must be cleared again
-    // when the store fails, or the purge would protect a session with no key and
-    // a later non-saved cleanup would fire against nothing.
     let parentFile = FileManager.default.temporaryDirectory
       .appendingPathComponent("ew-key-parent-\(UUID().uuidString)")
     try Data([0]).write(to: parentFile)
     let unwritableDir = parentFile.appendingPathComponent("keys", isDirectory: true)
     let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: unwritableDir)
     let spoolDir = Self.tempDir()
+    let replayer = FakeReplayer(isRecoveringProbe: { false })
     let coordinator = RecoveryCoordinator(
-      keyStore: keyStore, makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) })
-
+      keyStore: keyStore,
+      makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) },
+      replayer: replayer,
+      existingRecoveryIDs: { [] },
+      isDictationActive: { false })
     let result = await coordinator.makeDirective(
       settings: Self.freshSettings(crashRecoveryEnabled: true),
       backendType: .parakeet, supportsLanguageDetection: false)
-    #expect(result == nil, "a failed durable key store must disable recovery for the take")
-
-    // Nothing armed: a non-saved cleanup is a no-op, and the purge guards no
-    // phantom id. (handleRecordingEndedWithoutDurableSave returns nil ⇔ armed nil.)
-    #expect(coordinator.handleRecordingEndedWithoutDurableSave() == nil)
-  }
-
-  @Test("launch purge PROTECTS the session armed for an in-flight recording")
-  func purgeProtectsLiveArmedSession() async throws {
-    let h = Self.makeHarness()
-    // A recording armed concurrently with the launch purge.
-    let armed = try #require(
-      await h.coordinator.makeDirective(
-        settings: Self.freshSettings(crashRecoveryEnabled: true),
-        backendType: .parakeet, supportsLanguageDetection: false))
-    try Data([1]).write(to: h.spoolStore.spoolURL(for: armed.recoverySessionID))
-    // An orphan from a PRIOR run that must still be swept.
-    let orphan = "orphan-\(UUID().uuidString)"
-    try Data([2]).write(to: h.spoolStore.spoolURL(for: orphan))
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: orphan)
-
-    await h.coordinator.purgeOrphansOnLaunch().value
-
-    // Orphan swept …
+    #expect(result == nil, "a failed durable key store disables recovery for the take")
     #expect(
-      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: orphan).path))
-    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: orphan) }
-    // … but the live armed session's spool + key SURVIVE (deleting its key would
-    // make its spool unrecoverable after a crash — Codex code-diff r3 P2).
-    #expect(
-      FileManager.default.fileExists(
-        atPath: h.spoolStore.spoolURL(for: armed.recoverySessionID).path))
-    #expect((try? h.keyStore.retrieve(for: armed.recoverySessionID)) != nil)
+      coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: nil, terminal: .discard) == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -1,0 +1,220 @@
+@preconcurrency import AVFoundation
+import EnviousWisprASR
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+@testable import EnviousWisprStorage
+
+/// The per-orphan `RecoverySpoolReplayer` (#1063 PR2): decrypt → transcribe →
+/// polish → save a non-auto-pasting "Recovered" transcript, ONE attempt with a
+/// crash-loop marker, and a generation guard that drops a discarded-but-in-flight
+/// result before saving. Driven against a real encrypted spool on disk + a fake
+/// batch ASR.
+@MainActor
+@Suite("Recovery spool replayer (#1063 PR2)")
+struct RecoverySpoolReplayerTests {
+
+  /// Minimal batch-ASR fake: returns a canned result, counts calls, and runs an
+  /// optional hook when `transcribe` is entered (to simulate a mid-flight Discard).
+  final class FakeBatchASR: ASRManagerInterface {
+    var activeBackendType: ASRBackendType = .parakeet
+    var isModelLoaded = false
+    var isStreaming = false
+    var downloadProgress: Double = 0
+    var downloadPhase = "idle"
+    var downloadDetail = ""
+    var onServiceInterrupted: (() -> Void)?
+    var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
+
+    var transcribeCallCount = 0
+    var cannedText = "hello recovered world"
+    var onTranscribe: (() -> Void)?
+    var onLoadModel: (() -> Void)?
+
+    func loadModel() async throws {
+      isModelLoaded = true
+      onLoadModel?()
+    }
+    func unloadModel() async {}
+    func setInitialBackendType(_ type: ASRBackendType) { activeBackendType = type }
+    func switchBackend(to type: ASRBackendType) async { activeBackendType = type }
+    var activeBackendSupportsStreaming: Bool { get async { false } }
+    func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
+    {
+      transcribeCallCount += 1
+      onTranscribe?()
+      return ASRResult(
+        text: cannedText, language: options.language, duration: 1, processingTime: 1,
+        backendType: activeBackendType)
+    }
+    func startStreaming(options: TranscriptionOptions) async throws {}
+    func feedAudio(_ buffer: AVAudioPCMBuffer) async throws {}
+    func finalizeStreaming() async throws -> ASRResult {
+      ASRResult(text: "", language: nil, duration: 0, processingTime: 0, backendType: .parakeet)
+    }
+    func cancelStreaming() async {}
+    func noteTranscriptionComplete(policy: ModelUnloadPolicy) {}
+    func cancelIdleTimer() {}
+    func cancelInFlightLoad() {}
+  }
+
+  private static func tempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-replayer-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private static func key(_ byte: UInt8 = 7) -> Data {
+    Data(repeating: byte, count: RecoveryConstants.aesKeyByteCount)
+  }
+
+  /// Offline snapshot — no polish provider, deterministic chain.
+  private static func snapshot() -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: .parakeet,
+      backendSupportsLanguageDetection: false,
+      languageMode: .auto,
+      wordCorrectionEnabled: false,
+      fillerRemovalEnabled: false,
+      emojiFormatterEnabled: false,
+      customWordsVersion: nil,
+      llmProvider: "none",
+      llmModel: "",
+      polishPromptVersion: nil)
+  }
+
+  private struct Harness {
+    let replayer: RecoverySpoolReplayer
+    let asr: FakeBatchASR
+    let spoolStore: RecoverySpoolStore
+    let keyStore: RecoveryKeyStore
+    let transcriptStore: TranscriptStore
+    let transcriptCoordinator: TranscriptCoordinator
+  }
+
+  private static func makeHarness() -> Harness {
+    let spoolDir = tempDir()
+    let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: tempDir())
+    let transcriptStore = TranscriptStore(directory: tempDir())
+    let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    let asr = FakeBatchASR()
+    let replayer = RecoverySpoolReplayer(
+      asrManager: asr,
+      keyStore: keyStore,
+      makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) },
+      transcriptStore: transcriptStore,
+      transcriptCoordinator: transcriptCoordinator,
+      keychainManager: KeychainManager(),
+      outputClassifierHolder: OutputClassifierHolder(),
+      currentVocabulary: { (.empty, .empty) })
+    return Harness(
+      replayer: replayer, asr: asr,
+      spoolStore: RecoverySpoolStore(directory: spoolDir), keyStore: keyStore,
+      transcriptStore: transcriptStore, transcriptCoordinator: transcriptCoordinator)
+  }
+
+  /// Write a real encrypted spool + store its key, so the replayer can decrypt it.
+  private static func seedSpool(_ h: Harness, id: String, samples: [Float]) async throws {
+    let keyData = key()
+    try h.keyStore.store(keyData: keyData, for: id)
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: keyData)
+    let writer = RecoverySpoolWriter(
+      recoverySessionID: id, spoolURL: h.spoolStore.spoolURL(for: id),
+      cipher: cipher, settings: snapshot(), appVersion: "1.0.0",
+      createdAt: Date(timeIntervalSince1970: 0))
+    writer.start()
+    writer.append(samples)
+    await withCheckedContinuation { c in writer.finalize(reason: .cleanFinalized) { c.resume() } }
+  }
+
+  @Test("happy path: orphan recovered → saved as isRecovered, spool + key deleted")
+  func happyPath() async throws {
+    let h = Self.makeHarness()
+    let id = "ok-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .recovered)
+    #expect(h.asr.transcribeCallCount == 1)
+    let saved = h.transcriptCoordinator.transcripts
+    #expect(saved.count == 1)
+    #expect(saved.first?.isRecovered == true)
+    #expect(saved.first?.recoverySessionID == id)
+    #expect(saved.first?.displayText.contains("hello") == true)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  @Test("one-attempt guard: a marker present on entry ABANDONS (no transcribe, deleted)")
+  func markerPresentAbandons() async throws {
+    let h = Self.makeHarness()
+    let id = "loop-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.4])
+    // Simulate a prior attempt that crashed the app: its marker survived.
+    try h.spoolStore.writeAttemptMarker(for: id)
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .abandoned)
+    #expect(h.asr.transcribeCallCount == 0, "never re-transcribe a recording that crashed us")
+    #expect(h.transcriptCoordinator.transcripts.isEmpty)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+  }
+
+  @Test("the attempt marker is written BEFORE transcribe (crash-loop guard armed)")
+  func markerWrittenBeforeTranscribe() async throws {
+    let h = Self.makeHarness()
+    let id = "armed-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.5])
+    var markerPresentAtTranscribe = false
+    h.asr.onTranscribe = { [spoolStore = h.spoolStore] in
+      markerPresentAtTranscribe = spoolStore.hasAttemptMarker(for: id)
+    }
+    _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(markerPresentAtTranscribe, "marker must exist before the risky transcribe runs")
+  }
+
+  @Test("decrypt fail (missing key) → failed, deleted, no transcribe")
+  func missingKeyFails() async throws {
+    let h = Self.makeHarness()
+    let id = "nokey-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.6])
+    // Destroy the key so decrypt fails closed.
+    try h.keyStore.delete(for: id)
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .failed)
+    #expect(h.asr.transcribeCallCount == 0)
+    #expect(h.transcriptCoordinator.transcripts.isEmpty)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+  }
+
+  @Test("Discard during transcribe drops the result — nothing saved (generation guard, R2)")
+  func discardDuringTranscribeDropsResult() async throws {
+    let h = Self.makeHarness()
+    let id = "disc-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.7])
+    // The user hits Discard WHILE transcribe runs: flip the abort flag mid-flight.
+    var discarded = false
+    h.asr.onTranscribe = { discarded = true }
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { discarded })
+    #expect(outcome == .aborted)
+    #expect(h.transcriptCoordinator.transcripts.isEmpty, "a discarded result never saves")
+  }
+
+  @Test("Discard during loadModel skips the expensive transcribe (P2)")
+  func discardDuringLoadSkipsTranscribe() async throws {
+    let h = Self.makeHarness()
+    let id = "loaddisc-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.9])
+    // The user hits Discard while the model is still loading.
+    var discarded = false
+    h.asr.onLoadModel = { discarded = true }
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { discarded })
+    #expect(outcome == .aborted)
+    #expect(h.asr.transcribeCallCount == 0, "no transcribe runs after Discard during load")
+    #expect(h.transcriptCoordinator.transcripts.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -202,4 +202,39 @@ struct RecoverySpoolStoreTests {
     // Idempotent: deleting a missing spool is success.
     try store.delete(recoverySessionID: "alpha")
   }
+
+  // MARK: - One-attempt crash-loop marker (#1063 PR2)
+
+  @Test("attempt marker: write makes it present, delete removes it (idempotent)")
+  func attemptMarkerLifecycle() throws {
+    let store = makeStore()
+    let id = "marked-\(UUID().uuidString)"
+    #expect(!store.hasAttemptMarker(for: id))
+    try store.writeAttemptMarker(for: id)
+    #expect(store.hasAttemptMarker(for: id), "present after write — crash-loop guard armed")
+    try store.deleteAttemptMarker(for: id)
+    #expect(!store.hasAttemptMarker(for: id))
+    // Idempotent.
+    try store.deleteAttemptMarker(for: id)
+  }
+
+  @Test("deleting a spool also clears its attempt marker")
+  func deleteSpoolClearsMarker() async throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    await writeSpool(
+      store: store, sessionID: "gamma", cipher: cipher, chunks: [[0.3]], reason: .cleanFinalized)
+    try store.writeAttemptMarker(for: "gamma")
+    #expect(store.hasAttemptMarker(for: "gamma"))
+    try store.delete(recoverySessionID: "gamma")
+    #expect(!store.hasAttemptMarker(for: "gamma"), "spool delete cleared the marker")
+    #expect(try store.listSpoolSessionIDs() == [])
+  }
+
+  @Test("a marker file is not mistaken for a spool by the scan")
+  func markerNotListedAsSpool() throws {
+    let store = makeStore()
+    try store.writeAttemptMarker(for: "lonely-marker")
+    #expect(try store.listSpoolSessionIDs().isEmpty, "scan lists only .ewrec spools")
+  }
 }


### PR DESCRIPTION
Part of #1063. PR2 = the recovery REPLAY flow: on the next launch after a crash, find the orphaned encrypted audio spool PR1 wrote, decrypt + transcribe + polish it under its record-time settings, and save it to History as a non-auto-pasting "Recovered" entry. Recovery is a strict LIMB (never affects capture/transcribe/paste). Also resolves PR1's two parked cleanup-signal defects.

## What it does
- **Launch scan → recover.** `scanAndRecover()` (replaces PR1's launch purge) finds orphan spools, dedups any already in History, then recovers each behind a blocking "recovering your last recording" pill that holds new recordings off the one shared engine.
- **Blocking pill, not concurrency.** A record-press while recovering mints no session (shows the pill with a Discard affordance), mirroring the cold-engine not-ready gate. No contention with live dictation.
- **Discard = reliable escape.** Discard hard-resets the shared engine (the #445 service-kill), so the in-flight (otherwise uncancellable) transcribe returns at once for the default out-of-process engine and the gate opens exactly when the engine is actually free — works even mid-wedge.
- **One attempt.** A fsync'd per-spool `<id>.attempt` marker written before the risky load/transcribe; present-next-launch ⇒ abandon (delete + log), no retry/crash-loop.
- **Cleanup-signal redesign.** In-session non-saved-spool cleanup keys off the kernel's RAW terminal transition (carrying the recovery id + a discard-vs-failure terminal kind), never the externalError-pinnable published state. Discard-terminals delete the spool; failure-terminals retain it for next-launch recovery. `.cancelled` is disambiguated (user cancel → delete, fault/system cancel → retain) at the cancel call site.
- **History "Recovered" badge** (icon + text), telemetry (`recovery.found/completed/press_blocked`, privacy-safe buckets), Sentry breadcrumb categories.

## Validation
- **1,816 logic tests green** via `scripts/xcode-test.sh` (60+ recovery-specific, incl. real encrypted-spool replay).
- **6 `codex review` rounds + a grounded terminal-kind matrix**, iterated to convergence. Every data-loss / heart-path-contention / recording-lockout risk closed (key-cleanup races, fault-cancel disposition, scan fail-closed, gate staleness, backend-switch-during-recovery block, wedge/Discard reliability). Two best-effort quality nuances documented and routed to PR3 (record-time backend fidelity; deferred-apply of a dropped engine switch).
- **Live UAT on the running app (all PASS):** normal dictation unaffected (recovery on); crash mid-record → relaunch → "Recovered" entry with the valid captured prefix + correct session id; no auto-paste; "Recovered" badge renders; no-orphan launch byte-identical; recovery-off writes no spool.

## Scope deferred to PR3 (hardening)
Settings UI + disclosure, TTL, low-disk UX, Export Audio, real batch-transcribe-cancel, background wedge-timeout, record-time backend fidelity, same-session helper-crash.
https://claude.ai/code/session_019eBmrUBsavbz5E2BqF9hTN