### PR TITLE
docs: remove stale re-polish claim from README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Both models run entirely on-device using CoreML. First launch downloads and comp
 - 📚 **Custom vocabulary** for names, brands, and technical terms the ASR might miss
 - ⌨️ **Global hotkey** with push-to-talk, toggle, and hands-free modes (double-press to lock for long-form dictation)
 - 📋 **Auto-paste** directly into the active app, or just copy to clipboard
-- 🕘 **Transcript history** for browsing, searching, and reviewing past dictations, with one-click re-polish to re-run AI cleanup on any past transcript
+- 🕘 **Transcript history** for browsing, searching, and reviewing past dictations
 - 🧭 **Menu bar native** with minimal footprint
 - 🔄 **Auto-updates** via Sparkle
 


### PR DESCRIPTION
The saved-transcript re-polish (Enhance) feature was removed in #1109, but the README still advertised "one-click re-polish to re-run AI cleanup on any past transcript." Flagged by the Codex cloud review on #1109 and verified still-live in main.

Transcript history itself (browse / search / review) still exists, so only the removed re-polish clause is dropped; the bullet stays.

`council-skip: zero-blast-radius (user-facing copy)` — one line, README prose, single-commit revert, no logic.