### PR TITLE
ci(pipeline): honest build-skipped status on content-only PRs (#1089)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,6 +25,10 @@ jobs:
   build-debug:
     runs-on: macos-26
     timeout-minutes: 45
+    # Expose this lane's content-detection verdict so the build-check aggregator
+    # can report honestly whether a Swift compile actually ran (#1089).
+    outputs:
+      needs_build: ${{ steps.changes.outputs.needs_build }}
 
     steps:
       - name: Checkout
@@ -183,6 +187,10 @@ jobs:
   build-release:
     runs-on: macos-26
     timeout-minutes: 45
+    # Mirror of build-debug's output; the aggregator cross-checks both lanes and
+    # reports "unknown" on any divergence rather than overclaiming (#1089).
+    outputs:
+      needs_build: ${{ steps.changes.outputs.needs_build }}
 
     steps:
       - name: Checkout
@@ -337,3 +345,25 @@ jobs:
             exit 1
           fi
           echo "==> Both build lanes passed."
+
+      - name: Report build status
+        run: |
+          set -euo pipefail
+          # Honest at-a-glance signal for reviewers: distinguish a real Swift
+          # build + test pass from a content-only skip, without touching the
+          # required-check name or the per-step skip logic (#1089). Runs only
+          # after the fail-closed gate above, so it renders solely on a green
+          # run. Both lanes run identical content detection on the same SHAs;
+          # require them to agree, else report "unknown" rather than overclaim.
+          debug_needs="${{ needs.build-debug.outputs.needs_build }}"
+          release_needs="${{ needs.build-release.outputs.needs_build }}"
+          if [ "$debug_needs" = "true" ] && [ "$release_needs" = "true" ]; then
+            STATUS="build-check passed: Swift build and tests ran."
+          elif [ "$debug_needs" = "false" ] && [ "$release_needs" = "false" ]; then
+            STATUS="build-check passed: change classified as content-only, Swift build and tests intentionally skipped."
+          else
+            STATUS="build-check passed: build mode unknown (lane verdicts debug='$debug_needs' release='$release_needs')."
+          fi
+          echo "==> $STATUS"
+          echo "$STATUS" >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=build-check::$STATUS"


### PR DESCRIPTION
## What

`build-check` (the required aggregator) reported a plain green "passed" whether the app was actually compiled and tested or the build was intentionally skipped because the PR was content-only. A third-party reviewer scanning CI history could not tell the two apart, which can read as "merged code without building it." This surfaces an honest, distinct status.

## How

- Expose each lane's `Detect code changes` verdict as a job `outputs.needs_build` on both `build-debug` and `build-release`.
- Add a `Report build status` step to the `build-check` aggregator, **after** the existing fail-closed gate (so it renders only on a genuine green run). It cross-checks both lanes and writes one honest line to `$GITHUB_STEP_SUMMARY` + a `::notice::` annotation:
  - both `true` → "Swift build and tests ran."
  - both `false` → "change classified as content-only, Swift build and tests intentionally skipped."
  - divergent/empty → "build mode unknown (...)" — never a false "skipped."

## Out of scope (deliberate)

- The detection allowlist logic is unchanged (it is deny-by-default and correct).
- The required-check **context name `build-check` is unchanged**, so the `main-protection` ruleset needs no edit. No new permissions, no new status context.
- `#825` (the `fetch-depth: 2` diff-base reliability concern in the same step) is left open.

## Visibility ceiling (one acknowledged limitation)

The summary + notice shows in the run's Checks detail view / annotations (where an auditor who clicks "Details" lands), not in the collapsed `build-check ✅` row in the PR conversation list. A maximally-visible alternative — publishing a separate non-required `build-mode` commit status whose description renders inline next to the checkmark — was **deferred**: it needs `statuses: write` and adds a new status context to every PR, a contract change beyond this cosmetic scope. Happy to do it as a follow-up if we want the signal in the top-level checks row.

## Validation

- `actionlint` clean; local shell simulation of the report step covers all branches under `set -euo pipefail` (true/true, false/false, empty, divergent → correct, no abort).
- This PR edits `pr-check.yml`, which self-forces a full build, so `build-check` runs the real build against this HEAD SHA (CI/workflow-lane evidence) and exercises the both-`true` branch live (expect run-summary "Swift build and tests ran"). The skip branch's string selection is covered by the local sim; its GitHub plumbing is identical to the both-`true` branch proven here.

## Review

- Council coverage (GPT-5.5 + Gemini-3.1): adopted non-overclaiming wording, the `unknown` branch, and two-lane agreement.
- Codex grounded review: PROCEED-AS-PLANNED (round 2). Codex code-diff review: clean.

Closes #1089