### PR TITLE
ci(release): pin mise + sentry-cli installers before secret use (#1128, #1129)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,10 +241,32 @@ jobs:
         run: brew install create-dmg
 
       - name: Install mise + Tuist
+        env:
+          # Pin mise to a checksummed GitHub release binary instead of the
+          # unpinned `curl https://mise.run | sh` installer. This step runs in
+          # the signing job immediately before the Developer ID cert import, so a
+          # compromised installer endpoint could otherwise persist a shim that
+          # exfiltrates the signing identity. (#1128)
+          # Bump: set VERSION + SHA256 together — sha256 of
+          # mise-<VERSION>-macos-arm64, cross-checked vs the release SHASUMS256.txt.
+          MISE_VERSION: v2026.6.11
+          MISE_SHA256: 5cde7e282e64fd1cea3b1e28b1dc918ee118c3a651be4d8ce27b8494950a26c7
         run: |
           set -euo pipefail
-          curl https://mise.run | sh
+          [ "$(uname -m)" = arm64 ] || { echo "::error::Expected arm64 runner, got $(uname -m)"; exit 1; }
+          MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-macos-arm64"
+          MISE_TMP="$RUNNER_TEMP/mise"
+          echo "==> Downloading pinned mise ${MISE_VERSION} from ${MISE_URL}"
+          curl --proto '=https' --tlsv1.2 --fail --location \
+            --retry 3 --retry-connrefused --connect-timeout 15 --max-time 120 \
+            -sS -o "$MISE_TMP" "$MISE_URL"
+          echo "${MISE_SHA256}  ${MISE_TMP}" | shasum -a 256 -c -
+          mkdir -p "$HOME/.local/bin"
+          chmod +x "$MISE_TMP"
+          mv "$MISE_TMP" "$HOME/.local/bin/mise"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mise" --version | grep -qF "${MISE_VERSION#v}" \
+            || { echo "::error::mise version mismatch (expected ${MISE_VERSION#v})"; exit 1; }
           "$HOME/.local/bin/mise" install tuist@4.195.11
           "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
 
@@ -710,7 +732,7 @@ jobs:
 
   # ==========================================================================
   # LIMB Job D — Upload Sentry dSYMs
-  # Cannot block shipping. Uses pre-installed sentry-cli on runner.
+  # Cannot block shipping. Installs a pinned, checksummed sentry-cli (#1129).
   # ==========================================================================
   upload-sentry-dsyms:
     needs: [preflight, build-release-artifacts, publish-github-release]
@@ -745,7 +767,31 @@ jobs:
           run-id: ${{ needs.preflight.outputs.source-run-id }}
 
       - name: Install sentry-cli
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        env:
+          # Pin sentry-cli to a checksummed GitHub release binary instead of the
+          # unpinned `curl https://sentry.io/get-cli/ | bash` installer. The next
+          # step exposes SENTRY_AUTH_TOKEN (an org-scoped Sentry API token), so a
+          # compromised installer endpoint could otherwise persist a shim that
+          # exfiltrates it. (#1129)
+          # Bump: set VERSION + SHA256 together — sha256 of sentry-cli-Darwin-arm64.
+          SENTRY_CLI_VERSION: "3.5.1"
+          SENTRY_CLI_SHA256: d2b69f611c2e0701ffa09ad93db2f0d2fc845e1cf20a598270860a59cf698932
+        run: |
+          set -euo pipefail
+          [ "$(uname -m)" = arm64 ] || { echo "::error::Expected arm64 runner, got $(uname -m)"; exit 1; }
+          SENTRY_URL="https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}/sentry-cli-Darwin-arm64"
+          SENTRY_TMP="$RUNNER_TEMP/sentry-cli"
+          echo "==> Downloading pinned sentry-cli ${SENTRY_CLI_VERSION} from ${SENTRY_URL}"
+          curl --proto '=https' --tlsv1.2 --fail --location \
+            --retry 3 --retry-connrefused --connect-timeout 15 --max-time 120 \
+            -sS -o "$SENTRY_TMP" "$SENTRY_URL"
+          echo "${SENTRY_CLI_SHA256}  ${SENTRY_TMP}" | shasum -a 256 -c -
+          mkdir -p "$HOME/.local/bin"
+          chmod +x "$SENTRY_TMP"
+          mv "$SENTRY_TMP" "$HOME/.local/bin/sentry-cli"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/sentry-cli" --version | grep -qF "$SENTRY_CLI_VERSION" \
+            || { echo "::error::sentry-cli version mismatch (expected $SENTRY_CLI_VERSION)"; exit 1; }
 
       - name: Upload dSYMs to Sentry
         env:
@@ -756,9 +802,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # sentry-cli is installed by the prior step on the hosted runner; this guard is belt-and-suspenders
+          # sentry-cli is installed (pinned + checksummed) by the prior step; this guard is belt-and-suspenders
           if ! command -v sentry-cli &>/dev/null; then
-            echo "::error::sentry-cli not found. Install it on the runner: curl -sL https://sentry.io/get-cli/ | bash"
+            echo "::error::sentry-cli not found on PATH. The pinned 'Install sentry-cli' step must have failed."
             exit 1
           fi
           sentry-cli --version


### PR DESCRIPTION
## What

The hosted `release.yml` installed two CLI tools by piping **unpinned remote installers** into a shell, each immediately before a secret was exposed:

- **mise** — `curl https://mise.run | sh` in the **signing job**, run right before the Developer ID certificate import (`#1128`, P1).
- **sentry-cli** — `curl -sL https://sentry.io/get-cli/ | bash` in the **dSYM job**, run right before `SENTRY_AUTH_TOKEN` (an org-scoped Sentry API token) is exposed (`#1129`, P2).

A compromised installer endpoint or a moved-tag race could persist a malicious shim that runs while the signing identity / token is available and exfiltrate it. Every GitHub Action in this workflow is already SHA-pinned, so these were the **only unpinned remote-code-execution paths left in the two secret-bearing jobs**.

## How

Each `curl | sh` is replaced with a pinned, integrity-verified download of the tool's GitHub-release binary:

1. **arch guard** (`uname -m == arm64` — macos-26 is Apple Silicon today, but the workflow can't prove future runner arch),
2. **hardened curl** (`--proto '=https' --tlsv1.2 --fail --location --retry 3 --retry-connrefused --connect-timeout 15 --max-time 120`),
3. **committed sha256** verified with `shasum -a 256 -c -` — **fails closed before any secret is reached**,
4. PATH via `$GITHUB_PATH`,
5. a **no-token `--version` assertion**.

Pins (verified locally against the real arm64 assets; mise's matches its published `SHASUMS256.txt`):

| Tool | Version | Asset | sha256 |
|---|---|---|---|
| mise | `v2026.6.11` | `mise-v2026.6.11-macos-arm64` | `5cde7e28…0a26c7` |
| sentry-cli | `3.5.1` | `sentry-cli-Darwin-arm64` | `d2b69f61…698932` |

Two now-stale comments (the Job D banner and the belt-and-suspenders guard hint) are refreshed.

## Validation

- **Local empirical:** both binaries downloaded, sha256 computed, **run on this Apple Silicon Mac** reporting the pinned versions; mise's checksum matches its published SHASUMS256.
- **actionlint CLEAN** (runs shellcheck on the embedded `run:` blocks).
- **Council** (GPT-5.5 + Gemini): confirmed hardcoded-sha256 is the right anchor; surfaced the curl-retries / arch-guard / version-assertion hardening (folded in).
- **Codex grounded review** (plan): PROCEED-AS-PLANNED. **Codex code-diff review** (this diff): no bugs found.
- **Hosted `build-only` dry-run** on this branch exercises the new mise install → cert import → build → sign → notarize → staple end-to-end (run linked in PR thread). The sentry-cli step isn't reachable by build-only; it's covered by the local run + the byte-identical (build-only-proven) install mechanism + the in-step `--version` gate on first real release.

## Scope / follow-up

Scoped to `release.yml` (the two secret-bearing jobs / the actual findings). The same unpinned `curl https://mise.run | sh` also exists in `pr-check.yml` (×2) and `main-post-merge.yml` (×1) — build/test jobs with **no signing cert or token at risk**. Council preferred pinning all four here; I've routed the build-workflow pins (plus a shared composite-action/manifest DRY and a static `curl|sh` guard) to a defense-in-depth follow-up so that abstraction decision is made once, holistically, rather than as a half-done inline copy.

`council-skip: N/A — full council + 2-round Codex grounded review + Codex code-diff all ran.`

Closes #1128
Closes #1129