### PR TITLE
ci(release): confirm dSYM processing + proactive limb-failure alert (#1088)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -842,13 +842,14 @@ jobs:
           # step exposes SENTRY_AUTH_TOKEN (an org-scoped Sentry API token), so a
           # compromised installer endpoint could otherwise persist a shim that
           # exfiltrates it. (#1129)
-          # Bump: set VERSION + SHA256 together — sha256 of sentry-cli-Darwin-arm64.
+          # Bump: set VERSION + SHA256 together — sha256 of sentry-cli-Linux-x86_64.
           SENTRY_CLI_VERSION: "3.5.1"
-          SENTRY_CLI_SHA256: d2b69f611c2e0701ffa09ad93db2f0d2fc845e1cf20a598270860a59cf698932
+          SENTRY_CLI_SHA256: 50a1618336cdbb908e5559d6b941f3aa0ef5f341abeca08de40ed8c0070450b4
         run: |
           set -euo pipefail
-          [ "$(uname -m)" = arm64 ] || { echo "::error::Expected arm64 runner, got $(uname -m)"; exit 1; }
-          SENTRY_URL="https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}/sentry-cli-Darwin-arm64"
+          # #1117 moved this limb to ubuntu-latest (x86_64 Linux), so fetch the Linux binary, not Darwin (#1139).
+          [ "$(uname -m)" = x86_64 ] || { echo "::error::Expected x86_64 runner, got $(uname -m)"; exit 1; }
+          SENTRY_URL="https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}/sentry-cli-Linux-x86_64"
           SENTRY_TMP="$RUNNER_TEMP/sentry-cli"
           echo "==> Downloading pinned sentry-cli ${SENTRY_CLI_VERSION} from ${SENTRY_URL}"
           curl --proto '=https' --tlsv1.2 --fail --location \
@@ -861,6 +862,30 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/sentry-cli" --version | grep -qF "$SENTRY_CLI_VERSION" \
             || { echo "::error::sentry-cli version mismatch (expected $SENTRY_CLI_VERSION)"; exit 1; }
+
+      - name: Verify dSYMs present and parseable
+        run: |
+          set -euo pipefail
+          DSYM_DIR="build/dSYMs"
+          # First-party dSYMs we triage crashes on. The archive also ships ~5 Sparkle
+          # dSYMs (Sparkle.framework / Autoupdate / Updater.app / Installer.xpc / Downloader.xpc),
+          # which are uploaded too but NOT gated on (that set drifts with Sparkle versions).
+          FIRST_PARTY=(EnviousWispr.app.dSYM EnviousWisprAudioService.xpc.dSYM EnviousWisprASRService.xpc.dSYM)
+          missing=0
+          for b in "${FIRST_PARTY[@]}"; do
+            [ -d "$DSYM_DIR/$b" ] || { echo "::error::missing first-party dSYM: $b"; missing=1; }
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::dSYM guard failed (empty / mis-staged artifact). Contents of $DSYM_DIR:"
+            ls -1 "$DSYM_DIR" || true
+            exit 1
+          fi
+          for b in "${FIRST_PARTY[@]}"; do
+            dwarf=$(find "$DSYM_DIR/$b/Contents/Resources/DWARF" -type f 2>/dev/null | head -1)
+            { [ -n "$dwarf" ] && sentry-cli debug-files check "$dwarf" >/dev/null 2>&1; } \
+              || { echo "::error::dSYM parse-check failed for $b"; exit 1; }
+          done
+          echo "==> dSYM guard: all 3 first-party dSYMs present and parseable."
 
       - name: Upload dSYMs to Sentry
         env:
@@ -891,7 +916,10 @@ jobs:
           sentry-cli releases set-commits "v${VERSION}" --auto
 
           echo "==> Uploading dSYMs ..."
-          sentry-cli debug-files upload --include-sources build/dSYMs/
+          # --wait-for makes the command fail if the server cannot fully PROCESS the
+          # files (processing errors only surface with --wait/--wait-for). A green exit
+          # then means "symbols processed", not merely "bytes accepted". 300s < 900s job timeout.
+          sentry-cli debug-files upload --include-sources --wait-for 300 build/dSYMs/
 
           sentry-cli releases finalize "v${VERSION}"
           echo "==> Sentry release v${VERSION} finalized with dSYMs."
@@ -917,6 +945,10 @@ jobs:
           APPCAST_RESULT: ${{ needs.publish-appcast.result }}
           SENTRY_RESULT: ${{ needs.upload-sentry-dsyms.result }}
           DRY_RUN: ${{ inputs.dry_run }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -991,9 +1023,29 @@ jobs:
             exit 0
           fi
 
-          # Limb failures are warnings, not errors
+          # Limb failures are warnings, not errors. Reaching here means we passed the
+          # heart-failure exit guards AND the dry_run gate above, so this is a real
+          # release that actually shipped. Push a proactive Discord alert (the backup
+          # for unattended releases). Non-blocking: it can never fail the summary job,
+          # but its absence/failure is made VISIBLE (#1088).
           if [[ "$NEEDS_FOLLOWUP" == "Yes" ]]; then
             echo "::warning::Limb failures detected — release shipped but follow-up needed. See summary for recovery commands."
+            if [[ -z "${DISCORD_RELEASE_WEBHOOK:-}" ]]; then
+              echo "::warning::DISCORD_RELEASE_WEBHOOK not configured — proactive alert NOT sent."
+              echo "| Discord alert | NOT configured |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              MSG=$(printf 'RELEASE FOLLOW-UP NEEDED. v%s shipped to users, but a release limb needs attention.\nFollow-up:%b\nRun: %s\nSentry: %s / %s' \
+                "$VERSION" "${FOLLOWUP_ITEMS}" "$RUN_URL" "${SENTRY_ORG:-?}" "${SENTRY_PROJECT:-?}")
+              PAYLOAD=$(python3 -c 'import json,sys; print(json.dumps({"content": sys.argv[1]}))' "$MSG")
+              CODE=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$DISCORD_RELEASE_WEBHOOK" \
+                -H "Content-Type: application/json" -d "$PAYLOAD" || echo "000")
+              if [[ "$CODE" == "204" || "$CODE" == "200" ]]; then
+                echo "| Discord alert | sent ($CODE) |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "::warning::Discord alert POST failed (HTTP $CODE) — GitHub summary is the fallback record."
+                echo "| Discord alert | attempted, failed ($CODE) |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
           else
             echo "==> Release v${VERSION} fully shipped. All components successful."
           fi


### PR DESCRIPTION
## What & why

Makes the crash-symbol (dSYM) upload a **confirmed** part of finishing a release, without ever blocking shipping. dSYMs are what let a Sentry crash report come back as readable function/file/line instead of raw hex. Today the upload runs fire-and-forget and a clean exit doesn't prove the symbols were processed; a failure only shows on the run-summary page nobody routinely opens. Founder directive: confirming "did the symbols actually land?" should be a first-class, attended step of finishing a release, with on-the-spot remediation — but the app reaching users must never block on it (it stays a non-blocking limb).

Closes #1088.

## Changes (`.github/workflows/release.yml` only)

**Job D — `upload-sentry-dsyms`**
- **Pre-upload guard:** assert the 3 first-party dSYMs (`EnviousWispr.app`, `EnviousWisprAudioService.xpc`, `EnviousWisprASRService.xpc`) are present and parseable (`sentry-cli debug-files check` on each inner DWARF). Catches an empty/mis-staged artifact that would otherwise upload nothing and still exit 0. The archive also ships ~5 Sparkle dSYMs (uploaded, not gated on — that set drifts with Sparkle versions).
- **`--wait-for 300`** on the upload so a green exit means the server actually **processed** the symbols, not merely accepted the bytes.

**Job E — `release-summary`**
- When a shipped release needs limb follow-up (dSYM **or** appcast), post a proactive Discord alert (`DISCORD_RELEASE_WEBHOOK`) with the version, failed limb, run URL, Sentry org/project, and the exact recovery command. **Gated structurally** — the alert block sits after the existing heart-failure `exit 1` guards, so it only fires when the release actually shipped. **Non-blocking** (curl failure swallowed) but its absence/failure is made **visible** (summary line + `::warning::`).

Plus (local, not in this PR): the release-checklist runbook gains a required attended dSYM-confirmation step (the primary mechanism; Discord is the unattended backup), and a knowledge-doc dSYM-count correction.

## Heart & limbs preserved
dSYM stays a limb. The summary job still `exit 1`s only on build/GitHub-release (heart) failures. No app/SDK/Swift code touched.

## Identity check deferred → #1136
A dSYM↔shipped-binary UUID match was considered but deferred: `build-release-dmg.sh` wipes `build/dSYMs` and sources app+dSYMs from the same archive, so a wrong dSYM is structurally precluded (Codex-confirmed, file:line). Filed as #1136 (P4, defense-in-depth).

## Validation
- **Council** (both providers) coverage round + **Codex grounded review** (3 rounds → PROCEED-AS-PLANNED) + **Codex code-diff review** (clean).
- **actionlint** clean (YAML + expressions + run-block shellcheck).
- **Guard shell** validated locally against the real shipped v2.1.4 dSYM artifact: passes on the full 8-dSYM set; correct fail (exit 1, lists contents) when a first-party dSYM is removed.
- **Discord payload** validated locally: valid JSON, renders correctly.
- **Green-path dispatch** (`mode=sentry-only`, v2.1.4) — guard passed ("all 3 first-party dSYMs present and parseable"), `--wait-for` reported "File processing complete", summary "fully shipped", no Discord: https://github.com/saurabhav88/EnviousWispr/actions/runs/27912152966
- **Alert-wiring dispatch** (no-dSYM `source_run_id`) — Job D failed at the dSYM download (by design), Job E gating passed (build+release skipped), Discord alert POSTed (204; no "POST failed"/"NOT configured" warning): https://github.com/saurabhav88/EnviousWispr/actions/runs/27912245311

No app version is released — this is release-pipeline plumbing; it takes effect on the next real release.