### PR TITLE
chore(deps): pin vite >=7.3.5 via override (security)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5032,9 +5032,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,8 @@
   },
   "overrides": {
     "devalue": ">=5.8.1",
-    "undici": ">=7.24.0"
+    "undici": ">=7.24.0",
+    "vite": "^7.3.5"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.17",


### PR DESCRIPTION
Closes 2 Dependabot security alerts in `/website` by bumping vite **within astro 6.4.8's supported range** (astro declares `vite: ^7.3.2`; 7.3.5 satisfies it):

| Severity | Package | Issue | Patched |
|---|---|---|---|
| High | vite | `server.fs.deny` bypass on Windows alternate paths | 7.3.5 |
| Medium | vite | launch-editor NTLMv2 hash disclosure via UNC path (Windows) | 7.3.5 |

**No production exposure:** both are Windows dev-server-only issues in build-time tooling. The site builds on Linux CI and deploys as static output to Cloudflare Pages; no dev server runs in production. Override matches the existing `undici`/`devalue` pattern.

### Why esbuild is deliberately left at 0.27.x (one low alert stays open)
The remaining low-severity esbuild alert (arbitrary file read via dev server on Windows) is patched in 0.28.1, but **no consumer in the tree declares support for esbuild 0.28 yet**: astro 6.4.8 pins `esbuild ^0.27.3`, and vite (both 7.x and 8.x) pins `esbuild ^0.27.0`. Forcing esbuild to 0.28 via override would run both astro and vite against an untested esbuild minor (0.28 is a breaking release) purely to close a low, zero-production-exposure alert. That trade isn't worth the fragility — it will resolve naturally once astro/vite adopt esbuild 0.28 upstream. (Thanks to the reviewer who caught this; the first revision of this PR did force esbuild and has been dropped.)

**Validation:** `npm audit` (vite alerts cleared), `astro build` green (54 pages). Diff is minimal: one override line + vite 7.3.2 -> 7.3.5 in the lockfile.

council-skip: zero-blast-radius (single transitive dependency security override; lockfile bump only, no source/symbol change; build-check gates)