### PR TITLE
chore(deps): bump swift-minor group (Sparkle 2.9.3, PostHog 3.61.0, Sentry 9.18.0)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "957ce0300fc302d634b4343e99fd58a50f53928c9c5c463b8c4272c8a1a0dbf5",
+  "originHash" : "b300ed4830594d97095663a3db7624c6f3c7c0af1b15744ed2bdecbc0137a39c",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios.git",
       "state" : {
-        "revision" : "a604c96d138a2d73d2227241a9026536479c551f",
-        "version" : "3.57.6"
+        "revision" : "ee5b5705b0038f0c44646cde5fe972bb65387596",
+        "version" : "3.61.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "54d5fbcdea46c37a5de01bab5fef48dc78baec84",
-        "version" : "9.12.1"
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {


### PR DESCRIPTION
Carries the Dependabot `swift-minor` group bump on a clean branch off current main. Identical `Package.resolved` content to #941, which got wedged on a CI infrastructure race (its rebased commit pointed build-check's diff at a base SHA outside the shallow-clone depth, then a later rebase never triggered a run at all). A normal branch off the current main tip gives build-check a reachable base, so CI runs the real Swift build.

Updates (`Package.resolved` only):
- Sparkle 2.9.1 -> 2.9.3
- PostHog 3.57.6 -> 3.61.0
- Sentry 9.12.1 -> 9.18.0

Validated by build-check (debug + release Xcode build against current main). Supersedes #941.

council-skip: zero-blast-radius (dependency lockfile bump, no source/symbol change; build-check is the gate, same as a Dependabot PR)