### PR TITLE
ci(release): set-commits --ignore-missing so it never blocks dSYM upload (#1088 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -913,7 +913,13 @@ jobs:
           fi
 
           sentry-cli releases new "v${VERSION}"
-          sentry-cli releases set-commits "v${VERSION}" --auto
+          # Commit association is a nice-to-have (suspect-commits), NOT required for
+          # symbolication. `set-commits --auto` can hard-fail ("could not find the SHA
+          # of the previous release in the git history") — notably on a `mode=sentry-only`
+          # RE-RUN, which is exactly #1088's remediation path. --ignore-missing degrades
+          # it to default-commits instead of failing the whole dSYM upload; it is a no-op
+          # when --auto would have succeeded. Keeps the essential symbol upload unblocked.
+          sentry-cli releases set-commits "v${VERSION}" --auto --ignore-missing
 
           echo "==> Uploading dSYMs ..."
           # --wait-for makes the command fail if the server cannot fully PROCESS the


### PR DESCRIPTION
## What & why

Follow-up to #1088 / PR #1138. During the ubuntu validation of #1088 (run 27913816551), `sentry-cli releases set-commits "v${VERSION}" --auto` hard-failed Job D with *"Could not find the SHA of the previous release in the git history."*

Commit association (suspect-commits) is a **nice-to-have for Sentry, not required for symbolication** — but as written, a `set-commits` hiccup fails the **entire dSYM upload**. That failure is reachable specifically on a `mode=sentry-only` **re-run**, which is exactly the remediation path #1088 tells operators to use. So a failed dSYM upload could not be recovered by re-running — the recovery would fail at the same step.

## Change

One flag: `set-commits "v${VERSION}" --auto --ignore-missing` (+ explanatory comment). `--ignore-missing` degrades commit association to default-commits instead of failing the job. It is a **no-op when `--auto` would have succeeded**, so it never changes behavior on a healthy release (set-commits `--auto` has a 5-release success track record on real releases). It only changes the failure case: keep the essential symbol upload (and its re-run recovery) unblocked.

## Heart & limbs
Strictly safer. The dSYM upload (limb) becomes resilient to an ancillary step; nothing else changes. No app/Swift code.

## Validation
- actionlint clean.
- Codex code-diff review clean.
- Green-path dispatch on `ubuntu-latest` (`mode=sentry-only`, v2.1.4) — set-commits no longer hard-fails; full Job D completes (install → guard → set-commits → `--wait-for` upload → finalize): https://github.com/saurabhav88/EnviousWispr/actions/runs/27914380924

No app version is released — release-pipeline plumbing.