### PR TITLE
fix(llm): run leading-marker repair on the default (auto-language) path (#963)

### DIFF
--- a/Sources/EnviousWisprLLM/LeadingMarkerRepair.swift
+++ b/Sources/EnviousWisprLLM/LeadingMarkerRepair.swift
@@ -8,8 +8,13 @@ import Foundation
 /// own KEEP example. Instruction-only preservation is a ceiling; this helper
 /// restores the marker after the fact.
 ///
-/// Scope guards (Codex grounded review, 2026-06-12):
-///   - English-only (`expectedLanguage == "en"`); nil/unknown skips.
+/// Scope guards (Codex grounded review 2026-06-12; language guard widened on
+/// the 2026-06-21 #963 follow-up so the repair fires on the default path):
+///   - Runs on English-or-unknown; skips ONLY a positively-identified
+///     non-English language. The default Parakeet path reports no language
+///     (nil) → runs (this is the headline fix); WhisperKit reports its LID, or
+///     abstains to nil → a non-`en` code skips. The marker set is English-only,
+///     so a non-English first token no-ops the match regardless.
 ///   - Runs on the post-`EnviousOutputFilter` text (wrapper/preamble already
 ///     stripped). When the filter fell back to raw, the raw input still
 ///     starts with the marker, so the repair no-ops naturally.
@@ -19,6 +24,11 @@ import Foundation
 ///     polished output no longer starts with it — revision collapses like
 ///     "set it to thirty, actually make it sixty" never begin with a marker,
 ///     so they are untouched.
+///   - A leading marker introducing an immediate self-correction ("actually no
+///     send it Friday") is the abandoned cue, not an opener: skipped when the
+///     input's 2nd token is a correction cue (`no`/`wait`/`sorry`) AND that cue
+///     did not survive into the output (a normal "actually no one showed up"
+///     keeps "no", so it is still repaired).
 enum LeadingMarkerRepair {
 
   /// Marker → whether the restored opener takes a trailing comma.
@@ -38,10 +48,19 @@ enum LeadingMarkerRepair {
   /// apostrophes stripped) so "I'm" → "im" matches.
   private static let keepCapitalized: Set<String> = ["i", "im", "ill", "ive", "id"]
 
+  /// Immediate self-correction cues. When one of these is the dictation's
+  /// second token AND it did not survive into the polished output, the leading
+  /// marker introduced an abandoned correction ("actually no send it Friday")
+  /// rather than an opener, so the repair stands down. Stored `normalize`d.
+  private static let correctionCues: Set<String> = ["no", "wait", "sorry"]
+
   /// Restore a deleted leading discourse marker. Returns `output` unchanged
   /// whenever any scope guard fails.
   static func repair(input: String, output: String, expectedLanguage: String?) -> String {
-    guard expectedLanguage == "en" else { return output }
+    // Run on English-or-unknown; skip only a positively-identified non-English
+    // language. The default Parakeet path has no LID and reaches here with nil,
+    // so requiring `== "en"` switched the repair off for most users (#963).
+    if let language = expectedLanguage, language != "en" { return output }
 
     let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedOutput.isEmpty else { return output }
@@ -58,6 +77,24 @@ enum LeadingMarkerRepair {
     guard let firstOutputToken = outputTokens.first else { return output }
     // Output still opens with the marker — nothing was deleted.
     guard normalize(firstOutputToken) != marker else { return output }
+
+    // #963 P2: a leading marker introducing an immediate self-correction
+    // ("actually no send it Friday", "actually wait make it sixty") is the
+    // abandoned cue, not an opener to restore. Discriminator: the cue is the
+    // dictation's 2nd token (right after the marker), so on a normal sentence
+    // ("actually wait until Friday") dropping only the marker makes the cue the
+    // FIRST output token → restore; a collapsed correction drops the cue too,
+    // so the output opens with the post-correction content → skip. Checking the
+    // first output token is therefore sufficient (AFM polish is clean-only — it
+    // never prepends a word ahead of a surviving cue) AND safer than scanning
+    // the whole output, which would false-positive when a collapsed
+    // correction's tail repeats the cue ("actually no send it Friday, no
+    // rush"). The miss side is benign (marker stays dropped); a wrong restore
+    // corrupts — so the conservative first-token check is the right asymmetry.
+    let secondToken = normalize(inputTokens[1])
+    if correctionCues.contains(secondToken), normalize(firstOutputToken) != secondToken {
+      return output
+    }
 
     let needsComma = markers[marker] ?? true
     let capitalizedMarker = marker.prefix(1).uppercased() + marker.dropFirst()

--- a/Tests/EnviousWisprTests/LLM/LeadingMarkerRepairTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LeadingMarkerRepairTests.swift
@@ -132,13 +132,72 @@ struct LeadingMarkerRepairTests {
     #expect(out == "La reunión es mañana.")
   }
 
-  @Test("nil language is untouched")
-  func nilLanguageIsNoOp() {
+  @Test(
+    "nil/unknown language repairs — the default Parakeet path",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/963",
+      "repair was off when language is nil"))
+  func nilLanguageRepairs() {
+    // Parakeet has no language detection, so the polish step reaches the repair
+    // with expectedLanguage == nil. The pre-2026-06-21 guard required "en" and
+    // skipped this, leaving the headline bug live on the default path.
     let out = LeadingMarkerRepair.repair(
       input: "actually the fix is merged",
       output: "The fix is merged.",
       expectedLanguage: nil)
-    #expect(out == "The fix is merged.")
+    #expect(out == "Actually, the fix is merged.")
+  }
+
+  // MARK: P2 — correction-cue openers (survival check)
+
+  @Test(
+    "self-correction opener is not restored when the cue collapsed",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/963",
+      "do not re-prepend an abandoned correction cue"),
+    arguments: [
+      // Leading marker + immediate correction cue; polish collapsed the
+      // correction so the cue is gone from the output → do not restore.
+      ("actually no send it friday", "Send it Friday."),
+      ("actually wait make it sixty", "Make it sixty."),
+      ("actually sorry use the staging key", "Use the staging key."),
+    ])
+  func collapsedCorrectionCueIsNotRestored(input: String, polished: String) {
+    let out = LeadingMarkerRepair.repair(
+      input: input, output: polished, expectedLanguage: nil)
+    #expect(out == polished)
+  }
+
+  @Test(
+    "normal sentence whose second word is a cue is still repaired",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/963",
+      "cue survived → real sentence → restore"))
+  func survivingCueWordIsStillRepaired() {
+    // "no" here is part of "no one", not a correction cue — it survives into
+    // the output, so the survival check must NOT suppress the repair.
+    let out = LeadingMarkerRepair.repair(
+      input: "actually no one showed up",
+      output: "No one showed up.",
+      expectedLanguage: nil)
+    #expect(out == "Actually, no one showed up.")
+  }
+
+  @Test(
+    "imperative cue as the real opener is still repaired",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/963",
+      "first-token survival check, realistic form"))
+  func imperativeCueOpenerIsRepaired() {
+    // Codex code-diff review 2026-06-21: "wait" here is the sentence's real
+    // first word (an imperative), not an abandoned correction cue. Dropping
+    // "actually" leaves it the FIRST output token, so the survival check
+    // restores the marker rather than treating it as a collapsed correction.
+    let out = LeadingMarkerRepair.repair(
+      input: "actually wait until friday",
+      output: "Wait until Friday.",
+      expectedLanguage: nil)
+    #expect(out == "Actually, wait until Friday.")
   }
 
   @Test("blank output is untouched")


### PR DESCRIPTION
## What
Turns the deterministic leading-marker repair back on for the **default** dictation path, and hardens it against self-correction openers.

- **P1** — `LeadingMarkerRepair.repair` language guard widened from `expectedLanguage == "en"` to *skip only a positively-identified non-English language* (runs on English-or-unknown, including nil).
- **P2** — correction-cue survival guard: skip the restore only when the input's 2nd token is a cue (`no`/`wait`/`sorry`) **and that cue did not survive into the output** (i.e. polish collapsed a real self-correction). A normal "actually no one showed up" keeps "no" in the output → still repaired.

## Why
The repair shipped in #1039 was gated on confirmed English. On the **fresh-install default** (`languageMode == .auto`) with Parakeet (no language detection), the polish step receives `detectedLanguage == nil`, so the old guard skipped the repair entirely — the "first word vanishes" symptom ("Actually, let's go" → "Let's go") was still live for default users. A *locked-English* config already had `detectedLanguage == "en"` and the repair was eligible; this restores it for the default `.auto` audience. Confirmed against `SettingsManager` (default resolves to `.auto`), `KernelFinalizationWiring` (`.locked` → code, else nil), and the AFM connector (`LanguageNormalizer.baseCode(config.detectedLanguage)`).

WhisperKit reports a real LID language (or abstains to nil); the new guard preserves its non-English skip and now also fires on abstain (English-or-unknown, English-only marker set → safe).

## Scope
AFM-connector-only — the repair stays where it lives; the cross-provider move and the cloud arm (#1036) were descoped by the founder (cloud models don't drop markers in practice). No prompt change → no eval baseline bump (the repair isn't mirrored in `acceptance_gate.py`; the gpt-4o-mini CI gate is unaffected).

## Validation
- **18 unit tests** (`xcode-test.sh`): nil→repairs (the default path), en→repairs, es→skips, P2 collapse-skip ×3, P2 surviving-cue→repairs, imperative-cue→repairs, plus all prior coverage.
- **Codex grounded review** (plan): PROCEED — 5 revisions folded (tightened P2 survival check among them).
- **Codex code-diff review**: round 1 flagged first-token survival; addressed + tested; **round 2 clean**.
- **Live UAT** on Parakeet (menu-driven `test_recording`): repair restores end-to-end on the running app — a marker-stripped "Let's go to dinner tonight." came back "Actually, let's go to dinner tonight."

Closes #963