### PR TITLE
feat(triage): version-boundary eligibility gate for TIK reopens (#1143)

### DIFF
--- a/workers/sentry-triage/routine-prompt-tik-sentry.md
+++ b/workers/sentry-triage/routine-prompt-tik-sentry.md
@@ -137,6 +137,7 @@ If the step DOES document a per-step recovery, follow that recovery and continue
 - **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
 - **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
 - **Path C step 3 sub-issue link failure**, **Path C step 5 regression-comment write failure**, or any other Path C sub-step write failure between reopen and the label add: log + continue with the remaining Path C sub-steps. Do NOT abort Path C mid-sequence on a non-auth-expiry error.
+- **Path C eligibility-gate (Step 2.6.5) write failures** — the Step-H hold/canary audit-comment write OR the hold-label add: log + continue to the next Sentry issue (same log-and-continue rule as the reopen-path writes). A transient failure on a HOLD audit comment MUST NOT terminate the run; the issue simply stays correctly closed with the comment retried next run. (The events-fetch / helper-invocation failures inside Step 2.6.5 are NOT errors — they resolve to the `ambiguous` verdict and fail open by design.)
 
 A single transient MCP/Sentry hiccup MUST NOT terminate the whole run when the prompt documents a per-step skip-and-continue. Terminating in those cases drops remaining Sentry issues that should still be processed.
 
@@ -346,17 +347,26 @@ mcp__github__list_issue_comments(
 Grep the combined body + comment-bodies for markers matching:
 
 ```
-<!-- agent:sentry-triage v=4 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3> last_seen=<ISO> source_issue=#<N|none> source=sentry run_id=<id> -->
+<!-- agent:sentry-triage v=4 fingerprint=ENVIOUSWISPR-X decision=<decision> severity=<P0..P3|none> last_seen=<ISO> source_issue=#<N|none> source=sentry run_id=<id> -->
+```
+`severity=none` is valid for `decision=held` (and `ignored`) — those carry no severity. The parser MUST accept `none` so held decisions are recognized on the next run (else the hold throttle and reversal memory are skipped). Reopen/ambiguous decisions always carry `P0..P3`.
+
+Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`, `held`, `ambiguous`. (`held` = Path C eligibility gate held the reopen as pre-fix-tail / non-bug / dev-only; `ambiguous` = Path C could not prove benign and failed open to a visible-triage reopen — both are new in the Step 2.6.5 reopen gate below.) The `source_issue` field is the GitHub issue this fingerprint resolved to: `#N` for `created` / `updated` / `reopened` / `reversed` / `held` / `ambiguous` paths (the actual tracking issue number), or `none` if the prior decision was `ignored`. **Do NOT use the parent epic `#317` as `source_issue`** — `#317` is the Bugs epic parent only, not a tracking issue. Older `v=3` markers from the pre-split routine are ALSO valid and ALSO greppable — they lack `source_issue=`, treat as `source_issue=#<containing-issue>` (the issue the marker is on).
+
+**Also grep for the close-stamp marker** (written into the closing comment when an issue was closed — distinct from the `agent:sentry-triage` marker, no collision):
+
+```
+<!-- tik-close: class=<fixed|fixed-merged-unreleased|telemetry-noise|not-a-bug|by-design|duplicate|unknown> fix-commit=<sha|none> fix-released=<vX.Y.Z|none> canonical=#<N|none> -->
 ```
 
-Where `<decision>` is one of: `created`, `updated`, `reopened`, `reversed`, `ignored`. The `source_issue` field is the GitHub issue this fingerprint resolved to: `#N` for `created` / `updated` / `reopened` / `reversed` paths (the actual tracking issue number), or `none` if the prior decision was `ignored`. **Do NOT use the parent epic `#317` as `source_issue`** — `#317` is the Bugs epic parent only, not a tracking issue. Older `v=3` markers from the pre-split routine are ALSO valid and ALSO greppable — they lack `source_issue=`, treat as `source_issue=#<containing-issue>` (the issue the marker is on).
+If present, it gives the close-class and the fix-boundary inputs — but **mapping it to the helper input still follows Step 2.6.5 B exactly** (a stamp with `fix-released=none` + a `fix-commit` is RE-DERIVED at gate time, because a release may have shipped the fix since close; a stamp with no boundary source fails open). Do NOT treat a stamp as a finished boundary "with no derivation." If absent, derive local-git-only per Step 2.6.5. Hold the parsed `class`, `fix-commit`, `fix-released`, `canonical` for the reopen gate.
 
 **Default action when prior agent marker exists — gate on issue state FIRST:**
 
 - **If the GitHub issue is OPEN:** apply Path B's throttle (event count doubled OR new users OR no `agent:sentry-triage` comment in last 7 days — see Path B for canonical definition). If throttle blocks, skip silently. If throttle allows, post an UPDATE comment.
-- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry `is:unresolved + lastSeen within window` query (or the regression-watch bypass from Step 1) means the defect is firing again post-close. Route to **Path C (REOPEN + regression comment)**. The reversal-required rules below still apply.
+- **If the GitHub issue is CLOSED:** do NOT apply the throttle. The presence of the issue in the current Sentry query (or the regression-watch bypass from Step 1) means the fingerprint is firing post-close. Route to **Path C**, which **no longer reopens unconditionally** — it runs the eligibility gate (Step 2.6.5) to distinguish a true current-release regression (reopen) from pre-fix-tail / dev-only / non-bug noise (hold) before acting. The reversal-required rules below still apply.
 
-This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens.
+This state gate prevents closed-issue regressions from being silently swallowed by the throttle when a prior marker happens to exist. The throttle is for noise control on still-open issues, not for suppressing reopens. (Conversely, the Step 2.6.5 eligibility gate prevents the OPPOSITE failure — reopening a closed issue off a lifetime aggregate that is entirely pre-fix-tail, as happened to #979 on 2026-06-21. HOLD there requires proof; anything unprovable fails OPEN to a visible reopen, never a silent hold.)
 
 **If you genuinely disagree with the prior agent decision:** comment must open with `**Reversing prior agent call from <prior-date>:**` followed by the reason. Reversals are explicit and greppable. Reversal is REQUIRED when:
 - New severity differs from prior severity, OR
@@ -417,7 +427,7 @@ For each candidate hit, decide whether to route to Path B (comment on existing) 
 If 2+ match: route by the candidate issue's `state`:
 
 - **Candidate is open** → route as **Path B**. Open the comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: issue #N appears to track the same defect class.**`
-- **Candidate is closed** → route as **Path C**. The fingerprint split is itself a regression signal — the underlying defect is firing again under a new Sentry shortId. Open Path C's regression comment with `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: this issue appears to track the same defect class and is firing again.**` then proceed through the rest of Path C (reopen, sub-link, regression comment with template 5a or 5b, `regression` label).
+- **Candidate is closed** → route as **Path C**, which means **run the Step 2.6.5 eligibility gate FIRST** (fetch events for the SPLIT fingerprint's Sentry issue, resolve the boundary from the candidate's close-stamp/derivation, run the helper). Only on a `reopen`/`ambiguous` family do you reopen the candidate — and only then prepend the linked-fingerprint intro `**Linked from new Sentry fingerprint X because <2+ matched dimensions>: this issue appears to track the same defect class and is firing again.**`. If the gate returns a `hold`/`canary`/`route` family, do NOT reopen — post the Step-H audit comment (or route to canonical) instead. A fingerprint split whose post-close evidence is only pre-fix-tail or dev-only is NOT a reason to reopen.
 
 If only 1 matches OR none match: route as Path A NEW, but include in the body's References section: `Possibly related: #<N> (single dimension match: <which one>)`.
 
@@ -464,6 +474,8 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
 - P1-high: userCount >= 3 OR count >= 20
 - P2-medium: userCount >= 2 OR count >= 5
 - P3-low: everything else
+
+For Path A (new issue) and Path B (open issue), `userCount`/`count` are the Sentry issue aggregate. **For Path C reopens (and ambiguous fail-opens), use the eligibility gate's `eligible_user_count` / `eligible_count` (post-close, production, fix-containing partition) in place of `userCount`/`count` — NEVER the lifetime aggregate.** Scoring a reopen off the lifetime aggregate is exactly the #979 false-P0 (11 lifetime users, all pre-fix → P0). When the verdict is `ambiguous` (counts are 0 because nothing is provably eligible), default the reopen to the LOWEST tier consistent with a visible-triage signal (P3) unless the latest event is `level=fatal`.
 
 **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
 
@@ -559,55 +571,91 @@ If new severity differs from prior agent comment's severity, prepend `**Reversin
 
 ---
 
-### Path C — GitHub issue found, `state == "closed"` (REGRESSION)
+### Path C — GitHub issue found, `state == "closed"` (REGRESSION — eligibility-gated)
 
-This branch fires both reactively (Step 2 finds a closed match) AND as a sweep (Step 0.5 + Step 1 regression-watch keeps cold-but-recurring shortIds alive past the time filter).
+This branch fires both reactively (Step 2 finds a closed match) AND as a sweep (Step 0.5 + Step 1 regression-watch keeps cold-but-recurring shortIds alive past the time filter). It **does NOT reopen unconditionally** — it first runs the Step 2.6.5 eligibility gate, which distinguishes a true current-release regression from pre-fix-tail / dev-only / non-bug noise. The core invariant (council 2026-06-21; issue #1143): **HOLD requires proof; anything unprovable fails OPEN to a visible reopen, never a silent hold.** Severity, when reopening, is scored on the ELIGIBLE partition (post-close, production, on a fix-containing release), never the Sentry lifetime aggregate.
 
-**Note on idempotency:** Path C performs MULTIPLE writes (reopen, sub-issue link, regression comment, label). The `WRITTEN_THIS_RUN` add happens at the END of the sequence (step 6 below), NOT after the reopen, so subsequent writes in this same Path C invocation aren't blocked by the global "skip if shortId in WRITTEN_THIS_RUN" rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry into Path C for the same shortId on a logic-branch loop.
+**Note on idempotency:** Path C performs MULTIPLE writes. The `WRITTEN_THIS_RUN` add happens at the END of the sequence (final step), so subsequent writes in this same invocation aren't blocked by the global rule. The `WRITTEN_THIS_RUN` check at branch entry (Step 2 routing) prevents re-entry for the same shortId.
 
-1. Fetch latest Sentry event (Path A Step 1). If event-fetch fails, fall through with `event = null` — do NOT skip the reopen. The regression-comment hypothesis falls back to the fail-soft sentence at step 5b.
-2. Reopen via `mcp__github__issue_write` (set state=open). If reopen fails with non-auth-expiry error: log + skip remaining Path C steps for this shortId, continue to next Sentry issue. (Auth-expiry triggers the hard policy.)
-3. Ensure sub-issue link to #317 (Bugs) exists. If link fails with 422, it already exists (fine). Other failures: log + continue with step 4. Do NOT abort Path C here.
-4. If `event` is non-null, read source at CURRENT release tag (`git show {tag}:{filename}`). If `event` is null, skip the source read.
-5. Post regression comment via `mcp__github__add_issue_comment`:
+#### Step 2.6.5 — Eligibility gate (run FIRST, before any reopen)
 
-   5a. If `event` is non-null AND you can name a specific function + plausible precondition:
+**A. Fetch the events LIST** (not just `/events/latest/`):
+```bash
+curl -sD - -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{issue_id}/events/?full=true&statsPeriod=90d&per_page=100"
 ```
-**Regression detected** — This issue recurred after being closed.
+**PAGINATE — do NOT trust a single page.** The events list is paged (~100/page); a HOLD asserts "we saw every post-close event", so a missed later page that contains a post-fix production event would silently hold a real regression. Follow the `Link:` response header: while it contains `rel="next"; results="true"; cursor="<c>"`, refetch with `&cursor=<c>` and accumulate. Cap at 10 pages (1000 events) as a runaway guard; if the cap is hit with `results="true"` still pending, set `events_truncated=true` in the helper input. Per event extract: `dateCreated` and `user.id` (top-level); `release`, `environment`, `app.build_type` (from the `tags[]` array — `{key,value}` pairs, NOT top-level). If ANY page fetch fails (non-200/non-JSON): treat verdict as **ambiguous** (fail open) — do NOT silent-hold. (The helper independently downgrades any truncation-unsafe hold to `ambiguous` when `events_truncated=true`, so this is belt-and-suspenders.)
+
+**B. Resolve the fix boundary** (close-stamp first, else local-git-only derivation — TIK is BANNED from PR tools, so NEVER read a PR):
+- If the `tik-close` stamp (Step 2.5) is present, map it to the helper input: `close_class` = stamp `class`; `canonical` = stamp `canonical`. **`fix_merged` and `fix_released_version` are NOT taken on faith from `class` alone — they require a boundary source (a concrete released version OR a provable commit):**
+  - Stamp has a concrete `fix-released=vX.Y.Z` → `fix_released_version=vX.Y.Z`, `fix_merged=true`.
+  - Stamp has `fix-released=none` AND a `fix-commit` SHA → RE-DERIVE the release tag from the SHA at gate time (SHA-derivation steps below). A `fixed-merged-unreleased` stamp is frozen at close, but a release may have shipped the fix SINCE — re-deriving moves the boundary forward so a real post-release regression reopens instead of being held forever. Re-derivation finds a release tag → use it (`fix_released=vX`, `fix_merged=true`); proves merged-but-still-unreleased → `fix_released=none, fix_merged=true` (HOLD provable); SHA unprovable → `close_class=unknown, fix_merged=false` → ambiguous.
+  - **Stamp has `fix-released=none` AND NO `fix-commit` (or `fix-commit=none`)** → there is NO boundary source to prove anything → `close_class=unknown`, `fix_merged=false`, `fix_released=none` → the gate returns ambiguous → **fail open**. Do NOT set `fix_merged=true` from `class` alone — that would hold every shipped build forever, even one that ships the fix.
+- Else (no stamp) derive: scan the closing comment for a 7-40 char hex SHA.
+- **SHA-derivation steps (used by both the re-derive-above and the no-stamp path):** prove the SHA locally first:
+  ```bash
+  git rev-parse --verify "<sha>^{commit}"          # exit 0 = exists in clone
+  git merge-base --is-ancestor "<sha>" origin/main # exit 0 = merged to main
+  ```
+  - Both exit 0 → `git tag --contains "<sha>" -l 'v*' | sort -V | head -1` (**`-l 'v*'` is mandatory** — the repo has non-release tags like `autopilot-checkpoint-*` / `checkpoint/*` that sort before `v*` and would otherwise win `head -1` and break semver parsing): non-empty = `fix_released` = that release tag; empty = `fix_merged=true, fix_released=none` (merged-but-unreleased — HOLD is now provable).
+  - Either non-zero (bogus SHA / stale or shallow clone / not yet merged) → `close_class=unknown`, `fix_merged=false` → the gate returns ambiguous → **fail open**. Never assume merged-but-unreleased from an unproven SHA.
+  - Only a bare `#PR` with no resolvable local SHA → do NOT read the PR → `close_class=unknown` → fail open.
+- `close_class` defaults to `unknown` when neither stamp nor derivation yields one.
+
+**C. Run the deterministic helper** (the verdict math is unit-tested code, not prose — `workers/sentry-triage/test_tik_eligibility.py`):
+```bash
+echo '{"events":[...],"closed_at":"<ISO>","close_class":"<class>","fix_released_version":<v|null>,"fix_merged":<bool>,"latest_release":"<vX.Y.Z>","events_truncated":<bool>}' \
+  | python3 workers/sentry-triage/tik_eligibility.py
+```
+**`events_truncated` is REQUIRED** — set it `true` whenever step A hit the page cap with more pages pending (else `false`). Omitting it defaults to `false`, which lets a truncated hold stand (silent-hold risk) — always pass it explicitly. Returns `{verdict, family, reason, eligible_user_count, eligible_count, excluded_dev_count, observed_production_releases, dev_canary}`. A non-zero exit or unparseable output → treat as **ambiguous** (fail open). `latest_release` = `git tag -l 'v*' | sort -V | tail -1`.
+
+#### Branch on `family`
+
+- **`reopen` (verdict `reopen-eligible`)** — a production event on a fix-containing release. Reopen (steps R1-R4 below). Severity from `eligible_user_count` / `eligible_count` (NOT lifetime). Decision marker `decision=reopened`.
+- **`ambiguous`** — could not prove benign (unknown relation, missing fix info, fetch/helper failure, current-release evidence we can't classify). **Fail open:** reopen (R1-R4), but the comment opens with `**Unverified regression (boundary unprovable):**` and adds the label `tik-boundary-unknown` alongside `regression`. Decision marker `decision=ambiguous`. NEVER silent-hold.
+- **`hold` (verdicts `hold-prefix-tail` / `hold-nonbug` / `hold-dev-only` / `no-postclose-activity`)** — do NOT reopen. Post a throttled AUDIT comment (step H below) so the hold is visible. Label the still-closed issue: `tik-held-prefixtail` (prefix-tail), `tik-dev-only` (dev-only), else none. Decision marker `decision=held`.
+- **`canary` (verdict `dev-canary-postfix`)** — a fix-containing dogfood build still emits. Do NOT reopen for customers. Post the audit comment (step H) noting the internal early-warning; label `tik-dev-only`. Decision marker `decision=held`.
+- **`route` (verdict `route-to-canonical`)** — closed as duplicate. Do NOT touch the duplicate. Resolve the canonical issue (stamp `canonical=#N`, else the closing comment's "duplicate of #N"); apply Path B (if open) or this Path C gate (if closed) to the canonical. If no canonical resolves → fail open: treat as `ambiguous` on this issue.
+
+**Reopen steps R1-R4** (reopen + ambiguous families):
+- R1. Reopen via `mcp__github__issue_write` (state=open). Reopen fails (non-auth): log + skip remaining steps for this shortId. (Auth-expiry → hard policy.)
+- R2. Ensure sub-issue link to #317 (Bugs). 422 = already exists (fine). Other failure: log + continue.
+- R3. If you can name a specific function + plausible precondition from the latest event's stack at the current tag, write the fresh-hypothesis comment; else the fail-soft variant. Use the regression-comment template below.
+- R4. Add label `regression` (+ `tik-boundary-unknown` for the ambiguous family) via `mcp__github__issue_write`.
+
+Regression comment template (reopen / ambiguous):
+```
+**Regression detected** — eligibility gate verdict: {verdict}.
 | Metric | Value |
 |--------|-------|
-| Users now | {userCount} |
-| Occurrences now | {count} |
-| Release now | {release} |
+| Eligible users (post-fix, prod) | {eligible_user_count} |
+| Eligible occurrences | {eligible_count} |
+| Excluded dev/dogfood events | {excluded_dev_count} |
+| Observed production releases | {observed_production_releases} |
 
 [View in Sentry]({permalink})
 
 **Fresh hypothesis** (current source at {tag}):
-> [2 sentences — re-analyze, don't copy original.]
+> [2 sentences, OR "Hypothesis pending — investigation needed." for the fail-soft / ambiguous case.]
 
-<!-- agent:sentry-triage v=4 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source_issue=#{this_issue_number} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+<!-- agent:sentry-triage v=4 fingerprint={shortId} decision={reopened|ambiguous} severity={Pn} last_seen={lastSeen} source_issue=#{this_issue_number} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
 ```
 
-   5b. Fail-soft variant — use this when `event` is null OR evidence is insufficient for a confident hypothesis:
+**Step H — Audit comment (hold / canary families).** Do NOT reopen. Apply Path B's "no recent agent comment in last 7 days" throttle ONLY (not the doubled-count / new-users conditions) so a held issue is not re-commented daily. If the throttle allows, post:
 ```
-**Regression detected** — This issue recurred after being closed.
+**Held — eligibility gate verdict: {verdict}.** {reason}.
 | Metric | Value |
 |--------|-------|
-| Users now | {userCount} |
-| Occurrences now | {count} |
-| Last seen | {lastSeen} |
-| Release now | {release} |
+| Observed production releases | {observed_production_releases} |
+| Excluded dev/dogfood events | {excluded_dev_count} |
 
-[View in Sentry]({permalink})
+Not reopened: all post-close evidence is {pre-fix-tail / dev-only / non-actionable}. Resolution is shipping the next release (pre-fix tail) or N/A (dev-only / non-bug). [View in Sentry]({permalink})
 
-**Fresh hypothesis:**
-> Hypothesis pending — investigation needed. (Sentry event fetch failed OR stack-trace evidence insufficient.)
-
-<!-- agent:sentry-triage v=4 fingerprint={shortId} decision=reopened severity={Pn} last_seen={lastSeen} source_issue=#{this_issue_number} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
+<!-- agent:sentry-triage v=4 fingerprint={shortId} decision=held severity=none last_seen={lastSeen} source_issue=#{this_issue_number} source=sentry run_id=${CLAUDE_CODE_REMOTE_SESSION_ID} -->
 ```
+If the throttle blocks (a `held` comment with identical metrics was posted in the last 7 days), skip the comment silently (the issue stays correctly closed). Then add the hold label if not already present.
 
-   If the comment write fails with non-auth-expiry: log + continue to step 6 (still add the label so the reopened issue is tagged).
-6. Add label `regression` via `mcp__github__issue_write`. Then add `shortId` to `WRITTEN_THIS_RUN`.
+**Final step (all families):** add `shortId` to `WRITTEN_THIS_RUN`.
 
 ---
 

--- a/workers/sentry-triage/test_tik_eligibility.py
+++ b/workers/sentry-triage/test_tik_eligibility.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Unit tests for tik_eligibility.decide (issue #1143).
+
+Run: python3 -m pytest workers/sentry-triage/test_tik_eligibility.py
+  or: python3 workers/sentry-triage/test_tik_eligibility.py   (self-runner, no pytest dep)
+
+Each test is one council/Codex validation case. The whole point of this file is
+that the reopen/hold/ambiguous boundary is PROVABLE before the gate ships to an
+unattended daily cron.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tik_eligibility import decide, normalize_version, is_development, main  # noqa: E402
+
+CLOSED = "2026-06-17T06:00:00Z"
+
+
+def ev(release, *, env="production", build="release", user="u1", when="2026-06-20T00:00:00Z"):
+    return {"release": release, "environment": env, "build_type": build,
+            "user_id": user, "dateCreated": when}
+
+
+# ---- normalize_version ------------------------------------------------------
+
+def test_normalize_strips_bundle_and_v():
+    assert normalize_version("com.enviouswispr.app@2.1.0") == (2, 1, 0)
+    assert normalize_version("v2.1.10") == (2, 1, 10)
+    assert normalize_version("2.1.0+build45") == (2, 1, 0)
+    assert normalize_version("com.enviouswispr.app@2.0.3-4-gabcdef-dev") == (2, 0, 3)
+
+
+def test_normalize_ordering_two_digit():
+    # 2.1.10 must sort ABOVE 2.1.9 (numeric, not lexical)
+    assert normalize_version("2.1.10") > normalize_version("2.1.9")
+
+
+def test_normalize_unparseable_is_none():
+    assert normalize_version("garbage") is None
+    assert normalize_version("") is None
+    assert normalize_version(None) is None
+
+
+def test_is_development_signals():
+    assert is_development(ev("x@2.1.0", build="debug")) is True
+    assert is_development(ev("x@2.1.0", env="development")) is True
+    assert is_development(ev("com.enviouswispr.app@2.0.3-4-gabcdef-dev")) is True
+    assert is_development(ev("com.enviouswispr.app@2.1.0")) is False
+
+
+# ---- council validation cases ----------------------------------------------
+
+def test_case1_merged_but_unreleased_all_prefix_holds():
+    # The #979 case: fix merged, in no release; all prod events on pre-fix builds.
+    out = decide({"events": [ev("com.enviouswispr.app@2.1.0"), ev("com.enviouswispr.app@2.1.4", user="u2")],
+                  "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "hold-prefix-tail"
+    assert out["family"] == "hold"
+
+
+def test_case2_fixed_release_regression_reopens():
+    out = decide({"events": [ev("v2.1.5")],
+                  "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "reopen-eligible"
+    assert out["eligible_user_count"] == 1
+
+
+def test_case3_mixed_prefix_and_postfix_reopens_eligible_counts_postfix_only():
+    events = [ev("v2.1.0", user=f"old{i}") for i in range(100)] + [ev("v2.1.5", user="new1")]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "reopen-eligible"
+    # eligible counts ONLY the post-fix event, not the 100 pre-fix
+    assert out["eligible_user_count"] == 1
+    assert out["eligible_count"] == 1
+
+
+def test_case4_dev_only_spike_excluded_no_customer_severity():
+    # The #440 case: hundreds of events, one dev user.
+    events = [ev("com.enviouswispr.app@2.0.3-4-gabcdef-dev", build="debug",
+                 env="development", user="founder") for _ in range(259)]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "unknown",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["family"] == "hold"
+    assert out["verdict"] == "hold-dev-only"
+    assert out["excluded_dev_count"] == 259
+    assert out["eligible_user_count"] == 0
+
+
+def test_case5_dogfood_build_with_fix_is_canary():
+    out = decide({"events": [ev("v2.1.5-2-gabc123-dev", build="debug", env="development", user="founder")],
+                  "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "dev-canary-postfix"
+    assert out["family"] == "canary"
+
+
+def test_case6_notabug_volume_growth_holds():
+    events = [ev("v2.1.4", user=f"u{i}") for i in range(20)]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "not-a-bug",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "hold-nonbug"
+
+
+def test_case7_duplicate_routes_to_canonical():
+    out = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "duplicate",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "route-to-canonical"
+    assert out["family"] == "route"
+
+
+def test_case8_unknown_close_current_release_event_fails_open():
+    # No fix info at all + a production event we can't classify -> ambiguous (reopen).
+    out = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "unknown",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+    assert out["family"] == "ambiguous"
+
+
+def test_case9_malformed_release_never_prefix():
+    out = decide({"events": [ev("not-a-version")], "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    # unparseable production release -> unknown relation -> ambiguous, never pre-fix/hold
+    assert out["verdict"] == "ambiguous"
+
+
+def test_case10_semver_normalization_postfix():
+    out = decide({"events": [ev("com.enviouswispr.app@2.1.10")],
+                  "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.9", "fix_merged": True, "latest_release": "v2.1.10"})
+    assert out["verdict"] == "reopen-eligible"  # 2.1.10 >= 2.1.9
+
+
+def test_case11_empty_events_no_activity_holds_safely():
+    out = decide({"events": [], "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "no-postclose-activity"
+    assert out["family"] == "hold"
+
+
+def test_case12_preclose_events_ignored():
+    out = decide({"events": [ev("v2.1.5", when="2026-06-01T00:00:00Z")],  # before CLOSED
+                  "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    # the only event predates the close -> no post-close activity
+    assert out["verdict"] == "no-postclose-activity"
+
+
+# ---- fail-open guards (the Codex round-2/3 defect class) --------------------
+
+def test_fix_merged_false_with_no_release_is_unknown_not_prefix():
+    # If the routine could NOT prove the commit (fix_merged=False, fix_released=None),
+    # a production event must NOT be classed pre-fix/hold -> ambiguous (fail open).
+    out = decide({"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+
+
+def test_unparseable_timestamp_included_not_dropped():
+    out = decide({"events": [ev("v2.1.5", when="not-a-date")],
+                  "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    # bad timestamp is conservatively treated as post-close -> the event still counts
+    assert out["verdict"] == "reopen-eligible"
+
+
+def test_helper_errors_fail_open_via_cli():
+    # Malformed stdin must yield ambiguous (fail open), exit 0.
+    proc = subprocess.run([sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py")],
+                          input="not json", capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["verdict"] == "ambiguous"
+
+
+def test_truncated_events_downgrade_hold_to_ambiguous():
+    # A prefix-tail hold is unsafe if we could not read every page -> fail open.
+    base = {"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+            "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"}
+    assert decide({**base, "events_truncated": False})["verdict"] == "hold-prefix-tail"
+    assert decide({**base, "events_truncated": True})["verdict"] == "ambiguous"
+
+
+def test_truncated_does_not_downgrade_reopen():
+    # reopen-eligible already reopens -> truncation is irrelevant.
+    reopen = decide({"events": [ev("v2.1.5")], "closed_at": CLOSED, "close_class": "fixed",
+                     "fix_released_version": "v2.1.5", "fix_merged": True,
+                     "latest_release": "v2.1.5", "events_truncated": True})
+    assert reopen["verdict"] == "reopen-eligible"
+
+
+def test_truncated_downgrades_nonbug_too():
+    # not-a-bug still SUPPRESSES a reopen, and the new-signature check needs complete
+    # data -> truncation must fail it open like every other hold.
+    nonbug = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "not-a-bug",
+                     "fix_released_version": None, "fix_merged": False,
+                     "latest_release": "v2.1.4", "events_truncated": True})
+    assert nonbug["verdict"] == "ambiguous"
+
+
+def test_canary_surfaced_even_when_production_is_prefix_tail():
+    # All prod pre-fix, but a fix-containing dogfood build still emits.
+    events = [ev("v2.1.0", user="real"),
+              ev("v2.1.5-2-gabc-dev", build="debug", env="development", user="founder")]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "hold-prefix-tail"   # customers: still hold
+    assert out["dev_canary"].get("count") == 1    # but the canary is not hidden
+
+
+def test_mixed_dev_and_prefix_prod_excludes_dev_and_holds():
+    events = [ev("v2.1.0", user="real"), ev("v2.1.0-1-gabc-dev", build="debug", user="founder")]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "hold-prefix-tail"
+    assert out["excluded_dev_count"] == 1
+
+
+def test_fractional_second_event_in_close_second_is_post_close():
+    # Event 0.5s into the close second must count as post-close (not dropped by a
+    # string compare where '.' < 'Z').
+    out = decide({"events": [ev("v2.1.5", when="2026-06-17T06:00:00.500Z")],
+                  "closed_at": "2026-06-17T06:00:00Z", "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "reopen-eligible"  # the event is post-close and post-fix
+
+
+def test_string_false_fix_merged_does_not_prove_hold():
+    # Shell-built JSON with fix_merged="false" must NOT be coerced to True.
+    out = decide({"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": None, "fix_merged": "false", "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"  # unproven -> fail open, NOT hold-prefix-tail
+
+
+def test_string_true_fix_merged_is_honored():
+    out = decide({"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": "true", "latest_release": "v2.1.4"})
+    assert out["verdict"] == "hold-prefix-tail"
+
+
+def test_string_true_events_truncated_downgrades():
+    out = decide({"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4",
+                  "events_truncated": "true"})
+    assert out["verdict"] == "ambiguous"
+
+
+# ---- comprehensive-sweep hardening (Codex final sweep, 9 findings) ----------
+
+def test_missing_events_is_ambiguous_not_noactivity():
+    # Missing fetch is NOT proof of no activity.
+    out = decide({"closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "ambiguous"
+    # but an explicitly-empty list IS a provable no-activity hold
+    out2 = decide({"events": [], "closed_at": CLOSED, "close_class": "fixed",
+                   "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out2["verdict"] == "no-postclose-activity"
+
+
+def test_bad_closed_at_downgrades_hold():
+    out = decide({"events": [ev("v2.1.0")], "closed_at": "not-a-date",
+                  "close_class": "telemetry-noise", "fix_released_version": None,
+                  "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+
+
+def test_naive_closed_at_downgrades_hold():
+    out = decide({"events": [ev("v2.1.0")], "closed_at": "2026-06-17T06:00:00",  # no tz
+                  "close_class": "telemetry-noise", "fix_released_version": None,
+                  "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+
+
+def test_naive_event_timestamp_downgrades_hold():
+    # Finding 4: malformed/naive event time must not be silently held as pre-fix.
+    out = decide({"events": [ev("v2.1.0", when="2026-06-20T00:00:00")],  # no tz
+                  "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+
+
+def test_offset_timestamps_compared_correctly():
+    # Event at 08:00+02:00 == 06:00Z, one hour after a 05:00Z close -> post-close, post-fix.
+    out = decide({"events": [ev("v2.1.5", when="2026-06-17T08:00:00+02:00")],
+                  "closed_at": "2026-06-17T05:00:00Z", "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "reopen-eligible"
+
+
+def test_strict_semver_rejects_prerelease_4part_leading_zero():
+    assert normalize_version("v2.1.5-beta.1") is None
+    assert normalize_version("v2.1.5.1") is None
+    assert normalize_version("v02.001.004") is None
+    # but a real prod build that is all pre-fix-of-an-unparseable... stays safe:
+    out = decide({"events": [ev("v2.1.5-beta.1")], "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.9", "fix_merged": True, "latest_release": "v2.1.9"})
+    assert out["verdict"] == "ambiguous"  # unparseable prod release -> unknown -> fail open
+
+
+def test_close_class_trailing_space_normalized():
+    out = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "not-a-bug ",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "hold-nonbug"  # 'not-a-bug ' stripped to 'not-a-bug'
+
+
+def test_merged_unreleased_event_newer_than_latest_tag_fails_open():
+    # Fix merged-but-unreleased, but an event is on a build NEWER than the latest tag
+    # we know (stale fetch / untagged build) -> can't prove pre-fix -> fail open.
+    out = decide({"events": [ev("v2.1.6")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+    # an event at-or-below the latest tag still holds as pre-fix
+    held = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+                   "fix_released_version": None, "fix_merged": True, "latest_release": "v2.1.4"})
+    assert held["verdict"] == "hold-prefix-tail"
+
+
+def test_merged_unreleased_missing_latest_release_fails_open():
+    out = decide({"events": [ev("v2.1.0")], "closed_at": CLOSED, "close_class": "telemetry-noise",
+                  "fix_released_version": None, "fix_merged": True, "latest_release": None})
+    assert out["verdict"] == "ambiguous"  # no trustworthy ceiling -> cannot prove pre-fix
+
+
+def test_nonbug_with_broken_input_fails_open():
+    # not-a-bug + missing events -> cannot verify no new signature -> ambiguous.
+    out = decide({"close_class": "not-a-bug", "closed_at": CLOSED,
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"
+
+
+def test_garbage_close_class_becomes_unknown():
+    out = decide({"events": [ev("v2.1.4")], "closed_at": CLOSED, "close_class": "frobnicated",
+                  "fix_released_version": None, "fix_merged": False, "latest_release": "v2.1.4"})
+    assert out["verdict"] == "ambiguous"  # unknown class + no fix info -> fail open
+
+
+def test_null_user_ids_do_not_underscore_severity():
+    # 10 eligible post-fix events with null user_id must count as 10 users, not 0.
+    events = [ev("v2.1.5", user=None) for _ in range(10)]
+    out = decide({"events": events, "closed_at": CLOSED, "close_class": "fixed",
+                  "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
+    assert out["verdict"] == "reopen-eligible"
+    assert out["eligible_user_count"] == 10  # conservative: anon events each count
+
+
+# ---- self-runner (no pytest dependency in the routine sandbox) --------------
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/workers/sentry-triage/tik_eligibility.py
+++ b/workers/sentry-triage/tik_eligibility.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""TIK reopen/severity eligibility gate (issue #1143).
+
+Pure decision function for the TIK Sentry-triage routine. Given the post-close
+event set for a closed fingerprint plus the fix-version boundary, decide whether
+a recurrence is a real regression (reopen), pre-fix-tail noise (hold), or
+unprovable (ambiguous -> fail open).
+
+DESIGN INVARIANTS (council 2026-06-21, 2 rounds; Codex grounded review 3 rounds):
+  - HOLD requires PROOF. Anything we cannot prove benign fails OPEN (ambiguous ->
+    the routine reopens or files visible triage). We never silently suppress.
+  - Severity is scored on the ELIGIBLE partition (post-close, production, on a
+    release that actually contains the fix), never the Sentry lifetime aggregate.
+  - Dev/dogfood events never count toward customer severity, but a dev build that
+    DOES contain the fix is kept as an early-warning canary.
+  - This module does NO network and NO git. The routine resolves the fix boundary
+    (stamp or local-git-only derivation) and the event list, then pipes JSON here.
+    Keeping it pure is what makes the gate unit-testable before it ships.
+
+Input (JSON on stdin): see EXPECTED_INPUT_SHAPE below.
+Output (JSON on stdout): {"verdict", "family", "reason", "eligible_user_count",
+  "eligible_count", "excluded_dev_count", "observed_production_releases",
+  "dev_canary"}.
+On any internal error: prints an `ambiguous` verdict (fail open) and exits 0, so a
+helper bug can never become a silent hold.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+
+EXPECTED_INPUT_SHAPE = {
+    "events": "list of {release, environment, build_type, user_id, dateCreated}",
+    "closed_at": "ISO8601 string",
+    "close_class": "fixed|fixed-merged-unreleased|telemetry-noise|not-a-bug|by-design|duplicate|unknown",
+    "fix_released_version": "vX.Y.Z or null",
+    "fix_merged": "bool (true ONLY when the fix commit is proven present + ancestor of main)",
+    "latest_release": "vX.Y.Z (current shipped release)",
+    "events_truncated": "bool (true if the caller could NOT read every Sentry events page). "
+                        "A HOLD that asserts 'all events are pre-fix/dev/none' is unsafe when "
+                        "events may be missing -> downgrade those holds to ambiguous (fail open).",
+}
+
+# Every verdict that SUPPRESSES a customer reopen (does not reopen, does not route
+# to a canonical). Each of these is only valid on complete, trustworthy input -- a
+# truncated page or a malformed/missing field could hide a real regression, so any of
+# them must fail OPEN (downgrade to ambiguous) when input completeness is in doubt.
+# `hold-nonbug` is included: even a human "not a bug" close relies on the model being
+# able to spot a NEW signature in the events, which it cannot do on broken/partial data.
+# (route-to-canonical is excluded -- it is close-class-driven and events-independent.)
+_HOLD_VERDICTS = {"hold-prefix-tail", "hold-nonbug", "hold-dev-only",
+                  "no-postclose-activity", "dev-canary-postfix"}
+
+# Verdict -> action family. The routine branches on `family`.
+#   reopen   : reopen the issue (regression). Severity from eligible counts.
+#   hold     : leave closed; post a throttled audit comment.
+#   ambiguous: FAIL OPEN -- reopen + `unverified-regression`, never silent.
+#   route    : duplicate -> apply policy on the canonical issue, never the dup.
+#   canary   : do not reopen for customers; internal early-warning note only.
+VERDICT_FAMILY = {
+    "reopen-eligible": "reopen",
+    "ambiguous": "ambiguous",
+    "hold-prefix-tail": "hold",
+    "hold-nonbug": "hold",
+    "hold-dev-only": "hold",
+    "no-postclose-activity": "hold",
+    "dev-canary-postfix": "canary",
+    "route-to-canonical": "route",
+}
+
+# STRICT: MAJOR.MINOR.PATCH (no leading zeros) followed by ONLY end-of-string,
+# +buildmeta, or our dev suffix (-N-gHASH[-dev] / -dev). Anything else (prerelease
+# like -beta.1, a 4th component like .1) -> no match -> None -> relation unknown ->
+# fail open. (Lenient parsing of a weird production version could mis-class -> hold.)
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:\+[0-9A-Za-z.\-]+|-\d+-g[0-9a-f]+(?:-dev)?|-dev)?$",
+    re.IGNORECASE,
+)
+_DEV_SUFFIX_RE = re.compile(r"-\d+-g[0-9a-f]+", re.IGNORECASE)
+
+DOCUMENTED_CLASSES = {
+    "fixed", "fixed-merged-unreleased", "telemetry-noise",
+    "not-a-bug", "by-design", "duplicate", "unknown",
+}
+
+
+def normalize_version(release: str | None):
+    """Strip bundle prefix / leading v -> (major, minor, patch) or None (strict).
+
+    Accepts: 'com.enviouswispr.app@2.1.0' -> (2,1,0); 'v2.1.10' -> (2,1,10);
+    'com.enviouswispr.app@2.0.3-4-gabcdef-dev' -> (2,0,3); '2.1.0+build45' -> (2,1,0).
+    Rejects (-> None -> unknown -> fail open): '2.1.5-beta.1', '2.1.5.1', '02.001.004'.
+    """
+    if not release or not isinstance(release, str):
+        return None
+    tail = release.split("@", 1)[1] if "@" in release else release
+    tail = tail.strip()
+    if tail[:1] in ("v", "V"):
+        tail = tail[1:]
+    m = _SEMVER_RE.match(tail)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def is_development(event: dict) -> bool:
+    """Dev/dogfood if build_type=debug, environment=development, or a -dev/-N-g release.
+
+    app.build_type is the authoritative signal; environment + release suffix back it up.
+    """
+    bt = (event.get("build_type") or "").lower()
+    if bt == "debug":
+        return True
+    if bt == "release":
+        # explicit production build; release-suffix heuristic below is a backstop only
+        env = (event.get("environment") or "").lower()
+        rel = event.get("release") or ""
+        return "development" in env or "-dev" in rel.lower() or bool(_DEV_SUFFIX_RE.search(rel))
+    env = (event.get("environment") or "").lower()
+    rel = event.get("release") or ""
+    if "development" in env:
+        return True
+    if "-dev" in rel.lower() or _DEV_SUFFIX_RE.search(rel):
+        return True
+    return False
+
+
+def _parse_iso(ts: str | None):
+    """ISO8601 -> aware datetime, or None if unparseable.
+
+    Must be a real datetime parse, NOT a string compare: Sentry stamps fractional
+    seconds ('...06:00:00.500Z') while GitHub closed_at is whole seconds
+    ('...06:00:00Z'), and lexicographically '.' < 'Z' would wrongly sort the
+    fractional event BEFORE the close, dropping a real post-close event.
+    """
+    if not ts or not isinstance(ts, str):
+        return None
+    t = ts.strip()
+    if t.endswith("Z"):
+        t = t[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(t)
+    except ValueError:
+        return None
+    # A NAIVE timestamp (no tz) is NOT proof — assuming UTC could drop a real
+    # post-close event recorded in another offset. Reject -> caller fails open.
+    return dt if dt.tzinfo is not None else None
+
+
+def _as_bool(v) -> bool:
+    """Strict truthiness for shell-built JSON: only real `true` / "true" is True.
+
+    bool("false") is True in Python, so a string boolean from the shell would wrongly
+    'prove' a fix merged and silently hold. Anything not provably true -> False, which
+    is the fail-OPEN direction (unproven -> ambiguous -> reopen)."""
+    if v is True:
+        return True
+    if isinstance(v, str):
+        return v.strip().lower() == "true"
+    return False
+
+
+def is_post_close(event: dict, closed_at_key) -> bool:
+    """Post-close if dateCreated > closed_at. Unparseable timestamp => INCLUDE
+    (conservative: never silently drop potential evidence)."""
+    if closed_at_key is None:
+        return True
+    ek = _parse_iso(event.get("dateCreated"))
+    if ek is None:
+        return True
+    return ek > closed_at_key
+
+
+def classify_relation(event: dict, fix_released_version, fix_merged: bool,
+                       latest_release=None) -> str:
+    """pre-fix | post-fix | unknown for a single production event."""
+    ev = normalize_version(event.get("release"))
+    if ev is None:
+        return "unknown"
+    if fix_released_version is not None:
+        fv = normalize_version(fix_released_version)
+        if fv is None:
+            return "unknown"
+        return "post-fix" if ev >= fv else "pre-fix"
+    # No released version known. A PROVEN merged-but-unreleased fix means every
+    # release <= the latest tag we know about is pre-fix. BUT an event on a build
+    # NEWER than `latest_release` (stale/shallow tag fetch, or an untagged newer
+    # build) might be on a release that SHIPPED the fix since -- we cannot prove it
+    # pre-fix, so it is unknown -> fail open. (fix_merged is set true only after the
+    # routine proved the commit exists + is an ancestor of main -- see plan 3.2.)
+    if fix_merged:
+        lr = normalize_version(latest_release)
+        if lr is None:
+            return "unknown"          # no trustworthy ceiling -> cannot prove pre-fix
+        return "pre-fix" if ev <= lr else "unknown"
+    return "unknown"
+
+
+def _inputs_incomplete(data: dict) -> str | None:
+    """Return a reason string if inputs cannot support a PROVABLE hold, else None.
+
+    A hold asserts 'we saw every post-close event and none is post-fix'. That proof
+    collapses if we can't trust the close boundary or the event timestamps. Any such
+    gap must fail OPEN (downgrade holds to ambiguous), never silently hold.
+    """
+    if _parse_iso(data.get("closed_at")) is None:
+        return "closed_at missing/invalid/naive (no tz)"
+    events = data.get("events")
+    if not isinstance(events, list):
+        return "events not provided as a list (missing fetch != no activity)"
+    for e in events:
+        if not isinstance(e, dict) or _parse_iso(e.get("dateCreated")) is None:
+            return "an event has a missing/invalid/naive dateCreated"
+    return None
+
+
+def decide(data: dict) -> dict:
+    result = _decide_inner(data)
+    # A hold is only valid if we saw every post-close event AND can trust the
+    # boundary/timestamps. Truncated pages OR incomplete/untrustworthy inputs
+    # both defeat that proof -> downgrade any hold-family verdict to ambiguous.
+    if result["verdict"] in _HOLD_VERDICTS:
+        reason = None
+        if _as_bool(data.get("events_truncated")):
+            reason = "event list truncated (unread pages)"
+        else:
+            reason = _inputs_incomplete(data)
+        if reason:
+            return _out("ambiguous",
+                        f"cannot prove '{result['verdict']}' ({reason}); a hidden/post-fix "
+                        f"event could be a real regression -> fail open",
+                        excluded_dev_count=result.get("excluded_dev_count", 0),
+                        observed=result.get("observed_production_releases", []),
+                        dev_canary=result.get("dev_canary", {}))
+    return result
+
+
+def _decide_inner(data: dict) -> dict:
+    close_class = (data.get("close_class") or "unknown").strip().lower()
+    if close_class not in DOCUMENTED_CLASSES:
+        close_class = "unknown"  # malformed/unrecognized class -> treat as unknown
+    fix_released = data.get("fix_released_version")
+    fix_merged = _as_bool(data.get("fix_merged"))
+    latest_release = data.get("latest_release")
+    closed_at_key = _parse_iso(data.get("closed_at"))
+    events = data.get("events") if isinstance(data.get("events"), list) else []
+
+    # 1. Duplicate: never reopen the dup; route to canonical.
+    if close_class == "duplicate":
+        return _out("route-to-canonical",
+                    "closed as duplicate; apply recurrence policy on the canonical issue")
+
+    # Partition post-close events by channel.
+    post = [e for e in events if is_post_close(e, closed_at_key)]
+    prod = [e for e in post if not is_development(e)]
+    dev = [e for e in post if is_development(e)]
+    excluded_dev_count = len(dev)
+
+    # A fix-containing dogfood build still emitting is an early-warning canary,
+    # surfaced even when production is a clean pre-fix tail (computed up front so
+    # the prefix-tail return below does not hide it).
+    dev_postfix = [e for e in dev
+                   if classify_relation(e, fix_released, fix_merged, latest_release) == "post-fix"]
+    canary = {"count": len(dev_postfix)} if dev_postfix else {}
+
+    # 2. Closed not-a-bug / by-design: volume never reopens. A materially new
+    #    signature can escalate, but that is the model's judgment, not this gate.
+    if close_class in ("not-a-bug", "by-design"):
+        return _out("hold-nonbug",
+                    "closed as not-a-bug/by-design; volume growth alone does not reopen",
+                    excluded_dev_count=excluded_dev_count, dev_canary=canary)
+
+    # 3. Production relation partition.
+    prod_rel = [(e, classify_relation(e, fix_released, fix_merged, latest_release)) for e in prod]
+    observed = _summarize_releases(prod_rel)
+
+    has_postfix = any(r == "post-fix" for _, r in prod_rel)
+    has_unknown = any(r == "unknown" for _, r in prod_rel)
+
+    if has_postfix:
+        eligible = [e for e, r in prod_rel if r == "post-fix"]
+        return _out("reopen-eligible",
+                    "production event(s) on a release that contains the fix",
+                    eligible_user_count=_distinct_users(eligible),
+                    eligible_count=len(eligible),
+                    excluded_dev_count=excluded_dev_count,
+                    observed=observed, dev_canary=canary)
+
+    if has_unknown:
+        # Cannot prove pre-fix for at least one production event -> fail open.
+        return _out("ambiguous",
+                    "production event(s) with an unresolvable release relation; fail open",
+                    excluded_dev_count=excluded_dev_count, observed=observed, dev_canary=canary)
+
+    if prod_rel:  # non-empty and all pre-fix
+        return _out("hold-prefix-tail",
+                    "all post-close production events are on pre-fix releases",
+                    excluded_dev_count=excluded_dev_count, observed=observed,
+                    dev_canary=canary)
+
+    # 4. No post-close PRODUCTION events. Consider the dev canary.
+    if dev_postfix:
+        return _out("dev-canary-postfix",
+                    "fix-containing dev/dogfood build still emits; internal early warning",
+                    excluded_dev_count=excluded_dev_count, dev_canary=canary)
+    if dev:
+        return _out("hold-dev-only",
+                    "only dev/dogfood events post-close; no customer-facing signal",
+                    excluded_dev_count=excluded_dev_count)
+
+    # 5. Nothing fired post-close at all -> no regression to act on (provably safe).
+    return _out("no-postclose-activity",
+                "no post-close events (production or dev); not a recurrence")
+
+
+def _summarize_releases(prod_rel):
+    agg = {}
+    for e, r in prod_rel:
+        rel = e.get("release") or "unknown"
+        a = agg.setdefault(rel, {"release": rel, "relation": r, "users": set(), "count": 0})
+        a["count"] += 1
+        uid = e.get("user_id")
+        if uid:
+            a["users"].add(uid)
+    return [{"release": a["release"], "relation": a["relation"],
+             "users": len(a["users"]), "count": a["count"]} for a in agg.values()]
+
+
+def _distinct_users(events) -> int:
+    """Distinct eligible users, counting each null/missing user_id as its OWN user.
+
+    Severity must never be under-scored: 10 eligible events with null user_id could be
+    10 distinct people, so counting them as 0 would hide a P0. Over-counting (treating
+    each anonymous event as distinct) is the safe direction for severity.
+    """
+    known = {e.get("user_id") for e in events if e.get("user_id")}
+    anon = sum(1 for e in events if not e.get("user_id"))
+    return len(known) + anon
+
+
+def _out(verdict, reason, eligible_user_count=0, eligible_count=0,
+         excluded_dev_count=0, observed=None, dev_canary=None):
+    return {
+        "verdict": verdict,
+        "family": VERDICT_FAMILY[verdict],
+        "reason": reason,
+        "eligible_user_count": eligible_user_count,
+        "eligible_count": eligible_count,
+        "excluded_dev_count": excluded_dev_count,
+        "observed_production_releases": observed or [],
+        "dev_canary": dev_canary or {},
+    }
+
+
+def main(argv=None) -> int:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+        result = decide(data)
+    except Exception as exc:  # noqa: BLE001 -- fail OPEN on any helper error
+        result = _out("ambiguous", f"helper error: {type(exc).__name__}: {exc}")
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Gives the TIK Sentry-triage routine a **version-boundary eligibility gate** so it stops reopening closed issues (and inflating severity) off the Sentry **lifetime aggregate**. Root cause of the 2026-06-21 false P0 on #979: 11 lifetime users, all on pre-fix releases ≤v2.1.4, with the telemetry fix #1048 (`953dda0`) in no release — TIK reopened it P2→P0 anyway.

## How
- **`workers/sentry-triage/tik_eligibility.py`** — pure, unit-tested decision function (no network/git). Partitions post-close events by release × environment, excludes dev/dogfood from customer severity (keeps a fix-containing dev build as a canary), classifies each production release pre/post-fix vs the boundary, returns `hold-prefix-tail | hold-nonbug | hold-dev-only | no-postclose-activity | dev-canary-postfix | reopen-eligible | ambiguous | route-to-canonical`.
- **`workers/sentry-triage/test_tik_eligibility.py`** — 40 tests (council + Codex validation set + adversarial fail-open edge cases).
- **`routine-prompt-tik-sentry.md`** — Path C runs the gate (Step 2.6.5) before reopening; severity from **eligible** (not lifetime) counts; events-list pagination; close-stamp parsing + local-git-only boundary derivation (TIK is banned from PR tools); new `held`/`ambiguous` decisions + audit-comment-on-hold.

## Safety invariant
**HOLD requires proof; any malformed / missing / ambiguous / truncated / stale input fails OPEN** (reopen or visible triage) — never a silent hold. If the helper or git derivation can't run at all, the gate reopens.

## Validation
- 40/40 unit tests.
- Dry-run on the 4 fingerprints TIK reopened 2026-06-21: **#979 → hold-prefix-tail** (false P0 killed), **#980 (current release) → fail-open** (not buried), **#440 → 86/100 dogfood events excluded**.
- Git derivation proven on the real #1048 commit; bogus SHA fails open.
- Council (`tik-reopen-gate-2026-06-21`, 2 rounds, model named). Codex grounded review 3 rounds → PROCEED-AS-PLANNED; Codex code-diff 8 rounds (each caught a genuine fail-open-safety edge case) → only residual is one Codex-rated CONTRIVED item (caller omitting a documented-required field).

The routine's instruction text is redeployed to the live cron separately (the repo file is the reference copy); the helper rides in the routine's repo clone automatically on merge.

Closes #1143.