### PR TITLE
feat(telemetry): fingerprint handled errors by category + signature (#1144)

### DIFF
--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -163,6 +163,11 @@ public enum SentryBreadcrumb {
       event.extra = eventExtra
     }
 
+    // Group by category + underlying error signature so distinct defects that
+    // share a broad category get their own stable, release-independent issue
+    // instead of merging under one stacktrace bin (#1144).
+    event.fingerprint = Self.handledErrorFingerprint(for: category, error: error)
+
     // Also add a breadcrumb so the error appears in the trail
     add(
       stage: stage,
@@ -190,6 +195,26 @@ public enum SentryBreadcrumb {
   nonisolated static func structuredDescriptor(_ error: any Error) -> String {
     let ns = error as NSError
     return "\(ns.domain)#\(ns.code)"
+  }
+
+  /// Stable Sentry grouping key for a handled error: namespace + category + the
+  /// underlying error signature (`domain#code`). The namespace avoids colliding
+  /// with native-crash groups; the category is the defect class; the signature
+  /// splits distinct root causes that share a broad category so they do not
+  /// silently merge into one issue (#1144). `nonisolated` + pure so the
+  /// non-`@MainActor` test suite calls it directly.
+  nonisolated static func handledErrorFingerprint(
+    for category: ErrorCategory, error: any Error
+  ) -> [String] {
+    ["handled_error", category.rawValue, structuredDescriptor(error)]
+  }
+
+  /// Stable Sentry grouping key for the AI-availability failure event: namespace
+  /// + the sorted failure-reason set (bare namespace when empty). Sorted so the
+  /// key is order-independent across reports (#1144).
+  nonisolated static func aiFailureFingerprint(for reasons: [AIFailureReason]) -> [String] {
+    let sorted = reasons.map(\.rawValue).sorted()
+    return sorted.isEmpty ? ["ai_failure"] : ["ai_failure"] + sorted
   }
 
   private static func mergedExtra(_ extra: [String: Any]?) -> [String: Any]? {
@@ -243,6 +268,9 @@ public enum SentryBreadcrumb {
       "ai.failure_reasons": report.failureReasons.map(\.rawValue).joined(separator: ","),
     ]
     event.extra = report.sentryContext
+    // Group by the sorted failure-reason set so this stays one stable issue
+    // distinct from the handled-error groups (#1144).
+    event.fingerprint = Self.aiFailureFingerprint(for: report.failureReasons)
     SentrySDK.capture(event: event)
   }
 

--- a/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
@@ -1,0 +1,99 @@
+import EnviousWisprCore
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1144 — Sentry grouping fingerprints. Handled errors group by
+/// `[namespace, category, domain#code]` so distinct defects that share a broad
+/// category get their own stable, release-independent issue instead of merging
+/// under one stacktrace bin (the `ENVIOUSWISPR-8` pollution behind the #440
+/// false-reopen churn). The helpers are pure + `nonisolated`, so this suite is
+/// not `@MainActor` and calls them directly — no spy/delegate, no actor hop.
+@Suite("Sentry grouping fingerprints (#1144)")
+struct SentryFingerprintTests {
+
+  // MARK: - handled-error fingerprint
+
+  @Test("handled-error fingerprint is namespace + category + domain#code")
+  func handledErrorShape() {
+    let err = NSError(domain: "EnviousWispr", code: -3)
+    let fp = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: err)
+    #expect(fp == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
+  }
+
+  @Test("distinct categories produce distinct fingerprints")
+  func distinctCategoriesSplit() {
+    let err = NSError(domain: "EnviousWispr", code: -3)
+    let paste = SentryBreadcrumb.handledErrorFingerprint(for: .pasteFailed, error: err)
+    let audio = SentryBreadcrumb.handledErrorFingerprint(for: .audioCaptureFailed, error: err)
+    #expect(paste != audio)
+  }
+
+  /// The core property: a broad category must NOT merge two distinct root causes.
+  /// This is the masking the council reviewers + Codex flagged that category-only
+  /// grouping would reintroduce one level down.
+  @Test("same category with different underlying errors splits (masking prevention)")
+  func sameCategoryDifferentErrorSplits() {
+    let asrCrash = NSError(domain: "EnviousWispr", code: -3)
+    let replyFail = NSError(domain: "HeartPathError", code: 6)
+    let fpA = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: asrCrash)
+    let fpB = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: replyFail)
+    #expect(fpA != fpB)
+    #expect(fpA == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
+    #expect(fpB == ["handled_error", "xpc_service_error", "HeartPathError#6"])
+  }
+
+  @Test("same category and same error is stable across calls")
+  func stableForSameInputs() {
+    let err = NSError(domain: "EnviousWispr", code: -10)
+    let first = SentryBreadcrumb.handledErrorFingerprint(for: .modelLoadFailed, error: err)
+    let second = SentryBreadcrumb.handledErrorFingerprint(for: .modelLoadFailed, error: err)
+    #expect(first == second)
+  }
+
+  @Test("fingerprint signature excludes localizedDescription / user content")
+  func signatureIsContentFree() {
+    let secret = "PURPLE ELEPHANT SEVENTEEN"
+    let err = NSError(
+      domain: "AVFoundationErrorDomain", code: -11800,
+      userInfo: [NSLocalizedDescriptionKey: secret])
+    let fp = SentryBreadcrumb.handledErrorFingerprint(for: .audioCaptureFailed, error: err)
+    #expect(fp == ["handled_error", "audio_capture_failed", "AVFoundationErrorDomain#-11800"])
+    #expect(fp.contains { $0.contains(secret) } == false)
+  }
+
+  // MARK: - AI-failure fingerprint
+
+  @Test("AI-failure fingerprint is namespace + sorted reason rawValues")
+  func aiFailureSorted() {
+    let reasons: [AIFailureReason] = [.unsupportedOS, .modelNotReady]
+    let fp = SentryBreadcrumb.aiFailureFingerprint(for: reasons)
+    #expect(fp == ["ai_failure", "modelNotReady", "unsupportedOS"])
+  }
+
+  @Test("AI-failure fingerprint is order-independent")
+  func aiFailureOrderIndependent() {
+    let a = SentryBreadcrumb.aiFailureFingerprint(for: [.unsupportedOS, .modelNotReady])
+    let b = SentryBreadcrumb.aiFailureFingerprint(for: [.modelNotReady, .unsupportedOS])
+    #expect(a == b)
+  }
+
+  @Test("AI-failure fingerprint falls back to bare namespace when empty")
+  func aiFailureEmpty() {
+    let fp = SentryBreadcrumb.aiFailureFingerprint(for: [])
+    #expect(fp == ["ai_failure"])
+  }
+
+  // MARK: - redaction passthrough
+
+  @Test("sanitizeSentryEvent preserves a set fingerprint unchanged")
+  func sanitizePreservesFingerprint() {
+    let event = Event(level: .error)
+    let fingerprint = ["handled_error", "paste_failed", "HeartPathError#2"]
+    event.fingerprint = fingerprint
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(sanitized.fingerprint == fingerprint)
+  }
+}


### PR DESCRIPTION
## What

Handled errors funneled through `SentryBreadcrumb.captureError` carried `error.category` + `pipeline.stage` tags but **no explicit `fingerprint`**. Handled events carry a stacktrace (`attachStacktrace` default on), so Sentry's default grouping collapsed every handled-error class into one issue (`ENVIOUSWISPR-8`) and fragmented single categories across releases. That polluted bin is the root cause of the recurring false-reopen churn on #440.

This sets an explicit grouping key on every handled error:

```
event.fingerprint = ["handled_error", category.rawValue, structuredDescriptor(error)]
```

— category **plus** the underlying error signature (`domain#code`). One defect class becomes one stable, release-independent issue, and distinct root causes that share a *broad* category (e.g. an XPC error from audio capture vs from ASR) no longer silently merge. The AI-availability failure event keys on its sorted failure-reason set.

Both helpers are `nonisolated static` and pure; the `beforeSend` redaction never reads or mutates `fingerprint`; values are framework `domain#code`, never user content.

## Why always-append (not a broad-category allowlist)

Codex first suggested appending the signature only to a 7-category "broad" allowlist. Always-append is simpler and fails *safe*: an allowlist that misses a category which later turns broad silently re-masks distinct defects (the bug we are fixing), whereas always-append's worst case is a benign, visible extra issue. Codex's own per-category audit confirmed no current category over-splits under always-append. Codex round 2 explicitly confirmed always-append over its own allowlist.

## Validation

- **Council** (GPT-5.5 + Gemini-3.1, 1 round) — surfaced the broad-category masking risk + the rollout duplicate-ticket risk.
- **Codex grounded review** — 4 rounds to PROCEED-AS-PLANNED (`docs/audits/2026-06-21-issue1144-grounded-review{,-r2,-r3,-r4}.txt`).
- **Codex code-diff review** — clean, first pass (`docs/audits/2026-06-21-issue1144-code-diff-review.txt`).
- **Logic tests** — 1912 green, incl. 9 new (`SentryFingerprintTests`), notably the same-category-different-error **masking-prevention** case + a redaction-passthrough case.
- **Live UAT** — heart path intact on the rebuilt dev app (record → transcribe → polish → paste, 2.5s, clipboard write OK, no crash). The changed lines run only on error-reporting paths, so a successful dictation exercises none of them; per-category grouping is confirmed post-release via the Sentry API.
- **Alerts verified** — all three metric alerts are `count()` over `is:unresolved`; none pinned to an issue ID, so the regroup silences nothing.

## Release-day rollout (operational, NOT in this diff)

When this reaches a **production** release, splitting creates new Sentry shortIds and the daily triage's new-issue path would auto-file duplicate tickets for already-tracked categories. Settle sequence: pause the triage's new-issue creation for 24-48h, release, manually map the new canonical shortIds for hot categories to their existing GitHub issues (`<!-- sentry-issue-id: {shortId} -->`), then re-enable. Merging here only affects dev builds until then.

Part of #1144 (issue stays open as the release-day rollout tracker).