### PR TITLE
fix(observability): product-health drift alert keys on asr only + offset health-ping cron (#1130, #1131)

### DIFF
--- a/.github/workflows/product-health-ping.yml
+++ b/.github/workflows/product-health-ping.yml
@@ -10,7 +10,7 @@ name: Product Health Check
 
 on:
   schedule:
-    - cron: "0 14 * * *"   # 10am ET daily - ingestion-lag buffer for offline laptops
+    - cron: "17 14 * * *"  # ~10:17am ET daily. Offset minute (not :00): GitHub flags top-of-hour as a high-load window where scheduled runs are delayed/dropped (#1131). Minute drift is harmless - the worker evaluates the prior COMPLETED UTC day. The :14 hour is the ingestion-lag buffer for offline laptops.
   workflow_dispatch: {}
 
 permissions:

--- a/workers/product-health/README.md
+++ b/workers/product-health/README.md
@@ -68,8 +68,10 @@ the public workers.dev URL cannot be crawled into spamming Discord.
 
 The Cloudflare account is at its 5-cron free-plan limit (#1092), so the daily run
 is driven by `.github/workflows/product-health-ping.yml`, which curls the
-secret-gated endpoint at `0 14 * * *` (10am ET - ingestion-lag buffer). The same
-secret lives as repo secret `PRODUCT_HEALTH_TRIGGER_SECRET`:
+secret-gated endpoint at `17 14 * * *` (~10:17am ET - ingestion-lag buffer; the
+offset minute avoids GitHub's top-of-hour high-load window where runs can be
+delayed or dropped, #1131). The same secret lives as repo secret
+`PRODUCT_HEALTH_TRIGGER_SECRET`:
 
 ```bash
 security find-generic-password -w -a m4pro_sv -s enviouswispr.product-health-trigger-secret \

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -233,13 +233,19 @@ export function evaluateVolume(days, expectedT1, TH = THRESHOLDS.volume) {
   const trailing = days.filter((d) => String(d.day) !== String(expectedT1));
   const avg = trailing.reduce((a, d) => a + num(d.dictations), 0) / 7;
   const zeroAlert = t1d === 0 && avg >= TH.activeBaselineAvg;
-  // Co-firing blackout (schema drift): dictations succeeded but a co-firing
-  // success event vanished. asr/paste co-fire with dictation.completed on success.
-  const driftAlert = t1Row != null && t1d > 0 && (num(t1Row.pastes) === 0 || num(t1Row.asr) === 0);
+  // Co-firing blackout (schema drift): asr.completed co-fires UNCONDITIONALLY on
+  // every successful dictation (TelemetryService.swift:73-112 -> :501-529), so
+  // asr==0 with dictations>0 is genuine drift. We deliberately do NOT flag
+  // pastes==0: paste.completed is conditional (only emits when auto-paste runs;
+  // copy-only users never emit it, KernelFinalizationWiring.swift:279-284). A zero
+  // is ambiguous (copy-only vs broken; an AX-denied auto-paste still emits with a
+  // clipboard_only_ax_denied tier), so it is not an actionable alert (#1130).
+  const asrDrift = t1Row != null && t1d > 0 && num(t1Row.asr) === 0;
+  const driftAlert = asrDrift;
   const ratio = avg > 0 ? t1d / avg : null;
   return {
     state: zeroAlert || driftAlert ? "alerting" : "evaluated-ok",
-    t1: t1Row || null, t1d, avg, ratio, zeroAlert, driftAlert,
+    t1: t1Row || null, t1d, avg, ratio, zeroAlert, driftAlert, asrDrift,
   };
 }
 
@@ -329,8 +335,8 @@ export function buildMessage(r, versions = []) {
     }
     if (r.volume.driftAlert) {
       alerts.push(
-        `telemetry drift: T-1 had ${r.volume.t1d} dictations but a co-firing success event was 0 ` +
-        `(paste/asr should co-fire) - an event may have stopped emitting.`
+        `telemetry drift: T-1 had ${r.volume.t1d} dictations but asr.completed was 0 ` +
+        `(it co-fires on every successful dictation) - a success event may have stopped emitting.`
       );
     }
   }

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -158,14 +158,51 @@ test("volume: weekend dip below trailing avg does NOT false-fire", () => {
   assert.equal(evaluateVolume(days, "2026-06-21").state, "evaluated-ok");
 });
 
-test("volume: co-firing blackout (schema drift) -> alert", () => {
+test("volume: asr blackout (schema drift) -> alert", () => {
+  // asr.completed co-fires UNCONDITIONALLY on success, so asr==0 with dictations
+  // present is a genuine co-fire vanish (the only drift leg, #1130).
   const days = [
-    { day: "2026-06-19", dictations: 200, pastes: 0, asr: 200 }, // paste event vanished
+    { day: "2026-06-19", dictations: 200, pastes: 200, asr: 0 }, // asr event vanished
     { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
   ];
   const ev = evaluateVolume(days, "2026-06-19");
   assert.equal(ev.state, "alerting");
   assert.equal(ev.driftAlert, true);
+  assert.equal(ev.asrDrift, true);
+});
+
+test("volume: paste-only blackout does NOT alert (copy-only ambiguity, #1130)", () => {
+  // paste.completed is conditional (auto-paste only); pastes==0 is ambiguous
+  // (copy-only vs broken), so it must NOT fire a drift alert even on an active day.
+  const days = [
+    { day: "2026-06-19", dictations: 200, pastes: 0, asr: 200 },
+    { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.driftAlert, false);
+});
+
+test("volume: copy-only quiet day does NOT alert (#1130)", () => {
+  const days = [
+    { day: "2026-06-19", dictations: 8, pastes: 0, asr: 8 },
+    { day: "2026-06-18", dictations: 6, pastes: 0, asr: 6 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.driftAlert, false);
+});
+
+test("volume: copy-only ACTIVE day does NOT alert (#1130)", () => {
+  // The false-positive class the old (pastes==0) leg hit: a clearly active day
+  // whose users are all copy-only. Must stay quiet now.
+  const days = [
+    { day: "2026-06-19", dictations: 50, pastes: 0, asr: 50 },
+    { day: "2026-06-18", dictations: 200, pastes: 200, asr: 200 },
+  ];
+  const ev = evaluateVolume(days, "2026-06-19");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.driftAlert, false);
 });
 
 // ---- message ----
@@ -200,6 +237,17 @@ test("message: a crossing produces an ALERT header + block + dashboard link", ()
   assert.match(msg, /ax_denied 10, direct-paste-failed 7/);
   assert.match(msg, /v2\.1\.4: 12/);
   assert.match(msg, /dashboard/);
+});
+
+test("message: drift alert names asr.completed, not paste/asr (#1130)", () => {
+  const msg = buildMessage(
+    results({
+      volume: { state: "alerting", t1d: 200, avg: 200, ratio: 1.0, zeroAlert: false, driftAlert: true, asrDrift: true },
+    })
+  );
+  assert.match(msg, /health - ALERT/);
+  assert.match(msg, /asr\.completed was 0/);
+  assert.ok(!msg.includes("paste/asr"), "drift wording must not reference the dropped paste leg");
 });
 
 test("message: stays within Discord 2000-char cap", () => {

--- a/workers/product-health/wrangler.toml
+++ b/workers/product-health/wrangler.toml
@@ -5,8 +5,9 @@ compatibility_date = "2026-06-20"
 # No [triggers] cron here: the Cloudflare account is at its 5-cron free-plan limit
 # (#1092), so scheduling lives in a GitHub Actions workflow
 # (.github/workflows/product-health-ping.yml) that pings the secret-gated fetch
-# endpoint daily at 14:00 UTC (10am ET) - a deliberate ingestion-lag buffer so the
-# prior UTC day's events from sleeping/offline laptops have flushed.
+# endpoint daily at 14:17 UTC (~10:17am ET) - a deliberate ingestion-lag buffer so
+# the prior UTC day's events from sleeping/offline laptops have flushed. The :17
+# offset (not top-of-hour) avoids GitHub's high-load window where runs drop (#1131).
 
 [vars]
 POSTHOG_PROJECT_ID = "354235"


### PR DESCRIPTION
Closes #1130, closes #1131. Polish on the daily product-health monitor shipped in #1092 (PRs #1116/#1121).

## #1130 — drift alert false-fired in copy-only mode
The integrity guard flagged "telemetry drift" whenever T-1 had dictations but `pastes == 0` OR `asr == 0`. But `paste.completed` is conditional — it only emits when auto-paste runs; copy-only users (auto-paste off) emit none (`TelemetryService.swift:122`; copy-only never sets the paste result, `KernelFinalizationWiring.swift:279-284`). So on a low-volume day whose only active users are copy-only, `pastes == 0` is legitimate and the alert was a false positive. An AX-denied auto-paste still emits `paste.completed` (`clipboard_only_ax_denied` tier), so `pastes == 0` means "auto-paste not attempted", not "auto-paste failed" — inherently ambiguous, and no threshold removes that ambiguity.

**Fix (simple-drop):** key the drift alert on the unconditional `asr.completed` co-fire only (`driftAlert = t1d > 0 && asr == 0`). `asr.completed` fires on every successful dictation, so its absence with dictations present is genuine, unambiguous schema drift. Drift-alert wording updated to name `asr.completed`.

Accepted trade-off: a fresh `paste.completed`-specific break is no longer alerted on day 1 (it surfaces later as the paste-fallback metric going "skipped"). Acceptable for an advisory monitor — alerting on an ambiguous signal erodes trust, and the broader regression class is covered by the asr leg + app PR/UAT.

## #1131 — schedule ran at the top of the hour
Moved the GitHub Actions cron `0 14 * * *` → `17 14 * * *`. GitHub flags top-of-hour as a high-load window where scheduled runs are delayed or dropped; a dropped run means no heartbeat/alert that day. Minute drift is harmless (the worker evaluates the prior completed UTC day).

## Process
Plan → council (GPT + Gemini, split: robust-guard vs simple-drop) → Codex grounded review (2 rounds, PROCEED-AS-PLANNED on simple-drop) → Codex code-diff review (clean). Plan + audits under `docs/` (local).

## Validation
- `node --test` from `workers/product-health/`: 28 pass (was 24). New: copy-only quiet `{8,0,8}` no-alert, copy-only ACTIVE `{50,0,50}` no-alert, paste-only blackout `{200,0,200}` no-alert, asr blackout `{200,200,0}` alerts, drift-message names `asr.completed`.
- No app surface (worker + CI only) — no Swift build / Live UAT.
- Post-merge: `wrangler deploy` to update the live worker (Cloudflare free tier).