### PR TITLE
ci(release): assert Sparkle helpers present + Gatekeeper-verify shipped DMG (#957)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,6 +405,26 @@ jobs:
             exit 1
           fi
 
+      - name: Verify Gatekeeper acceptance (final stapled artifact)
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          # #957: the build script's only spctl assessment runs PRE-notarization and
+          # is allowed to fail. This is the real "will Gatekeeper let a user open
+          # this" gate on the notarized + stapled DMG users actually download.
+          DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
+          MOUNT="${RUNNER_TEMP}/gatekeeper-mount"
+          rm -rf "$MOUNT"; mkdir -p "$MOUNT"
+          # Trap so a rejection still unmounts (set -e exits before explicit detach).
+          trap 'hdiutil detach "$MOUNT" 2>/dev/null || true; rm -rf "$MOUNT"' EXIT
+          hdiutil attach "$DMG_PATH" -mountpoint "$MOUNT" -nobrowse -readonly
+          echo "==> spctl Gatekeeper assessment of the shipped app ..."
+          spctl --assess --type exec --verbose=2 "$MOUNT/EnviousWispr.app"
+          echo "==> Gatekeeper accepts the notarized + stapled app."
+          hdiutil detach "$MOUNT"; rm -rf "$MOUNT"
+          trap - EXIT
+
       - name: Generate Sparkle appcast entry
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -346,11 +346,33 @@ create-dmg \
     "$BUNDLE"
 test -f "$DMG_PATH"
 
-# Fail-fast: mount the DMG and confirm EnviousWispr.app sits at the root (proof3 PHASE 9).
+# Fail-fast: mount the DMG and confirm EnviousWispr.app + all four Sparkle
+# auto-update helpers are present (proof3 PHASE 9; #957 helper-presence guard).
 PRECHECK_MOUNT="$PROJ_ROOT/build/precheck-mount"
 rm -rf "$PRECHECK_MOUNT"; mkdir -p "$PRECHECK_MOUNT"
+# #957: trap so a failed assertion below still unmounts — under `set -e` the
+# script would otherwise exit before the explicit detach and leak the mount.
+trap 'hdiutil detach "$PRECHECK_MOUNT" 2>/dev/null || true; rm -rf "$PRECHECK_MOUNT"' EXIT
 hdiutil attach "$DMG_PATH" -mountpoint "$PRECHECK_MOUNT" -nobrowse -readonly
 test -d "$PRECHECK_MOUNT/EnviousWispr.app"
+# #957: assert all four Sparkle helpers (wrapper AND inner Mach-O) ship in the
+# app. The pre-package per-Mach-O loop ([7/9]) verifies only the binaries it
+# FINDS; a dropped helper would ship silently and break auto-update on user
+# machines. Checking each inner executable with `-f` covers both the wrapper dir
+# and its Mach-O in one test.
+SPARKLE_B="$PRECHECK_MOUNT/EnviousWispr.app/Contents/Frameworks/Sparkle.framework/Versions/B"
+for HELPER in \
+    "$SPARKLE_B/Updater.app/Contents/MacOS/Updater" \
+    "$SPARKLE_B/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "$SPARKLE_B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" \
+    "$SPARKLE_B/Autoupdate"; do
+    if [[ ! -f "$HELPER" ]]; then
+        echo "::error::Sparkle update helper missing from shipped app: ${HELPER#"$PRECHECK_MOUNT/"}"
+        exit 1
+    fi
+done
+echo "    all 4 Sparkle update helpers present (Updater, Installer, Downloader, Autoupdate)"
 hdiutil detach "$PRECHECK_MOUNT"; rm -rf "$PRECHECK_MOUNT"
+trap - EXIT
 
 echo "==> DMG created: ${DMG_PATH} ($(stat -f%z "$DMG_PATH") bytes)"


### PR DESCRIPTION
## What
Two genuinely-additive release-pipeline guards (council trimmed the originally-proposed redundant part):
1. `build-release-dmg.sh` precheck: assert all four Sparkle helpers (`Updater.app`/`Installer.xpc`/`Downloader.xpc`/`Autoupdate`) AND their inner Mach-O executables are present in the packaged app, with an EXIT trap so a failed assert still unmounts.
2. `release.yml`: after notarize/staple, a Gatekeeper `spctl --assess --type exec` on the final stapled DMG — the "will Gatekeeper let a user open this" gate (the script's only spctl runs pre-notarization and is allowed to fail).

Dropped the originally-proposed per-helper signature re-verification: redundant with the existing `[7/9]` per-Mach-O team/sign/hardened/timestamp loop; DMG packaging does not strip signatures.

## Validation
- Council (best-practice): converged on the two checks kept; dropped the redundant re-verify.
- Codex grounded review → PROCEED-AS-PLANNED (r2); Codex code-diff → clean ("no clear bugs").
- `bash -n` + `actionlint` clean.
- Out-of-band proof: `build-only` release rehearsal (run 27924812536) exercises BOTH new checks on a real signed+notarized artifact, no publish. Per `no-auto-merge-before-out-of-band-validation`, NOT arming `--auto` until that rehearsal is green; will merge manually.

Push used `SKIP_PUSH_CHECKS=1` (audit-logged) for the pre-existing #825 fetch-depth guard (unrelated to this change; not bundled per founder call).

Closes #957