### PR TITLE
ci(release): also Gatekeeper-assess the DMG container, not just the app (#957 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,16 @@ jobs:
           # is allowed to fail. This is the real "will Gatekeeper let a user open
           # this" gate on the notarized + stapled DMG users actually download.
           DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
+          # #957 follow-up (Codex P2 on #1153): assess the DMG CONTAINER itself —
+          # it is the artifact users download and double-click first. Apple's
+          # Gatekeeper guidance checks disk images with `-t open`
+          # (`--context context:primary-signature`); the `-t exec` assessment below
+          # only covers the nested app. `stapler validate` confirms the ticket
+          # stuck, but does not run the full Gatekeeper policy on the container.
+          echo "==> spctl Gatekeeper assessment of the shipped DMG container ..."
+          spctl -a -t open --context context:primary-signature -v "$DMG_PATH"
+          echo "==> Gatekeeper accepts the notarized + stapled DMG."
+          # Also assess the nested app (what the user launches after copying it out).
           MOUNT="${RUNNER_TEMP}/gatekeeper-mount"
           rm -rf "$MOUNT"; mkdir -p "$MOUNT"
           # Trap so a rejection still unmounts (set -e exits before explicit detach).


### PR DESCRIPTION
## What
Follow-up to #957 (PR #1153) addressing the GitHub Codex auto-reviewer's P2.

The Gatekeeper step assessed only the nested app (`spctl --assess --type exec`), but the published artifact is the **DMG** users download and double-click. Per Apple's Gatekeeper guidance, disk images are assessed with `spctl -a -t open --context context:primary-signature`. `stapler validate` confirms the notarization ticket is present but does not run the full Gatekeeper policy on the container — so a container-level signature/ticket problem could ship green.

Adds the DMG-container assessment alongside the existing app assessment; **both must pass**.

## Validation
- `actionlint` clean.
- Codex code-diff review (running).
- Out-of-band proof: `build-only` release rehearsal (run 27925657722) confirms the new DMG-container `spctl -a -t open` passes on a real notarized + stapled DMG. Per `no-auto-merge-before-out-of-band-validation`, not arming `--auto` until that rehearsal is green; will merge after.

Ref: Codex review comment on #1153.