### PR TITLE
ci(pr-check): shared tested classifier + merge-base diff + fetch-depth guard (#1151)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,46 +50,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          echo "==> Detecting changed files: base=$BASE_SHA head=$HEAD_SHA"
-          DIFF_RC=0
-          DIFF_ERR_FILE="${RUNNER_TEMP:-/tmp}/detect_diff_err.txt"
-          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>"$DIFF_ERR_FILE") || DIFF_RC=$?
-          if [ "$DIFF_RC" -ne 0 ]; then
-            # Fail safe: "Detect code changes" is a build-skipping optimization,
-            # not a gate (#825). A diff that cannot resolve base/head must not
-            # red the required build-check before any build runs.
-            echo "::warning title=detect-code-changes::git diff failed (base=$BASE_SHA head=$HEAD_SHA) rc=$DIFF_RC."
-            echo "::warning::git stderr: $(cat "$DIFF_ERR_FILE" 2>/dev/null || true)"
-            echo "==> is_shallow=$(git rev-parse --is-shallow-repository 2>/dev/null || echo unknown)"
-            if git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-              # Checkout is valid (current head present); only the base could not
-              # be resolved. Fall back to a FULL build of correct code.
-              echo "==> head present — failing safe to a full build"
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            else
-              # Merge ref is STALE (current head absent): the working tree is the
-              # WRONG code. Fail loud instead of greening a check on a stale tree.
-              echo "::error title=stale-merge-ref::HEAD_SHA $HEAD_SHA is not in the checkout — refs/pull/<N>/merge is stale. Close and reopen the PR so GitHub recomputes it, then re-run."
-              exit 1
-            fi
-          else
-            echo "==> Changed files:"
-            echo "$CHANGED"
-            # A change to the build/test workflows must validate itself (the Xcode
-            # build/cache/test logic), so force a full build for those.
-            if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<< "$CHANGED"; then
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-              echo "==> CI build workflow changed — full Xcode build required"
-            elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<< "$CHANGED"; then
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-              echo "==> Swift source changes detected — full Xcode build required"
-            else
-              echo "needs_build=false" >> "$GITHUB_OUTPUT"
-              echo "==> No Swift/build-workflow changes — skipping build"
-            fi
-          fi
+        run: scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
 
       - name: Verify environment
         if: steps.changes.outputs.needs_build == 'true'
@@ -239,46 +200,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          echo "==> Detecting changed files: base=$BASE_SHA head=$HEAD_SHA"
-          DIFF_RC=0
-          DIFF_ERR_FILE="${RUNNER_TEMP:-/tmp}/detect_diff_err.txt"
-          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>"$DIFF_ERR_FILE") || DIFF_RC=$?
-          if [ "$DIFF_RC" -ne 0 ]; then
-            # Fail safe: "Detect code changes" is a build-skipping optimization,
-            # not a gate (#825). A diff that cannot resolve base/head must not
-            # red the required build-check before any build runs.
-            echo "::warning title=detect-code-changes::git diff failed (base=$BASE_SHA head=$HEAD_SHA) rc=$DIFF_RC."
-            echo "::warning::git stderr: $(cat "$DIFF_ERR_FILE" 2>/dev/null || true)"
-            echo "==> is_shallow=$(git rev-parse --is-shallow-repository 2>/dev/null || echo unknown)"
-            if git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-              # Checkout is valid (current head present); only the base could not
-              # be resolved. Fall back to a FULL build of correct code.
-              echo "==> head present — failing safe to a full build"
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            else
-              # Merge ref is STALE (current head absent): the working tree is the
-              # WRONG code. Fail loud instead of greening a check on a stale tree.
-              echo "::error title=stale-merge-ref::HEAD_SHA $HEAD_SHA is not in the checkout — refs/pull/<N>/merge is stale. Close and reopen the PR so GitHub recomputes it, then re-run."
-              exit 1
-            fi
-          else
-            echo "==> Changed files:"
-            echo "$CHANGED"
-            # A change to the build/test workflows must validate itself (the Xcode
-            # build/cache/test logic), so force a full build for those.
-            if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<< "$CHANGED"; then
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-              echo "==> CI build workflow changed — full Xcode build required"
-            elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<< "$CHANGED"; then
-              echo "needs_build=true" >> "$GITHUB_OUTPUT"
-              echo "==> Swift source changes detected — full Xcode build required"
-            else
-              echo "needs_build=false" >> "$GITHUB_OUTPUT"
-              echo "==> No Swift/build-workflow changes — skipping build"
-            fi
-          fi
+        run: scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
 
       - name: Verify environment
         if: steps.changes.outputs.needs_build == 'true'
@@ -394,6 +316,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: CI self-tests (classify-changes + fetch-depth lint)
+        run: |
+          set -euo pipefail
+          scripts/ci/classify-changes.sh --self-test
+          scripts/ci/check-pr-check-fetch-depth.sh
+
       - name: Require both build lanes
         run: |
           if [ "${{ needs.build-debug.result }}" != "success" ] || [ "${{ needs.build-release.result }}" != "success" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ scripts/*
 # UAT helpers (per-PR Swift CLIs invoked during Live UAT, e.g. issue #845 keychain verifier)
 !scripts/uat/
 !scripts/uat/**
+# CI tooling scripts invoked by .github/workflows (issue #1151)
+!scripts/ci/
+!scripts/ci/**
 # Polish eval harness — PUBLIC tracked files only (see .claude/knowledge/polish-eval.md for scope rules)
 !scripts/eval/
 scripts/eval/*

--- a/scripts/ci/check-pr-check-fetch-depth.sh
+++ b/scripts/ci/check-pr-check-fetch-depth.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# scripts/ci/check-pr-check-fetch-depth.sh
+# Assert that pr-check.yml's pull_request build lanes keep `fetch-depth: 0`
+# (issue #1151, guarding the #825 fix). Runs in the required build-check
+# aggregator so an accidental re-shallow of a lane checkout reds the gate.
+#
+# Enforcement scope: ACCIDENTAL-DRIFT, not tamper-proof. Because build-check
+# runs the PR's own copy of this script and of pr-check.yml, a single PR could
+# re-shallow a lane AND neuter this lint together and pass. That is acceptable
+# for a solo-maintainer repo (the realistic threat is accidental drift). A
+# trusted-base-version lint is noted as deferred hardening in the #1151 plan.
+#
+# Policy enforced for pr-check.yml: every YAML `fetch-depth:` key must be 0, and
+# at least the two PR build lanes must declare it. The aggregator checkout uses
+# the default depth (no fetch-depth: key) so it is not counted. main-post-merge.yml
+# legitimately uses fetch-depth: 2 and is NOT linted here.
+#
+# Usage:
+#   check-pr-check-fetch-depth.sh [FILE]   default FILE: .github/workflows/pr-check.yml
+#   check-pr-check-fetch-depth.sh --self-test
+set -euo pipefail
+
+# lint <file>: 0 if every fetch-depth key is 0 and >=2 are present; else 1.
+lint() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    echo "::error title=fetch-depth-lint::$file not found"
+    return 1
+  fi
+  # Match YAML `fetch-depth:` KEYS only (leading whitespace), so a comment that
+  # merely mentions fetch-depth is not counted.
+  local depth_lines count bad=0
+  depth_lines="$(grep -nE '^[[:space:]]*fetch-depth:[[:space:]]*[0-9]+' "$file" || true)"
+  count="$(printf '%s' "$depth_lines" | grep -c . || true)"
+  if [ "$count" -lt 2 ]; then
+    echo "::error title=fetch-depth-lint::expected >=2 'fetch-depth: 0' PR-lane checkouts in $file, found $count. #825 requires the pull_request build lanes keep full history."
+    return 1
+  fi
+  local ln val
+  while IFS= read -r ln; do
+    [ -n "$ln" ] || continue
+    val="$(printf '%s\n' "$ln" | sed -E 's/.*fetch-depth:[[:space:]]*([0-9]+).*/\1/')"
+    if [ "$val" != "0" ]; then
+      echo "::error title=fetch-depth-lint::$file declares a non-zero fetch-depth ($ln). #825: pull_request build lanes must use fetch-depth: 0 (do not re-shallow)."
+      bad=1
+    fi
+  done <<<"$depth_lines"
+  if [ "$bad" -ne 0 ]; then
+    return 1
+  fi
+  echo "==> fetch-depth lint OK: $file has $count lane checkout(s), all fetch-depth: 0"
+}
+
+SELFTEST_FAILS=0
+
+# _expect <fixture-content> <expected-rc:0|1> <label>
+_expect() {
+  local content="$1" expected_rc="$2" label="$3"
+  local f rc
+  f="$(mktemp)"
+  printf '%s\n' "$content" >"$f"
+  rc=0
+  lint "$f" >/dev/null 2>&1 || rc=$?
+  rm -f "$f"
+  # Normalize any non-zero to 1 for comparison.
+  if [ "$rc" -ne 0 ]; then rc=1; fi
+  if [ "$rc" -eq "$expected_rc" ]; then
+    echo "ok   [$label] rc=$rc"
+  else
+    echo "FAIL [$label] expected rc=$expected_rc got rc=$rc"
+    SELFTEST_FAILS=$((SELFTEST_FAILS + 1))
+  fi
+}
+
+self_test() {
+  # Good: two lane checkouts at fetch-depth: 0 (aggregator has no key).
+  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 0 "two depth-0 lanes -> pass"
+  # Bad: a lane re-shallowed to 2.
+  _expect "$(printf '        with:\n          fetch-depth: 0\n        with:\n          fetch-depth: 2\n')" 1 "a re-shallowed lane (2) -> fail"
+  # Bad: only one depth-0 declaration (a lane lost its key).
+  _expect "$(printf '        with:\n          fetch-depth: 0\n')" 1 "fewer than two lanes -> fail"
+  # False-positive guard: a comment mentioning fetch-depth: 0 does not count;
+  # the real key is 2 -> must fail.
+  _expect "$(printf '          # keep fetch-depth: 0 here per #825\n          fetch-depth: 2\n          fetch-depth: 0\n')" 1 "comment fetch-depth: 0 does not mask a real 2 -> fail"
+
+  if [ "$SELFTEST_FAILS" -eq 0 ]; then
+    echo "== check-pr-check-fetch-depth self-test PASS =="
+  else
+    echo "== check-pr-check-fetch-depth self-test FAIL ($SELFTEST_FAILS) =="
+    return 1
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --self-test) self_test ;;
+    *) lint "${1:-.github/workflows/pr-check.yml}" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# scripts/ci/classify-changes.sh
+# Decide whether a PR needs a full Xcode build, for pr-check.yml's two build
+# lanes (issue #1151, follow-up to #825 / PR #1150). Writes needs_build=<bool>
+# to $GITHUB_OUTPUT and emits ==> / ::warning:: / ::error:: annotations.
+#
+# Usage:
+#   classify-changes.sh <BASE_SHA> <HEAD_SHA>   default: three-dot (merge-base)
+#                                               diff + #825 fail-safe, classify
+#   classify-changes.sh --classify-only         classify a newline file list
+#                                               read from stdin (no git)
+#   classify-changes.sh --self-test             run the verdict matrix; exit
+#                                               non-zero on any mismatch
+#
+# Classify contract (lifted VERBATIM from the pre-#1151 inline step):
+#   - a change to pr-check.yml / main-post-merge.yml self-forces a full build
+#   - any path outside (website/ docs/ .github/ content-engine/ .claude/
+#     CLAUDE.md) forces a full build
+#   - otherwise content-only -> skip
+#   Empty input -> true: the here-string feeds grep one blank line, which is
+#   NOT excluded, so the verbatim classifier over-builds. Preserved as-is; an
+#   empty three-dot diff (PR head is an ancestor of base) is rare and a safe
+#   over-build.
+set -euo pipefail
+
+# classify: read a newline file list on stdin; write needs_build to
+# $GITHUB_OUTPUT and echo a human-readable reason.
+classify() {
+  local changed
+  changed="$(cat)"
+  if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<<"$changed"; then
+    printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
+    echo "==> CI build workflow changed — full Xcode build required"
+  elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<<"$changed"; then
+    printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
+    echo "==> Swift source changes detected — full Xcode build required"
+  else
+    printf 'needs_build=false\n' >>"$GITHUB_OUTPUT"
+    echo "==> No Swift/build-workflow changes — skipping build"
+  fi
+}
+
+# detect: default mode. Acquire the PR's OWN changed files with a three-dot
+# (merge-base) diff, carrying the #825 fail-safe, then classify.
+detect() {
+  local base="${1:-}" head="${2:-}"
+  # Fail closed on an unknown event shape: an empty SHA must never let
+  # "${head}^{commit}" silently resolve to the checked-out HEAD.
+  if [ -z "$base" ] || [ -z "$head" ]; then
+    echo "::error title=classify-changes::BASE_SHA or HEAD_SHA is empty (base='$base' head='$head') — refusing to classify an unknown event shape."
+    exit 1
+  fi
+  echo "==> Detecting changed files (three-dot): base=$base head=$head"
+  local rc=0 err_file changed
+  err_file="${RUNNER_TEMP:-/tmp}/classify_diff_err.txt"
+  changed="$(git diff --name-only "${base}...${head}" 2>"$err_file")" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # #825 fail-safe: this detector is a build-skipping optimization, not a
+    # gate. A diff that cannot resolve base/head must not red the required
+    # build-check before any build runs. Branch on the RETURN CODE, not the
+    # stderr text (three-dot's "Invalid symmetric difference expression" and
+    # two-dot's "bad object" are handled identically).
+    echo "::warning title=classify-changes::git diff failed (base=$base head=$head) rc=$rc."
+    echo "::warning::git stderr: $(cat "$err_file" 2>/dev/null || true)"
+    echo "==> is_shallow=$(git rev-parse --is-shallow-repository 2>/dev/null || echo unknown)"
+    if git cat-file -e "${head}^{commit}" 2>/dev/null; then
+      # Checkout is valid (current head present); only the base could not be
+      # resolved. Fall back to a FULL build of correct code.
+      echo "==> head present — failing safe to a full build"
+      printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
+    else
+      # Merge ref is STALE (current head absent): the working tree is the WRONG
+      # code. Fail loud (no needs_build written) rather than green a stale tree.
+      echo "::error title=stale-merge-ref::HEAD_SHA $head is not in the checkout — refs/pull/<N>/merge is stale. Close and reopen the PR so GitHub recomputes it, then re-run."
+      exit 1
+    fi
+  else
+    echo "==> Changed files:"
+    echo "$changed"
+    classify <<<"$changed"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Self-test. Each case asserts $GITHUB_OUTPUT CONTENTS (not just exit code).
+# ---------------------------------------------------------------------------
+SELFTEST_FAILS=0
+
+# _expect_classify <input> <expected:true|false> <label>
+_expect_classify() {
+  local input="$1" expected="$2" label="$3"
+  local out got
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out"
+  classify <<<"$input" >/dev/null
+  got="$(grep -oE 'needs_build=(true|false)' "$out" | tail -n1 | cut -d= -f2 || true)"
+  rm -f "$out"
+  if [ "$got" = "$expected" ]; then
+    echo "ok   [$label] needs_build=$expected"
+  else
+    echo "FAIL [$label] expected needs_build=$expected got '$got'"
+    SELFTEST_FAILS=$((SELFTEST_FAILS + 1))
+  fi
+}
+
+# _expect_detect <base> <head> <expected:true|false> <label>  (run in a repo)
+_expect_detect() {
+  local base="$1" head="$2" expected="$3" label="$4"
+  local out got rc
+  out="$(mktemp)"
+  rc=0
+  ( GITHUB_OUTPUT="$out"; detect "$base" "$head" >/dev/null 2>&1 ) || rc=$?
+  got="$(grep -oE 'needs_build=(true|false)' "$out" | tail -n1 | cut -d= -f2 || true)"
+  rm -f "$out"
+  if [ "$got" = "$expected" ] && [ "$rc" -eq 0 ]; then
+    echo "ok   [$label] needs_build=$expected rc=0"
+  else
+    echo "FAIL [$label] expected needs_build=$expected rc=0; got needs_build='$got' rc=$rc"
+    SELFTEST_FAILS=$((SELFTEST_FAILS + 1))
+  fi
+}
+
+# _expect_exit1 <base> <head> <label>  — expects non-zero exit AND no output
+_expect_exit1() {
+  local base="$1" head="$2" label="$3"
+  local out lines rc
+  out="$(mktemp)"
+  rc=0
+  ( GITHUB_OUTPUT="$out"; detect "$base" "$head" >/dev/null 2>&1 ) || rc=$?
+  lines="$(grep -cE 'needs_build=' "$out" || true)"
+  rm -f "$out"
+  if [ "$rc" -ne 0 ] && [ "$lines" -eq 0 ]; then
+    echo "ok   [$label] exit=$rc, no needs_build written"
+  else
+    echo "FAIL [$label] expected exit!=0 and no needs_build; got rc=$rc needs_build_lines=$lines"
+    SELFTEST_FAILS=$((SELFTEST_FAILS + 1))
+  fi
+}
+
+self_test() {
+  echo "== classify contract (--classify-only path) =="
+  _expect_classify ".github/workflows/pr-check.yml" true "self-force pr-check"
+  _expect_classify "Sources/Foo.swift" true "swift source"
+  _expect_classify $'docs/x.md\nwebsite/y.astro' false "docs+website only"
+  _expect_classify ".github/actions/foo/action.yml" false "github actions dir excluded"
+  _expect_classify ".github/dependabot.yml" false "dependabot excluded"
+  _expect_classify "scripts/ci/classify-changes.sh" true "scripts not excluded"
+  _expect_classify ".gitignore" true "gitignore not excluded"
+  _expect_classify "" true "empty input -> over-build (verbatim quirk)"
+  _expect_classify $'docs/a.md\nSources/B.swift' true "mixed docs+swift"
+
+  echo "== three-dot diff + #825 fail-safe (temp repos) =="
+  local sb orig head head2 maintip
+  orig="$(pwd)"
+  sb="$(mktemp -d)"
+  cd "$sb"
+  git init -q -b main
+  git config user.email t@t.co
+  git config user.name t
+  mkdir -p docs
+  echo v1 >app.swift
+  echo d1 >docs/note.md
+  git add -A
+  git commit -qm base
+  git switch -qc pr
+  echo d2 >>docs/note.md
+  git add -A
+  git commit -qm "pr docs"
+  head="$(git rev-parse HEAD)"
+  git switch -q main
+  echo v2 >>app.swift
+  git add -A
+  git commit -qm "main swift"
+  maintip="$(git rev-parse main)"
+  # base = current main tip (what GitHub sends), head = PR head: three-dot must
+  # ignore main's post-branch app.swift and see only the PR's excluded docs/
+  # change -> needs_build=false (the over-classification fix). Two-dot here
+  # would also surface main's app.swift -> a wrong true.
+  _expect_detect "$maintip" "$head" false "content-only behind moved main"
+  git switch -q pr
+  echo prswift >pr.swift
+  git add -A
+  git commit -qm "pr swift"
+  head2="$(git rev-parse HEAD)"
+  _expect_detect "$maintip" "$head2" true "swift change on PR side"
+  # unreachable base, head present -> fail-safe full build (#825).
+  _expect_detect "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" "$head2" true "unreachable base -> fail-safe full build"
+  # absent head (stale merge ref) -> exit 1, no output.
+  _expect_exit1 "$maintip" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" "absent head -> stale-merge-ref exit 1"
+  # empty SHA precondition -> exit 1.
+  _expect_exit1 "" "$head2" "empty base -> exit 1"
+  _expect_exit1 "$maintip" "" "empty head -> exit 1"
+  cd "$orig"
+  rm -rf "$sb"
+
+  if [ "$SELFTEST_FAILS" -eq 0 ]; then
+    echo "== classify-changes self-test PASS =="
+  else
+    echo "== classify-changes self-test FAIL ($SELFTEST_FAILS) =="
+    return 1
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --classify-only) classify ;;
+    --self-test) self_test ;;
+    *) detect "${1:-}" "${2:-}" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## What

Extracts `pr-check.yml`'s duplicated `Detect code changes` step into one tracked, self-tested `scripts/ci/classify-changes.sh` called by both build lanes, and adds a fetch-depth guard. Follow-up to #825 / PR #1150.

- **Merge-base (three-dot) diff `BASE...HEAD`**: a content-only PR behind a moved main no longer over-classifies as a Swift change, so it stops triggering a wasteful full build. Two-dot surfaced main's post-branch files as the PR's own.
- **#825 fail-safe preserved verbatim** (head present → full build; stale merge ref → loud `exit 1`, no output) plus an explicit empty-SHA precondition that fails closed.
- **`scripts/ci/check-pr-check-fetch-depth.sh`** wired into the required `build-check` aggregator (new checkout + CI self-tests step), so a re-shallow of a PR lane checkout reds the gate. Accidental-drift enforcement, not tamper-proof (solo-repo threat model; trusted-base lint noted as deferred hardening).
- Both lanes keep their own `needs_build` output, so #1089's lane-divergence cross-check is intact; classifier logic is now common-mode and guarded by `--self-test`.
- `.gitignore`: allowlist `scripts/ci/` so the new scripts are tracked.

`main-post-merge.yml` is deliberately untouched. Its `HEAD~1 HEAD` push diff needs a separate `github.event.before..github.sha` robustness fix (it under-builds on a hypothetical multi-commit push); tracked as a follow-up rather than entrenched here.

## Validation

- `scripts/ci/classify-changes.sh --self-test` and `check-pr-check-fetch-depth.sh --self-test`: PASS. They assert `$GITHUB_OUTPUT` contents and lock the classifier contract (`.github/actions`/`dependabot.yml` skip; `scripts/`/`.gitignore` build; empty diff over-builds verbatim). The over-classification fix is proven by a content-only-behind-moved-main case.
- ShellCheck clean; `actionlint` clean.
- This PR self-forces a full build (it edits `pr-check.yml`), so `build-check` exercises the new detection and the CI self-tests live.

## Review trail

- Council (GPT-5.5 + Gemini-3.1) coverage.
- Codex grounded review r1→r3 → PROCEED-AS-PLANNED.
- Codex code-diff review: clean.
- Plan: `docs/feature-requests/issue-1151-2026-06-22-detect-changes-shared-classify.md` (local).

Closes #1151