### PR TITLE
feat(llm): specific cloud/Ollama polish failure reasons (notice + telemetry)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -158,7 +158,11 @@ struct StatusView: View {
             HStack(spacing: 6) {
               Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.stWarning)
-              Text("AI polish failed: \(polishError)")
+              // #945: the runner composes the full, lead-in-varied notice
+              // ("AI polish failed: ..." for real errors, "AI cleanup skipped:
+              // ..." for not-set-up / too-long / timeout), so render it verbatim
+              // instead of hardcoding the prefix here.
+              Text(polishError)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }

--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -335,14 +335,37 @@ public struct GeminiConnector: TranscriptPolisher {
         )
       }
     #endif
+    throw LLMError.classified(Self.classify(statusCode: statusCode, bodyString: body))
+  }
+
+  /// Pure status+body -> reason classifier (#945). Gemini's 429
+  /// `RESOURCE_EXHAUSTED` does NOT cleanly split rate-limit vs quota, so it maps
+  /// to the honest `rateLimitedOrQuota` rather than guessing (which is how the
+  /// old code recreated the out-of-credits-told-to-wait bug). Content-safety on a
+  /// non-200 is best-effort; a 200-with-`promptFeedback.blockReason` still
+  /// degrades to `emptyResponse` in the success parse (deferred enhancement).
+  /// Unit-testable without network mocking.
+  static func classify(statusCode: Int, bodyString: String) -> PolishFailureReason {
     switch statusCode {
     case 400:
-      if body.contains("API_KEY_INVALID") { throw LLMError.invalidAPIKey }
-      throw LLMError.requestFailed("Gemini rejected the request. Check model name and parameters.")
-    case 403: throw LLMError.invalidAPIKey
-    case 429: throw LLMError.rateLimited
+      if bodyString.contains("API_KEY_INVALID") { return .apiKeyRejected }
+      if bodyString.contains("exceeds the maximum number of tokens") { return .inputTooLong }
+      if bodyString.contains("PROHIBITED_CONTENT") || bodyString.contains("blockReason") {
+        return .contentBlocked
+      }
+      return .badRequest
+    case 401:
+      return .apiKeyRejected
+    case 403:
+      return .accessDenied
+    case 404:
+      return .modelUnavailable
+    case 429:
+      return .rateLimitedOrQuota
+    case 500...599:
+      return .providerServerError
     default:
-      throw LLMError.requestFailed(Self.friendlyMessage(for: statusCode))
+      return (400...499).contains(statusCode) ? .badRequest : .unknown
     }
   }
 
@@ -357,16 +380,6 @@ public struct GeminiConnector: TranscriptPolisher {
       return "cancelled"
     }
     return "\(type(of: error))"
-  }
-
-  private static func friendlyMessage(for statusCode: Int) -> String {
-    switch statusCode {
-    case 400: return "Gemini rejected the request. Check model name and parameters."
-    case 403: return "Gemini access denied. Check your API key permissions."
-    case 404: return "Gemini model not found. Verify the model name in settings."
-    case 500...599: return "Gemini server error (HTTP \(statusCode)). Try again shortly."
-    default: return "Gemini request failed (HTTP \(statusCode))."
-    }
   }
 
   // MARK: - Retry
@@ -401,12 +414,15 @@ public struct GeminiConnector: TranscriptPolisher {
 
   private func getAPIKey(config: LLMProviderConfig) throws -> String {
     guard let keychainId = config.apiKeyKeychainId else {
-      throw LLMError.invalidAPIKey
+      throw LLMError.classified(.apiKeyMissing)
     }
     do {
       return try keychainManager.retrieve(key: keychainId)
     } catch {
-      throw LLMError.invalidAPIKey
+      // A keychain id is set but the key could not be read (corrupt/inaccessible
+      // entry). Functionally there is no usable key; re-entering it in Settings
+      // (the `apiKeyMissing` action) fixes both this and the no-key case.
+      throw LLMError.classified(.apiKeyMissing)
     }
   }
 }

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -172,6 +172,13 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
   /// kept distinct from `requestFailed` so it never surfaces as "AI polish
   /// failed" in the UI.
   case outputLanguageDrift(expected: String, actual: String)
+  /// A cloud/Ollama polish failure carrying its specific classified reason
+  /// (#945). The single adapter that threads the rich `PolishFailureReason`
+  /// catalog through the existing `throws LLMError` contract: connectors throw
+  /// this on the polish path, and the runner unwraps it for the on-screen notice
+  /// and the telemetry reason tag. The pre-existing specific cases stay for the
+  /// Settings model-discovery path and backward compatibility.
+  case classified(PolishFailureReason)
 
   public var errorDescription: String? {
     switch self {
@@ -191,6 +198,12 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
         "Apple Intelligence does not support the input language '\(code)' for on-device polishing."
     case .outputLanguageDrift(let expected, let actual):
       return "LLM polish output drifted from expected language '\(expected)' to '\(actual)'."
+    case .classified(let reason):
+      // The user-facing, provider-specific notice is composed by the runner via
+      // `reason.composedMessage(provider:)`. This generic description exists only
+      // for logs / incidental `localizedDescription` reads where no provider is
+      // known — it is never the on-screen notice.
+      return "AI polish failed (\(reason.telemetryTag))."
     }
   }
 
@@ -209,6 +222,8 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
       return a == b
     case (.outputLanguageDrift(let le, let la), .outputLanguageDrift(let re, let ra)):
       return le == re && la == ra
+    case (.classified(let a), .classified(let b)):
+      return a == b
     default:
       return false
     }

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -14,6 +14,12 @@ enum LLMRetryPolicy {
       case .rateLimited: return true
       case .requestFailed(let msg):
         return msg.contains("server error")
+      case .classified(let reason):
+        // Retryability now lives in the catalog. This preserves today's 5xx
+        // retry (now `.providerServerError`) and rate-limit retry, while
+        // fail-fast reasons (out-of-credits, key problems, the Gemini
+        // rate-or-quota ambiguity) surface their actionable notice immediately.
+        return reason.isRetryable
       default: return false
       }
     }

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -310,7 +310,7 @@ public struct OllamaConnector: TranscriptPolisher {
         } catch let urlError as URLError {
           switch urlError.code {
           case .notConnectedToInternet, .cannotFindHost:
-            throw LLMError.providerUnavailable  // not transient, fail fast
+            throw LLMError.classified(.providerUnreachable)  // not transient, fail fast
           default:
             throw urlError  // let LLMRetryPolicy.isRetryable() decide
           }
@@ -323,12 +323,12 @@ public struct OllamaConnector: TranscriptPolisher {
         switch httpResponse.statusCode {
         case 200:
           return (data, httpResponse)
-        case 404:
-          throw LLMError.modelNotFound(config.model)
         default:
+          // #945: read the body INSIDE the error arm for classification (404 ->
+          // model not pulled, 5xx -> server error). `data` is in hand from above.
+          let bodyString = String(data: data, encoding: .utf8) ?? ""
           #if DEBUG
-            let body = String(data: data, encoding: .utf8) ?? ""
-            let truncated = String(body.prefix(200))
+            let truncated = String(bodyString.prefix(200))
             Task {
               await AppLogger.shared.log(
                 "Ollama HTTP \(httpResponse.statusCode): \(truncated)",
@@ -343,7 +343,8 @@ public struct OllamaConnector: TranscriptPolisher {
               )
             }
           #endif
-          throw LLMError.requestFailed(Self.friendlyMessage(for: httpResponse.statusCode))
+          throw LLMError.classified(
+            Self.classify(statusCode: httpResponse.statusCode, bodyString: bodyString))
         }
       } catch {
         lastError = error
@@ -352,16 +353,23 @@ public struct OllamaConnector: TranscriptPolisher {
     }
     // Convert exhausted connection errors to domain error for UI
     if let urlError = lastError as? URLError, urlError.code == .cannotConnectToHost {
-      throw LLMError.providerUnavailable
+      throw LLMError.classified(.providerUnreachable)
     }
     throw lastError ?? LLMError.requestFailed("All retries exhausted")
   }
 
-  private static func friendlyMessage(for statusCode: Int) -> String {
+  /// Pure status+body -> reason classifier (#945). 404 means the model is not
+  /// pulled; 5xx is a local Ollama server error. `bodyString` is accepted for
+  /// signature parity with the cloud classifiers (and future body-based splits).
+  /// Unit-testable without network mocking.
+  static func classify(statusCode: Int, bodyString: String) -> PolishFailureReason {
     switch statusCode {
-    case 400: return "Ollama rejected the request. Check model name and parameters."
-    case 500...599: return "Ollama server error (HTTP \(statusCode)). Try restarting Ollama."
-    default: return "Ollama request failed (HTTP \(statusCode))."
+    case 404:
+      return .modelUnavailable
+    case 500...599:
+      return .providerServerError
+    default:
+      return (400...499).contains(statusCode) ? .badRequest : .unknown
     }
   }
 }

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -134,14 +134,13 @@ public struct OpenAIConnector: TranscriptPolisher {
             statusForLog = "error_after_200:\(Self.shortError(error))"
             throw error
           }
-        case 401:
-          throw LLMError.invalidAPIKey
-        case 429:
-          throw LLMError.rateLimited
         default:
+          // #945: read the body INSIDE the error arm so the classifier can split
+          // the ambiguous pairs (out-of-credits vs rate-limited on 429; too-long
+          // vs generic 400). `data` is already in hand from the call above.
+          let bodyString = String(data: data, encoding: .utf8) ?? ""
           #if DEBUG
-            let body = String(data: data, encoding: .utf8) ?? ""
-            let truncated = String(body.prefix(200))
+            let truncated = String(bodyString.prefix(200))
             Task {
               await AppLogger.shared.log(
                 "OpenAI HTTP \(httpResponse.statusCode): \(truncated)",
@@ -156,7 +155,8 @@ public struct OpenAIConnector: TranscriptPolisher {
               )
             }
           #endif
-          throw LLMError.requestFailed(Self.friendlyMessage(for: httpResponse.statusCode))
+          throw LLMError.classified(
+            Self.classify(statusCode: httpResponse.statusCode, bodyString: bodyString))
         }
       } catch {
         if statusForLog == "pending" {
@@ -212,24 +212,44 @@ public struct OpenAIConnector: TranscriptPolisher {
     return "\(type(of: error))"
   }
 
-  private static func friendlyMessage(for statusCode: Int) -> String {
+  /// Pure status+body -> reason classifier (#945). Unit-testable without network
+  /// mocking: feed `(Int, String)` fixtures. `internal` so the same-module
+  /// connector throws it and `@testable` tests assert it.
+  static func classify(statusCode: Int, bodyString: String) -> PolishFailureReason {
     switch statusCode {
-    case 400: return "OpenAI rejected the request. Check model name and parameters."
-    case 403: return "OpenAI access denied. Check your API key permissions."
-    case 404: return "OpenAI model not found. Verify the model name in settings."
-    case 500...599: return "OpenAI server error (HTTP \(statusCode)). Try again shortly."
-    default: return "OpenAI request failed (HTTP \(statusCode))."
+    case 401:
+      return .apiKeyRejected
+    case 403:
+      return .accessDenied
+    case 404:
+      return .modelUnavailable
+    case 429:
+      // Split rate-limit vs out-of-credits by the body's `error.type`.
+      return bodyString.contains("insufficient_quota") ? .outOfCredits : .rateLimited
+    case 400:
+      if bodyString.contains("context_length_exceeded") { return .inputTooLong }
+      if bodyString.contains("content_filter") || bodyString.contains("content_policy") {
+        return .contentBlocked
+      }
+      return .badRequest
+    case 500...599:
+      return .providerServerError
+    default:
+      return (400...499).contains(statusCode) ? .badRequest : .unknown
     }
   }
 
   private func getAPIKey(config: LLMProviderConfig) throws -> String {
     guard let keychainId = config.apiKeyKeychainId else {
-      throw LLMError.invalidAPIKey
+      throw LLMError.classified(.apiKeyMissing)
     }
     do {
       return try keychainManager.retrieve(key: keychainId)
     } catch {
-      throw LLMError.invalidAPIKey
+      // A keychain id is set but the key could not be read (corrupt/inaccessible
+      // entry). Functionally there is no usable key; re-entering it in Settings
+      // (the `apiKeyMissing` action) fixes both this and the no-key case.
+      throw LLMError.classified(.apiKeyMissing)
     }
   }
 }

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -1,0 +1,224 @@
+import EnviousWisprCore
+import Foundation
+
+/// The single catalog/adapter for a cloud or local AI-cleanup failure (#945).
+///
+/// One closed set of distinguishable failure reasons. Each reason owns everything
+/// that downstream code needs for that failure:
+///   - `telemetryTag` — the low-cardinality Sentry reason tag.
+///   - `leadIn` — whether the on-screen notice reads "AI polish failed:" (a real
+///     error) or "AI cleanup skipped:" (not-really-broken: no key yet, too long,
+///     timed out).
+///   - `message(provider:)` — the actionable, self-contained user sentence.
+///   - `composedMessage(provider:)` — `<leadIn> <message>`, the full notice.
+///   - `isRetryable` — whether a connector's retry loop should retry this.
+///
+/// Adding a future warning is a one-file change here: a new case plus its four
+/// properties, and (only if it needs new detection) one branch in a provider's
+/// `classify`. UI, telemetry, the runner, and `LLMError` are untouched.
+///
+/// `LLMError` carries this through the existing `throws LLMError` contract via the
+/// single `LLMError.classified(_:)` case, so the type is `public` only because
+/// that public case carries it. The per-connector `classify` functions stay
+/// `internal`. The reason never holds raw provider text (privacy: telemetry and
+/// the user message both use this closed set, never the provider's error body).
+public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
+  /// No API key configured for the selected cloud provider, or the stored key
+  /// could not be read (re-entering it in Settings fixes both).
+  case apiKeyMissing
+  /// The provider rejected the supplied key (401; Gemini `API_KEY_INVALID`).
+  case apiKeyRejected
+  /// 403: permissions / billing-disabled / API-disabled / region.
+  case accessDenied
+  /// OpenAI 429 `insufficient_quota` — the account is out of credits.
+  case outOfCredits
+  /// OpenAI 429 rate limit (transient).
+  case rateLimited
+  /// Gemini 429 `RESOURCE_EXHAUSTED` — rate OR quota; Gemini does not cleanly
+  /// split the two, so the message names both honestly.
+  case rateLimitedOrQuota
+  /// 404 / model not found / Ollama model not pulled.
+  case modelUnavailable
+  /// 400 `context_length_exceeded` / token budget — the dictation is too long.
+  case inputTooLong
+  /// Provider blocked the text (content filter / safety). Best-effort detection.
+  case contentBlocked
+  /// Offline / DNS / connection lost / Ollama daemon down.
+  case providerUnreachable
+  /// 500 / 503 — the provider is having problems (transient).
+  case providerServerError
+  /// Residual 4xx the app constructed wrong (rare).
+  case badRequest
+  /// A 200 with no usable cleanup text.
+  case emptyResponse
+  /// Our polish budget was exceeded (the runner's timeout).
+  case timedOut
+  /// Unclassified.
+  case unknown
+
+  /// Whether the on-screen notice leads with "AI polish failed:" (a real error)
+  /// or "AI cleanup skipped:" (not-really-broken).
+  public enum LeadIn: Sendable, Equatable {
+    case failed
+    case skipped
+
+    public var text: String {
+      switch self {
+      case .failed: return "AI polish failed:"
+      case .skipped: return "AI cleanup skipped:"
+      }
+    }
+  }
+
+  /// Low-cardinality Sentry reason tag (`polish.error_case`).
+  public var telemetryTag: String {
+    switch self {
+    case .apiKeyMissing: return "api_key_missing"
+    case .apiKeyRejected: return "api_key_rejected"
+    case .accessDenied: return "access_denied"
+    case .outOfCredits: return "out_of_credits"
+    case .rateLimited: return "rate_limited"
+    case .rateLimitedOrQuota: return "rate_or_quota"
+    case .modelUnavailable: return "model_unavailable"
+    case .inputTooLong: return "input_too_long"
+    case .contentBlocked: return "content_blocked"
+    case .providerUnreachable: return "provider_unreachable"
+    case .providerServerError: return "provider_server_error"
+    case .badRequest: return "bad_request"
+    case .emptyResponse: return "empty_response"
+    case .timedOut: return "timed_out"
+    case .unknown: return "unknown"
+    }
+  }
+
+  /// "skipped" for the not-really-broken cases (no key yet, too long, timed out);
+  /// "failed" for the rest.
+  public var leadIn: LeadIn {
+    switch self {
+    case .apiKeyMissing, .inputTooLong, .timedOut: return .skipped
+    default: return .failed
+    }
+  }
+
+  /// Whether a connector retry loop should retry this failure. Preserves today's
+  /// behavior: transient server errors and rate limits retry; everything else
+  /// (out-of-credits, key problems, the Gemini rate-or-quota ambiguity, etc.)
+  /// fails fast so the actionable notice surfaces immediately.
+  public var isRetryable: Bool {
+    switch self {
+    case .providerServerError, .rateLimited: return true
+    default: return false
+    }
+  }
+
+  /// The actionable user sentence (no lead-in). Always rendered with a concrete
+  /// provider by the runner; `<Provider>` is the hardcoded display name, never a
+  /// user host URL.
+  public func message(provider: LLMProvider) -> String {
+    let name = provider.displayName
+    let isOllama = provider == .ollama
+    switch self {
+    case .apiKeyMissing:
+      return "no \(name) API key set yet. Add one in Settings."
+    case .apiKeyRejected:
+      return "\(name) rejected your API key. Check or replace it in Settings."
+    case .accessDenied:
+      return
+        "\(name) denied access. Check your provider billing, API access, region, or selected model."
+    case .outOfCredits:
+      return "your \(name) account is out of credits. Check your provider billing."
+    case .rateLimited:
+      return "too many requests to \(name) right now. It should work again in a moment."
+    case .rateLimitedOrQuota:
+      return
+        "\(name) hit a rate or quota limit. Wait a moment, or check your \(name) billing if it keeps happening."
+    case .modelUnavailable:
+      return isOllama
+        ? "that Ollama model isn't downloaded yet. Pull it in Ollama or pick another in Settings."
+        : "the selected \(name) model isn't available. Pick another in Settings."
+    case .inputTooLong:
+      return
+        "this dictation is too long for the selected model. Try a shorter one or a larger model in Settings."
+    case .contentBlocked:
+      return "\(name) blocked this text. Your original was pasted unchanged."
+    case .providerUnreachable:
+      return isOllama
+        ? "Ollama isn't reachable. Start Ollama and try again."
+        : "couldn't reach \(name). Check your internet connection, VPN, or proxy."
+    case .providerServerError:
+      return "\(name) is having problems right now. Try again shortly."
+    case .badRequest:
+      return "a configuration problem stopped it. Your original text was pasted unchanged."
+    case .emptyResponse:
+      return "\(name) returned no cleanup text. Try again."
+    case .timedOut:
+      return "the dictation took too long. Your original text was pasted unchanged."
+    case .unknown:
+      return "an unexpected error stopped it. Your original text was pasted unchanged."
+    }
+  }
+
+  /// The full self-contained notice: `<leadIn> <message>`.
+  public func composedMessage(provider: LLMProvider) -> String {
+    "\(leadIn.text) \(message(provider: provider))"
+  }
+
+  /// Whether a composed notice string represents a "skipped" (not-really-broken)
+  /// outcome rather than a hard failure. Keyed off the single `LeadIn.skipped.text`
+  /// constant that `composedMessage` also uses, so it can never drift from the
+  /// notice it inspects. The completion planner uses this to suppress the
+  /// transient "Polish failed -- using raw text" overlay for skips (the in-window
+  /// notice still shows the actionable "AI cleanup skipped: ..." message). A
+  /// legacy raw message or the Apple Intelligence "AI polish failed: ..." string
+  /// is correctly treated as NOT a skip, so its hard-failure toast still fires.
+  public static func isSkipNotice(_ noticeMessage: String) -> Bool {
+    noticeMessage.hasPrefix(LeadIn.skipped.text)
+  }
+
+  /// Maps every error the runner sees directly to a reason: the `.classified`
+  /// carrier (unwrap), the legacy `LLMError` cases connectors still throw on the
+  /// polish path (empty response, provider-unavailable, model-not-found,
+  /// ambiguous invalid-key, rate-limited, request-failed), the runner's own
+  /// `TimeoutError`, and a raw `URLError` from a cloud connector whose internal
+  /// retries were exhausted. Cancellation-like errors are excluded by the runner
+  /// before this is called.
+  public static func from(_ error: any Error) -> PolishFailureReason {
+    if let llmError = error as? LLMError {
+      switch llmError {
+      case .classified(let reason):
+        return reason
+      case .invalidAPIKey:
+        // Legacy ambiguous case: read as "key present but rejected". The
+        // connectors now disambiguate the no-key path via `.classified(.apiKeyMissing)`.
+        return .apiKeyRejected
+      case .rateLimited:
+        return .rateLimited
+      case .emptyResponse:
+        return .emptyResponse
+      case .providerUnavailable:
+        return .providerUnreachable
+      case .modelNotFound:
+        return .modelUnavailable
+      case .requestFailed(let msg):
+        return msg.contains("server error") ? .providerServerError : .badRequest
+      case .frameworkUnavailable, .modelNotReady,
+        .unsupportedInputLanguage, .outputLanguageDrift:
+        // Apple-Intelligence-only / silent-skip cases the runner never routes
+        // here (AFM is excluded; language gates are silent skips). Defensive.
+        return .unknown
+      }
+    }
+    if error is TimeoutError { return .timedOut }
+    if let urlError = error as? URLError {
+      switch urlError.code {
+      case .timedOut, .notConnectedToInternet, .cannotFindHost,
+        .cannotConnectToHost, .networkConnectionLost, .dnsLookupFailed,
+        .dataNotAllowed, .internationalRoamingOff:
+        return .providerUnreachable
+      default:
+        return .unknown
+      }
+    }
+    return .unknown
+  }
+}

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprLLM
 import Foundation
 
 /// Every side effect the state-change closure produces, as a value.
@@ -81,9 +82,17 @@ enum PipelineStateChangePlanner {
         resolvedOverlayIntent = .accessibilityToast
       } else if isClipboardFallback {
         resolvedOverlayIntent = .clipboardFallback
-      } else if lastPolishError != nil {
+      } else if let polishError = lastPolishError {
         resolvedOverlayIntent = pipelineOverlayIntent
-        effects.append(.schedulePolishFailedWarning)
+        // #945: a "skipped" notice (no key yet, too long, timed out) is not a
+        // hard failure — the in-window banner shows the actionable
+        // "AI cleanup skipped: ..." message, but the transient
+        // "Polish failed -- using raw text" overlay would contradict it, so
+        // suppress it for skips. Real failures (and the unchanged Apple
+        // Intelligence / legacy strings) still schedule the warning.
+        if !PolishFailureReason.isSkipNotice(polishError) {
+          effects.append(.schedulePolishFailedWarning)
+        }
       } else {
         resolvedOverlayIntent = pipelineOverlayIntent
       }

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -63,7 +63,10 @@ public final class RecoveryTextProcessor {
       inverseTextNormalization: InverseTextNormalizationStep(),
       llmPolish: llmPolish,
       emojiRestore: EmojiRestoreStep())
-    self.runner = TextProcessingRunner()
+    // #945: crash-recovery polish failures stay silent in telemetry (this is a
+    // live-only metric). A recovered take that fails to polish still returns its
+    // `polishError` in the outcome, but no `polish_provider_failed` event fires.
+    self.runner = TextProcessingRunner(captureError: { _, _, _, _, _, _ in })
   }
 
   /// Apply the recording's record-time settings snapshot so recovery replays

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -39,11 +39,29 @@ internal final class TextProcessingRunner {
     @escaping @MainActor () async throws -> TextProcessingContext
   ) async throws -> TextProcessingContext
 
+  /// Telemetry seam (#945) mirroring `timeoutExecutor`. Production default
+  /// delegates to `SentryBreadcrumb.captureError`; `RecoveryTextProcessor`
+  /// injects a no-op so crash-recovery polish failures stay silent, and tests
+  /// inject a spy. Fire-and-forget / non-throwing, so a capture can never break
+  /// the limb-failure continuation (heart & limbs). The trailing `String?` is the
+  /// fingerprint discriminator (#945): `.classified(reason)` bridges every reason
+  /// to one `NSError` code, so the reason tag must split the Sentry issue.
+  typealias CaptureError = @MainActor (
+    any Error, SentryBreadcrumb.ErrorCategory, String, [String: Any]?, [String: String], String?
+  ) -> Void
+
   private let logger: any PipelineLogging
   private let timeoutExecutor: TimeoutExecutor
+  private let captureError: CaptureError
 
   init(
     logger: any PipelineLogging = AppLoggerAdapter(),
+    captureError: @escaping CaptureError = {
+      error, category, stage, extra, tags, fingerprintDetail in
+      SentryBreadcrumb.captureError(
+        error, category: category, stage: stage, extra: extra, tags: tags,
+        fingerprintDetail: fingerprintDetail)
+    },
     timeoutExecutor: @escaping TimeoutExecutor = { seconds, op in
       // nonisolated(unsafe) bridges @MainActor `op` to withThrowingTimeout's
       // @Sendable contract. Safety: op is @MainActor and its return value
@@ -60,6 +78,7 @@ internal final class TextProcessingRunner {
     }
   ) {
     self.logger = logger
+    self.captureError = captureError
     self.timeoutExecutor = timeoutExecutor
   }
 
@@ -95,6 +114,11 @@ internal final class TextProcessingRunner {
       // switched providers mid-polish. Snapshotting here mirrors the step's own
       // entry snapshot of `provider` and the `stepName` snapshot above.
       let polishProviderAtStart = (step as? LLMPolishStep)?.llmProvider
+      // #945: snapshot the attempted model alongside the provider, pre-await. On
+      // failure `context.llmModel` is never stamped (set only on success,
+      // LLMPolishStep.swift), so the step snapshot is the only reliable source of
+      // the model the failed attempt actually used.
+      let polishModelAtStart = (step as? LLMPolishStep)?.llmModel
       do {
         context = try await timeoutExecutor(budgetSeconds) {
           try await step.process(input)
@@ -181,10 +205,53 @@ internal final class TextProcessingRunner {
         } else {
           isSilentPolishSkip = false
         }
+        // #945: a raw `URLError.cancelled` from a torn-down request is not a real
+        // failure — never surface a notice or fire a capture for it. Swift
+        // `CancellationError` is already short-circuited above
+        // (`catch is CancellationError`); this covers the URL-loading variant.
+        let isCancellationLike = (error as? URLError)?.code == .cancelled
         if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
           && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
+          && !isCancellationLike
         {
-          polishError = error.localizedDescription
+          if let provider = polishProviderAtStart, provider != .appleIntelligence {
+            // Cloud (OpenAI/Gemini) or local (Ollama): classify the specific
+            // reason once, then feed it into BOTH the self-contained on-screen
+            // notice and the telemetry reason tag (#945). The capture is
+            // fire-and-forget; the raw transcript/prompt/provider-body never
+            // leave the device (the reason set is closed and content-free).
+            let reason = PolishFailureReason.from(error)
+            polishError = reason.composedMessage(provider: provider)
+            captureError(
+              error,
+              .polishProviderFailed,
+              "polish",
+              [
+                "provider": provider.rawValue,
+                "model": polishModelAtStart ?? "unknown",
+                "is_timeout": isTimeout,
+              ],
+              [
+                "polish.error_case": reason.telemetryTag,
+                "polish.provider": provider.rawValue,
+                "polish.is_timeout": isTimeout ? "true" : "false",
+              ],
+              // Split the Sentry issue per reason: `.classified` bridges every
+              // reason to one NSError code, so the tag alone would merge them.
+              reason.telemetryTag
+            )
+          } else if polishProviderAtStart == .appleIntelligence {
+            // Apple Intelligence: preserve today's exact wording byte-for-byte.
+            // The view now renders `polishError` verbatim, so the runner owns the
+            // "AI polish failed:" prefix here. AFM generation failures are
+            // captured at the polish step, so no capture fires here.
+            polishError = "AI polish failed: " + error.localizedDescription
+          } else {
+            // No polish-provider snapshot: a non-LLMPolishStep surfacing step
+            // (only reachable in tests; production's sole `.surface` step is
+            // LLMPolishStep). Preserve the legacy raw message; no capture.
+            polishError = error.localizedDescription
+          }
         }
         // #1055: emit a dedicated skip event so we can measure how often long
         // dictations bypass on-device polish — input the future 1-hour-recording

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -134,13 +134,20 @@ public enum SentryBreadcrumb {
   ///   - stage: Pipeline stage where the error occurred.
   ///   - extra: Additional key-value pairs for this specific event.
   ///   - snapshot: Optional point-in-time recording state (attached via scope clone).
+  ///   - fingerprintDetail: Optional low-cardinality discriminator appended to the
+  ///     grouping key. Use when a single error TYPE carries its real root cause in
+  ///     an associated value the bridged `NSError` domain/code cannot see (e.g.
+  ///     `LLMError.classified(reason)` — every reason shares one case index, so
+  ///     without this they would all merge into one issue). Pass the stable reason
+  ///     tag so each cause gets its own Sentry issue (#945).
   public static func captureError(
     _ error: any Error,
     category: ErrorCategory,
     stage: String,
     extra: [String: Any]? = nil,
     snapshot: RecordingSnapshot? = nil,
-    tags: [String: String] = [:]
+    tags: [String: String] = [:],
+    fingerprintDetail: String? = nil
   ) {
     let event = Event(level: .error)
     event.message = SentryMessage(
@@ -166,7 +173,8 @@ public enum SentryBreadcrumb {
     // Group by category + underlying error signature so distinct defects that
     // share a broad category get their own stable, release-independent issue
     // instead of merging under one stacktrace bin (#1144).
-    event.fingerprint = Self.handledErrorFingerprint(for: category, error: error)
+    event.fingerprint = Self.handledErrorFingerprint(
+      for: category, error: error, detail: fingerprintDetail)
 
     // Also add a breadcrumb so the error appears in the trail
     add(
@@ -201,12 +209,16 @@ public enum SentryBreadcrumb {
   /// underlying error signature (`domain#code`). The namespace avoids colliding
   /// with native-crash groups; the category is the defect class; the signature
   /// splits distinct root causes that share a broad category so they do not
-  /// silently merge into one issue (#1144). `nonisolated` + pure so the
-  /// non-`@MainActor` test suite calls it directly.
+  /// silently merge into one issue (#1144). The optional `detail` adds a further
+  /// split for error types whose root cause lives in an associated value the
+  /// bridged `domain#code` cannot distinguish (#945 — `LLMError.classified`).
+  /// `nonisolated` + pure so the non-`@MainActor` test suite calls it directly.
   nonisolated static func handledErrorFingerprint(
-    for category: ErrorCategory, error: any Error
+    for category: ErrorCategory, error: any Error, detail: String? = nil
   ) -> [String] {
-    ["handled_error", category.rawValue, structuredDescriptor(error)]
+    var fingerprint = ["handled_error", category.rawValue, structuredDescriptor(error)]
+    if let detail { fingerprint.append(detail) }
+    return fingerprint
   }
 
   /// Stable Sentry grouping key for the AI-availability failure event: namespace
@@ -282,6 +294,12 @@ public enum SentryBreadcrumb {
     case availabilityCheckFailed = "availability_check_failed"
     case providerInitFailed = "provider_init_failed"
     case generationFailed = "generation_failed"
+    /// #945: a cloud (OpenAI/Gemini) or local (Ollama) AI-cleanup attempt failed
+    /// for a reason the user saw on screen. Carries a `polish.error_case` reason
+    /// tag (the closed `PolishFailureReason` set) so a wave of expired keys or a
+    /// provider outage is visible in triage. Apple Intelligence is excluded (its
+    /// generation failures are captured via `generationFailed`).
+    case polishProviderFailed = "polish_provider_failed"
     case fallbackFailed = "fallback_failed"
     case pasteFailed = "paste_failed"
     case stateMismatch = "state_mismatch"

--- a/Tests/EnviousWisprTests/LLM/ConnectorClassifyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ConnectorClassifyTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #945: the per-connector pure `classify(statusCode:bodyString:)` functions.
+/// These split the ambiguous pairs (out-of-credits vs rate-limited; too-long vs
+/// generic 400; rejected-key) from real HTTP status + body fixtures, with no
+/// network mocking — the whole point of keeping classification a pure function.
+@Suite("Connector classify")
+struct ConnectorClassifyTests {
+
+  // MARK: - OpenAI
+
+  @Test("OpenAI 429 insufficient_quota -> out of credits (the mislabel bug fix)")
+  func openAIQuota() {
+    let body = #"{"error":{"type":"insufficient_quota","message":"You exceeded your quota"}}"#
+    #expect(OpenAIConnector.classify(statusCode: 429, bodyString: body) == .outOfCredits)
+  }
+
+  @Test("OpenAI 429 rate limit (no quota marker) -> rate limited")
+  func openAIRate() {
+    let body = #"{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached"}}"#
+    #expect(OpenAIConnector.classify(statusCode: 429, bodyString: body) == .rateLimited)
+  }
+
+  @Test("OpenAI 401 -> key rejected")
+  func openAI401() {
+    #expect(OpenAIConnector.classify(statusCode: 401, bodyString: "") == .apiKeyRejected)
+  }
+
+  @Test("OpenAI 403 -> access denied")
+  func openAI403() {
+    #expect(OpenAIConnector.classify(statusCode: 403, bodyString: "") == .accessDenied)
+  }
+
+  @Test("OpenAI 404 -> model unavailable")
+  func openAI404() {
+    #expect(OpenAIConnector.classify(statusCode: 404, bodyString: "") == .modelUnavailable)
+  }
+
+  @Test("OpenAI 400 context_length_exceeded -> input too long")
+  func openAIContextLength() {
+    let body = #"{"error":{"code":"context_length_exceeded","message":"maximum context length"}}"#
+    #expect(OpenAIConnector.classify(statusCode: 400, bodyString: body) == .inputTooLong)
+  }
+
+  @Test("OpenAI 400 content filter -> content blocked")
+  func openAIContentFilter() {
+    let body = #"{"error":{"code":"content_filter","message":"flagged by content management"}}"#
+    #expect(OpenAIConnector.classify(statusCode: 400, bodyString: body) == .contentBlocked)
+  }
+
+  @Test("OpenAI 400 generic param error -> bad request (NOT input-too-long)")
+  func openAI400Generic() {
+    let body = #"{"error":{"type":"invalid_request_error","param":"temperature"}}"#
+    #expect(OpenAIConnector.classify(statusCode: 400, bodyString: body) == .badRequest)
+  }
+
+  @Test("OpenAI 500/503 -> provider server error")
+  func openAI5xx() {
+    #expect(OpenAIConnector.classify(statusCode: 500, bodyString: "") == .providerServerError)
+    #expect(OpenAIConnector.classify(statusCode: 503, bodyString: "") == .providerServerError)
+  }
+
+  @Test("OpenAI unexpected status -> unknown")
+  func openAIUnknown() {
+    #expect(OpenAIConnector.classify(statusCode: 600, bodyString: "") == .unknown)
+  }
+
+  // MARK: - Gemini
+
+  @Test("Gemini 400 API_KEY_INVALID -> key rejected")
+  func geminiKeyInvalid() {
+    let body = #"{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"API_KEY_INVALID"}}"#
+    #expect(GeminiConnector.classify(statusCode: 400, bodyString: body) == .apiKeyRejected)
+  }
+
+  @Test("Gemini 403 PERMISSION_DENIED -> access denied (was mislabeled invalid key)")
+  func gemini403() {
+    let body = #"{"error":{"code":403,"status":"PERMISSION_DENIED"}}"#
+    #expect(GeminiConnector.classify(statusCode: 403, bodyString: body) == .accessDenied)
+  }
+
+  @Test("Gemini 429 RESOURCE_EXHAUSTED -> rate-or-quota (honest, never plain rate)")
+  func gemini429() {
+    let body = #"{"error":{"code":429,"status":"RESOURCE_EXHAUSTED"}}"#
+    #expect(GeminiConnector.classify(statusCode: 429, bodyString: body) == .rateLimitedOrQuota)
+  }
+
+  @Test("Gemini 400 token-limit message -> input too long")
+  func geminiTokens() {
+    let body =
+      #"{"error":{"message":"The input token count exceeds the maximum number of tokens allowed"}}"#
+    #expect(GeminiConnector.classify(statusCode: 400, bodyString: body) == .inputTooLong)
+  }
+
+  @Test("Gemini 400 prohibited content -> content blocked (best-effort)")
+  func geminiBlocked() {
+    let body = #"{"error":{"message":"blockReason: PROHIBITED_CONTENT"}}"#
+    #expect(GeminiConnector.classify(statusCode: 400, bodyString: body) == .contentBlocked)
+  }
+
+  @Test("Gemini 404 -> model unavailable")
+  func gemini404() {
+    #expect(GeminiConnector.classify(statusCode: 404, bodyString: "") == .modelUnavailable)
+  }
+
+  @Test("Gemini 503 -> provider server error")
+  func gemini5xx() {
+    #expect(GeminiConnector.classify(statusCode: 503, bodyString: "") == .providerServerError)
+  }
+
+  // MARK: - Ollama
+
+  @Test("Ollama 404 -> model unavailable (not pulled)")
+  func ollama404() {
+    #expect(OllamaConnector.classify(statusCode: 404, bodyString: "") == .modelUnavailable)
+  }
+
+  @Test("Ollama 5xx -> provider server error (stays retryable)")
+  func ollama5xx() {
+    let reason = OllamaConnector.classify(statusCode: 500, bodyString: "")
+    #expect(reason == .providerServerError)
+    #expect(reason.isRetryable)
+  }
+
+  @Test("Ollama 400 -> bad request (not retryable)")
+  func ollama400() {
+    let reason = OllamaConnector.classify(statusCode: 400, bodyString: "")
+    #expect(reason == .badRequest)
+    #expect(!reason.isRetryable)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
@@ -50,6 +50,44 @@ struct LLMRetryPolicyTests {
     #expect(!LLMRetryPolicy.isRetryable(error))
   }
 
+  // MARK: - Classified-reason arm (#945)
+
+  @Test(
+    "classified server error stays retryable (5xx-retry preservation regression)")
+  func classifiedServerErrorRetryable() {
+    // Before #945, a 5xx rode on `requestFailed(\"...server error...\")` whose
+    // string-match made it retryable. The connectors now throw
+    // `.classified(.providerServerError)`; this must keep retrying transient
+    // outages or we silently stop retrying them.
+    #expect(LLMRetryPolicy.isRetryable(LLMError.classified(.providerServerError)))
+  }
+
+  @Test("classified rate-limited stays retryable")
+  func classifiedRateLimitedRetryable() {
+    #expect(LLMRetryPolicy.isRetryable(LLMError.classified(.rateLimited)))
+  }
+
+  @Test(
+    "classified fail-fast reasons are NOT retryable",
+    arguments: [
+      PolishFailureReason.apiKeyMissing,
+      PolishFailureReason.apiKeyRejected,
+      PolishFailureReason.accessDenied,
+      PolishFailureReason.outOfCredits,
+      PolishFailureReason.rateLimitedOrQuota,
+      PolishFailureReason.modelUnavailable,
+      PolishFailureReason.inputTooLong,
+      PolishFailureReason.contentBlocked,
+      PolishFailureReason.providerUnreachable,
+      PolishFailureReason.badRequest,
+      PolishFailureReason.emptyResponse,
+      PolishFailureReason.timedOut,
+      PolishFailureReason.unknown,
+    ])
+  func classifiedFailFastNotRetryable(reason: PolishFailureReason) {
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.classified(reason)))
+  }
+
   // MARK: - URLError retryable cases
 
   @Test(

--- a/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
+++ b/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
@@ -1,0 +1,232 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #945: the closed `PolishFailureReason` catalog — the single adapter that owns
+/// telemetry tag, lead-in, per-provider message, retryability, and the mapping
+/// from the errors the runner sees directly to a reason.
+@Suite("PolishFailureReason")
+struct PolishFailureReasonTests {
+
+  // MARK: - Telemetry tags
+
+  @Test(
+    "each reason has its stable low-cardinality telemetry tag",
+    arguments: [
+      (PolishFailureReason.apiKeyMissing, "api_key_missing"),
+      (.apiKeyRejected, "api_key_rejected"),
+      (.accessDenied, "access_denied"),
+      (.outOfCredits, "out_of_credits"),
+      (.rateLimited, "rate_limited"),
+      (.rateLimitedOrQuota, "rate_or_quota"),
+      (.modelUnavailable, "model_unavailable"),
+      (.inputTooLong, "input_too_long"),
+      (.contentBlocked, "content_blocked"),
+      (.providerUnreachable, "provider_unreachable"),
+      (.providerServerError, "provider_server_error"),
+      (.badRequest, "bad_request"),
+      (.emptyResponse, "empty_response"),
+      (.timedOut, "timed_out"),
+      (.unknown, "unknown"),
+    ])
+  func telemetryTags(reason: PolishFailureReason, expected: String) {
+    #expect(reason.telemetryTag == expected)
+  }
+
+  @Test("telemetry tags are unique across all reasons")
+  func telemetryTagsUnique() {
+    let tags = PolishFailureReason.allCases.map(\.telemetryTag)
+    #expect(Set(tags).count == tags.count)
+  }
+
+  // MARK: - Lead-in (skipped vs failed)
+
+  @Test(
+    "not-really-broken reasons lead with 'AI cleanup skipped:'",
+    arguments: [
+      PolishFailureReason.apiKeyMissing,
+      PolishFailureReason.inputTooLong,
+      PolishFailureReason.timedOut,
+    ])
+  func skippedLeadIn(reason: PolishFailureReason) {
+    #expect(reason.leadIn == .skipped)
+    #expect(reason.leadIn.text == "AI cleanup skipped:")
+  }
+
+  @Test(
+    "real-error reasons lead with 'AI polish failed:'",
+    arguments: [
+      PolishFailureReason.apiKeyRejected,
+      PolishFailureReason.accessDenied,
+      PolishFailureReason.outOfCredits,
+      PolishFailureReason.rateLimited,
+      PolishFailureReason.rateLimitedOrQuota,
+      PolishFailureReason.modelUnavailable,
+      PolishFailureReason.contentBlocked,
+      PolishFailureReason.providerUnreachable,
+      PolishFailureReason.providerServerError,
+      PolishFailureReason.badRequest,
+      PolishFailureReason.emptyResponse,
+      PolishFailureReason.unknown,
+    ])
+  func failedLeadIn(reason: PolishFailureReason) {
+    #expect(reason.leadIn == .failed)
+    #expect(reason.leadIn.text == "AI polish failed:")
+  }
+
+  // MARK: - Retryability
+
+  @Test("only server-error and rate-limited are retryable")
+  func retryability() {
+    for reason in PolishFailureReason.allCases {
+      let expected = reason == .providerServerError || reason == .rateLimited
+      #expect(reason.isRetryable == expected, "\(reason) retryable should be \(expected)")
+    }
+  }
+
+  // MARK: - Messages (copy)
+
+  @Test("the out-of-credits message names billing, never 'rate limited' (the bug it fixes)")
+  func outOfCreditsCopy() {
+    let msg = PolishFailureReason.outOfCredits.composedMessage(provider: .openAI)
+    #expect(
+      msg == "AI polish failed: your OpenAI account is out of credits. Check your provider billing."
+    )
+    #expect(!msg.lowercased().contains("rate limit"))
+  }
+
+  @Test("missing-key message uses the skipped lead-in and points to Settings")
+  func apiKeyMissingCopy() {
+    let msg = PolishFailureReason.apiKeyMissing.composedMessage(provider: .gemini)
+    #expect(msg == "AI cleanup skipped: no Gemini API key set yet. Add one in Settings.")
+  }
+
+  @Test("Gemini rate-or-quota copy names BOTH (Gemini cannot split them)")
+  func rateOrQuotaCopy() {
+    let msg = PolishFailureReason.rateLimitedOrQuota.composedMessage(provider: .gemini)
+    #expect(msg.contains("rate or quota"))
+    #expect(msg.contains("billing"))
+  }
+
+  @Test("model-unavailable and unreachable have distinct Ollama vs cloud variants")
+  func ollamaSpecificCopy() {
+    let cloudModel = PolishFailureReason.modelUnavailable.message(provider: .openAI)
+    let ollamaModel = PolishFailureReason.modelUnavailable.message(provider: .ollama)
+    #expect(cloudModel.contains("OpenAI model"))
+    #expect(ollamaModel.contains("Ollama"))
+    #expect(cloudModel != ollamaModel)
+
+    let cloudReach = PolishFailureReason.providerUnreachable.message(provider: .gemini)
+    let ollamaReach = PolishFailureReason.providerUnreachable.message(provider: .ollama)
+    #expect(cloudReach.contains("internet connection"))
+    #expect(ollamaReach.contains("Start Ollama"))
+    #expect(cloudReach != ollamaReach)
+  }
+
+  @Test("the generic fallback lines read cleanly after their lead-in (no restated lead-in)")
+  func genericFallbackCopyTightened() {
+    // Founder-approved tightening (2026-06-22): these three compose without
+    // repeating the lead-in (no "AI cleanup skipped: AI cleanup took too long").
+    #expect(
+      PolishFailureReason.timedOut.composedMessage(provider: .openAI)
+        == "AI cleanup skipped: the dictation took too long. Your original text was pasted unchanged."
+    )
+    #expect(
+      PolishFailureReason.badRequest.composedMessage(provider: .openAI)
+        == "AI polish failed: a configuration problem stopped it. Your original text was pasted unchanged."
+    )
+    #expect(
+      PolishFailureReason.unknown.composedMessage(provider: .openAI)
+        == "AI polish failed: an unexpected error stopped it. Your original text was pasted unchanged."
+    )
+  }
+
+  @Test("composedMessage is exactly '<leadIn> <message>'")
+  func composedShape() {
+    for reason in PolishFailureReason.allCases {
+      let composed = reason.composedMessage(provider: .openAI)
+      let expected = "\(reason.leadIn.text) \(reason.message(provider: .openAI))"
+      #expect(composed == expected)
+    }
+  }
+
+  @Test("no message uses em-dashes or en-dashes (human-facing copy rule)")
+  func noFancyDashes() {
+    for reason in PolishFailureReason.allCases {
+      for provider in [LLMProvider.openAI, .gemini, .ollama] {
+        let msg = reason.composedMessage(provider: provider)
+        #expect(!msg.contains("\u{2014}"), "\(reason)/\(provider) contains em-dash")
+        #expect(!msg.contains("\u{2013}"), "\(reason)/\(provider) contains en-dash")
+      }
+    }
+  }
+
+  // MARK: - from(_:) mapping
+
+  @Test("from unwraps the .classified carrier to its reason")
+  func fromUnwrapsClassified() {
+    for reason in PolishFailureReason.allCases {
+      #expect(PolishFailureReason.from(LLMError.classified(reason)) == reason)
+    }
+  }
+
+  @Test(
+    "from maps the legacy LLMError cases connectors still throw on the polish path",
+    arguments: [
+      (LLMError.invalidAPIKey, PolishFailureReason.apiKeyRejected),
+      (.rateLimited, .rateLimited),
+      (.emptyResponse, .emptyResponse),
+      (.providerUnavailable, .providerUnreachable),
+      (.modelNotFound("llama3"), .modelUnavailable),
+      (.requestFailed("Ollama server error (HTTP 503)"), .providerServerError),
+      (.requestFailed("Invalid response"), .badRequest),
+    ])
+  func fromMapsLegacyCases(error: LLMError, expected: PolishFailureReason) {
+    #expect(PolishFailureReason.from(error) == expected)
+  }
+
+  @Test("from maps the runner's own TimeoutError to timedOut")
+  func fromMapsTimeout() {
+    #expect(PolishFailureReason.from(TimeoutError(seconds: 5)) == .timedOut)
+  }
+
+  @Test(
+    "from maps connectivity URLErrors to providerUnreachable",
+    arguments: [
+      URLError.Code.notConnectedToInternet,
+      URLError.Code.cannotFindHost,
+      URLError.Code.cannotConnectToHost,
+      URLError.Code.networkConnectionLost,
+      URLError.Code.timedOut,
+      URLError.Code.dnsLookupFailed,
+    ])
+  func fromMapsURLErrors(code: URLError.Code) {
+    #expect(PolishFailureReason.from(URLError(code)) == .providerUnreachable)
+  }
+
+  @Test("from maps an unrecognized error to unknown")
+  func fromMapsUnknown() {
+    #expect(PolishFailureReason.from(NSError(domain: "x", code: 1)) == .unknown)
+  }
+
+  // MARK: - Adversarial (matcher-set-adversarial-tests)
+
+  @Test("a rate limit is NOT classified as out-of-credits, and vice versa")
+  func rateVsCreditsDistinct() {
+    #expect(PolishFailureReason.rateLimited != .outOfCredits)
+    #expect(
+      PolishFailureReason.rateLimited.telemetryTag != PolishFailureReason.outOfCredits.telemetryTag)
+    // The out-of-credits user must never be told to "try again in a moment".
+    #expect(
+      !PolishFailureReason.outOfCredits.message(provider: .openAI).lowercased().contains(
+        "try again"))
+  }
+
+  @Test("a present-but-rejected key is NOT the missing-key (skipped) reason")
+  func rejectedVsMissingDistinct() {
+    #expect(PolishFailureReason.apiKeyRejected.leadIn == .failed)
+    #expect(PolishFailureReason.apiKeyMissing.leadIn == .skipped)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprLLM
 import Foundation
 import Testing
 
@@ -116,6 +117,49 @@ struct PipelineStateChangePlannerTests {
     #expect(plan.effects.contains(.appendCompletedTranscript))
     #expect(plan.effects.contains(.reportDictationCompleted))
     #expect(!plan.effects.contains(.cancelPendingWarning))
+  }
+
+  @Test(
+    "complete + SKIPPED polish notice -> overlay shows but NO failure warning (#945)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/945",
+      "the transient 'Polish failed' overlay must not contradict an 'AI cleanup skipped:' banner"
+    )
+  )
+  func completeSkippedPolishSuppressesWarning() {
+    // A real skip reason's composed notice ("AI cleanup skipped: no OpenAI API
+    // key set yet. ...") must NOT schedule the hard-failure overlay.
+    let skipNotice = PolishFailureReason.apiKeyMissing.composedMessage(provider: .openAI)
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: skipNotice,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.showOverlay(.hidden)))
+    #expect(!plan.effects.contains(.schedulePolishFailedWarning))
+    // Still a completed dictation: telemetry + history append are unaffected.
+    #expect(plan.effects.contains(.appendCompletedTranscript))
+    #expect(plan.effects.contains(.reportDictationCompleted))
+  }
+
+  @Test("complete + real (failed) polish notice -> failure warning still fires (#945)")
+  func completeFailedPolishStillSchedulesWarning() {
+    // A real hard-failure reason's composed notice ("AI polish failed: your
+    // OpenAI account is out of credits. ...") must still schedule the overlay —
+    // the skip detector must not over-match the "AI polish failed:" lead-in.
+    let failNotice = PolishFailureReason.outOfCredits.composedMessage(provider: .openAI)
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: failNotice,
+      hasCurrentTranscript: true
+    )
+    #expect(plan.effects.contains(.schedulePolishFailedWarning))
   }
 
   @Test("complete + success (no fallback, no polish error) -> no warning, telemetry fires")

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -1,0 +1,246 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #945: the runner's classify -> composed-notice + telemetry path. These run a
+/// REAL `LLMPolishStep` (with an injected throwing polisher) through the runner,
+/// because the capture/compose path only fires for an actual polish step — the
+/// runner snapshots `(step as? LLMPolishStep)?.llmProvider/.llmModel` to know the
+/// provider and to exclude Apple Intelligence. A bare spy step has no provider,
+/// so the existing `TextProcessingRunnerTests` (which use bare spies) keep their
+/// legacy raw-message assertions and live in that suite.
+@MainActor
+@Suite("TextProcessingRunner telemetry + composed notice")
+struct TextProcessingRunnerCaptureTests {
+
+  /// A 16-word sentence that clears the polish step's <=3-word short-circuit
+  /// (LLMPolishStep.minWordsForPolish) so the injected polisher actually runs.
+  private static let longTranscript =
+    "so i was thinking we could maybe ship the new thing some time next week or so"
+
+  /// Records every runner capture so a test can assert exactly one fired with the
+  /// right reason tag, provider, and metadata.
+  @MainActor
+  final class CaptureSpy {
+    struct Call {
+      let category: SentryBreadcrumb.ErrorCategory
+      let stage: String
+      let extra: [String: Any]?
+      let tags: [String: String]
+      let fingerprintDetail: String?
+    }
+    private(set) var calls: [Call] = []
+    func sink(
+      _ error: any Error, _ category: SentryBreadcrumb.ErrorCategory,
+      _ stage: String, _ extra: [String: Any]?, _ tags: [String: String],
+      _ fingerprintDetail: String?
+    ) {
+      calls.append(
+        Call(
+          category: category, stage: stage, extra: extra, tags: tags,
+          fingerprintDetail: fingerprintDetail))
+    }
+  }
+
+  /// Polisher that always throws the supplied error. Implements only the legacy
+  /// `text:` method; the planner path reaches it via the protocol's default
+  /// `envelope:` bridge (same pattern as the reentrancy suite).
+  private struct ThrowingPolisher: TranscriptPolisher {
+    let makeError: @Sendable () -> any Error
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      throw makeError()
+    }
+  }
+
+  private func makeStep(
+    provider: LLMProvider,
+    model: String,
+    throwing makeError: @escaping @Sendable () -> any Error
+  ) -> LLMPolishStep {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = provider
+    step.llmModel = model
+    step.makePolisher = { _, _, _ in ThrowingPolisher(makeError: makeError) }
+    return step
+  }
+
+  private func makeRunner(_ spy: CaptureSpy) -> TextProcessingRunner {
+    // throwBelowSeconds 0.0 -> the executor runs every step (never injects a
+    // timeout); the polisher's own throw drives the failure.
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
+    return TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+  }
+
+  // MARK: - Cloud / local classified failures
+
+  @Test("cloud rejected key -> 'rejected' notice + api_key_rejected tag (one capture)")
+  func cloudKeyRejected() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { LLMError.invalidAPIKey }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(
+      result.polishError
+        == "AI polish failed: OpenAI rejected your API key. Check or replace it in Settings.")
+    #expect(spy.calls.count == 1)
+    let call = try #require(spy.calls.first)
+    #expect(call.category == .polishProviderFailed)
+    #expect(call.stage == "polish")
+    #expect(call.tags["polish.error_case"] == "api_key_rejected")
+    #expect(call.tags["polish.provider"] == "openAI")
+    #expect(call.tags["polish.is_timeout"] == "false")
+    #expect(call.extra?["provider"] as? String == "openAI")
+    #expect(call.extra?["model"] as? String == "gpt-4o-mini")
+    // #945: the reason also splits the Sentry issue (fingerprint discriminator).
+    #expect(call.fingerprintDetail == "api_key_rejected")
+  }
+
+  @Test("cloud missing key -> skipped lead-in + api_key_missing tag")
+  func cloudKeyMissing() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .gemini, model: "gemini-2.0-flash") {
+      LLMError.classified(.apiKeyMissing)
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(
+      result.polishError == "AI cleanup skipped: no Gemini API key set yet. Add one in Settings.")
+    #expect(spy.calls.count == 1)
+    #expect(spy.calls.first?.tags["polish.error_case"] == "api_key_missing")
+    #expect(spy.calls.first?.tags["polish.provider"] == "gemini")
+  }
+
+  @Test("cloud out-of-credits -> billing notice + out_of_credits tag (the mislabel fix)")
+  func cloudOutOfCredits() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      LLMError.classified(.outOfCredits)
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(
+      result.polishError
+        == "AI polish failed: your OpenAI account is out of credits. Check your provider billing.")
+    #expect(spy.calls.first?.tags["polish.error_case"] == "out_of_credits")
+  }
+
+  @Test("Ollama unreachable -> Ollama-specific notice + provider_unreachable tag")
+  func ollamaUnreachable() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .ollama, model: "llama3.2") {
+      LLMError.classified(.providerUnreachable)
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(
+      result.polishError == "AI polish failed: Ollama isn't reachable. Start Ollama and try again.")
+    #expect(spy.calls.first?.tags["polish.error_case"] == "provider_unreachable")
+    #expect(spy.calls.first?.tags["polish.provider"] == "ollama")
+    #expect(spy.calls.first?.extra?["model"] as? String == "llama3.2")
+  }
+
+  // MARK: - Timeout
+
+  @Test("runner polish-budget timeout -> timed_out tag + is_timeout=true")
+  func polishTimeout() async throws {
+    let spy = CaptureSpy()
+    // Polish step's cloud budget is 5s; throwing below 6s injects a TimeoutError
+    // for it (the executor short-circuits before calling the polisher).
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 6.0)
+    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      LLMError.requestFailed("unused")
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.count == 1)
+    #expect(spy.calls.first?.tags["polish.error_case"] == "timed_out")
+    #expect(spy.calls.first?.tags["polish.is_timeout"] == "true")
+    #expect(result.polishError?.hasPrefix("AI cleanup skipped:") == true)
+  }
+
+  // MARK: - Apple Intelligence is excluded
+
+  @Test("Apple Intelligence keeps today's exact wording and fires NO runner capture")
+  func appleIntelligenceExcluded() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") {
+      LLMError.requestFailed("boom")
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(
+      result.polishError == "AI polish failed: "
+        + LLMError.requestFailed("boom").localizedDescription)
+    #expect(spy.calls.isEmpty)
+  }
+
+  // MARK: - No-false-positive boundary
+
+  @Test("a cancelled cloud request fires no capture and surfaces no notice")
+  func cancellationLikeIgnored() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { URLError(.cancelled) }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(result.polishError == nil)
+    #expect(spy.calls.isEmpty)
+  }
+
+  @Test("a successful polish fires no capture")
+  func successNoCapture() async throws {
+    let spy = CaptureSpy()
+    let runner = makeRunner(spy)
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .openAI
+    step.llmModel = "gpt-4o-mini"
+    step.makePolisher = { _, _, _ in SucceedingPolisher() }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(result.polishError == nil)
+    #expect(spy.calls.isEmpty)
+  }
+
+  /// Polisher that returns clean text (no throw) for the success-path test.
+  private struct SucceedingPolisher: TranscriptPolisher {
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      LLMResult(polishedText: "So I was thinking we could ship the new thing next week.")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
@@ -64,6 +64,43 @@ struct SentryFingerprintTests {
     #expect(fp.contains { $0.contains(secret) } == false)
   }
 
+  // MARK: - detail discriminator (#945)
+
+  @Test("optional detail appends a fourth fingerprint component")
+  func detailAppends() {
+    let err = NSError(domain: "EnviousWisprLLM.LLMError", code: 10)
+    let fp = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: err, detail: "out_of_credits")
+    #expect(
+      fp == [
+        "handled_error", "polish_provider_failed", "EnviousWisprLLM.LLMError#10", "out_of_credits",
+      ]
+    )
+  }
+
+  /// The #945 property: `LLMError.classified` bridges every reason to ONE NSError
+  /// code, so without the detail these would merge into one issue. The detail
+  /// must split them.
+  @Test("same category + same domain#code but different detail splits the issue")
+  func detailSplitsSharedCode() {
+    let err = NSError(domain: "EnviousWisprLLM.LLMError", code: 10)
+    let credits = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: err, detail: "out_of_credits")
+    let rate = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: err, detail: "rate_limited")
+    #expect(credits != rate)
+  }
+
+  @Test("nil detail leaves the legacy three-component fingerprint unchanged")
+  func nilDetailIsBackwardCompatible() {
+    let err = NSError(domain: "EnviousWispr", code: -3)
+    let withNil = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, detail: nil)
+    let legacy = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: err)
+    #expect(withNil == legacy)
+    #expect(withNil == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
+  }
+
   // MARK: - AI-failure fingerprint
 
   @Test("AI-failure fingerprint is namespace + sorted reason rawValues")


### PR DESCRIPTION
Updates #945 (gap 1 of the pre-launch Sentry audit — AI-polish failures were silent for OpenAI/Gemini/Ollama).

## What this does
Classifies the **specific** reason an AI-cleanup attempt fails on a user's own cloud key (OpenAI/Gemini) or local model (Ollama), then feeds that one classified reason into BOTH:
1. a reworded, lead-in-varied, actionable on-screen notice, and
2. a new `polish_provider_failed` Sentry capture carrying a `polish.error_case` reason tag.

Cloud (OpenAI/Gemini) + local (Ollama) only. Apple Intelligence is byte-identical (founder decision).

**Fixes the active mislabel bug:** a 429 `insufficient_quota` (out of credits) was bucketed with rate limits, so the user was told "rate limited, try later" and waited forever. Now: "your OpenAI account is out of credits. Check your provider billing."

## Design — single adapter
One new `LLMError.classified(PolishFailureReason)` carrier threads the rich reason through the existing `throws LLMError` contract. `PolishFailureReason` is the single catalog owning `telemetryTag` + `leadIn` + per-provider `message` + `isRetryable`. Connectors classify via a pure `classify(statusCode:bodyString:)`; the runner unwraps once, composes the notice, and fires the capture. Adding a future warning is a one-file change.

Lead-in varies: **"AI polish failed:"** for real errors, **"AI cleanup skipped:"** for not-set-up / too-long / timeout.

## Safety / no false positives
- Capture is fire-and-forget, non-throwing (heart path can't regress; raw text always pastes).
- Apple Intelligence excluded; crash-recovery uses a no-op capture sink (stays silent); cancellation-like errors (`URLError.cancelled`) excluded.
- Privacy: telemetry + notice use the closed reason set; no transcript / prompt / provider body ever leaves the device.

## Review history (local Codex code-diff, 3 rounds)
- **r1** caught a real contradiction: the post-completion "Polish failed -- using raw text" overlay still fired for `.skipped` notices. Fixed (`PolishFailureReason.isSkipNotice` + planner gate).
- **r2** caught real Sentry fingerprint merging: `.classified` bridges every reason to one `NSError` code, so all reasons collapsed into one issue. Fixed via a `fingerprintDetail` discriminator.
- **r3** clean.

## Validation
- `scripts/xcode-test.sh` green (1972 tests; +~70 new).
- Live UAT (forced Ollama-unreachable): polish failed, **raw text still pasted** (heart path); app log confirmed end-to-end classification `provider_unreachable`; settings restored after.
- New tests: catalog (tags/lead-ins/per-provider copy/retryability/`from()` mapping/no em-dashes/adversarial rate≠credits), per-connector `classify` fixtures, retry-policy 5xx-preservation, runner capture/compose gating, planner skip-suppression, Sentry fingerprint split.

## Open founder-confirm item (copy)
Three approved generic lines read a little redundantly once the varied lead-in is prepended (e.g. "AI cleanup skipped: AI cleanup took too long and was skipped"). Shipped verbatim per no-unilateral-copy-change; will tighten if the founder prefers.