### PR TITLE
docs(app): fix stale brain-file path refs in app-shell comments

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
@@ -8,8 +8,8 @@ import Foundation
 /// source, current settings, paste-intent inference, and active-pipeline idle
 /// state at recording-start dispatch. Stateless: no stored state, no lifecycle.
 ///
-/// Extracted from `the former root state(triggerSource:)` per
-/// epic #763 PR5. Decision-tree rule #17 in `.claude/knowledge/appstate-ownership.md`.
+/// Extracted from the former root state's recording-config construction per
+/// epic #763 PR5. Decision-tree rule #17 in `state-ownership.md`.
 enum DictationSessionConfigFactory {
   @MainActor
   static func make(

--- a/Sources/EnviousWisprAppKit/App/LanguageSuggestionPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/LanguageSuggestionPresenter.swift
@@ -14,7 +14,7 @@ import Foundation
 /// (auto-switch hints, vocabulary suggestions, language-display preferences,
 /// future LID surfaces) do NOT belong here — they get their own home. The name
 /// `LanguageSuggestionPresenter` is broad on purpose so views inject one stable
-/// type, but the scope is narrow. See `appstate-ownership.md` decision-tree #6.
+/// type, but the scope is narrow. See `state-ownership.md` decision-tree #6.
 ///
 /// Heart-path: pure limb. All methods no-throw. Persistence is best-effort
 /// (corrupted UserDefaults: log breadcrumb, delete bad key, start empty).


### PR DESCRIPTION
Closes #822 — the last shovel-ready remainder of the post-#763 dead-code sweep (epic #821).

## What
Comment-only cleanup in two app-shell files:
- Rename the ownership decision-tree filename `appstate-ownership.md` → `state-ownership.md` (the brain file was renamed in epic #763) in two doc comments.
- Drop the leading local-config path prefix on the `DictationSessionConfigFactory` ref so it matches the sibling `LanguageSuggestionPresenter` comment (bare filename — no shipped-code reference to the local-only folder, per the no-shipped-dotfolder-ref convention).
- Clean the AppState-scrub artifact `the former root state(triggerSource:)` (a dangling method-signature fragment from the #763 scrub).

## Risk
Zero runtime behavior change — comments only, no symbols, no control flow. Below the zero-blast-radius threshold.

## Validation
- Local Codex code-diff review: clean (*"only updates comments and does not change runtime behavior; no actionable bug introduced"*).
- CI `build-check` compiles it.

council-skip: zero-blast-radius (user-facing copy / comment-only)