### PR TITLE
fix(ui): close onboarding Accessibility revocation hole (#735)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -42,6 +42,9 @@ final class OnboardingV2ViewModel {
 
   var micGranted = false
   var accessibilityGranted = false
+  /// #735: one-time guard so the grant telemetry + autoCopy default fire once per
+  /// onboarding session even though `accessibilityGranted` now toggles both ways. Never reset.
+  var hasAppliedAxGrant = false
 
   var downloadError: String?
   /// Raw error details for support diagnostics (hidden behind "Copy error details" button).
@@ -797,6 +800,14 @@ private struct PermissionsPhaseView: View {
       VStack(spacing: 8) {
         let bothGranted = viewModel.micGranted && viewModel.accessibilityGranted
         Button {
+          // #735: synchronous live recheck closes the stale-click race — revoke
+          // Accessibility then click Continue before the next poll. Block the
+          // advance and re-disable the gate if AX is no longer trusted.
+          permissions.refreshAccessibilityStatus()
+          guard permissions.accessibilityGranted else {
+            viewModel.accessibilityGranted = false
+            return
+          }
           viewModel.currentScreen = .ready
         } label: {
           Text("Continue")
@@ -817,7 +828,10 @@ private struct PermissionsPhaseView: View {
       permissions.refreshAccessibilityStatus()
       viewModel.micGranted = permissions.hasMicrophonePermission
       viewModel.accessibilityGranted = permissions.accessibilityGranted
+      // #735: relaunch-into-granted — pre-set the one-time latch so the poll loop
+      // doesn't re-fire grant telemetry for a permission granted in a prior session.
       if viewModel.accessibilityGranted {
+        viewModel.hasAppliedAxGrant = true
         settings.autoCopyToClipboard = true
       }
     }
@@ -836,13 +850,26 @@ private struct PermissionsPhaseView: View {
       elapsed += 2
 
       permissions.refreshAccessibilityStatus()
-      if permissions.accessibilityGranted && !viewModel.accessibilityGranted {
-        viewModel.accessibilityGranted = true
+      let axNow = permissions.accessibilityGranted
+
+      // One-time side effects (grant telemetry + autoCopy default): latch-guarded so
+      // they fire once per onboarding session, not on every poll and not again if the
+      // user revokes then re-grants.
+      if axNow && !viewModel.hasAppliedAxGrant {
+        viewModel.hasAppliedAxGrant = true
         settings.autoCopyToClipboard = true
         TelemetryService.shared.onboardingStepCompleted(
           step: "accessibility_permission", result: "granted")
       }
 
+      // #735 revocation fix: mirror LIVE Accessibility state BOTH directions so a
+      // grant-then-revoke (System Settings, before Continue) re-disables the gate
+      // within one poll cycle. Mic stays one-way below — its source is cached.
+      viewModel.accessibilityGranted = axNow
+
+      // Mic stays one-way: hasMicrophonePermission reads cached microphoneStatus
+      // (PermissionsService.swift:49-50), not a live check, so mirroring it both
+      // ways could flip a true flag false from stale cache.
       if permissions.hasMicrophonePermission && !viewModel.micGranted {
         viewModel.micGranted = true
         TelemetryService.shared.onboardingStepCompleted(step: "mic_permission", result: "granted")


### PR DESCRIPTION
## Summary

Closes the one-way-latch hole in the onboarding Accessibility gate (the gate itself shipped in PR #756). `pollPermissions()` only flipped `accessibilityGranted` false→true, never back, so a user who granted Accessibility then revoked it (System Settings, before pressing Continue) still slipped through — the Codex P2 finding attached to #735.

## Changes (one file, `OnboardingV2View.swift`)

- **Two-way Accessibility mirror** in the poll loop: `viewModel.accessibilityGranted = axNow` every cycle, so the gate reflects live state both directions.
- **`hasAppliedAxGrant` latch** so the grant telemetry + autoCopy default fire exactly once per onboarding session even though the gate flag now toggles (no double-fire on revoke-then-regrant).
- **Synchronous AX recheck** in the Continue action — blocks advancing if AX was revoked between the last poll and the click.
- **Mic stays one-way** by design: `hasMicrophonePermission` reads a cached status (`PermissionsService.swift:49-50`), not a live check, so a two-way mirror could flip a true flag false from stale cache.

## Validation

- Codex code-diff review (xhigh): no actionable findings.
- Live UAT (debug dev build, real onboarding window via AX inspection):
  - Permissions screen with AX granted → Accessibility row shows "Granted", no trust banner, Continue gated only by mic. ✅
  - Fresh process with AX revoked at the TCC DB level → Accessibility row shows "Grant", trust banner appears, Continue disabled. ✅ (read path + gate correct)
  - **Finding:** macOS caches `AXIsProcessTrusted()` per running process and defers Accessibility revocation until quit ("won't be able to control your computer until it is quit"). So the *mid-session* revoke does not flip within the running process on macOS 26 — the OS retains trust until relaunch. The fix is therefore a correctness/consistency improvement (gate now mirrors the source of truth that `.onAppear` already mirrored, plus the synchronous Continue recheck) and is harmless; the targeted scenario is largely self-healing at the OS level on current macOS.

Tier SMALL. No unit tests (UI/permissions is runtime-only-exempt per test-obligations).

Part of #735.