### PR TITLE
refactor(asr,pipeline,audio): remove confirmed-dead seams (#824)

### DIFF
--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -1,37 +1,16 @@
 import CryptoKit
 import EnviousWisprCore
-@preconcurrency import FluidAudio
 import Foundation
 
-/// Manages Parakeet model download with stall detection, Cloudflare R2 fallback,
-/// and checksum verification.
+/// Verifies the SHA-256 checksum of the downloaded Parakeet encoder model.
 ///
-/// This is a Heart bootstrap dependency — the app cannot transcribe without the model.
-/// If download progress plumbing breaks, it must not destabilize the actual ASR runtime.
-/// Worst case: missing progress UI, not broken model install.
-///
-/// Flow:
-/// 1. Try FluidAudio's normal HuggingFace download path
-/// 2. Monitor for stalls (no progress for `stallTimeout` seconds)
-/// 3. If stalled or failed, fall back to Cloudflare R2 direct download
-/// 4. Verify SHA-256 checksum of key model files
-/// 5. Load models via FluidAudio's compile path
-// periphery:ignore - verifyChecksum() and StallTracker are used by ParakeetBackend; actor instance methods are vestigial
-actor ModelDownloadManager {
-
-  /// Progress callback: (fractionCompleted, phaseString, detailString)
-  typealias ProgressCallback = @Sendable (Double, String, String) -> Void
+/// Heart bootstrap helper. `ParakeetBackend` downloads the model via FluidAudio
+/// directly (using `StallTracker` for stall detection) and calls
+/// `verifyChecksum()` afterward as defense-in-depth. A mismatch logs a warning
+/// but never blocks — a corrupted model is surfaced, not fatally gated.
+enum ModelDownloadManager {
 
   // MARK: - Configuration
-
-  /// Seconds of no byte progress before declaring a stall and switching to fallback.
-  private static let stallTimeout: TimeInterval = 20
-
-  /// Cloudflare R2 base URL for model fallback.
-  /// The model archive is hosted as a single .tar.gz at this URL.
-  /// Empty string = fallback disabled (no R2 bucket configured yet).
-  private static let r2BaseURL =
-    "https://models.enviouswispr.com/parakeet-tdt-0.6b-v3-coreml.tar.gz"
 
   /// SHA-256 checksum of the Encoder.mlmodelc/model.mlmodel file (the largest, most critical file).
   /// Empty string = verification skipped (checksum not yet computed for current model version).
@@ -45,169 +24,12 @@ actor ModelDownloadManager {
     return appSupport.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
   }()
 
-  init() {}
-
-  // MARK: - Public API
-
-  /// Download and load Parakeet v3 models with stall detection and optional R2 fallback.
-  /// Returns loaded AsrModels ready for transcription.
-  func downloadAndLoad(progressCallback: ProgressCallback?) async throws -> AsrModels {
-    let stallTracker = StallTracker(timeout: Self.stallTimeout)
-
-    do {
-      // Primary path: FluidAudio's HuggingFace download
-      let models = try await downloadViaFluidAudio(
-        progressCallback: progressCallback,
-        stallTracker: stallTracker
-      )
-
-      // Verify checksum if configured
-      Self.verifyChecksum()
-
-      return models
-    } catch {
-      // If we stalled and R2 is configured, try the fallback
-      if stallTracker.isStalled && !Self.r2BaseURL.isEmpty {
-        progressCallback?(0.01, "Trying alternate download source...", "")
-
-        do {
-          try await downloadViaR2(progressCallback: progressCallback)
-          let models = try await loadOnly(progressCallback: progressCallback)
-          Self.verifyChecksum()
-          return models
-        } catch {
-          throw ModelDownloadError.fallbackFailed(underlying: error)
-        }
-      }
-      throw error
-    }
-  }
-
-  // MARK: - Primary Download (FluidAudio / HuggingFace)
-
-  private func downloadViaFluidAudio(
-    progressCallback: ProgressCallback?,
-    stallTracker: StallTracker
-  ) async throws -> AsrModels {
-    let handler: DownloadUtils.ProgressHandler? = progressCallback.map {
-      callback -> DownloadUtils.ProgressHandler in
-      { progress in
-        // Update stall tracker — lock-based, no actor hop, zero overhead on download thread
-        stallTracker.recordProgress(fraction: progress.fractionCompleted)
-
-        let phase: String
-        let detail: String
-
-        switch progress.phase {
-        case .listing:
-          phase = "Preparing download..."
-          detail = ""
-        case .downloading:
-          phase = "Downloading speech model..."
-          let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
-          let downloadedMB = Int(downloadPct * 460)
-          let pct = Int(downloadPct * 100)
-          detail = "\(downloadedMB) MB of 460 MB (\(pct)%)"
-        case .compiling(let modelName):
-          phase = "Installing model..."
-          detail = modelName
-        }
-        callback(progress.fractionCompleted, phase, detail)
-      }
-    }
-
-    return try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
-  }
-
-  // MARK: - Fallback Download (Cloudflare R2)
-
-  private func downloadViaR2(progressCallback: ProgressCallback?) async throws {
-    guard let url = URL(string: Self.r2BaseURL) else {
-      throw ModelDownloadError.invalidFallbackURL
-    }
-
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("enviouswispr-model-download-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-    defer {
-      try? FileManager.default.removeItem(at: tempDir)
-    }
-
-    let tempArchive = tempDir.appendingPathComponent("model.tar.gz")
-
-    // Download the archive
-    let session = URLSession(configuration: .default)
-    let request = URLRequest(url: url, timeoutInterval: 1800)
-    let (downloadURL, response) = try await session.download(for: request)
-
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      throw ModelDownloadError.fallbackHTTPError(
-        statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1
-      )
-    }
-
-    // Move to our temp location
-    try FileManager.default.moveItem(at: downloadURL, to: tempArchive)
-
-    progressCallback?(0.4, "Extracting model files...", "")
-
-    // Extract tar.gz to the model cache directory
-    let targetDir = Self.modelCacheDir
-    if FileManager.default.fileExists(atPath: targetDir.path) {
-      try FileManager.default.removeItem(at: targetDir)
-    }
-    try FileManager.default.createDirectory(
-      at: targetDir.deletingLastPathComponent(),
-      withIntermediateDirectories: true
-    )
-
-    // Use tar to extract — simpler and more reliable than a Swift tar library
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
-    process.arguments = [
-      "-xzf", tempArchive.path, "-C", targetDir.deletingLastPathComponent().path,
-    ]
-    try process.run()
-    process.waitUntilExit()
-
-    guard process.terminationStatus == 0 else {
-      throw ModelDownloadError.extractionFailed
-    }
-
-    progressCallback?(0.5, "Model files extracted", "")
-  }
-
-  // MARK: - Load Only (after R2 download)
-
-  private func loadOnly(progressCallback: ProgressCallback?) async throws -> AsrModels {
-    let handler: DownloadUtils.ProgressHandler? = progressCallback.map {
-      callback -> DownloadUtils.ProgressHandler in
-      { progress in
-        switch progress.phase {
-        case .compiling(let modelName):
-          callback(0.5 + progress.fractionCompleted * 0.5, "Installing model...", modelName)
-        default:
-          callback(progress.fractionCompleted, "Loading models...", "")
-        }
-      }
-    }
-
-    return try await AsrModels.downloadAndLoad(
-      to: Self.modelCacheDir,
-      version: .v3,
-      progressHandler: handler
-    )
-  }
-
   // MARK: - Checksum Verification
 
   /// Verify the SHA-256 checksum of the encoder model file.
   /// Logs a warning if verification fails but does NOT block — the model may still work.
   /// This is a defense-in-depth measure, not a hard gate.
-  /// Static because it only reads from disk — no actor state needed.
+  /// Static because it only reads from disk — no instance state needed.
   static func verifyChecksum() {
     guard !Self.encoderChecksum.isEmpty else { return }
 
@@ -226,32 +48,6 @@ actor ModelDownloadManager {
           level: .info, category: "ASR"
         )
       }
-    }
-  }
-}
-
-// MARK: - Errors
-
-// periphery:ignore - used within ModelDownloadManager.downloadAndLoad()
-public enum ModelDownloadError: LocalizedError {
-  case stallDetected
-  case invalidFallbackURL
-  case fallbackHTTPError(statusCode: Int)
-  case extractionFailed
-  case fallbackFailed(underlying: any Error)
-
-  public var errorDescription: String? {
-    switch self {
-    case .stallDetected:
-      return "Download stalled — no progress for 20 seconds."
-    case .invalidFallbackURL:
-      return "Fallback download URL is invalid."
-    case .fallbackHTTPError(let code):
-      return "Fallback download failed with HTTP \(code)."
-    case .extractionFailed:
-      return "Failed to extract model files."
-    case .fallbackFailed(let error):
-      return "Both download sources failed: \(error.localizedDescription)"
     }
   }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -105,9 +105,6 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// Flips true on the MainActor inside `audioBufferCaptured` when any buffer
   /// for the active session reaches us. Reset to false when arming.
   private var hasReceivedBufferThisSession: Bool = false
-  /// Uptime-ns captured when the current watchdog armed; threaded into
-  /// `CaptureStallContext` for latency diagnostics.
-  private var stallArmedAtUptimeNs: UInt64 = 0
 
   /// 16kHz mono Float32 format used for buffer reconstruction.
   /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
@@ -221,7 +218,6 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     stallWorkItem?.cancel()
     let armedSession = activeCaptureGeneration
     let armedAtNs = DispatchTime.now().uptimeNanoseconds
-    stallArmedAtUptimeNs = armedAtNs
     let item = Self.makeStallWorkItem(
       armedSession: armedSession, armedAtNs: armedAtNs, proxy: self)
     stallWorkItem = item
@@ -618,7 +614,6 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
             XPCErrorContext(
               kind: .interruptCapturing,
               sessionID: endingSession,
-              timestampNs: firedAt,
               recordingDurationNs: durationNs
             )
           )
@@ -665,7 +660,6 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           XPCErrorContext(
             kind: wasCapturing ? .invalidateCapturing : .invalidateIdle,
             sessionID: wasCapturing ? endingSession : nil,
-            timestampNs: firedAt,
             recordingDurationNs: durationNs
           )
         )

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -124,9 +124,8 @@ public enum XPCErrorKind: String, Sendable {
 public struct XPCErrorContext: Sendable {
   public let kind: XPCErrorKind
   public let sessionID: UInt64?
-  public let timestampNs: UInt64
   /// #455: when the interrupt/invalidate fired while a capture session was
-  /// active, this is `timestampNs - capture-start-uptime-ns`. Nil for idle
+  /// active, this is the elapsed nanoseconds since capture start. Nil for idle
   /// interrupts. Surfaces in the Sentry breadcrumb as
   /// `audio.recording_duration_ms` so triage can distinguish "fired
   /// immediately after start" (likely device binding race) from "fired
@@ -137,12 +136,10 @@ public struct XPCErrorContext: Sendable {
   public init(
     kind: XPCErrorKind,
     sessionID: UInt64?,
-    timestampNs: UInt64,
     recordingDurationNs: UInt64? = nil
   ) {
     self.kind = kind
     self.sessionID = sessionID
-    self.timestampNs = timestampNs
     self.recordingDurationNs = recordingDurationNs
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -20,8 +20,8 @@ import Foundation
 // and `handleXPCReplyFailed(_:)` methods via `WedgeRecoveryRouter`'s
 // `resolveActiveTelemetryTarget()` (PR-4b.4 wires the App router's Parakeet
 // branch). The capture-stall signal — which the kernel DOES consume for
-// control flow — reaches the observer through the kernel's
-// `captureStallTelemetry` fan-out seam (PR-4 §3.9).
+// control flow — reaches the observer the same way, through the driver's
+// `HeartPathTelemetryTarget` conformance (PR-4 §3.9).
 //
 // PR-4a ships this production-unwired: no App-layer caller constructs it. The
 // lifecycle-event sink is injected — PR-4b supplies the production sink
@@ -129,10 +129,9 @@ final class KernelHeartPathTelemetryObserver {
   // App-facing `KernelDictationDriver` conforms to that protocol and forwards
   // its three methods here. The observer is the single telemetry brain.
 
-  /// Capture-stall telemetry. Reached through the kernel's `captureStallTelemetry`
-  /// fan-out seam (PR-4 §3.9) and through the driver's `HeartPathTelemetryTarget`
-  /// conformance. `HeartPathTelemetryEmitter` dedups per session, so a
-  /// double-call is harmless.
+  /// Capture-stall telemetry. Reached through the driver's
+  /// `HeartPathTelemetryTarget` conformance (PR-4 §3.9).
+  /// `HeartPathTelemetryEmitter` dedups per session, so a double-call is harmless.
   func handleCaptureStall(_ ctx: CaptureStallContext) {
     emitter.stallFired(ctx: ctx, isActivelyCapturing: audioCapture.isActivelyCapturing)
   }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -155,56 +155,6 @@ final class KernelLifecycleTelemetrySink {
     self.noAudioCapturedRich = noAudioCapturedRich
   }
 
-  convenience init(
-    backend: ASRBackendType,
-    audioCapture: any AudioCaptureInterface,
-    context: KernelSessionContext,
-    outcome: KernelFinalizationOutcome = KernelFinalizationOutcome(),
-    captureTelemetry: CaptureTelemetryState,
-    telemetryState: KernelTelemetryState = KernelTelemetryState(),
-    modelLoadWedgeTelemetry: @escaping @MainActor () -> KernelModelLoadWedgeTelemetry? = { nil },
-    breadcrumb: @escaping BreadcrumbSink = { stage, message, data in
-      SentryBreadcrumb.add(stage: stage, message: message, level: .info, data: data)
-    },
-    updateRecordingState: @escaping RecordingStateSink = { active, backend, isStreaming in
-      SentryBreadcrumb.updateRecordingState(
-        active: active, backend: backend, isStreaming: isStreaming)
-    },
-    updateAudioRoute: @escaping AudioRouteSink = { route in
-      SentryBreadcrumb.updateAudioRoute(route)
-    },
-    dictationInvoked: @escaping DictationInvokedSink = { trigger, mode, target in
-      TelemetryService.shared.dictationInvoked(
-        triggerSource: trigger, inputMode: mode, targetApp: target)
-    },
-    modelLoadWedged: @escaping @MainActor (_ backend: String) -> Void,
-    captureError: @escaping CaptureErrorSink = { error, category, stage, extra in
-      SentryBreadcrumb.captureError(error, category: category, stage: stage, extra: extra)
-    },
-    captureErrorWithSnapshot: @escaping SnapshotCaptureErrorSink = {
-      error, category, stage, extra, snapshot in
-      SentryBreadcrumb.captureError(
-        error, category: category, stage: stage, extra: extra, snapshot: snapshot)
-    }
-  ) {
-    self.init(
-      backend: backend,
-      audioCapture: audioCapture,
-      context: context,
-      outcome: outcome,
-      captureTelemetry: captureTelemetry,
-      telemetryState: telemetryState,
-      modelLoadWedgeTelemetry: modelLoadWedgeTelemetry,
-      breadcrumb: breadcrumb,
-      updateRecordingState: updateRecordingState,
-      updateAudioRoute: updateAudioRoute,
-      dictationInvoked: dictationInvoked,
-      modelLoadWedged: { backend, _ in modelLoadWedged(backend) },
-      captureError: captureError,
-      captureErrorWithSnapshot: captureErrorWithSnapshot
-    )
-  }
-
   /// Switch over the 12-case lifecycle vocabulary and emit each PR-1 §B.7.2
   /// kernel-owned event with byte-identical event identity
   /// (stage / message / category / event name). Payload fidelity per §3.7

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -194,14 +194,6 @@ final class RecordingSessionKernel {
 
   // MARK: Telemetry fan-out
 
-  /// Capture-stall telemetry fan-out (PR-4 plan §3.9). When the capture layer
-  /// reports a stall the kernel — besides routing `failed(.captureStalled)`
-  /// for control flow — hands the raw `CaptureStallContext` to this seam so a
-  /// telemetry observer receives the diagnostic payload the terminal state
-  /// cannot carry. A dumb fan-out: the kernel never reads it back, and it
-  /// keeps the kernel telemetry-infra-agnostic (the closure is a seam, like
-  /// `processText` / `store` / `deliver`). A no-op in the simulator.
-  private let captureStallTelemetry: @MainActor (CaptureStallContext) -> Void
   private let zombieZeroPeakTelemetry: @MainActor (ZeroPeakContext) -> Void
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
   private let markPipelineTimingStart: @MainActor () -> Void
@@ -478,7 +470,6 @@ final class RecordingSessionKernel {
     deliver: @escaping @MainActor (_ text: String) async -> KernelDeliveryOutcome,
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
-    captureStallTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in },
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
@@ -496,7 +487,6 @@ final class RecordingSessionKernel {
     self.deliver = deliver
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
-    self.captureStallTelemetry = captureStallTelemetry
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
     self.markPipelineTimingStart = markPipelineTimingStart

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -186,8 +186,8 @@ import Testing
     @Test("a capture stall handled by the observer reaches its telemetry emitter")
     func captureStallFanout() async {
       // PR-4b.1: the kernel no longer subscribes to `audioCapture.onCaptureStalled`,
-      // so the previous end-to-end path (capture callback → kernel
-      // `captureStallTelemetry` seam → observer) is unsubscribed. PR-4b.4 wires
+      // so the previous end-to-end path (capture callback → kernel telemetry
+      // seam → observer) is gone. PR-4b.4 wires
       // the driver to fan out a stall to BOTH `observer.handleCaptureStall(_:)`
       // AND `kernel.externalCaptureStalled(_:)` from a single App router
       // subscription. This test now pins the observer-emitter half of that

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -86,7 +86,7 @@ import Testing
           Recorder.DictationInvokedCall(
             triggerSource: trigger, inputMode: mode, targetApp: target))
       },
-      modelLoadWedged: { backend in recorder.modelLoadWedgedBackends.append(backend) },
+      modelLoadWedged: { backend, _ in recorder.modelLoadWedgedBackends.append(backend) },
       captureError: { error, category, stage, _ in
         recorder.captureErrors.append(
           Recorder.CaptureErrorCall(

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -230,8 +230,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
     onXPCServiceError?(
       XPCErrorContext(
         kind: .interruptCapturing,
-        sessionID: currentCaptureSessionID,
-        timestampNs: 0))
+        sessionID: currentCaptureSessionID))
   }
 
   // MARK: Helpers

--- a/Tests/EnviousWisprTests/Pipeline/XPCErrorContextRecordingDurationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/XPCErrorContextRecordingDurationTests.swift
@@ -17,14 +17,14 @@ struct XPCErrorContextRecordingDurationTests {
   @Test("default init omits recordingDurationNs (back-compat for idle invalidate)")
   func defaultInitOmitsField() {
     let ctx = XPCErrorContext(
-      kind: .invalidateIdle, sessionID: nil, timestampNs: 100)
+      kind: .invalidateIdle, sessionID: nil)
     #expect(ctx.recordingDurationNs == nil)
   }
 
   @Test("explicit nil recordingDurationNs is preserved")
   func explicitNilIsPreserved() {
     let ctx = XPCErrorContext(
-      kind: .invalidateIdle, sessionID: nil, timestampNs: 100,
+      kind: .invalidateIdle, sessionID: nil,
       recordingDurationNs: nil)
     #expect(ctx.recordingDurationNs == nil)
   }
@@ -32,7 +32,7 @@ struct XPCErrorContextRecordingDurationTests {
   @Test("explicit value is preserved for interruptCapturing")
   func valuePreservedForInterruptCapturing() {
     let ctx = XPCErrorContext(
-      kind: .interruptCapturing, sessionID: 42, timestampNs: 2_000_000_000,
+      kind: .interruptCapturing, sessionID: 42,
       recordingDurationNs: 1_500_000_000)
     #expect(ctx.kind == .interruptCapturing)
     #expect(ctx.recordingDurationNs == 1_500_000_000)
@@ -41,7 +41,7 @@ struct XPCErrorContextRecordingDurationTests {
   @Test("explicit value is preserved for invalidateCapturing")
   func valuePreservedForInvalidateCapturing() {
     let ctx = XPCErrorContext(
-      kind: .invalidateCapturing, sessionID: 7, timestampNs: 500_000_000,
+      kind: .invalidateCapturing, sessionID: 7,
       recordingDurationNs: 250_000_000)
     #expect(ctx.kind == .invalidateCapturing)
     #expect(ctx.recordingDurationNs == 250_000_000)
@@ -55,7 +55,7 @@ struct XPCErrorContextRecordingDurationTests {
   @Test("nanosecond → millisecond conversion shape used by the breadcrumb")
   func nsToMsConversion() {
     let ctx = XPCErrorContext(
-      kind: .interruptCapturing, sessionID: 1, timestampNs: 1_000_000_000,
+      kind: .interruptCapturing, sessionID: 1,
       recordingDurationNs: 1_500_000_000)
     let ms = ctx.recordingDurationNs.map { Int($0 / 1_000_000) }
     #expect(ms == 1500)


### PR DESCRIPTION
Part of #821 (post-#763 Periphery sweep). Tier-3 remainder — the genuinely-dead stragglers a Codex grounded re-check confirmed against current `main`. Deletions only; no behavior change on any live path.

## Removed (each confirmed assign-only / vestigial, no live reader)
- **`AudioCaptureProxy.stallArmedAtUptimeNs`** — write-only stored prop. The watchdog threads the local `armedAtNs`, never this field.
- **`XPCErrorContext.timestampNs`** — the sole consumer (`AudioEventRouter`) reads `kind`/`sessionID`/`recordingDurationNs`, never `timestampNs`. Removed the field, both call-site args, and the now-stale test args.
- **`ModelDownloadManager` instance path** — `ParakeetBackend` downloads via FluidAudio directly and uses only the static `verifyChecksum()` + `StallTracker`. Removed the never-called actor download orchestration (and the orphaned R2 fallback, `ModelDownloadError`, and the now-unused `FluidAudio` import). The type is a static-only namespace now, so `actor` → `enum`.
- **`KernelLifecycleTelemetrySink` convenience init** — production-unused (the factory builds via the primary init). One test depended on it (Periphery excludes test targets, which is why it read as dead); migrated that test to the primary init's two-arg `modelLoadWedged`.
- **`RecordingSessionKernel.captureStallTelemetry`** — stored seam that was never invoked. The live stall path is router → driver (`HeartPathTelemetryTarget`) → observer. Removed the decl + init param and refreshed the observer comments that still named the seam.

## Notable nuance
The triage said "tests use the primary init" and "ParakeetBackend uses StallTracker" — grounding against real code surfaced that one test actually used the convenience init, and that the `ModelDownloadManager` deletion cascades into the R2 fallback + `ModelDownloadError` + the FluidAudio import. Handled both.

## Validation
- `scripts/xcode-test.sh`: **1973 logic tests pass**, release + debug build green.
- Local Codex code-diff review: **clean** ("removes unused paths and updates the affected call sites consistently").
- **Dual-engine Live UAT (founder, live dictation):**
  - Parakeet — "Testing 1, 2, 3, 4, 5." → TOTAL ~0.86–1.13s, full pipeline fired.
  - WhisperKit — "Testing, one, two, three." → LID en/locked, TOTAL 2.157s, paste fired.
  - No crash, stall, XPC interrupt, or captureStall on either engine — heart path intact.

Tier: MEDIUM (heart-path-adjacent). After this lands, the periphery baseline is regenerated and epic #821 closes.