### PR TITLE
fix(pipeline): history-save failure no longer aborts delivery (#1167)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -238,7 +238,9 @@ final class DictationLifecycleCoordinator {
       to: newState,
       pipelineOverlayIntent: kernelDriver.overlayIntent,
       lastPolishError: kernelDriver.lastPolishError,
-      currentTranscript: kernelDriver.currentTranscript
+      currentTranscript: kernelDriver.currentTranscript,
+      historySaved: kernelDriver.lastHistorySaved,
+      historySaveReason: kernelDriver.lastHistorySaveReason
     )
     // PR7 of #763 — push polish error to the post-recording result home so
     // views can read `lastRecordingResult.polishError` without reaching
@@ -282,7 +284,9 @@ final class DictationLifecycleCoordinator {
       to: newState,
       pipelineOverlayIntent: whisperKitKernelDriver.overlayIntent,
       lastPolishError: whisperKitKernelDriver.lastPolishError,
-      currentTranscript: whisperKitKernelDriver.currentTranscript
+      currentTranscript: whisperKitKernelDriver.currentTranscript,
+      historySaved: whisperKitKernelDriver.lastHistorySaved,
+      historySaveReason: whisperKitKernelDriver.lastHistorySaveReason
     )
     lastRecordingResult.polishError = whisperKitKernelDriver.lastPolishError
     dispatchChipLifecycle(
@@ -392,12 +396,18 @@ final class DictationLifecycleCoordinator {
         TelemetryService.shared.reportDictationCompleted(
           transcript: t, inputMode: self.settings.recordingMode.rawValue,
           recordingSeconds: driver.lastRecordingDurationSeconds,
-          stopReason: driver.lastStopReason)
+          stopReason: driver.lastStopReason,
+          historySaveStatus: driver.lastHistorySaved ? "succeeded" : "failed",  // #1167
+          historySaveErrorClass: driver.lastHistorySaveErrorClass)
       },
       reportPipelineFailed: { msg in
         TelemetryService.shared.pipelineFailed(
           stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
           recoverable: false, backend: backendLabel)
+      },
+      // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
+      scheduleHistorySaveFailedWarning: { [weak self] reason in
+        self?.schedulePostCompletionWarning(message: "Couldn't save to history: \(reason)")
       }
     )
   }

--- a/Sources/EnviousWisprAppKit/App/LiveRecordingState.swift
+++ b/Sources/EnviousWisprAppKit/App/LiveRecordingState.swift
@@ -72,15 +72,16 @@ final class LiveRecordingState {
     audioCapture.audioLevel
   }
 
-  /// In-flight transcript from the active pipeline. Used as the live
-  /// fallback in `HistoryContentView` composition: selected-history else
-  /// live. Replaces the live-fallback half of the pre-PR7
-  /// the former root state getter.
+  /// In-flight transcript from the active pipeline. Live fallback in
+  /// `HistoryContentView`: selected-history else live. #1167: suppressed when
+  /// the last completion's durable save failed (never persisted; returns via
+  /// next-launch crash-recovery), so the detail pane shows no phantom row.
+  /// Telemetry reads the driver's `currentTranscript` directly, unaffected.
   var currentTranscript: Transcript? {
-    if asrManager.activeBackendType == .whisperKit {
-      return whisperKitKernelDriver.currentTranscript
-    }
-    return kernelDriver.currentTranscript
+    let driver =
+      asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
+    guard driver.lastHistorySaved else { return nil }
+    return driver.currentTranscript
   }
 }
 

--- a/Sources/EnviousWisprCore/HistorySaveErrorClass.swift
+++ b/Sources/EnviousWisprCore/HistorySaveErrorClass.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// #1167: normalized classification of a history-save failure
+/// (`TranscriptStore.save` throwing on a full disk / unwritable volume).
+///
+/// Lives in Core so the user-facing pill and the `dictation.completed`
+/// telemetry derive the SAME class from one place — no raw error strings or
+/// filesystem paths cross the telemetry-privacy boundary. The save is
+/// best-effort: a throw is recorded as one of these classes, delivery still
+/// proceeds, and the crash-recovery spool self-heals History on next launch.
+public enum HistorySaveErrorClass: String, Sendable {
+  case fullDisk = "full_disk"
+  case permissionDenied = "permission_denied"
+  case readOnly = "read_only"
+  case unknown = "unknown"
+
+  /// Map a storage `Error` to a normalized class. `TranscriptStore.save` can
+  /// surface the failure three ways: a raw POSIX errno (the `open` temp-file
+  /// guard, #1167), a Cocoa file-write error with a specific code, or a Cocoa
+  /// error that wraps the real errno under `NSUnderlyingErrorKey` (the
+  /// `FileHandle.write` path). Check the top-level error, then its underlying.
+  public init(storageError: Error) {
+    let ns = storageError as NSError
+    if let cls = Self.classify(ns) {
+      self = cls
+      return
+    }
+    if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? NSError,
+      let cls = Self.classify(underlying)
+    {
+      self = cls
+      return
+    }
+    self = .unknown
+  }
+
+  /// Classify a single `NSError` by domain + code; `nil` when it carries no
+  /// recognizable storage failure (so the caller can fall through to the
+  /// underlying error or `.unknown`).
+  private static func classify(_ ns: NSError) -> HistorySaveErrorClass? {
+    switch ns.domain {
+    case NSCocoaErrorDomain:
+      switch ns.code {
+      case NSFileWriteOutOfSpaceError: return .fullDisk
+      case NSFileWriteNoPermissionError: return .permissionDenied
+      case NSFileWriteVolumeReadOnlyError: return .readOnly
+      default: return nil
+      }
+    case NSPOSIXErrorDomain:
+      switch Int32(ns.code) {
+      case ENOSPC: return .fullDisk
+      case EACCES, EPERM: return .permissionDenied
+      case EROFS: return .readOnly
+      default: return nil
+      }
+    default:
+      return nil
+    }
+  }
+
+  /// Privacy-safe, human-readable reason for the user pill — no paths, no
+  /// usernames. Rendered as "Couldn't save to history: <userReason>".
+  public var userReason: String {
+    switch self {
+    case .fullDisk: return "disk is full"
+    case .permissionDenied: return "permission denied"
+    case .readOnly: return "the volume is read-only"
+    case .unknown: return "a storage error"
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -325,6 +325,24 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// The polish error from the last session, or `nil`.
   public var lastPolishError: String? { outcome.polishError }
 
+  /// #1167: whether the last session's durable history save succeeded. `false`
+  /// ⟺ the save threw but delivery still proceeded (best-effort save). The App
+  /// layer gates the recovery-spool cleanup, the in-memory history append, and
+  /// the history-save-failed pill on this.
+  public var lastHistorySaved: Bool { outcome.historySaved }
+
+  /// #1167: privacy-safe user reason for the history-save-failed pill, or `nil`
+  /// on a successful save. Rendered as "Couldn't save to history: <reason>".
+  public var lastHistorySaveReason: String? {
+    outcome.historySaveError.map { HistorySaveErrorClass(storageError: $0).userReason }
+  }
+
+  /// #1167: normalized error class for the `dictation.completed` telemetry
+  /// dimension, or `nil` on a successful save. No raw error strings / paths.
+  public var lastHistorySaveErrorClass: String? {
+    outcome.historySaveError.map { HistorySaveErrorClass(storageError: $0).rawValue }
+  }
+
   /// PR-7 (#827): the active engine adapter's normalized readiness, exposed
   /// read-only so the App layer can stamp the cold-start cohort
   /// (`engineReadinessAtPTT`) onto the `PTT-to-recording` log line at trigger
@@ -678,6 +696,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         outcome.polishDurationSeconds = 0
         outcome.pasteDurationSeconds = 0
         outcome.pasteResult = nil
+        // #1167: a fresh session starts assuming the save will succeed; the
+        // best-effort `store` closure flips these only on a real save throw.
+        outcome.historySaved = true
+        outcome.historySaveError = nil
         context.config = config
         context.targetApp = NSWorkspace.shared.frontmostApplication
         context.targetElement = PasteService.captureFocusedElement()
@@ -1147,8 +1169,6 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       return "Transcription stalled. Please try again."
     case .emptyAfterProcessing:
       return "No speech detected. Your clipboard is unchanged. Try again."
-    case .storageFailed:
-      return "Failed to save transcript"
     case .captureStalled:
       return "No audio detected — try again."
     }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -332,7 +332,15 @@ public enum KernelDictationDriverFactory {
       adapter: adapter,
       steps: limbSteps,
       textProcessingRunner: textProcessingRunner,
-      save: { transcript in try transcriptStore.save(transcript) },
+      save: { transcript in
+        // #1167 Live-UAT seam: force a storage failure so the best-effort save
+        // path is exercised end-to-end (paste still lands, pill shows). DEBUG
+        // only — never compiled into release.
+        #if DEBUG
+          if let fault = KernelDictationDriverFactory.injectedSaveFault() { throw fault }
+        #endif
+        try transcriptStore.save(transcript)
+      },
       deliverPaste: { request in await PasteCascadeExecutor().deliver(request) },
       pasteCompletionRegistry: pasteCompletionRegistry,
       // #950 — share the SAME telemetry state the kernel stamps so the metrics
@@ -440,4 +448,31 @@ public enum KernelDictationDriverFactory {
 
     return driver
   }
+
+  #if DEBUG
+    /// #1167 Live-UAT seam. When the app is launched with `EW_FAULT_INJECTION=1`
+    /// (the existing fault master switch) AND `EW_FAULT_SAVE` names a storage
+    /// error class, return the matching `NSError` so the production `save`
+    /// closure throws it — exercising the best-effort save path end-to-end
+    /// (delivery still runs, the history-save-failed pill shows, the spool is
+    /// retained). Returns `nil` (no fault) otherwise. DEBUG-only.
+    static func injectedSaveFault() -> Error? {
+      let env = ProcessInfo.processInfo.environment
+      guard env["EW_FAULT_INJECTION"] == "1", let kind = env["EW_FAULT_SAVE"] else {
+        return nil
+      }
+      // Mirror the POSIX errno shape the real `TranscriptStore.save` open-guard
+      // throws, so Live UAT exercises the actual classification path.
+      switch kind {
+      case "out_of_space":
+        return NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
+      case "no_permission":
+        return NSError(domain: NSPOSIXErrorDomain, code: Int(EACCES))
+      case "read_only":
+        return NSError(domain: NSPOSIXErrorDomain, code: Int(EROFS))
+      default:
+        return nil
+      }
+    }
+  #endif
 }

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -71,6 +71,18 @@ final class KernelFinalizationOutcome {
   var emojiRestored: Int?
   var emojiRestoreIncomplete: Bool?
   var emojiLatencyMs: Double?
+  /// #1167: whether the durable history save succeeded. `false` ⟺ the save
+  /// threw but delivery still proceeded (best-effort save). Default `true` (the
+  /// happy path); the `store` closure sets it explicitly on each save attempt,
+  /// and the driver resets it per session. The recovery-cleanup gate, the pill,
+  /// the in-memory append, the success marker, and the `dictation.completed`
+  /// telemetry all read this — clipboard behavior does NOT (it always reverts
+  /// per the user's setting; `pipeline-mechanics.md` RULE: clipboard-restore-is-sacred).
+  var historySaved = true
+  /// #1167: the storage error when `historySaved == false`, else `nil`. The
+  /// driver maps it to a normalized class + privacy-safe user reason via
+  /// `HistorySaveErrorClass`.
+  var historySaveError: Error?
 
   init() {}
 }
@@ -227,8 +239,16 @@ struct KernelFinalizationWiring {
 
     // store — build the Transcript exactly as TranscriptFinalizer.swift:129
     // (raw / polished from the side-channel, ASR metadata from the adapter),
-    // persist it, and hand it to the driver via the side-channel. A throw
-    // propagates so the kernel routes `failed(storageFailed)` (PR-4 §3.3).
+    // best-effort persist it, and hand it to the driver via the side-channel.
+    //
+    // #1167: the save is BEST-EFFORT. `outcome.transcript` is set BEFORE the
+    // save so completion telemetry + paste metrics (which read it) populate even
+    // when the save throws. A storage failure (full disk / permission / read-only)
+    // is recorded on the outcome + telemetry side-channel and ABSORBED — it does
+    // NOT propagate, so the kernel proceeds to deliver the already-polished text
+    // and finishes `.completed`. The crash-recovery spool is retained (cleanup is
+    // gated on `historySaved`), so History self-heals on next launch. Clipboard
+    // behavior is unchanged (`pipeline-mechanics.md` RULE: clipboard-restore-is-sacred).
     store = { text in
       let transcript = Transcript(
         text: outcome.rawText ?? text,
@@ -245,8 +265,19 @@ struct KernelFinalizationWiring {
         // live take, not a rescued one.
         recoverySessionID: context.config?.recoverySessionID,
         isRecovered: false)
-      try save(transcript)
       outcome.transcript = transcript
+      do {
+        try save(transcript)
+        outcome.historySaved = true
+        outcome.historySaveError = nil
+      } catch {
+        outcome.historySaved = false
+        outcome.historySaveError = error
+        // Mirror the failure onto the telemetry side-channel so the lifecycle
+        // sink can withhold the "transcript durably saved" success marker on a
+        // degraded-save completion (#1167).
+        telemetryState.historySaveFailed = true
+      }
     }
 
     // deliver — run the paste cascade or clipboard copy per the session's

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -228,7 +228,12 @@ final class KernelLifecycleTelemetrySink {
 
     case .pipelineCompleted:
       breadcrumb("pipeline", "Pipeline complete", pipelineCompletedPayload())
-      captureTelemetry.recordSuccessfulRecording()
+      // #1167: a degraded-save completion (history write threw, delivery still
+      // ran) must NOT stamp the "transcript durably saved" success marker — gate
+      // on the save outcome mirrored on the telemetry side-channel.
+      if !telemetryState.historySaveFailed {
+        captureTelemetry.recordSuccessfulRecording()
+      }
 
     case .failed(let reason):
       emitFailed(reason)
@@ -492,13 +497,6 @@ final class KernelLifecycleTelemetrySink {
           "polish.enabled": telemetryState.polishEnabled,
           "capture_session_id": Int(audioCapture.currentCaptureSessionID),
         ])
-    case .storageFailed:
-      let error =
-        telemetryState.storageFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -12,
-          userInfo: [NSLocalizedDescriptionKey: "Failed to save transcript"])
-      emitCaptureError(error, .asrFailed, "storage", nil)
     case .asrFailed, .asrWedged:
       let error =
         telemetryState.transcriptionFailureError

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -11,7 +11,12 @@ final class KernelTelemetryState {
   var asrEmptyDiagnostics: ASREmptyResultDiagnostics?
   var asrCompletedTelemetry: KernelASRCompletedTelemetry?
   var captureFailureError: (any Error)?
-  var storageFailureError: (any Error)?
+  /// #1167: set by the best-effort `store` closure when the durable history save
+  /// throws. The lifecycle sink reads it to withhold the "transcript durably
+  /// saved" success marker on a degraded-save completion. The operational source
+  /// of truth for recovery-spool cleanup is `KernelFinalizationOutcome.historySaved`,
+  /// NOT this telemetry mirror.
+  var historySaveFailed = false
   var transcriptionFailureError: (any Error)?
   var modelLoadError: (any Error)?
 
@@ -22,7 +27,7 @@ final class KernelTelemetryState {
     asrEmptyDiagnostics = nil
     asrCompletedTelemetry = nil
     captureFailureError = nil
-    storageFailureError = nil
+    historySaveFailed = false
     transcriptionFailureError = nil
     modelLoadError = nil
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -34,6 +34,8 @@ public final class PipelineStateChangeHandler {
   private let appendCompletedTranscript: @MainActor (Transcript) -> Void
   private let reportDictationCompleted: @MainActor (Transcript) -> Void
   private let reportPipelineFailed: @MainActor (String) -> Void
+  /// #1167: schedule the transient "Couldn't save to history: <reason>" pill.
+  private let scheduleHistorySaveFailedWarning: @MainActor (String) -> Void
 
   public init(
     showOverlay: @escaping ShowOverlay,
@@ -41,7 +43,8 @@ public final class PipelineStateChangeHandler {
     schedulePolishFailedWarning: @escaping @MainActor () -> Void,
     appendCompletedTranscript: @escaping @MainActor (Transcript) -> Void,
     reportDictationCompleted: @escaping @MainActor (Transcript) -> Void,
-    reportPipelineFailed: @escaping @MainActor (String) -> Void
+    reportPipelineFailed: @escaping @MainActor (String) -> Void,
+    scheduleHistorySaveFailedWarning: @escaping @MainActor (String) -> Void
   ) {
     self.showOverlay = showOverlay
     self.cancelPendingWarning = cancelPendingWarning
@@ -49,6 +52,7 @@ public final class PipelineStateChangeHandler {
     self.appendCompletedTranscript = appendCompletedTranscript
     self.reportDictationCompleted = reportDictationCompleted
     self.reportPipelineFailed = reportPipelineFailed
+    self.scheduleHistorySaveFailedWarning = scheduleHistorySaveFailedWarning
   }
 
   /// Drive the full state-change behavior contract for one pipeline.
@@ -61,7 +65,9 @@ public final class PipelineStateChangeHandler {
     to newState: any PipelineStateProtocol,
     pipelineOverlayIntent: OverlayIntent,
     lastPolishError: String?,
-    currentTranscript: Transcript?
+    currentTranscript: Transcript?,
+    historySaved: Bool,
+    historySaveReason: String?
   ) {
     let plan = PipelineStateChangePlanner.plan(
       to: newState,
@@ -70,7 +76,9 @@ public final class PipelineStateChangeHandler {
         || currentTranscript?.metrics?.pasteTier == "clipboard_only_ax_denied",
       isAccessibilityToast: currentTranscript?.metrics?.pasteTier == "clipboard_only_ax_denied",
       lastPolishError: lastPolishError,
-      hasCurrentTranscript: currentTranscript != nil
+      hasCurrentTranscript: currentTranscript != nil,
+      historySaved: historySaved,
+      historySaveReason: historySaveReason
     )
     for effect in plan.effects {
       switch effect {
@@ -90,6 +98,8 @@ public final class PipelineStateChangeHandler {
         }
       case .reportPipelineFailed(let msg):
         reportPipelineFailed(msg)
+      case .scheduleHistorySaveFailedWarning(let reason):
+        scheduleHistorySaveFailedWarning(reason)
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -36,6 +36,13 @@ enum PipelineStateSideEffect: Equatable, Sendable {
   /// code. The caller supplies the fixed `stage` / `errorCategory` / `backend`
   /// literals that today live in the former root state's closures.
   case reportPipelineFailed(errorCode: String)
+
+  /// #1167: schedule the transient "Couldn't save to history: <reason>" pill
+  /// ~400 ms after completion, concurrent with the (already-completed) paste.
+  /// Emitted ONLY on `.complete` when the durable history save threw but
+  /// delivery still ran (best-effort save). Reuses the single post-completion
+  /// warning slot, so it is mutually exclusive with `schedulePolishFailedWarning`.
+  case scheduleHistorySaveFailedWarning(reason: String)
 }
 
 struct PipelineStateChangePlan: Equatable, Sendable {
@@ -69,9 +76,15 @@ enum PipelineStateChangePlanner {
     isClipboardFallback: Bool,
     isAccessibilityToast: Bool,
     lastPolishError: String?,
-    hasCurrentTranscript: Bool
+    hasCurrentTranscript: Bool,
+    historySaved: Bool,
+    historySaveReason: String?
   ) -> PipelineStateChangePlan {
     var effects: [PipelineStateSideEffect] = []
+
+    // #1167: a degraded-save completion (delivery ran, history write threw).
+    // Only meaningful on `.complete` with a transcript in hand.
+    let historySaveFailed = hasCurrentTranscript && !historySaved
 
     // Step 1 — overlay resolution + warning scheduling / cancellation.
     // Order mirrors the production closures at the former root-state file: resolve intent, schedule warning iff applicable, then show.
@@ -90,7 +103,10 @@ enum PipelineStateChangePlanner {
         // "Polish failed -- using raw text" overlay would contradict it, so
         // suppress it for skips. Real failures (and the unchanged Apple
         // Intelligence / legacy strings) still schedule the warning.
-        if !PolishFailureReason.isSkipNotice(polishError) {
+        // #1167: a history-save failure takes the single post-completion
+        // warning slot (its pill is scheduled in Step 2), so suppress the
+        // polish-failed pill when both fired this session.
+        if !historySaveFailed, !PolishFailureReason.isSkipNotice(polishError) {
           effects.append(.schedulePolishFailedWarning)
         }
       } else {
@@ -111,7 +127,17 @@ enum PipelineStateChangePlanner {
     // history cache visibly fresh without an O(n) disk scan.
     if case .complete = newState.activity {
       if hasCurrentTranscript {
-        effects.append(.appendCompletedTranscript)
+        // #1167: skip the in-memory history append on a save failure — the row
+        // was never persisted, so the append would show a phantom entry that
+        // vanishes on restart (it reappears as a "Recovered" entry via the
+        // retained crash-recovery spool). Skipping the append also skips the
+        // `onDurableSave` spool cleanup wired inside that handler, so the spool
+        // is retained. Instead, schedule the reason pill. Telemetry still fires.
+        if historySaved {
+          effects.append(.appendCompletedTranscript)
+        } else if let reason = historySaveReason {
+          effects.append(.scheduleHistorySaveFailedWarning(reason: reason))
+        }
         effects.append(.reportDictationCompleted)
       }
     }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -34,7 +34,6 @@ public enum RecordingFailureReason: Equatable, Sendable {
   case asrFailed
   case asrWedged
   case emptyAfterProcessing
-  case storageFailed
   case captureStalled
 }
 
@@ -1447,10 +1446,12 @@ final class RecordingSessionKernel {
     do {
       try await store(processed)
     } catch {
-      guard isCurrent(sid) else { return }
-      telemetryState.storageFailureError = error
-      finishTerminal(.failed(.storageFailed), sid: sid)
-      return
+      // #1167: the history save is best-effort — `store` absorbs storage
+      // failures internally (records them on the finalization outcome +
+      // telemetry side-channel and still sets `outcome.transcript`), so it no
+      // longer throws on a save failure. Any residual throw can only be
+      // cancellation during finalize; honor the safe-point (a transcript is in
+      // hand) by falling through to deliver exactly as the success path would.
     }
     guard isCurrent(sid) else { return }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -58,7 +58,8 @@ public final class TelemetryService {
   /// Called by the former root state when a pipeline completes. Reads Transcript + ExecutionMetrics.
   public func reportDictationCompleted(
     transcript t: Transcript, inputMode: String,
-    recordingSeconds: Double? = nil, stopReason: String? = nil
+    recordingSeconds: Double? = nil, stopReason: String? = nil,
+    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil
   ) {
     #if DEBUG
       testEventHook?(
@@ -95,7 +96,9 @@ public final class TelemetryService {
       emojiRestoreIncomplete: m?.emojiRestoreIncomplete,
       emojiLatencyMs: m?.emojiLatencyMs,
       recordingSeconds: recordingSeconds,
-      stopReason: stopReason
+      stopReason: stopReason,
+      historySaveStatus: historySaveStatus,
+      historySaveErrorClass: historySaveErrorClass
     )
     if let e2e = m?.e2eSeconds {
       metricPipelineE2E(
@@ -234,7 +237,8 @@ public final class TelemetryService {
     itnLenBefore: Int? = nil, itnLenAfter: Int? = nil,
     emojiInInput: Int? = nil, emojiDropped: Int? = nil, emojiRestored: Int? = nil,
     emojiRestoreIncomplete: Bool? = nil, emojiLatencyMs: Double? = nil,
-    recordingSeconds: Double? = nil, stopReason: String? = nil
+    recordingSeconds: Double? = nil, stopReason: String? = nil,
+    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -268,6 +272,11 @@ public final class TelemetryService {
     if let er = emojiRestored { props["emoji_restored"] = er }
     if let inc = emojiRestoreIncomplete { props["emoji_restore_incomplete"] = inc }
     if let elat = emojiLatencyMs { props["emoji_latency_ms"] = String(format: "%.3f", elat) }
+    // #1167: degraded-save dimension. `succeeded` | `failed`; on failure a
+    // normalized class (`full_disk`/`permission_denied`/`read_only`/`unknown`).
+    // The top-line success metric is "completed AND history_save_status != failed".
+    if let hss = historySaveStatus { props["history_save_status"] = hss }
+    if let hec = historySaveErrorClass { props["history_save_error_class"] = hec }
     PostHogSDK.shared.capture("dictation.completed", properties: props)
   }
 

--- a/Sources/EnviousWisprStorage/TranscriptStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptStore.swift
@@ -49,7 +49,11 @@ public final class TranscriptStore {
     do {
       let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
       guard fd >= 0 else {
-        throw CocoaError(.fileWriteUnknown)
+        // #1167: preserve the POSIX errno (read immediately after the failed
+        // syscall) so the best-effort save path can classify the failure
+        // (disk full / permission / read-only) for the user pill + telemetry,
+        // instead of collapsing every cause into a generic fileWriteUnknown.
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
       }
       let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
       try fh.write(contentsOf: data)

--- a/Tests/EnviousWisprTests/Core/HistorySaveErrorClassTests.swift
+++ b/Tests/EnviousWisprTests/Core/HistorySaveErrorClassTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// #1167: the history-save error classifier maps storage `Error`s to a
+/// normalized, privacy-safe class + user reason shared by the pill and telemetry.
+@MainActor
+@Suite("HistorySaveErrorClass — classification + reason mapping")
+struct HistorySaveErrorClassTests {
+
+  @Test("Cocoa file-write codes map to the right class + reason")
+  func cocoaCodesMap() {
+    let cases: [(Int, HistorySaveErrorClass, String)] = [
+      (NSFileWriteOutOfSpaceError, .fullDisk, "disk is full"),
+      (NSFileWriteNoPermissionError, .permissionDenied, "permission denied"),
+      (NSFileWriteVolumeReadOnlyError, .readOnly, "the volume is read-only"),
+    ]
+    for (code, expectedClass, expectedReason) in cases {
+      let err = NSError(domain: NSCocoaErrorDomain, code: code)
+      let klass = HistorySaveErrorClass(storageError: err)
+      #expect(klass == expectedClass, "code \(code) should map to \(expectedClass)")
+      #expect(klass.userReason == expectedReason)
+    }
+  }
+
+  @Test("POSIX errnos map to the right class")
+  func posixCodesMap() {
+    #expect(
+      HistorySaveErrorClass(
+        storageError: NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))) == .fullDisk)
+    #expect(
+      HistorySaveErrorClass(
+        storageError: NSError(domain: NSPOSIXErrorDomain, code: Int(EACCES))) == .permissionDenied)
+    #expect(
+      HistorySaveErrorClass(
+        storageError: NSError(domain: NSPOSIXErrorDomain, code: Int(EROFS))) == .readOnly)
+  }
+
+  @Test("a Cocoa error wrapping a POSIX errno under NSUnderlyingErrorKey is unwrapped")
+  func underlyingPosixErrorUnwrapped() {
+    // The FileHandle.write path can surface a generic Cocoa file-write error
+    // that carries the real errno as its underlying error (#1167).
+    let underlying = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
+    let wrapper = NSError(
+      domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError,
+      userInfo: [NSUnderlyingErrorKey: underlying])
+    #expect(HistorySaveErrorClass(storageError: wrapper) == .fullDisk)
+  }
+
+  @Test("a bare fileWriteUnknown with no underlying errno falls back to .unknown")
+  func cocoaUnknownWithoutUnderlyingIsUnknown() {
+    let err = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError)
+    #expect(HistorySaveErrorClass(storageError: err) == .unknown)
+  }
+
+  @Test("an unrecognized error falls back to .unknown with a generic reason")
+  func unknownFallback() {
+    let klass = HistorySaveErrorClass(
+      storageError: NSError(domain: "SomethingElse", code: 42))
+    #expect(klass == .unknown)
+    #expect(klass.userReason == "a storage error")
+  }
+
+  @Test("rawValue strings are the telemetry-stable, privacy-safe class names")
+  func rawValuesAreStable() {
+    #expect(HistorySaveErrorClass.fullDisk.rawValue == "full_disk")
+    #expect(HistorySaveErrorClass.permissionDenied.rawValue == "permission_denied")
+    #expect(HistorySaveErrorClass.readOnly.rawValue == "read_only")
+    #expect(HistorySaveErrorClass.unknown.rawValue == "unknown")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -64,7 +64,6 @@ import Testing
   func failureMessages() {
     #expect(KernelDictationDriver.failureMessage(.asrEmpty) == "Couldn't catch that -- try again")
     #expect(KernelDictationDriver.failureMessage(.noAudioCaptured) == "No audio captured")
-    #expect(KernelDictationDriver.failureMessage(.storageFailed) == "Failed to save transcript")
     #expect(
       KernelDictationDriver.failureMessage(.emptyAfterProcessing)
         == "No speech detected. Your clipboard is unchanged. Try again.")

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -235,14 +235,37 @@ import Testing
     #expect(saved.transcript?.backendType == .parakeet)
     #expect(saved.transcript?.llmProvider == "openai")
     #expect(outcome.transcript?.text == "raw asr text", "the driver reads the transcript here")
+    // #1167: a clean save marks the outcome saved and clears any prior error.
+    #expect(outcome.historySaved)
+    #expect(outcome.historySaveError == nil)
   }
 
-  @Test("store rethrows a storage failure so the kernel routes failed(storageFailed)")
-  func storeRethrows() async {
-    let wiring = makeWiring(save: { _ in throw WiringTestError.storage })
-    await #expect(throws: WiringTestError.self) {
-      try await wiring.store("text")
-    }
+  @Test(
+    "store absorbs a storage failure: records it on the outcome + telemetry, does NOT throw (#1167)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1167",
+      "a history-save throw must not abort delivery"
+    )
+  )
+  func storeAbsorbsStorageFailure() async throws {
+    let outcome = KernelFinalizationOutcome()
+    outcome.rawText = "the delivered words"
+    let telemetryState = KernelTelemetryState()
+    let wiring = makeWiring(
+      outcome: outcome,
+      save: { _ in throw WiringTestError.storage },
+      telemetryState: telemetryState)
+    // Best-effort: the save throw is absorbed — `store` does NOT propagate it,
+    // so the kernel proceeds to deliver instead of routing a terminal failure.
+    try await wiring.store("the delivered words")
+    #expect(outcome.historySaved == false)
+    #expect(outcome.historySaveError != nil)
+    // The transcript is set BEFORE the save attempt, so completion telemetry +
+    // paste metrics populate and delivery proceeds with the polished text.
+    #expect(outcome.transcript?.text == "the delivered words")
+    // Mirrored onto the telemetry side-channel so the lifecycle sink withholds
+    // the "transcript durably saved" success marker.
+    #expect(telemetryState.historySaveFailed)
   }
 
   // MARK: emoji-restore telemetry never leaks across dictations (#761)
@@ -326,6 +349,7 @@ import Testing
     deliverPaste: @escaping @MainActor (PasteDeliveryRequest) async -> PasteDeliveryResult = {
       _ in Self.deliveredResult
     },
+    telemetryState: KernelTelemetryState = KernelTelemetryState(),
     currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
   ) -> KernelFinalizationWiring {
     KernelFinalizationWiring(
@@ -345,7 +369,8 @@ import Testing
       save: save,
       deliverPaste: deliverPaste,
       pasteCompletionRegistry: nil,
-      currentTime: currentTime)
+      currentTime: currentTime,
+      telemetryState: telemetryState)
   }
 }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -62,13 +62,14 @@ import Testing
     recorder: Recorder,
     backend: ASRBackendType = .parakeet,
     context: KernelSessionContext = KernelSessionContext(),
-    telemetryState: KernelTelemetryState = KernelTelemetryState()
+    telemetryState: KernelTelemetryState = KernelTelemetryState(),
+    captureTelemetry: CaptureTelemetryState = CaptureTelemetryState()
   ) -> KernelLifecycleTelemetrySink {
     KernelLifecycleTelemetrySink(
       backend: backend,
       audioCapture: FakeAudioCapture(),
       context: context,
-      captureTelemetry: CaptureTelemetryState(),
+      captureTelemetry: captureTelemetry,
       telemetryState: telemetryState,
       breadcrumb: { stage, message, data in
         recorder.breadcrumbs.append(
@@ -538,14 +539,31 @@ import Testing
     #expect(recorder.captureErrors.first?.stage == "processing")
   }
 
-  @Test(".failed(.storageFailed) emits .asrFailed captureError at 'storage'")
-  func failedStorageFailedEmission() {
+  // #1167: a clean completion stamps the "transcript durably saved" success
+  // marker; a degraded-save completion (history write threw, delivery still
+  // ran) must NOT — the marker gates on `telemetryState.historySaveFailed`.
+  @Test(".pipelineCompleted records the success marker when the save succeeded")
+  func pipelineCompletedRecordsSuccessMarkerOnSave() {
     let recorder = Recorder()
-    let sink = makeSink(recorder: recorder)
-    sink.emit(.failed(.storageFailed))
-    #expect(recorder.captureErrors.count == 1)
-    #expect(recorder.captureErrors.first?.category == .asrFailed)
-    #expect(recorder.captureErrors.first?.stage == "storage")
+    let captureTelemetry = CaptureTelemetryState()
+    let state = KernelTelemetryState()
+    state.historySaveFailed = false
+    let sink = makeSink(
+      recorder: recorder, telemetryState: state, captureTelemetry: captureTelemetry)
+    sink.emit(.pipelineCompleted)
+    #expect(captureTelemetry.timeSinceLastSuccessfulRecordingMs() != nil)
+  }
+
+  @Test(".pipelineCompleted withholds the success marker on a degraded save (#1167)")
+  func pipelineCompletedWithholdsSuccessMarkerOnSaveFailure() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    let state = KernelTelemetryState()
+    state.historySaveFailed = true
+    let sink = makeSink(
+      recorder: recorder, telemetryState: state, captureTelemetry: captureTelemetry)
+    sink.emit(.pipelineCompleted)
+    #expect(captureTelemetry.timeSinceLastSuccessfulRecordingMs() == nil)
   }
 
   @Test(".failed(.asrFailed) emits .asrFailed captureError at 'transcription'")

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -22,7 +22,7 @@ struct KernelTerminalKindTests {
   @Test("failure terminals → .failure (RETAIN the recoverable audio)")
   func failureTerminals() {
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .failed(.storageFailed)) == .failure)
+      KernelDictationDriver.endedWithoutSaveKind(for: .failed(.asrFailed)) == .failure)
     #expect(KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted) == .failure)
     #expect(KernelDictationDriver.endedWithoutSaveKind(for: .asrInterrupted) == .failure)
   }

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -40,6 +40,8 @@ struct PipelineStateChangeHandlerTests {
     var appendedCalls: [Transcript] = []
     var completedCalls: [Transcript] = []
     var failedCalls: [String] = []
+    /// #1167: reasons passed to the history-save-failed pill.
+    var historySaveWarnings: [String] = []
   }
 
   private static func makeHandler(
@@ -52,7 +54,8 @@ struct PipelineStateChangeHandlerTests {
       schedulePolishFailedWarning: { callbacks.scheduleWarningCount += 1 },
       appendCompletedTranscript: { callbacks.appendedCalls.append($0) },
       reportDictationCompleted: { callbacks.completedCalls.append($0) },
-      reportPipelineFailed: { callbacks.failedCalls.append($0) }
+      reportPipelineFailed: { callbacks.failedCalls.append($0) },
+      scheduleHistorySaveFailedWarning: { callbacks.historySaveWarnings.append($0) }
     )
   }
 
@@ -83,7 +86,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: transcript
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(spy.calls == [OverlaySpy.Call(intent: .hidden)])
@@ -106,7 +111,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: "openai_timeout",
-      currentTranscript: transcript
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(calls.scheduleWarningCount == 1)
@@ -127,7 +134,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: "still set but fallback wins",
-      currentTranscript: transcript
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(spy.calls == [OverlaySpy.Call(intent: .clipboardFallback)])
@@ -147,7 +156,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: transcript
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     // Must NOT show the clipboard-fallback or accessibility-toast overlay —
@@ -168,7 +179,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: transcript
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(spy.calls == [OverlaySpy.Call(intent: .accessibilityToast)])
@@ -192,7 +205,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: nil
+      currentTranscript: nil,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(calls.appendedCalls.isEmpty)
@@ -212,7 +227,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.recording,
       pipelineOverlayIntent: .recording(audioLevel: 0),
       lastPolishError: nil,
-      currentTranscript: nil
+      currentTranscript: nil,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(calls.cancelWarningCount == 1)
@@ -239,7 +256,9 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.error("mic_disconnected"),
       pipelineOverlayIntent: .error(message: "mic_disconnected"),
       lastPolishError: nil,
-      currentTranscript: nil
+      currentTranscript: nil,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(calls.cancelWarningCount == 1)
@@ -264,17 +283,47 @@ struct PipelineStateChangeHandlerTests {
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: first
+      currentTranscript: first,
+      historySaved: true,
+      historySaveReason: nil
     )
     handler.handle(
       to: PipelineState.complete,
       pipelineOverlayIntent: .hidden,
       lastPolishError: nil,
-      currentTranscript: second
+      currentTranscript: second,
+      historySaved: true,
+      historySaveReason: nil
     )
 
     #expect(calls.appendedCalls.count == 2)
     #expect(calls.completedCalls.count == 2)
     #expect(calls.completedCalls.map(\.id) == [first.id, second.id])
+  }
+
+  // MARK: - #1167 history-save best-effort
+
+  @Test("complete + history save failed: pill scheduled, append skipped, telemetry still fires")
+  func completeHistorySaveFailedRoutesPill() {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "direct")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: transcript,
+      historySaved: false,
+      historySaveReason: "disk is full"
+    )
+
+    #expect(calls.historySaveWarnings == ["disk is full"])
+    // The row was never persisted -> no in-memory append (no phantom entry).
+    #expect(calls.appendedCalls.isEmpty)
+    // Telemetry still fires so the degraded-save dimension is recorded.
+    #expect(calls.completedCalls.count == 1)
+    #expect(calls.scheduleWarningCount == 0)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -36,7 +36,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: true,
       isAccessibilityToast: false,
       lastPolishError: "polish failed for some reason",
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.clipboardFallback)))
     #expect(!plan.effects.contains(.schedulePolishFailedWarning))
@@ -54,7 +56,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: true,
       isAccessibilityToast: true,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.accessibilityToast)))
     #expect(!plan.effects.contains(.showOverlay(.clipboardFallback)))
@@ -68,7 +72,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: true,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.clipboardFallback)))
     #expect(!plan.effects.contains(.showOverlay(.accessibilityToast)))
@@ -82,7 +88,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: true,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.accessibilityToast)))
     #expect(!plan.effects.contains(.showOverlay(.clipboardFallback)))
@@ -96,7 +104,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: true,
       isAccessibilityToast: true,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(!plan.effects.contains(.showOverlay(.accessibilityToast)))
     #expect(plan.effects.contains(.showOverlay(Self.recordingIntent)))
@@ -110,7 +120,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: "openai 429 rate-limited",
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.hidden)))
     #expect(plan.effects.contains(.schedulePolishFailedWarning))
@@ -136,7 +148,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: skipNotice,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.hidden)))
     #expect(!plan.effects.contains(.schedulePolishFailedWarning))
@@ -157,7 +171,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: failNotice,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.schedulePolishFailedWarning))
   }
@@ -170,7 +186,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.showOverlay(.hidden)))
     #expect(!plan.effects.contains(.schedulePolishFailedWarning))
@@ -193,7 +211,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: false
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(!plan.effects.contains(.appendCompletedTranscript))
     #expect(!plan.effects.contains(.reportDictationCompleted))
@@ -213,7 +233,9 @@ struct PipelineStateChangePlannerTests {
         isClipboardFallback: false,
         isAccessibilityToast: false,
         lastPolishError: nil,
-        hasCurrentTranscript: false
+        hasCurrentTranscript: false,
+        historySaved: true,
+        historySaveReason: nil
       )
       #expect(
         plan.effects.first == .cancelPendingWarning,
@@ -249,7 +271,9 @@ struct PipelineStateChangePlannerTests {
         isClipboardFallback: false,
         isAccessibilityToast: false,
         lastPolishError: nil,
-        hasCurrentTranscript: false
+        hasCurrentTranscript: false,
+        historySaved: true,
+        historySaveReason: nil
       )
       #expect(
         plan.effects.contains(.showOverlay(intent)),
@@ -273,7 +297,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: false
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(plan.effects.contains(.reportPipelineFailed(errorCode: "mic_disconnected")))
     #expect(plan.effects.contains(.cancelPendingWarning))
@@ -297,7 +323,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     // Order matches the production closure: show overlay, reload history,
     // report telemetry. No warning-cancel, no warning-schedule.
@@ -317,7 +345,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: "fail",
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(
       plan.effects == [
@@ -336,7 +366,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: true,
       isAccessibilityToast: false,
       lastPolishError: "fail",
-      hasCurrentTranscript: true
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(
       plan.effects == [
@@ -354,7 +386,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: false
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(
       plan.effects == [
@@ -371,7 +405,9 @@ struct PipelineStateChangePlannerTests {
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
-      hasCurrentTranscript: false
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil
     )
     #expect(
       plan.effects == [
@@ -379,6 +415,60 @@ struct PipelineStateChangePlannerTests {
         .showOverlay(.error(message: "bad")),
         .reportPipelineFailed(errorCode: "bad"),
       ])
+  }
+
+  // MARK: - #1167 history-save best-effort
+
+  @Test("complete + history save failed -> pill scheduled, append skipped, telemetry still fires")
+  func completeHistorySaveFailedSchedulesPillSkipsAppend() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: false,
+      historySaveReason: "disk is full"
+    )
+    #expect(plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "disk is full")))
+    // Append skipped (so onDurableSave is skipped -> spool retained); the row
+    // was never persisted, so an in-memory append would show a phantom entry.
+    #expect(!plan.effects.contains(.appendCompletedTranscript))
+    // Telemetry still fires so the degraded-save dimension is recorded.
+    #expect(plan.effects.contains(.reportDictationCompleted))
+  }
+
+  @Test("complete + history save failed + polish failed -> history pill wins the single slot")
+  func completeHistorySaveFailedSuppressesPolishWarning() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: "openai 429 rate-limited",
+      hasCurrentTranscript: true,
+      historySaved: false,
+      historySaveReason: "permission denied"
+    )
+    #expect(plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "permission denied")))
+    #expect(!plan.effects.contains(.schedulePolishFailedWarning))
+  }
+
+  @Test("complete + history saved (success) -> append fires, no history pill")
+  func completeHistorySavedAppendsNoPill() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil
+    )
+    #expect(plan.effects.contains(.appendCompletedTranscript))
+    #expect(!plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "disk is full")))
   }
 
   // MARK: - Activity projection integrity

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
@@ -22,7 +22,6 @@ enum FSMFailureReason: Equatable, Sendable {
   case asrFailed
   case asrWedged
   case emptyAfterProcessing
-  case storageFailed
   case captureStalled
 }
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -157,6 +157,11 @@ final class KernelRecordingSession: RecordingSessionDriving {
         return raw
       },
       store: { _ in
+        // #1167: a throwing save models the best-effort store seam. The kernel
+        // ABSORBS the throw (records it on the finalization outcome) and still
+        // proceeds to deliver + `.completed` — it no longer routes a terminal
+        // storage failure. The `KernelLimbError.storageFailed` test seam is
+        // retained to exercise that the kernel swallows a store throw.
         if limb.storageWriteFails { throw KernelLimbError.storageFailed }
       },
       deliver: { text in
@@ -323,7 +328,6 @@ final class KernelRecordingSession: RecordingSessionDriving {
     case .asrFailed: return .asrFailed
     case .asrWedged: return .asrWedged
     case .emptyAfterProcessing: return .emptyAfterProcessing
-    case .storageFailed: return .storageFailed
     case .captureStalled: return .captureStalled
     }
   }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -425,15 +425,19 @@ enum ScenarioInventory {
         transcript: .nonEmpty),
       tags: [.concurrencySensitive]),
     Scenario(
-      id: "L6", name: "transcript disk-save fails after transcript",
+      id: "L6", name: "transcript disk-save fails but delivery still completes (#1167)",
       steps: [
         .engine(.setBehavior(.batchSuccess(text: "delivered text"))),
         .limb(.storageWriteFails),
         .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
       ],
+      // #1167: a history-save throw is best-effort — the kernel absorbs it and
+      // still delivers the polished text, reaching `.completed` with no
+      // user-visible error. (The pill + recovery-spool retention are App-layer
+      // concerns covered in the wiring / planner / handler unit tests.)
       expected: ExpectedOutcome(
-        terminalState: .failed(.storageFailed), pasteCount: 0, pasteOutcome: .none,
-        transcript: .none, userVisibleError: .recoverableError)),
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty)),
   ]
 
   /// The exact canonical ID set — `ScenarioInventoryTests` asserts the inventory


### PR DESCRIPTION
Closes #1167.

## What
The post-ASR history save is now **best-effort**. When `TranscriptStore.save` throws (full disk / unwritable volume), the kernel records the failure and **absorbs** it — delivery (paste + clipboard) still runs with the already-polished text and the session finishes `.completed`. Previously a save throw routed `.failed(.storageFailed)`, so the user lost their already-polished words and saw "Failed to save transcript."

Order is **unchanged** (save stays before paste). Per founder directive: paste is the *unverifiable* channel (~half of paste targets can't confirm a paste landed, #1154), history is the *grounded* safety net — so the reliable channel keeps its first-class, save-first position; the change only makes it stop aborting.

## Behavior on a save failure
- Paste still delivers the polished text; session reaches `.completed`, no crash.
- A transient pill **"Couldn't save to history: <reason>"** shows concurrent with the paste (disk full / permission denied / read-only / generic).
- The crash-recovery spool (#1063) is **retained** (cleanup gated on `historySaved`), so History self-heals as a "Recovered" entry next launch.
- **Clipboard behavior is UNCHANGED** — it always reverts per the user's setting. We never override the clipboard to "protect" an unsaved transcript (paste is unverifiable, so that would clobber the clipboard on the common case where the paste *did* land). Recorded as `pipeline-mechanics.md` RULE: clipboard-restore-is-sacred.
- `dictation.completed` gains `history_save_status` + `history_save_error_class`; the durable-save success marker is withheld on a degraded-save completion.

## Notable scope adjustments (from Codex grounded + code-diff review)
- `TranscriptStore.save` now **preserves the POSIX errno** on the `open`-guard failure (was a generic `fileWriteUnknown`), so the reason is accurate for disk-full / permission / read-only; the new `HistorySaveErrorClass` classifier also unwraps `NSUnderlyingErrorKey`.
- `LiveRecordingState.currentTranscript` (the History detail-pane live fallback) is **suppressed when the save failed**, so an unsaved transcript doesn't appear as a phantom row that vanishes on restart.
- `RecordingFailureReason.storageFailed` removed (no longer produced).

## Validation
- `scripts/xcode-test.sh` — **1973 tests pass**. New/updated unit tests: best-effort store, degraded-save success-marker gate, planner/handler pill + append-skip, error-class classifier (incl. POSIX + underlying-unwrap), simulator L6 now asserts `.completed` + delivered.
- Local `codex review` clean (2 P2s found and fixed: errno preservation, History phantom row).
- **Live UAT** (dev build, `EW_FAULT_INJECTION=1 EW_FAULT_SAVE=out_of_space`): dictated → transcribed → polished → **pasted into the active app** (`tier=cgevent`); **no History file written** (save threw); **recovery spool retained**; **clipboard reverted to the pre-set sentinel**; **pill captured via AX: "Couldn't save to history: disk is full"**; no hard error; `.completed` terminal.

Plan: `docs/feature-requests/issue-1167-2026-06-22-history-save-best-effort.md`.