### PR TITLE
feat(telemetry): Phase 0 conventions — flush reason, snapshot seam, release DSN guard (#1169)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
           HAS_APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_BASE64 != '' }}
           HAS_APP_ID: ${{ secrets.APP_ID != '' }}
           HAS_APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY != '' }}
+          HAS_SENTRY_DSN: ${{ secrets.SENTRY_DSN != '' }}
           MODE: ${{ inputs.mode || 'full' }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
@@ -198,6 +199,17 @@ jobs:
             [[ "$HAS_SPARKLE_PRIVATE_KEY" == "true" ]] || { echo "::error::SPARKLE_PRIVATE_KEY missing"; FAIL=1; }
             [[ "$HAS_DEVELOPER_ID_CERT" == "true" ]]    || { echo "::error::DEVELOPER_ID_CERT_BASE64 missing"; FAIL=1; }
             [[ "$HAS_APPLE_API_KEY" == "true" ]]         || { echo "::error::APPLE_API_KEY_BASE64 missing"; FAIL=1; }
+          fi
+
+          # Sentry DSN — required ONLY for modes that BUILD+STAMP the app (mirror of the
+          # build-release-artifacts job's if: push || full || build-only). #1169 / #945
+          # gap 6: a release must not ship green with crash reporting silently OFF.
+          # release-only republishes existing already-stamped DMGs and
+          # appcast-only/sentry-only never build, so they need no DSN. dry_run with
+          # full/build-only still builds+stamps, so it stays required there.
+          # Pro-telemetry (keeps capture ON), not content-policing.
+          if [[ "$MODE" == "full" || "$MODE" == "build-only" ]]; then
+            [[ "$HAS_SENTRY_DSN" == "true" ]] || { echo "::error::SENTRY_DSN missing — release would ship with crash reporting OFF"; FAIL=1; }
           fi
 
           # App token — required for appcast push. #1117 least-privilege: a dry_run

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -145,19 +145,14 @@ final class AppLifecycleCoordinator {
     dictationRuntime.startHotkeyServiceIfEnabled()
 
     if settings.onboardingState == .completed {
-      let s = settings
-      let hasKeys =
-        (try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
-        || (try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
-      TelemetryService.shared.settingsSnapshot(
-        asrBackend: s.selectedBackend.rawValue,
-        llmProvider: s.llmProvider.rawValue,
-        recordingMode: s.recordingMode.rawValue,
-        fillerRemoval: s.fillerRemovalEnabled,
-        customWordsCount: customWordsCoordinator.customWords.count,
-        hasApiKeys: hasKeys,
-        noiseSuppression: s.noiseSuppression
-      )
+      // Telemetry Bible Phase 0 (#1169): the standing settings snapshot now
+      // routes through one named seam (extended by Phase 3/4). Behavior-
+      // preserving — same event, same fields, same launch timing.
+      StandingSnapshotBuilder(
+        settings: settings,
+        keychainManager: keychainManager,
+        customWordsCoordinator: customWordsCoordinator
+      ).emit()
     }
 
     // Run Apple Intelligence diagnostics via coordinator.

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -218,7 +218,7 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
       isCritical: item.isCriticalUpdate,
       source: source
     )
-    TelemetryService.shared.flushTelemetry()
+    TelemetryService.shared.flushTelemetry(reason: .updateInstall)
   }
 
   /// Issue #343: silent install-on-quit path. This is a separate Sparkle
@@ -237,7 +237,7 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
       isCritical: item.isCriticalUpdate,
       source: "install_on_quit"
     )
-    TelemetryService.shared.flushTelemetry()
+    TelemetryService.shared.flushTelemetry(reason: .updateInstall)
     // Returning false lets Sparkle's automatic install-on-quit proceed normally.
     return false
   }

--- a/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
+++ b/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
@@ -1,0 +1,46 @@
+import EnviousWisprLLM
+import EnviousWisprServices
+
+/// Telemetry Bible Phase 0 (#1169): the single home that builds and emits the
+/// standing settings/permission snapshot.
+///
+/// Today it emits the launch-time `settings.snapshot` — a behavior-preserving
+/// extraction of the former inline block in `AppLifecycleCoordinator`
+/// (identical event, identical seven fields, identical launch timing). Phase 3
+/// (#1172) extends it with microphone / Accessibility posture; Phase 4 (#1173)
+/// adds the debounced change-driven re-emit. Telemetry is a limb: this never
+/// throws and must not block launch — Keychain reads stay `try?`-guarded so a
+/// read failure degrades to `hasApiKeys = false` exactly as before.
+@MainActor
+struct StandingSnapshotBuilder {
+  private let settings: SettingsManager
+  private let keychainManager: KeychainManager
+  private let customWordsCoordinator: CustomWordsCoordinator
+
+  init(
+    settings: SettingsManager,
+    keychainManager: KeychainManager,
+    customWordsCoordinator: CustomWordsCoordinator
+  ) {
+    self.settings = settings
+    self.keychainManager = keychainManager
+    self.customWordsCoordinator = customWordsCoordinator
+  }
+
+  /// Build the current snapshot values and emit `settings.snapshot`.
+  func emit() {
+    let s = settings
+    let hasKeys =
+      (try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)) != nil
+      || (try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)) != nil
+    TelemetryService.shared.settingsSnapshot(
+      asrBackend: s.selectedBackend.rawValue,
+      llmProvider: s.llmProvider.rawValue,
+      recordingMode: s.recordingMode.rawValue,
+      fillerRemoval: s.fillerRemovalEnabled,
+      customWordsCount: customWordsCoordinator.customWords.count,
+      hasApiKeys: hasKeys,
+      noiseSuppression: s.noiseSuppression
+    )
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -357,7 +357,7 @@ final class UpdateCoordinator {
       isCritical: isCritical,
       secondsVisible: secondsVisible
     )
-    TelemetryService.shared.flushTelemetry()
+    TelemetryService.shared.flushTelemetry(reason: .updateInstall)
     service.triggerInstall()
   }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -633,6 +633,22 @@ public final class TelemetryService {
     fillerRemoval: Bool, customWordsCount: Int,
     hasApiKeys: Bool, noiseSuppression: Bool
   ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "settings.snapshot",
+          stringProps: [
+            "asr_backend": asrBackend,
+            "llm_provider": llmProvider,
+            "recording_mode": recordingMode,
+          ],
+          intProps: ["custom_words_count": customWordsCount],
+          boolProps: [
+            "filler_removal": fillerRemoval,
+            "has_api_keys": hasApiKeys,
+            "noise_suppression": noiseSuppression,
+          ]))
+    #endif
     PostHogSDK.shared.capture(
       "settings.snapshot",
       properties: [
@@ -1028,9 +1044,31 @@ public final class TelemetryService {
     )
   }
 
+  /// Why a telemetry flush was requested. Carried on `telemetry.flush_requested`.
+  /// Only `.updateInstall` is live today (the Sparkle pre-relaunch flush). Future
+  /// reasons (appTerminate / crash / manual) are added by the phases that wire
+  /// their real call sites — Telemetry Bible Phase 1 (#1170) — never as
+  /// un-emitted cases here.
+  public enum FlushReason: String {
+    case updateInstall = "update_install"
+  }
+
   /// Synchronously flushes buffered events. Called before triggering install
-  /// so click/start events survive Sparkle's relaunch.
-  public func flushTelemetry() {
+  /// so click/start events survive Sparkle's relaunch. Emits
+  /// `telemetry.flush_requested` carrying `reason` first; PostHog `capture`
+  /// writes the event to its disk-backed queue synchronously (before this
+  /// `flush()` is called), so the flush includes it and it survives a relaunch
+  /// regardless. PostHog `flush()` exposes no delivery result (G3 is not
+  /// observable app-side) — delivery health is watched by the product-health
+  /// integrity heartbeat, not here.
+  public func flushTelemetry(reason: FlushReason) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "telemetry.flush_requested", stringProps: ["reason": reason.rawValue]))
+    #endif
+    PostHogSDK.shared.capture(
+      "telemetry.flush_requested", properties: ["reason": reason.rawValue])
     PostHogSDK.shared.flush()
   }
 

--- a/Tests/EnviousWisprTests/App/StandingSnapshotBuilderTests.swift
+++ b/Tests/EnviousWisprTests/App/StandingSnapshotBuilderTests.swift
@@ -1,0 +1,62 @@
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+#if DEBUG
+
+  /// Telemetry Bible Phase 0 (#1169): the `StandingSnapshotBuilder` seam is a
+  /// behavior-preserving extraction of the former inline launch emission. This
+  /// pins that `emit()` sends `settings.snapshot` with the current settings
+  /// values, so a later Phase-3/4 extension can't silently change the launch
+  /// payload. Body is synchronous (set hook -> emit -> read -> restore, no
+  /// await), so the process-global `testEventHook` is flake-immune per
+  /// swift-patterns RULE: tests-no-process-global-mutable-delegate.
+  @Suite("Standing snapshot builder", .serialized)
+  struct StandingSnapshotBuilderTests {
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: CapturedTelemetryEvent?
+      func set(_ event: CapturedTelemetryEvent) { lock.withLock { stored = event } }
+      var value: CapturedTelemetryEvent? { lock.withLock { stored } }
+    }
+
+    @MainActor
+    @Test("emit() sends settings.snapshot carrying the current settings values")
+    func emitSendsSnapshotWithCurrentValues() {
+      let suite = UserDefaults(suiteName: "StandingSnapshotBuilderTests-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      let customWords = CustomWordsCoordinator()
+      let builder = StandingSnapshotBuilder(
+        settings: settings,
+        keychainManager: KeychainManager(),
+        customWordsCoordinator: customWords
+      )
+
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "settings.snapshot" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      builder.emit()
+
+      guard let event = box.value else {
+        Issue.record("Expected settings.snapshot event")
+        return
+      }
+      #expect(event.stringProps["asr_backend"] == settings.selectedBackend.rawValue)
+      #expect(event.stringProps["llm_provider"] == settings.llmProvider.rawValue)
+      #expect(event.stringProps["recording_mode"] == settings.recordingMode.rawValue)
+      #expect(event.boolProps["filler_removal"] == settings.fillerRemovalEnabled)
+      #expect(event.intProps["custom_words_count"] == customWords.customWords.count)
+      #expect(event.boolProps["noise_suppression"] == settings.noiseSuppression)
+      // has_api_keys depends on the machine's Keychain/file backend, so assert
+      // presence (not a fixed truth value) to stay deterministic across runs.
+      #expect(event.boolProps["has_api_keys"] != nil)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
@@ -1,0 +1,44 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// Telemetry Bible Phase 0 (#1169): `flushTelemetry(reason:)` must emit
+  /// `telemetry.flush_requested` carrying the reason (request-attempted, not
+  /// delivery). Delivery itself is unobservable app-side (G3), so there is no
+  /// seam to assert `flush()` ran — that is structural (the line after capture).
+  @Suite("Telemetry flush reason", .serialized)
+  struct TelemetryFlushReasonTests {
+
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var events: [CapturedTelemetryEvent] = []
+      func append(_ event: CapturedTelemetryEvent) { lock.withLock { events.append(event) } }
+      var all: [CapturedTelemetryEvent] { lock.withLock { events } }
+    }
+
+    @MainActor
+    @Test("flushTelemetry(reason:) emits one telemetry.flush_requested carrying the reason")
+    func flushEmitsRequestedEventWithReason() {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "telemetry.flush_requested" { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.flushTelemetry(reason: .updateInstall)
+
+      #expect(box.all.count == 1)
+      #expect(box.all.first?.stringProps["reason"] == "update_install")
+    }
+
+    @Test("FlushReason raw values are the bounded expected set")
+    func flushReasonRawValuesBounded() {
+      // Only `.updateInstall` is live today; future reasons are added with their
+      // real call sites (Telemetry Bible Phase 1), never as un-emitted cases.
+      #expect(TelemetryService.FlushReason.updateInstall.rawValue == "update_install")
+    }
+  }
+
+#endif


### PR DESCRIPTION
## Telemetry Bible Phase 0 — shared conventions

Foundation phase of the Telemetry Bible (#1168). Locks the conventions the later phases reuse so none of them reinvents event names, snapshot logic, the flush entry point, or the alert home.

**Closes #1169. Part of #1168.**

### What changed
- **Flush convention.** `flushTelemetry()` → `flushTelemetry(reason:)`; emits `telemetry.flush_requested` carrying the reason (request-attempted, **not** delivery — PostHog `flush()` exposes no delivery result, so G3 is unobservable app-side). Only `.updateInstall` exists as an enum case today; future reasons are reserved as doc vocabulary and added with their real call sites (Phase 1). The 3 existing Sparkle install callers updated.
- **Standing-snapshot seam.** New `StandingSnapshotBuilder` (AppKit) is a behavior-preserving extraction of the inline launch `settings.snapshot` emission — same event, same 7 fields, same launch timing. Phase 3 extends it with permission posture; Phase 4 adds the change-driven re-emit.
- **Release DSN preflight (#945 gap 6).** `release.yml` "Check required secrets" now hard-fails when `SENTRY_DSN` is missing for `full | build-only` (the modes that build+stamp the app, per the `build-release-artifacts` `if:`). Upgrades the prior warn-only. `release-only`/`appcast-only`/`sentry-only` never stamp, so they're excluded. Pro-telemetry (keeps crash reporting ON), not content-policing.

### Out of scope (deferred, founder directive 2026-06-22)
Privacy-enforcement tooling (a new telemetry grep gate / tripwire extension) is **not** built — this program adds telemetry, it does not build new self-policing tooling. The existing `beforeSend` sanitizer + existing tripwire stay in force; new payloads remain metadata-only by design.

### Validation
- Plan: coverage council (GPT-5.5 + Gemini-3.1) → Codex grounded review 3 rounds → PROCEED-AS-PLANNED.
- `scripts/xcode-test.sh` green (1976 tests), incl. new `TelemetryFlushReasonTests` + `StandingSnapshotBuilderTests`.
- Codex code-diff review: no bugs.
- Live UAT: N — additive telemetry + behavior-preserving refactor, no heart-path/audio/paste surface. Codex confirmed the council's capture/flush race does not apply to the pinned SDK (capture writes the disk-backed queue before flush).