### PR TITLE
feat(telemetry): flush on normal quit + clean-quit context (#1170)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -144,6 +144,16 @@ final class AppLifecycleCoordinator {
     // Carbon RegisterEventHotKey requires an active run loop for event delivery.
     dictationRuntime.startHotkeyServiceIfEnabled()
 
+    // Telemetry Bible Phase 1 (#1170): supply `active_recording` / `app_phase`
+    // to every telemetry flush (Sparkle pre-relaunch + normal-quit terminate)
+    // without coupling the sink to pipeline types. Wired here at launch, before
+    // any flush path can fire, so the provider is never nil in production.
+    TelemetryService.shared.flushContextProvider = { [weak self] in
+      let phase = self?.liveRecordingState.pipelineState ?? .idle
+      return TelemetryService.FlushContext(
+        activeRecording: phase.isActive, appPhase: phase.telemetryLabel)
+    }
+
     if settings.onboardingState == .completed {
       // Telemetry Bible Phase 0 (#1169): the standing settings snapshot now
       // routes through one named seam (extended by Phase 3/4). Behavior-
@@ -266,6 +276,16 @@ final class AppLifecycleCoordinator {
   }
 
   func runWillTerminate() {
+    // Telemetry Bible Phase 1 (#1170): best-effort at-quit delivery attempt +
+    // a durable clean-quit marker (carries active_recording / app_phase).
+    // Non-blocking: PostHog flush() only schedules delivery, and capture() has
+    // already persisted events to disk, so nothing is lost if the scheduled
+    // send doesn't finish before exit. Runs FIRST so the context reflects the
+    // real in-flight phase (teardown below resets pipeline state). Crash-time
+    // flush is intentionally absent — native crash handlers can't safely do
+    // async network; pre-crash events survive via PostHog's disk queue.
+    TelemetryService.shared.flushTelemetry(reason: .appTerminate)
+
     // PR-B.2 of #763: both window-close observers are torn down by the
     // coordinator now.
     appWindowCoordinator.tearDown()

--- a/Sources/EnviousWisprCore/AppSettings.swift
+++ b/Sources/EnviousWisprCore/AppSettings.swift
@@ -32,6 +32,22 @@ public enum PipelineState: Equatable, Sendable {
     }
   }
 
+  /// Stable lowercase phase label for telemetry (e.g. the `app_phase` property
+  /// on `telemetry.flush_requested`, Telemetry Bible Phase 1 / #1170). Total
+  /// switch (no `default`) so a new `PipelineState` case forces a compile-time
+  /// decision here rather than silently mapping to a stale label.
+  public var telemetryLabel: String {
+    switch self {
+    case .idle: return "idle"
+    case .loadingModel: return "loading_model"
+    case .recording: return "recording"
+    case .transcribing: return "transcribing"
+    case .polishing: return "polishing"
+    case .complete: return "complete"
+    case .error: return "error"
+    }
+  }
+
 }
 
 /// Policy controlling when idle ASR models are unloaded from memory.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1054,30 +1054,73 @@ public final class TelemetryService {
   }
 
   /// Why a telemetry flush was requested. Carried on `telemetry.flush_requested`.
-  /// Only `.updateInstall` is live today (the Sparkle pre-relaunch flush). Future
-  /// reasons (appTerminate / crash / manual) are added by the phases that wire
-  /// their real call sites — Telemetry Bible Phase 1 (#1170) — never as
-  /// un-emitted cases here.
+  /// `.updateInstall` = the Sparkle pre-relaunch flush. `.appTerminate` = the
+  /// normal-quit best-effort flush (Telemetry Bible Phase 1 / #1170). A crash-time
+  /// reason is intentionally absent — native crash handlers can't safely do async
+  /// network, so crash flush is documented-infeasible, not wired.
   public enum FlushReason: String {
     case updateInstall = "update_install"
+    case appTerminate = "app_terminate"
   }
 
-  /// Synchronously flushes buffered events. Called before triggering install
-  /// so click/start events survive Sparkle's relaunch. Emits
-  /// `telemetry.flush_requested` carrying `reason` first; PostHog `capture`
-  /// writes the event to its disk-backed queue synchronously (before this
-  /// `flush()` is called), so the flush includes it and it survives a relaunch
-  /// regardless. PostHog `flush()` exposes no delivery result (G3 is not
-  /// observable app-side) — delivery health is watched by the product-health
-  /// integrity heartbeat, not here.
+  /// Late-bound context for a flush, supplied by a provider closure (mirrors
+  /// `SentryBreadcrumb.audioEnvironmentProvider`). Plain already-collected data
+  /// only — the provider must not await, take locks, or query Core Audio.
+  public struct FlushContext: Sendable {
+    public let activeRecording: Bool
+    public let appPhase: String
+    public init(activeRecording: Bool, appPhase: String) {
+      self.activeRecording = activeRecording
+      self.appPhase = appPhase
+    }
+  }
+
+  /// Supplies `active_recording` / `app_phase` for every flush without coupling
+  /// this sink to AppKit/pipeline types. Wired once at launch from the live
+  /// recording state; nil only in unit tests / before launch wiring, in which
+  /// case `flushTelemetry` falls back to `(false, "unknown")` and logs a DEBUG
+  /// warning so the fallback is never a silent production steady state.
+  public var flushContextProvider: (@MainActor () -> FlushContext)?
+
+  /// Best-effort, non-blocking flush. Used before a Sparkle relaunch and on
+  /// normal termination. Emits `telemetry.flush_requested` (carrying `reason`,
+  /// `active_recording`, `app_phase`) first; PostHog `capture` writes the event
+  /// to its disk-backed queue synchronously (so it is durable and included in
+  /// the flush regardless of whether the scheduled delivery completes before a
+  /// relaunch/quit). PostHog `flush()` only schedules async delivery and returns
+  /// immediately — it never blocks the caller, and it exposes no delivery result
+  /// (G3 is not observable app-side; delivery health is watched by the
+  /// product-health integrity heartbeat, not here).
   public func flushTelemetry(reason: FlushReason) {
+    let context: FlushContext
+    if let provided = flushContextProvider?() {
+      context = provided
+    } else {
+      context = FlushContext(activeRecording: false, appPhase: "unknown")
+      #if DEBUG
+        Task {
+          await AppLogger.shared.log(
+            "flushTelemetry: context provider not wired — using fallback "
+              + "(active_recording=false, app_phase=unknown)",
+            level: .debug, category: "Telemetry")
+        }
+      #endif
+    }
+
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
-          name: "telemetry.flush_requested", stringProps: ["reason": reason.rawValue]))
+          name: "telemetry.flush_requested",
+          stringProps: ["reason": reason.rawValue, "app_phase": context.appPhase],
+          boolProps: ["active_recording": context.activeRecording]))
     #endif
     PostHogSDK.shared.capture(
-      "telemetry.flush_requested", properties: ["reason": reason.rawValue])
+      "telemetry.flush_requested",
+      properties: [
+        "reason": reason.rawValue,
+        "active_recording": context.activeRecording,
+        "app_phase": context.appPhase,
+      ])
     PostHogSDK.shared.flush()
   }
 

--- a/Tests/EnviousWisprTests/Core/PipelineStateTelemetryLabelTests.swift
+++ b/Tests/EnviousWisprTests/Core/PipelineStateTelemetryLabelTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// Telemetry Bible Phase 1 (#1170): `PipelineState.telemetryLabel` is the stable
+/// lowercase `app_phase` value carried on `telemetry.flush_requested`. The mapping
+/// is a total switch — every case has an explicit label, and `.error` collapses
+/// to "error" regardless of its associated message.
+@Suite("PipelineState telemetry label")
+struct PipelineStateTelemetryLabelTests {
+
+  @Test("every PipelineState case maps to its stable telemetry label")
+  func everyCaseMapsToStableLabel() {
+    #expect(PipelineState.idle.telemetryLabel == "idle")
+    #expect(PipelineState.loadingModel.telemetryLabel == "loading_model")
+    #expect(PipelineState.recording.telemetryLabel == "recording")
+    #expect(PipelineState.transcribing.telemetryLabel == "transcribing")
+    #expect(PipelineState.polishing.telemetryLabel == "polishing")
+    #expect(PipelineState.complete.telemetryLabel == "complete")
+    #expect(PipelineState.error("boom").telemetryLabel == "error")
+  }
+
+  @Test("error label is independent of the associated message")
+  func errorLabelIgnoresMessage() {
+    #expect(PipelineState.error("").telemetryLabel == "error")
+    #expect(PipelineState.error("some failure").telemetryLabel == "error")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
@@ -4,10 +4,11 @@ import Testing
 
 #if DEBUG
 
-  /// Telemetry Bible Phase 0 (#1169): `flushTelemetry(reason:)` must emit
-  /// `telemetry.flush_requested` carrying the reason (request-attempted, not
-  /// delivery). Delivery itself is unobservable app-side (G3), so there is no
-  /// seam to assert `flush()` ran — that is structural (the line after capture).
+  /// Telemetry Bible Phase 0 (#1169) + Phase 1 (#1170): `flushTelemetry(reason:)`
+  /// must emit `telemetry.flush_requested` carrying the reason (request-attempted,
+  /// not delivery — delivery is unobservable app-side, G3) plus the Phase 1
+  /// diagnostic context `active_recording` / `app_phase`, sourced from the
+  /// `flushContextProvider` closure with a `(false, "unknown")` fallback.
   @Suite("Telemetry flush reason", .serialized)
   struct TelemetryFlushReasonTests {
 
@@ -22,6 +23,7 @@ import Testing
     @Test("flushTelemetry(reason:) emits one telemetry.flush_requested carrying the reason")
     func flushEmitsRequestedEventWithReason() {
       let box = EventBox()
+      TelemetryService.shared.flushContextProvider = nil
       TelemetryService.shared.testEventHook = { @Sendable event in
         if event.name == "telemetry.flush_requested" { box.append(event) }
       }
@@ -35,9 +37,52 @@ import Testing
 
     @Test("FlushReason raw values are the bounded expected set")
     func flushReasonRawValuesBounded() {
-      // Only `.updateInstall` is live today; future reasons are added with their
-      // real call sites (Telemetry Bible Phase 1), never as un-emitted cases.
+      // `.updateInstall` (Sparkle pre-relaunch) + `.appTerminate` (normal quit,
+      // Phase 1) are the only live reasons; a crash reason is intentionally absent.
       #expect(TelemetryService.FlushReason.updateInstall.rawValue == "update_install")
+      #expect(TelemetryService.FlushReason.appTerminate.rawValue == "app_terminate")
+    }
+
+    @MainActor
+    @Test("flushTelemetry falls back to (false, unknown) when no context provider is wired")
+    func flushUsesFallbackContextWhenProviderNil() {
+      let box = EventBox()
+      TelemetryService.shared.flushContextProvider = nil
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "telemetry.flush_requested" { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.flushTelemetry(reason: .appTerminate)
+
+      #expect(box.all.count == 1)
+      let event = box.all.first
+      #expect(event?.stringProps["reason"] == "app_terminate")
+      #expect(event?.boolProps["active_recording"] == false)
+      #expect(event?.stringProps["app_phase"] == "unknown")
+    }
+
+    @MainActor
+    @Test("flushTelemetry carries active_recording / app_phase from the context provider")
+    func flushCarriesProviderContext() {
+      let box = EventBox()
+      TelemetryService.shared.flushContextProvider = {
+        TelemetryService.FlushContext(activeRecording: true, appPhase: "recording")
+      }
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "telemetry.flush_requested" { box.append(event) }
+      }
+      defer {
+        TelemetryService.shared.testEventHook = nil
+        TelemetryService.shared.flushContextProvider = nil
+      }
+
+      TelemetryService.shared.flushTelemetry(reason: .appTerminate)
+
+      #expect(box.all.count == 1)
+      let event = box.all.first
+      #expect(event?.boolProps["active_recording"] == true)
+      #expect(event?.stringProps["app_phase"] == "recording")
     }
   }
 


### PR DESCRIPTION
Closes #1170. Part of #1168 (Telemetry Bible Phase 1).

## What
On a normal quit the app made no at-quit flush and emitted no clean-quit signal. **Captured events are already durable** (verified against pinned posthog-ios 3.61.0: `capture()` is synchronous-to-disk, delivers next launch), so this is **not a data-loss fix**. It adds:
1. A new `FlushReason.appTerminate`, flushed at the **top** of `runWillTerminate` — best-effort, non-blocking (PostHog `flush()` only schedules delivery; never blocks quit).
2. A durable **clean-quit marker**: `telemetry.flush_requested` now carries `active_recording` + `app_phase`, so a quit-during-dictation (incl. the impatient quit-during-polish) is observable.
3. The two fields are sourced via a `@MainActor` `FlushContext` provider wired once at launch — covers the 3 existing Sparkle flushes too, no call-site churn. Nil provider → `(false, "unknown")` + DEBUG warning (never silent).

Crash-time flush documented infeasible (native crash handlers can't safely do async network). G3 (no app-side delivery signal) stays documented-unsupported (Phase 0).

## Design
Provider injection (Option A) chosen over explicit params / state-push — Codex grounded review confirmed it fits the existing `audioEnvironmentProvider` / `pipelineStateProvider` idioms. `PipelineState.telemetryLabel` is a pure total switch in Core.

## Validation
- Logic tests: `scripts/xcode-test.sh` green (1991 tests, 0 failures) — new flush-reason + provider-context + fallback + phase-label cases.
- Codex code-diff review: clean (no blocking bugs).
- Council (GPT-5.5 + Gemini-3.1) + Codex grounded review: 4 rounds to PROCEED-AS-PLANNED.
- **Live UAT:** dictate → transcript pastes (heart path PASS, 1.67s); clean Cocoa quit → on-disk PostHog queue holds `telemetry.flush_requested reason=app_terminate app_phase=complete active_recording=false` (synchronous capture proven; provider wired — real phase, not fallback); no crash; process gone.

## Tier / lane
MEDIUM, Code lane. Heart path, PostHog buffering config, Sentry/crash path, and the 3 Sparkle flush lines untouched.