### PR TITLE
feat(release): auto-publish marketing-friendly release notes from What's New

### DIFF
--- a/.github/workflows/ci-drift-check.yml
+++ b/.github/workflows/ci-drift-check.yml
@@ -63,6 +63,13 @@ jobs:
             .github/workflows/*.yml
           echo "All workflows pass YAML validation."
 
+      - name: Check release-notes renderer parses What's New
+        run: |
+          echo "==> Verifying the release-notes renderer can read WhatsNewContent.swift ..."
+          # Catches drift between the Swift What's New format and the parser the
+          # release workflow relies on, before it silently falls back to auto-notes.
+          python3 scripts/ci/render-release-notes.py --self-test
+
       - name: Drift check summary
         if: always()
         run: |
@@ -70,3 +77,4 @@ jobs:
           echo "- Action SHA pinning: checked"
           echo "- Script existence: checked"
           echo "- YAML validity: checked"
+          echo "- Release-notes renderer: checked"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,12 +600,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.preflight.outputs.tag }}
+          COMMITISH: ${{ github.sha }}
         run: |
           set -uo pipefail
           CURATED="build/release-notes-curated.md"
           if [ -s "$CURATED" ]; then
+            # target_commitish is required by the generate-notes API when the tag
+            # does not yet exist (e.g. a workflow_dispatch release that creates the
+            # tag); it is ignored when the tag already exists (the normal tag-push
+            # path), so passing it always is safe and preserves the changelog in both.
             AUTO=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
-              -f tag_name="$TAG" --jq '.body' 2>/dev/null || true)
+              -f tag_name="$TAG" -f target_commitish="$COMMITISH" --jq '.body' 2>/dev/null || true)
             {
               cat "$CURATED"
               if [ -n "${AUTO:-}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,15 +495,30 @@ jobs:
           VERSION: ${{ needs.preflight.outputs.version }}
         run: cp "build/EnviousWispr-${VERSION}.dmg" "build/EnviousWispr.dmg"
 
+      - name: Render curated release notes
+        # Render marketing-friendly notes from the in-app What's New copy (the single
+        # source of truth: WhatsNewContent.swift). Best-effort by design: on any
+        # failure the publish job falls back to GitHub's auto-generated notes, so this
+        # step can never block a release or ship it with a blank body.
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          python3 scripts/ci/render-release-notes.py \
+            --version "$VERSION" --out build/release-notes-curated.md \
+          || echo "::warning::Could not render curated notes for v$VERSION; release will use auto-generated notes"
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts-${{ needs.preflight.outputs.version }}
           retention-days: 30
+          if-no-files-found: warn
           path: |
             build/EnviousWispr-*.dmg
             build/EnviousWispr.dmg
             build/appcast-entry.xml
+            build/release-notes-curated.md
 
       - name: Upload dSYM artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -576,6 +591,32 @@ jobs:
             echo "==> Release $TAG does not exist — will create"
           fi
 
+      - name: Compose release notes
+        # If the build job rendered curated What's New notes, wrap them with the
+        # auto-generated PR changelog (collapsed) into the final release body. If no
+        # curated notes exist, leave no body file so the create step falls back to
+        # --generate-notes. This step never fails the release.
+        if: steps.check-release.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.preflight.outputs.tag }}
+        run: |
+          set -uo pipefail
+          CURATED="build/release-notes-curated.md"
+          if [ -s "$CURATED" ]; then
+            AUTO=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="$TAG" --jq '.body' 2>/dev/null || true)
+            {
+              cat "$CURATED"
+              if [ -n "${AUTO:-}" ]; then
+                printf '\n<details>\n<summary>Full technical changelog</summary>\n\n%s\n\n</details>\n' "$AUTO"
+              fi
+            } > build/release-body.md
+            echo "==> Composed curated release notes ($(wc -l < build/release-body.md) lines)"
+          else
+            echo "::warning::No curated What's New notes found; release will use auto-generated notes"
+          fi
+
       - name: Create GitHub Release
         if: steps.check-release.outputs.exists == 'false' && inputs.dry_run != true
         env:
@@ -585,10 +626,17 @@ jobs:
         run: |
           # --repo is required on hosted runners: this job has no checkout, so a
           # fresh hosted workspace has no .git for gh to infer the repo from. (#1087)
+          if [ -s build/release-body.md ]; then
+            NOTES_ARGS=(--notes-file build/release-body.md)
+            echo "==> Using curated release notes"
+          else
+            NOTES_ARGS=(--generate-notes)
+            echo "==> Using auto-generated release notes (no curated notes available)"
+          fi
           gh release create "$TAG" \
             --repo "${{ github.repository }}" \
             --title "EnviousWispr v${VERSION}" \
-            --generate-notes \
+            "${NOTES_ARGS[@]}" \
             "build/EnviousWispr-${VERSION}.dmg" \
             "build/EnviousWispr.dmg"
 
@@ -598,9 +646,15 @@ jobs:
           VERSION: ${{ needs.preflight.outputs.version }}
           TAG: ${{ needs.preflight.outputs.tag }}
         run: |
-          # #1117: rehearsal — print the exact command that WOULD run, create nothing.
-          echo "DRY RUN: would run:"
-          echo "  gh release create \"$TAG\" --repo \"${{ github.repository }}\" --title \"EnviousWispr v${VERSION}\" --generate-notes build/EnviousWispr-${VERSION}.dmg build/EnviousWispr.dmg"
+          # #1117: rehearsal — print what WOULD run, create nothing.
+          if [ -s build/release-body.md ]; then
+            echo "DRY RUN: would create release $TAG with CURATED notes (--notes-file):"
+            echo "----------------------------------------"
+            cat build/release-body.md
+            echo "----------------------------------------"
+          else
+            echo "DRY RUN: would create release $TAG with AUTO-generated notes (--generate-notes)"
+          fi
           ls -la build/EnviousWispr-*.dmg build/EnviousWispr.dmg 2>/dev/null || echo "::warning::expected DMGs not found in dry-run download"
 
       - name: Upload assets to existing release (recovery only)

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Render marketing-friendly GitHub release notes from the in-app What's New copy.
+
+Single source of truth: Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+(the same copy users see in Settings > What's New). This script extracts the entries
+for one version and emits grouped, plain-English markdown for the GitHub release body.
+
+Used by .github/workflows/release.yml. Designed to fail SAFELY: if it cannot produce
+notes for the requested version, it exits non-zero and the workflow falls back to
+GitHub's auto-generated notes, so a release is never blocked or shipped blank.
+
+Usage:
+  render-release-notes.py --version 2.1.4 [--swift-file PATH] [--out FILE]
+  render-release-notes.py --list
+  render-release-notes.py --self-test   # parse + assert currentContentVersion renders
+"""
+import argparse
+import collections
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_SWIFT = os.path.join(
+    REPO_ROOT, "Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift"
+)
+CONSTANTS_SWIFT = os.path.join(
+    REPO_ROOT, "Sources/EnviousWisprCore/WhatsNewConstants.swift"
+)
+
+# Mirror of WhatsNewContent.Category raw values, in display order.
+CATEGORY_RAW = {
+    "newFeatures": "New Features",
+    "smarterAIPolish": "Smarter AI Polish",
+    "betterOllamaSupport": "Better Ollama Support",
+    "fasterAndMoreReliable": "Faster and More Reliable",
+    "qualityOfLife": "Quality of Life",
+    "privacyAndSecurity": "Privacy and Security",
+}
+CATEGORY_ORDER = list(CATEGORY_RAW.values())
+
+ENTRY_RE = re.compile(r"Entry\(\s*(.*?)\)\s*,?\s*(?=Entry\(|\]\s*\n)", re.DOTALL)
+
+
+def parse_entries(swift_path):
+    with open(swift_path, encoding="utf-8") as fh:
+        text = fh.read()
+    entries = []
+    for m in ENTRY_RE.finditer(text):
+        body = m.group(1)
+        t = re.search(r'title:\s*\n?\s*"((?:[^"\\]|\\.)*)"', body, re.DOTALL)
+        d = re.search(r'description:\s*\n?\s*"((?:[^"\\]|\\.)*)"', body, re.DOTALL)
+        c = re.search(r"category:\s*\.(\w+)", body)
+        v = re.search(r'version:\s*"([\d.]+)"', body)
+        if not (t and d and c and v):
+            continue
+        title = t.group(1).replace('\\"', '"')
+        title = re.sub(r"\s*\\\s*\n\s*", " ", title)
+        title = re.sub(r"\s+", " ", title).strip()
+        desc = d.group(1).replace('\\"', '"')
+        desc = re.sub(r"\s*\\\s*\n\s*", " ", desc)
+        desc = re.sub(r"\s+", " ", desc).strip()
+        entries.append(
+            {
+                "title": title,
+                "desc": desc,
+                "category": CATEGORY_RAW.get(c.group(1), c.group(1)),
+                "version": v.group(1),
+            }
+        )
+    return entries
+
+
+def version_key(v):
+    return tuple(int(x) for x in v.split("."))
+
+
+def render(entries, version):
+    es = [e for e in entries if e["version"] == version]
+    if not es:
+        return None
+    out = []
+    for cat in CATEGORY_ORDER:
+        ces = [e for e in es if e["category"] == cat]
+        if not ces:
+            continue
+        out.append(f"### {cat}\n")
+        for e in ces:
+            title = e["title"].rstrip()
+            if title and title[-1] not in ".!?":
+                title += "."
+            out.append(f"- **{title}** {e['desc']}")
+        out.append("")
+    rendered = "\n".join(out).strip()
+    return rendered or None
+
+
+def current_content_version():
+    try:
+        with open(CONSTANTS_SWIFT, encoding="utf-8") as fh:
+            m = re.search(r'currentContentVersion\s*=\s*"([\d.]+)"', fh.read())
+            return m.group(1) if m else None
+    except OSError:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--version")
+    ap.add_argument("--swift-file", default=DEFAULT_SWIFT)
+    ap.add_argument("--out")
+    ap.add_argument("--list", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    entries = parse_entries(args.swift_file)
+    if not entries:
+        print("error: parsed 0 entries from What's New source", file=sys.stderr)
+        return 2
+
+    if args.list:
+        versions = sorted({e["version"] for e in entries}, key=version_key, reverse=True)
+        print("\n".join(versions))
+        return 0
+
+    if args.self_test:
+        cv = current_content_version()
+        if not cv:
+            print("error: could not read currentContentVersion", file=sys.stderr)
+            return 2
+        body = render(entries, cv)
+        if not body:
+            print(
+                f"error: no What's New entries render for currentContentVersion {cv}; "
+                "the parser or the content may have drifted",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"self-test OK: {cv} renders {body.count('- **')} item(s)")
+        return 0
+
+    if not args.version:
+        print("error: --version is required", file=sys.stderr)
+        return 2
+
+    body = render(entries, args.version)
+    if not body:
+        print(
+            f"error: no What's New entries for version {args.version}", file=sys.stderr
+        )
+        return 2
+
+    text = f"## What's new in v{args.version}\n\n{body}\n"
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        print(f"wrote {args.out} ({body.count('- **')} item(s))", file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -39,19 +39,20 @@ CATEGORY_RAW = {
 }
 CATEGORY_ORDER = list(CATEGORY_RAW.values())
 
-ENTRY_RE = re.compile(r"Entry\(\s*(.*?)\)\s*,?\s*(?=Entry\(|\]\s*\n)", re.DOTALL)
-
-
 def parse_entries(swift_path):
     with open(swift_path, encoding="utf-8") as fh:
         text = fh.read()
+    # Split on `Entry(` boundaries: each chunk after the first holds exactly one
+    # entry's fields at its start. This is robust to the `// MARK:` comments
+    # between version sections (a previous lookahead-based regex over-extended
+    # across those comments and silently swallowed the first entry of each older
+    # version section).
     entries = []
-    for m in ENTRY_RE.finditer(text):
-        body = m.group(1)
-        t = re.search(r'title:\s*\n?\s*"((?:[^"\\]|\\.)*)"', body, re.DOTALL)
-        d = re.search(r'description:\s*\n?\s*"((?:[^"\\]|\\.)*)"', body, re.DOTALL)
-        c = re.search(r"category:\s*\.(\w+)", body)
-        v = re.search(r'version:\s*"([\d.]+)"', body)
+    for chunk in text.split("Entry(")[1:]:
+        t = re.search(r'title:\s*\n?\s*"((?:[^"\\]|\\.)*)"', chunk, re.DOTALL)
+        d = re.search(r'description:\s*\n?\s*"((?:[^"\\]|\\.)*)"', chunk, re.DOTALL)
+        c = re.search(r"category:\s*\.(\w+)", chunk)
+        v = re.search(r'version:\s*"([\d.]+)"', chunk)
         if not (t and d and c and v):
             continue
         title = t.group(1).replace('\\"', '"')
@@ -132,6 +133,19 @@ def main():
         return 0
 
     if args.self_test:
+        # Integrity check: every entry has exactly one `version:` field, so the
+        # number of parsed entries must equal the number of version fields in the
+        # source. A mismatch means the parser dropped entries (e.g. the MARK-comment
+        # swallowing bug), even if individual versions still render.
+        with open(args.swift_file, encoding="utf-8") as fh:
+            field_count = len(re.findall(r'version:\s*"[\d.]+"', fh.read()))
+        if len(entries) != field_count:
+            print(
+                f"error: parsed {len(entries)} entries but the source has {field_count} "
+                "version fields; the parser dropped entries (drift)",
+                file=sys.stderr,
+            )
+            return 2
         cv = current_content_version()
         if not cv:
             print("error: could not read currentContentVersion", file=sys.stderr)
@@ -144,7 +158,10 @@ def main():
                 file=sys.stderr,
             )
             return 2
-        print(f"self-test OK: {cv} renders {body.count('- **')} item(s)")
+        print(
+            f"self-test OK: {len(entries)} entries parsed (matches source); "
+            f"{cv} renders {body.count('- **')} item(s)"
+        )
         return 0
 
     if not args.version:

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -79,8 +79,16 @@ def render(entries, version):
     es = [e for e in entries if e["version"] == version]
     if not es:
         return None
+    # Known categories first in canonical display order, then any category present
+    # in the entries but not in CATEGORY_ORDER (e.g. a new WhatsNewContent.Category
+    # case added in Swift) appended in first-appearance order, so an entry is never
+    # silently dropped from release notes.
+    ordered = list(CATEGORY_ORDER)
+    for e in es:
+        if e["category"] not in ordered:
+            ordered.append(e["category"])
     out = []
-    for cat in CATEGORY_ORDER:
+    for cat in ordered:
         ces = [e for e in es if e["category"] == cat]
         if not ces:
             continue


### PR DESCRIPTION
## What and why

Our GitHub release pages have shown raw merged-PR titles (`gh release create --generate-notes`). Meanwhile the app already ships polished, plain-English release copy in **Settings > What's New** (`WhatsNewContent.swift`). This wires the two together so every release publishes that curated copy automatically. No more writing release notes twice, and no more engineer-changelog as the public face of a release.

Pairs with the retroactive backfill already applied to v2.0.0–v2.1.4 (done via the same renderer).

## How it works

- **`scripts/ci/render-release-notes.py`** parses the What's New entries for a version from `WhatsNewContent.swift` (the single source of truth) and renders grouped, plain-English markdown. Fails safe: non-zero exit on missing/unparseable content.
- **`release.yml`**: the build job renders curated notes (best-effort, `continue-on-error`) and uploads them; the publish job composes curated notes + the auto-generated PR changelog (collapsed under `<details>`) and uses `--notes-file`, falling back to `--generate-notes` when no curated notes exist. **The feature can never block a release or ship it blank.**
- **`ci-drift-check.yml`**: a weekly `--self-test` that the renderer still parses the What's New format, so drift is caught before it can silently degrade a release.

## Why no app-code change

The original plan was to move What's New into a bundled JSON the app loads. On inspection, adding a new bundled resource to `EnviousWisprAppKit` goes through the Tuist/`Bundle.module` resource path that was the source of the #913 migration pain. Not worth that risk for a release-notes convenience. Keeping the Swift content as the source of truth and rendering from it at release time achieves the same outcome with **no app rebuild and no UAT**. Codex grounded review endorsed this fallback.

## Validation
- Codex diff review: **CLEAN** (verified bash safety, fail-safe fallback, path handoff between build/publish jobs, and that `gh api generate-notes` works pre-release with the failure path swallowed)
- Both workflow YAMLs validate; renderer `--self-test` passes; compose + fallback simulated locally
- CI-only + new script, no app logic. No Sources/Tests touched.

Lane: Code (`.github/workflows/`, allowlisted `scripts/ci/`). No runtime app behavior change.