### PR TITLE
feat(release): ship GPL license + source pointer + notices in the DMG

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,1011 @@
+THIRD-PARTY NOTICES — EnviousWispr
+==================================
+
+EnviousWispr itself is licensed under the GNU GPL version 3 (see LICENSE).
+It bundles the following third-party components, each under its own
+permissive license. The required copyright and permission notices follow.
+None of these components is GPL/LGPL-licensed.
+
+--------------------------------------------------------------------------------
+WhisperKit (argmax-oss-swift)
+  Version: 1.0.0
+  License: MIT
+  Source:  https://github.com/argmaxinc/argmax-oss-swift
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2024 argmax, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+FluidAudio
+  Version: 46e96f40 (fork saurabhav88/FluidAudio)
+  License: Apache-2.0
+  Source:  https://github.com/saurabhav88/FluidAudio
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
+PostHog iOS
+  Version: 3.61.0
+  License: MIT
+  Source:  https://github.com/PostHog/posthog-ios
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) [2023] [PostHog]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+Sentry Cocoa
+  Version: 9.18.0
+  License: MIT
+  Source:  https://github.com/getsentry/sentry-cocoa
+--------------------------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+Sparkle
+  Version: 2.9.3
+  License: MIT (with bundled BSD/MIT components)
+  Source:  https://github.com/sparkle-project/Sparkle
+--------------------------------------------------------------------------------
+
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions 
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
+swift-argument-parser
+  Version: 1.7.1
+  License: Apache-2.0
+  Source:  https://github.com/apple/swift-argument-parser
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+--------------------------------------------------------------------------------
+fastcluster (bundled in FluidAudio)
+  Version: n/a
+  License: BSD-2-Clause
+  Source:  https://github.com/dmuellner/fastcluster
+--------------------------------------------------------------------------------
+
+Copyright:
+  * Until package version 1.1.23: © 2011 Daniel Müllner <https://danifold.net>
+  * All changes from version 1.1.24 on: © Google Inc. <https://www.google.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
+VBx (bundled in FluidAudio)
+  Version: n/a
+  License: Apache-2.0
+  Source:  https://github.com/BUTSpeechFIT/VBx
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but not
+limited to compiled object code, generated documentation, and
+conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2021-2024 BUT Speech@FIT (original VBx project)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+--------------------------------------------------------------------------------
+PLCrashReporter + protobuf-c (bundled in PostHog)
+  Version: n/a
+  License: MIT / Apache-2.0
+  Source:  https://github.com/microsoft/plcrashreporter
+--------------------------------------------------------------------------------
+
+Except as noted below, PLCrashReporter is provided under the
+following license:
+
+    Copyright (c) Microsoft Corporation.
+    Copyright (c) 2008 - 2014 Plausible Labs Cooperative, Inc.
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+Additional contributions have been made under the same license terms
+as above, with copyright held by their respective authors:
+
+       Damian Morris <damian@moso.com.au>
+       Copyright (c) 2010 MOSO Corporation, Pty Ltd.
+       All rights reserved.
+
+       HockeyApp/Bitstadium
+       Copyright (c) 2012 HockeyApp, Bit Stadium GmbH.
+       All rights reserved.
+
+The protobuf-c library, as well as the PLCrashLogWriterEncoding.c
+file are licensed as follows:
+
+    Copyright 2008, Dave Benson.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with
+    the License. You may obtain a copy of the License
+    at http://www.apache.org/licenses/LICENSE-2.0 Unless
+    required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+--------------------------------------------------------------------------------
+libwebp (bundled in PostHog)
+  Version: n/a
+  License: BSD-3-Clause
+  Source:  https://chromium.googlesource.com/webm/libwebp
+--------------------------------------------------------------------------------
+
+Copyright (c) 2010, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Google nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+--------------------------------------------------------------------------------
+Speech recognition model (downloaded at runtime, NOT bundled in this DMG)
+--------------------------------------------------------------------------------
+
+EnviousWispr downloads the Parakeet TDT speech model (CoreML) from Hugging
+Face on first use; it is not distributed inside this disk image. The model
+is provided under CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/).
+Source: https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -352,6 +352,17 @@ test -f "$NOTICES_SRC"  || { echo "::error::THIRD-PARTY-NOTICES.txt missing at $
 # the Xcode/DerivedData build).
 "$PROJ_ROOT/scripts/ci/gen-third-party-notices.sh" --check
 COMMIT="$(git -C "$PROJ_ROOT" rev-parse HEAD)"
+# If the advertised tag already exists, the build commit MUST be that tag's
+# commit, else SOURCE.txt would point at the wrong corresponding source. On a
+# tag-triggered release HEAD == tag commit by construction; this guards the
+# workflow_dispatch path where the checkout ref can differ from the tag input
+# (cloud review #1).
+if git -C "$PROJ_ROOT" rev-parse -q --verify "refs/tags/v${VERSION}^{commit}" >/dev/null 2>&1; then
+    TAG_COMMIT="$(git -C "$PROJ_ROOT" rev-parse "refs/tags/v${VERSION}^{commit}")"
+    if [[ "$TAG_COMMIT" != "$COMMIT" ]]; then
+        echo "::error::build commit ${COMMIT} != tag v${VERSION} commit ${TAG_COMMIT}; SOURCE.txt would advertise the wrong corresponding source."; exit 1
+    fi
+fi
 DMG_EXTRAS="$PROJ_ROOT/build/dmg-extras"
 rm -rf "$DMG_EXTRAS"; mkdir -p "$DMG_EXTRAS"
 SOURCE_TXT="$DMG_EXTRAS/SOURCE.txt"

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -334,6 +334,43 @@ find "$PROJ_ROOT/build/dSYMs" -maxdepth 2 -name '*.dSYM' -print | sort
 echo "==> [9/9] Create DMG"
 DMG_PATH="build/EnviousWispr-${VERSION}.dmg"
 rm -f "$DMG_PATH"
+
+# GPLv3 §6: the conveyed object code must ship the license text + clear
+# directions to the corresponding source. We drop three files into the DMG:
+#   LICENSE                 — the GPLv3 text (already at repo root)
+#   SOURCE.txt              — directions to the exact tagged source (this build's commit)
+#   THIRD-PARTY-NOTICES.txt — attribution for bundled MIT/Apache/BSD components
+# The build commit IS the tag commit on a tag-triggered release, so HEAD's sha
+# is the corresponding source.
+LICENSE_SRC="$PROJ_ROOT/LICENSE"
+NOTICES_SRC="$PROJ_ROOT/THIRD-PARTY-NOTICES.txt"
+test -f "$LICENSE_SRC"  || { echo "::error::LICENSE missing at $LICENSE_SRC"; exit 1; }
+test -f "$NOTICES_SRC"  || { echo "::error::THIRD-PARTY-NOTICES.txt missing at $NOTICES_SRC (run scripts/ci/gen-third-party-notices.sh)"; exit 1; }
+# Enforce notices freshness ON the release path (Codex code-diff r2): fail the
+# release if Package.resolved gained a dep with no notices entry, or the
+# committed notices are stale. --check needs no SwiftPM checkouts (works under
+# the Xcode/DerivedData build).
+"$PROJ_ROOT/scripts/ci/gen-third-party-notices.sh" --check
+COMMIT="$(git -C "$PROJ_ROOT" rev-parse HEAD)"
+DMG_EXTRAS="$PROJ_ROOT/build/dmg-extras"
+rm -rf "$DMG_EXTRAS"; mkdir -p "$DMG_EXTRAS"
+SOURCE_TXT="$DMG_EXTRAS/SOURCE.txt"
+cat > "$SOURCE_TXT" <<SOURCE_EOF
+EnviousWispr Corresponding Source
+
+This DMG contains object code for EnviousWispr version ${VERSION},
+built from git tag v${VERSION}, commit ${COMMIT}.
+
+The Corresponding Source for this binary is available at no charge:
+  Release page:  https://github.com/saurabhav88/EnviousWispr/releases/tag/v${VERSION}
+  Source (tar):  https://github.com/saurabhav88/EnviousWispr/archive/refs/tags/v${VERSION}.tar.gz
+  Git:           git clone https://github.com/saurabhav88/EnviousWispr.git && git checkout ${COMMIT}
+
+EnviousWispr is licensed under the GNU GPL version 3 (see LICENSE in this DMG).
+Build instructions: README.md and scripts/build-release-dmg.sh in the source.
+Third-party component licenses: see THIRD-PARTY-NOTICES.txt in this DMG.
+SOURCE_EOF
+
 create-dmg \
     --volname "EnviousWispr ${VERSION}" \
     --window-pos 200 120 \
@@ -341,6 +378,9 @@ create-dmg \
     --icon-size 100 \
     --icon "${APP_NAME}" 175 190 \
     --app-drop-link 425 190 \
+    --add-file LICENSE "$LICENSE_SRC" 175 300 \
+    --add-file SOURCE.txt "$SOURCE_TXT" 300 300 \
+    --add-file THIRD-PARTY-NOTICES.txt "$NOTICES_SRC" 425 300 \
     --no-internet-enable \
     "$DMG_PATH" \
     "$BUNDLE"
@@ -372,6 +412,26 @@ for HELPER in \
     fi
 done
 echo "    all 4 Sparkle update helpers present (Updater, Installer, Downloader, Autoupdate)"
+
+# GPLv3 §6: assert the license + source pointer + third-party notices actually
+# shipped in the DMG, with CONTENT checks (not just presence) so a stale or
+# wrong file fails the build before publish.
+LICENSE_IN_DMG="$PRECHECK_MOUNT/LICENSE"
+SOURCE_IN_DMG="$PRECHECK_MOUNT/SOURCE.txt"
+NOTICES_IN_DMG="$PRECHECK_MOUNT/THIRD-PARTY-NOTICES.txt"
+if ! { [[ -f "$LICENSE_IN_DMG" ]] && grep -q "GNU GENERAL PUBLIC LICENSE" "$LICENSE_IN_DMG" && grep -q "Version 3" "$LICENSE_IN_DMG"; }; then
+    echo "::error::GPLv3 LICENSE missing or wrong in DMG ($LICENSE_IN_DMG)"; exit 1
+fi
+if ! { [[ -f "$SOURCE_IN_DMG" ]] && grep -q "${VERSION}" "$SOURCE_IN_DMG" && grep -q "${COMMIT}" "$SOURCE_IN_DMG"; }; then
+    echo "::error::SOURCE.txt missing or not pinned to ${VERSION}/${COMMIT} in DMG"; exit 1
+fi
+if ! { [[ -f "$NOTICES_IN_DMG" ]] && grep -q "THIRD-PARTY NOTICES" "$NOTICES_IN_DMG" \
+        && grep -q "None of these components is GPL/LGPL" "$NOTICES_IN_DMG" \
+        && grep -q "FluidAudio" "$NOTICES_IN_DMG"; }; then
+    echo "::error::THIRD-PARTY-NOTICES.txt missing or not a valid notices file in DMG"; exit 1
+fi
+echo "    GPL compliance files present (LICENSE [GPLv3], SOURCE.txt [v${VERSION} @ ${COMMIT:0:8}], THIRD-PARTY-NOTICES.txt)"
+
 hdiutil detach "$PRECHECK_MOUNT"; rm -rf "$PRECHECK_MOUNT"
 trap - EXIT
 

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -356,7 +356,11 @@ COMMIT="$(git -C "$PROJ_ROOT" rev-parse HEAD)"
 # commit, else SOURCE.txt would point at the wrong corresponding source. On a
 # tag-triggered release HEAD == tag commit by construction; this guards the
 # workflow_dispatch path where the checkout ref can differ from the tag input
-# (cloud review #1).
+# (cloud review #1). Fetch the tag first so a shallow clone that didn't pull it
+# can't silently bypass the guard (cloud review r2 #1); a non-existent tag (e.g.
+# a pre-tag rehearsal) fetches nothing and the guard correctly skips — the build
+# commit is still the true corresponding source.
+git -C "$PROJ_ROOT" fetch --quiet origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}" >/dev/null 2>&1 || true
 if git -C "$PROJ_ROOT" rev-parse -q --verify "refs/tags/v${VERSION}^{commit}" >/dev/null 2>&1; then
     TAG_COMMIT="$(git -C "$PROJ_ROOT" rev-parse "refs/tags/v${VERSION}^{commit}")"
     if [[ "$TAG_COMMIT" != "$COMMIT" ]]; then

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -374,12 +374,15 @@ cat > "$SOURCE_TXT" <<SOURCE_EOF
 EnviousWispr Corresponding Source
 
 This DMG contains object code for EnviousWispr version ${VERSION},
-built from git tag v${VERSION}, commit ${COMMIT}.
+released as tag v${VERSION}, built from commit ${COMMIT}.
 
-The Corresponding Source for this binary is available at no charge:
-  Release page:  https://github.com/saurabhav88/EnviousWispr/releases/tag/v${VERSION}
-  Source (tar):  https://github.com/saurabhav88/EnviousWispr/archive/refs/tags/v${VERSION}.tar.gz
+The Corresponding Source for this binary is exactly commit ${COMMIT}, available
+at no charge. These commit-pinned URLs resolve for any pushed commit regardless
+of tag timing:
+  Source (tar):  https://github.com/saurabhav88/EnviousWispr/archive/${COMMIT}.tar.gz
+  Browse:        https://github.com/saurabhav88/EnviousWispr/tree/${COMMIT}
   Git:           git clone https://github.com/saurabhav88/EnviousWispr.git && git checkout ${COMMIT}
+  Release page:  https://github.com/saurabhav88/EnviousWispr/releases/tag/v${VERSION}
 
 EnviousWispr is licensed under the GNU GPL version 3 (see LICENSE in this DMG).
 Build instructions: README.md and scripts/build-release-dmg.sh in the source.

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -49,17 +49,24 @@ COMPONENTS=(
 # (a bump rarely changes the license text, only the displayed version).
 RESOLVED="${PROJ_ROOT}/Package.resolved"
 test -f "$RESOLVED" || { echo "error: $RESOLVED not found." >&2; exit 1; }
+# identity<TAB>version map from Package.resolved (version = semver or revision).
+resolved_map="$(python3 -c "
+import json
+d=json.load(open('$RESOLVED'))
+for p in d.get('pins',[]):
+    st=p.get('state',{})
+    v=st.get('version') or st.get('revision','')
+    print(p['identity']+'\t'+v)
+")"
+resolved_ids="$(cut -f1 <<< "$resolved_map" | sort)"
 covered_ids=""
 for entry in "${COMPONENTS[@]}"; do
   IFS='|' read -r _ _ _ _ _ ident <<< "$entry"
   [[ -n "$ident" ]] && covered_ids+="${ident}"$'\n'
 done
-resolved_ids="$(python3 -c "
-import json
-d=json.load(open('$RESOLVED'))
-print('\n'.join(sorted(p['identity'] for p in d.get('pins',[]))))
-")"
 miss=0
+# Coverage: every resolved direct dep must have an entry here (else it would
+# ship with no attribution).
 while IFS= read -r rid; do
   [[ -z "$rid" ]] && continue
   if ! grep -qxF "$rid" <<< "$covered_ids"; then
@@ -73,23 +80,38 @@ while IFS= read -r cid; do
     echo "warning: generator lists '$cid' but Package.resolved no longer has it — remove its entry." >&2
   fi
 done <<< "$covered_ids"
+# Version sync: a resolved direct dep that was bumped without updating this list
+# (and the notices) is a hard fail, not just stale display (cloud review #2).
+for entry in "${COMPONENTS[@]}"; do
+  IFS='|' read -r _ cversion _ _ _ ident <<< "$entry"
+  [[ -z "$ident" ]] && continue
+  rv="$(awk -F'\t' -v id="$ident" '$1==id{print $2}' <<< "$resolved_map")"
+  [[ -z "$rv" ]] && continue   # not resolved (handled by coverage above)
+  if [[ "$cversion" != *"${rv:0:8}"* ]]; then
+    echo "error: '$ident' version drift — Package.resolved has '${rv}' but generator lists '${cversion}'. Update the generator + regenerate the notices." >&2
+    miss=1
+  fi
+done
 [[ "$miss" -eq 1 ]] && exit 1
 
-# --check (release gate): verify the COMMITTED notices file names every covered
-# component, then exit. Needs no checkouts, so it runs on the release path.
+# --check (release gate): verify the COMMITTED notices file actually carries each
+# covered component's name + license + source URL (not just the name — cloud
+# review #2). Needs no checkouts, so it runs on the release path.
 if [[ "$MODE" == "check" ]]; then
   NOTICES="${PROJ_ROOT}/THIRD-PARTY-NOTICES.txt"
   test -f "$NOTICES" || { echo "error: $NOTICES missing — run the generator." >&2; exit 1; }
   stale=0
   for entry in "${COMPONENTS[@]}"; do
-    IFS='|' read -r name _ _ _ _ _ <<< "$entry"
-    if ! grep -qF "$name" "$NOTICES"; then
-      echo "error: THIRD-PARTY-NOTICES.txt does not name '$name' — regenerate it (scripts/ci/gen-third-party-notices.sh > THIRD-PARTY-NOTICES.txt)." >&2
-      stale=1
-    fi
+    IFS='|' read -r name _ license _ url _ <<< "$entry"
+    for needle in "$name" "$license" "$url"; do
+      if ! grep -qF "$needle" "$NOTICES"; then
+        echo "error: THIRD-PARTY-NOTICES.txt is missing '$needle' (component '$name') — regenerate it (scripts/ci/gen-third-party-notices.sh > THIRD-PARTY-NOTICES.txt)." >&2
+        stale=1
+      fi
+    done
   done
   [[ "$stale" -eq 1 ]] && exit 1
-  echo "third-party notices coverage OK (${#COMPONENTS[@]} components vs Package.resolved + committed notices)"
+  echo "third-party notices verified (${#COMPONENTS[@]} components: coverage + version sync vs Package.resolved + name/license/url in committed notices)"
   exit 0
 fi
 

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -102,8 +102,11 @@ if [[ "$MODE" == "check" ]]; then
   test -f "$NOTICES" || { echo "error: $NOTICES missing — run the generator." >&2; exit 1; }
   stale=0
   for entry in "${COMPONENTS[@]}"; do
-    IFS='|' read -r name _ license _ url _ <<< "$entry"
-    for needle in "$name" "$license" "$url"; do
+    IFS='|' read -r name cversion license _ url _ <<< "$entry"
+    # Include the version: a dep bumped in this list (version-sync passes) but
+    # NOT regenerated into the notices is caught here, because the committed
+    # notices still carry the OLD version string (cloud review r2 #6).
+    for needle in "$name" "$cversion" "$license" "$url"; do
       if ! grep -qF "$needle" "$NOTICES"; then
         echo "error: THIRD-PARTY-NOTICES.txt is missing '$needle' (component '$name') — regenerate it (scripts/ci/gen-third-party-notices.sh > THIRD-PARTY-NOTICES.txt)." >&2
         stale=1

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Generate THIRD-PARTY-NOTICES.txt from the resolved dependency checkouts.
+#
+# Why: EnviousWispr is GPLv3, but it bundles permissively-licensed third-party
+# code (MIT / Apache-2.0 / BSD). Those licenses require their copyright +
+# permission notice ship with the binary. This concatenates each bundled
+# component's license text into a single notices file that build-release-dmg.sh
+# drops into the release DMG (GPLv3 attribution is separate — see LICENSE).
+#
+# Usage:
+#   scripts/ci/gen-third-party-notices.sh > THIRD-PARTY-NOTICES.txt   # (re)generate
+#   scripts/ci/gen-third-party-notices.sh --check                     # release gate
+#
+# --check enforces freshness WITHOUT the SwiftPM checkouts (so it can run on the
+# release path, where Xcode resolves packages into DerivedData not .build):
+# it cross-checks the component list against Package.resolved AND verifies the
+# committed THIRD-PARTY-NOTICES.txt actually names every covered component.
+# Full generation requires the checkouts (run after a build/resolve).
+set -euo pipefail
+
+MODE="generate"
+if [[ "${1:-}" == "--check" ]]; then MODE="check"; fi
+
+PROJ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CO="${PROJ_ROOT}/.build/checkouts"
+
+# component | version | license | path-under-.build/checkouts | upstream URL | SwiftPM-identity
+# The last field is the Package.resolved `identity` for DIRECT SwiftPM deps; it
+# is empty for components vendored INSIDE another dep (not their own pin). The
+# cross-check below hard-fails if Package.resolved gains/loses a direct dep that
+# this list does not cover, so the notices can't silently go stale (Codex #2).
+COMPONENTS=(
+  "WhisperKit (argmax-oss-swift)|1.0.0|MIT|argmax-oss-swift/LICENSE|https://github.com/argmaxinc/argmax-oss-swift|argmax-oss-swift"
+  "FluidAudio|46e96f40 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "PostHog iOS|3.61.0|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
+  "Sentry Cocoa|9.18.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
+  "Sparkle|2.9.3|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"
+  "swift-argument-parser|1.7.1|Apache-2.0|swift-argument-parser/LICENSE.txt|https://github.com/apple/swift-argument-parser|swift-argument-parser"
+  "fastcluster (bundled in FluidAudio)|n/a|BSD-2-Clause|FluidAudio/ThirdPartyLicenses/fastcluster-LICENSE.md|https://github.com/dmuellner/fastcluster|"
+  "VBx (bundled in FluidAudio)|n/a|Apache-2.0|FluidAudio/ThirdPartyLicenses/vbx-LICENSE.md|https://github.com/BUTSpeechFIT/VBx|"
+  "PLCrashReporter + protobuf-c (bundled in PostHog)|n/a|MIT / Apache-2.0|posthog-ios/vendor/PHPLCrashReporter/LICENSE|https://github.com/microsoft/plcrashreporter|"
+  "libwebp (bundled in PostHog)|n/a|BSD-3-Clause|posthog-ios/vendor/libwebp/COPYING|https://chromium.googlesource.com/webm/libwebp|"
+)
+
+# --- Cross-check the DIRECT-dep coverage against Package.resolved (Codex #2) ---
+# Hard-fail if Package.resolved lists a direct dependency this generator does not
+# cover (a new/renamed dep would otherwise ship with no attribution), or if this
+# list names a dep that is no longer resolved. Version drift is a soft warning
+# (a bump rarely changes the license text, only the displayed version).
+RESOLVED="${PROJ_ROOT}/Package.resolved"
+test -f "$RESOLVED" || { echo "error: $RESOLVED not found." >&2; exit 1; }
+covered_ids=""
+for entry in "${COMPONENTS[@]}"; do
+  IFS='|' read -r _ _ _ _ _ ident <<< "$entry"
+  [[ -n "$ident" ]] && covered_ids+="${ident}"$'\n'
+done
+resolved_ids="$(python3 -c "
+import json
+d=json.load(open('$RESOLVED'))
+print('\n'.join(sorted(p['identity'] for p in d.get('pins',[]))))
+")"
+miss=0
+while IFS= read -r rid; do
+  [[ -z "$rid" ]] && continue
+  if ! grep -qxF "$rid" <<< "$covered_ids"; then
+    echo "error: Package.resolved has direct dep '$rid' with NO entry in this generator — add its license + notice." >&2
+    miss=1
+  fi
+done <<< "$resolved_ids"
+while IFS= read -r cid; do
+  [[ -z "$cid" ]] && continue
+  if ! grep -qxF "$cid" <<< "$resolved_ids"; then
+    echo "warning: generator lists '$cid' but Package.resolved no longer has it — remove its entry." >&2
+  fi
+done <<< "$covered_ids"
+[[ "$miss" -eq 1 ]] && exit 1
+
+# --check (release gate): verify the COMMITTED notices file names every covered
+# component, then exit. Needs no checkouts, so it runs on the release path.
+if [[ "$MODE" == "check" ]]; then
+  NOTICES="${PROJ_ROOT}/THIRD-PARTY-NOTICES.txt"
+  test -f "$NOTICES" || { echo "error: $NOTICES missing — run the generator." >&2; exit 1; }
+  stale=0
+  for entry in "${COMPONENTS[@]}"; do
+    IFS='|' read -r name _ _ _ _ _ <<< "$entry"
+    if ! grep -qF "$name" "$NOTICES"; then
+      echo "error: THIRD-PARTY-NOTICES.txt does not name '$name' — regenerate it (scripts/ci/gen-third-party-notices.sh > THIRD-PARTY-NOTICES.txt)." >&2
+      stale=1
+    fi
+  done
+  [[ "$stale" -eq 1 ]] && exit 1
+  echo "third-party notices coverage OK (${#COMPONENTS[@]} components vs Package.resolved + committed notices)"
+  exit 0
+fi
+
+# generation path needs the resolved checkouts to cat the license texts
+if [[ ! -d "$CO" ]]; then
+  echo "error: ${CO} not found — run a build/resolve first so the checkouts exist." >&2
+  exit 1
+fi
+
+printf 'THIRD-PARTY NOTICES — EnviousWispr\n'
+printf '==================================\n\n'
+printf 'EnviousWispr itself is licensed under the GNU GPL version 3 (see LICENSE).\n'
+printf 'It bundles the following third-party components, each under its own\n'
+printf 'permissive license. The required copyright and permission notices follow.\n'
+printf 'None of these components is GPL/LGPL-licensed.\n\n'
+
+for entry in "${COMPONENTS[@]}"; do
+  IFS='|' read -r name version license relpath url _ident <<< "$entry"
+  lf="${CO}/${relpath}"
+  if [[ ! -f "$lf" ]]; then
+    echo "error: license file not found: ${lf}" >&2
+    exit 1
+  fi
+  printf -- '--------------------------------------------------------------------------------\n'
+  printf '%s\n' "$name"
+  printf '  Version: %s\n' "$version"
+  printf '  License: %s\n' "$license"
+  printf '  Source:  %s\n' "$url"
+  printf -- '--------------------------------------------------------------------------------\n\n'
+  cat "$lf"
+  printf '\n\n'
+done
+
+printf -- '--------------------------------------------------------------------------------\n'
+printf 'Speech recognition model (downloaded at runtime, NOT bundled in this DMG)\n'
+printf -- '--------------------------------------------------------------------------------\n\n'
+printf 'EnviousWispr downloads the Parakeet TDT speech model (CoreML) from Hugging\n'
+printf 'Face on first use; it is not distributed inside this disk image. The model\n'
+printf 'is provided under CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/).\n'
+printf 'Source: https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml\n'


### PR DESCRIPTION
## What

Ships GPLv3 §6 compliance in the release download. The relicense to GPLv3 (#1184) made the distributed binary GPL-licensed; §6 requires object code conveyed from a network server to carry the license text plus clear directions to the corresponding source. The DMG previously carried only the app bundle.

This adds three files to the release DMG via `create-dmg --add-file`:

- **`LICENSE`** — the GPLv3 text (already at repo root).
- **`SOURCE.txt`** — generated per build, pinned to the exact version + commit SHA, with release-page / tarball / git-checkout directions.
- **`THIRD-PARTY-NOTICES.txt`** — attribution for the bundled MIT/Apache/BSD components (every bundled dependency is permissive; **zero GPL/LGPL** — the one GPL component, `espeak-ng`, is build-excluded by FluidAudio's `Package.swift`).

The `[9/9]` mount-precheck now asserts all three are present **and content-correct** (GPLv3 marker in `LICENSE`; version+commit in `SOURCE.txt`; valid notices markers), so a regression fails the build before publish.

A new `scripts/ci/gen-third-party-notices.sh` generates the notices from the resolved checkouts, with a `--check` mode (needs no checkouts) that the release build calls to **enforce freshness on the release path**: it hard-fails if `Package.resolved` gains a dependency not covered, or the committed notices go stale.

## Why this is the §6(d) mechanism (not `--eula`)

The GPL is explicitly not an end-user license agreement, so it must not be presented as click-through-to-accept. Visible files in the DMG + a source pointer to the exact tag (whose source tarball GitHub auto-attaches to every release) satisfy "convey from a network server with clear directions to the corresponding source."

## Validation

- **Isolated proof:** built a DMG with the three `--add-file` flags against a dummy bundle; mounted and confirmed all three files present + content asserts pass.
- **Generator:** `--check` passes without `.build/checkouts` (the release-path case); full generation reproduces the committed file exactly (no drift); negative test confirms a simulated new dependency hard-fails coverage.
- **`shellcheck`** clean on both changed scripts (the 3 remaining infos are pre-existing, untouched code).
- **Out-of-band integration proof:** `build-only` dispatch of the release pipeline (real signed + notarized DMG, no publish) — run linked in a comment below; required green before merge per the no-auto-merge-before-out-of-band-validation rule.

## Review trail

Plan: `docs/feature-requests/issue-1186-2026-06-23-release-output-license-and-cask-autobump.md`. Council (GPT-5.5 + Gemini-3.1, coverage) → Codex grounded review (6 rounds → PROCEED-AS-PLANNED) → Codex code-diff (3 rounds → clean).

## Scope / blast radius

Touches only the release packaging script + a new CI helper + the notices file. No app `Sources/**`, no signing/notarization logic, no website. Single-commit revert. Does not require cutting a release — prepares the next one.

The Homebrew cask auto-bump (Phase 2 in the plan) is deliberately a separate follow-up; it needs a cross-repo access token.

Closes #1186