### PR TITLE
docs: surface Homebrew install on README + website homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ See the [full release history](https://github.com/saurabhav88/EnviousWispr/relea
 
 ## Quick Start
 
+Install with [Homebrew](https://brew.sh):
+
+```bash
+brew install --cask saurabhav88/tap/enviouswispr
+```
+
+Or download manually:
+
 1. Download [EnviousWispr.dmg](https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg) from the latest release
 2. Drag to Applications, launch
 3. Grant **Microphone**, **Accessibility**, and (on first paste fallback) **Automation** permissions when prompted

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -227,6 +227,8 @@ const jsonLdFaq = JSON.stringify({
         <span class="trust-item"><span class="trust-dot" aria-hidden="true"></span>No account needed</span>
         <span class="trust-item"><span class="trust-dot" aria-hidden="true"></span>Works offline</span>
       </div>
+
+      <p class="hero-brew reveal" style="--i:4.5">Prefer the terminal? <code>brew install --cask saurabhav88/tap/enviouswispr</code></p>
     </div>
   </section>
 
@@ -642,6 +644,8 @@ const jsonLdFaq = JSON.stringify({
           100% Private <span class="cdot" aria-hidden="true">&#183;</span>
           Free forever
         </p>
+
+        <p class="cta-brew">Or with Homebrew: <code>brew install --cask saurabhav88/tap/enviouswispr</code></p>
       </div>
     </div>
   </section>
@@ -708,6 +712,13 @@ const jsonLdFaq = JSON.stringify({
 .hero-trust {
   font-size: 13px; color: var(--text-3);
   display: flex; align-items: center; justify-content: center; gap: 24px; flex-wrap: wrap;
+}
+.hero-brew { font-size: 13px; color: var(--text-3); margin: 18px 0 0; }
+.cta-brew { font-size: 13px; color: var(--text-3); margin: 14px 0 0; }
+.hero-brew code, .cta-brew code {
+  font-family: var(--font-mono); font-size: 12.5px; color: var(--text-2);
+  background: var(--accent-soft); border: 1px solid var(--border-hover);
+  border-radius: 6px; padding: 3px 8px; user-select: all; overflow-wrap: anywhere;
 }
 .trust-item { display: flex; align-items: center; gap: 7px; }
 .trust-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); }


### PR DESCRIPTION
## What

Surface the existing Homebrew cask install as a first-class option on both the README and the website homepage. EnviousWispr already ships a public cask (`saurabhav88/homebrew-tap`, `Casks/enviouswispr.rb` @ v2.1.4), but nothing pointed users to it.

- **README Quick Start** now leads with `brew install --cask saurabhav88/tap/enviouswispr`, then "Or download manually" before the DMG steps.
- **Homepage hero** gains a quiet "Prefer the terminal?" line under the trust badges.
- **Bottom CTA** gains "Or with Homebrew:".
- Both web spots render the command in a selectable mono chip using existing brand tokens (`--accent-soft` / `--border-hover` / `--font-mono`). No new JS, no logic.

## Lane / process

Content/copy change — `council-skip: zero-blast-radius (user-facing copy)`. 19 insertions, 2 files, no new symbols/types/control-flow/deps.

## Validation

- `npm run build` (astro) green — 54 pages.
- Visual confirm via headless Chrome at 1280px and narrow widths: command renders cleanly and wraps without overflow in both the hero and the bottom CTA.
- Verified the tap repo is public and `Casks/enviouswispr.rb` resolves (v2.1.4, valid sha256) so the advertised command works today.
- Local `codex review` was unavailable (usage limit reset Jun 24); relying on the cloud Codex review gate on this PR as the code-diff pass.