### PR TITLE
feat(itn): AP-style number formatting (spell one-nine, digits 10+)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -86,6 +86,37 @@ public struct InverseTextNormalizer: Sendable {
   static let numword: Set<String> = Set(units.keys).union(tens.keys).union(scales.keys)
     .union(["and"])
 
+  // ── AP-style number policy ──────────────────────────────────────────────────
+  static let apThreshold = 10  // spell out 1..9, digits for 10+
+  static let unitNouns: Set<String> = [
+    "miles", "mile", "feet", "foot", "inch", "inches", "yard", "yards", "pound", "pounds", "lb",
+    "lbs", "ounce", "ounces", "oz", "kg", "kilogram", "kilograms", "gram", "grams", "km",
+    "kilometer", "kilometers", "meter", "meters", "metre", "metres", "cm", "centimeter",
+    "centimeters", "liter", "liters", "litre", "litres", "gallon", "gallons", "cup", "cups",
+    "tablespoon", "tablespoons", "tbsp", "teaspoon", "teaspoons", "tsp", "degree", "degrees",
+    "mph", "percent", "milligram", "milligrams", "mg", "milliliter", "milliliters", "ml",
+    "millimeter", "millimeters", "mm",
+  ]
+  static let agePeriods: Set<String> = [
+    "year", "years", "month", "months", "week", "weeks", "day", "days",
+  ]
+  // compound-ordinal tails (additive): final ordinal word in 'one hundred (and) <tail>'.
+  static let ordTail: [String: Int] = [
+    "first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5, "sixth": 6, "seventh": 7,
+    "eighth": 8, "ninth": 9, "tenth": 10, "eleventh": 11, "twelfth": 12, "thirteenth": 13,
+    "fourteenth": 14, "fifteenth": 15, "sixteenth": 16, "seventeenth": 17, "eighteenth": 18,
+    "nineteenth": 19, "twentieth": 20, "thirtieth": 30, "fortieth": 40, "fiftieth": 50,
+    "sixtieth": 60, "seventieth": 70, "eightieth": 80, "ninetieth": 90,
+  ]
+  // scale ordinals: '(coeff) hundredth/thousandth/...' -> coeff*scale, suffix 'th'.
+  static let ordScale: [String: Int] = [
+    "hundredth": 100, "thousandth": 1000, "millionth": 1_000_000, "billionth": 1_000_000_000,
+  ]
+  /// `re.sub(r"[^a-z]", "", w.lower())` — strip to bare lowercase letters.
+  static func clean(_ w: String) -> String {
+    String(w.lowercased().unicodeScalars.filter { ("a"..."z").contains(Character($0)) })
+  }
+
   // MARK: - Precomputed alternations (longest-first, deterministic — strictly safe vs
   // Python's hash-ordered sets: \b-wrapped uses and backtracking make output identical).
 
@@ -106,11 +137,36 @@ public struct InverseTextNormalizer: Sendable {
   static let unitsTensAlt = alt(Set(units.keys).union(tens.keys))
   static let monthsAlt = alt(Array(months.keys))
   static let centuryAlt = alt(Array(century.keys))
+  // AP additions
+  static let numwordNoAnd = numword.subtracting(["and"])
+  static let numwordNoAndAlt = alt(numwordNoAnd)
+  // range/slash/by token: a number-word (no "and") OR an already-digit token.
+  static let rangeTok = alt(numwordNoAnd) + #"|\d[\d,]*"#
+  static let rangeTokFull = alt(numword) + #"|\d[\d,]*"#  // later tokens may be "and"
+  static let rangeRun = #"(?:"# + rangeTok + #")(?:\s+(?:"# + rangeTok + #"))*"#  // no "and" (between)
+  // to/through/slash/by endpoints allow an internal "and" so spoken hundreds parse whole
+  // ("one hundred and five to one hundred and ten" -> "105-110", not "100 5-100 and 10").
+  static let rangeRunAnd = #"(?:"# + rangeTok + #")(?:\s+(?:"# + rangeTokFull + #"))*"#
+  // bare number-word run (no "and"), for the cardinal pass.
+  static let numwordRun = #"(?:"# + numwordNoAndAlt + #")(?:\s+(?:"# + numwordAlt + #"))*"#
+  static let ordTailAlt = alt(Array(ordTail.keys))
+  static let ordScaleAlt = alt(Array(ordScale.keys))
+  static let cardRun = #"(?:"# + numwordAlt + #")(?:\s+(?:"# + numwordAlt + #"))*"#
 
   // MARK: - Public entry point
 
   public func normalize(_ text: String) -> String {
     var t = " " + text.trimmingCharacters(in: .whitespacesAndNewlines) + " "
+
+    // "shout" = the whole utterance is upper-case (typed in caps). In shout text a capitalized
+    // number word is a number, not a proper noun, so the cardinal pass converts it. Computed from
+    // the original text (capitalization is preserved through the passes). A Title fragment inside
+    // normal text ('TWELVE ANGRY MEN screened tonight') is NOT shout, so titles stay protected.
+    let lineAlpha = String(
+      text.unicodeScalars.filter {
+        ("A"..."Z").contains(Character($0)) || ("a"..."z").contains(Character($0))
+      })
+    let shout = lineAlpha.count > 1 && lineAlpha == lineAlpha.uppercased()
 
     // register-preserve (our enhancement): keep "quarter to/past N", "half past N" spelled,
     // plus ordinal idioms ("eleventh hour"). Shielded from the number passes via a sentinel.
@@ -119,14 +175,58 @@ public struct InverseTextNormalizer: Sendable {
       protected.append(m.whole)
       return " \u{0}\(protected.count - 1)\u{0} "
     }
+    let protectSub: (String) -> String = { val in
+      protected.append(val)
+      return " \u{0}\(protected.count - 1)\u{0} "
+    }
     t = reSub(#"\b(?:a |an )?(?:quarter|half)\s+(?:past|to)\s+\w+"#, t) { protect($0) }
     t = reSub(
       #"\beleventh hour\b|\bseventh heaven\b|\bthe fourth wall\b|\bthe fifth wheel\b"#
         + #"|\bthe fifth column\b|\bthe fourth estate\b|\bfirst among equals\b"#, t
     ) { protect($0) }
+    // AP "a hundred": shield approximations ("a couple/few/several/many hundred" stay spelled),
+    // then drop the article on a bare "a/an hundred" so the cardinal pass yields 100 (not "a 100").
+    t = reSub(#"\b(?:a |an )?(?:couple|few|several|many)\s+hundred\b"#, t) { protect($0) }
+    // lowercase only: a capitalized "A Hundred ..." is a title ("A Hundred Years of Solitude"),
+    // not a number — dropping its article would corrupt the title.
+    // not before a hyphenated compound ("a hundred-year lease" keeps its article); only bare
+    // "a hundred <noun>" drops the article so the cardinal yields 100.
+    t = reSub(#"\b(?:a|an)\s+(hundred\b)(?!-)"#, t, caseInsensitive: false) { m in
+      " " + (m.g(1) ?? "")
+    }
+    // idiom: keep "the whole nine yards" spelled despite the unit rule on "yards"
+    t = reSub(#"\bthe whole nine yards\b"#, t) { protect($0) }
+    // idiom "Catch-22" ONLY as a determiner-led noun phrase ("a/the/that catch twenty two"), so the
+    // literal verb usage "catch twenty two fish" still becomes "catch 22 fish".
+    t = reSub(#"\b(a|an|the|this|that|another)\s+catch[\s-]+twenty[\s-]+two\b"#, t) { m in
+      " \(m.g(1) ?? "") " + protectSub("Catch-22")
+    }
+    t = reSub(#"\b(a|an|the|this|that|another)\s+catch[\s-]+22\b"#, t) { m in
+      " \(m.g(1) ?? "") " + protectSub("Catch-22")
+    }
+    // join hyphenated number compounds: "twenty-two" -> "twenty two" so the run parses as 22.
+    // EXCLUDE "and": a hyphenated "and" ("one-and-done") is an idiom, not a spoken compound.
+    // First part any-case, second part LOWERCASE: joins "twenty-two" and sentence-start
+    // "Twenty-two" (-> 22) but NOT the Title "Twenty-Two" (a name; second part capitalized).
+    // second part may also be an ordinal tail ("twenty-first" -> "twenty first" -> "21st").
+    let hyphenJoinPat =
+      #"\b((?i:"# + Self.numwordNoAndAlt + #"))-(?=(?:"# + Self.numwordNoAndAlt + #"|"#
+      + Self.ordTailAlt + #")\b)"#
+    var prev = ""
+    while prev != t {
+      prev = t
+      t = reSub(hyphenJoinPat, t, caseInsensitive: false) { m in (m.g(1) ?? "") + " " }
+    }
 
     t = emails(t)
     t = urls(t)
+    // protect spoken dotted chains (versions / IP-like: "one dot two dot three", >=2 dots) so the
+    // 'dot'-decimal path can't partly convert them ("1.2 dot three"). A single "X dot Y" still
+    // becomes a decimal; only multi-dot chains are shielded and left for the AI-polish layer.
+    let dotPart =
+      #"(?:"# + Self.digitWordAlt + #"|\d[\d,]*)(?:\s+(?:"# + Self.digitWordAlt + #"|\d[\d,]*))*"#
+    let dotChainPat: String = #"\b"# + dotPart + #"(?:\s+dot\s+"# + dotPart + #"){2,}\b"#
+    t = reSub(dotChainPat, t) { protect($0) }
     t = decimals(t)
 
     t = moneyPct(t)  // currency + percent (re-run after years below)
@@ -161,9 +261,11 @@ public struct InverseTextNormalizer: Sendable {
 
     // date: MONTH ORDINAL YEAR(words) -> Month D, YYYY
     let ordAlt = Self.alt(Array(Self.ordinalWord.keys))
+    // year must be year-SHAPED (>=2 number words: "twenty twelve", "two thousand nine"); a single
+    // word ("On June second, five people signed up") is a count, not a year -> no false date match.
     let datePat =
-      #"\s(?<mon>"# + Self.monthsAlt + #")\s+(?<day>"# + ordAlt + #"|\d{1,2})\s+(?<yr>(?:"#
-      + Self.numwordAlt + #")(?:\s+(?:"# + Self.numwordAlt + #")){0,3})\s"#
+      #"\s(?<mon>"# + Self.monthsAlt + #")\s+(?<day>"# + ordAlt + #"|\d{1,2}),?\s+(?<yr>(?:"#
+      + Self.numwordAlt + #")(?:\s+(?:"# + Self.numwordAlt + #")){1,3})(?=[\s.,;:!?)\]”"']|$)"#
     t = reSub(datePat, t) { m in
       guard let mon = Self.months[(m.g("mon") ?? "").lowercased()] else { return nil }
       let dayraw = (m.g("day") ?? "").trimmingCharacters(in: .whitespaces)
@@ -211,19 +313,157 @@ public struct InverseTextNormalizer: Sendable {
       return " \(comma(n)) "
     }
 
-    // generic cardinals: longest runs of number-words -> int. Left case-SENSITIVE on purpose: a
-    // capitalized number word here has no unit/operator anchor, so it is ambiguous between a count
-    // and prose / a proper noun ("Hundred Acre Wood", "One Million Moms"). A scale word does NOT
-    // disambiguate (proper nouns use them too), so capitalized cardinals stay untouched and that
-    // context call is left to the AI-polish layer. (Unit-anchored caps ARE handled — see currency/
-    // percent/decimals below.)
-    let cardPat = #"(?:\b(?:"# + Self.numwordAlt + #")\b\s*){1,}"#
-    t = reSub(cardPat, t) { m in
-      let words = Self.splitWords(m.whole)
-      guard !words.isEmpty, m.whole.trimmingCharacters(in: .whitespaces) != "and",
-        let n = Self.wordsToInt(words)
+    // AP word-ranges / word-slashes / dimensions: BEFORE the cardinal threshold so spoken
+    // endpoints are digitized (a range/date is a numeric context -> digits regardless of size).
+    // Endpoints may be number-words OR already-digit tokens; pure-digit pairs defer to the guarded
+    // numeric passes below.
+    func rng(_ a: String, _ b: String) -> String? {
+      let digitCommaSpace: (String) -> Bool = { s in
+        !s.isEmpty && s.allSatisfy { ("0"..."9").contains($0) || $0 == "," || $0 == " " }
+      }
+      if digitCommaSpace(a) && digitCommaSpace(b) { return nil }  // pure-digit -> numeric pass owns it
+      guard let x = Self.wordsToInt(Self.splitWords(a.lowercased())),
+        let y = Self.wordsToInt(Self.splitWords(b.lowercased()))
       else { return nil }
-      return " \(comma(n)) "
+      return "\(comma(x))-\(comma(y))"  // group thousands ("one thousand to two thousand"->1,000-2,000)
+    }
+    let betweenPat =
+      #"\bbetween\s+(?<a>"# + Self.rangeRun + #")\s+and\s+(?<b>"# + Self.rangeRun + #")\b"#
+    // 'between A and B' uses no-"and" endpoints (the "and" is the separator). When an endpoint
+    // itself contains "and" ("between one hundred and five and one hundred and ten") the split is
+    // ambiguous, so DECLINE rather than corrupt: a trailing "and <number>" means the endpoint was
+    // truncated — leave the phrase spelled for the AI-polish layer.
+    let trailAndPat = #"^\s+and\s+(?:"# + Self.numwordAlt + #"|\d)"#  // number-word OR digit endpoint
+    t = reSub(betweenPat, t) { m in
+      let end = m.result.range.location + m.result.range.length
+      if firstMatch(trailAndPat, m.ns.substring(from: end)) != nil { return nil }
+      guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
+      return " between \(r) "
+    }
+    let toPat =
+      #"\b(?<a>"# + Self.rangeRunAnd + #")\s+(?:to|through)\s+(?<b>"# + Self.rangeRunAnd + #")\b"#
+    t = reSub(toPat, t) { m in
+      guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
+      return " \(r) "
+    }
+    // match ALL slash-separated parts (not just 2-3) so a 4+ chain isn't left half-rewritten.
+    let wslashPat =
+      #"\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+slash\s+(?:"# + Self.rangeRunAnd + #"))+\b"#
+    t = reSub(wslashPat, t) { m in
+      let parts = splitOnSlash(m.whole)
+      let vals = parts.compactMap { Self.wordsToInt(Self.splitWords($0.lowercased())) }
+      guard vals.count == parts.count else { return nil }
+      return " " + vals.map { String($0) }.joined(separator: "/") + " "
+    }
+    // match ALL legs so a 3D size ("two by four by six" -> "2 by 4 by 6") is fully normalized.
+    let byPat = #"\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+by\s+(?:"# + Self.rangeRunAnd + #"))+\b"#
+    t = reSub(byPat, t) { m in
+      let parts = splitOnBy(m.whole)
+      let legs = parts.compactMap { Self.wordsToInt(Self.splitWords($0.lowercased())) }
+      guard legs.count == parts.count else { return nil }
+      // idiom guard: "one by one" is prose ("do it one by one"), not a dimension. Narrow to
+      // all-ones AND no unit noun after (so "one by one inch" stays a real dimension). "two by
+      // two", "three by three", or any >=10 are dimensions and convert.
+      let end = m.result.range.location + m.result.range.length
+      let nxtAfter = Self.clean(Self.splitWords(m.ns.substring(from: end)).first ?? "")
+      if Set(legs) == [1], !Self.unitNouns.contains(nxtAfter) { return nil }
+      return " " + legs.map { comma($0) }.joined(separator: " by ") + " "
+    }
+
+    // generic cardinals -> AP policy. spell 1-9, digits 10+, with digit-forcing exceptions
+    // (age / measurement unit) and ALL-CAPS handling (shout convert / isolated emphasis / Title
+    // protect). A capitalized number word with no unit/operator anchor stays a word — it is
+    // ambiguous between a count and a proper noun ("Hundred Acre Wood", "One Million Moms"), left
+    // to the AI-polish layer. Unit-anchored caps ARE handled (see currency/percent/decimals).
+    // First token may NOT be "and" (else "cats and fifteen" matches as a run and drops the "and");
+    // subsequent tokens may be the full numword set ("one hundred and one").
+    let cardPat = #"\b(?:"# + Self.numwordNoAndAlt + #")\b(?:\s+(?:"# + Self.numwordAlt + #")\b)*"#
+    t = reSub(cardPat, t) { m in
+      let raw = m.whole
+      var words = Self.splitWords(raw)
+      if words.isEmpty || raw.trimmingCharacters(in: .whitespaces) == "and" { return nil }
+      // a trailing "and" is a conjunction, not part of the number ("Twenty and change"); strip it
+      // and re-append so it isn't swallowed (wordsToInt ignores "and", which would drop it).
+      var trailAnd = 0
+      while let last = words.last, last.lowercased() == "and" {
+        words.removeLast()
+        trailAnd += 1
+      }
+      if words.isEmpty { return nil }
+      let tailAnd = String(repeating: " and", count: trailAnd)
+      let start = m.result.range.location
+      let end = start + m.result.range.length
+      let after = m.ns.substring(from: end)
+      let toksAfter = Self.splitWords(after)
+      let nxt = toksAfter.first ?? ""
+      let nxtCap = nxt.first?.isUppercase ?? false
+      // a capitalized hyphenated compound ('Twenty-Two') is not joined (lowercase-only join) and
+      // the proper-noun guard can't see past the leading '-'; leave the whole compound spelled
+      // rather than convert only the first half into '20-Two'.
+      if after.first == "-",
+        Self.numword.contains(Self.clean(nxt)) || Self.ordTail[Self.clean(nxt)] != nil
+      {
+        return nil  // capitalized hyphenated compound/ordinal ("Twenty-Two","Twenty-First") -> leave
+      }
+      guard let n = Self.wordsToInt(words.map { $0.lowercased() }) else {
+        // dosage salvage: a failed run ending in a 1-9 word a unit noun anchors
+        // ('two five milligram' = count + dosage -> 'two 5 milligram'); keep the count spelled.
+        let lw = (words.last ?? "").lowercased()
+        if words.count >= 2, let v = Self.units[lw], (1..<Self.apThreshold).contains(v),
+          Self.unitNouns.contains(Self.clean(nxt))
+        {
+          return " \(words.dropLast().joined(separator: " ")) \(v)\(tailAnd) "
+        }
+        return nil
+      }
+      let firstCap = words[0].first?.isUppercase ?? false
+      let noninitialCap = words.dropFirst().contains { $0.first?.isUppercase ?? false }
+      let single = words.count == 1
+      let capsw: (String) -> Bool = { w in
+        !w.isEmpty && w.contains(where: { $0.isLetter }) && w == w.uppercased()
+      }
+      let runAllcaps = raw.contains(where: { $0.isLetter }) && raw == raw.uppercased()
+      var capsConvert = false
+      if runAllcaps {
+        if shout {
+          capsConvert = true
+        } else {
+          let prevW = Self.splitWords(m.ns.substring(to: start)).last ?? ""
+          if capsw(prevW) || capsw(nxt) { return nil }  // part of an all-caps Title -> leave
+          capsConvert = true  // isolated caps number = emphasis -> convert
+        }
+      }
+      if !capsConvert {
+        if noninitialCap { return nil }  // "One Million Moms"
+        if firstCap && single && nxtCap { return nil }  // brand "Hundred Acre Wood","Forty Niners"
+        if firstCap {
+          var before = m.ns.substring(to: start)
+          while let last = before.last, last.isWhitespace { before.removeLast() }
+          let sentinel: Set<Character> = [".", "!", "?", "\n", "\"", "'", "(", "["]
+          let sentenceInitial = before.isEmpty || sentinel.contains(before.last!)
+          if !sentenceInitial { return nil }  // capitalized mid-sentence, ambiguous -> spelled
+        }
+      }
+      var force = false
+      if n < Self.apThreshold {
+        let nxtw = Self.clean(nxt)
+        if Self.unitNouns.contains(nxtw) {
+          force = true
+        } else if nxtw == "square" || nxtw == "cubic", toksAfter.count >= 2,
+          Self.unitNouns.contains(Self.clean(toksAfter[1]))
+        {
+          force = true  // unit with a modifier: "two square miles", "two cubic meters"
+        } else if Self.agePeriods.contains(nxtw), toksAfter.count >= 2,
+          Self.clean(toksAfter[1]) == "old"
+        {
+          force = true
+        } else if firstMatch(#"^-(?:year|month|week|day)s?-old\b"#, after) != nil {
+          // hyphenated age compound ("five-year-old") is one token; AP uses figures for ages.
+          force = true
+        }
+      }
+      if n >= Self.apThreshold || force { return " \(comma(n))\(tailAnd) " }
+      return nil
     }
 
     // numeric slash-dates: "4 slash 6 slash 2,021" -> "4/6/2021". digit-slash-digit only.
@@ -241,6 +481,9 @@ public struct InverseTextNormalizer: Sendable {
       "\(m.g(1) ?? "")-\(m.g(2) ?? "")"
     }
 
+    // decimal percent: "5.5 percent" -> "5.5%" (the word-amount percent pass can't span the dot).
+    t = reSub(#"\b(\d[\d,]*\.\d+)\s+(?:percent|per\s+cent)\b"#, t) { m in "\(m.g(1) ?? "")% " }
+
     t = keepMagnitude(t)  // '$80,000,000'->'$80 million' (founder house style), keep the word
     t = applyPunct(t)
 
@@ -250,6 +493,16 @@ public struct InverseTextNormalizer: Sendable {
         of: "\u{0}\(i)\u{0}", with: p.trimmingCharacters(in: .whitespacesAndNewlines))
     }
     t = reSub(#"\s+([,.!?;:])"#, t, caseInsensitive: false) { m in m.g(1) }
+    t = reSub(#"([(\[“‘])\s+"#, t, caseInsensitive: false) { m in m.g(1) }  // open quote/bracket tight
+    t = reSub(#"\s+([)\]”’])"#, t, caseInsensitive: false) { m in m.g(1) }  // space before close tight
+    // straight-quoted number: tighten ONLY when a number is fully enclosed in straight quotes
+    // ('" 23 "' -> '"23"'). A single-sided rule corrupted adjacent quotes ('twenty "special"' ->
+    // '20"special"'), so require both quotes around the number.
+    t = reSub(#""\s+(\d[\d.,]*)\s+""#, t, caseInsensitive: false) { m in "\"\(m.g(1) ?? "")\"" }
+    // hyphenated compound modifier: converting "twenty-step" leaves "20 -step" (the cardinal pass
+    // re-emits " 20 " with pad spaces). Re-tighten "digit space-hyphen word" -> "digit-word".
+    t = reSub(#"(\d)\s+-(\w)"#, t, caseInsensitive: false) { m in "\(m.g(1) ?? "")-\(m.g(2) ?? "")"
+    }
     t = reSub(#"[ \t]+"#, t, caseInsensitive: false) { _ in " " }  // collapse spaces (keep newlines)
     return t.trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -361,20 +614,23 @@ public struct InverseTextNormalizer: Sendable {
     }
   }
 
-  private func decimals(_ t: String) -> String {
+  private func decimals(_ t0: String) -> String {
+    var t = t0
+    let sep = #"(?:point|dot)"#  // 'dot' accepted alongside 'point' (spoken versions / measures)
+    let endB = #"(?=[\s.,;:!?)\]”"']|$)"#
+    func digsOf(_ s: String) -> String {
+      Self.splitWords(s.lowercased()).compactMap { Self.units[$0].map { String($0) } }.joined()
+    }
     let pat =
-      #"\s(?<w>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+point\s+"#
+      #"\s(?<w>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+"# + sep + #"\s+"#
       + #"(?<d>(?:"# + Self.digitWordAlt + #")(?:\s+(?:"# + Self.digitWordAlt + #"))*)"#
-      + #"(?:\s+(?<scale>million|billion|thousand))?\s"#
-    return reSub(pat, t) { m in
-      // 'point' anchors numeric intent, so lowercasing the captured amount is corruption-safe.
+      + #"(?:\s+(?<scale>million|billion|thousand))?"# + endB
+    t = reSub(pat, t) { m in
+      // 'point'/'dot' anchors numeric intent, so lowercasing the captured amount is corruption-safe.
       guard let whole = Self.wordsToInt(Self.splitWords((m.g("w") ?? "").lowercased())) else {
         return nil
       }
-      // Lowercase the fraction words too: the case-insensitive regex can capture 'Five' in
-      // 'Three Point Five', and Self.units[$0]! would force-unwrap nil on the capitalized key.
-      let digs = Self.splitWords((m.g("d") ?? "").lowercased()).map { String(Self.units[$0]!) }
-        .joined()
+      let digs = digsOf(m.g("d") ?? "")
       let scale = (m.g("scale") ?? "").trimmingCharacters(in: .whitespaces).lowercased()
       if !scale.isEmpty, let sv = Self.scales[scale] {
         let value = (Double("\(whole).\(digs)") ?? 0) * Double(sv)
@@ -382,16 +638,36 @@ public struct InverseTextNormalizer: Sendable {
       }
       return " \(whole).\(digs) "
     }
+    // leading decimal (no integer word): 'negative point five'->'-0.5', 'point three zero one'
+    // ->'0.301'. Fired only when unambiguous (sign word present, or >=3 fractional digits) so the
+    // everyday noun 'point' ('at this point one thing') is safe.
+    // LEADING decimal uses 'point' ONLY (never 'dot'): a leading 'dot N' is almost always a spoken
+    // dotted identifier / IP segment, not a decimal, so converting it would corrupt the address.
+    // (The main path keeps 'dot' — its required whole-number part disambiguates 'two dot oh'->2.0.)
+    let leadPat =
+      #"\s(?<sg>negative\s+|minus\s+)?point\s+(?<d>(?:"# + Self.digitWordAlt
+      + #")(?:\s+(?:"# + Self.digitWordAlt + #"))*)"# + endB
+    t = reSub(leadPat, t) { m in
+      let sign = (m.g("sg") ?? "").trimmingCharacters(in: .whitespaces).lowercased()
+      let digs = digsOf(m.g("d") ?? "")
+      if sign.isEmpty && digs.count < 3 { return nil }
+      return " \(sign.isEmpty ? "" : "negative ")0.\(digs) "
+    }
+    return t
   }
 
   // MARK: - Currency / percent
 
   private func moneyPct(_ t0: String) -> String {
     var t = t0
+    // trailing boundary is a LOOKAHEAD (whitespace OR sentence punctuation OR end), not a consumed
+    // space — otherwise a sentence-final "...dollars." / "...percent." never fires. "per cent"
+    // (two words) is accepted alongside "percent".
+    let endB = #"(?=[\s.,;:!?)\]”"']|$)"#
     let curPat =
-      #"\s((?<d>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+dollars"#
+      #"\s((?<d>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+dollars?"#
       + #"(?:\s+and\s+(?<c>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok
-      + #"))*)\s+cents)?)\s"#
+      + #"))*)\s+cents?)?)"# + endB
     // 'dollars'/'cents'/'percent' anchor numeric intent, so lowercasing the captured amount is
     // corruption-safe: a capitalized sentence-initial 'Twenty dollars'/'Twenty percent' is a number,
     // never prose. (Bare cardinals stay case-sensitive — see the cardinal pass above.)
@@ -405,14 +681,16 @@ public struct InverseTextNormalizer: Sendable {
       return " $\(comma(d)) "
     }
     let centsPat =
-      #"\s((?<c>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+cents)\s"#
+      #"\s((?<c>(?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+cents?)"# + endB
     t = reSub(centsPat, t) { m in
       guard let c = Self.wordsToInt(Self.splitWords((m.g("c") ?? "").lowercased())) else {
         return nil
       }
       return " $\(String(format: "%.2f", Double(c) / 100.0)) "
     }
-    let pctPat = #"\s((?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+percent\b"#
+    let pctPat =
+      #"\s((?:"# + Self.numtok + #")(?:\s+(?:"# + Self.numtok + #"))*)\s+(?:percent|per\s+cent)"#
+      + endB
     t = reSub(pctPat, t) { m in
       guard let n = Self.wordsToInt(Self.splitWords((m.g(1) ?? "").lowercased())) else {
         return nil
@@ -461,8 +739,42 @@ public struct InverseTextNormalizer: Sendable {
   private func ordinals(_ t0: String) -> String {
     var t = t0
     let unitAlt = Self.alt(Array(Self.ordUnit.keys))
+    // scale ordinals: 'one thousandth'->1,000th, 'two hundredth'->200th, bare 'thousandth'
+    // ->1,000th. Optional cardinal coefficient.
+    let scaleCard = [
+      "hundredth": "hundred", "thousandth": "thousand", "millionth": "million",
+      "billionth": "billion",
+    ]
+    let scalePat = #"\b(?:(?<lead>"# + Self.cardRun + #")\s+)?(?<s>"# + Self.ordScaleAlt + #")\b"#
+    t = reSub(scalePat, t) { m in
+      let sword = (m.g("s") ?? "").lowercased()
+      let n: Int
+      if let lead = m.g("lead") {
+        // reconstruct the full cardinal phrase ('one thousand one hundredth' -> 'one thousand one
+        // hundred' = 1100) instead of multiplying the lead (which overcounts compounds).
+        guard
+          let v = Self.wordsToInt(Self.splitWords((lead + " " + scaleCard[sword]!).lowercased()))
+        else { return nil }
+        n = v
+      } else {
+        n = Self.ordScale[sword]!  // bare 'thousandth' -> 1000th
+      }
+      return " \(comma(n))\(ordSuffix(n)) "
+    }
+    // additive compound with a SCALE lead: 'one hundred (and) tenth'->110th, 'hundred and first'
+    // ->101st. Lead must end in a scale word so this never touches 'twenty third' (comp owns that).
+    let leadScale =
+      #"(?:(?:"# + Self.numwordAlt + #")\s+)*(?:hundred|thousand|million|billion)(?:\s+and)?"#
+    let addPat = #"\b(?<lead>"# + leadScale + #")\s+(?<o>"# + Self.ordTailAlt + #")\b"#
+    t = reSub(addPat, t) { m in
+      guard let base = Self.wordsToInt(Self.splitWords((m.g("lead") ?? "").lowercased())) else {
+        return nil
+      }
+      let n = base + Self.ordTail[(m.g("o") ?? "").lowercased()]!
+      return " \(comma(n))\(ordSuffix(n)) "
+    }
     // compound: '<tens> <unit-ordinal>' -> 'Nth' ('seventy third'->73rd), capturing the next word
-    // so the 'second' duration guard fires ('thirty second video'->left).
+    // so the 'second' duration guard fires ('thirty second video'->left). Result is always >=21.
     let compPat =
       #"\b(?<t>"# + Self.tensAlt + #")\s+(?<u>"# + unitAlt + #")\b(?:\s+(?<nxt>[a-z]+))?"#
     t = reSub(compPat, t) { m in
@@ -473,19 +785,14 @@ public struct InverseTextNormalizer: Sendable {
       let tail = nxt.isEmpty ? "" : " " + nxt
       return " \(n)\(ordSuffix(n))\(tail) "
     }
-    // standalone unambiguous: 'fourth'->4th, 'fiftieth'->50th, 'twentieth'->20th
+    // standalone: 'tenth'->10th, 'twentieth'->20th. AP: spell first-ninth, so values <10 stay.
     let simpleAlt = Self.alt(Array(Self.ordStandalone.keys))
     t = reSub(#"\b(?:"# + simpleAlt + #")\b"#, t) { m in
       let n = Self.ordStandalone[m.whole.lowercased()]!
+      if n < Self.apThreshold { return nil }  // first-ninth stay spelled under AP
       return "\(n)\(ordSuffix(n))"
     }
-    // contextual first/second/third: only after 'the' or a month name.
-    let ctxAlt = Self.alt(Array(Self.ordContextual.keys))
-    let ctxPat = #"(?<lead>\b(?:the|"# + Self.monthsAlt + #")\s+)(?<w>"# + ctxAlt + #")\b"#
-    t = reSub(ctxPat, t) { m in
-      let n = Self.ordContextual[(m.g("w") ?? "").lowercased()]!
-      return "\(m.g("lead") ?? "")\(n)\(ordSuffix(n))"
-    }
+    // contextual first/second/third are all <10 under AP -> stay spelled (no conversion pass).
     return t
   }
 

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -340,15 +340,19 @@ public struct InverseTextNormalizer: Sendable {
       guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
       return " between \(r) "
     }
+    // (?<![\d.]) so the endpoint can't begin at the fraction digit of an existing decimal
+    // ("version 1.2 to three" must not grab "2 to three").
     let toPat =
-      #"\b(?<a>"# + Self.rangeRunAnd + #")\s+(?:to|through)\s+(?<b>"# + Self.rangeRunAnd + #")\b"#
+      #"(?<![\d.])\b(?<a>"# + Self.rangeRunAnd + #")\s+(?:to|through)\s+(?<b>"# + Self.rangeRunAnd
+      + #")\b"#
     t = reSub(toPat, t) { m in
       guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
       return " \(r) "
     }
     // match ALL slash-separated parts (not just 2-3) so a 4+ chain isn't left half-rewritten.
     let wslashPat =
-      #"\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+slash\s+(?:"# + Self.rangeRunAnd + #"))+\b"#
+      #"(?<![\d.])\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+slash\s+(?:"# + Self.rangeRunAnd
+      + #"))+\b"#
     t = reSub(wslashPat, t) { m in
       let parts = splitOnSlash(m.whole)
       let vals = parts.compactMap { Self.wordsToInt(Self.splitWords($0.lowercased())) }
@@ -356,7 +360,8 @@ public struct InverseTextNormalizer: Sendable {
       return " " + vals.map { String($0) }.joined(separator: "/") + " "
     }
     // match ALL legs so a 3D size ("two by four by six" -> "2 by 4 by 6") is fully normalized.
-    let byPat = #"\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+by\s+(?:"# + Self.rangeRunAnd + #"))+\b"#
+    let byPat =
+      #"(?<![\d.])\b(?<a>"# + Self.rangeRunAnd + #")(?:\s+by\s+(?:"# + Self.rangeRunAnd + #"))+\b"#
     t = reSub(byPat, t) { m in
       let parts = splitOnBy(m.whole)
       let legs = parts.compactMap { Self.wordsToInt(Self.splitWords($0.lowercased())) }
@@ -499,6 +504,12 @@ public struct InverseTextNormalizer: Sendable {
     // ('" 23 "' -> '"23"'). A single-sided rule corrupted adjacent quotes ('twenty "special"' ->
     // '20"special"'), so require both quotes around the number.
     t = reSub(#""\s+(\d[\d.,]*)\s+""#, t, caseInsensitive: false) { m in "\"\(m.g(1) ?? "")\"" }
+    // opening straight quote + padded number ('"Twenty..."' -> '" 20 ...' -> '"20 ...'): tighten
+    // ONLY in opening position (preceded by start or whitespace) so a CLOSING quote before a number
+    // ('he said "hi." 5 times') is never merged.
+    t = reSub(#"(^|\s)(["'])\s+(?=\d)"#, t, caseInsensitive: false) { m in
+      (m.g(1) ?? "") + (m.g(2) ?? "")
+    }
     // hyphenated compound modifier: converting "twenty-step" leaves "20 -step" (the cardinal pass
     // re-emits " 20 " with pad spaces). Re-tighten "digit space-hyphen word" -> "digit-word".
     t = reSub(#"(\d)\s+-(\w)"#, t, caseInsensitive: false) { m in "\(m.g(1) ?? "")-\(m.g(2) ?? "")"

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -765,13 +765,19 @@ public struct InverseTextNormalizer: Sendable {
     // ->101st. Lead must end in a scale word so this never touches 'twenty third' (comp owns that).
     let leadScale =
       #"(?:(?:"# + Self.numwordAlt + #")\s+)*(?:hundred|thousand|million|billion)(?:\s+and)?"#
-    let addPat = #"\b(?<lead>"# + leadScale + #")\s+(?<o>"# + Self.ordTailAlt + #")\b"#
+    let addPat =
+      #"\b(?<lead>"# + leadScale + #")\s+(?<o>"# + Self.ordTailAlt + #")\b(?:\s+(?<nxt>[a-z]+))?"#
     t = reSub(addPat, t) { m in
+      let ow = (m.g("o") ?? "").lowercased()
+      let nxt = m.g("nxt") ?? ""
+      // duration guard: "one hundred second video" is a 100-SECOND clip, not the 102nd.
+      if ow == "second", Self.durationNouns.contains(nxt.lowercased()) { return nil }
       guard let base = Self.wordsToInt(Self.splitWords((m.g("lead") ?? "").lowercased())) else {
         return nil
       }
-      let n = base + Self.ordTail[(m.g("o") ?? "").lowercased()]!
-      return " \(comma(n))\(ordSuffix(n)) "
+      let n = base + Self.ordTail[ow]!
+      let tail = nxt.isEmpty ? "" : " " + nxt
+      return " \(comma(n))\(ordSuffix(n))\(tail) "
     }
     // compound: '<tens> <unit-ordinal>' -> 'Nth' ('seventy third'->73rd), capturing the next word
     // so the 'second' duration guard fires ('thirty second video'->left). Result is always >=21.

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -465,6 +465,13 @@ public struct InverseTextNormalizer: Sendable {
         } else if firstMatch(#"^-(?:year|month|week|day)s?-old\b"#, after) != nil {
           // hyphenated age compound ("five-year-old") is one token; AP uses figures for ages.
           force = true
+        } else if after.first == "-",
+          (after.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? "")
+            .split(separator: "-").contains(where: {
+              Self.unitNouns.contains(Self.clean(String($0)))
+            })
+        {
+          force = true  // unit inside a hyphenated compound: "five-foot-tall" -> "5-foot-tall"
         }
       }
       if n >= Self.apThreshold || force { return " \(comma(n))\(tailAnd) " }
@@ -759,6 +766,9 @@ public struct InverseTextNormalizer: Sendable {
     let scalePat = #"\b(?:(?<lead>"# + Self.cardRun + #")\s+)?(?<s>"# + Self.ordScaleAlt + #")\b"#
     t = reSub(scalePat, t) { m in
       let sword = (m.g("s") ?? "").lowercased()
+      // fraction guard: "a thousandth of a second" is 1/1000, not the 1,000th -> leave spelled.
+      let afterScale = m.ns.substring(from: m.result.range.location + m.result.range.length)
+      if firstMatch(#"^\s+of\b"#, afterScale) != nil { return nil }
       let n: Int
       if let lead = m.g("lead") {
         // reconstruct the full cardinal phrase ('one thousand one hundredth' -> 'one thousand one
@@ -783,6 +793,7 @@ public struct InverseTextNormalizer: Sendable {
       let nxt = m.g("nxt") ?? ""
       // duration guard: "one hundred second video" is a 100-SECOND clip, not the 102nd.
       if ow == "second", Self.durationNouns.contains(nxt.lowercased()) { return nil }
+      if nxt.lowercased() == "of" { return nil }  // fraction ("a hundred and fiftieth of ...")
       guard let base = Self.wordsToInt(Self.splitWords((m.g("lead") ?? "").lowercased())) else {
         return nil
       }

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizerSupport.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizerSupport.swift
@@ -45,6 +45,10 @@ private final class RegexCache: @unchecked Sendable {
     defer { lock.unlock() }
     if let cached = store[key] { return cached }
     guard let compiled = try? NSRegularExpression(pattern: pattern, options: options) else {
+      // A malformed pattern would silently no-op the pass (and break oracle parity). Crash loudly
+      // in DEBUG/tests so it is caught at build time; in release the limb degrades gracefully
+      // (ITN must never crash the heart path) — the pass is skipped, raw text passes through.
+      assertionFailure("ITN regex failed to compile: \(pattern)")
       return nil
     }
     store[key] = compiled
@@ -99,9 +103,9 @@ func allMatches(_ pattern: String, _ s: String, caseInsensitive: Bool = true) ->
   }
 }
 
-/// `re.split(r"\s+slash\s+", s, flags=re.I)`.
-func splitOnSlash(_ s: String) -> [String] {
-  guard let re = RegexCache.shared.regex(#"\s+slash\s+"#, [.caseInsensitive]) else { return [s] }
+/// `re.split(pattern, s, flags=re.I)` for a separator pattern.
+private func splitOnPattern(_ s: String, _ pattern: String) -> [String] {
+  guard let re = RegexCache.shared.regex(pattern, [.caseInsensitive]) else { return [s] }
   let ns = s as NSString
   var parts: [String] = []
   var last = 0
@@ -112,6 +116,12 @@ func splitOnSlash(_ s: String) -> [String] {
   parts.append(ns.substring(with: NSRange(location: last, length: ns.length - last)))
   return parts
 }
+
+/// `re.split(r"\s+slash\s+", s, flags=re.I)`.
+func splitOnSlash(_ s: String) -> [String] { splitOnPattern(s, #"\s+slash\s+"#) }
+
+/// `re.split(r"\s+by\s+", s, flags=re.I)` — for chained dimensions ("two by four by six").
+func splitOnBy(_ s: String) -> [String] { splitOnPattern(s, #"\s+by\s+"#) }
 
 /// `f"{n:,}"` — thousands grouping, locale-independent (matches Python).
 func comma(_ n: Int) -> String {

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -178,4 +178,35 @@ struct InverseTextNormalizerParityTests {
   func categoryFixes(input: String, expected: String) {
     #expect(InverseTextNormalizer().normalize(input) == expected)
   }
+
+  // AP-style number formatting (#1187). Spell one-nine; digits for 10+; always-digit exceptions
+  // for money/percent/age/units/decimals/ranges/ordinals-10th+. Each line is the verbatim Python
+  // oracle output (the byte-parity fixtures lock the full set; these document the policy in-place).
+  @Test(
+    "AP number policy holds (oracle-verified)",
+    arguments: [
+      // the #1187 report: a sentence-initial spelled-out large number was passing through untouched
+      ("Nine hundred forty five.", "945."),
+      // spell out one-nine in prose (the founder feedback: "they said 1, it wrote 1")
+      ("I have two cats.", "I have two cats."),
+      ("twenty three people came", "23 people came"),
+      // exceptions still digitize sub-ten values
+      ("she is five years old", "she is 5 years old"),
+      ("walk five miles", "walk 5 miles"),
+      // per-token in a mixed sentence (one stays spelled, one converts)
+      ("nine out of ten dentists", "nine out of 10 dentists"),
+      // ranges -> hyphenated digits; small ordinals stay spelled, 10th+ convert
+      ("between three and seven", "between 3-7"),
+      ("the third option is best", "the third option is best"),
+      ("the twentieth century", "the 20th century"),
+      ("the hundred and first complaint", "the 101st complaint"),
+      // spoken decimals; money at sentence end keeps the dollar sign
+      ("negative point five", "negative 0.5"),
+      ("He paid fifteen hundred dollars.", "He paid $1,500."),
+      // brands/titles with a number word stay spelled
+      ("we ate at Five Guys", "we ate at Five Guys"),
+    ])
+  func apNumberPolicy(input: String, expected: String) {
+    #expect(InverseTextNormalizer().normalize(input) == expected)
+  }
 }

--- a/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
+++ b/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
@@ -2058,3 +2058,5 @@
 {"input": "On June second, five people signed up", "expected": "On June second, five people signed up", "category": "numeric", "slice": "ap_gold"}
 {"input": "twenty-first century", "expected": "21st century", "category": "numeric", "slice": "ap_gold"}
 {"input": "the twenty-second of may", "expected": "the 22nd of may", "category": "numeric", "slice": "ap_gold"}
+{"input": "one hundred second video", "expected": "100 second video", "category": "numeric", "slice": "ap_gold"}
+{"input": "one hundred and second in line", "expected": "102nd in line", "category": "numeric", "slice": "ap_gold"}

--- a/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
+++ b/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
@@ -2060,3 +2060,5 @@
 {"input": "the twenty-second of may", "expected": "the 22nd of may", "category": "numeric", "slice": "ap_gold"}
 {"input": "one hundred second video", "expected": "100 second video", "category": "numeric", "slice": "ap_gold"}
 {"input": "one hundred and second in line", "expected": "102nd in line", "category": "numeric", "slice": "ap_gold"}
+{"input": "a thousandth of a second", "expected": "a thousandth of a second", "category": "numeric", "slice": "ap_gold"}
+{"input": "a five-foot-tall person", "expected": "a 5-foot-tall person", "category": "numeric", "slice": "ap_gold"}

--- a/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
+++ b/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
@@ -183,7 +183,7 @@
 {"input": "11th", "expected": "11th", "category": "numeric", "slice": "idempotence"}
 {"input": "sixty first", "expected": "61st", "category": "numeric", "slice": "gold"}
 {"input": "61st", "expected": "61st", "category": "numeric", "slice": "idempotence"}
-{"input": "fourth", "expected": "4th", "category": "numeric", "slice": "gold"}
+{"input": "fourth", "expected": "fourth", "category": "numeric", "slice": "gold"}
 {"input": "4th", "expected": "4th", "category": "numeric", "slice": "idempotence"}
 {"input": "seventy fourth", "expected": "74th", "category": "numeric", "slice": "gold"}
 {"input": "74th", "expected": "74th", "category": "numeric", "slice": "idempotence"}
@@ -191,7 +191,7 @@
 {"input": "94th", "expected": "94th", "category": "numeric", "slice": "idempotence"}
 {"input": "thirty fifth", "expected": "35th", "category": "numeric", "slice": "gold"}
 {"input": "35th", "expected": "35th", "category": "numeric", "slice": "idempotence"}
-{"input": "seventh", "expected": "7th", "category": "numeric", "slice": "gold"}
+{"input": "seventh", "expected": "seventh", "category": "numeric", "slice": "gold"}
 {"input": "7th", "expected": "7th", "category": "numeric", "slice": "idempotence"}
 {"input": "six to fifty five", "expected": "6-55", "category": "numeric", "slice": "gold"}
 {"input": "6-55", "expected": "6-55", "category": "numeric", "slice": "idempotence"}
@@ -961,22 +961,22 @@
 {"input": "Dear team:", "expected": "Dear team:", "category": "punctuation", "slice": "idempotence"}
 {"input": "it works comma but slowly period", "expected": "it works, but slowly.", "category": "punctuation", "slice": "gold"}
 {"input": "It works, but slowly.", "expected": "It works, but slowly.", "category": "punctuation", "slice": "idempotence"}
-{"input": "give me five", "expected": "give me 5", "category": "negative", "slice": "negative"}
-{"input": "on cloud nine", "expected": "on cloud 9", "category": "negative", "slice": "negative"}
+{"input": "give me five", "expected": "give me five", "category": "negative", "slice": "negative"}
+{"input": "on cloud nine", "expected": "on cloud nine", "category": "negative", "slice": "negative"}
 {"input": "a thousand thanks", "expected": "a thousand thanks", "category": "negative", "slice": "negative"}
-{"input": "one of a kind", "expected": "1 of a kind", "category": "negative", "slice": "negative"}
-{"input": "back to square one", "expected": "back to square 1", "category": "negative", "slice": "negative"}
+{"input": "one of a kind", "expected": "one of a kind", "category": "negative", "slice": "negative"}
+{"input": "back to square one", "expected": "back to square one", "category": "negative", "slice": "negative"}
 {"input": "at the eleventh hour", "expected": "at the eleventh hour", "category": "negative", "slice": "negative"}
 {"input": "a picture is worth a thousand words", "expected": "a picture is worth a thousand words", "category": "negative", "slice": "negative"}
-{"input": "two heads are better than one", "expected": "2 heads are better than 1", "category": "negative", "slice": "negative"}
-{"input": "it takes two to tango", "expected": "it takes 2 to tango", "category": "negative", "slice": "negative"}
+{"input": "two heads are better than one", "expected": "two heads are better than one", "category": "negative", "slice": "negative"}
+{"input": "it takes two to tango", "expected": "it takes two to tango", "category": "negative", "slice": "negative"}
 {"input": "in seventh heaven", "expected": "in seventh heaven", "category": "negative", "slice": "negative"}
-{"input": "the whole nine yards", "expected": "the whole 9 yards", "category": "negative", "slice": "negative"}
+{"input": "the whole nine yards", "expected": "the whole nine yards", "category": "negative", "slice": "negative"}
 {"input": "dressed to the nines", "expected": "dressed to the nines", "category": "negative", "slice": "negative"}
 {"input": "a million miles away", "expected": "a million miles away", "category": "negative", "slice": "negative"}
 {"input": "second to none", "expected": "second to none", "category": "negative", "slice": "negative"}
 {"input": "first things first", "expected": "first things first", "category": "negative", "slice": "negative"}
-{"input": "six of one half a dozen of the other", "expected": "6 of 1 half a dozen of the other", "category": "negative", "slice": "negative"}
+{"input": "six of one half a dozen of the other", "expected": "six of one half a dozen of the other", "category": "negative", "slice": "negative"}
 {"input": "let me think about that for a moment", "expected": "let me think about that for a moment", "category": "negative", "slice": "negative"}
 {"input": "i really appreciate you taking the time to look into this", "expected": "i really appreciate you taking the time to look into this", "category": "negative", "slice": "negative"}
 {"input": "can you walk me through how this works", "expected": "can you walk me through how this works", "category": "negative", "slice": "negative"}
@@ -1025,7 +1025,7 @@
 {"input": "You're like watching the market multiple times a day.", "expected": "You're like watching the market multiple times a day.", "category": "negative", "slice": "negative"}
 {"input": "I don't know anything about day trading.", "expected": "I don't know anything about day trading.", "category": "negative", "slice": "negative"}
 {"input": "Sounds good.", "expected": "Sounds good.", "category": "negative", "slice": "negative"}
-{"input": "By the way, no one's gonna be speaking foreign languages into parakeet, or at least they should not.", "expected": "By the way, no 1 's gonna be speaking foreign languages into parakeet, or at least they should not.", "category": "negative", "slice": "negative"}
+{"input": "By the way, no one's gonna be speaking foreign languages into parakeet, or at least they should not.", "expected": "By the way, no one's gonna be speaking foreign languages into parakeet, or at least they should not.", "category": "negative", "slice": "negative"}
 {"input": "Test.", "expected": "Test.", "category": "negative", "slice": "negative"}
 {"input": "Test. Test.", "expected": "Test. Test.", "category": "negative", "slice": "negative"}
 {"input": "Hmm.", "expected": "Hmm.", "category": "negative", "slice": "negative"}
@@ -1113,7 +1113,7 @@
 {"input": "Stand testing.", "expected": "Stand testing.", "category": "negative", "slice": "negative"}
 {"input": "So my question to you is, was this test valuable? Did it explain anything to you or are you saying there's just too much variance and it's not validating anything?", "expected": "So my question to you is, was this test valuable? Did it explain anything to you or are you saying there's just too much variance and it's not validating anything?", "category": "negative", "slice": "negative"}
 {"input": "we need to run these UAT tests but I don't think we need to like hyperfixate if sudden burst is not working properly. But things like normal speech and stuff", "expected": "we need to run these UAT tests but I don't think we need to like hyperfixate if sudden burst is not working properly. But things like normal speech and stuff", "category": "negative", "slice": "negative"}
-{"input": "I mean things that to me are equally as important is are we capturing the first part of a speech sentence? Are we making sure that nothing's getting clipped at the end of the recording?", "expected": "I mean things that to me are equally as important is are we capturing the 1st part of a speech sentence? Are we making sure that nothing's getting clipped at the end of the recording?", "category": "negative", "slice": "negative"}
+{"input": "I mean things that to me are equally as important is are we capturing the first part of a speech sentence? Are we making sure that nothing's getting clipped at the end of the recording?", "expected": "I mean things that to me are equally as important is are we capturing the first part of a speech sentence? Are we making sure that nothing's getting clipped at the end of the recording?", "category": "negative", "slice": "negative"}
 {"input": "Is the transcription engine able to batch properly on longer recordings?", "expected": "Is the transcription engine able to batch properly on longer recordings?", "category": "negative", "slice": "negative"}
 {"input": "How good is the engine at capturing short dictations?", "expected": "How good is the engine at capturing short dictations?", "category": "negative", "slice": "negative"}
 {"input": "If the user is pressing the record key but not saying anything, are we making sure that our engines aren't returning hallucinations?", "expected": "If the user is pressing the record key but not saying anything, are we making sure that our engines aren't returning hallucinations?", "category": "negative", "slice": "negative"}
@@ -1409,11 +1409,11 @@
 {"input": "he has twenty twenty vision", "expected": "he has 2020 vision", "category": "numeric", "slice": "ambiguity"}
 {"input": "the final score was twenty twenty", "expected": "the final score was 2020", "category": "numeric", "slice": "ambiguity"}
 {"input": "we won five to three", "expected": "we won 5-3", "category": "numeric", "slice": "ambiguity"}
-{"input": "i need five apples", "expected": "i need 5 apples", "category": "numeric", "slice": "ambiguity"}
+{"input": "i need five apples", "expected": "i need five apples", "category": "numeric", "slice": "ambiguity"}
 {"input": "i live at three twenty west thirty eighth street", "expected": "i live at three twenty west 38th street", "category": "numeric", "slice": "ambiguity"}
 {"input": "we picked three hundred twenty apples", "expected": "we picked 320 apples", "category": "numeric", "slice": "ambiguity"}
-{"input": "the store is on fifth avenue", "expected": "the store is on 5th avenue", "category": "numeric", "slice": "ambiguity"}
-{"input": "she finished in fifth place", "expected": "she finished in 5th place", "category": "negative", "slice": "negative"}
+{"input": "the store is on fifth avenue", "expected": "the store is on fifth avenue", "category": "numeric", "slice": "ambiguity"}
+{"input": "she finished in fifth place", "expected": "she finished in fifth place", "category": "negative", "slice": "negative"}
 {"input": "upgrade to version two point oh", "expected": "upgrade to version 2.0", "category": "numeric", "slice": "ambiguity"}
 {"input": "the gap was two point five inches", "expected": "the gap was 2.5 inches", "category": "numeric", "slice": "ambiguity"}
 {"input": "add a quarter cup of sugar", "expected": "add a quarter cup of sugar", "category": "negative", "slice": "negative"}
@@ -1423,18 +1423,18 @@
 {"input": "see section two zero three", "expected": "see section 203", "category": "numeric", "slice": "ambiguity"}
 {"input": "the meeting is at o eight hundred", "expected": "the meeting is at 800", "category": "time", "slice": "ambiguity"}
 {"input": "we sold eight hundred units", "expected": "we sold 800 units", "category": "numeric", "slice": "ambiguity"}
-{"input": "the deadline is march third", "expected": "the deadline is march 3rd", "category": "date", "slice": "ambiguity"}
+{"input": "the deadline is march third", "expected": "the deadline is march third", "category": "date", "slice": "ambiguity"}
 {"input": "the ratio is three to one", "expected": "the ratio is 3-1", "category": "numeric", "slice": "ambiguity"}
 {"input": "i ran a ten k this morning", "expected": "i ran a 10 k this morning", "category": "numeric", "slice": "ambiguity"}
 {"input": "they offered ten k more", "expected": "they offered 10 k more", "category": "currency", "slice": "ambiguity"}
 {"input": "interest is five percent", "expected": "interest is 5%", "category": "numeric", "slice": "ambiguity"}
-{"input": "about five of them agreed", "expected": "about 5 of them agreed", "category": "negative", "slice": "negative"}
-{"input": "meet me on the second", "expected": "meet me on the 2nd", "category": "date", "slice": "ambiguity"}
+{"input": "about five of them agreed", "expected": "about five of them agreed", "category": "negative", "slice": "negative"}
+{"input": "meet me on the second", "expected": "meet me on the second", "category": "date", "slice": "ambiguity"}
 {"input": "wait a second", "expected": "wait a second", "category": "negative", "slice": "negative"}
 {"input": "my pin is double oh seven five", "expected": "my pin is double 075", "category": "numeric", "slice": "ambiguity"}
 {"input": "it's worth twenty bucks", "expected": "it's worth 20 bucks", "category": "currency", "slice": "ambiguity"}
 {"input": "there are twenty bucks in the field", "expected": "there are 20 bucks in the field", "category": "negative", "slice": "negative"}
-{"input": "nine trillion seven hundred eighty nine billion three hundred eighty two million five hundred thirty six thousand one hundred thirty", "expected": "9 trillion 789,382,536,130", "category": "numeric", "slice": "public"}
+{"input": "nine trillion seven hundred eighty nine billion three hundred eighty two million five hundred thirty six thousand one hundred thirty", "expected": "nine trillion 789,382,536,130", "category": "numeric", "slice": "public"}
 {"input": "two hundred and fifty four", "expected": "254", "category": "numeric", "slice": "public"}
 {"input": "one hundred forty seven thousand four hundred fifty one", "expected": "147,451", "category": "numeric", "slice": "public"}
 {"input": "one million one hundred fifty six thousand one hundred seventy three", "expected": "1,156,173", "category": "numeric", "slice": "public"}
@@ -1443,11 +1443,11 @@
 {"input": "seventeen sextillion eight hundred fifty five quintillion thirty six quadrillion six hundred fifty seven trillion seven billion five hundred ninety six million one hundred ten thousand nine hundred forty nine", "expected": "17 sextillion 855 quintillion 36 quadrillion 657 trillion 7,596,110,949", "category": "numeric", "slice": "public"}
 {"input": "ten quadrillion ten trillion ten million one hundred thousand ten", "expected": "10 quadrillion 10 trillion 10,100,010", "category": "numeric", "slice": "public"}
 {"input": "minus twenty five thousand thirty seven", "expected": "minus 25,037", "category": "numeric", "slice": "public"}
-{"input": "one quadrillion two hundred sixty four trillion three hundred one billion nine hundred thirty eight million one hundred four", "expected": "1 quadrillion 264 trillion 301,938,000,104", "category": "numeric", "slice": "public"}
+{"input": "one quadrillion two hundred sixty four trillion three hundred one billion nine hundred thirty eight million one hundred four", "expected": "one quadrillion 264 trillion 301,938,000,104", "category": "numeric", "slice": "public"}
 {"input": "minus sixty", "expected": "minus 60", "category": "numeric", "slice": "public"}
 {"input": "forty six thousand six hundred sixty four", "expected": "46,664", "category": "numeric", "slice": "public"}
 {"input": "sixty", "expected": "60", "category": "numeric", "slice": "public"}
-{"input": "zero", "expected": "0", "category": "numeric", "slice": "public"}
+{"input": "zero", "expected": "zero", "category": "numeric", "slice": "public"}
 {"input": "two million three", "expected": "2,000,003", "category": "numeric", "slice": "public"}
 {"input": "one thousand thirteen", "expected": "1,013", "category": "numeric", "slice": "public"}
 {"input": "one thousand one", "expected": "1,001", "category": "numeric", "slice": "public"}
@@ -1472,7 +1472,7 @@
 {"input": "the twenty second of july twenty twelve", "expected": "the 22nd of july 2012", "category": "date", "slice": "public"}
 {"input": "the fifteenth of january", "expected": "the 15th of january", "category": "date", "slice": "public"}
 {"input": "the seventeenth of may twenty ten", "expected": "the 17th of may 2010", "category": "date", "slice": "public"}
-{"input": "january first", "expected": "january 1st", "category": "date", "slice": "public"}
+{"input": "january first", "expected": "january first", "category": "date", "slice": "public"}
 {"input": "july twenty second two thousand eight", "expected": "July 22, 2008", "category": "date", "slice": "public"}
 {"input": "june thirty", "expected": "june 30", "category": "date", "slice": "public"}
 {"input": "july twenty fifth twenty twelve", "expected": "July 25, 2012", "category": "date", "slice": "public"}
@@ -1530,7 +1530,7 @@
 {"input": "fifteen billion", "expected": "15 billion", "category": "numeric", "slice": "public"}
 {"input": "two million", "expected": "2 million", "category": "numeric", "slice": "public"}
 {"input": "eight million", "expected": "8 million", "category": "numeric", "slice": "public"}
-{"input": "point one two o five", "expected": "point 1205", "category": "numeric", "slice": "public"}
+{"input": "point one two o five", "expected": "0.1205", "category": "numeric", "slice": "public"}
 {"input": "minus sixty point two four zero zero", "expected": "minus 60.2400", "category": "numeric", "slice": "public"}
 {"input": "zero point two six", "expected": "0.26", "category": "numeric", "slice": "public"}
 {"input": "point zero two", "expected": "point 02", "category": "numeric", "slice": "public"}
@@ -1568,11 +1568,11 @@
 {"input": "a b c at g mail dot a b c", "expected": "a b c at g mail dot a b c", "category": "email", "slice": "public"}
 {"input": "a b c at a b c dot com", "expected": "a b c at a b c.com", "category": "email", "slice": "public"}
 {"input": "a s d f one two three at a b c dot com", "expected": "a s d f one two three at a b c.com", "category": "email", "slice": "public"}
-{"input": "a one b two at a b c dot com", "expected": "a 1 b 2 at a b c.com", "category": "email", "slice": "public"}
-{"input": "a b three dot s d d dot three at g mail dot com", "expected": "a b 3 dot s d d dot 3 at g mail.com", "category": "email", "slice": "public"}
-{"input": "dot three at g mail dot com", "expected": "dot 3 at g mail.com", "category": "email", "slice": "public"}
+{"input": "a one b two at a b c dot com", "expected": "a one b two at a b c.com", "category": "email", "slice": "public"}
+{"input": "a b three dot s d d dot three at g mail dot com", "expected": "a b three dot s d d dot three at g mail.com", "category": "email", "slice": "public"}
+{"input": "dot three at g mail dot com", "expected": "dot three at g mail.com", "category": "email", "slice": "public"}
 {"input": "one three at g mail dot com", "expected": "one three at g mail.com", "category": "email", "slice": "public"}
-{"input": "a b three hyphen s d d dash three at g mail dot com", "expected": "a b 3 hyphen s d d dash 3 at g mail.com", "category": "email", "slice": "public"}
+{"input": "a b three hyphen s d d dash three at g mail dot com", "expected": "a b three hyphen s d d dash three at g mail.com", "category": "email", "slice": "public"}
 {"input": "h t t p colon slash slash w w w dot o u r d a i l y n e w s dot com dot s m", "expected": "h t t p: slash slash w w w dot o u r d a i l y n e w s.com dot s m", "category": "url", "slice": "public"}
 {"input": "h t t p colon slash slash w w w dot c o m d a i l y n e w s dot a b dot s m", "expected": "h t t p: slash slash w w w dot c o m d a i l y n e w s dot a b dot s m", "category": "url", "slice": "public"}
 {"input": "h t t p colon slash slash w w w dot c o m d a i l y n e w s dot a b slash s m", "expected": "h t t p: slash slash w w w dot c o m d a i l y n e w s dot a b slash s m", "category": "url", "slice": "public"}
@@ -1589,11 +1589,11 @@
 {"input": "forty two thousand two hundred fifty nine per square meter", "expected": "42,259 per square meter", "category": "numeric", "slice": "public"}
 {"input": "minus two thousand twelve kilo liters", "expected": "minus 2012 kilo liters", "category": "numeric", "slice": "public"}
 {"input": "minus sixty six kilograms", "expected": "minus 66 kilograms", "category": "numeric", "slice": "public"}
-{"input": "two kilo watt hours", "expected": "2 kilo watt hours", "category": "numeric", "slice": "public"}
+{"input": "two kilo watt hours", "expected": "two kilo watt hours", "category": "numeric", "slice": "public"}
 {"input": "one point o o o o two eight cubic deci meters", "expected": "1.000028 cubic deci meters", "category": "numeric", "slice": "public"}
 {"input": "seven point five peta bytes", "expected": "7.5 peta bytes", "category": "numeric", "slice": "public"}
-{"input": "three hours", "expected": "3 hours", "category": "numeric", "slice": "public"}
-{"input": "one milli volt", "expected": "1 milli volt", "category": "numeric", "slice": "public"}
+{"input": "three hours", "expected": "three hours", "category": "numeric", "slice": "public"}
+{"input": "one milli volt", "expected": "one milli volt", "category": "numeric", "slice": "public"}
 {"input": "two cubic meters", "expected": "2 cubic meters", "category": "numeric", "slice": "public"}
 {"input": "ninety grams", "expected": "90 grams", "category": "numeric", "slice": "public"}
 {"input": "one hundred twenty four point three lumens", "expected": "124.3 lumens", "category": "numeric", "slice": "public"}
@@ -1621,17 +1621,17 @@
 {"input": "eighteen point five kilometers", "expected": "18.5 kilometers", "category": "numeric", "slice": "public"}
 {"input": "eighteen point five two square kilometers", "expected": "18.52 square kilometers", "category": "numeric", "slice": "public"}
 {"input": "eighteen point nine one square kilometers", "expected": "18.91 square kilometers", "category": "numeric", "slice": "public"}
-{"input": "eighteen point one four percent", "expected": "18.14 percent", "category": "numeric", "slice": "public"}
-{"input": "eighteen point one six percent", "expected": "18.16 percent", "category": "numeric", "slice": "public"}
+{"input": "eighteen point one four percent", "expected": "18.14%", "category": "numeric", "slice": "public"}
+{"input": "eighteen point one six percent", "expected": "18.16%", "category": "numeric", "slice": "public"}
 {"input": "eighteen point one square kilometers", "expected": "18.1 square kilometers", "category": "numeric", "slice": "public"}
-{"input": "eighteen point six percent", "expected": "18.6 percent", "category": "numeric", "slice": "public"}
+{"input": "eighteen point six percent", "expected": "18.6%", "category": "numeric", "slice": "public"}
 {"input": "eighteen point two two kilometers", "expected": "18.22 kilometers", "category": "numeric", "slice": "public"}
 {"input": "eighteen point zero kilometers", "expected": "18.0 kilometers", "category": "numeric", "slice": "public"}
-{"input": "eighteen point zero percent", "expected": "18.0 percent", "category": "numeric", "slice": "public"}
+{"input": "eighteen point zero percent", "expected": "18.0%", "category": "numeric", "slice": "public"}
 {"input": "eighteen square kilometers", "expected": "18 square kilometers", "category": "numeric", "slice": "public"}
 {"input": "eighteen thousand eight hundred giga watt hours", "expected": "18,800 giga watt hours", "category": "numeric", "slice": "public"}
 {"input": "eighteen thousand seven hundred hectares", "expected": "18,700 hectares", "category": "numeric", "slice": "public"}
-{"input": "eight hectares", "expected": "8 hectares", "category": "numeric", "slice": "public"}
+{"input": "eight hectares", "expected": "eight hectares", "category": "numeric", "slice": "public"}
 {"input": "eight hundred eighty five astronomical units", "expected": "885 astronomical units", "category": "numeric", "slice": "public"}
 {"input": "eight hundred eighty hectares", "expected": "880 hectares", "category": "numeric", "slice": "public"}
 {"input": "eight hundred eighty kilobytes", "expected": "880 kilobytes", "category": "numeric", "slice": "public"}
@@ -1681,21 +1681,21 @@
 {"input": "eight hundred twenty one point zero feet", "expected": "821.0 feet", "category": "numeric", "slice": "public"}
 {"input": "eight hundred two point eight nine kilometers", "expected": "802.89 kilometers", "category": "numeric", "slice": "public"}
 {"input": "eight hundred volts", "expected": "800 volts", "category": "numeric", "slice": "public"}
-{"input": "eight kilobits", "expected": "8 kilobits", "category": "numeric", "slice": "public"}
+{"input": "eight kilobits", "expected": "eight kilobits", "category": "numeric", "slice": "public"}
 {"input": "eight kilograms", "expected": "8 kilograms", "category": "numeric", "slice": "public"}
 {"input": "eight million two hundred thousand feet", "expected": "8.2 million feet", "category": "numeric", "slice": "public"}
 {"input": "eight point eight kilometers", "expected": "8.8 kilometers", "category": "numeric", "slice": "public"}
 {"input": "eight point eight meters", "expected": "8.8 meters", "category": "numeric", "slice": "public"}
 {"input": "eight point eight miles", "expected": "8.8 miles", "category": "numeric", "slice": "public"}
 {"input": "eight point five centimeters", "expected": "8.5 centimeters", "category": "numeric", "slice": "public"}
-{"input": "eight point five five percent", "expected": "8.55 percent", "category": "numeric", "slice": "public"}
+{"input": "eight point five five percent", "expected": "8.55%", "category": "numeric", "slice": "public"}
 {"input": "eight point five megawatts", "expected": "8.5 megawatts", "category": "numeric", "slice": "public"}
 {"input": "eight point five meters", "expected": "8.5 meters", "category": "numeric", "slice": "public"}
-{"input": "eight point five two percent", "expected": "8.52 percent", "category": "numeric", "slice": "public"}
-{"input": "eight point four four percent", "expected": "8.44 percent", "category": "numeric", "slice": "public"}
+{"input": "eight point five two percent", "expected": "8.52%", "category": "numeric", "slice": "public"}
+{"input": "eight point four four percent", "expected": "8.44%", "category": "numeric", "slice": "public"}
 {"input": "two dollars", "expected": "$2", "category": "currency", "slice": "public"}
-{"input": "one cent", "expected": "1 cent", "category": "currency", "slice": "public"}
-{"input": "four united states dollars and sixty nine cents", "expected": "4 united states dollars $0.69", "category": "currency", "slice": "public"}
+{"input": "one cent", "expected": "$0.01", "category": "currency", "slice": "public"}
+{"input": "four united states dollars and sixty nine cents", "expected": "four united states dollars $0.69", "category": "currency", "slice": "public"}
 {"input": "seventy five dollars sixty three", "expected": "$75 63", "category": "currency", "slice": "public"}
 {"input": "twenty nine dollars fifty cents", "expected": "$29 $0.50", "category": "currency", "slice": "public"}
 {"input": "eleven dollars and fifty one cents", "expected": "$11.51", "category": "currency", "slice": "public"}
@@ -1711,12 +1711,12 @@
 {"input": "one point six nine billion yuan", "expected": "1.69 billion yuan", "category": "currency", "slice": "public"}
 {"input": "one point four three six billion yuan", "expected": "1.436 billion yuan", "category": "currency", "slice": "public"}
 {"input": "four million yuan", "expected": "4 million yuan", "category": "currency", "slice": "public"}
-{"input": "one dollar", "expected": "1 dollar", "category": "currency", "slice": "public"}
+{"input": "one dollar", "expected": "$1", "category": "currency", "slice": "public"}
 {"input": "fifteen thousand dollars", "expected": "$15,000", "category": "currency", "slice": "public"}
 {"input": "one dollars", "expected": "$1", "category": "currency", "slice": "public"}
-{"input": "twenty dollar", "expected": "20 dollar", "category": "currency", "slice": "public"}
+{"input": "twenty dollar", "expected": "$20", "category": "currency", "slice": "public"}
 {"input": "twenty point five o six dollars", "expected": "20.506 dollars", "category": "currency", "slice": "public"}
-{"input": "point five o six dollars", "expected": "point 506 dollars", "category": "currency", "slice": "public"}
+{"input": "point five o six dollars", "expected": "0.506 dollars", "category": "currency", "slice": "public"}
 {"input": "eighteen dollars", "expected": "$18", "category": "currency", "slice": "public"}
 {"input": "eighteen million nine hundred twenty five thousand dollars", "expected": "$18.925 million", "category": "currency", "slice": "public"}
 {"input": "eighteen thousand eight hundred fifty four dollars", "expected": "$18,854", "category": "currency", "slice": "public"}
@@ -1744,9 +1744,9 @@
 {"input": "one fifty five dollars", "expected": "one fifty five dollars", "category": "currency", "slice": "public"}
 {"input": "fifteen hundred dollars", "expected": "$1,500", "category": "currency", "slice": "public"}
 {"input": "ninety nine hundred dollars", "expected": "$9,900", "category": "currency", "slice": "public"}
-{"input": "ninety nine hundred and fifteen dollars and one cent", "expected": "$9,915 1 cent", "category": "currency", "slice": "public"}
-{"input": "one hundredth", "expected": "1 hundredth", "category": "numeric", "slice": "public"}
-{"input": "twenty five thousand one hundred eleventh", "expected": "25,100 11th", "category": "numeric", "slice": "public"}
+{"input": "ninety nine hundred and fifteen dollars and one cent", "expected": "$9,915.01", "category": "currency", "slice": "public"}
+{"input": "one hundredth", "expected": "100th", "category": "numeric", "slice": "public"}
+{"input": "twenty five thousand one hundred eleventh", "expected": "25,111th", "category": "numeric", "slice": "public"}
 {"input": "second", "expected": "second", "category": "numeric", "slice": "public"}
 {"input": "zeroth", "expected": "zeroth", "category": "numeric", "slice": "public"}
 {"input": "first", "expected": "first", "category": "numeric", "slice": "public"}
@@ -1755,19 +1755,19 @@
 {"input": "thirteenth", "expected": "13th", "category": "numeric", "slice": "public"}
 {"input": "twenty first", "expected": "21st", "category": "numeric", "slice": "public"}
 {"input": "twenty third", "expected": "23rd", "category": "numeric", "slice": "public"}
-{"input": "one hundred eleventh", "expected": "100 11th", "category": "numeric", "slice": "public"}
-{"input": "one thousandth", "expected": "1 thousandth", "category": "numeric", "slice": "public"}
+{"input": "one hundred eleventh", "expected": "111th", "category": "numeric", "slice": "public"}
+{"input": "one thousandth", "expected": "1,000th", "category": "numeric", "slice": "public"}
 {"input": "one hundred twenty first", "expected": "100 21st", "category": "numeric", "slice": "public"}
 {"input": "eleven hundred twenty first", "expected": "1,100 21st", "category": "numeric", "slice": "public"}
 {"input": "tenth", "expected": "10th", "category": "numeric", "slice": "public"}
-{"input": "sixth", "expected": "6th", "category": "numeric", "slice": "public"}
+{"input": "sixth", "expected": "sixth", "category": "numeric", "slice": "public"}
 {"input": "nineteenth", "expected": "19th", "category": "numeric", "slice": "public"}
 {"input": "forty eighth", "expected": "48th", "category": "numeric", "slice": "public"}
 {"input": "seventy first", "expected": "71st", "category": "numeric", "slice": "public"}
 {"input": "forty second", "expected": "42nd", "category": "numeric", "slice": "public"}
 {"input": "seventeenth", "expected": "17th", "category": "numeric", "slice": "public"}
 {"input": "twentieth", "expected": "20th", "category": "numeric", "slice": "public"}
-{"input": "fifth", "expected": "5th", "category": "numeric", "slice": "public"}
+{"input": "fifth", "expected": "fifth", "category": "numeric", "slice": "public"}
 {"input": "one two three one two three five six seven eight", "expected": "123-123-5678", "category": "phone", "slice": "public"}
 {"input": "plus nine one one two three one two three five six seven eight", "expected": "plus nine one one two three one two three five six seven eight", "category": "phone", "slice": "public"}
 {"input": "plus forty four one two three one two three five six seven eight", "expected": "plus forty four one two three one two three five six seven eight", "category": "phone", "slice": "public"}
@@ -1777,15 +1777,15 @@
 {"input": "oh two three one two three five six seven eight", "expected": "023-123-5678", "category": "phone", "slice": "public"}
 {"input": "double oh three one two three five six seven eight", "expected": "double oh three one two three five six seven eight", "category": "phone", "slice": "public"}
 {"input": "four three two double seven three two one four three two one four three double zero five", "expected": "four three two double 732-143-2143 double 05", "category": "phone", "slice": "public"}
-{"input": "one two three dot one two three dot o dot four o", "expected": "one two three dot one two three dot o dot 40", "category": "phone", "slice": "public"}
-{"input": "one twenty three dot one two three dot o dot four o", "expected": "one twenty three dot one two three dot o dot 40", "category": "phone", "slice": "public"}
-{"input": "two two five dot double five dot o dot four o", "expected": "two two five dot double 5 dot o dot 40", "category": "phone", "slice": "public"}
-{"input": "two two five dot double five dot o dot forty five", "expected": "two two five dot double 5 dot o dot 45", "category": "phone", "slice": "public"}
-{"input": "ssn is seven double nine one two three double one three", "expected": "ssn is 7 double nine one two three double one three", "category": "phone", "slice": "public"}
+{"input": "one two three dot one two three dot o dot four o", "expected": "one two three dot one two three dot o dot four o", "category": "phone", "slice": "public"}
+{"input": "one twenty three dot one two three dot o dot four o", "expected": "one twenty three dot one two three dot o dot four o", "category": "phone", "slice": "public"}
+{"input": "two two five dot double five dot o dot four o", "expected": "two two five dot double five dot o dot four o", "category": "phone", "slice": "public"}
+{"input": "two two five dot double five dot o dot forty five", "expected": "two two five dot double 5.0 dot 45", "category": "phone", "slice": "public"}
+{"input": "ssn is seven double nine one two three double one three", "expected": "ssn is seven double nine one two three double one three", "category": "phone", "slice": "public"}
 {"input": "seven nine nine", "expected": "seven nine nine", "category": "phone", "slice": "public"}
-{"input": "a b nine", "expected": "a b 9", "category": "phone", "slice": "public"}
+{"input": "a b nine", "expected": "a b nine", "category": "phone", "slice": "public"}
 {"input": "a b c", "expected": "a b c", "category": "phone", "slice": "public"}
-{"input": "five w k r a three one", "expected": "5 w k r a three one", "category": "phone", "slice": "public"}
+{"input": "five w k r a three one", "expected": "five w k r a three one", "category": "phone", "slice": "public"}
 {"input": "x eighty six", "expected": "x 86", "category": "phone", "slice": "public"}
 {"input": "x three eighty six", "expected": "x three eighty six", "category": "phone", "slice": "public"}
 {"input": "a thirty six", "expected": "a 36", "category": "phone", "slice": "public"}
@@ -1814,10 +1814,10 @@
 {"input": "quarter to one", "expected": "quarter to one", "category": "time", "slice": "public"}
 {"input": "quarter to twelve", "expected": "quarter to twelve", "category": "time", "slice": "public"}
 {"input": "set alarm at ten to eleven pm", "expected": "set alarm at 10-11:00 PM", "category": "time", "slice": "public"}
-{"input": "one min to one am", "expected": "1 min to 1:00 AM", "category": "time", "slice": "public"}
-{"input": ", one", "expected": ", 1", "category": "negative", "slice": "negative"}
-{"input": ", one , two , three , four", "expected": ", 1, 2, 3, 4", "category": "negative", "slice": "negative"}
-{"input": "e s three", "expected": "e s 3", "category": "negative", "slice": "negative"}
+{"input": "one min to one am", "expected": "one min to 1:00 AM", "category": "time", "slice": "public"}
+{"input": ", one", "expected": ", one", "category": "negative", "slice": "negative"}
+{"input": ", one , two , three , four", "expected": ", one, two, three, four", "category": "negative", "slice": "negative"}
+{"input": "e s three", "expected": "e s three", "category": "negative", "slice": "negative"}
 {"input": "yahoo!", "expected": "yahoo!", "category": "negative", "slice": "negative"}
 {"input": "twenty!", "expected": "20!", "category": "negative", "slice": "negative"}
 {"input": "x", "expected": "x", "category": "negative", "slice": "negative"}
@@ -1885,14 +1885,176 @@
 {"input": "oh i see what you mean now", "expected": "oh i see what you mean now", "category": "negative", "slice": "negative"}
 {"input": "oh no not this again", "expected": "oh no not this again", "category": "negative", "slice": "negative"}
 {"input": "oh well these things happen", "expected": "oh well these things happen", "category": "negative", "slice": "negative"}
-{"input": "no one really knows for sure", "expected": "no 1 really knows for sure", "category": "negative", "slice": "negative"}
-{"input": "she is the one for this job", "expected": "she is the 1 for this job", "category": "negative", "slice": "negative"}
-{"input": "that is one way to look at it", "expected": "that is 1 way to look at it", "category": "negative", "slice": "negative"}
-{"input": "for one thing it is already late", "expected": "for 1 thing it is already late", "category": "negative", "slice": "negative"}
+{"input": "no one really knows for sure", "expected": "no one really knows for sure", "category": "negative", "slice": "negative"}
+{"input": "she is the one for this job", "expected": "she is the one for this job", "category": "negative", "slice": "negative"}
+{"input": "that is one way to look at it", "expected": "that is one way to look at it", "category": "negative", "slice": "negative"}
+{"input": "for one thing it is already late", "expected": "for one thing it is already late", "category": "negative", "slice": "negative"}
 {"input": "wait a second while i check", "expected": "wait a second while i check", "category": "negative", "slice": "negative"}
 {"input": "give me a second to think", "expected": "give me a second to think", "category": "negative", "slice": "negative"}
-{"input": "at one point i almost gave up", "expected": "at 1 point i almost gave up", "category": "negative", "slice": "negative"}
-{"input": "you are the one i trust", "expected": "you are the 1 i trust", "category": "negative", "slice": "negative"}
-{"input": "one more thing before you go", "expected": "1 more thing before you go", "category": "negative", "slice": "negative"}
-{"input": "hold on one sec", "expected": "hold on 1 sec", "category": "negative", "slice": "negative"}
+{"input": "at one point i almost gave up", "expected": "at one point i almost gave up", "category": "negative", "slice": "negative"}
+{"input": "you are the one i trust", "expected": "you are the one i trust", "category": "negative", "slice": "negative"}
+{"input": "one more thing before you go", "expected": "one more thing before you go", "category": "negative", "slice": "negative"}
+{"input": "hold on one sec", "expected": "hold on one sec", "category": "negative", "slice": "negative"}
 {"input": "it is half past caring honestly", "expected": "it is half past caring honestly", "category": "negative", "slice": "negative"}
+{"input": "I have two cats.", "expected": "I have two cats.", "category": "numeric", "slice": "ap_gold"}
+{"input": "He scored three goals.", "expected": "He scored three goals.", "category": "numeric", "slice": "ap_gold"}
+{"input": "seven samples remained", "expected": "seven samples remained", "category": "numeric", "slice": "ap_gold"}
+{"input": "there were four of us", "expected": "there were four of us", "category": "numeric", "slice": "ap_gold"}
+{"input": "we were on cloud nine", "expected": "we were on cloud nine", "category": "numeric", "slice": "ap_gold"}
+{"input": "it happened three times", "expected": "it happened three times", "category": "numeric", "slice": "ap_gold"}
+{"input": "nine lives", "expected": "nine lives", "category": "numeric", "slice": "ap_gold"}
+{"input": "one of them left", "expected": "one of them left", "category": "numeric", "slice": "ap_gold"}
+{"input": "we tested ninety four cases", "expected": "we tested 94 cases", "category": "numeric", "slice": "ap_gold"}
+{"input": "twenty three people came", "expected": "23 people came", "category": "numeric", "slice": "ap_gold"}
+{"input": "there are fifteen items", "expected": "there are 15 items", "category": "numeric", "slice": "ap_gold"}
+{"input": "ten dogs", "expected": "10 dogs", "category": "numeric", "slice": "ap_gold"}
+{"input": "nine dogs", "expected": "nine dogs", "category": "numeric", "slice": "ap_gold"}
+{"input": "eleven players", "expected": "11 players", "category": "numeric", "slice": "ap_gold"}
+{"input": "one hundred twenty three widgets", "expected": "123 widgets", "category": "numeric", "slice": "ap_gold"}
+{"input": "Twenty three people came.", "expected": "23 people came.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Nine hundred forty five.", "expected": "945.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Fifteen people on the call.", "expected": "15 people on the call.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Two hundred Americans attended.", "expected": "200 Americans attended.", "category": "numeric", "slice": "ap_gold"}
+{"input": "One thousand two hundred people attended.", "expected": "1,200 people attended.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Three of them left.", "expected": "Three of them left.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Five of us stayed.", "expected": "Five of us stayed.", "category": "numeric", "slice": "ap_gold"}
+{"input": "One thing I noticed.", "expected": "One thing I noticed.", "category": "numeric", "slice": "ap_gold"}
+{"input": "it cost five dollars", "expected": "it cost $5", "category": "numeric", "slice": "ap_gold"}
+{"input": "five percent growth", "expected": "5% growth", "category": "numeric", "slice": "ap_gold"}
+{"input": "call me at five pm", "expected": "call me at 5:00 PM", "category": "numeric", "slice": "ap_gold"}
+{"input": "three point five", "expected": "3.5", "category": "numeric", "slice": "ap_gold"}
+{"input": "we raised eighty million dollars last year", "expected": "we raised $80 million last year", "category": "numeric", "slice": "ap_gold"}
+{"input": "twenty twenty six is the target", "expected": "2026 is the target", "category": "numeric", "slice": "ap_gold"}
+{"input": "i was born in nineteen eighty seven", "expected": "i was born in 1987", "category": "numeric", "slice": "ap_gold"}
+{"input": "five million users", "expected": "5 million users", "category": "numeric", "slice": "ap_gold"}
+{"input": "nine billion dollars", "expected": "$9 billion", "category": "numeric", "slice": "ap_gold"}
+{"input": "she is five years old", "expected": "she is 5 years old", "category": "numeric", "slice": "ap_gold"}
+{"input": "my daughter is two years old", "expected": "my daughter is 2 years old", "category": "numeric", "slice": "ap_gold"}
+{"input": "the baby is eight months old", "expected": "the baby is 8 months old", "category": "numeric", "slice": "ap_gold"}
+{"input": "a two year old toddler", "expected": "a 2 year old toddler", "category": "numeric", "slice": "ap_gold"}
+{"input": "walk five miles", "expected": "walk 5 miles", "category": "numeric", "slice": "ap_gold"}
+{"input": "add two tablespoons", "expected": "add 2 tablespoons", "category": "numeric", "slice": "ap_gold"}
+{"input": "he is six feet tall", "expected": "he is 6 feet tall", "category": "numeric", "slice": "ap_gold"}
+{"input": "it weighs nine pounds", "expected": "it weighs 9 pounds", "category": "numeric", "slice": "ap_gold"}
+{"input": "drive three kilometers", "expected": "drive 3 kilometers", "category": "numeric", "slice": "ap_gold"}
+{"input": "set it to four degrees", "expected": "set it to 4 degrees", "category": "numeric", "slice": "ap_gold"}
+{"input": "five years later", "expected": "five years later", "category": "numeric", "slice": "ap_gold"}
+{"input": "five years of data", "expected": "five years of data", "category": "numeric", "slice": "ap_gold"}
+{"input": "two weeks from now", "expected": "two weeks from now", "category": "numeric", "slice": "ap_gold"}
+{"input": "pick a number from five to ten", "expected": "pick a number from 5-10", "category": "numeric", "slice": "ap_gold"}
+{"input": "between three and seven", "expected": "between 3-7", "category": "numeric", "slice": "ap_gold"}
+{"input": "we need six to eight people", "expected": "we need 6-8 people", "category": "numeric", "slice": "ap_gold"}
+{"input": "the meeting is four slash six", "expected": "the meeting is 4/6", "category": "numeric", "slice": "ap_gold"}
+{"input": "about a hundred people", "expected": "about 100 people", "category": "numeric", "slice": "ap_gold"}
+{"input": "a hundred and one dalmatians", "expected": "101 dalmatians", "category": "numeric", "slice": "ap_gold"}
+{"input": "a hundred thousand strong", "expected": "100,000 strong", "category": "numeric", "slice": "ap_gold"}
+{"input": "a couple hundred people", "expected": "a couple hundred people", "category": "numeric", "slice": "ap_gold"}
+{"input": "several hundred attendees", "expected": "several hundred attendees", "category": "numeric", "slice": "ap_gold"}
+{"input": "this is my first time", "expected": "this is my first time", "category": "numeric", "slice": "ap_gold"}
+{"input": "he finished ninth", "expected": "he finished ninth", "category": "numeric", "slice": "ap_gold"}
+{"input": "the third option is best", "expected": "the third option is best", "category": "numeric", "slice": "ap_gold"}
+{"input": "he finished tenth", "expected": "he finished 10th", "category": "numeric", "slice": "ap_gold"}
+{"input": "the twentieth century", "expected": "the 20th century", "category": "numeric", "slice": "ap_gold"}
+{"input": "she came in twenty first", "expected": "she came in 21st", "category": "numeric", "slice": "ap_gold"}
+{"input": "One Million Moms protested", "expected": "One Million Moms protested", "category": "numeric", "slice": "ap_gold"}
+{"input": "Hundred Acre Wood is fictional", "expected": "Hundred Acre Wood is fictional", "category": "numeric", "slice": "ap_gold"}
+{"input": "Seven Eleven is open late", "expected": "Seven Eleven is open late", "category": "numeric", "slice": "ap_gold"}
+{"input": "the Forty Niners won", "expected": "the Forty Niners won", "category": "numeric", "slice": "ap_gold"}
+{"input": "One Direction released an album", "expected": "One Direction released an album", "category": "numeric", "slice": "ap_gold"}
+{"input": "we ate at Five Guys", "expected": "we ate at Five Guys", "category": "numeric", "slice": "ap_gold"}
+{"input": "the movie Five Feet Apart", "expected": "the movie Five Feet Apart", "category": "numeric", "slice": "ap_gold"}
+{"input": "Oh my god that was close", "expected": "Oh my god that was close", "category": "numeric", "slice": "ap_gold"}
+{"input": "I have two cats and fifteen fish", "expected": "I have two cats and 15 fish", "category": "numeric", "slice": "ap_gold"}
+{"input": "nine out of ten dentists", "expected": "nine out of 10 dentists", "category": "numeric", "slice": "ap_gold"}
+{"input": "twelve out of fifteen passed", "expected": "12 out of 15 passed", "category": "numeric", "slice": "ap_gold"}
+{"input": "The order includes nine bolts, 10 washers and eleven nuts.", "expected": "The order includes nine bolts, 10 washers and 11 nuts.", "category": "numeric", "slice": "ap_gold"}
+{"input": "We need five to 10 volunteers.", "expected": "We need 5-10 volunteers.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The options are eight, nine and 10.", "expected": "The options are eight, nine and 10.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Use the five-step, 12-step and twenty-step plans.", "expected": "Use the five-step, 12-step and 20-step plans.", "category": "numeric", "slice": "ap_gold"}
+{"input": "She fired a twenty-one-gun salute.", "expected": "She fired a 21-gun salute.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Pack two-, four- and 12-packs separately.", "expected": "Pack two-, four- and 12-packs separately.", "category": "numeric", "slice": "ap_gold"}
+{"input": "This is a 10-item list with three sub-items and eleven notes.", "expected": "This is a 10-item list with three sub-items and 11 notes.", "category": "numeric", "slice": "ap_gold"}
+{"input": "She offered a three-point plan and a 12-point memo.", "expected": "She offered a three-point plan and a 12-point memo.", "category": "numeric", "slice": "ap_gold"}
+{"input": "A one-and-done rule ended the debate.", "expected": "A one-and-done rule ended the debate.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The password is four plus signs and two digits.", "expected": "The password is four plus signs and two digits.", "category": "numeric", "slice": "ap_gold"}
+{"input": "It was minus five degrees at dawn.", "expected": "It was minus 5 degrees at dawn.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The balance fell to negative ten.", "expected": "The balance fell to negative 10.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The fund posted minus five percent.", "expected": "The fund posted minus 5%.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The reading was negative point five.", "expected": "The reading was negative 0.5.", "category": "numeric", "slice": "ap_gold"}
+{"input": "He finished twenty third in the heat.", "expected": "He finished 23rd in the heat.", "category": "numeric", "slice": "ap_gold"}
+{"input": "This is the hundred and first complaint.", "expected": "This is the 101st complaint.", "category": "numeric", "slice": "ap_gold"}
+{"input": "She was the one hundred tenth caller.", "expected": "She was the 110th caller.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The twenty first century began with argument.", "expected": "The 21st century began with argument.", "category": "numeric", "slice": "ap_gold"}
+{"input": "He won his ninth and 10th games.", "expected": "He won his ninth and 10th games.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The one thousandth customer gets a prize.", "expected": "The 1,000th customer gets a prize.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The crowd was eleven hundred strong.", "expected": "The crowd was 1,100 strong.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The warehouse has fifteen hundred boxes.", "expected": "The warehouse has 1,500 boxes.", "category": "numeric", "slice": "ap_gold"}
+{"input": "He paid fifteen hundred dollars.", "expected": "He paid $1,500.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Pi starts three point one four one five.", "expected": "Pi starts 3.1415.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The release is version two dot zero zero.", "expected": "The release is version 2.00.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The batting average was point three zero one.", "expected": "The batting average was 0.301.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Say zero point zero zero five slowly.", "expected": "Say 0.005 slowly.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The file is named four dot txt.", "expected": "The file is named four dot txt.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Her GPA is three point oh.", "expected": "Her GPA is 3.0.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The company is worth two point five billion.", "expected": "The company is worth 2.5 billion.", "category": "numeric", "slice": "ap_gold"}
+{"input": "They counted nine hundred ninety nine thousand ballots.", "expected": "They counted 999,000 ballots.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The estimate was one hundred one million.", "expected": "The estimate was 101 million.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The debt hit seven hundred fifty billion.", "expected": "The debt hit 750 billion.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The town has one thousand one residents.", "expected": "The town has 1,001 residents.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The budget tops zero point nine trillion.", "expected": "The budget tops 0.9 trillion.", "category": "numeric", "slice": "ap_gold"}
+{"input": "TWELVE ANGRY MEN screened tonight.", "expected": "TWELVE ANGRY MEN screened tonight.", "category": "numeric", "slice": "ap_gold"}
+{"input": "I NEED TWELVE EGGS AND TWO PANS.", "expected": "I NEED 12 EGGS AND TWO PANS.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Twenty pilots arrived, but THIRTEEN left.", "expected": "20 pilots arrived, but 13 left.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Only five per cent responded.", "expected": "Only 5% responded.", "category": "numeric", "slice": "ap_gold"}
+{"input": "I ordered 12 apples and three oranges.", "expected": "I ordered 12 apples and three oranges.", "category": "numeric", "slice": "ap_gold"}
+{"input": "It is minus five degrees outside.", "expected": "It is minus 5 degrees outside.", "category": "numeric", "slice": "ap_gold"}
+{"input": "A low of negative ten degrees.", "expected": "A low of negative 10 degrees.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Absolute zero is minus two hundred seventy three degrees.", "expected": "Absolute zero is minus 273 degrees.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The hundred and first airborne division.", "expected": "The 101st airborne division.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Her twenty third birthday.", "expected": "Her 23rd birthday.", "category": "numeric", "slice": "ap_gold"}
+{"input": "He placed one hundred and second in the race.", "expected": "He placed 102nd in the race.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The rent is fifteen hundred dollars.", "expected": "The rent is $1,500.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Download version two point oh oh.", "expected": "Download version 2.00.", "category": "numeric", "slice": "ap_gold"}
+{"input": "It weighs zero dot five grams.", "expected": "It weighs 0.5 grams.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Two point five billion dollars.", "expected": "$2.5 billion.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Nine hundred ninety nine thousand people.", "expected": "999,000 people.", "category": "numeric", "slice": "ap_gold"}
+{"input": "TWENTY two people died.", "expected": "22 people died.", "category": "numeric", "slice": "ap_gold"}
+{"input": "I am one hundred percent sure.", "expected": "I am 100% sure.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Fifty five percent of the vote.", "expected": "55% of the vote.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Five point five percent interest.", "expected": "5.5% interest.", "category": "numeric", "slice": "ap_gold"}
+{"input": "I have 3 cats and four dogs.", "expected": "I have 3 cats and four dogs.", "category": "numeric", "slice": "ap_gold"}
+{"input": "She took 2 buses and walked three miles.", "expected": "She took 2 buses and walked 3 miles.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Bring one, 2, and three forms of ID.", "expected": "Bring one, 2, and three forms of ID.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Buy a two liter bottle and five gallon bucket.", "expected": "Buy a 2 liter bottle and 5 gallon bucket.", "category": "numeric", "slice": "ap_gold"}
+{"input": "The six inch by eight inch card fit.", "expected": "The 6 inch by 8 inch card fit.", "category": "numeric", "slice": "ap_gold"}
+{"input": "Take two five milligram tablets.", "expected": "Take two 5 milligram tablets.", "category": "numeric", "slice": "ap_gold"}
+{"input": "A ten year sentence.", "expected": "A 10 year sentence.", "category": "numeric", "slice": "ap_gold"}
+{"input": "one hundred and five to one hundred and ten", "expected": "105-110", "category": "numeric", "slice": "ap_gold"}
+{"input": "She said \"twenty three\" today", "expected": "She said \"23\" today", "category": "numeric", "slice": "ap_gold"}
+{"input": "The Twenty-Two Steps", "expected": "The Twenty-Two Steps", "category": "numeric", "slice": "ap_gold"}
+{"input": "I read A Hundred Years of Solitude", "expected": "I read A Hundred Years of Solitude", "category": "numeric", "slice": "ap_gold"}
+{"input": "one thousand to two thousand", "expected": "1,000-2,000", "category": "numeric", "slice": "ap_gold"}
+{"input": "one thousand one hundredth", "expected": "1,100th", "category": "numeric", "slice": "ap_gold"}
+{"input": "one thousand by two thousand pixels", "expected": "1,000 by 2,000 pixels", "category": "numeric", "slice": "ap_gold"}
+{"input": "Twenty-Two Steps", "expected": "Twenty-Two Steps", "category": "numeric", "slice": "ap_gold"}
+{"input": "one slash two slash three slash four", "expected": "1/2/3/4", "category": "numeric", "slice": "ap_gold"}
+{"input": "between one hundred and five and one hundred and ten", "expected": "between one hundred and five and one hundred and ten", "category": "numeric", "slice": "ap_gold"}
+{"input": "two dollars and one cent", "expected": "$2.01", "category": "numeric", "slice": "ap_gold"}
+{"input": "a five-year-old boy", "expected": "a 5-year-old boy", "category": "numeric", "slice": "ap_gold"}
+{"input": "two by four by six", "expected": "2 by 4 by 6", "category": "numeric", "slice": "ap_gold"}
+{"input": "June fourth, twenty twenty six", "expected": "June 4, 2026", "category": "numeric", "slice": "ap_gold"}
+{"input": "go one by one", "expected": "go one by one", "category": "numeric", "slice": "ap_gold"}
+{"input": "june second, twenty twenty six.", "expected": "June 2, 2026.", "category": "numeric", "slice": "ap_gold"}
+{"input": "twenty \"special\" items", "expected": "20 \"special\" items", "category": "numeric", "slice": "ap_gold"}
+{"input": "Twenty and change", "expected": "20 and change", "category": "numeric", "slice": "ap_gold"}
+{"input": "a hundred-year lease", "expected": "a 100-year lease", "category": "numeric", "slice": "ap_gold"}
+{"input": "version one dot two dot three", "expected": "version one dot two dot three", "category": "numeric", "slice": "ap_gold"}
+{"input": "two by two inch card", "expected": "2 by 2 inch card", "category": "numeric", "slice": "ap_gold"}
+{"input": "five point five per cent", "expected": "5.5%", "category": "numeric", "slice": "ap_gold"}
+{"input": "we need to catch twenty two fish", "expected": "we need to catch 22 fish", "category": "numeric", "slice": "ap_gold"}
+{"input": "it is a catch twenty two", "expected": "it is a Catch-22", "category": "numeric", "slice": "ap_gold"}
+{"input": "Twenty-two people came", "expected": "22 people came", "category": "numeric", "slice": "ap_gold"}
+{"input": "between one hundred and five and 110", "expected": "between 105 and 110", "category": "numeric", "slice": "ap_gold"}
+{"input": "On June second, five people signed up", "expected": "On June second, five people signed up", "category": "numeric", "slice": "ap_gold"}
+{"input": "twenty-first century", "expected": "21st century", "category": "numeric", "slice": "ap_gold"}
+{"input": "the twenty-second of may", "expected": "the 22nd of may", "category": "numeric", "slice": "ap_gold"}

--- a/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity_holdout.jsonl
+++ b/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity_holdout.jsonl
@@ -110,7 +110,7 @@
 {"input": "33%", "expected": "33%", "category": "numeric", "slice": "idempotence"}
 {"input": "forty third", "expected": "43rd", "category": "numeric", "slice": "gold"}
 {"input": "43rd", "expected": "43rd", "category": "numeric", "slice": "idempotence"}
-{"input": "eighth", "expected": "8th", "category": "numeric", "slice": "gold"}
+{"input": "eighth", "expected": "eighth", "category": "numeric", "slice": "gold"}
 {"input": "8th", "expected": "8th", "category": "numeric", "slice": "idempotence"}
 {"input": "eighty second", "expected": "82nd", "category": "numeric", "slice": "gold"}
 {"input": "82nd", "expected": "82nd", "category": "numeric", "slice": "idempotence"}
@@ -123,7 +123,7 @@
 {"input": "17th", "expected": "17th", "category": "numeric", "slice": "idempotence"}
 {"input": "seventy ninth", "expected": "79th", "category": "numeric", "slice": "gold"}
 {"input": "79th", "expected": "79th", "category": "numeric", "slice": "idempotence"}
-{"input": "ninth", "expected": "9th", "category": "numeric", "slice": "gold"}
+{"input": "ninth", "expected": "ninth", "category": "numeric", "slice": "gold"}
 {"input": "9th", "expected": "9th", "category": "numeric", "slice": "idempotence"}
 {"input": "six to forty four", "expected": "6-44", "category": "numeric", "slice": "gold"}
 {"input": "6-44", "expected": "6-44", "category": "numeric", "slice": "idempotence"}
@@ -541,27 +541,27 @@
 {"input": "enviouswispr dot dev slash blog", "expected": "enviouswispr.dev/blog", "category": "url", "slice": "gold"}
 {"input": "enviouswispr.dev/blog", "expected": "enviouswispr.dev/blog", "category": "url", "slice": "idempotence"}
 {"input": "road ninety one", "expected": "road 91", "category": "numeric", "slice": "gtn"}
-{"input": "three is", "expected": "3 is", "category": "numeric", "slice": "gtn"}
+{"input": "three is", "expected": "three is", "category": "numeric", "slice": "gtn"}
 {"input": "volume thirty five", "expected": "volume 35", "category": "numeric", "slice": "gtn"}
-{"input": "game two", "expected": "game 2", "category": "numeric", "slice": "gtn"}
-{"input": "three on", "expected": "3 on", "category": "numeric", "slice": "gtn"}
-{"input": "for four consecutive", "expected": "for 4 consecutive", "category": "numeric", "slice": "gtn"}
+{"input": "game two", "expected": "game two", "category": "numeric", "slice": "gtn"}
+{"input": "three on", "expected": "three on", "category": "numeric", "slice": "gtn"}
+{"input": "for four consecutive", "expected": "for four consecutive", "category": "numeric", "slice": "gtn"}
 {"input": "porsche nine hundred thirty five turbo", "expected": "porsche 935 turbo", "category": "numeric", "slice": "gtn"}
 {"input": "one million sixty five thousand five hundred twenty", "expected": "1,065,520", "category": "numeric", "slice": "gtn"}
-{"input": "number nine on", "expected": "number 9 on", "category": "numeric", "slice": "gtn"}
+{"input": "number nine on", "expected": "number nine on", "category": "numeric", "slice": "gtn"}
 {"input": "interstate three ten over", "expected": "interstate three ten over", "category": "numeric", "slice": "gtn"}
-{"input": "homes three were", "expected": "homes 3 were", "category": "numeric", "slice": "gtn"}
+{"input": "homes three were", "expected": "homes three were", "category": "numeric", "slice": "gtn"}
 {"input": "while nineteen were", "expected": "while 19 were", "category": "numeric", "slice": "gtn"}
 {"input": "approximately one hundred five mares", "expected": "approximately 105 mares", "category": "numeric", "slice": "gtn"}
-{"input": "volume six", "expected": "volume 6", "category": "numeric", "slice": "gtn"}
-{"input": "p point one six one", "expected": "p point one six one", "category": "numeric", "slice": "gtn"}
+{"input": "volume six", "expected": "volume six", "category": "numeric", "slice": "gtn"}
+{"input": "p point one six one", "expected": "p 0.161", "category": "numeric", "slice": "gtn"}
 {"input": "volume fifty", "expected": "volume 50", "category": "numeric", "slice": "gtn"}
-{"input": "p point six", "expected": "p point 6", "category": "numeric", "slice": "gtn"}
-{"input": "meir two", "expected": "meir 2", "category": "numeric", "slice": "gtn"}
+{"input": "p point six", "expected": "p point six", "category": "numeric", "slice": "gtn"}
+{"input": "meir two", "expected": "meir two", "category": "numeric", "slice": "gtn"}
 {"input": "by twenty points", "expected": "by 20 points", "category": "numeric", "slice": "gtn"}
 {"input": "environments thirty", "expected": "environments 30", "category": "numeric", "slice": "gtn"}
-{"input": "one", "expected": "1", "category": "numeric", "slice": "gtn"}
-{"input": "line one of", "expected": "line 1 of", "category": "numeric", "slice": "gtn"}
+{"input": "one", "expected": "one", "category": "numeric", "slice": "gtn"}
+{"input": "line one of", "expected": "line one of", "category": "numeric", "slice": "gtn"}
 {"input": "was thirty two years", "expected": "was 32 years", "category": "numeric", "slice": "gtn"}
 {"input": "from sixty eight pages", "expected": "from 68 pages", "category": "numeric", "slice": "gtn"}
 {"input": "eighty seven of", "expected": "87 of", "category": "numeric", "slice": "gtn"}
@@ -569,23 +569,23 @@
 {"input": "one hundred two perry", "expected": "102 perry", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred eleven perry", "expected": "111 perry", "category": "numeric", "slice": "gtn"}
 {"input": "eleven appliances", "expected": "11 appliances", "category": "numeric", "slice": "gtn"}
-{"input": "are six bytes", "expected": "are 6 bytes", "category": "numeric", "slice": "gtn"}
+{"input": "are six bytes", "expected": "are six bytes", "category": "numeric", "slice": "gtn"}
 {"input": "to thirty bytes", "expected": "to 30 bytes", "category": "numeric", "slice": "gtn"}
-{"input": "fourth ed", "expected": "4th ed", "category": "numeric", "slice": "gtn"}
-{"input": "contain one to", "expected": "contain 1 to", "category": "numeric", "slice": "gtn"}
+{"input": "fourth ed", "expected": "fourth ed", "category": "numeric", "slice": "gtn"}
+{"input": "contain one to", "expected": "contain one to", "category": "numeric", "slice": "gtn"}
 {"input": "to ten parts", "expected": "to 10 parts", "category": "numeric", "slice": "gtn"}
 {"input": "contains one point six parts", "expected": "contains 1.6 parts", "category": "numeric", "slice": "gtn"}
-{"input": "to point two six seven", "expected": "to point two six seven", "category": "numeric", "slice": "gtn"}
-{"input": "to point two six six", "expected": "to point two six six", "category": "numeric", "slice": "gtn"}
-{"input": "kosmos three", "expected": "kosmos 3", "category": "numeric", "slice": "gtn"}
-{"input": "panther two", "expected": "panther 2", "category": "numeric", "slice": "gtn"}
+{"input": "to point two six seven", "expected": "to 0.267", "category": "numeric", "slice": "gtn"}
+{"input": "to point two six six", "expected": "to 0.266", "category": "numeric", "slice": "gtn"}
+{"input": "kosmos three", "expected": "kosmos three", "category": "numeric", "slice": "gtn"}
+{"input": "panther two", "expected": "panther two", "category": "numeric", "slice": "gtn"}
 {"input": "of fifty thousand or", "expected": "of 50,000 or", "category": "numeric", "slice": "gtn"}
 {"input": "eleven to", "expected": "11 to", "category": "numeric", "slice": "gtn"}
 {"input": "to twenty five", "expected": "to 25", "category": "numeric", "slice": "gtn"}
 {"input": "sept point one three", "expected": "sept point one three", "category": "numeric", "slice": "gtn"}
-{"input": "two volume", "expected": "2 volume", "category": "numeric", "slice": "gtn"}
+{"input": "two volume", "expected": "two volume", "category": "numeric", "slice": "gtn"}
 {"input": "forty one", "expected": "41", "category": "numeric", "slice": "gtn"}
-{"input": "one minus three", "expected": "1 minus 3", "category": "numeric", "slice": "gtn"}
+{"input": "one minus three", "expected": "one minus three", "category": "numeric", "slice": "gtn"}
 {"input": "acadia thirty one", "expected": "acadia 31", "category": "numeric", "slice": "gtn"}
 {"input": "hits one hundred thousand", "expected": "hits 100,000", "category": "numeric", "slice": "gtn"}
 {"input": "plays thirteen instruments", "expected": "plays 13 instruments", "category": "numeric", "slice": "gtn"}
@@ -599,15 +599,15 @@
 {"input": "while one hundred eighty six or", "expected": "while 186 or", "category": "numeric", "slice": "gtn"}
 {"input": "two o o", "expected": "200", "category": "numeric", "slice": "gtn"}
 {"input": "days two thousand people", "expected": "days 2,000 people", "category": "numeric", "slice": "gtn"}
-{"input": "number two", "expected": "number 2", "category": "numeric", "slice": "gtn"}
-{"input": "four", "expected": "4", "category": "numeric", "slice": "gtn"}
+{"input": "number two", "expected": "number two", "category": "numeric", "slice": "gtn"}
+{"input": "four", "expected": "four", "category": "numeric", "slice": "gtn"}
 {"input": "volume nineteen", "expected": "volume 19", "category": "numeric", "slice": "gtn"}
 {"input": "every one hundred females", "expected": "every 100 females", "category": "numeric", "slice": "gtn"}
 {"input": "were one hundred eight point five males", "expected": "were 108.5 males", "category": "numeric", "slice": "gtn"}
 {"input": "sixty one", "expected": "61", "category": "numeric", "slice": "gtn"}
-{"input": "released six albums", "expected": "released 6 albums", "category": "numeric", "slice": "gtn"}
+{"input": "released six albums", "expected": "released six albums", "category": "numeric", "slice": "gtn"}
 {"input": "seven four seven", "expected": "seven four seven", "category": "numeric", "slice": "gtn"}
-{"input": "one two thousand seventh", "expected": "one two thousand 7th", "category": "numeric", "slice": "gtn"}
+{"input": "one two thousand seventh", "expected": "one two thousand seventh", "category": "numeric", "slice": "gtn"}
 {"input": "ninety three to", "expected": "93 to", "category": "numeric", "slice": "gtn"}
 {"input": "to one hundred two ion", "expected": "to 102 ion", "category": "numeric", "slice": "gtn"}
 {"input": "chisinau one thousand nine hundred seventeen", "expected": "chisinau 1,917", "category": "numeric", "slice": "gtn"}
@@ -618,26 +618,26 @@
 {"input": "twenty one", "expected": "21", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred ten to", "expected": "110 to", "category": "numeric", "slice": "gtn"}
 {"input": "to one hundred nineteen", "expected": "to 119", "category": "numeric", "slice": "gtn"}
-{"input": "five", "expected": "5", "category": "numeric", "slice": "gtn"}
+{"input": "five", "expected": "five", "category": "numeric", "slice": "gtn"}
 {"input": "fifty six", "expected": "56", "category": "numeric", "slice": "gtn"}
-{"input": "three", "expected": "3", "category": "numeric", "slice": "gtn"}
+{"input": "three", "expected": "three", "category": "numeric", "slice": "gtn"}
 {"input": "seventy one to", "expected": "71 to", "category": "numeric", "slice": "gtn"}
 {"input": "to seventy nine", "expected": "to 79", "category": "numeric", "slice": "gtn"}
-{"input": "volume one", "expected": "volume 1", "category": "numeric", "slice": "gtn"}
+{"input": "volume one", "expected": "volume one", "category": "numeric", "slice": "gtn"}
 {"input": "in two thousand twelve", "expected": "in 2012", "category": "numeric", "slice": "gtn"}
 {"input": "thirteen", "expected": "13", "category": "numeric", "slice": "gtn"}
-{"input": "andrey the fifth kulsha", "expected": "andrey the 5th kulsha", "category": "numeric", "slice": "gtn"}
-{"input": "the four", "expected": "the 4", "category": "numeric", "slice": "gtn"}
-{"input": "top five for", "expected": "top 5 for", "category": "numeric", "slice": "gtn"}
+{"input": "andrey the fifth kulsha", "expected": "andrey the fifth kulsha", "category": "numeric", "slice": "gtn"}
+{"input": "the four", "expected": "the four", "category": "numeric", "slice": "gtn"}
+{"input": "top five for", "expected": "top five for", "category": "numeric", "slice": "gtn"}
 {"input": "at one hundred forty four on", "expected": "at 144 on", "category": "numeric", "slice": "gtn"}
 {"input": "p point seven o", "expected": "p point 70", "category": "numeric", "slice": "gtn"}
 {"input": "top two hundred albums", "expected": "top 200 albums", "category": "numeric", "slice": "gtn"}
-{"input": "project two", "expected": "project 2", "category": "numeric", "slice": "gtn"}
-{"input": "war two", "expected": "war 2", "category": "numeric", "slice": "gtn"}
+{"input": "project two", "expected": "project two", "category": "numeric", "slice": "gtn"}
+{"input": "war two", "expected": "war two", "category": "numeric", "slice": "gtn"}
 {"input": "investigate seven hundred seventy seven silence", "expected": "investigate 777 silence", "category": "numeric", "slice": "gtn"}
-{"input": "racing seven", "expected": "racing 7", "category": "numeric", "slice": "gtn"}
-{"input": "ferdinand the first", "expected": "ferdinand the 1st", "category": "numeric", "slice": "gtn"}
-{"input": "one drawers", "expected": "1 drawers", "category": "numeric", "slice": "gtn"}
+{"input": "racing seven", "expected": "racing seven", "category": "numeric", "slice": "gtn"}
+{"input": "ferdinand the first", "expected": "ferdinand the first", "category": "numeric", "slice": "gtn"}
+{"input": "one drawers", "expected": "one drawers", "category": "numeric", "slice": "gtn"}
 {"input": "controls one point seven million eight hundred numbers", "expected": "controls 1.7 million 800 numbers", "category": "numeric", "slice": "gtn"}
 {"input": "late eighteenth century", "expected": "late 18th century", "category": "numeric", "slice": "gtn"}
 {"input": "top ten upcoming", "expected": "top 10 upcoming", "category": "numeric", "slice": "gtn"}
@@ -645,7 +645,7 @@
 {"input": "his fifteen marathons", "expected": "his 15 marathons", "category": "numeric", "slice": "gtn"}
 {"input": "two hundred thirty five thousand seven hundred fifty eight", "expected": "235,758", "category": "numeric", "slice": "gtn"}
 {"input": "twenty four thousand six hundred six", "expected": "24,606", "category": "numeric", "slice": "gtn"}
-{"input": "season five", "expected": "season 5", "category": "numeric", "slice": "gtn"}
+{"input": "season five", "expected": "season five", "category": "numeric", "slice": "gtn"}
 {"input": "was two point four two and", "expected": "was 2.42 and", "category": "numeric", "slice": "gtn"}
 {"input": "was three point o eight", "expected": "was 3.08", "category": "numeric", "slice": "gtn"}
 {"input": "nearly seventy at", "expected": "nearly 70 at", "category": "numeric", "slice": "gtn"}
@@ -659,7 +659,7 @@
 {"input": "where ten computers", "expected": "where 10 computers", "category": "numeric", "slice": "gtn"}
 {"input": "thirty three new", "expected": "33 new", "category": "numeric", "slice": "gtn"}
 {"input": "route one eleven and", "expected": "route one eleven and", "category": "numeric", "slice": "gtn"}
-{"input": "and thirty one man", "expected": "31 man", "category": "numeric", "slice": "gtn"}
+{"input": "and thirty one man", "expected": "and 31 man", "category": "numeric", "slice": "gtn"}
 {"input": "two hundred buses", "expected": "200 buses", "category": "numeric", "slice": "gtn"}
 {"input": "verve's fifty power", "expected": "verve's 50 power", "category": "numeric", "slice": "gtn"}
 {"input": "than fifty student", "expected": "than 50 student", "category": "numeric", "slice": "gtn"}
@@ -677,26 +677,26 @@
 {"input": "lond six hundred forty seven to", "expected": "lond 647 to", "category": "numeric", "slice": "gtn"}
 {"input": "to six hundred fifty five", "expected": "to 655", "category": "numeric", "slice": "gtn"}
 {"input": "early twentieth century", "expected": "early 20th century", "category": "numeric", "slice": "gtn"}
-{"input": "topoisomerase two in", "expected": "topoisomerase 2 in", "category": "numeric", "slice": "gtn"}
-{"input": "biotechnology four to", "expected": "biotechnology 4 to", "category": "numeric", "slice": "gtn"}
+{"input": "topoisomerase two in", "expected": "topoisomerase two in", "category": "numeric", "slice": "gtn"}
+{"input": "biotechnology four to", "expected": "biotechnology four to", "category": "numeric", "slice": "gtn"}
 {"input": "to two hundred seventeen minus two hundred twenty five", "expected": "to 217 minus 225", "category": "numeric", "slice": "gtn"}
 {"input": "fifty seven", "expected": "57", "category": "numeric", "slice": "gtn"}
 {"input": "fifty eight", "expected": "58", "category": "numeric", "slice": "gtn"}
-{"input": "chapter three", "expected": "chapter 3", "category": "numeric", "slice": "gtn"}
-{"input": "to eight to", "expected": "to 8 to", "category": "numeric", "slice": "gtn"}
-{"input": "to zero when", "expected": "to 0 when", "category": "numeric", "slice": "gtn"}
+{"input": "chapter three", "expected": "chapter three", "category": "numeric", "slice": "gtn"}
+{"input": "to eight to", "expected": "to eight to", "category": "numeric", "slice": "gtn"}
+{"input": "to zero when", "expected": "to zero when", "category": "numeric", "slice": "gtn"}
 {"input": "as second grade", "expected": "as second grade", "category": "numeric", "slice": "gtn"}
 {"input": "to nine thousand three hundred ninety two", "expected": "to 9,392", "category": "numeric", "slice": "gtn"}
 {"input": "one six six five ext", "expected": "one six six five ext", "category": "numeric", "slice": "gtn"}
 {"input": "twenty featured", "expected": "20 featured", "category": "numeric", "slice": "gtn"}
 {"input": "a twelve bolt", "expected": "a 12 bolt", "category": "numeric", "slice": "gtn"}
-{"input": "a six lug", "expected": "a 6 lug", "category": "numeric", "slice": "gtn"}
+{"input": "a six lug", "expected": "a six lug", "category": "numeric", "slice": "gtn"}
 {"input": "twelve species", "expected": "12 species", "category": "numeric", "slice": "gtn"}
 {"input": "richard the tenth album", "expected": "richard the 10th album", "category": "numeric", "slice": "gtn"}
 {"input": "richard the tenth presents", "expected": "richard the 10th presents", "category": "numeric", "slice": "gtn"}
 {"input": "is four thousand people", "expected": "is 4,000 people", "category": "numeric", "slice": "gtn"}
 {"input": "two thousand nine hundred sixty eight", "expected": "2,968", "category": "numeric", "slice": "gtn"}
-{"input": "grade nine students", "expected": "grade 9 students", "category": "numeric", "slice": "gtn"}
+{"input": "grade nine students", "expected": "grade nine students", "category": "numeric", "slice": "gtn"}
 {"input": "the o eight", "expected": "the 08", "category": "numeric", "slice": "gtn"}
 {"input": "o nine year", "expected": "09 year", "category": "numeric", "slice": "gtn"}
 {"input": "scored eleven point four points", "expected": "scored 11.4 points", "category": "numeric", "slice": "gtn"}
@@ -708,32 +708,32 @@
 {"input": "of ten thousand forty four passengers", "expected": "of 10,044 passengers", "category": "numeric", "slice": "gtn"}
 {"input": "forty seven", "expected": "47", "category": "numeric", "slice": "gtn"}
 {"input": "returned thirty one days", "expected": "returned 31 days", "category": "numeric", "slice": "gtn"}
-{"input": "number one", "expected": "number 1", "category": "numeric", "slice": "gtn"}
+{"input": "number one", "expected": "number one", "category": "numeric", "slice": "gtn"}
 {"input": "nine seven eight o five two one eight four three one six four p", "expected": "nine seven eight o five two one eight four three one six four p", "category": "numeric", "slice": "gtn"}
-{"input": "p point one seven eight", "expected": "p point one seven eight", "category": "numeric", "slice": "gtn"}
+{"input": "p point one seven eight", "expected": "p 0.178", "category": "numeric", "slice": "gtn"}
 {"input": "april twenty zero p", "expected": "april twenty zero p", "category": "numeric", "slice": "gtn"}
 {"input": "p point four three collectible", "expected": "p point four three collectible", "category": "numeric", "slice": "gtn"}
 {"input": "was ninety five point seven people", "expected": "was 95.7 people", "category": "numeric", "slice": "gtn"}
 {"input": "the twelve thousand six hundred thirty nine twelve thousand six hundred fortieths brindavan", "expected": "the twelve thousand six hundred thirty nine twelve thousand six hundred fortieths brindavan", "category": "numeric", "slice": "gtn"}
 {"input": "holds ten thousand people", "expected": "holds 10,000 people", "category": "numeric", "slice": "gtn"}
-{"input": "cuts two into", "expected": "cuts 2 into", "category": "numeric", "slice": "gtn"}
-{"input": "age eighteen and", "expected": "age 18", "category": "numeric", "slice": "gtn"}
+{"input": "cuts two into", "expected": "cuts two into", "category": "numeric", "slice": "gtn"}
+{"input": "age eighteen and", "expected": "age 18 and", "category": "numeric", "slice": "gtn"}
 {"input": "were eighty point six males", "expected": "were 80.6 males", "category": "numeric", "slice": "gtn"}
 {"input": "of nineteen thousand five hundred six", "expected": "of 19,506", "category": "numeric", "slice": "gtn"}
-{"input": "top six remained", "expected": "top 6 remained", "category": "numeric", "slice": "gtn"}
+{"input": "top six remained", "expected": "top six remained", "category": "numeric", "slice": "gtn"}
 {"input": "indy five hundred", "expected": "indy 500", "category": "numeric", "slice": "gtn"}
 {"input": "the twenty fifth anniversary", "expected": "the 25th anniversary", "category": "numeric", "slice": "gtn"}
 {"input": "eight billion one hundred seventy four million seven hundred eighty one thousand seven hundred fifty seven", "expected": "8,174,781,757", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred fifty four", "expected": "154", "category": "numeric", "slice": "gtn"}
 {"input": "on eighteenth century", "expected": "on 18th century", "category": "numeric", "slice": "gtn"}
-{"input": "mid ninth century", "expected": "mid 9th century", "category": "numeric", "slice": "gtn"}
-{"input": "two species", "expected": "2 species", "category": "numeric", "slice": "gtn"}
-{"input": "two subspecies", "expected": "2 subspecies", "category": "numeric", "slice": "gtn"}
+{"input": "mid ninth century", "expected": "mid ninth century", "category": "numeric", "slice": "gtn"}
+{"input": "two species", "expected": "two species", "category": "numeric", "slice": "gtn"}
+{"input": "two subspecies", "expected": "two subspecies", "category": "numeric", "slice": "gtn"}
 {"input": "the six hundred sixty first", "expected": "the 600 61st", "category": "numeric", "slice": "gtn"}
 {"input": "eighteen radars", "expected": "18 radars", "category": "numeric", "slice": "gtn"}
 {"input": "four hundred fifty features", "expected": "450 features", "category": "numeric", "slice": "gtn"}
 {"input": "fifteen", "expected": "15", "category": "numeric", "slice": "gtn"}
-{"input": "nine", "expected": "9", "category": "numeric", "slice": "gtn"}
+{"input": "nine", "expected": "nine", "category": "numeric", "slice": "gtn"}
 {"input": "one three o", "expected": "130", "category": "numeric", "slice": "gtn"}
 {"input": "an eight point five on", "expected": "an 8.5 on", "category": "numeric", "slice": "gtn"}
 {"input": "an eighty one on", "expected": "an 81 on", "category": "numeric", "slice": "gtn"}
@@ -741,10 +741,10 @@
 {"input": "the three hundred forty fifth bombardment", "expected": "the 300 45th bombardment", "category": "numeric", "slice": "gtn"}
 {"input": "approximates thirteen thousand hectares", "expected": "approximates 13,000 hectares", "category": "numeric", "slice": "gtn"}
 {"input": "thirty two thousand acres", "expected": "32,000 acres", "category": "numeric", "slice": "gtn"}
-{"input": "by two multiple", "expected": "by 2 multiple", "category": "numeric", "slice": "gtn"}
-{"input": "bipolar two", "expected": "bipolar 2", "category": "numeric", "slice": "gtn"}
+{"input": "by two multiple", "expected": "by two multiple", "category": "numeric", "slice": "gtn"}
+{"input": "bipolar two", "expected": "bipolar two", "category": "numeric", "slice": "gtn"}
 {"input": "two two nine o and", "expected": "2290 and", "category": "numeric", "slice": "gtn"}
-{"input": "and two", "expected": "2", "category": "numeric", "slice": "gtn"}
+{"input": "and two", "expected": "and two", "category": "numeric", "slice": "gtn"}
 {"input": "two thousand three hundred ninety five transistors", "expected": "2,395 transistors", "category": "numeric", "slice": "gtn"}
 {"input": "in fifty eight matches", "expected": "in 58 matches", "category": "numeric", "slice": "gtn"}
 {"input": "scoring forty goals", "expected": "scoring 40 goals", "category": "numeric", "slice": "gtn"}
@@ -755,29 +755,29 @@
 {"input": "over two thousand products", "expected": "over 2,000 products", "category": "numeric", "slice": "gtn"}
 {"input": "to forty countries", "expected": "to 40 countries", "category": "numeric", "slice": "gtn"}
 {"input": "exploded thirty one people", "expected": "exploded 31 people", "category": "numeric", "slice": "gtn"}
-{"input": "six", "expected": "6", "category": "numeric", "slice": "gtn"}
-{"input": "volume two", "expected": "volume 2", "category": "numeric", "slice": "gtn"}
+{"input": "six", "expected": "six", "category": "numeric", "slice": "gtn"}
+{"input": "volume two", "expected": "volume two", "category": "numeric", "slice": "gtn"}
 {"input": "than four thousand eight hundred homes", "expected": "than 4,800 homes", "category": "numeric", "slice": "gtn"}
 {"input": "dos six hundred ten", "expected": "dos 610", "category": "numeric", "slice": "gtn"}
 {"input": "w sixty four sixty", "expected": "w sixty four sixty", "category": "numeric", "slice": "gtn"}
-{"input": "seven", "expected": "7", "category": "numeric", "slice": "gtn"}
+{"input": "seven", "expected": "seven", "category": "numeric", "slice": "gtn"}
 {"input": "one o gasoline", "expected": "10 gasoline", "category": "numeric", "slice": "gtn"}
 {"input": "was two point five six and", "expected": "was 2.56 and", "category": "numeric", "slice": "gtn"}
 {"input": "was three point o o", "expected": "was 3.00", "category": "numeric", "slice": "gtn"}
 {"input": "letters eighty nine", "expected": "letters 89", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred six thousand eight hundred one", "expected": "106,801", "category": "numeric", "slice": "gtn"}
-{"input": "bu one and", "expected": "bu 1", "category": "numeric", "slice": "gtn"}
-{"input": "one or", "expected": "1 or", "category": "numeric", "slice": "gtn"}
-{"input": "two accessories", "expected": "2 accessories", "category": "numeric", "slice": "gtn"}
-{"input": "from four to", "expected": "from 4 to", "category": "numeric", "slice": "gtn"}
-{"input": "to three to", "expected": "to 3 to", "category": "numeric", "slice": "gtn"}
+{"input": "bu one and", "expected": "bu one and", "category": "numeric", "slice": "gtn"}
+{"input": "one or", "expected": "one or", "category": "numeric", "slice": "gtn"}
+{"input": "two accessories", "expected": "two accessories", "category": "numeric", "slice": "gtn"}
+{"input": "from four to", "expected": "from four to", "category": "numeric", "slice": "gtn"}
+{"input": "to three to", "expected": "to three to", "category": "numeric", "slice": "gtn"}
 {"input": "to sixteen to", "expected": "to 16 to", "category": "numeric", "slice": "gtn"}
-{"input": "to nine", "expected": "to 9", "category": "numeric", "slice": "gtn"}
+{"input": "to nine", "expected": "to nine", "category": "numeric", "slice": "gtn"}
 {"input": "was two point five five and", "expected": "was 2.55 and", "category": "numeric", "slice": "gtn"}
 {"input": "three thousand six hundred sixty five acres", "expected": "3,665 acres", "category": "numeric", "slice": "gtn"}
 {"input": "divorced ten years", "expected": "divorced 10 years", "category": "numeric", "slice": "gtn"}
-{"input": "two into", "expected": "2 into", "category": "numeric", "slice": "gtn"}
-{"input": "two removal", "expected": "2 removal", "category": "numeric", "slice": "gtn"}
+{"input": "two into", "expected": "two into", "category": "numeric", "slice": "gtn"}
+{"input": "two removal", "expected": "two removal", "category": "numeric", "slice": "gtn"}
 {"input": "were two hundred eighty settlements", "expected": "were 280 settlements", "category": "numeric", "slice": "gtn"}
 {"input": "to two hundred thirty two", "expected": "to 232", "category": "numeric", "slice": "gtn"}
 {"input": "then thirty nine", "expected": "then 39", "category": "numeric", "slice": "gtn"}
@@ -791,7 +791,7 @@
 {"input": "in fifty eight households", "expected": "in 58 households", "category": "numeric", "slice": "gtn"}
 {"input": "slooh two point zero", "expected": "slooh 2.0", "category": "numeric", "slice": "gtn"}
 {"input": "were ninety three point three males", "expected": "were 93.3 males", "category": "numeric", "slice": "gtn"}
-{"input": "caught one pass", "expected": "caught 1 pass", "category": "numeric", "slice": "gtn"}
+{"input": "caught one pass", "expected": "caught one pass", "category": "numeric", "slice": "gtn"}
 {"input": "for eleven yards", "expected": "for 11 yards", "category": "numeric", "slice": "gtn"}
 {"input": "in one thousand nine hundred seven", "expected": "in 1,907", "category": "numeric", "slice": "gtn"}
 {"input": "one thousand nine hundred eight", "expected": "1,908", "category": "numeric", "slice": "gtn"}
@@ -802,17 +802,17 @@
 {"input": "nineteen thousand seven hundred forty eight", "expected": "19,748", "category": "numeric", "slice": "gtn"}
 {"input": "three hundred twenty two seventy eight", "expected": "three hundred twenty two seventy eight", "category": "numeric", "slice": "gtn"}
 {"input": "some two hundred labor", "expected": "some 200 labor", "category": "numeric", "slice": "gtn"}
-{"input": "and twenty five training", "expected": "25 training", "category": "numeric", "slice": "gtn"}
+{"input": "and twenty five training", "expected": "and 25 training", "category": "numeric", "slice": "gtn"}
 {"input": "of thirty on", "expected": "of 30 on", "category": "numeric", "slice": "gtn"}
-{"input": "chapter five", "expected": "chapter 5", "category": "numeric", "slice": "gtn"}
-{"input": "two", "expected": "2", "category": "numeric", "slice": "gtn"}
+{"input": "chapter five", "expected": "chapter five", "category": "numeric", "slice": "gtn"}
+{"input": "two", "expected": "two", "category": "numeric", "slice": "gtn"}
 {"input": "one thousand nine hundred twenty three", "expected": "1,923", "category": "numeric", "slice": "gtn"}
-{"input": "one thousand nine hundred twenty four and", "expected": "1,924", "category": "numeric", "slice": "gtn"}
+{"input": "one thousand nine hundred twenty four and", "expected": "1,924 and", "category": "numeric", "slice": "gtn"}
 {"input": "ranked eighty seventh worldwide", "expected": "ranked 87th worldwide", "category": "numeric", "slice": "gtn"}
 {"input": "the eighty six", "expected": "the 86", "category": "numeric", "slice": "gtn"}
 {"input": "station twenty two", "expected": "station 22", "category": "numeric", "slice": "gtn"}
-{"input": "zero proves", "expected": "0 proves", "category": "numeric", "slice": "gtn"}
-{"input": "only seven days", "expected": "only 7 days", "category": "numeric", "slice": "gtn"}
+{"input": "zero proves", "expected": "zero proves", "category": "numeric", "slice": "gtn"}
+{"input": "only seven days", "expected": "only seven days", "category": "numeric", "slice": "gtn"}
 {"input": "the one thousand nine hundred ninety two", "expected": "the 1,992", "category": "numeric", "slice": "gtn"}
 {"input": "ninety three all", "expected": "93 all", "category": "numeric", "slice": "gtn"}
 {"input": "the one thousand nine hundred ninety four", "expected": "the 1,994", "category": "numeric", "slice": "gtn"}
@@ -820,19 +820,19 @@
 {"input": "tenth ed", "expected": "10th ed", "category": "numeric", "slice": "gtn"}
 {"input": "were four hundred sixty nine people", "expected": "were 469 people", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred eighty nine households", "expected": "189 households", "category": "numeric", "slice": "gtn"}
-{"input": "and one hundred nineteen families", "expected": "119 families", "category": "numeric", "slice": "gtn"}
+{"input": "and one hundred nineteen families", "expected": "and 119 families", "category": "numeric", "slice": "gtn"}
 {"input": "was five hundred twenty six", "expected": "was 526", "category": "numeric", "slice": "gtn"}
 {"input": "in eighty five families", "expected": "in 85 families", "category": "numeric", "slice": "gtn"}
 {"input": "of seven hundred fifteen located", "expected": "of 715 located", "category": "numeric", "slice": "gtn"}
-{"input": "a six", "expected": "a 6", "category": "numeric", "slice": "gtn"}
+{"input": "a six", "expected": "a six", "category": "numeric", "slice": "gtn"}
 {"input": "about one mile", "expected": "about 1 mile", "category": "numeric", "slice": "gtn"}
 {"input": "strain one hundred twenty four", "expected": "strain 124", "category": "numeric", "slice": "gtn"}
-{"input": "years one to", "expected": "years 1 to", "category": "numeric", "slice": "gtn"}
-{"input": "to eight", "expected": "to 8", "category": "numeric", "slice": "gtn"}
+{"input": "years one to", "expected": "years one to", "category": "numeric", "slice": "gtn"}
+{"input": "to eight", "expected": "to eight", "category": "numeric", "slice": "gtn"}
 {"input": "age seventy three", "expected": "age 73", "category": "numeric", "slice": "gtn"}
 {"input": "was twenty nine point seven per", "expected": "was 29.7 per", "category": "numeric", "slice": "gtn"}
 {"input": "about thirty thousand", "expected": "about 30,000", "category": "numeric", "slice": "gtn"}
-{"input": "the three", "expected": "the 3", "category": "numeric", "slice": "gtn"}
+{"input": "the three", "expected": "the three", "category": "numeric", "slice": "gtn"}
 {"input": "five thousand three", "expected": "5,003", "category": "numeric", "slice": "gtn"}
 {"input": "five thousand ninety six", "expected": "5,096", "category": "numeric", "slice": "gtn"}
 {"input": "five thousand six hundred sixty three", "expected": "5,663", "category": "numeric", "slice": "gtn"}
@@ -840,21 +840,21 @@
 {"input": "in one hundred ninety seven theaters", "expected": "in 197 theaters", "category": "numeric", "slice": "gtn"}
 {"input": "two thousand nine to", "expected": "2009 to", "category": "numeric", "slice": "gtn"}
 {"input": "to twenty three road", "expected": "to 23 road", "category": "numeric", "slice": "gtn"}
-{"input": "age fifteen and", "expected": "age 15", "category": "numeric", "slice": "gtn"}
+{"input": "age fifteen and", "expected": "age 15 and", "category": "numeric", "slice": "gtn"}
 {"input": "ninety six", "expected": "96", "category": "numeric", "slice": "gtn"}
 {"input": "thirteen of", "expected": "13 of", "category": "numeric", "slice": "gtn"}
 {"input": "fifty four members", "expected": "54 members", "category": "numeric", "slice": "gtn"}
 {"input": "the nineteenth century", "expected": "the 19th century", "category": "numeric", "slice": "gtn"}
-{"input": "division one baseball", "expected": "division 1 baseball", "category": "numeric", "slice": "gtn"}
-{"input": "mom two", "expected": "mom 2", "category": "numeric", "slice": "gtn"}
+{"input": "division one baseball", "expected": "division one baseball", "category": "numeric", "slice": "gtn"}
+{"input": "mom two", "expected": "mom two", "category": "numeric", "slice": "gtn"}
 {"input": "of seventeen he", "expected": "of 17 he", "category": "numeric", "slice": "gtn"}
-{"input": "michael the first norton", "expected": "michael the 1st norton", "category": "numeric", "slice": "gtn"}
+{"input": "michael the first norton", "expected": "michael the first norton", "category": "numeric", "slice": "gtn"}
 {"input": "the thirty five point eight square", "expected": "the 35.8 square", "category": "numeric", "slice": "gtn"}
 {"input": "of seventy seven thousand two hundred forty nine", "expected": "of 77,249", "category": "numeric", "slice": "gtn"}
 {"input": "top one hundred fifty friday", "expected": "top 150 friday", "category": "numeric", "slice": "gtn"}
 {"input": "policy thirty six", "expected": "policy 36", "category": "numeric", "slice": "gtn"}
 {"input": "two thousand one hundred nine", "expected": "2,109", "category": "numeric", "slice": "gtn"}
-{"input": "zero to", "expected": "0 to", "category": "numeric", "slice": "gtn"}
+{"input": "zero to", "expected": "zero to", "category": "numeric", "slice": "gtn"}
 {"input": "to four hundred seventy one", "expected": "to 471", "category": "numeric", "slice": "gtn"}
 {"input": "seven seven one five two", "expected": "seven seven one five two", "category": "numeric", "slice": "gtn"}
 {"input": "four hundred sixty six fay", "expected": "466 fay", "category": "numeric", "slice": "gtn"}
@@ -864,77 +864,77 @@
 {"input": "seven point nine in", "expected": "7.9 in", "category": "numeric", "slice": "gtn"}
 {"input": "four hundred ninety three nine eighteen", "expected": "four hundred ninety three nine eighteen", "category": "numeric", "slice": "gtn"}
 {"input": "o o o nine", "expected": "0009", "category": "numeric", "slice": "gtn"}
-{"input": "egypt two", "expected": "egypt 2", "category": "numeric", "slice": "gtn"}
+{"input": "egypt two", "expected": "egypt two", "category": "numeric", "slice": "gtn"}
 {"input": "physics fourteen", "expected": "physics 14", "category": "numeric", "slice": "gtn"}
 {"input": "sixty nine", "expected": "69", "category": "numeric", "slice": "gtn"}
 {"input": "seventy two", "expected": "72", "category": "numeric", "slice": "gtn"}
 {"input": "documenta twelve magazines", "expected": "documenta 12 magazines", "category": "numeric", "slice": "gtn"}
 {"input": "fifty eight undergraduate", "expected": "58 undergraduate", "category": "numeric", "slice": "gtn"}
 {"input": "der five hundred thirty nine", "expected": "der 539", "category": "numeric", "slice": "gtn"}
-{"input": "i seven", "expected": "i 7", "category": "numeric", "slice": "gtn"}
-{"input": "s point one to", "expected": "s point 1 to", "category": "numeric", "slice": "gtn"}
+{"input": "i seven", "expected": "i seven", "category": "numeric", "slice": "gtn"}
+{"input": "s point one to", "expected": "s point one to", "category": "numeric", "slice": "gtn"}
 {"input": "to two hundred eighty seven", "expected": "to 287", "category": "numeric", "slice": "gtn"}
-{"input": "point one to", "expected": "point 1 to", "category": "numeric", "slice": "gtn"}
+{"input": "point one to", "expected": "point one to", "category": "numeric", "slice": "gtn"}
 {"input": "to fifteen", "expected": "to 15", "category": "numeric", "slice": "gtn"}
 {"input": "s point two five", "expected": "s point two five", "category": "numeric", "slice": "gtn"}
 {"input": "offs eleven twelfths leading", "expected": "offs 11 twelfths leading", "category": "numeric", "slice": "gtn"}
 {"input": "of fifty", "expected": "of 50", "category": "numeric", "slice": "gtn"}
-{"input": "for five days", "expected": "for 5 days", "category": "numeric", "slice": "gtn"}
+{"input": "for five days", "expected": "for five days", "category": "numeric", "slice": "gtn"}
 {"input": "eighty nine minus five thousand five hundred eighteen", "expected": "89 minus 5,518", "category": "numeric", "slice": "gtn"}
 {"input": "second viscount", "expected": "second viscount", "category": "numeric", "slice": "gtn"}
-{"input": "five sevenths roh", "expected": "5 sevenths roh", "category": "numeric", "slice": "gtn"}
+{"input": "five sevenths roh", "expected": "five sevenths roh", "category": "numeric", "slice": "gtn"}
 {"input": "three hundred four", "expected": "304", "category": "numeric", "slice": "gtn"}
 {"input": "around one thousand", "expected": "around 1,000", "category": "numeric", "slice": "gtn"}
 {"input": "eight eight seven", "expected": "eight eight seven", "category": "numeric", "slice": "gtn"}
 {"input": "ninety thousand two hundred ten", "expected": "90,210", "category": "numeric", "slice": "gtn"}
-{"input": "is eight laps", "expected": "is 8 laps", "category": "numeric", "slice": "gtn"}
+{"input": "is eight laps", "expected": "is eight laps", "category": "numeric", "slice": "gtn"}
 {"input": "the eighteenth century", "expected": "the 18th century", "category": "numeric", "slice": "gtn"}
 {"input": "two hundred ninety to", "expected": "290 to", "category": "numeric", "slice": "gtn"}
 {"input": "to two hundred ninety one article", "expected": "to 291 article", "category": "numeric", "slice": "gtn"}
 {"input": "article one hundred seventy one", "expected": "article 171", "category": "numeric", "slice": "gtn"}
-{"input": "leader one can", "expected": "leader 1 can", "category": "numeric", "slice": "gtn"}
+{"input": "leader one can", "expected": "leader one can", "category": "numeric", "slice": "gtn"}
 {"input": "people forty years", "expected": "people 40 years", "category": "numeric", "slice": "gtn"}
 {"input": "twenty five was", "expected": "25 was", "category": "numeric", "slice": "gtn"}
 {"input": "the four point three l", "expected": "the 4.3 l", "category": "numeric", "slice": "gtn"}
 {"input": "l ninety", "expected": "l 90", "category": "numeric", "slice": "gtn"}
 {"input": "one hundred forty three", "expected": "143", "category": "numeric", "slice": "gtn"}
-{"input": "one avian", "expected": "1 avian", "category": "numeric", "slice": "gtn"}
-{"input": "one influenza", "expected": "1 influenza", "category": "numeric", "slice": "gtn"}
+{"input": "one avian", "expected": "one avian", "category": "numeric", "slice": "gtn"}
+{"input": "one influenza", "expected": "one influenza", "category": "numeric", "slice": "gtn"}
 {"input": "are zero point four to", "expected": "are 0.4 to", "category": "numeric", "slice": "gtn"}
 {"input": "the four hundred twenty five point six", "expected": "the 425.6", "category": "numeric", "slice": "gtn"}
 {"input": "seven point zero l", "expected": "7.0 l", "category": "numeric", "slice": "gtn"}
 {"input": "four point two five", "expected": "4.25", "category": "numeric", "slice": "gtn"}
 {"input": "five point o", "expected": "5.0", "category": "numeric", "slice": "gtn"}
-{"input": "by four cab", "expected": "by 4 cab", "category": "numeric", "slice": "gtn"}
+{"input": "by four cab", "expected": "by four cab", "category": "numeric", "slice": "gtn"}
 {"input": "fifty live", "expected": "50 live", "category": "numeric", "slice": "gtn"}
-{"input": "est one", "expected": "est 1", "category": "numeric", "slice": "gtn"}
+{"input": "est one", "expected": "est one", "category": "numeric", "slice": "gtn"}
 {"input": "two thousand six", "expected": "2006", "category": "date", "slice": "gtn"}
 {"input": "romance's two thousand seven shows", "expected": "romance's 2007 shows", "category": "date", "slice": "gtn"}
 {"input": "two thousand eight tour", "expected": "2008 tour", "category": "date", "slice": "gtn"}
-{"input": "retrieved the fourth of march twenty fourteen", "expected": "retrieved the 4th of march 2014", "category": "date", "slice": "gtn"}
+{"input": "retrieved the fourth of march twenty fourteen", "expected": "retrieved the fourth of march 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved april tenth twenty thirteen", "expected": "retrieved April 10, 2013", "category": "date", "slice": "gtn"}
-{"input": "on the seventh of august two thousand seven", "expected": "on the 7th of august 2007", "category": "date", "slice": "gtn"}
+{"input": "on the seventh of august two thousand seven", "expected": "on the seventh of august 2007", "category": "date", "slice": "gtn"}
 {"input": "nineteen eighty seven", "expected": "1987", "category": "date", "slice": "gtn"}
 {"input": "nineteen ninety six", "expected": "1996", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty second of september twenty fifteen", "expected": "retrieved the 22nd of september 2015", "category": "date", "slice": "gtn"}
 {"input": "on november fourth twenty fourteen", "expected": "on November 4, 2014", "category": "date", "slice": "gtn"}
 {"input": "in nineteen sixteen and", "expected": "in 1916 and", "category": "date", "slice": "gtn"}
 {"input": "the nineteen eighty two championship", "expected": "the 1982 championship", "category": "date", "slice": "gtn"}
-{"input": "retrieved the seventh of december twenty fifteen", "expected": "retrieved the 7th of december 2015", "category": "date", "slice": "gtn"}
+{"input": "retrieved the seventh of december twenty fifteen", "expected": "retrieved the seventh of december 2015", "category": "date", "slice": "gtn"}
 {"input": "november seventeenth o nine", "expected": "november 17th 09", "category": "date", "slice": "gtn"}
 {"input": "august sixteenth two thousand five", "expected": "August 16, 2005", "category": "date", "slice": "gtn"}
 {"input": "years fifteen seventy three to", "expected": "years 1573 to", "category": "date", "slice": "gtn"}
 {"input": "to fifteen ninety five they", "expected": "to 1595 they", "category": "date", "slice": "gtn"}
 {"input": "in nineteen twenty nine", "expected": "in 1929", "category": "date", "slice": "gtn"}
 {"input": "in nineteen thirty three at", "expected": "in 1933 at", "category": "date", "slice": "gtn"}
-{"input": "retrieved the third of february twenty sixteen", "expected": "retrieved the 3rd of february 2016", "category": "date", "slice": "gtn"}
+{"input": "retrieved the third of february twenty sixteen", "expected": "retrieved the third of february 2016", "category": "date", "slice": "gtn"}
 {"input": "born september fifth eighteen ninety five", "expected": "born September 5, 1895", "category": "date", "slice": "gtn"}
 {"input": "on december twenty ninth twenty twelve", "expected": "on December 29, 2012", "category": "date", "slice": "gtn"}
 {"input": "cars nineteen forty six to", "expected": "cars 1946 to", "category": "date", "slice": "gtn"}
 {"input": "to nineteen seventy five", "expected": "to 1975", "category": "date", "slice": "gtn"}
 {"input": "before nineteen nineteen", "expected": "before 1919", "category": "date", "slice": "gtn"}
 {"input": "between nineteen ninety and", "expected": "between 1990 and", "category": "date", "slice": "gtn"}
-{"input": "and two thousand", "expected": "2,000", "category": "date", "slice": "gtn"}
+{"input": "and two thousand", "expected": "and 2,000", "category": "date", "slice": "gtn"}
 {"input": "in two thousand four", "expected": "in 2004", "category": "date", "slice": "gtn"}
 {"input": "in two thousand eight", "expected": "in 2008", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty fifth of july twenty twelve", "expected": "retrieved the 25th of july 2012", "category": "date", "slice": "gtn"}
@@ -958,7 +958,7 @@
 {"input": "august nineteen ninety nine", "expected": "august 1999", "category": "date", "slice": "gtn"}
 {"input": "retrieved july eighteenth twenty fifteen", "expected": "retrieved July 18, 2015", "category": "date", "slice": "gtn"}
 {"input": "january thirtieth nineteen eighty seven", "expected": "January 30, 1987", "category": "date", "slice": "gtn"}
-{"input": "retrieved the fourth of february twenty fourteen", "expected": "retrieved the 4th of february 2014", "category": "date", "slice": "gtn"}
+{"input": "retrieved the fourth of february twenty fourteen", "expected": "retrieved the fourth of february 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved the eighteenth of february two thousand eight", "expected": "retrieved the 18th of february 2008", "category": "date", "slice": "gtn"}
 {"input": "twenty ten", "expected": "2010", "category": "date", "slice": "gtn"}
 {"input": "the sixteenth of december two thousand six", "expected": "the 16th of december 2006", "category": "date", "slice": "gtn"}
@@ -993,7 +993,7 @@
 {"input": "retrieved the twenty first of september twenty fourteen", "expected": "retrieved the 21st of september 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved the nineteenth of september twenty fifteen", "expected": "retrieved the 19th of september 2015", "category": "date", "slice": "gtn"}
 {"input": "two thousand eight", "expected": "2008", "category": "date", "slice": "gtn"}
-{"input": "the second of september two thousand nine", "expected": "the 2nd of september 2009", "category": "date", "slice": "gtn"}
+{"input": "the second of september two thousand nine", "expected": "the second of september 2009", "category": "date", "slice": "gtn"}
 {"input": "handball twenty fifteen with", "expected": "handball 2015 with", "category": "date", "slice": "gtn"}
 {"input": "archived december seventeenth two thousand six", "expected": "archived December 17, 2006", "category": "date", "slice": "gtn"}
 {"input": "the twelfth of october two thousand eight", "expected": "the 12th of october 2008", "category": "date", "slice": "gtn"}
@@ -1006,8 +1006,8 @@
 {"input": "october twenty sixth two thousand eight", "expected": "October 26, 2008", "category": "date", "slice": "gtn"}
 {"input": "in fourteen ninety eight and", "expected": "in fourteen ninety eight and", "category": "date", "slice": "gtn"}
 {"input": "from fifteen o five", "expected": "from 1505", "category": "date", "slice": "gtn"}
-{"input": "retrieved the fourth of february twenty twelve", "expected": "retrieved the 4th of february 2012", "category": "date", "slice": "gtn"}
-{"input": "retrieved the third of february twenty twelve", "expected": "retrieved the 3rd of february 2012", "category": "date", "slice": "gtn"}
+{"input": "retrieved the fourth of february twenty twelve", "expected": "retrieved the fourth of february 2012", "category": "date", "slice": "gtn"}
+{"input": "retrieved the third of february twenty twelve", "expected": "retrieved the third of february 2012", "category": "date", "slice": "gtn"}
 {"input": "two thousand eight information", "expected": "2008 information", "category": "date", "slice": "gtn"}
 {"input": "the twenty first of september twenty fourteen", "expected": "the 21st of september 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved the thirtieth of january twenty twelve", "expected": "retrieved the 30th of january 2012", "category": "date", "slice": "gtn"}
@@ -1020,13 +1020,13 @@
 {"input": "eighteen sixty two", "expected": "1862", "category": "date", "slice": "gtn"}
 {"input": "the twelfth of july twenty fourteen", "expected": "the 12th of july 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty second of february twenty twelve", "expected": "retrieved the 22nd of february 2012", "category": "date", "slice": "gtn"}
-{"input": "retrieved the eighth of october twenty fifteen", "expected": "retrieved the 8th of october 2015", "category": "date", "slice": "gtn"}
+{"input": "retrieved the eighth of october twenty fifteen", "expected": "retrieved the eighth of october 2015", "category": "date", "slice": "gtn"}
 {"input": "nineteen fifty three", "expected": "1953", "category": "date", "slice": "gtn"}
 {"input": "the twenty ten census", "expected": "the 2010 census", "category": "date", "slice": "gtn"}
-{"input": "retrieved the third of january twenty thirteen", "expected": "retrieved the 3rd of january 2013", "category": "date", "slice": "gtn"}
+{"input": "retrieved the third of january twenty thirteen", "expected": "retrieved the third of january 2013", "category": "date", "slice": "gtn"}
 {"input": "the nineteenth of november two thousand eight", "expected": "the 19th of november 2008", "category": "date", "slice": "gtn"}
 {"input": "nineteen thirty two", "expected": "1932", "category": "date", "slice": "gtn"}
-{"input": "the third of july two thousand seven", "expected": "the 3rd of july 2007", "category": "date", "slice": "gtn"}
+{"input": "the third of july two thousand seven", "expected": "the third of july 2007", "category": "date", "slice": "gtn"}
 {"input": "retrieved may fourth twenty fifteen", "expected": "retrieved May 4, 2015", "category": "date", "slice": "gtn"}
 {"input": "nineteen sixty eight", "expected": "1968", "category": "date", "slice": "gtn"}
 {"input": "in eighteen sixty five", "expected": "in 1865", "category": "date", "slice": "gtn"}
@@ -1064,10 +1064,10 @@
 {"input": "retrieved june twenty third twenty twelve", "expected": "retrieved June 23, 2012", "category": "date", "slice": "gtn"}
 {"input": "in two thousand one", "expected": "in 2001", "category": "date", "slice": "gtn"}
 {"input": "the seventeenth of june two thousand nine", "expected": "the 17th of june 2009", "category": "date", "slice": "gtn"}
-{"input": "archived the fourth of november twenty fourteen at", "expected": "archived the 4th of november 2014 at", "category": "date", "slice": "gtn"}
+{"input": "archived the fourth of november twenty fourteen at", "expected": "archived the fourth of november 2014 at", "category": "date", "slice": "gtn"}
 {"input": "in twenty ten", "expected": "in 2010", "category": "date", "slice": "gtn"}
 {"input": "in twenty twelve for", "expected": "in 2012 for", "category": "date", "slice": "gtn"}
-{"input": "retrieved the fourth of october twenty fifteen", "expected": "retrieved the 4th of october 2015", "category": "date", "slice": "gtn"}
+{"input": "retrieved the fourth of october twenty fifteen", "expected": "retrieved the fourth of october 2015", "category": "date", "slice": "gtn"}
 {"input": "in july two thousand two and", "expected": "in july 2002 and", "category": "date", "slice": "gtn"}
 {"input": "on thursday the seventeenth of february twenty eleven", "expected": "on thursday the 17th of february 2011", "category": "date", "slice": "gtn"}
 {"input": "retrieved the thirtieth of july twenty eleven", "expected": "retrieved the 30th of july 2011", "category": "date", "slice": "gtn"}
@@ -1083,14 +1083,14 @@
 {"input": "the twenty second of september twenty fifteen", "expected": "the 22nd of september 2015", "category": "date", "slice": "gtn"}
 {"input": "nineteen eighty five", "expected": "1985", "category": "date", "slice": "gtn"}
 {"input": "of october two thousand six", "expected": "of october 2006", "category": "date", "slice": "gtn"}
-{"input": "the first of january two thousand four", "expected": "the 1st of january 2004", "category": "date", "slice": "gtn"}
+{"input": "the first of january two thousand four", "expected": "the first of january 2004", "category": "date", "slice": "gtn"}
 {"input": "miami two thousand nine football", "expected": "miami 2009 football", "category": "date", "slice": "gtn"}
 {"input": "in eighteen fifty eight", "expected": "in 1858", "category": "date", "slice": "gtn"}
 {"input": "between two thousand one and", "expected": "between 2001 and", "category": "date", "slice": "gtn"}
 {"input": "and two thousand nine", "expected": "and 2009", "category": "date", "slice": "gtn"}
 {"input": "nineteen seventy eight", "expected": "1978", "category": "date", "slice": "gtn"}
 {"input": "march twenty thirteen", "expected": "march 2013", "category": "date", "slice": "gtn"}
-{"input": "retrieved the third of june twenty fourteen", "expected": "retrieved the 3rd of june 2014", "category": "date", "slice": "gtn"}
+{"input": "retrieved the third of june twenty fourteen", "expected": "retrieved the third of june 2014", "category": "date", "slice": "gtn"}
 {"input": "the seventeenth of november two thousand three", "expected": "the 17th of november 2003", "category": "date", "slice": "gtn"}
 {"input": "retrieved the sixteenth of march twenty sixteen", "expected": "retrieved the 16th of march 2016", "category": "date", "slice": "gtn"}
 {"input": "in nineteen seventy one", "expected": "in 1971", "category": "date", "slice": "gtn"}
@@ -1099,18 +1099,18 @@
 {"input": "on december ninth twenty fourteen the", "expected": "on December 9, 2014 the", "category": "date", "slice": "gtn"}
 {"input": "retrieved july thirtieth twenty fourteen", "expected": "retrieved July 30, 2014", "category": "date", "slice": "gtn"}
 {"input": "her twenty fifteen calendar", "expected": "her 2015 calendar", "category": "date", "slice": "gtn"}
-{"input": "retrieved the ninth of may twenty eleven", "expected": "retrieved the 9th of may 2011", "category": "date", "slice": "gtn"}
+{"input": "retrieved the ninth of may twenty eleven", "expected": "retrieved the ninth of may 2011", "category": "date", "slice": "gtn"}
 {"input": "cup eighteen fifty one to", "expected": "cup 1851 to", "category": "date", "slice": "gtn"}
 {"input": "to nineteen eighty seven", "expected": "to 1987", "category": "date", "slice": "gtn"}
 {"input": "until nineteen ninety four", "expected": "until 1994", "category": "date", "slice": "gtn"}
 {"input": "retrieved february twelfth twenty thirteen", "expected": "retrieved February 12, 2013", "category": "date", "slice": "gtn"}
-{"input": "on the first of june nineteen forty two", "expected": "on the 1st of june 1942", "category": "date", "slice": "gtn"}
+{"input": "on the first of june nineteen forty two", "expected": "on the first of june 1942", "category": "date", "slice": "gtn"}
 {"input": "may nineteenth twenty ten", "expected": "May 19, 2010", "category": "date", "slice": "gtn"}
 {"input": "retrieved february sixth two thousand eight", "expected": "retrieved February 6, 2008", "category": "date", "slice": "gtn"}
 {"input": "retrieved september twentieth twenty eleven", "expected": "retrieved September 20, 2011", "category": "date", "slice": "gtn"}
 {"input": "retrieved the thirtieth of october twenty ten", "expected": "retrieved the 30th of october 2010", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty seventh of may twenty eleven", "expected": "retrieved the 27th of may 2011", "category": "date", "slice": "gtn"}
-{"input": "the ninth of august nineteen ninety three", "expected": "the 9th of august 1993", "category": "date", "slice": "gtn"}
+{"input": "the ninth of august nineteen ninety three", "expected": "the ninth of august 1993", "category": "date", "slice": "gtn"}
 {"input": "in two thousand one chairman", "expected": "in 2001 chairman", "category": "date", "slice": "gtn"}
 {"input": "september tenth two thousand five", "expected": "September 10, 2005", "category": "date", "slice": "gtn"}
 {"input": "sessions nineteen sixty to", "expected": "sessions 1960 to", "category": "date", "slice": "gtn"}
@@ -1122,9 +1122,9 @@
 {"input": "the twenty ninth of may twenty eleven", "expected": "the 29th of may 2011", "category": "date", "slice": "gtn"}
 {"input": "on the twenty ninth of december nineteen twenty three", "expected": "on the 29th of december 1923", "category": "date", "slice": "gtn"}
 {"input": "the twenty seventh of june two thousand six", "expected": "the 27th of june 2006", "category": "date", "slice": "gtn"}
-{"input": "retrieved the first of april twenty ten pineau", "expected": "retrieved the 1st of april 2010 pineau", "category": "date", "slice": "gtn"}
+{"input": "retrieved the first of april twenty ten pineau", "expected": "retrieved the first of april 2010 pineau", "category": "date", "slice": "gtn"}
 {"input": "the twentieth of october twenty ten", "expected": "the 20th of october 2010", "category": "date", "slice": "gtn"}
-{"input": "retrieved the eighth of april twenty fifteen", "expected": "retrieved the 8th of april 2015", "category": "date", "slice": "gtn"}
+{"input": "retrieved the eighth of april twenty fifteen", "expected": "retrieved the eighth of april 2015", "category": "date", "slice": "gtn"}
 {"input": "in eighteen forty", "expected": "in 1840", "category": "date", "slice": "gtn"}
 {"input": "retrieved december ninth twenty fifteen", "expected": "retrieved December 9, 2015", "category": "date", "slice": "gtn"}
 {"input": "october nineteen sixty three", "expected": "october 1963", "category": "date", "slice": "gtn"}
@@ -1148,7 +1148,7 @@
 {"input": "twenty fourteen", "expected": "2014", "category": "date", "slice": "gtn"}
 {"input": "may twenty third", "expected": "may 23rd", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty sixth of october twenty thirteen", "expected": "retrieved the 26th of october 2013", "category": "date", "slice": "gtn"}
-{"input": "retrieved the eighth of november twenty fourteen", "expected": "retrieved the 8th of november 2014", "category": "date", "slice": "gtn"}
+{"input": "retrieved the eighth of november twenty fourteen", "expected": "retrieved the eighth of november 2014", "category": "date", "slice": "gtn"}
 {"input": "on the twenty first of august", "expected": "on the 21st of august", "category": "date", "slice": "gtn"}
 {"input": "in seventeen ninety three", "expected": "in 1793", "category": "date", "slice": "gtn"}
 {"input": "on may twenty eighth twenty fourteen", "expected": "on May 28, 2014", "category": "date", "slice": "gtn"}
@@ -1156,7 +1156,7 @@
 {"input": "on the twenty fifth of june nineteen nineteen", "expected": "on the 25th of june 1919", "category": "date", "slice": "gtn"}
 {"input": "october thirtieth twenty fifteen", "expected": "October 30, 2015", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty second of january twenty fourteen", "expected": "retrieved the 22nd of january 2014", "category": "date", "slice": "gtn"}
-{"input": "on the fourth of august nineteen nineteen", "expected": "on the 4th of august 1919", "category": "date", "slice": "gtn"}
+{"input": "on the fourth of august nineteen nineteen", "expected": "on the fourth of august 1919", "category": "date", "slice": "gtn"}
 {"input": "in twenty twelve stylus", "expected": "in 2012 stylus", "category": "date", "slice": "gtn"}
 {"input": "since two thousand two", "expected": "since 2002", "category": "date", "slice": "gtn"}
 {"input": "in nineteen fifty seven to", "expected": "in 1957 to", "category": "date", "slice": "gtn"}
@@ -1172,7 +1172,7 @@
 {"input": "in july eighteen thirty three", "expected": "in july 1833", "category": "date", "slice": "gtn"}
 {"input": "nineteen seventy one chevrolet", "expected": "1971 chevrolet", "category": "date", "slice": "gtn"}
 {"input": "a nineteen twenty four american", "expected": "a 1924 american", "category": "date", "slice": "gtn"}
-{"input": "retrieved the second of january twenty fifteen", "expected": "retrieved the 2nd of january 2015", "category": "date", "slice": "gtn"}
+{"input": "retrieved the second of january twenty fifteen", "expected": "retrieved the second of january 2015", "category": "date", "slice": "gtn"}
 {"input": "nineteen ninety", "expected": "1990", "category": "date", "slice": "gtn"}
 {"input": "retrieved march ninth two thousand nine", "expected": "retrieved March 9, 2009", "category": "date", "slice": "gtn"}
 {"input": "retrieved september twenty eighth twenty fourteen", "expected": "retrieved September 28, 2014", "category": "date", "slice": "gtn"}
@@ -1193,29 +1193,29 @@
 {"input": "retrieved the tenth of january twenty twelve", "expected": "retrieved the 10th of january 2012", "category": "date", "slice": "gtn"}
 {"input": "february nineteen ninety eight", "expected": "february 1998", "category": "date", "slice": "gtn"}
 {"input": "june twenty seventh two thousand two", "expected": "June 27, 2002", "category": "date", "slice": "gtn"}
-{"input": "retrieved the seventh of december twenty fourteen", "expected": "retrieved the 7th of december 2014", "category": "date", "slice": "gtn"}
+{"input": "retrieved the seventh of december twenty fourteen", "expected": "retrieved the seventh of december 2014", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty second of june twenty twelve", "expected": "retrieved the 22nd of june 2012", "category": "date", "slice": "gtn"}
 {"input": "seventeen ninety seven", "expected": "1797", "category": "date", "slice": "gtn"}
 {"input": "the fourteenth of february twenty thirteen", "expected": "the 14th of february 2013", "category": "date", "slice": "gtn"}
-{"input": "on the sixth of may two thousand nine", "expected": "on the 6th of may 2009", "category": "date", "slice": "gtn"}
+{"input": "on the sixth of may two thousand nine", "expected": "on the sixth of may 2009", "category": "date", "slice": "gtn"}
 {"input": "on the tenth of march twenty sixteen", "expected": "on the 10th of march 2016", "category": "date", "slice": "gtn"}
 {"input": "two thousand seven election", "expected": "2007 election", "category": "date", "slice": "gtn"}
 {"input": "twenty twelve election", "expected": "2012 election", "category": "date", "slice": "gtn"}
-{"input": "of the seventh of may", "expected": "of the 7th of may", "category": "date", "slice": "gtn"}
+{"input": "of the seventh of may", "expected": "of the seventh of may", "category": "date", "slice": "gtn"}
 {"input": "in september twenty twelve", "expected": "in september 2012", "category": "date", "slice": "gtn"}
 {"input": "on the thirteenth of october twenty twelve", "expected": "on the 13th of october 2012", "category": "date", "slice": "gtn"}
 {"input": "in nineteen fifty seven", "expected": "in 1957", "category": "date", "slice": "gtn"}
 {"input": "in june two thousand two", "expected": "in june 2002", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twelfth of november twenty twelve", "expected": "retrieved the 12th of november 2012", "category": "date", "slice": "gtn"}
-{"input": "on the seventh of february twenty thirteen the", "expected": "on the 7th of february 2013 the", "category": "date", "slice": "gtn"}
+{"input": "on the seventh of february twenty thirteen the", "expected": "on the seventh of february 2013 the", "category": "date", "slice": "gtn"}
 {"input": "retrieved november eleventh twenty thirteen", "expected": "retrieved November 11, 2013", "category": "date", "slice": "gtn"}
-{"input": "on the eighth of december twenty thirteen", "expected": "on the 8th of december 2013", "category": "date", "slice": "gtn"}
+{"input": "on the eighth of december twenty thirteen", "expected": "on the eighth of december 2013", "category": "date", "slice": "gtn"}
 {"input": "retrieved the eighteenth of july twenty fourteen", "expected": "retrieved the 18th of july 2014", "category": "date", "slice": "gtn"}
 {"input": "the tenth of april two thousand six", "expected": "the 10th of april 2006", "category": "date", "slice": "gtn"}
 {"input": "september eighteenth nineteen sixty four", "expected": "September 18, 1964", "category": "date", "slice": "gtn"}
-{"input": "retrieved the ninth of august two thousand eight", "expected": "retrieved the 9th of august 2008", "category": "date", "slice": "gtn"}
+{"input": "retrieved the ninth of august two thousand eight", "expected": "retrieved the ninth of august 2008", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twenty seventh of july two thousand nine", "expected": "retrieved the 27th of july 2009", "category": "date", "slice": "gtn"}
-{"input": "on march sixth", "expected": "on march 6th", "category": "date", "slice": "gtn"}
+{"input": "on march sixth", "expected": "on march sixth", "category": "date", "slice": "gtn"}
 {"input": "on june nineteenth two thousand six", "expected": "on June 19, 2006", "category": "date", "slice": "gtn"}
 {"input": "twenty eleven", "expected": "2011", "category": "date", "slice": "gtn"}
 {"input": "in seventeen eighty five in", "expected": "in 1785 in", "category": "date", "slice": "gtn"}
@@ -1255,20 +1255,20 @@
 {"input": "twenty thirteen buses", "expected": "2013 buses", "category": "date", "slice": "gtn"}
 {"input": "november first two thousand nine", "expected": "November 1, 2009", "category": "date", "slice": "gtn"}
 {"input": "on the twenty third of may two thousand six", "expected": "on the 23rd of may 2006", "category": "date", "slice": "gtn"}
-{"input": "on the seventh of september", "expected": "on the 7th of september", "category": "date", "slice": "gtn"}
+{"input": "on the seventh of september", "expected": "on the seventh of september", "category": "date", "slice": "gtn"}
 {"input": "retrieved may twenty second twenty fourteen", "expected": "retrieved May 22, 2014", "category": "date", "slice": "gtn"}
 {"input": "bullard two thousand seven", "expected": "bullard 2007", "category": "date", "slice": "gtn"}
-{"input": "retrieved the fourth of august twenty twelve", "expected": "retrieved the 4th of august 2012", "category": "date", "slice": "gtn"}
+{"input": "retrieved the fourth of august twenty twelve", "expected": "retrieved the fourth of august 2012", "category": "date", "slice": "gtn"}
 {"input": "retrieved may twenty third twenty fourteen", "expected": "retrieved May 23, 2014", "category": "date", "slice": "gtn"}
-{"input": "the fourth of june twenty fourteen", "expected": "the 4th of june 2014", "category": "date", "slice": "gtn"}
-{"input": "on the fifth of june", "expected": "on the 5th of june", "category": "date", "slice": "gtn"}
+{"input": "the fourth of june twenty fourteen", "expected": "the fourth of june 2014", "category": "date", "slice": "gtn"}
+{"input": "on the fifth of june", "expected": "on the fifth of june", "category": "date", "slice": "gtn"}
 {"input": "the nineteen ninety two winter", "expected": "the 1992 winter", "category": "date", "slice": "gtn"}
 {"input": "on the twenty second of june twenty twelve", "expected": "on the 22nd of june 2012", "category": "date", "slice": "gtn"}
 {"input": "retrieved the twelfth of april twenty fourteen", "expected": "retrieved the 12th of april 2014", "category": "date", "slice": "gtn"}
 {"input": "the thirty first of december twenty thirteen", "expected": "the 31st of december 2013", "category": "date", "slice": "gtn"}
 {"input": "retrieved october eighth two thousand seven", "expected": "retrieved October 8, 2007", "category": "date", "slice": "gtn"}
 {"input": "on september nineteenth two thousand eight", "expected": "on September 19, 2008", "category": "date", "slice": "gtn"}
-{"input": "retrieved the second of july twenty ten", "expected": "retrieved the 2nd of july 2010", "category": "date", "slice": "gtn"}
+{"input": "retrieved the second of july twenty ten", "expected": "retrieved the second of july 2010", "category": "date", "slice": "gtn"}
 {"input": "the seventeenth of november twenty ten", "expected": "the 17th of november 2010", "category": "date", "slice": "gtn"}
 {"input": "nineteen ninety two", "expected": "1992", "category": "date", "slice": "gtn"}
 {"input": "on may twenty first two thousand eight", "expected": "on May 21, 2008", "category": "date", "slice": "gtn"}
@@ -1289,7 +1289,7 @@
 {"input": "a fifty million dollars grant", "expected": "a $50 million grant", "category": "currency", "slice": "gtn"}
 {"input": "grossed one hundred twenty three million fifty four thousand forty one dollars worldwide", "expected": "grossed $123,054,041 worldwide", "category": "currency", "slice": "gtn"}
 {"input": "totalling eight million nine hundred five thousand dollars", "expected": "totalling $8.905 million", "category": "currency", "slice": "gtn"}
-{"input": "sets one dollar per", "expected": "sets 1 dollar per", "category": "currency", "slice": "gtn"}
+{"input": "sets one dollar per", "expected": "sets $1 per", "category": "currency", "slice": "gtn"}
 {"input": "of thirty two thousand six hundred fifty six dollars versus", "expected": "of $32,656 versus", "category": "currency", "slice": "gtn"}
 {"input": "versus twenty thousand two hundred eight dollars for", "expected": "versus $20,208 for", "category": "currency", "slice": "gtn"}
 {"input": "for one thousand four dollars", "expected": "for $1,004", "category": "currency", "slice": "gtn"}
@@ -1306,7 +1306,7 @@
 {"input": "was two hundred thirty six thousand two hundred thirty eight dollars", "expected": "was $236,238", "category": "currency", "slice": "gtn"}
 {"input": "almost eight million pounds on", "expected": "almost 8 million pounds on", "category": "currency", "slice": "gtn"}
 {"input": "of nine hundred million dollars due", "expected": "of $900 million due", "category": "currency", "slice": "gtn"}
-{"input": "the five thousand dollars seven", "expected": "the $5,000 7", "category": "currency", "slice": "gtn"}
+{"input": "the five thousand dollars seven", "expected": "the $5,000 seven", "category": "currency", "slice": "gtn"}
 {"input": "winning one hundred forty two thousand dollars", "expected": "winning $142,000", "category": "currency", "slice": "gtn"}
 {"input": "almost one hundred thousand pounds for", "expected": "almost 100,000 pounds for", "category": "currency", "slice": "gtn"}
 {"input": "taxpayers five point one million dollars to", "expected": "taxpayers $5.1 million to", "category": "currency", "slice": "gtn"}
@@ -1326,7 +1326,7 @@
 {"input": "of twenty thousand pounds owed", "expected": "of 20,000 pounds owed", "category": "currency", "slice": "gtn"}
 {"input": "a five dollars", "expected": "a $5", "category": "currency", "slice": "gtn"}
 {"input": "paid twelve dollars per", "expected": "paid $12 per", "category": "currency", "slice": "gtn"}
-{"input": "a one dollar hourly", "expected": "a 1 dollar hourly", "category": "currency", "slice": "gtn"}
+{"input": "a one dollar hourly", "expected": "a $1 hourly", "category": "currency", "slice": "gtn"}
 {"input": "was eighteen thousand eight hundred eighty seven dollars", "expected": "was $18,887", "category": "currency", "slice": "gtn"}
 {"input": "was fourteen thousand one hundred twenty three dollars", "expected": "was $14,123", "category": "currency", "slice": "gtn"}
 {"input": "raises five point four million dollars", "expected": "raises $5.4 million", "category": "currency", "slice": "gtn"}
@@ -1355,7 +1355,7 @@
 {"input": "estimated ten billion dollars impact", "expected": "estimated $10 billion impact", "category": "currency", "slice": "gtn"}
 {"input": "estimated three hundred billion dollars impact", "expected": "estimated $300 billion impact", "category": "currency", "slice": "gtn"}
 {"input": "thirty five dollars and", "expected": "$35 and", "category": "currency", "slice": "gtn"}
-{"input": "as one thousand eight hundred thirty four pounds four", "expected": "as 1,834 pounds 4", "category": "currency", "slice": "gtn"}
+{"input": "as one thousand eight hundred thirty four pounds four", "expected": "as 1,834 pounds four", "category": "currency", "slice": "gtn"}
 {"input": "over eighty five thousand euros payout", "expected": "over 85,000 euros payout", "category": "currency", "slice": "gtn"}
 {"input": "than one hundred sixty thousand dollars to", "expected": "than $160,000 to", "category": "currency", "slice": "gtn"}
 {"input": "only one million dollars", "expected": "only $1 million", "category": "currency", "slice": "gtn"}
@@ -1560,7 +1560,7 @@
 {"input": "for three hundred eleven thousand seven hundred eighty six dollars with", "expected": "for $311,786 with", "category": "currency", "slice": "gtn"}
 {"input": "sixty million dollars harvest", "expected": "$60 million harvest", "category": "currency", "slice": "gtn"}
 {"input": "for one point four billion dollars", "expected": "for $1.4 billion", "category": "currency", "slice": "gtn"}
-{"input": "numb three rupees", "expected": "numb 3 rupees", "category": "currency", "slice": "gtn"}
+{"input": "numb three rupees", "expected": "numb three rupees", "category": "currency", "slice": "gtn"}
 {"input": "provided one point five million dollars in", "expected": "provided $1.5 million in", "category": "currency", "slice": "gtn"}
 {"input": "pay eighty three million dollars for", "expected": "pay $83 million for", "category": "currency", "slice": "gtn"}
 {"input": "raise one point six billion dollars in", "expected": "raise $1.6 billion in", "category": "currency", "slice": "gtn"}
@@ -1584,7 +1584,7 @@
 {"input": "was eight hundred thousand dollars", "expected": "was $800,000", "category": "currency", "slice": "gtn"}
 {"input": "the seventeen pounds cream", "expected": "the 17 pounds cream", "category": "currency", "slice": "gtn"}
 {"input": "was thirty thousand five hundred twenty one dollars", "expected": "was $30,521", "category": "currency", "slice": "gtn"}
-{"input": "received three czech korunas", "expected": "received 3 czech korunas", "category": "currency", "slice": "gtn"}
+{"input": "received three czech korunas", "expected": "received three czech korunas", "category": "currency", "slice": "gtn"}
 {"input": "was twenty five thousand seven hundred fifty nine dollars", "expected": "was $25,759", "category": "currency", "slice": "gtn"}
 {"input": "cost six hundred million dollars to", "expected": "cost $600 million to", "category": "currency", "slice": "gtn"}
 {"input": "of thirty two thousand eighty three dollars versus", "expected": "of $32,083 versus", "category": "currency", "slice": "gtn"}
@@ -1653,7 +1653,7 @@
 {"input": "of twenty four thousand one hundred thirty nine dollars versus", "expected": "of $24,139 versus", "category": "currency", "slice": "gtn"}
 {"input": "versus eighteen thousand seven hundred fifty dollars for", "expected": "versus $18,750 for", "category": "currency", "slice": "gtn"}
 {"input": "for sixty seven point one million dollars", "expected": "for $67.1 million", "category": "currency", "slice": "gtn"}
-{"input": "for one dollar", "expected": "for 1 dollar", "category": "currency", "slice": "gtn"}
+{"input": "for one dollar", "expected": "for $1", "category": "currency", "slice": "gtn"}
 {"input": "a three million two hundred thirty one thousand three hundred dollars signing", "expected": "a $3,231,300 signing", "category": "currency", "slice": "gtn"}
 {"input": "another two hundred forty billion dollars between", "expected": "another $240 billion between", "category": "currency", "slice": "gtn"}
 {"input": "was eighteen thousand four hundred fifty five dollars", "expected": "was $18,455", "category": "currency", "slice": "gtn"}
@@ -1695,7 +1695,7 @@
 {"input": "at eighteen forty three", "expected": "at 1843", "category": "time", "slice": "gtn"}
 {"input": "eleven eleven", "expected": "eleven eleven", "category": "time", "slice": "gtn"}
 {"input": "three fifty nine", "expected": "three fifty nine", "category": "time", "slice": "gtn"}
-{"input": "one thirteen one fifth", "expected": "one thirteen one 5th", "category": "time", "slice": "gtn"}
+{"input": "one thirteen one fifth", "expected": "one thirteen one fifth", "category": "time", "slice": "gtn"}
 {"input": "at two eleven of", "expected": "at two eleven of", "category": "time", "slice": "gtn"}
 {"input": "at five fifty eight p m", "expected": "at 5:58 PM", "category": "time", "slice": "gtn"}
 {"input": "at three p m", "expected": "at 3:00 PM", "category": "time", "slice": "gtn"}
@@ -1728,7 +1728,7 @@
 {"input": "about three thirty p m", "expected": "about 3:30 PM", "category": "time", "slice": "gtn"}
 {"input": "fourteen twenty six g m t", "expected": "fourteen twenty six g m t", "category": "time", "slice": "gtn"}
 {"input": "at sixteen hundred", "expected": "at 1,600", "category": "time", "slice": "gtn"}
-{"input": "is two hours forty two minutes and forty four seconds set", "expected": "is 2 hours 42 minutes 44 seconds set", "category": "time", "slice": "gtn"}
+{"input": "is two hours forty two minutes and forty four seconds set", "expected": "is two hours 42 minutes and 44 seconds set", "category": "time", "slice": "gtn"}
 {"input": "biology eight forty six", "expected": "biology eight forty six", "category": "time", "slice": "gtn"}
 {"input": "at nine fifteen p m c s t", "expected": "at 9:15 PM c s t", "category": "time", "slice": "gtn"}
 {"input": "at five fifty seven", "expected": "at five fifty seven", "category": "time", "slice": "gtn"}
@@ -1748,9 +1748,9 @@
 {"input": "to eight p m nightly", "expected": "to 8:00 PM nightly", "category": "time", "slice": "gtn"}
 {"input": "to one twenty p m", "expected": "to 1:20 PM", "category": "time", "slice": "gtn"}
 {"input": "at one fifty seven a m of", "expected": "at 1:57 AM of", "category": "time", "slice": "gtn"}
-{"input": "of thirty one minutes eighteen seconds and eighty five milliseconds minutes", "expected": "of 31 minutes 18 seconds 85 milliseconds minutes", "category": "time", "slice": "gtn"}
+{"input": "of thirty one minutes eighteen seconds and eighty five milliseconds minutes", "expected": "of 31 minutes 18 seconds and 85 milliseconds minutes", "category": "time", "slice": "gtn"}
 {"input": "of one fifty eight with", "expected": "of one fifty eight with", "category": "time", "slice": "gtn"}
-{"input": "exactly one thirty five point o o o", "expected": "exactly one thirty five point 000", "category": "time", "slice": "gtn"}
+{"input": "exactly one thirty five point o o o", "expected": "exactly one thirty five 0.000", "category": "time", "slice": "gtn"}
 {"input": "does eleven a m to", "expected": "does 11:00 AM to", "category": "time", "slice": "gtn"}
 {"input": "to three p m", "expected": "to 3:00 PM", "category": "time", "slice": "gtn"}
 {"input": "about seven thirty p m a", "expected": "about 7:30 PM a", "category": "time", "slice": "gtn"}
@@ -1772,7 +1772,7 @@
 {"input": "at seven p m e s t on", "expected": "at 7:00 PM e s t on", "category": "time", "slice": "gtn"}
 {"input": "from ten p m to", "expected": "from 10:00 PM to", "category": "time", "slice": "gtn"}
 {"input": "to twelve a m on", "expected": "to 12:00 AM on", "category": "time", "slice": "gtn"}
-{"input": "in three hours forty six minutes and forty six seconds", "expected": "in 3 hours 46 minutes 46 seconds", "category": "time", "slice": "gtn"}
+{"input": "in three hours forty six minutes and forty six seconds", "expected": "in three hours 46 minutes and 46 seconds", "category": "time", "slice": "gtn"}
 {"input": "after seventeen hundred central", "expected": "after 1,700 central", "category": "time", "slice": "gtn"}
 {"input": "was one a m", "expected": "was 1:00 AM", "category": "time", "slice": "gtn"}
 {"input": "by twelve fifteen a m", "expected": "by 12:15 AM", "category": "time", "slice": "gtn"}
@@ -1792,19 +1792,19 @@
 {"input": "to twelve a m mike", "expected": "to 12:00 AM mike", "category": "time", "slice": "gtn"}
 {"input": "three seventeen", "expected": "three seventeen", "category": "time", "slice": "gtn"}
 {"input": "two fifty two", "expected": "two fifty two", "category": "time", "slice": "gtn"}
-{"input": "in two hours twenty nine minutes and fifty eight seconds", "expected": "in 2 hours 29 minutes 58 seconds", "category": "time", "slice": "gtn"}
+{"input": "in two hours twenty nine minutes and fifty eight seconds", "expected": "in two hours 29 minutes and 58 seconds", "category": "time", "slice": "gtn"}
 {"input": "fourteen twenty nine", "expected": "fourteen twenty nine", "category": "time", "slice": "gtn"}
 {"input": "two thirty nine", "expected": "two thirty nine", "category": "time", "slice": "gtn"}
 {"input": "two forty six", "expected": "two forty six", "category": "time", "slice": "gtn"}
-{"input": "clocks one hour seven minutes and forty four seconds in", "expected": "clocks 1 hour 7 minutes 44 seconds in", "category": "time", "slice": "gtn"}
+{"input": "clocks one hour seven minutes and forty four seconds in", "expected": "clocks one hour seven minutes and 44 seconds in", "category": "time", "slice": "gtn"}
 {"input": "at ten fifty five p m", "expected": "at 10:55 PM", "category": "time", "slice": "gtn"}
 {"input": "genetics six forty three", "expected": "genetics six forty three", "category": "time", "slice": "gtn"}
 {"input": "four nineteen", "expected": "four nineteen", "category": "time", "slice": "gtn"}
 {"input": "fifteen fifty two", "expected": "1552", "category": "time", "slice": "gtn"}
 {"input": "at eight fifty nine p m mountain", "expected": "at 8:59 PM mountain", "category": "time", "slice": "gtn"}
 {"input": "at three thirty p m dickie", "expected": "at 3:30 PM dickie", "category": "time", "slice": "gtn"}
-{"input": "cruises two hours six minutes and ten seconds course", "expected": "cruises 2 hours 6 minutes 10 seconds course", "category": "time", "slice": "gtn"}
-{"input": "two minutes three seconds and ten milliseconds", "expected": "2 minutes 3 seconds 10 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "cruises two hours six minutes and ten seconds course", "expected": "cruises two hours six minutes and 10 seconds course", "category": "time", "slice": "gtn"}
+{"input": "two minutes three seconds and ten milliseconds", "expected": "two minutes three seconds and 10 milliseconds", "category": "time", "slice": "gtn"}
 {"input": "at four thirty five into", "expected": "at four thirty five into", "category": "time", "slice": "gtn"}
 {"input": "from fourteen hundred c e t", "expected": "from 1,400 c e t", "category": "time", "slice": "gtn"}
 {"input": "approximately twenty three thirty", "expected": "approximately twenty three thirty", "category": "time", "slice": "gtn"}
@@ -1813,14 +1813,14 @@
 {"input": "eighteen thirty seven", "expected": "1837", "category": "time", "slice": "gtn"}
 {"input": "sotah four eleven", "expected": "sotah four eleven", "category": "time", "slice": "gtn"}
 {"input": "at two forty four of", "expected": "at two forty four of", "category": "time", "slice": "gtn"}
-{"input": "of one minute nineteen seconds and thirteen milliseconds", "expected": "of 1 minute 19 seconds 13 milliseconds", "category": "time", "slice": "gtn"}
-{"input": "seven minutes fifty seconds and forty milliseconds", "expected": "7 minutes 50 seconds 40 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "of one minute nineteen seconds and thirteen milliseconds", "expected": "of one minute 19 seconds and 13 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "seven minutes fifty seconds and forty milliseconds", "expected": "seven minutes 50 seconds and 40 milliseconds", "category": "time", "slice": "gtn"}
 {"input": "twenty fifty five and", "expected": "2055 and", "category": "time", "slice": "gtn"}
 {"input": "and twenty one twenty", "expected": "and twenty one twenty", "category": "time", "slice": "gtn"}
 {"input": "at twenty one fifty", "expected": "at twenty one fifty", "category": "time", "slice": "gtn"}
 {"input": "vision twelve seventeen", "expected": "vision twelve seventeen", "category": "time", "slice": "gtn"}
 {"input": "at two thirty p m sullivan", "expected": "at 2:30 PM sullivan", "category": "time", "slice": "gtn"}
-{"input": "of two minutes twenty four seconds and thirty six milliseconds was", "expected": "of 2 minutes 24 seconds 36 milliseconds was", "category": "time", "slice": "gtn"}
+{"input": "of two minutes twenty four seconds and thirty six milliseconds was", "expected": "of two minutes 24 seconds and 36 milliseconds was", "category": "time", "slice": "gtn"}
 {"input": "three twenty", "expected": "three twenty", "category": "time", "slice": "gtn"}
 {"input": "news six p m sports", "expected": "news 6:00 PM sports", "category": "time", "slice": "gtn"}
 {"input": "at nineteen fifty five for", "expected": "at 1955 for", "category": "time", "slice": "gtn"}
@@ -1863,14 +1863,14 @@
 {"input": "the twelve p m", "expected": "the 12:00 PM", "category": "time", "slice": "gtn"}
 {"input": "at two forty three of", "expected": "at two forty three of", "category": "time", "slice": "gtn"}
 {"input": "eleven a m e d t", "expected": "11:00 AM e d t", "category": "time", "slice": "gtn"}
-{"input": "at twenty hours fifty three minutes and six seconds u t c on", "expected": "at 20 hours 53 minutes 6 seconds u t c on", "category": "time", "slice": "gtn"}
+{"input": "at twenty hours fifty three minutes and six seconds u t c on", "expected": "at 20 hours 53 minutes and six seconds u t c on", "category": "time", "slice": "gtn"}
 {"input": "at two p m on", "expected": "at 2:00 PM on", "category": "time", "slice": "gtn"}
 {"input": "at eighteen o six g m t on", "expected": "at 1806 g m t on", "category": "time", "slice": "gtn"}
 {"input": "clandestino three thirty eight", "expected": "clandestino three thirty eight", "category": "time", "slice": "gtn"}
 {"input": "at twelve o'clock u t c on", "expected": "at 12:00 u t c on", "category": "time", "slice": "gtn"}
 {"input": "by twelve twenty five hours", "expected": "by twelve twenty five hours", "category": "time", "slice": "gtn"}
 {"input": "around one thirty a m", "expected": "around 1:30 AM", "category": "time", "slice": "gtn"}
-{"input": "of two hours nineteen minutes and twenty six seconds point seven five", "expected": "of 2 hours 19 minutes 26 seconds point seven five", "category": "time", "slice": "gtn"}
+{"input": "of two hours nineteen minutes and twenty six seconds point seven five", "expected": "of two hours 19 minutes and 26 seconds point seven five", "category": "time", "slice": "gtn"}
 {"input": "from eight a m to", "expected": "from 8:00 AM to", "category": "time", "slice": "gtn"}
 {"input": "about two p m", "expected": "about 2:00 PM", "category": "time", "slice": "gtn"}
 {"input": "two fifty six", "expected": "two fifty six", "category": "time", "slice": "gtn"}
@@ -1878,7 +1878,7 @@
 {"input": "world twenty four thirty two", "expected": "world twenty four thirty two", "category": "time", "slice": "gtn"}
 {"input": "one o five", "expected": "105", "category": "time", "slice": "gtn"}
 {"input": "ten fifty five a m", "expected": "10:55 AM", "category": "time", "slice": "gtn"}
-{"input": "of one minute forty eight seconds and twenty three milliseconds", "expected": "of 1 minute 48 seconds 23 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "of one minute forty eight seconds and twenty three milliseconds", "expected": "of one minute 48 seconds and 23 milliseconds", "category": "time", "slice": "gtn"}
 {"input": "begins five fifty minutes", "expected": "begins five fifty minutes", "category": "time", "slice": "gtn"}
 {"input": "at eleven o'clock", "expected": "at 11:00", "category": "time", "slice": "gtn"}
 {"input": "at ten a m", "expected": "at 10:00 AM", "category": "time", "slice": "gtn"}
@@ -1891,11 +1891,11 @@
 {"input": "two fifty five", "expected": "two fifty five", "category": "time", "slice": "gtn"}
 {"input": "fourteen twenty two g m t", "expected": "fourteen twenty two g m t", "category": "time", "slice": "gtn"}
 {"input": "at fourteen twenty the", "expected": "at fourteen twenty the", "category": "time", "slice": "gtn"}
-{"input": "was two hours seven minutes and seven seconds", "expected": "was 2 hours 7 minutes 7 seconds", "category": "time", "slice": "gtn"}
+{"input": "was two hours seven minutes and seven seconds", "expected": "was two hours seven minutes and seven seconds", "category": "time", "slice": "gtn"}
 {"input": "at eighteen hundred", "expected": "at 1,800", "category": "time", "slice": "gtn"}
 {"input": "three fifty four", "expected": "three fifty four", "category": "time", "slice": "gtn"}
 {"input": "at five thirty p m", "expected": "at 5:30 PM", "category": "time", "slice": "gtn"}
-{"input": "of four minutes fourteen seconds and sixty milliseconds minutes", "expected": "of 4 minutes 14 seconds 60 milliseconds minutes", "category": "time", "slice": "gtn"}
+{"input": "of four minutes fourteen seconds and sixty milliseconds minutes", "expected": "of four minutes 14 seconds and 60 milliseconds minutes", "category": "time", "slice": "gtn"}
 {"input": "at eight thirty p m from", "expected": "at 8:30 PM from", "category": "time", "slice": "gtn"}
 {"input": "programming ten twenty three", "expected": "programming ten twenty three", "category": "time", "slice": "gtn"}
 {"input": "at eight thirty a m", "expected": "at 8:30 AM", "category": "time", "slice": "gtn"}
@@ -1919,14 +1919,14 @@
 {"input": "at fourteen twenty and", "expected": "at fourteen twenty and", "category": "time", "slice": "gtn"}
 {"input": "at eight p m on", "expected": "at 8:00 PM on", "category": "time", "slice": "gtn"}
 {"input": "one thirty four", "expected": "one thirty four", "category": "time", "slice": "gtn"}
-{"input": "in seven minutes thirty eight seconds and ninety three milliseconds", "expected": "in 7 minutes 38 seconds 93 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "in seven minutes thirty eight seconds and ninety three milliseconds", "expected": "in seven minutes 38 seconds and 93 milliseconds", "category": "time", "slice": "gtn"}
 {"input": "at three o seven p m on", "expected": "at 3:07 PM on", "category": "time", "slice": "gtn"}
-{"input": "at ten hours thirty five minutes and forty seven seconds local", "expected": "at 10 hours 35 minutes 47 seconds local", "category": "time", "slice": "gtn"}
+{"input": "at ten hours thirty five minutes and forty seven seconds local", "expected": "at 10 hours 35 minutes and 47 seconds local", "category": "time", "slice": "gtn"}
 {"input": "at four a m", "expected": "at 4:00 AM", "category": "time", "slice": "gtn"}
 {"input": "three forty two", "expected": "three forty two", "category": "time", "slice": "gtn"}
 {"input": "about seven a m", "expected": "about 7:00 AM", "category": "time", "slice": "gtn"}
 {"input": "as one a m as", "expected": "as 1:00 AM as", "category": "time", "slice": "gtn"}
-{"input": "in two hours twenty three minutes and fifteen seconds", "expected": "in 2 hours 23 minutes 15 seconds", "category": "time", "slice": "gtn"}
+{"input": "in two hours twenty three minutes and fifteen seconds", "expected": "in two hours 23 minutes and 15 seconds", "category": "time", "slice": "gtn"}
 {"input": "of twelve thirty p m eastern", "expected": "of 12:30 PM eastern", "category": "time", "slice": "gtn"}
 {"input": "at two thirty p m pacific", "expected": "at 2:30 PM pacific", "category": "time", "slice": "gtn"}
 {"input": "about nine twenty two", "expected": "about nine twenty two", "category": "time", "slice": "gtn"}
@@ -1952,13 +1952,13 @@
 {"input": "nephi three twenty eight", "expected": "nephi three twenty eight", "category": "time", "slice": "gtn"}
 {"input": "at seven twenty five p", "expected": "at seven twenty five p", "category": "time", "slice": "gtn"}
 {"input": "are nine a m to", "expected": "are 9:00 AM to", "category": "time", "slice": "gtn"}
-{"input": "of thirty minutes twenty eight seconds and thirty milliseconds minutes", "expected": "of 30 minutes 28 seconds 30 milliseconds minutes", "category": "time", "slice": "gtn"}
+{"input": "of thirty minutes twenty eight seconds and thirty milliseconds minutes", "expected": "of 30 minutes 28 seconds and 30 milliseconds minutes", "category": "time", "slice": "gtn"}
 {"input": "to ten p m", "expected": "to 10:00 PM", "category": "time", "slice": "gtn"}
 {"input": "five o five o two", "expected": "50502", "category": "time", "slice": "gtn"}
 {"input": "three forty o four", "expected": "three forty 04", "category": "time", "slice": "gtn"}
 {"input": "four o seven", "expected": "407", "category": "time", "slice": "gtn"}
 {"input": "three fourteen", "expected": "three fourteen", "category": "time", "slice": "gtn"}
-{"input": "of two hours ten minutes and twenty one seconds", "expected": "of 2 hours 10 minutes 21 seconds", "category": "time", "slice": "gtn"}
+{"input": "of two hours ten minutes and twenty one seconds", "expected": "of two hours 10 minutes and 21 seconds", "category": "time", "slice": "gtn"}
 {"input": "at eight p m e d t", "expected": "at 8:00 PM e d t", "category": "time", "slice": "gtn"}
 {"input": "between seven twenty seven p m and", "expected": "between 7:27 PM and", "category": "time", "slice": "gtn"}
 {"input": "and eight fifteen p m", "expected": "and 8:15 PM", "category": "time", "slice": "gtn"}
@@ -2001,10 +2001,10 @@
 {"input": "retrieved twenty o three", "expected": "retrieved 2003", "category": "time", "slice": "gtn"}
 {"input": "just three fifty nine to", "expected": "just three fifty nine to", "category": "time", "slice": "gtn"}
 {"input": "two twenty four point nine nine", "expected": "two twenty four point nine nine", "category": "time", "slice": "gtn"}
-{"input": "from one hour twenty two minutes and fifty two seconds to", "expected": "from 1 hour 22 minutes 52 seconds to", "category": "time", "slice": "gtn"}
-{"input": "to one hour twenty three minutes and twelve seconds", "expected": "to 1 hour 23 minutes 12 seconds", "category": "time", "slice": "gtn"}
-{"input": "from one hour seventeen minutes and fifty seconds to", "expected": "from 1 hour 17 minutes 50 seconds to", "category": "time", "slice": "gtn"}
-{"input": "to one hour eighteen minutes and eight seconds", "expected": "to 1 hour 18 minutes 8 seconds", "category": "time", "slice": "gtn"}
+{"input": "from one hour twenty two minutes and fifty two seconds to", "expected": "from one hour 22 minutes and 52 seconds to", "category": "time", "slice": "gtn"}
+{"input": "to one hour twenty three minutes and twelve seconds", "expected": "to one hour 23 minutes and 12 seconds", "category": "time", "slice": "gtn"}
+{"input": "from one hour seventeen minutes and fifty seconds to", "expected": "from one hour 17 minutes and 50 seconds to", "category": "time", "slice": "gtn"}
+{"input": "to one hour eighteen minutes and eight seconds", "expected": "to one hour 18 minutes and eight seconds", "category": "time", "slice": "gtn"}
 {"input": "zero twenty", "expected": "zero twenty", "category": "time", "slice": "gtn"}
 {"input": "to seven p m", "expected": "to 7:00 PM", "category": "time", "slice": "gtn"}
 {"input": "at four p m with", "expected": "at 4:00 PM with", "category": "time", "slice": "gtn"}
@@ -2016,11 +2016,11 @@
 {"input": "at twenty one hundred", "expected": "at 2,100", "category": "time", "slice": "gtn"}
 {"input": "two o one uhr", "expected": "201 uhr", "category": "time", "slice": "gtn"}
 {"input": "at eighteen fifteen and", "expected": "at 1815 and", "category": "time", "slice": "gtn"}
-{"input": "two minutes zero seconds and ninety seven milliseconds", "expected": "2 minutes 0 seconds 97 milliseconds", "category": "time", "slice": "gtn"}
+{"input": "two minutes zero seconds and ninety seven milliseconds", "expected": "two minutes zero seconds and 97 milliseconds", "category": "time", "slice": "gtn"}
 {"input": "around ten thirty a m on", "expected": "around 10:30 AM on", "category": "time", "slice": "gtn"}
 {"input": "at seven p m at", "expected": "at 7:00 PM at", "category": "time", "slice": "gtn"}
 {"input": "sixteen fifty one e d t", "expected": "1651 e d t", "category": "time", "slice": "gtn"}
-{"input": "at five hours fifty two minutes and two seconds g m t on", "expected": "at 5 hours 52 minutes 2 seconds g m t on", "category": "time", "slice": "gtn"}
+{"input": "at five hours fifty two minutes and two seconds g m t on", "expected": "at five hours 52 minutes and two seconds g m t on", "category": "time", "slice": "gtn"}
 {"input": "endocrinology four thirty three", "expected": "endocrinology four thirty three", "category": "time", "slice": "gtn"}
 {"input": "at fifteen thirty six", "expected": "at 1536", "category": "time", "slice": "gtn"}
 {"input": "after one o'clock", "expected": "after 1:00", "category": "time", "slice": "gtn"}
@@ -2327,7 +2327,7 @@
 {"input": "a n k a n g dot g o v dot c n", "expected": "a n k a n g dot g o v dot c n", "category": "url", "slice": "gtn"}
 {"input": "java dot r m i", "expected": "java dot r m i", "category": "url", "slice": "gtn"}
 {"input": "sun dot r m i package", "expected": "sun dot r m i package", "category": "url", "slice": "gtn"}
-{"input": "from p b s dot o r g the first of february twenty thirteen", "expected": "from p b s dot o r g the 1st of february 2013", "category": "url", "slice": "gtn"}
+{"input": "from p b s dot o r g the first of february twenty thirteen", "expected": "from p b s dot o r g the first of february 2013", "category": "url", "slice": "gtn"}
 {"input": "the j u d o i n s i d e dot c o m", "expected": "the j u d o i n s i d e dot c o m", "category": "url", "slice": "gtn"}
 {"input": "on j a v a dot c o m from", "expected": "on j a v a dot c o m from", "category": "url", "slice": "gtn"}
 {"input": "at l a n d i n g s dot c o m", "expected": "at l a n d i n g s dot c o m", "category": "url", "slice": "gtn"}
@@ -2583,7 +2583,7 @@
 {"input": "miller sands et al", "expected": "miller sands et al", "category": "negative", "slice": "gtn_neg"}
 {"input": "once the round ends normal play resumes", "expected": "once the round ends normal play resumes", "category": "negative", "slice": "gtn_neg"}
 {"input": "mandela marketplace about us mandela marketplace", "expected": "mandela marketplace about us mandela marketplace", "category": "negative", "slice": "gtn_neg"}
-{"input": "barbados has qualified two shooters", "expected": "barbados has qualified 2 shooters", "category": "negative", "slice": "gtn_neg"}
+{"input": "barbados has qualified two shooters", "expected": "barbados has qualified two shooters", "category": "negative", "slice": "gtn_neg"}
 {"input": "kinship and gender", "expected": "kinship and gender", "category": "negative", "slice": "gtn_neg"}
 {"input": "pizza event architecture foundation", "expected": "pizza event architecture foundation", "category": "negative", "slice": "gtn_neg"}
 {"input": "kickoff times are in cet", "expected": "kickoff times are in cet", "category": "negative", "slice": "gtn_neg"}
@@ -2634,7 +2634,7 @@
 {"input": "encyclopaedia of plymouth history", "expected": "encyclopaedia of plymouth history", "category": "negative", "slice": "gtn_neg"}
 {"input": "ohio department of natural resources", "expected": "ohio department of natural resources", "category": "negative", "slice": "gtn_neg"}
 {"input": "united states national institute of standards and technology", "expected": "united states national institute of standards and technology", "category": "negative", "slice": "gtn_neg"}
-{"input": "all three houses were of stone construction", "expected": "all 3 houses were of stone construction", "category": "negative", "slice": "gtn_neg"}
+{"input": "all three houses were of stone construction", "expected": "all three houses were of stone construction", "category": "negative", "slice": "gtn_neg"}
 {"input": "abe sada poem", "expected": "abe sada poem", "category": "negative", "slice": "gtn_neg"}
 {"input": "bee removers association of south africa", "expected": "bee removers association of south africa", "category": "negative", "slice": "gtn_neg"}
 {"input": "fulbeck's work explores identity politics", "expected": "fulbeck's work explores identity politics", "category": "negative", "slice": "gtn_neg"}
@@ -2670,7 +2670,7 @@
 {"input": "box office india", "expected": "box office india", "category": "negative", "slice": "gtn_neg"}
 {"input": "showcase is downloadable at downloads page", "expected": "showcase is downloadable at downloads page", "category": "negative", "slice": "gtn_neg"}
 {"input": "der bischofshof zu strassburg", "expected": "der bischofshof zu strassburg", "category": "negative", "slice": "gtn_neg"}
-{"input": "five named substitutes", "expected": "5 named substitutes", "category": "negative", "slice": "gtn_neg"}
+{"input": "five named substitutes", "expected": "five named substitutes", "category": "negative", "slice": "gtn_neg"}
 {"input": "however it may lead to different impacts", "expected": "however it may lead to different impacts", "category": "negative", "slice": "gtn_neg"}
 {"input": "pennsylvania castle and church ope portland", "expected": "pennsylvania castle and church ope portland", "category": "negative", "slice": "gtn_neg"}
 {"input": "stadion nou la ploiesti", "expected": "stadion nou la ploiesti", "category": "negative", "slice": "gtn_neg"}
@@ -2727,7 +2727,7 @@
 {"input": "he eventually marries elizabeth", "expected": "he eventually marries elizabeth", "category": "negative", "slice": "gtn_neg"}
 {"input": "why call it love", "expected": "why call it love", "category": "negative", "slice": "gtn_neg"}
 {"input": "carbon nanotube based stationary phases for microchip chromatography", "expected": "carbon nanotube based stationary phases for microchip chromatography", "category": "negative", "slice": "gtn_neg"}
-{"input": "he played all two matches as a midfielder", "expected": "he played all 2 matches as a midfielder", "category": "negative", "slice": "gtn_neg"}
+{"input": "he played all two matches as a midfielder", "expected": "he played all two matches as a midfielder", "category": "negative", "slice": "gtn_neg"}
 {"input": "brindabella crisis groundings sparks fears for airline", "expected": "brindabella crisis groundings sparks fears for airline", "category": "negative", "slice": "gtn_neg"}
 {"input": "bullying is social media amplifying meanness and cruelty", "expected": "bullying is social media amplifying meanness and cruelty", "category": "negative", "slice": "gtn_neg"}
 {"input": "grubb jeff david noonan and bruce cordell", "expected": "grubb jeff david noonan and bruce cordell", "category": "negative", "slice": "gtn_neg"}
@@ -2814,7 +2814,7 @@
 {"input": "reed new zealand atlas", "expected": "reed new zealand atlas", "category": "negative", "slice": "gtn_neg"}
 {"input": "hancock went into college coaching after graduation", "expected": "hancock went into college coaching after graduation", "category": "negative", "slice": "gtn_neg"}
 {"input": "the detroit news", "expected": "the detroit news", "category": "negative", "slice": "gtn_neg"}
-{"input": "the couple had four children", "expected": "the couple had 4 children", "category": "negative", "slice": "gtn_neg"}
+{"input": "the couple had four children", "expected": "the couple had four children", "category": "negative", "slice": "gtn_neg"}
 {"input": "jusufbegovic will replace janjos in bosnian", "expected": "jusufbegovic will replace janjos in bosnian", "category": "negative", "slice": "gtn_neg"}
 {"input": "environmental physiology of animals", "expected": "environmental physiology of animals", "category": "negative", "slice": "gtn_neg"}
 {"input": "encyclopedia of arab women filmmakers", "expected": "encyclopedia of arab women filmmakers", "category": "negative", "slice": "gtn_neg"}
@@ -2830,7 +2830,7 @@
 {"input": "international plant names index", "expected": "international plant names index", "category": "negative", "slice": "gtn_neg"}
 {"input": "century casinos unit completes acquisition of co", "expected": "century casinos unit completes acquisition of co", "category": "negative", "slice": "gtn_neg"}
 {"input": "thousands of students expected to march against fees", "expected": "thousands of students expected to march against fees", "category": "negative", "slice": "gtn_neg"}
-{"input": "no one sings like morten", "expected": "no 1 sings like morten", "category": "negative", "slice": "gtn_neg"}
+{"input": "no one sings like morten", "expected": "no one sings like morten", "category": "negative", "slice": "gtn_neg"}
 {"input": "broad run academics overview", "expected": "broad run academics overview", "category": "negative", "slice": "gtn_neg"}
 {"input": "waking season album personnel adapted from allmusic", "expected": "waking season album personnel adapted from allmusic", "category": "negative", "slice": "gtn_neg"}
 {"input": "moon fact sheet", "expected": "moon fact sheet", "category": "negative", "slice": "gtn_neg"}
@@ -2874,7 +2874,7 @@
 {"input": "your presence is wanted at this ghostly ball", "expected": "your presence is wanted at this ghostly ball", "category": "negative", "slice": "gtn_neg"}
 {"input": "carbon offsets have several common features vintage", "expected": "carbon offsets have several common features vintage", "category": "negative", "slice": "gtn_neg"}
 {"input": "excludes all electric vehicles", "expected": "excludes all electric vehicles", "category": "negative", "slice": "gtn_neg"}
-{"input": "charges filed against the pirate bay four", "expected": "charges filed against the pirate bay 4", "category": "negative", "slice": "gtn_neg"}
+{"input": "charges filed against the pirate bay four", "expected": "charges filed against the pirate bay four", "category": "negative", "slice": "gtn_neg"}
 {"input": "no complaints as ospreys time run to perfection", "expected": "no complaints as ospreys time run to perfection", "category": "negative", "slice": "gtn_neg"}
 {"input": "on the rights of citizens of the union", "expected": "on the rights of citizens of the union", "category": "negative", "slice": "gtn_neg"}
 {"input": "expedition great white", "expected": "expedition great white", "category": "negative", "slice": "gtn_neg"}
@@ -2922,7 +2922,7 @@
 {"input": "canberra parliamentary library", "expected": "canberra parliamentary library", "category": "negative", "slice": "gtn_neg"}
 {"input": "mrs audrey jean willing", "expected": "mrs audrey jean willing", "category": "negative", "slice": "gtn_neg"}
 {"input": "private land claims in the south", "expected": "private land claims in the south", "category": "negative", "slice": "gtn_neg"}
-{"input": "there are two approaches to high quality reproduction", "expected": "there are 2 approaches to high quality reproduction", "category": "negative", "slice": "gtn_neg"}
+{"input": "there are two approaches to high quality reproduction", "expected": "there are two approaches to high quality reproduction", "category": "negative", "slice": "gtn_neg"}
 {"input": "chief inspector the reverend hehani daroa", "expected": "chief inspector the reverend hehani daroa", "category": "negative", "slice": "gtn_neg"}
 {"input": "queen genia genialina suffers from melancholy", "expected": "queen genia genialina suffers from melancholy", "category": "negative", "slice": "gtn_neg"}
 {"input": "the next year followed chotis de la lola", "expected": "the next year followed chotis de la lola", "category": "negative", "slice": "gtn_neg"}
@@ -3076,8 +3076,8 @@
 {"input": "lloraste en el generalife", "expected": "lloraste en el generalife", "category": "negative", "slice": "gtn_neg"}
 {"input": "architectural heritage the little mosque", "expected": "architectural heritage the little mosque", "category": "negative", "slice": "gtn_neg"}
 {"input": "don kaye of kerrang", "expected": "don kaye of kerrang", "category": "negative", "slice": "gtn_neg"}
-{"input": "two kinds of stem family system", "expected": "2 kinds of stem family system", "category": "negative", "slice": "gtn_neg"}
-{"input": "oh is there not one maiden breast", "expected": "oh is there not 1 maiden breast", "category": "negative", "slice": "gtn_neg"}
+{"input": "two kinds of stem family system", "expected": "two kinds of stem family system", "category": "negative", "slice": "gtn_neg"}
+{"input": "oh is there not one maiden breast", "expected": "oh is there not one maiden breast", "category": "negative", "slice": "gtn_neg"}
 {"input": "wetlands program fact sheet no", "expected": "wetlands program fact sheet no", "category": "negative", "slice": "gtn_neg"}
 {"input": "garigal national park sydney", "expected": "garigal national park sydney", "category": "negative", "slice": "gtn_neg"}
 {"input": "mootwingee aboriginal site western new south wales", "expected": "mootwingee aboriginal site western new south wales", "category": "negative", "slice": "gtn_neg"}
@@ -3116,7 +3116,7 @@
 {"input": "moab real people press", "expected": "moab real people press", "category": "negative", "slice": "gtn_neg"}
 {"input": "she was also usually taciturn and lived simply", "expected": "she was also usually taciturn and lived simply", "category": "negative", "slice": "gtn_neg"}
 {"input": "united states topographic map", "expected": "united states topographic map", "category": "negative", "slice": "gtn_neg"}
-{"input": "app annie towermadness zero", "expected": "app annie towermadness 0", "category": "negative", "slice": "gtn_neg"}
+{"input": "app annie towermadness zero", "expected": "app annie towermadness zero", "category": "negative", "slice": "gtn_neg"}
 {"input": "office for national statistics", "expected": "office for national statistics", "category": "negative", "slice": "gtn_neg"}
 {"input": "oh no disrupted ads", "expected": "oh no disrupted ads", "category": "negative", "slice": "gtn_neg"}
 {"input": "census commission of india", "expected": "census commission of india", "category": "negative", "slice": "gtn_neg"}
@@ -3259,7 +3259,7 @@
 {"input": "sound on sound", "expected": "sound on sound", "category": "negative", "slice": "gtn_neg"}
 {"input": "of men of yore and a stately home", "expected": "of men of yore and a stately home", "category": "negative", "slice": "gtn_neg"}
 {"input": "kansas city missouri national catholic reporter", "expected": "kansas city missouri national catholic reporter", "category": "negative", "slice": "gtn_neg"}
-{"input": "west coast challenge one pocket event", "expected": "west coast challenge 1 pocket event", "category": "negative", "slice": "gtn_neg"}
+{"input": "west coast challenge one pocket event", "expected": "west coast challenge one pocket event", "category": "negative", "slice": "gtn_neg"}
 {"input": "record number of entrants for nordic game funding", "expected": "record number of entrants for nordic game funding", "category": "negative", "slice": "gtn_neg"}
 {"input": "guava paste can also be included", "expected": "guava paste can also be included", "category": "negative", "slice": "gtn_neg"}
 {"input": "it is currently chaired by lord inglewood", "expected": "it is currently chaired by lord inglewood", "category": "negative", "slice": "gtn_neg"}
@@ -3274,7 +3274,7 @@
 {"input": "it is found in india the andamans", "expected": "it is found in india the andamans", "category": "negative", "slice": "gtn_neg"}
 {"input": "a brief history of the syrian jewish community", "expected": "a brief history of the syrian jewish community", "category": "negative", "slice": "gtn_neg"}
 {"input": "a hierarchical classification of polysaccharide lyases for glycogenomics", "expected": "a hierarchical classification of polysaccharide lyases for glycogenomics", "category": "negative", "slice": "gtn_neg"}
-{"input": "at the second interchange it enters glendale", "expected": "at the 2nd interchange it enters glendale", "category": "negative", "slice": "gtn_neg"}
+{"input": "at the second interchange it enters glendale", "expected": "at the second interchange it enters glendale", "category": "negative", "slice": "gtn_neg"}
 {"input": "the real news", "expected": "the real news", "category": "negative", "slice": "gtn_neg"}
 {"input": "african economic outlook", "expected": "african economic outlook", "category": "negative", "slice": "gtn_neg"}
 {"input": "eden nachmani signed with hapoel jerusalem in hebrew", "expected": "eden nachmani signed with hapoel jerusalem in hebrew", "category": "negative", "slice": "gtn_neg"}
@@ -3289,7 +3289,7 @@
 {"input": "nurses also monitor each child's weight", "expected": "nurses also monitor each child's weight", "category": "negative", "slice": "gtn_neg"}
 {"input": "the film was a decent hit", "expected": "the film was a decent hit", "category": "negative", "slice": "gtn_neg"}
 {"input": "london the times", "expected": "london the times", "category": "negative", "slice": "gtn_neg"}
-{"input": "one way ticket west puzzles reinhart", "expected": "1 way ticket west puzzles reinhart", "category": "negative", "slice": "gtn_neg"}
+{"input": "one way ticket west puzzles reinhart", "expected": "one way ticket west puzzles reinhart", "category": "negative", "slice": "gtn_neg"}
 {"input": "phantom pocket vibration syndrome", "expected": "phantom pocket vibration syndrome", "category": "negative", "slice": "gtn_neg"}
 {"input": "slaughter enjoyed driving cars fast on his ranches", "expected": "slaughter enjoyed driving cars fast on his ranches", "category": "negative", "slice": "gtn_neg"}
 {"input": "the philadelphia inquirer", "expected": "the philadelphia inquirer", "category": "negative", "slice": "gtn_neg"}
@@ -3321,7 +3321,7 @@
 {"input": "recording industry association of america", "expected": "recording industry association of america", "category": "negative", "slice": "gtn_neg"}
 {"input": "city of edmonton", "expected": "city of edmonton", "category": "negative", "slice": "gtn_neg"}
 {"input": "many both rich and poor succumbed", "expected": "many both rich and poor succumbed", "category": "negative", "slice": "gtn_neg"}
-{"input": "the eight rowers were yale undergraduates", "expected": "the 8 rowers were yale undergraduates", "category": "negative", "slice": "gtn_neg"}
+{"input": "the eight rowers were yale undergraduates", "expected": "the eight rowers were yale undergraduates", "category": "negative", "slice": "gtn_neg"}
 {"input": "wang's supporters did not recognize these decisions", "expected": "wang's supporters did not recognize these decisions", "category": "negative", "slice": "gtn_neg"}
 {"input": "united states geological survey", "expected": "united states geological survey", "category": "negative", "slice": "gtn_neg"}
 {"input": "now that may change", "expected": "now that may change", "category": "negative", "slice": "gtn_neg"}
@@ -3370,7 +3370,7 @@
 {"input": "singer finds her own path", "expected": "singer finds her own path", "category": "negative", "slice": "gtn_neg"}
 {"input": "statement on conscientious objection", "expected": "statement on conscientious objection", "category": "negative", "slice": "gtn_neg"}
 {"input": "koop noted that", "expected": "koop noted that", "category": "negative", "slice": "gtn_neg"}
-{"input": "fisher run has one unnamed tributary", "expected": "fisher run has 1 unnamed tributary", "category": "negative", "slice": "gtn_neg"}
+{"input": "fisher run has one unnamed tributary", "expected": "fisher run has one unnamed tributary", "category": "negative", "slice": "gtn_neg"}
 {"input": "salt lake city", "expected": "salt lake city", "category": "negative", "slice": "gtn_neg"}
 {"input": "sunday service has never been provided", "expected": "sunday service has never been provided", "category": "negative", "slice": "gtn_neg"}
 {"input": "primetime would you fall for that", "expected": "primetime would you fall for that", "category": "negative", "slice": "gtn_neg"}
@@ -3394,7 +3394,7 @@
 {"input": "accredited to california", "expected": "accredited to california", "category": "negative", "slice": "gtn_neg"}
 {"input": "newspaper source plus", "expected": "newspaper source plus", "category": "negative", "slice": "gtn_neg"}
 {"input": "st louis post dispatch", "expected": "st louis post dispatch", "category": "negative", "slice": "gtn_neg"}
-{"input": "pigafetta the first italian in the philippines", "expected": "pigafetta the 1st italian in the philippines", "category": "negative", "slice": "gtn_neg"}
+{"input": "pigafetta the first italian in the philippines", "expected": "pigafetta the first italian in the philippines", "category": "negative", "slice": "gtn_neg"}
 {"input": "media control charts", "expected": "media control charts", "category": "negative", "slice": "gtn_neg"}
 {"input": "he was educated at ushaw college durham", "expected": "he was educated at ushaw college durham", "category": "negative", "slice": "gtn_neg"}
 {"input": "hawke's bay today", "expected": "hawke's bay today", "category": "negative", "slice": "gtn_neg"}
@@ -3411,7 +3411,7 @@
 {"input": "francisco coronel olympic results", "expected": "francisco coronel olympic results", "category": "negative", "slice": "gtn_neg"}
 {"input": "the upper floors most likely provided accommodation", "expected": "the upper floors most likely provided accommodation", "category": "negative", "slice": "gtn_neg"}
 {"input": "minerals of scotland", "expected": "minerals of scotland", "category": "negative", "slice": "gtn_neg"}
-{"input": "but never mind it's only for nine months", "expected": "but never mind it's only for 9 months", "category": "negative", "slice": "gtn_neg"}
+{"input": "but never mind it's only for nine months", "expected": "but never mind it's only for nine months", "category": "negative", "slice": "gtn_neg"}
 {"input": "deleites y responsos", "expected": "deleites y responsos", "category": "negative", "slice": "gtn_neg"}
 {"input": "the evolution and reform of tanzanian wildlife management", "expected": "the evolution and reform of tanzanian wildlife management", "category": "negative", "slice": "gtn_neg"}
 {"input": "oxford dictionary of national biography", "expected": "oxford dictionary of national biography", "category": "negative", "slice": "gtn_neg"}
@@ -3459,9 +3459,9 @@
 {"input": "wheaton il crossway", "expected": "wheaton il crossway", "category": "negative", "slice": "gtn_neg"}
 {"input": "feel the tropic thunder", "expected": "feel the tropic thunder", "category": "negative", "slice": "gtn_neg"}
 {"input": "ammour remporte le ballon d'or algérien", "expected": "ammour remporte le ballon d'or algérien", "category": "negative", "slice": "gtn_neg"}
-{"input": "one was the conductor artur rodzinski", "expected": "1 was the conductor artur rodzinski", "category": "negative", "slice": "gtn_neg"}
+{"input": "one was the conductor artur rodzinski", "expected": "one was the conductor artur rodzinski", "category": "negative", "slice": "gtn_neg"}
 {"input": "federal office of civil protection", "expected": "federal office of civil protection", "category": "negative", "slice": "gtn_neg"}
-{"input": "nobody was predicting more than five games", "expected": "nobody was predicting more than 5 games", "category": "negative", "slice": "gtn_neg"}
+{"input": "nobody was predicting more than five games", "expected": "nobody was predicting more than five games", "category": "negative", "slice": "gtn_neg"}
 {"input": "nederlands dagblad in dutch", "expected": "nederlands dagblad in dutch", "category": "negative", "slice": "gtn_neg"}
 {"input": "national rugby league", "expected": "national rugby league", "category": "negative", "slice": "gtn_neg"}
 {"input": "in second season the wildcard twist was introduced", "expected": "in second season the wildcard twist was introduced", "category": "negative", "slice": "gtn_neg"}
@@ -3548,10 +3548,10 @@
 {"input": "nikkei asia prize for kiran mazumdar shaw", "expected": "nikkei asia prize for kiran mazumdar shaw", "category": "negative", "slice": "gtn_neg"}
 {"input": "official web site", "expected": "official web site", "category": "negative", "slice": "gtn_neg"}
 {"input": "ai weiwei speaks", "expected": "ai weiwei speaks", "category": "negative", "slice": "gtn_neg"}
-{"input": "four dogs shouldnot be interpreted as four vedas", "expected": "4 dogs shouldnot be interpreted as 4 vedas", "category": "negative", "slice": "gtn_neg"}
+{"input": "four dogs shouldnot be interpreted as four vedas", "expected": "four dogs shouldnot be interpreted as four vedas", "category": "negative", "slice": "gtn_neg"}
 {"input": "vertebrate neurogenesis cell polarity", "expected": "vertebrate neurogenesis cell polarity", "category": "negative", "slice": "gtn_neg"}
 {"input": "swindon crowood press", "expected": "swindon crowood press", "category": "negative", "slice": "gtn_neg"}
-{"input": "duque is married and has five children", "expected": "duque is married and has 5 children", "category": "negative", "slice": "gtn_neg"}
+{"input": "duque is married and has five children", "expected": "duque is married and has five children", "category": "negative", "slice": "gtn_neg"}
 {"input": "social mobility index", "expected": "social mobility index", "category": "negative", "slice": "gtn_neg"}
 {"input": "paul healy was the assistant coach", "expected": "paul healy was the assistant coach", "category": "negative", "slice": "gtn_neg"}
 {"input": "naval history and heritage command", "expected": "naval history and heritage command", "category": "negative", "slice": "gtn_neg"}
@@ -3578,7 +3578,7 @@
 {"input": "angola warns nam settlers", "expected": "angola warns nam settlers", "category": "negative", "slice": "gtn_neg"}
 {"input": "gazeta wyborcza in polish", "expected": "gazeta wyborcza in polish", "category": "negative", "slice": "gtn_neg"}
 {"input": "daughters of the american revolution", "expected": "daughters of the american revolution", "category": "negative", "slice": "gtn_neg"}
-{"input": "at least one member must be a woman", "expected": "at least 1 member must be a woman", "category": "negative", "slice": "gtn_neg"}
+{"input": "at least one member must be a woman", "expected": "at least one member must be a woman", "category": "negative", "slice": "gtn_neg"}
 {"input": "chelsea house publishers", "expected": "chelsea house publishers", "category": "negative", "slice": "gtn_neg"}
 {"input": "dortmund macht lewandowski transfer perfekt", "expected": "dortmund macht lewandowski transfer perfekt", "category": "negative", "slice": "gtn_neg"}
 {"input": "berlin heidelberg springer", "expected": "berlin heidelberg springer", "category": "negative", "slice": "gtn_neg"}
@@ -3633,7 +3633,7 @@
 {"input": "the piece earned high critical praise", "expected": "the piece earned high critical praise", "category": "negative", "slice": "gtn_neg"}
 {"input": "scaling up the very busy background compiler", "expected": "scaling up the very busy background compiler", "category": "negative", "slice": "gtn_neg"}
 {"input": "jasmin sudic forlanger in swedish", "expected": "jasmin sudic forlanger in swedish", "category": "negative", "slice": "gtn_neg"}
-{"input": "hence these two shuhadaas are called kanakkedukkum manthirigal", "expected": "hence these 2 shuhadaas are called kanakkedukkum manthirigal", "category": "negative", "slice": "gtn_neg"}
+{"input": "hence these two shuhadaas are called kanakkedukkum manthirigal", "expected": "hence these two shuhadaas are called kanakkedukkum manthirigal", "category": "negative", "slice": "gtn_neg"}
 {"input": "hong kong film award", "expected": "hong kong film award", "category": "negative", "slice": "gtn_neg"}
 {"input": "such horses are sometimes mistakenly registered as dun", "expected": "such horses are sometimes mistakenly registered as dun", "category": "negative", "slice": "gtn_neg"}
 {"input": "microsoft visual sourcesafe best practices", "expected": "microsoft visual sourcesafe best practices", "category": "negative", "slice": "gtn_neg"}
@@ -3717,13 +3717,13 @@
 {"input": "buffalo new york firefly books", "expected": "buffalo new york firefly books", "category": "negative", "slice": "gtn_neg"}
 {"input": "the essential herva nelli", "expected": "the essential herva nelli", "category": "negative", "slice": "gtn_neg"}
 {"input": "many are to some extent self inflicted", "expected": "many are to some extent self inflicted", "category": "negative", "slice": "gtn_neg"}
-{"input": "the most prominent one is dysphagia", "expected": "the most prominent 1 is dysphagia", "category": "negative", "slice": "gtn_neg"}
+{"input": "the most prominent one is dysphagia", "expected": "the most prominent one is dysphagia", "category": "negative", "slice": "gtn_neg"}
 {"input": "datura leichhardtii is a species of thorn apple", "expected": "datura leichhardtii is a species of thorn apple", "category": "negative", "slice": "gtn_neg"}
 {"input": "this is critical for the initiation of neurogenesis", "expected": "this is critical for the initiation of neurogenesis", "category": "negative", "slice": "gtn_neg"}
 {"input": "queensland heritage council", "expected": "queensland heritage council", "category": "negative", "slice": "gtn_neg"}
 {"input": "the jakarta post in indonesian", "expected": "the jakarta post in indonesian", "category": "negative", "slice": "gtn_neg"}
 {"input": "gazetteer of australia online", "expected": "gazetteer of australia online", "category": "negative", "slice": "gtn_neg"}
-{"input": "they entered the tournament in the third stage", "expected": "they entered the tournament in the 3rd stage", "category": "negative", "slice": "gtn_neg"}
+{"input": "they entered the tournament in the third stage", "expected": "they entered the tournament in the third stage", "category": "negative", "slice": "gtn_neg"}
 {"input": "loch etive and the sons of uisnach", "expected": "loch etive and the sons of uisnach", "category": "negative", "slice": "gtn_neg"}
 {"input": "happy new year", "expected": "happy new year", "category": "negative", "slice": "gtn_neg"}
 {"input": "brugmansia and datura angel's trumpets and thorn apples", "expected": "brugmansia and datura angel's trumpets and thorn apples", "category": "negative", "slice": "gtn_neg"}
@@ -3760,122 +3760,122 @@
 {"input": "joint typhoon warning center", "expected": "joint typhoon warning center", "category": "negative", "slice": "gtn_neg"}
 {"input": "the assam tribune guwahati", "expected": "the assam tribune guwahati", "category": "negative", "slice": "gtn_neg"}
 {"input": "several aspects of the latter program raised controversy", "expected": "several aspects of the latter program raised controversy", "category": "negative", "slice": "gtn_neg"}
-{"input": "Step one, two, three.", "expected": "Step 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing, one, two, three.", "expected": "Testing, 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing one, two, three, four, five, six, seven.", "expected": "Testing 1, 2, 3, 4, 5, 6, 7.", "category": "realnb", "slice": "realnb"}
-{"input": "State one, two, three.", "expected": "State 1, 2, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "Step one, two, three.", "expected": "Step one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing, one, two, three.", "expected": "Testing, one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing one, two, three, four, five, six, seven.", "expected": "Testing one, two, three, four, five, six, seven.", "category": "realnb", "slice": "realnb"}
+{"input": "State one, two, three.", "expected": "State one, two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "swapping to parakeet from sorry swapping to Vesper kit one two three", "expected": "swapping to parakeet from sorry swapping to Vesper kit one two three", "category": "realnb", "slice": "realnb"}
-{"input": "Okay, swap to Gemini Polish, testing one, two, three.", "expected": "Okay, swap to Gemini Polish, testing 1, 2, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "Okay, swap to Gemini Polish, testing one, two, three.", "expected": "Okay, swap to Gemini Polish, testing one, two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "I'm testing parakeet 1, 2, 3, 4, 5.", "expected": "I'm testing parakeet 1, 2, 3, 4, 5.", "category": "realnb", "slice": "realnb"}
-{"input": "This is me testing Whisper Kit, one, two, three, four.", "expected": "This is me testing Whisper Kit, 1, 2, 3, 4.", "category": "realnb", "slice": "realnb"}
-{"input": "Let's uh wrap here after you're done with this and I'll start C two in a fresh session.", "expected": "Let's uh wrap here after you're done with this and I'll start C 2 in a fresh session.", "category": "realnb", "slice": "realnb"}
-{"input": "Some testing one, two, three.", "expected": "Some testing 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing, testing, one, two, three.", "expected": "Testing, testing, 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Audio test one, two, three.", "expected": "Audio test 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing whisper kit, one, two, three.", "expected": "Testing whisper kit, 1, 2, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "This is me testing Whisper Kit, one, two, three, four.", "expected": "This is me testing Whisper Kit, one, two, three, four.", "category": "realnb", "slice": "realnb"}
+{"input": "Let's uh wrap here after you're done with this and I'll start C two in a fresh session.", "expected": "Let's uh wrap here after you're done with this and I'll start C two in a fresh session.", "category": "realnb", "slice": "realnb"}
+{"input": "Some testing one, two, three.", "expected": "Some testing one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing, testing, one, two, three.", "expected": "Testing, testing, one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Audio test one, two, three.", "expected": "Audio test one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing whisper kit, one, two, three.", "expected": "Testing whisper kit, one, two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "Testing one two three", "expected": "Testing one two three", "category": "realnb", "slice": "realnb"}
-{"input": "Wrap PR one, I'll start PR two in the first session.", "expected": "Wrap PR 1, I'll start PR 2 in the 1st session.", "category": "realnb", "slice": "realnb"}
+{"input": "Wrap PR one, I'll start PR two in the first session.", "expected": "Wrap PR one, I'll start PR two in the first session.", "category": "realnb", "slice": "realnb"}
 {"input": "Recently did a detailed test and benchmark scoring with three hundred different samples.", "expected": "Recently did a detailed test and benchmark scoring with 300 different samples.", "category": "realnb", "slice": "realnb"}
-{"input": "Run the grounded review again for round two and then figure out why our n our brain files aren't encouraging this behavior automatically.", "expected": "Run the grounded review again for round 2 then figure out why our n our brain files aren't encouraging this behavior automatically.", "category": "realnb", "slice": "realnb"}
+{"input": "Run the grounded review again for round two and then figure out why our n our brain files aren't encouraging this behavior automatically.", "expected": "Run the grounded review again for round two and then figure out why our n our brain files aren't encouraging this behavior automatically.", "category": "realnb", "slice": "realnb"}
 {"input": "Fantastic, one two three.", "expected": "Fantastic, one two three.", "category": "realnb", "slice": "realnb"}
 {"input": "I'm testing one two three.", "expected": "I'm testing one two three.", "category": "realnb", "slice": "realnb"}
-{"input": "You're running it on low, you gotta bump it up to high. You're comparing Codex five point five high, which is a crazy strong model against Gemini three point five flash low, which is like comparing a fifth grader to a senior", "expected": "You're running it on low, you gotta bump it up to high. You're comparing Codex 5.5 high, which is a crazy strong model against Gemini 3.5 flash low, which is like comparing a 5th grader to a senior", "category": "realnb", "slice": "realnb"}
-{"input": "I was thinking both, but instead of assuming that those data sets aren't good, we should sample them to see if they have any data quality that we can actually use. So let's not make call judgment based on what we think it will be, but actually sample and confirm that okay, yeah, you know what, we looked at a sample and agreed that the data is not usable. And then this was just a quick query and it found five different data sets. There must be even more data sets out there that we might not be aware of.", "expected": "I was thinking both, but instead of assuming that those data sets aren't good, we should sample them to see if they have any data quality that we can actually use. So let's not make call judgment based on what we think it will be, but actually sample and confirm that okay, yeah, you know what, we looked at a sample and agreed that the data is not usable. And then this was just a quick query and it found 5 different data sets. There must be even more data sets out there that we might not be aware of.", "category": "realnb", "slice": "realnb"}
+{"input": "You're running it on low, you gotta bump it up to high. You're comparing Codex five point five high, which is a crazy strong model against Gemini three point five flash low, which is like comparing a fifth grader to a senior", "expected": "You're running it on low, you gotta bump it up to high. You're comparing Codex 5.5 high, which is a crazy strong model against Gemini 3.5 flash low, which is like comparing a fifth grader to a senior", "category": "realnb", "slice": "realnb"}
+{"input": "I was thinking both, but instead of assuming that those data sets aren't good, we should sample them to see if they have any data quality that we can actually use. So let's not make call judgment based on what we think it will be, but actually sample and confirm that okay, yeah, you know what, we looked at a sample and agreed that the data is not usable. And then this was just a quick query and it found five different data sets. There must be even more data sets out there that we might not be aware of.", "expected": "I was thinking both, but instead of assuming that those data sets aren't good, we should sample them to see if they have any data quality that we can actually use. So let's not make call judgment based on what we think it will be, but actually sample and confirm that okay, yeah, you know what, we looked at a sample and agreed that the data is not usable. And then this was just a quick query and it found five different data sets. There must be even more data sets out there that we might not be aware of.", "category": "realnb", "slice": "realnb"}
 {"input": "And let me tell you why I want to do a V4 and a V5 and a V6. I'm in the middle of a engine refractor with you. That's happening in another session. And that's gonna take all of next week. So we have a lot of time to do this in parallel. So there's no rush to get this out because we need to finish that first.", "expected": "And let me tell you why I want to do a V4 and a V5 and a V6. I'm in the middle of a engine refractor with you. That's happening in another session. And that's gonna take all of next week. So we have a lot of time to do this in parallel. So there's no rush to get this out because we need to finish that first.", "category": "realnb", "slice": "realnb"}
-{"input": "Please validate with contact seven on how to pull data sets properly.", "expected": "Please validate with contact 7 on how to pull data sets properly.", "category": "realnb", "slice": "realnb"}
-{"input": "Is it something we find in context seven? Do we go hunt for their API documentation or README's? Do we have to go read their actual manuals?", "expected": "Is it something we find in context 7? Do we go hunt for their API documentation or README's? Do we have to go read their actual manuals?", "category": "realnb", "slice": "realnb"}
-{"input": "The reason I say that is we've been working on training this set for almost two days now and it took one council session to go, Oh yeah, no shit, we should have done that from the start.", "expected": "The reason I say that is we've been working on training this set for almost 2 days now and it took 1 council session to go, Oh yeah, no shit, we should have done that from the start.", "category": "realnb", "slice": "realnb"}
-{"input": "So let's start off by getting the five models on our computer. Let's see what's available in terms of resources. And then what I want you to do is put together your initial frame of attack for these five models in terms of your architecture. And then I want you to go to council and say, hey, am I missing something? Or is there anything else I can do to maximize or pull out any other ounce of value from these existing models for the classifier.", "expected": "So let's start off by getting the 5 models on our computer. Let's see what's available in terms of resources. And then what I want you to do is put together your initial frame of attack for these 5 models in terms of your architecture. And then I want you to go to council and say, hey, am I missing something? Or is there anything else I can do to maximize or pull out any other ounce of value from these existing models for the classifier.", "category": "realnb", "slice": "realnb"}
-{"input": "For phase zero, how much data are we pushing through the classifiers to determine their viability?", "expected": "For phase 0, how much data are we pushing through the classifiers to determine their viability?", "category": "realnb", "slice": "realnb"}
-{"input": "How did we end up with two different plans? What was the purpose of that?", "expected": "How did we end up with 2 different plans? What was the purpose of that?", "category": "realnb", "slice": "realnb"}
+{"input": "Please validate with contact seven on how to pull data sets properly.", "expected": "Please validate with contact seven on how to pull data sets properly.", "category": "realnb", "slice": "realnb"}
+{"input": "Is it something we find in context seven? Do we go hunt for their API documentation or README's? Do we have to go read their actual manuals?", "expected": "Is it something we find in context seven? Do we go hunt for their API documentation or README's? Do we have to go read their actual manuals?", "category": "realnb", "slice": "realnb"}
+{"input": "The reason I say that is we've been working on training this set for almost two days now and it took one council session to go, Oh yeah, no shit, we should have done that from the start.", "expected": "The reason I say that is we've been working on training this set for almost two days now and it took one council session to go, Oh yeah, no shit, we should have done that from the start.", "category": "realnb", "slice": "realnb"}
+{"input": "So let's start off by getting the five models on our computer. Let's see what's available in terms of resources. And then what I want you to do is put together your initial frame of attack for these five models in terms of your architecture. And then I want you to go to council and say, hey, am I missing something? Or is there anything else I can do to maximize or pull out any other ounce of value from these existing models for the classifier.", "expected": "So let's start off by getting the five models on our computer. Let's see what's available in terms of resources. And then what I want you to do is put together your initial frame of attack for these five models in terms of your architecture. And then I want you to go to council and say, hey, am I missing something? Or is there anything else I can do to maximize or pull out any other ounce of value from these existing models for the classifier.", "category": "realnb", "slice": "realnb"}
+{"input": "For phase zero, how much data are we pushing through the classifiers to determine their viability?", "expected": "For phase zero, how much data are we pushing through the classifiers to determine their viability?", "category": "realnb", "slice": "realnb"}
+{"input": "How did we end up with two different plans? What was the purpose of that?", "expected": "How did we end up with two different plans? What was the purpose of that?", "category": "realnb", "slice": "realnb"}
 {"input": "I wish Claude code would just give us access to Sonnet with 1 million tokens as a default.", "expected": "I wish Claude code would just give us access to Sonnet with 1 million tokens as a default.", "category": "realnb", "slice": "realnb"}
-{"input": "Wait, where are you going, Des? - Home. - Home? I feel like Des has been here for like three days. This is the first time I've seen him. I get it, you guys just wanna like, but y'all still have a duty, like there's like", "expected": "Wait, where are you going, Des? - Home. - Home? I feel like Des has been here for like 3 days. This is the 1st time I've seen him. I get it, you guys just wanna like, but y'all still have a duty, like there's like", "category": "realnb", "slice": "realnb"}
+{"input": "Wait, where are you going, Des? - Home. - Home? I feel like Des has been here for like three days. This is the first time I've seen him. I get it, you guys just wanna like, but y'all still have a duty, like there's like", "expected": "Wait, where are you going, Des? - Home. - Home? I feel like Des has been here for like three days. This is the first time I've seen him. I get it, you guys just wanna like, but y'all still have a duty, like there's like", "category": "realnb", "slice": "realnb"}
 {"input": "Testing one two three.", "expected": "Testing one two three.", "category": "realnb", "slice": "realnb"}
-{"input": "This is me testing one, two, three, four, five.", "expected": "This is me testing 1, 2, 3, 4, 5.", "category": "realnb", "slice": "realnb"}
-{"input": "Like we kept Parakeet and WhisperKid in two completely separate files. Like they were operating in complete isolation from each other. We would never expect them to operate as one. The goal was always that parakeet as it was prior to the migration and parakeet post migration kept parity.", "expected": "Like we kept Parakeet and WhisperKid in 2 completely separate files. Like they were operating in complete isolation from each other. We would never expect them to operate as 1. The goal was always that parakeet as it was prior to the migration and parakeet post migration kept parity.", "category": "realnb", "slice": "realnb"}
-{"input": "I mean the other three tests passed, right? It was just the one test that we had some variance in, but it was still working. It wasn't like detrimenting the user behavior.", "expected": "I mean the other 3 tests passed, right? It was just the 1 test that we had some variance in, but it was still working. It wasn't like detrimenting the user behavior.", "category": "realnb", "slice": "realnb"}
+{"input": "This is me testing one, two, three, four, five.", "expected": "This is me testing one, two, three, four, five.", "category": "realnb", "slice": "realnb"}
+{"input": "Like we kept Parakeet and WhisperKid in two completely separate files. Like they were operating in complete isolation from each other. We would never expect them to operate as one. The goal was always that parakeet as it was prior to the migration and parakeet post migration kept parity.", "expected": "Like we kept Parakeet and WhisperKid in two completely separate files. Like they were operating in complete isolation from each other. We would never expect them to operate as one. The goal was always that parakeet as it was prior to the migration and parakeet post migration kept parity.", "category": "realnb", "slice": "realnb"}
+{"input": "I mean the other three tests passed, right? It was just the one test that we had some variance in, but it was still working. It wasn't like detrimenting the user behavior.", "expected": "I mean the other three tests passed, right? It was just the one test that we had some variance in, but it was still working. It wasn't like detrimenting the user behavior.", "category": "realnb", "slice": "realnb"}
 {"input": "I think we should keep the gates but the understanding should be just documenting any variance as we go along and then deciding at the end like okay this is the documented variance um do we need to do a post-implementation deep dive into fixing this or is it a nothing burger?", "expected": "I think we should keep the gates but the understanding should be just documenting any variance as we go along and then deciding at the end like okay this is the documented variance um do we need to do a post-implementation deep dive into fixing this or is it a nothing burger?", "category": "realnb", "slice": "realnb"}
-{"input": "There's something different in this one that I", "expected": "There's something different in this 1 that I", "category": "realnb", "slice": "realnb"}
+{"input": "There's something different in this one that I", "expected": "There's something different in this one that I", "category": "realnb", "slice": "realnb"}
 {"input": "So let's go ahead and do what you were suggesting, which is path A, and address those 12 fixes, but we every fix needs to be paused and then validated.", "expected": "So let's go ahead and do what you were suggesting, which is path A, and address those 12 fixes, but we every fix needs to be paused and then validated.", "category": "realnb", "slice": "realnb"}
 {"input": "I'm thinking we use the same codex session and ask it to actually do the fixes, the 12 fixes that it's recommending, and then you validate its work.", "expected": "I'm thinking we use the same codex session and ask it to actually do the fixes, the 12 fixes that it's recommending, and then you validate its work.", "category": "realnb", "slice": "realnb"}
 {"input": "Additionally, I want you to look at those common themes of failure. So it looks like it's telemetry and some other parts of the tool. And I want you to send parallel codex agents to go out and double click on each aspect to see what else might have been missed.", "expected": "Additionally, I want you to look at those common themes of failure. So it looks like it's telemetry and some other parts of the tool. And I want you to send parallel codex agents to go out and double click on each aspect to see what else might have been missed.", "category": "realnb", "slice": "realnb"}
-{"input": "This way we are having individual sniffing dogs. Sniffing dogs. Listening to different parts of our existing software versus trying to get one giant dog to do the job.", "expected": "This way we are having individual sniffing dogs. Sniffing dogs. Listening to different parts of our existing software versus trying to get 1 giant dog to do the job.", "category": "realnb", "slice": "realnb"}
-{"input": "Let's see how well the fixer did at one shotting.", "expected": "Let's see how well the fixer did at 1 shotting.", "category": "realnb", "slice": "realnb"}
-{"input": "I mean that was a lot of work to fix in one go.", "expected": "I mean that was a lot of work to fix in 1 go.", "category": "realnb", "slice": "realnb"}
-{"input": "This is me testing a longer dictation. My take on the experiment. I executed the plan with high fidelity and didn't deviate on shape. Fix three's council revised form is correct. The key down ordering is exact. The weak set choice for the metadata deferral is the right one. The miss URL stamp performance is the kind of bug that comes up from following the letter of mark permanently unsuitable with data envious rejected without noticing two of the four call sites are naturally permanent, a subto-logic gap, not a sloppiness gap. But better than I expected the Manon Adversal Codex pass.", "expected": "This is me testing a longer dictation. My take on the experiment. I executed the plan with high fidelity and didn't deviate on shape. Fix 3 's council revised form is correct. The key down ordering is exact. The weak set choice for the metadata deferral is the right 1. The miss URL stamp performance is the kind of bug that comes up from following the letter of mark permanently unsuitable with data envious rejected without noticing 2 of the 4 call sites are naturally permanent, a subto-logic gap, not a sloppiness gap. But better than I expected the Manon Adversal Codex pass.", "category": "realnb", "slice": "realnb"}
-{"input": "Okay, streaming is on. Why not are they asking me this? This is ridiculous on the site. So why not show the crap? No, because I don't I don't I I generally thought the question was so silly that I wanted to like get to the bottom of it but where was this belt before I used an answer because I just thought it was so far from left field. And you might have done the knocking. So you both denied the those. So you two have never opened it. No. I've never even like I've done dress up with my eyes. Okay. But like that's as far as possible. Um Hannah David R. from Chicago said, don't you find it a little shady to spread a rumor based on what a psychic texted you? Seems like a bit of a stretch. My psychic says Lindsay is not going to respond kindly at this rumor. reunion.", "expected": "Okay, streaming is on. Why not are they asking me this? This is ridiculous on the site. So why not show the crap? No, because I don't I don't I I generally thought the question was so silly that I wanted to like get to the bottom of it but where was this belt before I used an answer because I just thought it was so far from left field. And you might have done the knocking. So you both denied the those. So you 2 have never opened it. No. I've never even like I've done dress up with my eyes. Okay. But like that's as far as possible. Um Hannah David R. From Chicago said, don't you find it a little shady to spread a rumor based on what a psychic texted you? Seems like a bit of a stretch. My psychic says Lindsay is not going to respond kindly at this rumor. Reunion.", "category": "realnb", "slice": "realnb"}
-{"input": "Nothing, one, two, three.", "expected": "Nothing, 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing one, two, three.", "expected": "Testing 1, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "That's it. One, two, three.", "expected": "That's it. One, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing one two three. Testing, one two, three, testing.", "expected": "Testing one two three. Testing, one two, 3, testing.", "category": "realnb", "slice": "realnb"}
-{"input": "Wanna test one more thing?", "expected": "Wanna test 1 more thing?", "category": "realnb", "slice": "realnb"}
-{"input": "We're going to do the Bluetooth error one more time.", "expected": "We're going to do the Bluetooth error 1 more time.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing. One, two, three.", "expected": "Testing. One, 2, 3.", "category": "realnb", "slice": "realnb"}
-{"input": "This is a test. One, two, three, four, five.", "expected": "This is a test. One, 2, 3, 4, 5.", "category": "realnb", "slice": "realnb"}
+{"input": "This way we are having individual sniffing dogs. Sniffing dogs. Listening to different parts of our existing software versus trying to get one giant dog to do the job.", "expected": "This way we are having individual sniffing dogs. Sniffing dogs. Listening to different parts of our existing software versus trying to get one giant dog to do the job.", "category": "realnb", "slice": "realnb"}
+{"input": "Let's see how well the fixer did at one shotting.", "expected": "Let's see how well the fixer did at one shotting.", "category": "realnb", "slice": "realnb"}
+{"input": "I mean that was a lot of work to fix in one go.", "expected": "I mean that was a lot of work to fix in one go.", "category": "realnb", "slice": "realnb"}
+{"input": "This is me testing a longer dictation. My take on the experiment. I executed the plan with high fidelity and didn't deviate on shape. Fix three's council revised form is correct. The key down ordering is exact. The weak set choice for the metadata deferral is the right one. The miss URL stamp performance is the kind of bug that comes up from following the letter of mark permanently unsuitable with data envious rejected without noticing two of the four call sites are naturally permanent, a subto-logic gap, not a sloppiness gap. But better than I expected the Manon Adversal Codex pass.", "expected": "This is me testing a longer dictation. My take on the experiment. I executed the plan with high fidelity and didn't deviate on shape. Fix three's council revised form is correct. The key down ordering is exact. The weak set choice for the metadata deferral is the right one. The miss URL stamp performance is the kind of bug that comes up from following the letter of mark permanently unsuitable with data envious rejected without noticing two of the four call sites are naturally permanent, a subto-logic gap, not a sloppiness gap. But better than I expected the Manon Adversal Codex pass.", "category": "realnb", "slice": "realnb"}
+{"input": "Okay, streaming is on. Why not are they asking me this? This is ridiculous on the site. So why not show the crap? No, because I don't I don't I I generally thought the question was so silly that I wanted to like get to the bottom of it but where was this belt before I used an answer because I just thought it was so far from left field. And you might have done the knocking. So you both denied the those. So you two have never opened it. No. I've never even like I've done dress up with my eyes. Okay. But like that's as far as possible. Um Hannah David R. from Chicago said, don't you find it a little shady to spread a rumor based on what a psychic texted you? Seems like a bit of a stretch. My psychic says Lindsay is not going to respond kindly at this rumor. reunion.", "expected": "Okay, streaming is on. Why not are they asking me this? This is ridiculous on the site. So why not show the crap? No, because I don't I don't I I generally thought the question was so silly that I wanted to like get to the bottom of it but where was this belt before I used an answer because I just thought it was so far from left field. And you might have done the knocking. So you both denied the those. So you two have never opened it. No. I've never even like I've done dress up with my eyes. Okay. But like that's as far as possible. Um Hannah David R. From Chicago said, don't you find it a little shady to spread a rumor based on what a psychic texted you? Seems like a bit of a stretch. My psychic says Lindsay is not going to respond kindly at this rumor. Reunion.", "category": "realnb", "slice": "realnb"}
+{"input": "Nothing, one, two, three.", "expected": "Nothing, one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing one, two, three.", "expected": "Testing one, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "That's it. One, two, three.", "expected": "That's it. One, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing one two three. Testing, one two, three, testing.", "expected": "Testing one two three. Testing, one two, three, testing.", "category": "realnb", "slice": "realnb"}
+{"input": "Wanna test one more thing?", "expected": "Wanna test one more thing?", "category": "realnb", "slice": "realnb"}
+{"input": "We're going to do the Bluetooth error one more time.", "expected": "We're going to do the Bluetooth error one more time.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing. One, two, three.", "expected": "Testing. One, two, three.", "category": "realnb", "slice": "realnb"}
+{"input": "This is a test. One, two, three, four, five.", "expected": "This is a test. One, two, three, four, five.", "category": "realnb", "slice": "realnb"}
 {"input": "This is a RUN2A propagation verification recording.", "expected": "This is a RUN2A propagation verification recording.", "category": "realnb", "slice": "realnb"}
 {"input": "This is a Runk 2B kernel call site verification recording.", "expected": "This is a Runk 2B kernel call site verification recording.", "category": "realnb", "slice": "realnb"}
 {"input": "This is a Rung 2B kernel call site verification recording.", "expected": "This is a Rung 2B kernel call site verification recording.", "category": "realnb", "slice": "realnb"}
-{"input": "This is a parakeet smoke test for run four point five.", "expected": "This is a parakeet smoke test for run 4 point 5.", "category": "realnb", "slice": "realnb"}
-{"input": "Okay. So I'm using push to talk just fine on English and they're having zero issues.", "expected": "Okay. So I'm using push to talk just fine on English and they're having 0 issues.", "category": "realnb", "slice": "realnb"}
-{"input": "Hold on a second. First. I want you to do what we typically do after you finish coding, which is have Codex review your work until it gives you the green light. If that iterative work catches this telemetry bug, great. If it does not, that is a fast follow of, hey, now that we've audited and you've given me the green light, here's something I noticed. We never wired this telemetry. What else did we forget to wire? And that will be the second detailed dive with codex, which is then gonna uncover additional things we might need to resolve. And only then do we go back to UAT.", "expected": "Hold on a second. First. I want you to do what we typically do after you finish coding, which is have Codex review your work until it gives you the green light. If that iterative work catches this telemetry bug, great. If it does not, that is a fast follow of, hey, now that we've audited and you've given me the green light, here's something I noticed. We never wired this telemetry. What else did we forget to wire? And that will be the 2nd detailed dive with codex, which is then gonna uncover additional things we might need to resolve. And only then do we go back to UAT.", "category": "realnb", "slice": "realnb"}
-{"input": "What were you using for international testing like two hours ago?", "expected": "What were you using for international testing like 2 hours ago?", "category": "realnb", "slice": "realnb"}
-{"input": "We were testing this literally two hours ago when we ran into those problems and sent us on this two-hour journey of fixing a bunch of bugs and multiple compactions. Now we're back to the starting point where we are kind of back to testing. So you were running international TTS for me. Either it was using Azure or it was using Gemini. I don't recall which of the two you ended up using. I think I found it in the notes. Here, I'll paste it for you.", "expected": "We were testing this literally 2 hours ago when we ran into those problems and sent us on this 2 -hour journey of fixing a bunch of bugs and multiple compactions. Now we're back to the starting point where we are kind of back to testing. So you were running international TTS for me. Either it was using Azure or it was using Gemini. I don't recall which of the 2 you ended up using. I think I found it in the notes. Here, I'll paste it for you.", "category": "realnb", "slice": "realnb"}
+{"input": "This is a parakeet smoke test for run four point five.", "expected": "This is a parakeet smoke test for run 4.5.", "category": "realnb", "slice": "realnb"}
+{"input": "Okay. So I'm using push to talk just fine on English and they're having zero issues.", "expected": "Okay. So I'm using push to talk just fine on English and they're having zero issues.", "category": "realnb", "slice": "realnb"}
+{"input": "Hold on a second. First. I want you to do what we typically do after you finish coding, which is have Codex review your work until it gives you the green light. If that iterative work catches this telemetry bug, great. If it does not, that is a fast follow of, hey, now that we've audited and you've given me the green light, here's something I noticed. We never wired this telemetry. What else did we forget to wire? And that will be the second detailed dive with codex, which is then gonna uncover additional things we might need to resolve. And only then do we go back to UAT.", "expected": "Hold on a second. First. I want you to do what we typically do after you finish coding, which is have Codex review your work until it gives you the green light. If that iterative work catches this telemetry bug, great. If it does not, that is a fast follow of, hey, now that we've audited and you've given me the green light, here's something I noticed. We never wired this telemetry. What else did we forget to wire? And that will be the second detailed dive with codex, which is then gonna uncover additional things we might need to resolve. And only then do we go back to UAT.", "category": "realnb", "slice": "realnb"}
+{"input": "What were you using for international testing like two hours ago?", "expected": "What were you using for international testing like two hours ago?", "category": "realnb", "slice": "realnb"}
+{"input": "We were testing this literally two hours ago when we ran into those problems and sent us on this two-hour journey of fixing a bunch of bugs and multiple compactions. Now we're back to the starting point where we are kind of back to testing. So you were running international TTS for me. Either it was using Azure or it was using Gemini. I don't recall which of the two you ended up using. I think I found it in the notes. Here, I'll paste it for you.", "expected": "We were testing this literally two hours ago when we ran into those problems and sent us on this two-hour journey of fixing a bunch of bugs and multiple compactions. Now we're back to the starting point where we are kind of back to testing. So you were running international TTS for me. Either it was using Azure or it was using Gemini. I don't recall which of the two you ended up using. I think I found it in the notes. Here, I'll paste it for you.", "category": "realnb", "slice": "realnb"}
 {"input": "です。トピックが10個あります。最初のトピックは、子供の時の話。ああ、子供の時。いいですね。シュンは、どんな子供でした?ご視聴ありがとうございました", "expected": "です。トピックが10個あります。最初のトピックは、子供の時の話。ああ、子供の時。いいですね。シュンは、どんな子供でした?ご視聴ありがとうございました", "category": "realnb", "slice": "realnb"}
-{"input": "Alternating failure diagnostic run number one here.", "expected": "Alternating failure diagnostic run number 1 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Alternating failure diagnostic run number three here.", "expected": "Alternating failure diagnostic run number 3 here.", "category": "realnb", "slice": "realnb"}
-{"input": "failure diagnostic run number four here.", "expected": "failure diagnostic run number 4 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number one here.", "expected": "Parity fix verification recording number 1 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number three here.", "expected": "Parity fix verification recording number 3 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number four here.", "expected": "Parity fix verification recording number 4 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number five here.", "expected": "Parity fix verification recording number 5 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number six here.", "expected": "Parity fix verification recording number 6 here.", "category": "realnb", "slice": "realnb"}
-{"input": "Parity fix verification recording number seven here.", "expected": "Parity fix verification recording number 7 here.", "category": "realnb", "slice": "realnb"}
+{"input": "Alternating failure diagnostic run number one here.", "expected": "Alternating failure diagnostic run number one here.", "category": "realnb", "slice": "realnb"}
+{"input": "Alternating failure diagnostic run number three here.", "expected": "Alternating failure diagnostic run number three here.", "category": "realnb", "slice": "realnb"}
+{"input": "failure diagnostic run number four here.", "expected": "failure diagnostic run number four here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number one here.", "expected": "Parity fix verification recording number one here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number three here.", "expected": "Parity fix verification recording number three here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number four here.", "expected": "Parity fix verification recording number four here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number five here.", "expected": "Parity fix verification recording number five here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number six here.", "expected": "Parity fix verification recording number six here.", "category": "realnb", "slice": "realnb"}
+{"input": "Parity fix verification recording number seven here.", "expected": "Parity fix verification recording number seven here.", "category": "realnb", "slice": "realnb"}
 {"input": "Parity Fix Verification Recording Number 8 here.", "expected": "Parity Fix Verification Recording Number 8 here.", "category": "realnb", "slice": "realnb"}
 {"input": "This is a much longer Polish timeout test designed to make the local model think for a very long time about a rambling paragraph full of clauses and asides so that the cold model load plus the reasoning evaluation together exceed the 15 second budget and the per step timeout finally fires as intended.", "expected": "This is a much longer Polish timeout test designed to make the local model think for a very long time about a rambling paragraph full of clauses and asides so that the cold model load plus the reasoning evaluation together exceed the 15 second budget and the per step timeout finally fires as intended.", "category": "realnb", "slice": "realnb"}
 {"input": "But it wouldn't really be something that gives us money back. Or by very small margins. Versus in the country, it's easier because less, you know, dealing with foreign hurdles. This is the preload race test sentence. Depending on where you buy, you could get money back. So I was researching into that and it seems like it's the same. Like I looked into this a year ago as well, but right now the Midwest is the place to buy and Texas, but the Midwest is even better, even less expensive right now. Places like Indianapolis are up and coming, like really growing. Cleveland, Ohio, Columbus, Ohio. I guess Charlotte's already maybe a little past. Thank you. I would say. Houston is good. Houston is really good long term. But depending on what you buy, right? Because property taxes can also be really high. They change every year. But I would be open to like Indianapolis. Then for fun I looked into Miami and Austin. And I was like, Miami would be a lifestyle thing. Like you could make money from it, but it's a lot more to buy in. And it would take years to get it back. But it'd be fun. It's like then at the end you have like a trend a trendy condo in Miami or whatever you're buying. That million dollar home was beautiful. How much million, 10 million? - 10 million. - Beautiful. That's not a million, oh my goodness. So what price range are you looking at? 300k or less.", "expected": "But it wouldn't really be something that gives us money back. Or by very small margins. Versus in the country, it's easier because less, you know, dealing with foreign hurdles. This is the preload race test sentence. Depending on where you buy, you could get money back. So I was researching into that and it seems like it's the same. Like I looked into this a year ago as well, but right now the Midwest is the place to buy and Texas, but the Midwest is even better, even less expensive right now. Places like Indianapolis are up and coming, like really growing. Cleveland, Ohio, Columbus, Ohio. I guess Charlotte's already maybe a little past. Thank you. I would say. Houston is good. Houston is really good long term. But depending on what you buy, right? Because property taxes can also be really high. They change every year. But I would be open to like Indianapolis. Then for fun I looked into Miami and Austin. And I was like, Miami would be a lifestyle thing. Like you could make money from it, but it's a lot more to buy in. And it would take years to get it back. But it'd be fun. It's like then at the end you have like a trend a trendy condo in Miami or whatever you're buying. That million dollar home was beautiful. How much million, 10 million? - 10 million. - Beautiful. That's not a million, oh my goodness. So what price range are you looking at? 300k or less.", "category": "realnb", "slice": "realnb"}
-{"input": "Please read the relevant knowledge files before you work. There's knowledge files for Swift code, knowledge files for everything. So just look through our tier two and tier three doc names so you know when to pull those resources.", "expected": "Please read the relevant knowledge files before you work. There's knowledge files for Swift code, knowledge files for everything. So just look through our tier 2 tier 3 doc names so you know when to pull those resources.", "category": "realnb", "slice": "realnb"}
-{"input": "Yes, go ahead and build grouping in the validated way. For number two, you're good to spend money, no concerns there. For number three, yes, you can go ahead and get started. And for number four, I'm good with labeling, we can always change this later on.", "expected": "Yes, go ahead and build grouping in the validated way. For number 2, you're good to spend money, no concerns there. For number 3, yes, you can go ahead and get started. And for number 4, I'm good with labeling, we can always change this later on.", "category": "realnb", "slice": "realnb"}
-{"input": "We can let this finish, but honestly, you could have probably done this research on your own in five minutes versus these agents now taking probably around 20 minutes to do this work.", "expected": "We can let this finish, but honestly, you could have probably done this research on your own in 5 minutes versus these agents now taking probably around 20 minutes to do this work.", "category": "realnb", "slice": "realnb"}
-{"input": "Walk me through each rule one at a time, why we have it, what purpose it serves, and whether it it's really applicable at a global level or it should be moved to a individual project.", "expected": "Walk me through each rule 1 at a time, why we have it, what purpose it serves, and whether it it's really applicable at a global level or it should be moved to a individual project.", "category": "realnb", "slice": "realnb"}
-{"input": "I feel like this can be summarized into one sentence. Before any cloud spend, please verify with Sarub first. If the plan build with Sorub Calls for using cloud spend, please make sure we validate the amount and approval in the written plan so it's not a blocker.", "expected": "I feel like this can be summarized into 1 sentence. Before any cloud spend, please verify with Sarub first. If the plan build with Sorub Calls for using cloud spend, please make sure we validate the amount and approval in the written plan so it's not a blocker.", "category": "realnb", "slice": "realnb"}
-{"input": "Uh one thing I wanted to add on the listings page. So Seventh Saddle Road, the stage it's actually in is staging your photos. But what it shows is draft. Do we know what the stages we represent on the listings are today?", "expected": "Uh 1 thing I wanted to add on the listings page. So 7th Saddle Road, the stage it's actually in is staging your photos. But what it shows is draft. Do we know what the stages we represent on the listings are today?", "category": "realnb", "slice": "realnb"}
+{"input": "Please read the relevant knowledge files before you work. There's knowledge files for Swift code, knowledge files for everything. So just look through our tier two and tier three doc names so you know when to pull those resources.", "expected": "Please read the relevant knowledge files before you work. There's knowledge files for Swift code, knowledge files for everything. So just look through our tier two and tier three doc names so you know when to pull those resources.", "category": "realnb", "slice": "realnb"}
+{"input": "Yes, go ahead and build grouping in the validated way. For number two, you're good to spend money, no concerns there. For number three, yes, you can go ahead and get started. And for number four, I'm good with labeling, we can always change this later on.", "expected": "Yes, go ahead and build grouping in the validated way. For number two, you're good to spend money, no concerns there. For number three, yes, you can go ahead and get started. And for number four, I'm good with labeling, we can always change this later on.", "category": "realnb", "slice": "realnb"}
+{"input": "We can let this finish, but honestly, you could have probably done this research on your own in five minutes versus these agents now taking probably around 20 minutes to do this work.", "expected": "We can let this finish, but honestly, you could have probably done this research on your own in five minutes versus these agents now taking probably around 20 minutes to do this work.", "category": "realnb", "slice": "realnb"}
+{"input": "Walk me through each rule one at a time, why we have it, what purpose it serves, and whether it it's really applicable at a global level or it should be moved to a individual project.", "expected": "Walk me through each rule one at a time, why we have it, what purpose it serves, and whether it it's really applicable at a global level or it should be moved to a individual project.", "category": "realnb", "slice": "realnb"}
+{"input": "I feel like this can be summarized into one sentence. Before any cloud spend, please verify with Sarub first. If the plan build with Sorub Calls for using cloud spend, please make sure we validate the amount and approval in the written plan so it's not a blocker.", "expected": "I feel like this can be summarized into one sentence. Before any cloud spend, please verify with Sarub first. If the plan build with Sorub Calls for using cloud spend, please make sure we validate the amount and approval in the written plan so it's not a blocker.", "category": "realnb", "slice": "realnb"}
+{"input": "Uh one thing I wanted to add on the listings page. So Seventh Saddle Road, the stage it's actually in is staging your photos. But what it shows is draft. Do we know what the stages we represent on the listings are today?", "expected": "Uh one thing I wanted to add on the listings page. So Seventh Saddle Road, the stage it's actually in is staging your photos. But what it shows is draft. Do we know what the stages we represent on the listings are today?", "category": "realnb", "slice": "realnb"}
 {"input": "Write a quick email to Sarah saying the kickoff move to Friday at 10.", "expected": "Write a quick email to Sarah saying the kickoff move to Friday at 10.", "category": "realnb", "slice": "realnb"}
 {"input": "Give me a polished LinkedIn post announcing that we just shipped version 2.", "expected": "Give me a polished LinkedIn post announcing that we just shipped version 2.", "category": "realnb", "slice": "realnb"}
 {"input": "Write a quick email to Sarah saying the kickoff moved to Friday at 10.", "expected": "Write a quick email to Sarah saying the kickoff moved to Friday at 10.", "category": "realnb", "slice": "realnb"}
 {"input": "Write a quick email to Sarah saying the kickoff move de Friday at 10.", "expected": "Write a quick email to Sarah saying the kickoff move de Friday at 10.", "category": "realnb", "slice": "realnb"}
 {"input": "Write a quick email to Sarah, saying the kickoff moved to Friday at 10.", "expected": "Write a quick email to Sarah, saying the kickoff moved to Friday at 10.", "category": "realnb", "slice": "realnb"}
-{"input": "Compose a short recap of stand-up about the awe three factor for the team.", "expected": "Compose a short recap of stand-up about the awe 3 factor for the team.", "category": "realnb", "slice": "realnb"}
-{"input": "compose a short recap of stand-up about the Aw three factor for the team.", "expected": "compose a short recap of stand-up about the Aw 3 factor for the team.", "category": "realnb", "slice": "realnb"}
-{"input": "Uh I'm just trying to understand w like, is that information stale in the distribution? Was there a old requirement? Um do we need to keep the old cert now like we can get critique whatever requirement of not deleting it was probably a requirement in the past but now that be move it over to Xcode, validate that claim of do we need to hold on to the old one.", "expected": "Uh I'm just trying to understand w like, is that information stale in the distribution? Was there a old requirement? Um do we need to keep the old cert now like we can get critique whatever requirement of not deleting it was probably a requirement in the past but now that be move it over to Xcode, validate that claim of do we need to hold on to the old 1.", "category": "realnb", "slice": "realnb"}
-{"input": "Regarding the current emoji situation we can throw it on the back burner because there's really no easy solution for us. The one idea I had is that we have our classifier or the other deterministic gate that we have reject any changes. Basically it looks if there was an emoji and if the emoji was removed it rejects the prompt and it it fires as raw and then we do m deterministic cleanups.", "expected": "Regarding the current emoji situation we can throw it on the back burner because there's really no easy solution for us. The 1 idea I had is that we have our classifier or the other deterministic gate that we have reject any changes. Basically it looks if there was an emoji and if the emoji was removed it rejects the prompt and it it fires as raw and then we do m deterministic cleanups.", "category": "realnb", "slice": "realnb"}
-{"input": "Or I guess there is the alternative, which is we test to see is adding one sentence to the Apple intelligence prompt sufficient to stop it from removing emojis without degrading the performance.", "expected": "Or I guess there is the alternative, which is we test to see is adding 1 sentence to the Apple intelligence prompt sufficient to stop it from removing emojis without degrading the performance.", "category": "realnb", "slice": "realnb"}
+{"input": "Compose a short recap of stand-up about the awe three factor for the team.", "expected": "Compose a short recap of stand-up about the awe three factor for the team.", "category": "realnb", "slice": "realnb"}
+{"input": "compose a short recap of stand-up about the Aw three factor for the team.", "expected": "compose a short recap of stand-up about the Aw three factor for the team.", "category": "realnb", "slice": "realnb"}
+{"input": "Uh I'm just trying to understand w like, is that information stale in the distribution? Was there a old requirement? Um do we need to keep the old cert now like we can get critique whatever requirement of not deleting it was probably a requirement in the past but now that be move it over to Xcode, validate that claim of do we need to hold on to the old one.", "expected": "Uh I'm just trying to understand w like, is that information stale in the distribution? Was there a old requirement? Um do we need to keep the old cert now like we can get critique whatever requirement of not deleting it was probably a requirement in the past but now that be move it over to Xcode, validate that claim of do we need to hold on to the old one.", "category": "realnb", "slice": "realnb"}
+{"input": "Regarding the current emoji situation we can throw it on the back burner because there's really no easy solution for us. The one idea I had is that we have our classifier or the other deterministic gate that we have reject any changes. Basically it looks if there was an emoji and if the emoji was removed it rejects the prompt and it it fires as raw and then we do m deterministic cleanups.", "expected": "Regarding the current emoji situation we can throw it on the back burner because there's really no easy solution for us. The one idea I had is that we have our classifier or the other deterministic gate that we have reject any changes. Basically it looks if there was an emoji and if the emoji was removed it rejects the prompt and it it fires as raw and then we do m deterministic cleanups.", "category": "realnb", "slice": "realnb"}
+{"input": "Or I guess there is the alternative, which is we test to see is adding one sentence to the Apple intelligence prompt sufficient to stop it from removing emojis without degrading the performance.", "expected": "Or I guess there is the alternative, which is we test to see is adding one sentence to the Apple intelligence prompt sufficient to stop it from removing emojis without degrading the performance.", "category": "realnb", "slice": "realnb"}
 {"input": "I think we would actually start there. So can we update the GitHub issue for the Apple polishing situation? Sorry, the the emoji emission situation. And the idea is we run TTS or even if we can do it without real audio, if we just run text with emojis through AFM, see how many times it emits smiley faces. So we basically push emoji face based text let's take say 300 through AFM and we see how many times it removes it. Then we add a sentence to the prompt and we rerun it and see is it or is it not honoring the emoji and we see the change in performance.", "expected": "I think we would actually start there. So can we update the GitHub issue for the Apple polishing situation? Sorry, the the emoji emission situation. And the idea is we run TTS or even if we can do it without real audio, if we just run text with emojis through AFM, see how many times it emits smiley faces. So we basically push emoji face based text let's take say 300 through AFM and we see how many times it removes it. Then we add a sentence to the prompt and we rerun it and see is it or is it not honoring the emoji and we see the change in performance.", "category": "realnb", "slice": "realnb"}
 {"input": "The next issue I was actually hoping to tackle is making sure our app works best on cold boot ups. I know that was something we had talked about as a step as part of the engine refractor. Do you know what we did there and if our engine is more robust on terms of like first installs or cold boots?", "expected": "The next issue I was actually hoping to tackle is making sure our app works best on cold boot ups. I know that was something we had talked about as a step as part of the engine refractor. Do you know what we did there and if our engine is more robust on terms of like first installs or cold boots?", "category": "realnb", "slice": "realnb"}
 {"input": "Okay, watch out for the PR two seven one. Let me know what's in.", "expected": "Okay, watch out for the PR two seven one. Let me know what's in.", "category": "realnb", "slice": "realnb"}
-{"input": "I would say one, two, three.", "expected": "I would say 1, 2, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "I would say one, two, three.", "expected": "I would say one, two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "Okay, testing one two three four.", "expected": "Okay, testing one two three four.", "category": "realnb", "slice": "realnb"}
-{"input": "Alright, we have a problem. It's rendering two pills at the same time.", "expected": "Alright, we have a problem. It's rendering 2 pills at the same time.", "category": "realnb", "slice": "realnb"}
-{"input": "Alright, we have a problem. It's s rendering two pills at the same time.", "expected": "Alright, we have a problem. It's s rendering 2 pills at the same time.", "category": "realnb", "slice": "realnb"}
+{"input": "Alright, we have a problem. It's rendering two pills at the same time.", "expected": "Alright, we have a problem. It's rendering two pills at the same time.", "category": "realnb", "slice": "realnb"}
+{"input": "Alright, we have a problem. It's s rendering two pills at the same time.", "expected": "Alright, we have a problem. It's s rendering two pills at the same time.", "category": "realnb", "slice": "realnb"}
 {"input": "Testing one two three four five this is Sarb speaking using the new system.", "expected": "Testing one two three four five this is Sarb speaking using the new system.", "category": "realnb", "slice": "realnb"}
-{"input": "Uh one thing I'm noticing there's a quick flicker on launch. Do you know what that is?", "expected": "Uh 1 thing I'm noticing there's a quick flicker on launch. Do you know what that is?", "category": "realnb", "slice": "realnb"}
-{"input": "Testing one, two, three, four, five. This is me testing parakeet.", "expected": "Testing 1, 2, 3, 4, 5. This is me testing parakeet.", "category": "realnb", "slice": "realnb"}
-{"input": "Hello, one, two, three, four.", "expected": "Hello, 1, 2, 3, 4.", "category": "realnb", "slice": "realnb"}
-{"input": "That's the one too far.", "expected": "That's the 1 too far.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing. One, two, three, four.", "expected": "Testing. One, 2, 3, 4.", "category": "realnb", "slice": "realnb"}
-{"input": "Testing, one two, three.", "expected": "Testing, one two, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "Uh one thing I'm noticing there's a quick flicker on launch. Do you know what that is?", "expected": "Uh one thing I'm noticing there's a quick flicker on launch. Do you know what that is?", "category": "realnb", "slice": "realnb"}
+{"input": "Testing one, two, three, four, five. This is me testing parakeet.", "expected": "Testing one, two, three, four, five. This is me testing parakeet.", "category": "realnb", "slice": "realnb"}
+{"input": "Hello, one, two, three, four.", "expected": "Hello, one, two, three, four.", "category": "realnb", "slice": "realnb"}
+{"input": "That's the one too far.", "expected": "That's the one too far.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing. One, two, three, four.", "expected": "Testing. One, two, three, four.", "category": "realnb", "slice": "realnb"}
+{"input": "Testing, one two, three.", "expected": "Testing, one two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "And then mark it as a P0 and I need uh figure out what happened at that time.", "expected": "And then mark it as a P0 and I need uh figure out what happened at that time.", "category": "realnb", "slice": "realnb"}
 {"input": "So that twenty second gap is cycling the preparing dictation window that was running.", "expected": "So that 20 second gap is cycling the preparing dictation window that was running.", "category": "realnb", "slice": "realnb"}
-{"input": "I also want you to look at Super Whisper and I want you to understand how they boot up and how they avoid it. Like they offer multiple engines and polishing solutions and it always works on the first button press. So I would love to understand how they do it.", "expected": "I also want you to look at Super Whisper and I want you to understand how they boot up and how they avoid it. Like they offer multiple engines and polishing solutions and it always works on the 1st button press. So I would love to understand how they do it.", "category": "realnb", "slice": "realnb"}
-{"input": "Because I load Super Whisper now, I guarantee you I can start dictating within two seconds of the app being on. And here you're telling me that we would potentially need to wait a minute", "expected": "Because I load Super Whisper now, I guarantee you I can start dictating within 2 seconds of the app being on. And here you're telling me that we would potentially need to wait a minute", "category": "realnb", "slice": "realnb"}
-{"input": "Testing, testing, one two, three.", "expected": "Testing, testing, one two, 3.", "category": "realnb", "slice": "realnb"}
+{"input": "I also want you to look at Super Whisper and I want you to understand how they boot up and how they avoid it. Like they offer multiple engines and polishing solutions and it always works on the first button press. So I would love to understand how they do it.", "expected": "I also want you to look at Super Whisper and I want you to understand how they boot up and how they avoid it. Like they offer multiple engines and polishing solutions and it always works on the first button press. So I would love to understand how they do it.", "category": "realnb", "slice": "realnb"}
+{"input": "Because I load Super Whisper now, I guarantee you I can start dictating within two seconds of the app being on. And here you're telling me that we would potentially need to wait a minute", "expected": "Because I load Super Whisper now, I guarantee you I can start dictating within two seconds of the app being on. And here you're telling me that we would potentially need to wait a minute", "category": "realnb", "slice": "realnb"}
+{"input": "Testing, testing, one two, three.", "expected": "Testing, testing, one two, three.", "category": "realnb", "slice": "realnb"}
 {"input": "This is what I'm thinking. My concern and what I wanted to validate was that all the telemetry we already have today works. If there's opportunity for additional telemetry, let's go ahead and file those SP2. those as P2. It's just not load-bearing for launch.", "expected": "This is what I'm thinking. My concern and what I wanted to validate was that all the telemetry we already have today works. If there's opportunity for additional telemetry, let's go ahead and file those SP2. Those as P2. It's just not load-bearing for launch.", "category": "realnb", "slice": "realnb"}
-{"input": "Sponsored by Squarespace. Brace yourselves because Sylvanas was right. The jailer's warning is paying off. The Shadowlands actually did mean something, which is rather shocking. And you might be thinking, Michael, have you absolutely lost your mind? Have Blizzard's crack squad of elite men finally got to me and ruined my brain? No. You see, the biggest problem with Shadowlands is how so much of its story was told, and some fundamental things it did reaching back into Warcraft 3 and changing things about. But here's the thing, it happened. The Warcraft verse has to deal with that. And I think Blizzard are doing a good job at taking the cool lore and pulling it forward and kind of just ignoring the stuff that we really didn't like. But what did I mean by any of that? Well, Sylvanus did say the world is a prison. And what did we discover? Well, we discovered Azeroth chained at the center of our planet. That, at least, is all true. According to Blizzard's current campaign to hammer Shadowlands back into Warcraft lore. You may be wondering what the hell I'm talking about? Well pretty simply, it's this. My penance. My true work has only begun, little sister. The Shadowlands are not at all of what they seem. I cannot rest until I've uncovered the truth. Still, I hope to see you both again before the end begins. What the hell is she on about? What is the end beginning? What is the true nature of the Shadowlands? Why does every character have to show up vague post that us and then run away for a bit? Well, Blizzard has clearly set Sylvanus on the trail of another conspiracy, and it's one that goes back to what Madsen said was at the core of the world soul saga, a conspiracy orchestrated by the Titans. Now that's the sort of thing that we've had at least some idea of really since Wrath of the Lich King. And even in the Shadowlands expansion, we were all speculating about Titan involvement because looking around the place, everything did seem to be kind of in their art style. Now, here's the short version. The Titans have totally wrecked how the universe works. They've been going about the place and changing everything to suit their ends. They turned the Shadowlands into a basically a power plant to fuel their ambition of ordering reality. But the problem is doing that had huge consequences, such as death kinda stopped doing its job. It stopped being the final barrier against everything in creation just being consumed by the void. And that is something we're seeing Zalotath pursue literally as we speak in the Midnight Expansion. Now, there is loads to figure out here. This is gonna be a pretty broad video, but I think we can do it together. So many people playing wow, it can be hard to stand out, hard to get the perfect mug. It's a bit like that online. Everyone's online, but the question is, do you look pro or do you look forgettable?", "expected": "Sponsored by Squarespace. Brace yourselves because Sylvanas was right. The jailer's warning is paying off. The Shadowlands actually did mean something, which is rather shocking. And you might be thinking, Michael, have you absolutely lost your mind? Have Blizzard's crack squad of elite men finally got to me and ruined my brain? No. You see, the biggest problem with Shadowlands is how so much of its story was told, and some fundamental things it did reaching back into Warcraft 3 and changing things about. But here's the thing, it happened. The Warcraft verse has to deal with that. And I think Blizzard are doing a good job at taking the cool lore and pulling it forward and kind of just ignoring the stuff that we really didn't like. But what did I mean by any of that? Well, Sylvanus did say the world is a prison. And what did we discover? Well, we discovered Azeroth chained at the center of our planet. That, at least, is all true. According to Blizzard's current campaign to hammer Shadowlands back into Warcraft lore. You may be wondering what the hell I'm talking about? Well pretty simply, it's this. My penance. My true work has only begun, little sister. The Shadowlands are not at all of what they seem. I cannot rest until I've uncovered the truth. Still, I hope to see you both again before the end begins. What the hell is she on about? What is the end beginning? What is the true nature of the Shadowlands? Why does every character have to show up vague post that us and then run away for a bit? Well, Blizzard has clearly set Sylvanus on the trail of another conspiracy, and it's 1 that goes back to what Madsen said was at the core of the world soul saga, a conspiracy orchestrated by the Titans. Now that's the sort of thing that we've had at least some idea of really since Wrath of the Lich King. And even in the Shadowlands expansion, we were all speculating about Titan involvement because looking around the place, everything did seem to be kind of in their art style. Now, here's the short version. The Titans have totally wrecked how the universe works. They've been going about the place and changing everything to suit their ends. They turned the Shadowlands into a basically a power plant to fuel their ambition of ordering reality. But the problem is doing that had huge consequences, such as death kinda stopped doing its job. It stopped being the final barrier against everything in creation just being consumed by the void. And that is something we're seeing Zalotath pursue literally as we speak in the Midnight Expansion. Now, there is loads to figure out here. This is gonna be a pretty broad video, but I think we can do it together. So many people playing wow, it can be hard to stand out, hard to get the perfect mug. It's a bit like that online. Everyone's online, but the question is, do you look pro or do you look forgettable?", "category": "realnb", "slice": "realnb"}
+{"input": "Sponsored by Squarespace. Brace yourselves because Sylvanas was right. The jailer's warning is paying off. The Shadowlands actually did mean something, which is rather shocking. And you might be thinking, Michael, have you absolutely lost your mind? Have Blizzard's crack squad of elite men finally got to me and ruined my brain? No. You see, the biggest problem with Shadowlands is how so much of its story was told, and some fundamental things it did reaching back into Warcraft 3 and changing things about. But here's the thing, it happened. The Warcraft verse has to deal with that. And I think Blizzard are doing a good job at taking the cool lore and pulling it forward and kind of just ignoring the stuff that we really didn't like. But what did I mean by any of that? Well, Sylvanus did say the world is a prison. And what did we discover? Well, we discovered Azeroth chained at the center of our planet. That, at least, is all true. According to Blizzard's current campaign to hammer Shadowlands back into Warcraft lore. You may be wondering what the hell I'm talking about? Well pretty simply, it's this. My penance. My true work has only begun, little sister. The Shadowlands are not at all of what they seem. I cannot rest until I've uncovered the truth. Still, I hope to see you both again before the end begins. What the hell is she on about? What is the end beginning? What is the true nature of the Shadowlands? Why does every character have to show up vague post that us and then run away for a bit? Well, Blizzard has clearly set Sylvanus on the trail of another conspiracy, and it's one that goes back to what Madsen said was at the core of the world soul saga, a conspiracy orchestrated by the Titans. Now that's the sort of thing that we've had at least some idea of really since Wrath of the Lich King. And even in the Shadowlands expansion, we were all speculating about Titan involvement because looking around the place, everything did seem to be kind of in their art style. Now, here's the short version. The Titans have totally wrecked how the universe works. They've been going about the place and changing everything to suit their ends. They turned the Shadowlands into a basically a power plant to fuel their ambition of ordering reality. But the problem is doing that had huge consequences, such as death kinda stopped doing its job. It stopped being the final barrier against everything in creation just being consumed by the void. And that is something we're seeing Zalotath pursue literally as we speak in the Midnight Expansion. Now, there is loads to figure out here. This is gonna be a pretty broad video, but I think we can do it together. So many people playing wow, it can be hard to stand out, hard to get the perfect mug. It's a bit like that online. Everyone's online, but the question is, do you look pro or do you look forgettable?", "expected": "Sponsored by Squarespace. Brace yourselves because Sylvanas was right. The jailer's warning is paying off. The Shadowlands actually did mean something, which is rather shocking. And you might be thinking, Michael, have you absolutely lost your mind? Have Blizzard's crack squad of elite men finally got to me and ruined my brain? No. You see, the biggest problem with Shadowlands is how so much of its story was told, and some fundamental things it did reaching back into Warcraft 3 and changing things about. But here's the thing, it happened. The Warcraft verse has to deal with that. And I think Blizzard are doing a good job at taking the cool lore and pulling it forward and kind of just ignoring the stuff that we really didn't like. But what did I mean by any of that? Well, Sylvanus did say the world is a prison. And what did we discover? Well, we discovered Azeroth chained at the center of our planet. That, at least, is all true. According to Blizzard's current campaign to hammer Shadowlands back into Warcraft lore. You may be wondering what the hell I'm talking about? Well pretty simply, it's this. My penance. My true work has only begun, little sister. The Shadowlands are not at all of what they seem. I cannot rest until I've uncovered the truth. Still, I hope to see you both again before the end begins. What the hell is she on about? What is the end beginning? What is the true nature of the Shadowlands? Why does every character have to show up vague post that us and then run away for a bit? Well, Blizzard has clearly set Sylvanus on the trail of another conspiracy, and it's one that goes back to what Madsen said was at the core of the world soul saga, a conspiracy orchestrated by the Titans. Now that's the sort of thing that we've had at least some idea of really since Wrath of the Lich King. And even in the Shadowlands expansion, we were all speculating about Titan involvement because looking around the place, everything did seem to be kind of in their art style. Now, here's the short version. The Titans have totally wrecked how the universe works. They've been going about the place and changing everything to suit their ends. They turned the Shadowlands into a basically a power plant to fuel their ambition of ordering reality. But the problem is doing that had huge consequences, such as death kinda stopped doing its job. It stopped being the final barrier against everything in creation just being consumed by the void. And that is something we're seeing Zalotath pursue literally as we speak in the Midnight Expansion. Now, there is loads to figure out here. This is gonna be a pretty broad video, but I think we can do it together. So many people playing wow, it can be hard to stand out, hard to get the perfect mug. It's a bit like that online. Everyone's online, but the question is, do you look pro or do you look forgettable?", "category": "realnb", "slice": "realnb"}
 {"input": "Here are my requirements for a standing desk. One, I want it to have an integrated power supply. Two, it should have excellent cable management. Three ideally it is made of high quality wood. Four, it can handle very high amounts of weight and has a really good motor.", "expected": "Here are my requirements for a standing desk. One, I want it to have an integrated power supply. Two, it should have excellent cable management. Three ideally it is made of high quality wood. Four, it can handle very high amounts of weight and has a really good motor.", "category": "realnb", "slice": "realnb"}
 {"input": "We want to just have you take notes right now and then once we get through all eighteen we can take it to the next step.", "expected": "We want to just have you take notes right now and then once we get through all 18 we can take it to the next step.", "category": "realnb", "slice": "realnb"}
-{"input": "For on four twelve should be four dash twelve.", "expected": "For on four twelve should be 4 dash 12.", "category": "realnb", "slice": "realnb"}
-{"input": "Do me a favor look at all eighteen and get a crisp understanding of how all eighteen work today. So this way as we continue to go by each one one by one, I want you to say this is the feature, this is how Supervisper is doing it today. And then I can talk to you about how we want to make enhancements.", "expected": "Do me a favor look at all 18 get a crisp understanding of how all 18 work today. So this way as we continue to go by each one one by 1, I want you to say this is the feature, this is how Supervisper is doing it today. And then I can talk to you about how we want to make enhancements.", "category": "realnb", "slice": "realnb"}
+{"input": "For on four twelve should be four dash twelve.", "expected": "For on four twelve should be four dash 12.", "category": "realnb", "slice": "realnb"}
+{"input": "Do me a favor look at all eighteen and get a crisp understanding of how all eighteen work today. So this way as we continue to go by each one one by one, I want you to say this is the feature, this is how Supervisper is doing it today. And then I can talk to you about how we want to make enhancements.", "expected": "Do me a favor look at all 18 and get a crisp understanding of how all 18 work today. So this way as we continue to go by each one one by one, I want you to say this is the feature, this is how Supervisper is doing it today. And then I can talk to you about how we want to make enhancements.", "category": "realnb", "slice": "realnb"}
 {"input": "Because if that is, then I'm assuming the person who's not saying four forty five but quarter to five probably wants us to write quarter to five.", "expected": "Because if that is, then I'm assuming the person who's not saying four forty five but quarter to five probably wants us to write quarter to five.", "category": "realnb", "slice": "realnb"}
-{"input": "Yeah, we'll probably have to dig in with council more on this one. Kinda think of different variations, how people talk about money, what are the gotchas and then kinda build around that.", "expected": "Yeah, we'll probably have to dig in with council more on this 1. Kinda think of different variations, how people talk about money, what are the gotchas and then kinda build around that.", "category": "realnb", "slice": "realnb"}
+{"input": "Yeah, we'll probably have to dig in with council more on this one. Kinda think of different variations, how people talk about money, what are the gotchas and then kinda build around that.", "expected": "Yeah, we'll probably have to dig in with council more on this one. Kinda think of different variations, how people talk about money, what are the gotchas and then kinda build around that.", "category": "realnb", "slice": "realnb"}
 {"input": "One thing that I want to figure out as we work on this is like we built a classifier that does a really good thing. I don't know if there's like transformers that use the same like machine learning.", "expected": "One thing that I want to figure out as we work on this is like we built a classifier that does a really good thing. I don't know if there's like transformers that use the same like machine learning.", "category": "realnb", "slice": "realnb"}
-{"input": "My phone number is two zero three nine five four eight eight seven nine. Today's date is june second, twenty twenty six. My address is three hundred twenty West thirty eighth Street, New York, New York one zero zero one eight and my website is mbspisper.com", "expected": "My phone number is 203-954-8879. Today's date is june 2nd, 2026. My address is 320 West 38th Street, New York, New York 10018 and my website is mbspisper.com", "category": "realnb", "slice": "realnb"}
-{"input": "Okay, what you need to do is look at the options where the data failed and understand where to implement the fixes. So for example, we notice that Nemo tends to add a zero in front of numbers, that's not good. And then we also notice that um your hand rolled output is adding numbers together, and that's also not good. So what I'm almost thinking is like you need to look where there are failures right for example C section two zero three turned into C section five which is unacceptable like we can't roll that out. But it was fine with the Nemo version. So there's some script language in Nemo that we can keep that is and then there's things in your hand roll that we can keep. So we can kind of create a Frankenstein version that is the best of both worlds.", "expected": "Okay, what you need to do is look at the options where the data failed and understand where to implement the fixes. So for example, we notice that Nemo tends to add a 0 in front of numbers, that's not good. And then we also notice that um your hand rolled output is adding numbers together, and that's also not good. So what I'm almost thinking is like you need to look where there are failures right for example C section 203 turned into C section 5 which is unacceptable like we can't roll that out. But it was fine with the Nemo version. So there's some script language in Nemo that we can keep that is and then there's things in your hand roll that we can keep. So we can kind of create a Frankenstein version that is the best of both worlds.", "category": "realnb", "slice": "realnb"}
+{"input": "My phone number is two zero three nine five four eight eight seven nine. Today's date is june second, twenty twenty six. My address is three hundred twenty West thirty eighth Street, New York, New York one zero zero one eight and my website is mbspisper.com", "expected": "My phone number is 203-954-8879. Today's date is June 2, 2026. My address is 320 West 38th Street, New York, New York 10018 and my website is mbspisper.com", "category": "realnb", "slice": "realnb"}
+{"input": "Okay, what you need to do is look at the options where the data failed and understand where to implement the fixes. So for example, we notice that Nemo tends to add a zero in front of numbers, that's not good. And then we also notice that um your hand rolled output is adding numbers together, and that's also not good. So what I'm almost thinking is like you need to look where there are failures right for example C section two zero three turned into C section five which is unacceptable like we can't roll that out. But it was fine with the Nemo version. So there's some script language in Nemo that we can keep that is and then there's things in your hand roll that we can keep. So we can kind of create a Frankenstein version that is the best of both worlds.", "expected": "Okay, what you need to do is look at the options where the data failed and understand where to implement the fixes. So for example, we notice that Nemo tends to add a zero in front of numbers, that's not good. And then we also notice that um your hand rolled output is adding numbers together, and that's also not good. So what I'm almost thinking is like you need to look where there are failures right for example C section 203 turned into C section five which is unacceptable like we can't roll that out. But it was fine with the Nemo version. So there's some script language in Nemo that we can keep that is and then there's things in your hand roll that we can keep. So we can kind of create a Frankenstein version that is the best of both worlds.", "category": "realnb", "slice": "realnb"}


### PR DESCRIPTION
## What

Switches the deterministic Inverse Text Normalizer (ITN) from "digitize every spoken number" to **AP-style number formatting**: spell out one through nine, use digits for 10+, with always-digit exceptions for money, percent, clock times (am/pm), years, decimals, ages, measurement units, ranges, and ordinals 10th+.

Closes #1187 (the report: sentence-initial spelled-out large numbers like "Nine hundred forty five." passed through untouched — now "945.").

## Why

User feedback: forcing every "one" to "1" reads wrong. AP grammar is what people expect in written text. ITN is the always-on raw-fallback floor that runs *before* AI polish, so getting it grammatically right improves every dictation even when polish is off or unavailable.

## How

- The Swift engine remains a **byte-for-byte mirror of the Python oracle**. Both parity fixtures regenerated to AP outputs: **0/5,916 mismatches**, with 137 curated AP cases baked in as locked regression rows.
- New passes (all extend existing ones, no parallel mechanisms): AP threshold + age/unit digit-forcing in the cardinal pass; compound/scale ordinals; word-level ranges/slash/dimensions; "dot" decimals + leading decimals; money/percent sentence-end boundary + "per cent"; all-caps shout/emphasis handling; hyphen-compound + dosage salvage.

## Validation

- **0 corruption** across the 5,779-row natural-speech corpus; idempotence preserved (1 known-degenerate input, already excluded).
- Methodology: Python bake-off (council-refereed 136-case curated set, 100%) → ported to Swift → grounded review (PROCEED) → 2 rounds of code-diff review (4 edge-case regressions found and fixed: ranges with spoken "and", straight-quote spacing, hyphenated/article title preservation).
- Latency unchanged (sub-millisecond).