### PR TITLE
feat(telemetry): permission posture in launch snapshot + accessibility change event (#1172)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -154,17 +154,6 @@ final class AppLifecycleCoordinator {
         activeRecording: phase.isActive, appPhase: phase.telemetryLabel)
     }
 
-    if settings.onboardingState == .completed {
-      // Telemetry Bible Phase 0 (#1169): the standing settings snapshot now
-      // routes through one named seam (extended by Phase 3/4). Behavior-
-      // preserving — same event, same fields, same launch timing.
-      StandingSnapshotBuilder(
-        settings: settings,
-        keychainManager: keychainManager,
-        customWordsCoordinator: customWordsCoordinator
-      ).emit()
-    }
-
     // Run Apple Intelligence diagnostics via coordinator.
     // Handles: Sentry context, PostHog event, persistence, first-launch re-check.
     let isFreshInstall = settings.onboardingState != .completed
@@ -204,6 +193,22 @@ final class AppLifecycleCoordinator {
 
     // Begin smart polling if Accessibility is not yet granted.
     permissions.startMonitoring()
+
+    if settings.onboardingState == .completed {
+      // Telemetry Bible Phase 0 (#1169) seam, extended by Phase 3 (#1172) with
+      // microphone / Accessibility posture. Emitted AFTER refreshOnLaunch() so
+      // the posture fields reflect the settled launch state — in particular
+      // accessibility_warning_dismissed, which refreshOnLaunch() resets to false
+      // when Accessibility is denied (Codex code-diff review caught the stale
+      // pre-refresh read). The seven pre-existing settings fields are unaffected
+      // by ordering.
+      StandingSnapshotBuilder(
+        settings: settings,
+        keychainManager: keychainManager,
+        customWordsCoordinator: customWordsCoordinator,
+        permissions: permissions
+      ).emit()
+    }
 
     // Pre-warm LLM backend with a real inference request.
     LLMNetworkSession.shared.preWarmModel(

--- a/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
+++ b/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
@@ -16,15 +16,18 @@ struct StandingSnapshotBuilder {
   private let settings: SettingsManager
   private let keychainManager: KeychainManager
   private let customWordsCoordinator: CustomWordsCoordinator
+  private let permissions: PermissionsService
 
   init(
     settings: SettingsManager,
     keychainManager: KeychainManager,
-    customWordsCoordinator: CustomWordsCoordinator
+    customWordsCoordinator: CustomWordsCoordinator,
+    permissions: PermissionsService
   ) {
     self.settings = settings
     self.keychainManager = keychainManager
     self.customWordsCoordinator = customWordsCoordinator
+    self.permissions = permissions
   }
 
   /// Build the current snapshot values and emit `settings.snapshot`.
@@ -40,7 +43,14 @@ struct StandingSnapshotBuilder {
       fillerRemoval: s.fillerRemovalEnabled,
       customWordsCount: customWordsCoordinator.customWords.count,
       hasApiKeys: hasKeys,
-      noiseSuppression: s.noiseSuppression
+      noiseSuppression: s.noiseSuppression,
+      // Phase 3 (#1172): point-in-time microphone / Accessibility posture. A mic
+      // change is only observable across launches (macOS hides an out-of-process
+      // mic toggle from a running app), so the launch snapshot is the one place
+      // it surfaces.
+      microphoneStatus: permissions.microphoneStatusString,
+      accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied",
+      accessibilityWarningDismissed: permissions.accessibilityWarningDismissed
     )
   }
 }

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -31,9 +31,14 @@ public final class PermissionsService {
     !accessibilityGranted && !accessibilityWarningDismissed
   }
 
-  public init() {
+  /// Injected so tests can drive a grant/revoke flip deterministically; defaults
+  /// to the live no-prompt system check in production.
+  private let accessibilityReader: () -> Bool
+
+  public init(accessibilityReader: @escaping () -> Bool = { AXIsProcessTrusted() }) {
+    self.accessibilityReader = accessibilityReader
     microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-    accessibilityGranted = AXIsProcessTrusted()
+    accessibilityGranted = accessibilityReader()
   }
 
   /// Request microphone access. Returns true if granted.
@@ -48,6 +53,18 @@ public final class PermissionsService {
   /// Whether microphone permission has been granted.
   public var hasMicrophonePermission: Bool {
     microphoneStatus == .authorized
+  }
+
+  /// Microphone authorization as a stable, content-free telemetry string.
+  /// Telemetry Bible Phase 3 (#1172): fed into the launch `settings.snapshot`.
+  public var microphoneStatusString: String {
+    switch microphoneStatus {
+    case .authorized: return "authorized"
+    case .denied: return "denied"
+    case .restricted: return "restricted"
+    case .notDetermined: return "not_determined"
+    @unknown default: return "unknown"
+    }
   }
 
   /// Prompt the user to grant Accessibility permission in System Settings.
@@ -69,13 +86,23 @@ public final class PermissionsService {
   /// Detects revocation transitions (granted → revoked) and re-arms the warning.
   public func refreshAccessibilityStatus() {
     let wasGranted = accessibilityGranted
-    let nowGranted = AXIsProcessTrusted()
+    let nowGranted = accessibilityReader()
     accessibilityGranted = nowGranted
+
+    guard wasGranted != nowGranted else { return }
 
     // Revocation detected: re-arm the warning so it shows again.
     if wasGranted && !nowGranted {
       resetAccessibilityWarningDismissal()
     }
+
+    // Telemetry Bible Phase 3 (#1172): record the grant/revoke flip wherever the
+    // app already re-checks (background poll / onboarding / launch / pre-record).
+    // Limb: fire-and-forget metadata only, never blocks the heart path.
+    TelemetryService.shared.permissionStatus(
+      permission: "accessibility",
+      status: nowGranted ? "granted" : "denied",
+      context: "changed")
   }
 
   /// Mark the accessibility warning as dismissed by the user.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -204,6 +204,16 @@ public final class TelemetryService {
   // MARK: - Permissions
 
   public func permissionStatus(permission: String, status: String, context: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "permission.status",
+          stringProps: [
+            "permission": permission,
+            "status": status,
+            "context": context,
+          ]))
+    #endif
     PostHogSDK.shared.capture(
       "permission.status",
       properties: [
@@ -640,7 +650,9 @@ public final class TelemetryService {
   public func settingsSnapshot(
     asrBackend: String, llmProvider: String, recordingMode: String,
     fillerRemoval: Bool, customWordsCount: Int,
-    hasApiKeys: Bool, noiseSuppression: Bool
+    hasApiKeys: Bool, noiseSuppression: Bool,
+    microphoneStatus: String, accessibilityStatus: String,
+    accessibilityWarningDismissed: Bool
   ) {
     #if DEBUG
       testEventHook?(
@@ -650,12 +662,15 @@ public final class TelemetryService {
             "asr_backend": asrBackend,
             "llm_provider": llmProvider,
             "recording_mode": recordingMode,
+            "microphone_status": microphoneStatus,
+            "accessibility_status": accessibilityStatus,
           ],
           intProps: ["custom_words_count": customWordsCount],
           boolProps: [
             "filler_removal": fillerRemoval,
             "has_api_keys": hasApiKeys,
             "noise_suppression": noiseSuppression,
+            "accessibility_warning_dismissed": accessibilityWarningDismissed,
           ]))
     #endif
     PostHogSDK.shared.capture(
@@ -668,6 +683,9 @@ public final class TelemetryService {
         "custom_words_count": customWordsCount,
         "has_api_keys": hasApiKeys,
         "noise_suppression": noiseSuppression,
+        "microphone_status": microphoneStatus,
+        "accessibility_status": accessibilityStatus,
+        "accessibility_warning_dismissed": accessibilityWarningDismissed,
       ])
   }
 

--- a/Tests/EnviousWisprTests/App/StandingSnapshotBuilderTests.swift
+++ b/Tests/EnviousWisprTests/App/StandingSnapshotBuilderTests.swift
@@ -29,10 +29,14 @@ import Testing
       let suite = UserDefaults(suiteName: "StandingSnapshotBuilderTests-\(UUID().uuidString)")!
       let settings = SettingsManager(defaults: suite)
       let customWords = CustomWordsCoordinator()
+      // Phase 3 (#1172): inject a granted Accessibility reader so the posture
+      // field is deterministic; microphone status is the machine's real value.
+      let permissions = PermissionsService(accessibilityReader: { true })
       let builder = StandingSnapshotBuilder(
         settings: settings,
         keychainManager: KeychainManager(),
-        customWordsCoordinator: customWords
+        customWordsCoordinator: customWords,
+        permissions: permissions
       )
 
       let box = EventBox()
@@ -56,6 +60,12 @@ import Testing
       // has_api_keys depends on the machine's Keychain/file backend, so assert
       // presence (not a fixed truth value) to stay deterministic across runs.
       #expect(event.boolProps["has_api_keys"] != nil)
+      // Phase 3 (#1172): permission posture fields.
+      #expect(event.stringProps["accessibility_status"] == "granted")
+      // microphone_status is the machine's real authorization, so assert
+      // presence rather than a fixed value.
+      #expect(event.stringProps["microphone_status"] != nil)
+      #expect(event.boolProps["accessibility_warning_dismissed"] != nil)
     }
   }
 

--- a/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
@@ -1,0 +1,88 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// Telemetry Bible Phase 3 (#1172): `refreshAccessibilityStatus()` emits a
+  /// `permission.status context=changed` event on a real grant/revoke flip, at
+  /// the detection points the app already runs (background poll / onboarding /
+  /// launch / pre-record). The injected `accessibilityReader` drives the flip
+  /// deterministically. Bodies are synchronous (set hook -> flip -> refresh ->
+  /// read -> restore, no await), so the process-global `testEventHook` stays
+  /// flake-immune per swift-patterns RULE: tests-no-process-global-mutable-delegate.
+  @Suite("Permissions service permission.status", .serialized)
+  struct PermissionsServiceTests {
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ event: CapturedTelemetryEvent) { lock.withLock { stored.append(event) } }
+      var events: [CapturedTelemetryEvent] { lock.withLock { stored } }
+    }
+
+    @MainActor
+    @Test("revoke flip emits accessibility/denied/changed and re-arms the warning")
+    func revokeEmitsAndRearms() {
+      var granted = true
+      let svc = PermissionsService(accessibilityReader: { granted })
+      svc.dismissAccessibilityWarning()
+      #expect(svc.accessibilityWarningDismissed == true)
+
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "permission.status" { box.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      granted = false
+      svc.refreshAccessibilityStatus()
+
+      #expect(box.events.count == 1)
+      let event = box.events.first
+      #expect(event?.stringProps["permission"] == "accessibility")
+      #expect(event?.stringProps["status"] == "denied")
+      #expect(event?.stringProps["context"] == "changed")
+      // Revocation re-arms the warning so it shows again.
+      #expect(svc.accessibilityWarningDismissed == false)
+    }
+
+    @MainActor
+    @Test("grant flip emits accessibility/granted/changed")
+    func grantEmits() {
+      var granted = false
+      let svc = PermissionsService(accessibilityReader: { granted })
+
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "permission.status" { box.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      granted = true
+      svc.refreshAccessibilityStatus()
+
+      #expect(box.events.count == 1)
+      #expect(box.events.first?.stringProps["status"] == "granted")
+      #expect(box.events.first?.stringProps["context"] == "changed")
+    }
+
+    @MainActor
+    @Test("no state change emits nothing (idempotent)")
+    func noChangeNoEmit() {
+      let svc = PermissionsService(accessibilityReader: { true })
+
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "permission.status" { box.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // No flip: state stays granted across repeated refreshes.
+      svc.refreshAccessibilityStatus()
+      svc.refreshAccessibilityStatus()
+
+      #expect(box.events.isEmpty)
+    }
+  }
+
+#endif


### PR DESCRIPTION
## Telemetry Bible Phase 3 (#1172) — permission posture (minimal)

**Goal:** so we can read our own analytics and tell whether a stalled user had the microphone or Accessibility turned off, vs just lost interest. Today `permission.status` only fires on our in-app request, and the launch snapshot carries no permission state — Accessibility shows a 90d `granted=1, denied=40` artifact (request-time-only capture).

**Observability only. Zero behavior change. Nothing new on the recording path beyond a fire-and-forget emit that rides existing detection.**

### What changed
- **`settings.snapshot`** now carries `microphone_status` (`authorized`/`denied`/`restricted`/`not_determined`), `accessibility_status` (`granted`/`denied`), `accessibility_warning_dismissed` (Bool). This is the standing posture record — a microphone change is visible only across launches, because macOS hides an out-of-process mic toggle from a running app. Emitted after `refreshOnLaunch()` so the posture reflects settled launch state.
- **`permission.status context=changed`** is emitted from inside the existing `refreshAccessibilityStatus()` flip detection (binary grant compare, idempotent) — it fires wherever the app already re-checks (background poll / onboarding / launch / pre-record), so an Accessibility revocation is recorded the moment the user next tries to dictate. Accessibility only (mic isn't in-session-observable).
- **`permission.status` DEBUG test hook** so the emit is unit-testable.

### What it deliberately does NOT do
No proactive/activate-time re-check, no microphone in-session detection, no cross-session persistence, no new permission prompt, no change to app behavior or recording-path control flow. (An earlier broader draft added those; founder caught the scope drift and it was re-scoped to observability-only.)

### Scope decisions
- Microphone posture lives only in the launch snapshot (OS limitation documented), not as an in-session transition event.
- Accessibility detection stays reactive (caught at pre-record / next launch), matching current app behavior — no proactive watcher added.
- `permission.status.status` stays binary across all contexts; existing prompt-outcome dashboards filter `context = 'request'`.
- Competitive check: SuperWhisper 2.16.1 binary ships Sentry + Sparkle only, no product-analytics SDK, no permission-posture funnel — this isn't table-stakes a competitor invests in, which informed keeping it minimal.

### Validation
- Logic tests: full suite green (2022 tests). New `PermissionsServiceTests` (revoke / grant / no-change-idempotent, via injected reader); `StandingSnapshotBuilderTests` extended for the 3 posture fields.
- Plan: council (GPT + Gemini) coverage + Codex grounded review (PROCEED-AS-PLANNED). Codex code-diff review clean after fixing one ordering finding (snapshot now emits after the launch permission refresh).
- Live UAT (dev build): smoke (launched clean, no crash); heart path intact (pipeline complete 1.366s — ASR 0.082 / polish 0.957 / paste 0.282 — plus a real-human dictation by the founder transcribed + delivered cleanly on this build); no permission prompt fired. **`settings.snapshot` posture fields confirmed in PostHog** (dev launch event: `microphone_status=authorized`, `accessibility_status=granted`, `accessibility_warning_dismissed=false`). The `permission.status context=changed` emit on an Accessibility flip is covered by unit tests (revoke/grant/idempotent) + the flip-detection + banner behavior is unchanged from the shipped app; a live TCC revoke was not run to avoid disrupting the dev-bundle grant (re-grant requires manual System Settings interaction).

Closes #1172.