### PR TITLE
feat(telemetry): config + API-key visibility (Telemetry Bible Phase 4, #1173)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -44,7 +44,7 @@ final class BackendMetadata {
 
   var llmLabel: String {
     guard settings.llmProvider != .none else { return "LLM Deactivated" }
-    let model = settings.llmProvider == .ollama ? settings.ollamaModel : settings.llmModel
+    let model = settings.effectiveLLMModel  // #1173: single source of truth
     if model.isEmpty { return settings.llmProvider.displayName }
     if let info = llmDiscovery.discoveredModels.first(where: { $0.id == model }) {
       return info.displayName

--- a/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationSessionConfigFactory.swift
@@ -41,13 +41,9 @@ enum DictationSessionConfigFactory {
     // the cascade entirely (TranscriptFinalizer:143 direct copyToClipboard),
     // depriving AX-denied users of both the diagnostic and the toast.
     let autoPaste = activePipelineIdle
-    let resolvedModel: String = {
-      switch settings.llmProvider {
-      case .appleIntelligence: return "apple-intelligence"
-      case .ollama: return settings.ollamaModel
-      default: return settings.llmModel
-      }
-    }()
+    // #1173: the single source of truth for the effective model (was an inline
+    // switch here; now shared with the settings telemetry projection).
+    let resolvedModel = settings.effectiveLLMModel
     return DictationSessionConfig(
       autoCopyToClipboard: settings.autoCopyToClipboard,
       inputMode: settings.recordingMode,

--- a/Sources/EnviousWisprAppKit/App/LLMModelDiscoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LLMModelDiscoveryCoordinator.swift
@@ -31,7 +31,12 @@ final class LLMModelDiscoveryCoordinator {
 
   /// Validate an API key and discover available models for the given provider.
   /// Pass `settings` to auto-correct model selection if the current model is unavailable.
-  func validateKeyAndDiscoverModels(provider: LLMProvider, settings: SettingsManager) async {
+  /// `source` (#1173) tags which user action drove the pass for telemetry; the
+  /// six refresh / provider-switch call sites take the default.
+  func validateKeyAndDiscoverModels(
+    provider: LLMProvider, settings: SettingsManager,
+    source: ApiKeyValidationSource = .modelDiscovery
+  ) async {
     keyValidationState = .validating
     isDiscoveringModels = true
 
@@ -42,6 +47,8 @@ final class LLMModelDiscoveryCoordinator {
       let keychainId =
         provider == .openAI ? KeychainManager.openAIKeyID : KeychainManager.geminiKeyID
       guard let key = try? keychainManager.retrieve(key: keychainId), !key.isEmpty else {
+        // Missing-key guard: no validation actually ran, so NO
+        // `api_key.validation_completed` event (#1173).
         keyValidationState = .invalid("No API key found")
         isDiscoveringModels = false
         return
@@ -57,6 +64,7 @@ final class LLMModelDiscoveryCoordinator {
         cacheModels(models, for: provider)
       }
       keyValidationState = .valid
+      emitValidationCompleted(provider: provider, result: "valid", source: source)
 
       settings.applyDiscoveredModels(models, for: provider)
     } catch LLMError.providerUnavailable {
@@ -66,15 +74,31 @@ final class LLMModelDiscoveryCoordinator {
           : "Apple Intelligence not available on this system."
       )
       discoveredModels = []
+      emitValidationCompleted(provider: provider, result: "provider_unavailable", source: source)
     } catch let error as LLMError where error == .invalidAPIKey {
       keyValidationState = .invalid("Invalid API key")
       discoveredModels = []
+      emitValidationCompleted(provider: provider, result: "invalid", source: source)
     } catch {
       keyValidationState = .invalid(error.localizedDescription)
       discoveredModels = []
+      emitValidationCompleted(provider: provider, result: "error", source: source)
     }
 
     isDiscoveringModels = false
+  }
+
+  /// #1173: emit `api_key.validation_completed` for a terminal validation result.
+  /// Provider identity only — never the key. Gated to OpenAI/Gemini (Codex r2):
+  /// Ollama and Apple Intelligence are keyless local providers, so their
+  /// discovery outcome is NOT an API-key validation and must stay out of the
+  /// `api_key.*` metrics.
+  private func emitValidationCompleted(
+    provider: LLMProvider, result: String, source: ApiKeyValidationSource
+  ) {
+    guard provider == .openAI || provider == .gemini else { return }
+    TelemetryService.shared.apiKeyValidationCompleted(
+      provider: provider.rawValue, result: result, source: source.rawValue)
   }
 
   /// Load cached models from UserDefaults for the given provider.

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -74,7 +74,7 @@ final class PipelineSettingsSync {
 
     // #295: seed eviction tracker. No initial eviction on app launch.
     lastEvictableOllamaModel = OllamaConnector.effectiveOllamaModel(
-      provider: settings.llmProvider, model: resolvedModel(settings)
+      provider: settings.llmProvider, model: settings.effectiveLLMModel
     )
 
     // #728: AppLogger defaults to debug=off / level=.info. Sync the persisted
@@ -182,23 +182,13 @@ final class PipelineSettingsSync {
     }
   }
 
-  /// Resolve the effective LLM model ID for the current provider.
-  /// Apple Intelligence has a fixed model; Ollama uses its own model field.
-  private func resolvedModel(_ settings: SettingsManager) -> String {
-    switch settings.llmProvider {
-    case .appleIntelligence: return "apple-intelligence"
-    case .ollama: return settings.ollamaModel
-    default: return settings.llmModel
-    }
-  }
-
   // MARK: - Ollama eviction on swap (#295)
 
   /// Fires best-effort unload when the tracked previous Ollama model differs
   /// from the new one. Also coalesces cascading .llmModel → .ollamaModel fires.
   private func reconcileOllamaEviction(settings: SettingsManager) {
     let new = OllamaConnector.effectiveOllamaModel(
-      provider: settings.llmProvider, model: resolvedModel(settings)
+      provider: settings.llmProvider, model: settings.effectiveLLMModel
     )
     let pre = lastEvictableOllamaModel
     guard let pre, pre != new else {

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -138,13 +138,8 @@ final class RecoveryCoordinator {
     let recoverySessionID = UUID().uuidString
     let keyData = RecoveryKeyStore.makeKey()
 
-    let resolvedModel: String = {
-      switch settings.llmProvider {
-      case .appleIntelligence: return "apple-intelligence"
-      case .ollama: return settings.ollamaModel
-      default: return settings.llmModel
-      }
-    }()
+    // #1173: single source of truth for the effective model.
+    let resolvedModel = settings.effectiveLLMModel
     let snapshot = RecordingSettingsSnapshot(
       backendType: backendType,
       backendSupportsLanguageDetection: supportsLanguageDetection,

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -1,0 +1,369 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+
+/// Telemetry Bible Phase 4 (#1173): the privacy projection shared by the
+/// baseline `settings.snapshot` (its comprehensive `config` block) and the
+/// per-change `settings.changed` deltas. ONE source of the projected value
+/// vocabulary so the holistic per-user config reconstructs cleanly query-side
+/// (baseline overlaid with subsequent deltas). No raw model strings, key codes,
+/// or locked language codes ever leave memory.
+enum SettingsProjection {
+  /// Every user-facing logical setting that gets a `settings.changed` delta.
+  /// Excludes the Phase-2-owned backend, dev-only knobs (debug mode/level),
+  /// device overrides, the deprecated WhisperKit language, the uninstrumented
+  /// `ollamaModel` mirror, the cold XPC knob, and lifecycle/onboarding state.
+  enum Logical: String, CaseIterable {
+    case recordingMode = "recording_mode"
+    case llmProvider = "llm_provider"
+    case llmModel = "llm_model"
+    case autoCopy = "auto_copy"
+    case hotkeyEnabled = "hotkey_enabled"
+    case vadAutoStop = "vad_auto_stop"
+    case vadSilenceTimeout = "vad_silence_timeout"
+    case vadSensitivity = "vad_sensitivity"
+    case vadEnergyGate = "vad_energy_gate"
+    case modelUnloadPolicy = "model_unload_policy"
+    case restoreClipboard = "restore_clipboard"
+    case wordCorrection = "word_correction"
+    case fillerRemoval = "filler_removal"
+    case contactsSync = "contacts_sync"
+    case emojiFormatter = "emoji_formatter"
+    case crashRecovery = "crash_recovery"
+    case useExtendedThinking = "use_extended_thinking"
+    case languageMode = "language_mode"
+    case streamingASR = "streaming_asr"
+    case warmEnginePolicy = "warm_engine_policy"
+    case appearance = "appearance"
+    case toggleHotkeyShape = "toggle_hotkey_shape"
+    case pushToTalkHotkeyShape = "push_to_talk_hotkey_shape"
+    case cancelHotkeyShape = "cancel_hotkey_shape"
+  }
+
+  /// Logicals whose underlying control is a slider; they earn the longer
+  /// debounce so a drag collapses to one bucketed delta.
+  static let sliderLogicals: Set<Logical> = [.vadSilenceTimeout, .vadSensitivity]
+
+  /// Map a raw `SettingKey` to its logical setting; nil = not instrumented.
+  /// Each hotkey role groups its keyCode + modifiers keys into one shape logical
+  /// (so a key+modifier reassignment is one delta, never two).
+  static func logical(for key: SettingsManager.SettingKey) -> Logical? {
+    switch key {
+    case .recordingMode: return .recordingMode
+    case .llmProvider: return .llmProvider
+    // #1173: both the cloud `llmModel` and the local `ollamaModel` feed the one
+    // `llm_model` logical — the projection reads the EFFECTIVE model
+    // (`SettingsManager.effectiveLLMModel`, ollama→ollamaModel else llmModel), so
+    // a mirror/discovery write to either field re-emits. Coalescing-by-logical
+    // collapses a `.llmModel`+`.ollamaModel` pair (the Ollama mirror) into ONE
+    // delta. (Codex r7 pivot.)
+    case .llmModel, .ollamaModel: return .llmModel
+    case .autoCopyToClipboard: return .autoCopy
+    case .hotkeyEnabled: return .hotkeyEnabled
+    case .vadAutoStop: return .vadAutoStop
+    case .vadSilenceTimeout: return .vadSilenceTimeout
+    case .vadSensitivity: return .vadSensitivity
+    case .vadEnergyGate: return .vadEnergyGate
+    case .modelUnloadPolicy: return .modelUnloadPolicy
+    case .restoreClipboardAfterPaste: return .restoreClipboard
+    case .wordCorrectionEnabled: return .wordCorrection
+    case .fillerRemovalEnabled: return .fillerRemoval
+    case .contactsSyncOnLaunchEnabled: return .contactsSync
+    case .emojiFormatterEnabled: return .emojiFormatter
+    case .crashRecoveryEnabled: return .crashRecovery
+    case .useExtendedThinking: return .useExtendedThinking
+    case .languageMode: return .languageMode
+    case .useStreamingASR: return .streamingASR
+    case .warmEnginePolicy: return .warmEnginePolicy
+    case .appearance: return .appearance
+    case .toggleKeyCode, .toggleModifiers: return .toggleHotkeyShape
+    case .pushToTalkKeyCode, .pushToTalkModifiers: return .pushToTalkHotkeyShape
+    case .cancelKeyCode, .cancelModifiers: return .cancelHotkeyShape
+    // Not instrumented.
+    case .selectedBackend, .onboardingState, .hasCompletedOnboarding,
+      .isDebugModeEnabled, .debugLogLevel, .whisperKitLanguage, .selectedInputDeviceUID,
+      .noiseSuppression, .preferredInputDeviceIDOverride, .useXPCAudioService:
+      return nil
+    }
+  }
+
+  /// Project one logical to its privacy-safe emitted value, reading the current
+  /// state from `settings`.
+  @MainActor
+  static func value(for logical: Logical, settings: SettingsManager) -> String {
+    switch logical {
+    case .recordingMode: return settings.recordingMode.rawValue
+    case .llmProvider: return settings.llmProvider.rawValue
+    case .llmModel: return model(settings)
+    case .autoCopy: return onOff(settings.autoCopyToClipboard)
+    case .hotkeyEnabled: return onOff(settings.hotkeyEnabled)
+    case .vadAutoStop: return onOff(settings.vadAutoStop)
+    case .vadSilenceTimeout: return silenceTimeout(settings.vadSilenceTimeout)
+    case .vadSensitivity: return sensitivityBucket(settings.vadSensitivity)
+    case .vadEnergyGate: return onOff(settings.vadEnergyGate)
+    case .modelUnloadPolicy: return settings.modelUnloadPolicy.rawValue
+    case .restoreClipboard: return onOff(settings.restoreClipboardAfterPaste)
+    case .wordCorrection: return onOff(settings.wordCorrectionEnabled)
+    case .fillerRemoval: return onOff(settings.fillerRemovalEnabled)
+    case .contactsSync: return onOff(settings.contactsSyncOnLaunchEnabled)
+    case .emojiFormatter: return onOff(settings.emojiFormatterEnabled)
+    case .crashRecovery: return onOff(settings.crashRecoveryEnabled)
+    case .useExtendedThinking: return onOff(settings.useExtendedThinking)
+    case .languageMode: return languageModeLabel(settings.languageMode)
+    case .streamingASR: return onOff(settings.useStreamingASR)
+    case .warmEnginePolicy: return settings.warmEnginePolicy.rawValue
+    case .appearance: return settings.appearancePreference.rawValue
+    case .toggleHotkeyShape: return hotkeyShape(settings.toggleKeyCode)
+    case .pushToTalkHotkeyShape: return hotkeyShape(settings.pushToTalkKeyCode)
+    case .cancelHotkeyShape: return hotkeyShape(settings.cancelKeyCode)
+    }
+  }
+
+  /// The comprehensive `config` block for `settings.snapshot` — every instrumented
+  /// logical EXCEPT the three already emitted as dedicated typed snapshot fields
+  /// (`recording_mode`, `llm_provider`, `filler_removal`), so keys never collide.
+  @MainActor
+  static func snapshotConfig(_ settings: SettingsManager) -> [String: String] {
+    let typed: Set<Logical> = [.recordingMode, .llmProvider, .fillerRemoval]
+    var out: [String: String] = [:]
+    for logical in Logical.allCases where !typed.contains(logical) {
+      out[logical.rawValue] = value(for: logical, settings: settings)
+    }
+    return out
+  }
+
+  // MARK: - Field projections
+
+  private static func onOff(_ v: Bool) -> String { v ? "on" : "off" }
+
+  /// Project the EFFECTIVE model (`SettingsManager.effectiveLLMModel` — the same
+  /// value the runtime uses) DENY-BY-DEFAULT: a model id is emitted only when it
+  /// is on a known-safe allowlist, otherwise `custom`. This makes a private local
+  /// model name impossible to leak regardless of the brief provider/model lag
+  /// after a switch (Codex r7 pivot):
+  /// - Ollama: the SHIPPED catalog only (canonicalized). The user's own pulled
+  ///   models are NOT an allowlist — a private finetune name collapses to `custom`.
+  /// - OpenAI / Gemini: a curated set of known public cloud ids (date-snapshot
+  ///   suffix normalized away). A stale local id carried over before discovery
+  ///   corrects `llmModel` is not on this list → `custom`, never the raw name.
+  @MainActor
+  private static func model(_ settings: SettingsManager) -> String {
+    let id = settings.effectiveLLMModel
+    switch settings.llmProvider {
+    case .appleIntelligence: return "apple-intelligence"
+    case .none: return "none"
+    case .ollama:
+      let canonical = OllamaSetupService.canonicalModelName(id)
+      let catalog = Set(
+        OllamaSetupService.modelCatalog.map { OllamaSetupService.canonicalModelName($0.name) })
+      return catalog.contains(canonical) ? canonical : "custom"
+    case .openAI, .gemini:
+      let base = stripDateSnapshotSuffix(id)
+      return cloudModelAllowlist.contains(base) ? base : "custom"
+    }
+  }
+
+  /// Curated known PUBLIC cloud model ids (OpenAI + Gemini). Deny-by-default
+  /// anchor: anything not here is `custom`, so no private/unknown string leaks.
+  /// Trade-off: a brand-new public model not yet listed reads `custom` until
+  /// added (itself a useful "on an unrecognized model" signal). Seeded from the
+  /// shipped defaults + the families the discovery filters accept
+  /// (`LLMModelDiscovery`: gpt-/o1/o3/o4, gemini-).
+  private static let cloudModelAllowlist: Set<String> = [
+    // OpenAI
+    "gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-4.1", "gpt-4.1-mini",
+    "gpt-4.1-nano", "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro",
+    "o1", "o1-mini", "o1-preview", "o3", "o3-mini", "o4-mini", "chatgpt-4o-latest",
+    // Gemini
+    "gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.5-flash-8b",
+    "gemini-2.0-flash", "gemini-2.0-flash-lite",
+    "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+  ]
+
+  /// Strip a trailing `-YYYY-MM-DD` provider date-snapshot suffix so dated
+  /// variants (`gpt-5-mini-2025-08-07`) match their base allowlist entry. The
+  /// suffix is public/non-sensitive; this only collapses cardinality.
+  private static func stripDateSnapshotSuffix(_ id: String) -> String {
+    guard
+      let r = id.range(
+        of: "-[0-9]{4}-[0-9]{2}-[0-9]{2}$", options: .regularExpression)
+    else { return id }
+    return String(id[..<r.lowerBound])
+  }
+
+  private static func languageModeLabel(_ mode: LanguageMode) -> String {
+    switch mode {
+    case .auto: return "auto"
+    case .locked: return "locked"  // mode only, never the language code
+    }
+  }
+
+  /// Modifier-only trigger (e.g. right Option alone) vs a regular-key chord.
+  /// Never the keys themselves — a chord→chord reassignment is a projected no-op.
+  private static func hotkeyShape(_ keyCode: UInt16) -> String {
+    ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
+  }
+
+  private static func sensitivityBucket(_ v: Float) -> String {
+    switch v {
+    case ..<0.34: return "low"
+    case ..<0.67: return "medium"
+    default: return "high"
+    }
+  }
+
+  /// Already low-cardinality (0.5–3.0, stepped by 0.25); emit the stepped value.
+  private static func silenceTimeout(_ v: Double) -> String {
+    String(format: "%.2f", v)
+  }
+}
+
+/// Telemetry Bible Phase 4 (#1173): observes the single `SettingsManager.onChange`
+/// funnel, classifies each change's source, coalesces a burst into one truthful
+/// delta per logical setting, and emits `settings.changed`. Also fires the
+/// comprehensive baseline at onboarding-completion (the first-run gap). A limb:
+/// it never throws or awaits in the setter path; the debounce is emission
+/// coalescing on an already-observed change, not a watcher. Held as an
+/// app-lifetime `let` on `WisprBootstrapper` (a weak-only hold would dealloc and
+/// silently stop emitting).
+@MainActor
+final class SettingsChangeTelemetry {
+  private let settings: SettingsManager
+  private let emitBaseline: @MainActor () -> Void
+  private let toggleWindow: Duration
+  private let sliderWindow: Duration
+
+  /// Last emitted (or seeded) projected value per logical — the `from` source.
+  private var committedBaseline: [SettingsProjection.Logical: String] = [:]
+  /// Value at the start of the in-flight burst, set once per window per logical.
+  private var pendingOriginal: [SettingsProjection.Logical: String] = [:]
+  /// Burst source per logical (system iff every contributing write was system).
+  private var pendingSource: [SettingsProjection.Logical: Source] = [:]
+  private var settleTask: Task<Void, Never>?
+
+  enum Source: String { case user, system }
+
+  init(
+    settings: SettingsManager,
+    emitBaseline: @escaping @MainActor () -> Void,
+    toggleWindow: Duration = .milliseconds(500),
+    sliderWindow: Duration = .seconds(1)
+  ) {
+    self.settings = settings
+    self.emitBaseline = emitBaseline
+    self.toggleWindow = toggleWindow
+    self.sliderWindow = sliderWindow
+    // Seed the committed baseline so the first post-launch change emits a
+    // truthful `from`. Constructed after `SettingsManager.init` (whose writes
+    // fire before the funnel is wired), so these reads are the launch state.
+    seedBaseline()
+  }
+
+  /// Snapshot every logical's current projected value into `committedBaseline`.
+  /// Used at construction (launch) and after the onboarding-completion baseline
+  /// so the committed `from` always matches the most recently emitted snapshot.
+  private func seedBaseline() {
+    for logical in SettingsProjection.Logical.allCases {
+      committedBaseline[logical] = SettingsProjection.value(for: logical, settings: settings)
+    }
+  }
+
+  /// The funnel entry: every `SettingsManager.onChange(key)` routes here.
+  func handle(_ key: SettingsManager.SettingKey) {
+    // Onboarding completion → emit the comprehensive baseline once. Fixes the
+    // first-run gap: a fresh user who finishes setup and keeps the app open has
+    // no launch snapshot until the next relaunch. `onboardingState` is otherwise
+    // not an instrumented setting.
+    if key == .onboardingState {
+      if settings.onboardingState == .completed {
+        emitBaseline()
+        // Re-sync to the just-emitted snapshot. Onboarding suppression updates
+        // committedBaseline only for the logical whose key fired — a DERIVED
+        // projection (e.g. `llm_model` after an onboarding provider switch with
+        // no model write) would otherwise stay stale and make a later real
+        // delta look like a no-op, drifting reconstruction off the snapshot
+        // (Codex r4). Clear any straggler and re-seed every logical.
+        settleTask?.cancel()
+        settleTask = nil
+        pendingOriginal.removeAll()
+        pendingSource.removeAll()
+        seedBaseline()
+      }
+      return
+    }
+    guard let logical = SettingsProjection.logical(for: key) else { return }
+
+    // Suppress onboarding-time writes (the onboarding-completion baseline
+    // captures the final state); keep the committed baseline current so the
+    // first real post-onboarding change has a truthful `from`.
+    if settings.onboardingState != .completed {
+      committedBaseline[logical] = SettingsProjection.value(for: logical, settings: settings)
+      pendingOriginal[logical] = nil
+      pendingSource[logical] = nil
+      return
+    }
+
+    let source: Source = settings.isApplyingSystemWrite ? .system : .user
+    enqueue(logical, source: source)
+    // `llm_model`'s projection also depends on `llmProvider` (cloud id vs Ollama
+    // catalog vs `none`/`apple-intelligence`), so a provider change can alter the
+    // projected model even with NO `llmModel` write — e.g. turning polish off →
+    // `none`. Refresh it so reconstruction never holds a stale model. The flush
+    // no-op check drops it when the projection is unchanged (e.g. OpenAI → Gemini
+    // keeping a cloud id). The provider switch is a user gesture, so this enqueues
+    // `user`; if async discovery then corrects the model inside the same window,
+    // last-writer-wins re-stamps it `system` (Codex r6).
+    if logical == .llmProvider {
+      enqueue(.llmModel, source: source)
+    }
+    scheduleSettle()
+  }
+
+  /// Stage a pending delta for `logical`. The burst ORIGIN (committed baseline)
+  /// is fixed once per window; the SOURCE is last-writer-wins — it always tracks
+  /// the most recent write, so a coalesced delta reports the provenance of the
+  /// FINAL value in `to`. This is the unifying rule for `llm_model`, whose value
+  /// can be set in one window by a user pick, a provider-switch canonicalization
+  /// (user gesture), or an async `applyDiscoveredModels` correction (system):
+  /// whichever wrote last owns the source (Codex r5/r6).
+  private func enqueue(_ logical: SettingsProjection.Logical, source: Source) {
+    if pendingOriginal[logical] == nil {
+      pendingOriginal[logical] =
+        committedBaseline[logical] ?? SettingsProjection.value(for: logical, settings: settings)
+    }
+    pendingSource[logical] = source
+  }
+
+  /// Emit one coalesced delta per pending logical (net no-op bursts skipped) and
+  /// advance the committed baseline. Invoked by the debounce timer in production;
+  /// tests call it directly — the debounce delay is not a SUT measurement, so no
+  /// clock seam is needed (`tests-no-real-time-scheduling-precision`).
+  func flush() {
+    settleTask?.cancel()
+    settleTask = nil
+    let pending = pendingOriginal
+    let sources = pendingSource
+    pendingOriginal.removeAll()
+    pendingSource.removeAll()
+    for (logical, original) in pending {
+      let latest = SettingsProjection.value(for: logical, settings: settings)
+      guard latest != original else { continue }  // net no-op (A→B→A)
+      TelemetryService.shared.settingsChanged(
+        setting: logical.rawValue, from: original, to: latest,
+        source: (sources[logical] ?? .user).rawValue)
+      committedBaseline[logical] = latest
+    }
+  }
+
+  private func scheduleSettle() {
+    settleTask?.cancel()
+    let hasSlider = pendingOriginal.keys.contains { SettingsProjection.sliderLogicals.contains($0) }
+    let window = hasSlider ? sliderWindow : toggleWindow
+    settleTask = Task { [weak self] in
+      try? await Task.sleep(for: window)
+      guard !Task.isCancelled else { return }
+      self?.flush()
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
+++ b/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
@@ -4,13 +4,16 @@ import EnviousWisprServices
 /// Telemetry Bible Phase 0 (#1169): the single home that builds and emits the
 /// standing settings/permission snapshot.
 ///
-/// Today it emits the launch-time `settings.snapshot` — a behavior-preserving
-/// extraction of the former inline block in `AppLifecycleCoordinator`
-/// (identical event, identical seven fields, identical launch timing). Phase 3
-/// (#1172) extends it with microphone / Accessibility posture; Phase 4 (#1173)
-/// adds the debounced change-driven re-emit. Telemetry is a limb: this never
-/// throws and must not block launch — Keychain reads stay `try?`-guarded so a
-/// read failure degrades to `hasApiKeys = false` exactly as before.
+/// It emits `settings.snapshot` — a comprehensive baseline of every user-facing
+/// setting (Phase 4 #1173), projected privacy-safe via `SettingsProjection`. The
+/// ten pre-existing fields stay byte-identical (Phase 0/3 contract); the rest
+/// ride in the `config` block. Emitted at launch (`AppLifecycleCoordinator`) AND
+/// at onboarding-completion (via the settings funnel), so a long-running app
+/// that rarely relaunches still has a current per-user baseline that the
+/// `settings.changed` deltas overlay. Phase 3 (#1172) added microphone /
+/// Accessibility posture. Telemetry is a limb: this never throws and must not
+/// block launch — Keychain reads stay `try?`-guarded so a read failure degrades
+/// to `hasApiKeys = false` exactly as before.
 @MainActor
 struct StandingSnapshotBuilder {
   private let settings: SettingsManager
@@ -50,7 +53,10 @@ struct StandingSnapshotBuilder {
       // it surfaces.
       microphoneStatus: permissions.microphoneStatusString,
       accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied",
-      accessibilityWarningDismissed: permissions.accessibilityWarningDismissed
+      accessibilityWarningDismissed: permissions.accessibilityWarningDismissed,
+      // Phase 4 (#1173): the comprehensive per-setting projection block (all
+      // other user-facing settings) for query-side holistic reconstruction.
+      config: SettingsProjection.snapshotConfig(s)
     )
   }
 }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -61,6 +61,11 @@ public final class WisprBootstrapper {
   /// live-dictation `LLMPolishStep`s pick it up once ready.
   let outputClassifierHolder: OutputClassifierHolder
 
+  /// Telemetry Bible Phase 4 (#1173). Observes the settings funnel for coalesced
+  /// `settings.changed` deltas + the onboarding-completion baseline. Held
+  /// app-lifetime (a weak-only hold would dealloc and silently stop emitting).
+  let settingsChangeTelemetry: SettingsChangeTelemetry
+
   public init() {
     // ===== Subsystem construction (epic #763) =====
     // `EnviousWisprApp` is the composition root: every subsystem is constructed
@@ -245,9 +250,31 @@ public final class WisprBootstrapper {
     SentryBreadcrumb.updateASRBackend(
       settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
 
-    settings.onChange = { [weak settingsSync, weak settings, outputClassifierHolder] key in
+    // #1173: settings-change telemetry observer. `emitBaseline` re-emits the
+    // comprehensive `settings.snapshot` at onboarding-completion (fixes the
+    // first-run gap for a long-running app). Built before the funnel is wired.
+    let settingsChangeTelemetry = SettingsChangeTelemetry(
+      settings: settings,
+      emitBaseline: { [keychainManager, customWordsCoordinator, permissions] in
+        StandingSnapshotBuilder(
+          settings: settings, keychainManager: keychainManager,
+          customWordsCoordinator: customWordsCoordinator, permissions: permissions
+        ).emit()
+      })
+    // #1173: drain a pending settings delta before any telemetry flush (quit /
+    // update-relaunch) so a change made inside the debounce window isn't lost.
+    TelemetryService.shared.onBeforeFlush = { [weak settingsChangeTelemetry] in
+      settingsChangeTelemetry?.flush()
+    }
+
+    settings.onChange = {
+      [weak settingsSync, weak settings, weak settingsChangeTelemetry, outputClassifierHolder] key
+      in
       guard let settingsSync, let settings else { return }
       settingsSync.handleSettingChanged(key, settings: settings)
+      // #1173: emit coalesced settings.changed deltas (fire-and-forget, never
+      // throws/awaits into the setter path).
+      settingsChangeTelemetry?.handle(key)
       // #1047: appearance is a view-shell concern (no pipeline sync) — apply it
       // to NSApp here so both the menu and the Settings picker take effect live.
       if key == .appearance {
@@ -587,6 +614,9 @@ public final class WisprBootstrapper {
 
     // #832/#913 PR8: App-owned output-safety classifier holder.
     self.outputClassifierHolder = outputClassifierHolder
+
+    // #1173: App-owned settings-change telemetry observer.
+    self.settingsChangeTelemetry = settingsChangeTelemetry
 
     // #1171 — launch the coordinator's reconcile worker + WhisperKit setup-state
     // observation and fire the initial reconcile. Wiring above (the picker /

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -424,13 +424,13 @@ struct AIPolishSettingsView: View {
             guard saveKey(key: openAIKey, keychainId: KeychainManager.openAIKeyID) else { return }
             Task {
               await llmDiscovery.validateKeyAndDiscoverModels(
-                provider: .openAI, settings: settings)
+                provider: .openAI, settings: settings, source: .save)
             }
           } else {
             guard saveKey(key: geminiKey, keychainId: KeychainManager.geminiKeyID) else { return }
             Task {
               await llmDiscovery.validateKeyAndDiscoverModels(
-                provider: .gemini, settings: settings)
+                provider: .gemini, settings: settings, source: .save)
             }
           }
         }
@@ -1001,14 +1001,27 @@ struct AIPolishSettingsView: View {
         try? await Task.sleep(for: .seconds(2))
         validationStatus = ""
       }
+      TelemetryService.shared.apiKeyChanged(
+        provider: apiKeyProviderLabel(keychainId), action: "save", result: "success")
       return true
     } catch {
       aiPolishKeychainUILog.error(
         "Save key failed action=save keyID=\(keychainId, privacy: .public) error=\(String(describing: error), privacy: .public)"
       )
       validationStatus = AIPolishKeychainFailureMessage.text(for: error, action: .save)
+      TelemetryService.shared.apiKeyChanged(
+        provider: apiKeyProviderLabel(keychainId), action: "save", result: "failure")
       return false
     }
+  }
+
+  /// #1173: map a keychain id to the provider label used in API-key telemetry —
+  /// the same `LLMProvider.rawValue` vocabulary as `api_key.validation_completed`,
+  /// so both events group by the same provider. Never the key value.
+  private func apiKeyProviderLabel(_ keychainId: String) -> String {
+    if keychainId == KeychainManager.openAIKeyID { return LLMProvider.openAI.rawValue }
+    if keychainId == KeychainManager.geminiKeyID { return LLMProvider.gemini.rawValue }
+    return keychainId
   }
 
   /// Clears any "Failed: …" validation badge the moment the user resumes
@@ -1026,12 +1039,16 @@ struct AIPolishSettingsView: View {
     do {
       try keychainManager.delete(key: keychainId)
       validationStatus = ""
+      TelemetryService.shared.apiKeyChanged(
+        provider: apiKeyProviderLabel(keychainId), action: "remove", result: "success")
       return true
     } catch {
       aiPolishKeychainUILog.error(
         "Clear key failed action=clear keyID=\(keychainId, privacy: .public) error=\(String(describing: error), privacy: .public)"
       )
       validationStatus = AIPolishKeychainFailureMessage.text(for: error, action: .clear)
+      TelemetryService.shared.apiKeyChanged(
+        provider: apiKeyProviderLabel(keychainId), action: "remove", result: "failure")
       return false
     }
   }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -47,6 +47,15 @@ public final class SettingsManager {
 
   public var onChange: ((SettingKey) -> Void)?
 
+  /// Telemetry Bible Phase 4 (#1173) support flag — true only while async model
+  /// DISCOVERY (`applyDiscoveredModels`) is auto-correcting a setting behind the
+  /// user's back, so the change observer can stamp that delta `source=system`.
+  /// Provider-switch canonicalization is deliberately NOT flagged — it is part of
+  /// the user's provider gesture and stays `source=user` (Codex r5). NOT a
+  /// product-behavior knob: it gates no logic, only the telemetry label. Set/
+  /// reset synchronously on the main actor (no `await` between, so no reentrancy).
+  public var isApplyingSystemWrite = false
+
   /// The store backing all user-preference reads/writes. Injected for testability;
   /// production resolves to `SettingsDefaults.store` (the build-shared suite, #923).
   /// EXCEPTION: the per-build `useXPCAudioService` knob deliberately uses
@@ -91,7 +100,12 @@ public final class SettingsManager {
         TelemetryService.shared.providerChanged(from: oldValue.rawValue, to: llmProvider.rawValue)
       }
       defaults.set(llmProvider.rawValue, forKey: "llmProvider")
-      // Canonicalize model for the new provider
+      // Canonicalize the model for the new provider. This is NOT flagged a system
+      // write (#1173 / Codex r5): it is a synchronous consequence of the user's
+      // provider pick, so the resulting `llm_model` delta stays `source=user`,
+      // consistent across providers (turning polish off from Apple Intelligence
+      // vs OpenAI both read `user`). Only async background discovery
+      // (`applyDiscoveredModels`) is `system`.
       if llmProvider == .appleIntelligence {
         llmModel = "apple-intelligence"
       } else if llmModel == "apple-intelligence" || llmModel.isEmpty {
@@ -398,6 +412,20 @@ public final class SettingsManager {
 
   public var activePolishInstructions: PolishInstructions { .default }
 
+  /// The model the runtime actually uses for the current provider — the SINGLE
+  /// source of truth (#1173). Apple Intelligence is a fixed literal; Ollama reads
+  /// `ollamaModel` (its picker-mirrored / discovery-resolved local model); cloud
+  /// providers read `llmModel`. `DictationSessionConfigFactory` and the settings
+  /// telemetry projection both read THIS, so neither re-derives the model from
+  /// raw fields that lag during a provider switch.
+  public var effectiveLLMModel: String {
+    switch llmProvider {
+    case .appleIntelligence: return "apple-intelligence"
+    case .ollama: return ollamaModel
+    case .openAI, .gemini, .none: return llmModel
+    }
+  }
+
   public var isPushToTalk: Bool {
     get { recordingMode == .pushToTalk }
     set { recordingMode = newValue ? .pushToTalk : .toggle }
@@ -605,6 +633,12 @@ public final class SettingsManager {
   ///   - provider: The provider these models belong to. Stale results (user already switched) are dropped.
   public func applyDiscoveredModels(_ models: [LLMModelInfo], for provider: LLMProvider) {
     guard provider == llmProvider else { return }
+    // System write (#1173): the model/ollamaModel mutations below are an
+    // auto-correction, not a user pick — tag their deltas `source=system`. The
+    // flag covers the full body (incl. the early-return `models.isEmpty` path)
+    // via `defer`.
+    isApplyingSystemWrite = true
+    defer { isApplyingSystemWrite = false }
     if models.isEmpty {
       llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
       return

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -39,6 +39,14 @@ import PostHog
   }
 #endif
 
+/// Telemetry Bible Phase 4 (#1173): which user action triggered an API-key
+/// validation pass. Threaded into `validateKeyAndDiscoverModels` (defaulted to
+/// `.modelDiscovery`); only the two Save buttons pass `.save`.
+public enum ApiKeyValidationSource: String, Sendable {
+  case save
+  case modelDiscovery = "model_discovery"
+}
+
 /// Thin wrapper — type-safe event names, no business logic.
 /// Limb: observes facts from domain objects, publishes to PostHog.
 @MainActor
@@ -647,24 +655,35 @@ public final class TelemetryService {
 
   // MARK: - Settings Snapshot
 
+  /// Telemetry Bible Phase 4 (#1173): `config` carries the comprehensive
+  /// per-setting projection block (all OTHER user-facing settings, privacy-
+  /// projected as low-cardinality strings — see `SettingsProjection`). The ten
+  /// pre-existing fields stay byte-identical (Phase 0/3 contract); `config` adds
+  /// the rest as flat `properties` keys so the holistic per-user config can be
+  /// reconstructed query-side from this baseline overlaid with `settings.changed`
+  /// deltas. Boolean settings appear as `on`/`off` strings in `config` and the
+  /// deltas (normalize against the legacy bool `filler_removal` in the query).
   public func settingsSnapshot(
     asrBackend: String, llmProvider: String, recordingMode: String,
     fillerRemoval: Bool, customWordsCount: Int,
     hasApiKeys: Bool, noiseSuppression: Bool,
     microphoneStatus: String, accessibilityStatus: String,
-    accessibilityWarningDismissed: Bool
+    accessibilityWarningDismissed: Bool,
+    config: [String: String] = [:]
   ) {
     #if DEBUG
+      var hookStrings: [String: String] = [
+        "asr_backend": asrBackend,
+        "llm_provider": llmProvider,
+        "recording_mode": recordingMode,
+        "microphone_status": microphoneStatus,
+        "accessibility_status": accessibilityStatus,
+      ]
+      hookStrings.merge(config) { _, new in new }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "settings.snapshot",
-          stringProps: [
-            "asr_backend": asrBackend,
-            "llm_provider": llmProvider,
-            "recording_mode": recordingMode,
-            "microphone_status": microphoneStatus,
-            "accessibility_status": accessibilityStatus,
-          ],
+          stringProps: hookStrings,
           intProps: ["custom_words_count": customWordsCount],
           boolProps: [
             "filler_removal": fillerRemoval,
@@ -673,19 +692,97 @@ public final class TelemetryService {
             "accessibility_warning_dismissed": accessibilityWarningDismissed,
           ]))
     #endif
+    var props: [String: Any] = [
+      "asr_backend": asrBackend,
+      "llm_provider": llmProvider,
+      "recording_mode": recordingMode,
+      "filler_removal": fillerRemoval,
+      "custom_words_count": customWordsCount,
+      "has_api_keys": hasApiKeys,
+      "noise_suppression": noiseSuppression,
+      "microphone_status": microphoneStatus,
+      "accessibility_status": accessibilityStatus,
+      "accessibility_warning_dismissed": accessibilityWarningDismissed,
+    ]
+    props.merge(config) { _, new in new }
+    PostHogSDK.shared.capture("settings.snapshot", properties: props)
+  }
+
+  /// Telemetry Bible Phase 4 (#1173): a single user-facing setting changed
+  /// post-launch, coalesced into one truthful delta per logical setting (no-op
+  /// bursts skipped). `source` distinguishes a direct user change (`user`) from
+  /// a system auto-correction such as model canonicalization (`system`); both
+  /// are emitted so query-side reconstruction never goes stale. `from`/`to` are
+  /// privacy-projected (no raw model strings, key codes, or locked language
+  /// codes). Onboarding-time writes are suppressed (the onboarding-completion
+  /// baseline captures the final state).
+  public func settingsChanged(setting: String, from: String, to: String, source: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "settings.changed",
+          stringProps: [
+            "setting": setting,
+            "from": from,
+            "to": to,
+            "source": source,
+          ]))
+    #endif
     PostHogSDK.shared.capture(
-      "settings.snapshot",
+      "settings.changed",
       properties: [
-        "asr_backend": asrBackend,
-        "llm_provider": llmProvider,
-        "recording_mode": recordingMode,
-        "filler_removal": fillerRemoval,
-        "custom_words_count": customWordsCount,
-        "has_api_keys": hasApiKeys,
-        "noise_suppression": noiseSuppression,
-        "microphone_status": microphoneStatus,
-        "accessibility_status": accessibilityStatus,
-        "accessibility_warning_dismissed": accessibilityWarningDismissed,
+        "setting": setting,
+        "from": from,
+        "to": to,
+        "source": source,
+      ])
+  }
+
+  /// Telemetry Bible Phase 4 (#1173): an API key was saved or removed. `action`
+  /// is `save` (code can't cheaply tell first-add from overwrite) or `remove`;
+  /// `result` is `success` or `failure`. Key material is never logged.
+  public func apiKeyChanged(provider: String, action: String, result: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "api_key.changed",
+          stringProps: [
+            "provider": provider,
+            "action": action,
+            "result": result,
+          ]))
+    #endif
+    PostHogSDK.shared.capture(
+      "api_key.changed",
+      properties: [
+        "provider": provider,
+        "action": action,
+        "result": result,
+      ])
+  }
+
+  /// Telemetry Bible Phase 4 (#1173): an API-key validation actually ran and
+  /// reached a terminal result (`valid` / `invalid` / `provider_unavailable` /
+  /// `error`). NOT emitted for the missing-key guard (no validation ran).
+  /// `source` is `save` (user pressed Save) or `model_discovery` (a refresh /
+  /// provider-switch discovery pass).
+  public func apiKeyValidationCompleted(provider: String, result: String, source: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "api_key.validation_completed",
+          stringProps: [
+            "provider": provider,
+            "result": result,
+            "source": source,
+          ]))
+    #endif
+    PostHogSDK.shared.capture(
+      "api_key.validation_completed",
+      properties: [
+        "provider": provider,
+        "result": result,
+        "source": source,
       ])
   }
 
@@ -1208,6 +1305,14 @@ public final class TelemetryService {
   /// warning so the fallback is never a silent production steady state.
   public var flushContextProvider: (@MainActor () -> FlushContext)?
 
+  /// Telemetry Bible Phase 4 (#1173): drained synchronously at the START of every
+  /// flush so a debounced `settings.changed` delta still pending inside its
+  /// coalescing window (a setting changed <1 s before quit / update-relaunch) is
+  /// captured to PostHog's disk-backed queue before this flush schedules delivery.
+  /// Wired once by the composition root to `SettingsChangeTelemetry.flush()`; nil
+  /// in unit tests / before launch wiring (harmless no-op).
+  public var onBeforeFlush: (@MainActor () -> Void)?
+
   /// Best-effort, non-blocking flush. Used before a Sparkle relaunch and on
   /// normal termination. Emits `telemetry.flush_requested` (carrying `reason`,
   /// `active_recording`, `app_phase`) first; PostHog `capture` writes the event
@@ -1218,6 +1323,10 @@ public final class TelemetryService {
   /// (G3 is not observable app-side; delivery health is watched by the
   /// product-health integrity heartbeat, not here).
   public func flushTelemetry(reason: FlushReason) {
+    // #1173: drain any pending debounced settings delta first, so a change made
+    // just before quit/relaunch is captured (sync-to-disk) within this flush.
+    onBeforeFlush?()
+
     let context: FlushContext
     if let provided = flushContextProvider?() {
       context = provided

--- a/Tests/EnviousWisprTests/App/Phase4TelemetryEventsTests.swift
+++ b/Tests/EnviousWisprTests/App/Phase4TelemetryEventsTests.swift
@@ -1,0 +1,164 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprLLM
+
+#if DEBUG
+
+  /// Telemetry Bible Phase 4 (#1173): the new event facades, the comprehensive
+  /// snapshot `config` block, and the validation-guard contract. Synchronous
+  /// set-hook → act → read → restore (serialized for the process-global hook).
+  @MainActor
+  @Suite("Phase 4 telemetry events", .serialized)
+  struct Phase4TelemetryEventsTests {
+
+    final class Box: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
+      func named(_ n: String) -> [CapturedTelemetryEvent] { all.filter { $0.name == n } }
+    }
+
+    private func capture(_ body: () -> Void) -> Box {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      body()
+      return box
+    }
+
+    @Test("settingsChanged carries setting/from/to/source")
+    func settingsChangedFacade() {
+      let box = capture {
+        TelemetryService.shared.settingsChanged(
+          setting: "recording_mode", from: "pushToTalk", to: "toggle", source: "user")
+      }
+      let e = box.named("settings.changed").first
+      #expect(e?.stringProps["setting"] == "recording_mode")
+      #expect(e?.stringProps["from"] == "pushToTalk")
+      #expect(e?.stringProps["to"] == "toggle")
+      #expect(e?.stringProps["source"] == "user")
+    }
+
+    @Test("apiKeyChanged carries provider/action/result, never key material")
+    func apiKeyChangedFacade() {
+      let box = capture {
+        TelemetryService.shared.apiKeyChanged(
+          provider: "openAI", action: "save", result: "success")
+      }
+      let e = box.named("api_key.changed").first
+      #expect(e?.stringProps["provider"] == "openAI")
+      #expect(e?.stringProps["action"] == "save")
+      #expect(e?.stringProps["result"] == "success")
+    }
+
+    @Test("apiKeyValidationCompleted carries provider/result/source")
+    func apiKeyValidationFacade() {
+      let box = capture {
+        TelemetryService.shared.apiKeyValidationCompleted(
+          provider: "gemini", result: "invalid", source: "save")
+      }
+      let e = box.named("api_key.validation_completed").first
+      #expect(e?.stringProps["provider"] == "gemini")
+      #expect(e?.stringProps["result"] == "invalid")
+      #expect(e?.stringProps["source"] == "save")
+    }
+
+    @Test("ApiKeyValidationSource rawValues match the wire vocabulary")
+    func validationSourceRawValues() {
+      #expect(ApiKeyValidationSource.save.rawValue == "save")
+      #expect(ApiKeyValidationSource.modelDiscovery.rawValue == "model_discovery")
+    }
+
+    @Test("Comprehensive snapshot includes the projected config block")
+    func snapshotConfigBlock() {
+      let suite = UserDefaults(suiteName: "P4Snap-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      let permissions = PermissionsService(accessibilityReader: { true })
+      let builder = StandingSnapshotBuilder(
+        settings: settings,
+        keychainManager: KeychainManager(),
+        customWordsCoordinator: CustomWordsCoordinator(),
+        permissions: permissions)
+      let box = capture { builder.emit() }
+      let snap = box.named("settings.snapshot").first
+      // New comprehensive fields ride alongside the ten legacy fields.
+      #expect(snap?.stringProps["llm_model"] != nil)
+      #expect(snap?.stringProps["crash_recovery"] == "on")  // default ON
+      #expect(snap?.stringProps["toggle_hotkey_shape"] == "modifier_only")  // default rightOption
+      #expect(snap?.stringProps["language_mode"] == "auto")
+      // The legacy typed fields are still present and unchanged.
+      #expect(snap?.stringProps["recording_mode"] == settings.recordingMode.rawValue)
+      // The three typed fields never duplicate into the config block.
+      #expect(snap?.boolProps["filler_removal"] != nil)
+    }
+
+    @Test("Snapshot never leaks a stale private model name under a cloud provider")
+    func snapshotStaleCloudCarryoverIsCustom() {
+      let suite = UserDefaults(suiteName: "P4Stale-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      // P1: provider is a cloud one but llmModel still holds a private local id
+      // (carried over from a prior Ollama selection, before discovery corrected it).
+      settings.llmProvider = .openAI
+      settings.llmModel = "acme-private-tuned"
+      let builder = StandingSnapshotBuilder(
+        settings: settings,
+        keychainManager: KeychainManager(),
+        customWordsCoordinator: CustomWordsCoordinator(),
+        permissions: PermissionsService(accessibilityReader: { true }))
+      let snap = capture { builder.emit() }.named("settings.snapshot").first
+      #expect(snap?.stringProps["llm_model"] == "custom")  // deny-by-default, never the raw name
+    }
+
+    @Test("flushTelemetry drains a pending settings delta before flushing (onBeforeFlush)")
+    func flushDrainsPendingSettingsDelta() {
+      let suite = UserDefaults(suiteName: "P4Flush-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      settings.onboardingState = .completed
+      let telemetry = SettingsChangeTelemetry(settings: settings, emitBaseline: {})
+      settings.onChange = { [weak telemetry] key in telemetry?.handle(key) }
+      TelemetryService.shared.flushContextProvider = nil
+      TelemetryService.shared.onBeforeFlush = { [weak telemetry] in telemetry?.flush() }
+      defer { TelemetryService.shared.onBeforeFlush = nil }
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      // Change a setting but DO NOT flush() — it sits pending in the debounce
+      // window, exactly as it would if the user quit immediately after.
+      settings.recordingMode = .toggle
+      #expect(box.named("settings.changed").isEmpty)  // still pending
+      // A terminate/update flush must drain it first.
+      TelemetryService.shared.flushTelemetry(reason: .appTerminate)
+      #expect(
+        box.named("settings.changed").contains {
+          $0.stringProps["setting"] == "recording_mode" && $0.stringProps["to"] == "toggle"
+        })
+      _ = telemetry  // keep alive past the flush
+    }
+
+    @Test("Missing-key validation guard emits NO validation_completed event")
+    func missingKeyNoValidationEvent() async {
+      // Isolated EMPTY key store in a temp dir — never touch the developer's or
+      // CI's real `~/.enviouswispr-keys` (Codex r1). With no key present, the
+      // guard returns before any validation runs.
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("P4Guard-\(UUID().uuidString)", isDirectory: true)
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let keychain = KeychainManager(
+        backend: .legacyFiles, legacyStore: FileLegacyKeyStore(storageDirectory: dir))
+      let coordinator = LLMModelDiscoveryCoordinator(keychainManager: keychain)
+      let suite = UserDefaults(suiteName: "P4Guard-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      await coordinator.validateKeyAndDiscoverModels(provider: .openAI, settings: settings)
+      #expect(box.named("api_key.validation_completed").isEmpty)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -1,0 +1,391 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+#if DEBUG
+
+  /// Telemetry Bible Phase 4 (#1173): coalescing, source classification,
+  /// projection, and the onboarding-completion baseline of `SettingsChangeTelemetry`.
+  /// The debounce delay is bypassed by calling `flush()` directly — it is not a
+  /// SUT measurement, so no clock seam is needed (`tests-no-real-time-scheduling-precision`).
+  /// Body is synchronous (set hook → mutate → flush → read → restore), so the
+  /// process-global `testEventHook` is flake-immune (suite is `.serialized`).
+  @MainActor
+  @Suite("Settings change telemetry", .serialized)
+  struct SettingsChangeTelemetryTests {
+
+    /// Collects every `settings.changed` event the hook sees, in order.
+    final class DeltaBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      func clear() { lock.withLock { stored.removeAll() } }
+      var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
+    }
+
+    final class BaselineSpy: @unchecked Sendable {
+      private let lock = NSLock()
+      private var n = 0
+      func bump() { lock.withLock { n += 1 } }
+      var count: Int { lock.withLock { n } }
+    }
+
+    /// Build a settings manager + wired observer + a captured-delta box.
+    /// `onboarding` defaults to `.completed` so changes are NOT suppressed.
+    private func makeHarness(
+      onboarding: OnboardingState = .completed
+    ) -> (SettingsManager, SettingsChangeTelemetry, DeltaBox, BaselineSpy) {
+      let suite = UserDefaults(suiteName: "SCT-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      settings.onboardingState = onboarding
+      let spy = BaselineSpy()
+      let telemetry = SettingsChangeTelemetry(
+        settings: settings, emitBaseline: { spy.bump() })
+      settings.onChange = { [weak telemetry] key in telemetry?.handle(key) }
+      let box = DeltaBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "settings.changed" { box.add(event) }
+      }
+      return (settings, telemetry, box, spy)
+    }
+
+    private func deltas(_ box: DeltaBox, setting: String) -> [CapturedTelemetryEvent] {
+      box.all.filter { $0.stringProps["setting"] == setting }
+    }
+
+    @Test("A→B→A net no-op emits nothing")
+    func noOpBurst() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.recordingMode = .toggle
+      settings.recordingMode = .pushToTalk  // back to launch default
+      telemetry.flush()
+      #expect(deltas(box, setting: "recording_mode").isEmpty)
+    }
+
+    @Test("A→B→C coalesces to one delta from A to C")
+    func coalesceToSingle() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      // appearance has three values; default is .system.
+      settings.appearancePreference = .light
+      settings.appearancePreference = .dark
+      telemetry.flush()
+      let d = deltas(box, setting: "appearance")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["from"] == "system")
+      #expect(d.first?.stringProps["to"] == "dark")
+      #expect(d.first?.stringProps["source"] == "user")
+    }
+
+    @Test("Two settings in one window emit two deltas")
+    func twoSettingsTwoDeltas() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.recordingMode = .toggle
+      settings.autoCopyToClipboard = false
+      telemetry.flush()
+      #expect(deltas(box, setting: "recording_mode").count == 1)
+      #expect(deltas(box, setting: "auto_copy").count == 1)
+      #expect(deltas(box, setting: "auto_copy").first?.stringProps["to"] == "off")
+    }
+
+    @Test("Hotkey keyCode-only change within the same shape emits nothing")
+    func hotkeySameShapeNoOp() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      // Default toggle keyCode is right Option (modifier-only). Switch to left
+      // Option (also modifier-only) — the projected shape is unchanged.
+      settings.toggleKeyCode = ModifierKeyCodes.leftOption
+      telemetry.flush()
+      #expect(deltas(box, setting: "toggle_hotkey_shape").isEmpty)
+    }
+
+    @Test("Hotkey shape transition emits one shape-only delta")
+    func hotkeyShapeTransition() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.toggleKeyCode = 49  // Space — a regular key → chord
+      telemetry.flush()
+      let d = deltas(box, setting: "toggle_hotkey_shape")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["from"] == "modifier_only")
+      #expect(d.first?.stringProps["to"] == "chord")
+    }
+
+    @Test("Hotkey keyCode + modifiers in one edit emit one grouped delta")
+    func hotkeyGroupedKeyAndModifiers() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.toggleKeyCode = 49  // Space
+      settings.toggleModifiers = .option
+      telemetry.flush()
+      #expect(deltas(box, setting: "toggle_hotkey_shape").count == 1)
+    }
+
+    @Test("System model auto-correction is tagged source=system, not suppressed")
+    func systemWriteTagged() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .openAI
+      telemetry.flush()
+      box.clear()  // drop the provider-switch deltas; isolate the discovery write
+      // Empty discovery → applyDiscoveredModels resets to the provider default
+      // under the isApplyingSystemWrite flag.
+      settings.llmModel = "gpt-4o"  // a user-ish divergence first
+      telemetry.flush()
+      box.clear()
+      settings.applyDiscoveredModels([], for: .openAI)  // → "gpt-4o-mini", system
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["source"] == "system")
+      #expect(d.first?.stringProps["to"] == "gpt-4o-mini")
+    }
+
+    @Test("Onboarding-time writes are suppressed but advance the baseline")
+    func onboardingSuppressedThenBaseline() {
+      let (settings, telemetry, box, _) = makeHarness(onboarding: .needsPermissions)
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.recordingMode = .toggle  // onboarding write → suppressed
+      telemetry.flush()
+      #expect(deltas(box, setting: "recording_mode").isEmpty)
+      // Complete onboarding, then a real change emits from the suppressed value.
+      settings.onboardingState = .completed
+      settings.recordingMode = .pushToTalk
+      telemetry.flush()
+      let d = deltas(box, setting: "recording_mode")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["from"] == "toggle")  // baseline advanced
+      #expect(d.first?.stringProps["to"] == "pushToTalk")
+    }
+
+    @Test("Onboarding completion re-seeds baseline for a derived projection")
+    func onboardingCompletionReseedsDerivedProjection() {
+      let (settings, telemetry, box, _) = makeHarness(onboarding: .needsPermissions)
+      defer { TelemetryService.shared.testEventHook = nil }
+      // During onboarding: OpenAI (model canonicalizes → gpt-4o-mini), then Ollama
+      // — the latter does NOT rewrite llmModel, but the EFFECTIVE model flips to
+      // ollamaModel ("llama3.2") with no `.llmModel`/`.ollamaModel` fire.
+      // committedBaseline[llm_model] would stay stale ("gpt-4o-mini") without the
+      // completion re-seed.
+      settings.llmProvider = .openAI
+      settings.llmProvider = .ollama
+      settings.onboardingState = .completed  // snapshot (llm_model=llama3.2) + re-seed
+      box.clear()
+      // Post-onboarding: back to OpenAI → effective model llama3.2 → gpt-4o-mini.
+      // Must emit a real delta, NOT be skipped against a stale baseline.
+      settings.llmProvider = .openAI
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["from"] == "llama3.2")  // re-seeded from effective Ollama model
+      #expect(d.first?.stringProps["to"] == "gpt-4o-mini")
+    }
+
+    @Test("Onboarding completion emits the baseline exactly once")
+    func onboardingCompletionBaselineOnce() {
+      // Bind `telemetry`: the onChange closure captures it weakly, so the
+      // observer must be held for the duration (as the bootstrapper holds it).
+      let (settings, telemetry, _, spy) = makeHarness(onboarding: .needsPermissions)
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.onboardingState = .completed
+      #expect(spy.count == 1)
+      // A later unrelated change does not re-fire the baseline.
+      settings.recordingMode = .toggle
+      #expect(spy.count == 1)
+      _ = telemetry  // keep alive past the final assertion
+    }
+
+    @Test("Ollama pick: the llm_model + ollamaModel mirror coalesce to one delta")
+    func ollamaMirrorCoalescesToOneDelta() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .ollama  // canonicalizes effective model → default "llama3.2"
+      telemetry.flush()
+      box.clear()
+      // Reproduce the production mirror: the picker writes llmModel, then
+      // PipelineSettingsSync mirrors it into ollamaModel. Both map to the one
+      // `llm_model` logical → exactly ONE coalesced delta to the effective model.
+      settings.llmModel = "mistral"  // a DIFFERENT shipped-catalog id
+      settings.ollamaModel = "mistral"  // the mirror (now instrumented, coalesced)
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["to"] == "mistral")
+    }
+
+    @Test("Ollama projection reads the effective ollamaModel, not a stale llmModel")
+    func ollamaReadsEffectiveModel() {
+      let suite = UserDefaults(suiteName: "SCT-eff-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      settings.llmProvider = .ollama
+      // Simulate the lag: llmModel still holds a cloud id, ollamaModel is the real one.
+      settings.llmModel = "gpt-4o-mini"
+      settings.ollamaModel = "llama3.2"
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "llama3.2")
+    }
+
+    @Test("Ollama discovery correction emits one source=system delta")
+    func ollamaDiscoveryIsSystem() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .ollama
+      telemetry.flush()
+      box.clear()
+      // Discovery finds the current model unavailable and swaps it (writes both
+      // llmModel and ollamaModel under the system flag) — one coalesced delta.
+      settings.applyDiscoveredModels(
+        [LLMModelInfo(id: "mistral", displayName: "M", provider: .ollama, isAvailable: true)],
+        for: .ollama)
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["to"] == "mistral")
+      #expect(d.first?.stringProps["source"] == "system")
+    }
+
+    @Test("Turning polish off refreshes llm_model to `none` (provider-derived)")
+    func providerOffRefreshesModel() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .openAI  // canonicalizes model → gpt-4o-mini
+      telemetry.flush()
+      box.clear()
+      settings.llmProvider = LLMProvider.none  // no llmModel write, but projection → none
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["to"] == "none")
+      #expect(d.first?.stringProps["source"] == "user")
+    }
+
+    @Test("Provider-switch model canonicalization is tagged user, not system")
+    func providerSwitchCanonicalizationIsUser() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .openAI
+      telemetry.flush()
+      box.clear()
+      settings.llmProvider = .appleIntelligence  // canonicalizes llmModel → apple-intelligence
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["to"] == "apple-intelligence")
+      // A provider switch is a user gesture — its model canonicalization reads
+      // `user`, consistent with the OpenAI→None turn-off path (Codex r5). Only
+      // async `applyDiscoveredModels` is `system`.
+      #expect(d.first?.stringProps["source"] == "user")
+    }
+
+    @Test("System discovery inside a provider-switch window wins the source (last-writer)")
+    func discoveryWithinProviderWindowIsSystem() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .openAI
+      telemetry.flush()
+      box.clear()
+      // User switches provider (enqueues llm_model=user via the derived refresh),
+      // then fast async discovery corrects the model to "mistral" WITHIN the same
+      // 500 ms debounce window. The final value came from the system write.
+      settings.llmProvider = .ollama
+      settings.applyDiscoveredModels(
+        [LLMModelInfo(id: "mistral", displayName: "M", provider: .ollama, isAvailable: true)],
+        for: .ollama)
+      telemetry.flush()
+      let d = deltas(box, setting: "llm_model")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["to"] == "mistral")
+      #expect(d.first?.stringProps["source"] == "system")  // last writer = discovery
+    }
+
+    @Test("A custom local Ollama model collapses to `custom`")
+    func customModelProjection() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.llmProvider = .ollama
+      telemetry.flush()
+      box.clear()
+      settings.ollamaModel = "my-private-finetune"  // the effective Ollama model
+      telemetry.flush()
+      #expect(deltas(box, setting: "llm_model").first?.stringProps["to"] == "custom")
+    }
+
+    @Test("A `:latest` Ollama tag canonicalizes to its catalog name, not custom")
+    func ollamaLatestTagCanonicalizes() {
+      let suite = UserDefaults(suiteName: "SCT-canon-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      settings.llmProvider = .ollama
+      settings.ollamaModel = "llama3.2:latest"  // standard install tag
+      // Canonicalizes to the catalog's "llama3.2" — NOT reported as "custom".
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "llama3.2")
+      // A non-catalog private pull still collapses to custom.
+      settings.ollamaModel = "my-private:latest"
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "custom")
+    }
+
+    @Test("Cloud projection is deny-by-default: stale/private id → custom, known id passes")
+    func cloudDenyByDefault() {
+      let suite = UserDefaults(suiteName: "SCT-cloud-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      settings.llmProvider = .openAI
+      // P1 leak scenario: a private Ollama name carried over before discovery
+      // corrects llmModel. It is NOT on the cloud allowlist → custom, never raw.
+      settings.llmModel = "acme-internal-finetune"
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "custom")
+      // A recognized public cloud id passes through.
+      settings.llmModel = "gpt-4o-mini"
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "gpt-4o-mini")
+      // A dated snapshot of a known model normalizes to its base id.
+      settings.llmModel = "gpt-5-mini-2025-08-07"
+      #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "gpt-5-mini")
+    }
+
+    @Test("Language lock projects to mode only, never the code")
+    func languageModeProjection() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.languageMode = .locked("de")
+      telemetry.flush()
+      let d = deltas(box, setting: "language_mode")
+      #expect(d.first?.stringProps["from"] == "auto")
+      #expect(d.first?.stringProps["to"] == "locked")  // no "de"
+    }
+
+    @Test("Sensitivity slider projects to a bucket")
+    func sensitivityBucketProjection() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.vadSensitivity = 0.9
+      telemetry.flush()
+      let d = deltas(box, setting: "vad_sensitivity")
+      #expect(d.first?.stringProps["from"] == "medium")  // 0.5 default
+      #expect(d.first?.stringProps["to"] == "high")
+    }
+
+    @Test("A non-instrumented key (selected_backend) emits no delta")
+    func adversarialNonInstrumented() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.selectedBackend = settings.selectedBackend == .parakeet ? .whisperKit : .parakeet
+      telemetry.flush()
+      #expect(box.all.isEmpty)
+    }
+
+    @Test("Observer keeps emitting while strongly held (retention)")
+    func strongRetentionEmits() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      // `telemetry` is held by this scope (as the bootstrapper holds it). The
+      // onChange closure captures it weakly; emission must still happen.
+      settings.wordCorrectionEnabled = false
+      telemetry.flush()
+      #expect(deltas(box, setting: "word_correction").count == 1)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -113,13 +113,19 @@ import Testing
   ///   objects). Injected into the main Window scene; consumed by `DictationRuntime`,
   ///   `RecoveryCoordinator`, `PipelineSettingsSync`, and the Settings affordance. The
   ///   pre-#1171 count was already at the cap (30), so adding one home needs +1.
+  /// - 31 → 32 in #1173 (2026-06-23, Telemetry Bible Phase 4): App-owned
+  ///   `settingsChangeTelemetry` — the settings-funnel observer that emits
+  ///   coalesced `settings.changed` deltas + the onboarding-completion baseline.
+  ///   A narrow new App-owned home (the #763 direction: many narrow homes), held
+  ///   app-lifetime so it never deallocs and stops emitting. The pre-#1173 count
+  ///   was already at the cap (31), so adding one home needs +1.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 31,
+      count <= 32,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 31. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 32. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -227,14 +233,22 @@ import Testing
   /// `start()`. Net of deleting the `onNeedsPreloadObservation` wiring + the
   /// `whisperKitSetup` settingsSync arg. Cap set by the deterministic rule
   /// (post-change actual 831 + 10, rounded up to nearest 5 = 845).
+  /// Ratcheted 845→870 in #1173 (2026-06-23, Telemetry Bible Phase 4): the
+  /// composition root builds the App-owned `SettingsChangeTelemetry` home (its
+  /// `emitBaseline` closure constructs a `StandingSnapshotBuilder` for the
+  /// onboarding-completion baseline), adds one fan-out branch (`handle(key)`)
+  /// + its weak capture to the `settings.onChange` closure, and stores it. A
+  /// narrow new App-owned home (+1 stored property, ≤ 31) keeping the funnel the
+  /// single observation seam. Cap set by the deterministic rule (post-change
+  /// actual 857 + 10, rounded up to nearest 5 = 870).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 845,
+      lineCount <= 870,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 845. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 870. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }


### PR DESCRIPTION
## Telemetry Bible Phase 4 (#1173) — config + API-key visibility

Closes the F1/F2/F3 gaps so we can see how the product is actually configured, post-launch, for our long-running (rarely-relaunched) app.

### What it adds
- **Comprehensive `settings.snapshot`** — every user-facing setting, privacy-projected, emitted at launch AND onboarding-completion (fixes the first-run baseline gap).
- **`settings.changed{setting, from, to, source}`** — one coalesced delta per logical setting via the single `SettingsManager.onChange` funnel. Debounced (toggles ~500 ms, sliders ~1 s), no-op bursts skipped, `source` last-writer-wins (`user` vs `system`).
- **`api_key.changed{provider, action, result}`** + **`api_key.validation_completed{provider, result, source}`** (key-backed providers only; missing-key guard emits nothing).
- **Holistic per-user config** is reconstructed query-side (baseline + deltas). Person properties rejected (anonymous-only setup would force a global cost-mode change).

### Design notes
- **Observation-only (a limb):** the observer never throws/awaits into the setter path; a pending delta is drained from the existing terminate/flush path so a change made just before quit isn't lost.
- **Model projection (the hard part):** reads the **effective** model via the new single-source-of-truth `SettingsManager.effectiveLLMModel` (adopted by `DictationSessionConfigFactory` / `PipelineSettingsSync` / `RecoveryCoordinator` / `BackendMetadata`), and is **deny-by-default** — a model id is emitted only on a known-safe allowlist hit, else `custom`, so a private local model name can never leak during the brief provider/model lag after a switch.
- No raw model strings, key codes, or locked language codes in any payload.

### Validation
- Logic tests: new `SettingsChangeTelemetryTests` + `Phase4TelemetryEventsTests` (full write-path × provider matrix) + existing factory/recovery/pipeline-sync/backend-metadata suites — all green.
- Local `codex review` clean (the model-projection design was hardened across review rounds, then refactored to the single-resolver + deny-by-default approach that closed the class).
- Release build green; ceiling tests updated (Bible §30 entries for the new App-owned home).
- Live UAT: heart path verified (record → transcribe → polish → paste), app healthy, no telemetry/settings errors.

Part of #1168 (Telemetry Bible epic).
Closes #1173.