### PR TITLE
feat(telemetry): XPC helper crash visibility via shared ObservabilityCore (#1174)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,17 @@ let package = Package(
       name: "EnviousWisprCore",
       path: "Sources/EnviousWisprCore"
     ),
+    // Sentry-only privacy + crash-reporting leaf (#1174): the single home for
+    // the event sanitizer + the helper Sentry bootstrap shared by the app (via
+    // Services) AND both XPC helpers. Keeps the redactor one source of truth and
+    // contains the Sentry SDK to exactly the modules that need it.
+    .target(
+      name: "EnviousWisprObservabilityCore",
+      dependencies: [
+        .product(name: "Sentry", package: "sentry-cocoa")
+      ],
+      path: "Sources/EnviousWisprObservabilityCore"
+    ),
     .target(
       name: "EnviousWisprStorage",
       dependencies: ["EnviousWisprCore"],
@@ -62,6 +73,7 @@ let package = Package(
       name: "EnviousWisprServices",
       dependencies: [
         "EnviousWisprCore",
+        "EnviousWisprObservabilityCore",
         .product(name: "PostHog", package: "posthog-ios"),
         .product(name: "Sentry", package: "sentry-cocoa"),
       ],
@@ -130,6 +142,7 @@ let package = Package(
       dependencies: [
         "EnviousWisprCore",
         "EnviousWisprAudio",
+        "EnviousWisprObservabilityCore",
       ],
       path: "Sources/EnviousWisprAudioService",
       exclude: ["Resources"]
@@ -140,6 +153,7 @@ let package = Package(
         "EnviousWisprCore",
         "EnviousWisprASR",
         "EnviousWisprAudio",
+        "EnviousWisprObservabilityCore",
         .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
       ],
@@ -161,6 +175,7 @@ let package = Package(
       name: "EnviousWisprTests",
       dependencies: [
         "EnviousWisprCore",
+        "EnviousWisprObservabilityCore",
         "EnviousWisprPostProcessing",
         "EnviousWisprLLM",
         "EnviousWisprPipeline",

--- a/Project.swift
+++ b/Project.swift
@@ -207,8 +207,17 @@ let project = Project(
   ],
   settings: projectSettings,
   targets: [
-    // ---- 9 first-party modules (native static frameworks) ----
+    // ---- first-party modules (native static frameworks) ----
     firstPartyLibrary("EnviousWisprCore", dependencies: []),
+    // Sentry-only privacy + crash-reporting leaf (#1174). The single home for
+    // the event sanitizer + the helper Sentry bootstrap, shared by the app (via
+    // Services) AND both XPC helpers — so the redactor has one source of truth
+    // and the Sentry SDK stays contained to exactly the modules that need it.
+    firstPartyLibrary(
+      "EnviousWisprObservabilityCore",
+      dependencies: [
+        .package(product: "Sentry")
+      ]),
     firstPartyLibrary(
       "EnviousWisprStorage",
       dependencies: [
@@ -229,6 +238,7 @@ let project = Project(
       "EnviousWisprServices",
       dependencies: [
         .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprObservabilityCore"),
         .package(product: "PostHog"),
         .package(product: "Sentry"),
       ]),
@@ -304,6 +314,8 @@ let project = Project(
       dependencies: [
         .target(name: "EnviousWisprCore"),
         .target(name: "EnviousWisprAudio"),
+        // Sentry-only crash-reporting bootstrap for this helper (#1174).
+        .target(name: "EnviousWisprObservabilityCore"),
         // Transitive FluidAudio C-target modules (see Pipeline note above).
         .package(product: "FluidAudio"),
       ],
@@ -324,6 +336,8 @@ let project = Project(
         .target(name: "EnviousWisprCore"),
         .target(name: "EnviousWisprASR"),
         .target(name: "EnviousWisprAudio"),
+        // Sentry-only crash-reporting bootstrap for this helper (#1174).
+        .target(name: "EnviousWisprObservabilityCore"),
         .package(product: "WhisperKit"),
         .package(product: "FluidAudio"),
       ],
@@ -391,6 +405,9 @@ let project = Project(
       dependencies: firstPartyTargetDeps + [
         .target(name: "EnviousWisprAppKit"),
         .target(name: "EnviousWisprContacts"),
+        // HelperObservabilityConfigTests imports the module directly; Xcode test
+        // targets need every direct import as a declared edge (#1174).
+        .target(name: "EnviousWisprObservabilityCore"),
         .package(product: "FluidAudio"),
         .package(product: "Sparkle"),
       ],

--- a/Sources/EnviousWisprASRService/main.swift
+++ b/Sources/EnviousWisprASRService/main.swift
@@ -1,4 +1,10 @@
+import EnviousWisprObservabilityCore
 import Foundation
+
+// Crash reporting for this helper process (limb — never blocks XPC readiness):
+// start Sentry BEFORE serving requests so a native crash in model load /
+// inference is captured, sanitized, and role-tagged. Missing DSN skips reporting.
+HelperObservability.start(role: .asrXPC)
 
 let delegate = ASRServiceDelegate()
 let listener = NSXPCListener.service()

--- a/Sources/EnviousWisprAudioService/main.swift
+++ b/Sources/EnviousWisprAudioService/main.swift
@@ -1,4 +1,10 @@
+import EnviousWisprObservabilityCore
 import Foundation
+
+// Crash reporting for this helper process (limb — never blocks XPC readiness):
+// start Sentry BEFORE serving requests so a native crash in audio capture is
+// captured, sanitized, and role-tagged. A missing DSN simply skips reporting.
+HelperObservability.start(role: .audioXPC)
 
 let delegate = AudioServiceDelegate()
 let listener = NSXPCListener.service()

--- a/Sources/EnviousWisprObservabilityCore/HelperObservability.swift
+++ b/Sources/EnviousWisprObservabilityCore/HelperObservability.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Sentry
+
+/// Which background process a crash event came from, stamped as the
+/// `process.role` tag so triage can slice host vs audio-helper vs asr-helper.
+public enum ProcessRole: String, Sendable {
+  case audioXPC = "audio_xpc"
+  case asrXPC = "asr_xpc"
+}
+
+/// The asserted Sentry configuration for a helper process, derived purely from
+/// the process bundle — NO side effects, so the unit tests can check every field
+/// without launching a real XPC process (#1174 Codex r1 #5).
+public struct HelperSentryConfig: Sendable {
+  /// Reported as the `process.role` tag.
+  public let role: ProcessRole
+  /// The SAME release identity the app reports, so all three processes group
+  /// under one release (NOT a helper-bundle-derived variant).
+  public let releaseName: String
+  /// `development` for `.dev`-suffixed bundles, else `production`.
+  public let environment: String
+  /// Reported as the `app.build_type` tag (`debug` / `release`).
+  public let buildType: String
+  /// Reported as the `xpc.service_bundle_id` tag.
+  public let bundleId: String
+}
+
+/// Sentry-ONLY crash-reporting bootstrap for the two XPC helper processes (audio
+/// capture, ASR inference). It deliberately knows nothing about PostHog or
+/// product analytics, and it bakes `enableAutoSessionTracking = false` in by
+/// construction — the helpers never expose that knob, so three processes can't
+/// inflate release-health session counts.
+///
+/// This is a LIMB: `start` never throws and a missing/empty DSN simply skips
+/// reporting. The heart path (audio capture / inference) does not depend on it.
+public enum HelperObservability {
+
+  /// Derive the asserted config from a bundle. Pure — performs no SDK calls.
+  /// Reads the process identity, then defers to the raw-string core below.
+  public static func makeConfig(role: ProcessRole, bundle: Bundle = .main) -> HelperSentryConfig {
+    makeConfig(
+      role: role,
+      bundleID: bundle.bundleIdentifier ?? "",
+      version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        ?? "unknown"
+    )
+  }
+
+  /// The unit-testable pure core: derive the config from raw identity strings
+  /// (no Bundle needed), so the tests can assert every field deterministically.
+  public static func makeConfig(role: ProcessRole, bundleID: String, version: String)
+    -> HelperSentryConfig
+  {
+    let environment = bundleID.hasSuffix(".dev") ? "development" : "production"
+    return HelperSentryConfig(
+      role: role,
+      // Lock to the app's exact release string (NOT `com.enviouswispr.<helper>@…`)
+      // so the app + both helpers report under one release identity (#1174). The
+      // helper bundle is stamped to the same semver as the app, so `version` here
+      // equals the app's version.
+      releaseName: "com.enviouswispr.app@\(version)",
+      environment: environment,
+      buildType: environment == "development" ? "debug" : "release",
+      bundleId: bundleID
+    )
+  }
+
+  /// Stamp a `Sentry.Options` from a config + DSN. Pure — this is the asserted
+  /// surface the unit tests check (auto-session-tracking off, all auto-collection
+  /// off, `beforeSend` wired to the shared sanitizer).
+  public static func apply(config: HelperSentryConfig, dsn: String, to options: Options) {
+    options.dsn = dsn
+    options.releaseName = config.releaseName
+    options.environment = config.environment
+
+    // Privacy: no PII, no default data collection.
+    options.sendDefaultPii = false
+
+    // Crash reporting: the core reason Sentry exists here.
+    #if os(macOS)
+      options.enableUncaughtNSExceptionReporting = true
+    #endif
+
+    // Three processes must not inflate release-health session counts — helpers
+    // never start sessions. Baked OFF here so it can never be set wrong.
+    options.enableAutoSessionTracking = false
+
+    // Manual-only instrumentation, mirroring the app: disable all auto-collection
+    // to avoid surprise data, noise, and hidden swizzling.
+    options.enableAutoBreadcrumbTracking = false
+    options.enableNetworkBreadcrumbs = false
+    options.enableCaptureFailedRequests = false
+    options.enableSwizzling = false
+    options.enableFileIOTracing = false
+    options.enableCoreDataTracing = false
+    options.enableAppHangTracking = false
+    options.tracesSampleRate = NSNumber(value: 0)
+
+    // PII redaction: the FINAL payload seam, the exact same function the app
+    // runs. Native helper crashes replay through this on the next launch.
+    options.beforeSend = { event in
+      SentryEventSanitizer.sanitize(event)
+    }
+  }
+
+  /// Start crash reporting for a helper process. Call ONCE, before
+  /// `listener.resume()`. A LIMB — never throws; a missing or empty DSN just
+  /// skips reporting. The SDK start + scope config + DSN resolution are injected
+  /// (defaulting to the real ones) so the config can be unit-tested without
+  /// launching a real XPC process.
+  public static func start(
+    role: ProcessRole,
+    bundle: Bundle = .main,
+    dsnResolver: () -> String? = {
+      KeyResolver.resolveKey(plistKey: "SentryDSN", fileName: "sentry-dsn")
+    },
+    startSDK: (@escaping (Options) -> Void) -> Void = { SentrySDK.start(configureOptions: $0) },
+    configureScope: (@escaping (Scope) -> Void) -> Void = { SentrySDK.configureScope($0) }
+  ) {
+    // Treat an EMPTY string as missing, not just nil: the release script stamps
+    // `SentryDSN` UNCONDITIONALLY (empty when the secret is unset), so an
+    // unstamped/empty placeholder must read as "no DSN, skip" — never a real DSN
+    // (#1087 P2 trap).
+    guard let dsn = dsnResolver(), !dsn.isEmpty else {
+      print(
+        "[HelperObservability] Warning: Sentry DSN not found — skipping crash reporting for "
+          + role.rawValue)
+      return
+    }
+
+    let config = makeConfig(role: role, bundle: bundle)
+
+    startSDK { options in
+      apply(config: config, dsn: dsn, to: options)
+    }
+
+    // Stable tags available on every event, including fatal crashes.
+    configureScope { scope in
+      scope.setTag(value: config.role.rawValue, key: "process.role")
+      scope.setTag(value: config.buildType, key: "app.build_type")
+      scope.setTag(value: config.bundleId, key: "xpc.service_bundle_id")
+    }
+  }
+}

--- a/Sources/EnviousWisprObservabilityCore/KeyResolver.swift
+++ b/Sources/EnviousWisprObservabilityCore/KeyResolver.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Generic secret/key resolver shared across every EnviousWispr process. Checks
+/// the process `Info.plist` first (stamped at build time for release builds),
+/// then falls back to the `~/.enviouswispr-keys/<fileName>` file (dev builds).
+/// Moved verbatim from `EnviousWisprServices.ObservabilityBootstrap` (#1174) so
+/// the app and the two XPC helpers resolve keys through the identical path — the
+/// helpers already read `homeDirectoryForCurrentUser` successfully, so the file
+/// fallback works in a non-sandboxed helper with zero new wiring.
+public enum KeyResolver {
+
+  /// Resolves a key by checking Info.plist first, then falling back to the file
+  /// system path `~/.enviouswispr-keys/<fileName>`. Returns `nil` when neither
+  /// source yields a non-empty value.
+  public static func resolveKey(plistKey: String, fileName: String) -> String? {
+    // Try Info.plist first (stamped at build time for release builds)
+    if let plistValue = Bundle.main.object(forInfoDictionaryKey: plistKey) as? String,
+      !plistValue.isEmpty
+    {
+      return plistValue
+    }
+
+    // Fall back to file system (dev builds)
+    let keysDir = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".enviouswispr-keys")
+    let keyFile = keysDir.appendingPathComponent(fileName)
+    if let value = try? String(contentsOf: keyFile, encoding: .utf8).trimmingCharacters(
+      in: .whitespacesAndNewlines),
+      !value.isEmpty
+    {
+      return value
+    }
+
+    return nil
+  }
+}

--- a/Sources/EnviousWisprObservabilityCore/SentryEventSanitizer.swift
+++ b/Sources/EnviousWisprObservabilityCore/SentryEventSanitizer.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Sentry
+
+/// The single privacy sanitizer shared by every EnviousWispr process — the main
+/// app and both XPC helper processes. Moved verbatim from
+/// `EnviousWisprServices.ObservabilityBootstrap` (#1174) so all three processes
+/// run the IDENTICAL redactor: one source of truth, no copy to drift. The
+/// redaction tripwire (#1095) guards the exact output; `ObservabilityBootstrap`
+/// keeps thin forwarders so its call sites + the existing tests stay
+/// byte-identical.
+public enum SentryEventSanitizer {
+
+  /// Sanitize a Sentry event in place and return it. This is the EXACT body the
+  /// SDK `beforeSend` runs — the FINAL payload seam (#1095). Asserted by the
+  /// redaction tripwire so dictation text can never reach the wire payload.
+  /// Pure, idempotent, and never throws (a limb — heart path is unaffected).
+  public static func sanitize(_ event: Event) -> Event {
+    // Redact event message (SentryMessage wraps formatted + raw strings)
+    if let sentryMsg = event.message {
+      let redacted = redactString(sentryMsg.formatted)
+      if redacted != sentryMsg.formatted {
+        event.message = SentryMessage(formatted: redacted)
+      }
+    }
+
+    // Redact extra context values
+    if let extra = event.extra {
+      event.extra = redactDict(extra)
+    }
+
+    // Redact breadcrumb messages and data
+    if let crumbs = event.breadcrumbs {
+      for crumb in crumbs {
+        if let msg = crumb.message {
+          crumb.message = redactString(msg)
+        }
+        if let data = crumb.data {
+          crumb.data = redactDict(data)
+        }
+      }
+    }
+
+    // Redact exception value + mechanism data. Sentry's native crash
+    // handler captures the formatted exception message into
+    // `event.exceptions[].value`; without this pass, a future
+    // `fatalError("transcript=\(text)")` would leak. Verified during V3
+    // audit (#566): no current call sites interpolate transcript-typed
+    // values into fatal traps, but defense-in-depth — a regression
+    // would be invisible until users started crashing.
+    if let exceptions = event.exceptions {
+      for exception in exceptions {
+        if let value = exception.value {
+          exception.value = redactString(value)
+        }
+        if let mechData = exception.mechanism?.data {
+          exception.mechanism?.data = redactDict(mechData)
+        }
+      }
+    }
+
+    // Redact context dictionaries (arbitrary nested string values).
+    // Current contexts are diagnostic counts/statuses, but context is
+    // the natural place where future diagnostic strings would land —
+    // protect it now so a future change doesn't bypass redaction.
+    if let context = event.context {
+      var redactedContext: [String: [String: Any]] = [:]
+      for (key, inner) in context {
+        redactedContext[key] = redactDict(inner)
+      }
+      event.context = redactedContext
+    }
+
+    // Redact tag values. Current tags are low-cardinality strings
+    // (build_type, app_version), but cheap defense-in-depth against
+    // a future tag whose value bleeds transcript-shaped data.
+    if let tags = event.tags {
+      var redactedTags: [String: String] = [:]
+      for (key, value) in tags {
+        redactedTags[key] = redactString(value)
+      }
+      event.tags = redactedTags
+    }
+
+    // #1095 Layer C — native-crash surfaces. Hard crashes (segfault /
+    // NSException) are written to disk and replayed through `beforeSend` on
+    // next launch carrying stack frames + `debugMeta` (and no `message`). These
+    // fields hold image/source paths, not dictation, but a release build's
+    // paths can embed the developer/user home directory (`/Users/<name>/…`).
+    // Clear the host identifier and scrub the username segment from every
+    // stack-frame and debug-image path so a crash report carries no identity.
+    // Frames live in three serialized surfaces — `event.stacktrace`, each
+    // `thread.stacktrace`, and each `exception.stacktrace` (the SDK sets the
+    // crashed thread's stacktrace directly on the exception for native crashes)
+    // — so cover all three, not just `threads`.
+    event.serverName = nil
+    redactUserPaths(in: event.stacktrace)
+    for thread in event.threads ?? [] {
+      redactUserPaths(in: thread.stacktrace)
+    }
+    for exception in event.exceptions ?? [] {
+      redactUserPaths(in: exception.stacktrace)
+    }
+    for meta in event.debugMeta ?? [] {
+      if let codeFile = meta.codeFile { meta.codeFile = redactUserPath(codeFile) }
+    }
+
+    return event
+  }
+
+  /// Scrub `/Users/<name>/` usernames from every frame's path fields in a
+  /// stacktrace, in place. No-op for a nil stacktrace. (#1095 Layer C helper.)
+  private static func redactUserPaths(in stacktrace: SentryStacktrace?) {
+    guard let frames = stacktrace?.frames else { return }
+    for frame in frames {
+      if let package = frame.package { frame.package = redactUserPath(package) }
+      if let fileName = frame.fileName { frame.fileName = redactUserPath(fileName) }
+    }
+  }
+
+  /// Replace the username segment of a macOS home path (`/Users/<name>/…`)
+  /// with a placeholder, leaving the rest of the path intact for triage.
+  /// No-op when the string contains no such segment. Idempotent; never throws.
+  /// Mirrors the server-side "Usernames in filepaths" scrubbing rule (#1095).
+  public static func redactUserPath(_ input: String) -> String {
+    input.replacingOccurrences(
+      of: #"/Users/[^/]+"#,
+      with: "/Users/[REDACTED]",
+      options: .regularExpression
+    )
+  }
+
+  /// Redact every String value in a `[String: Any]` dictionary recursively,
+  /// leaving non-string scalar values untouched. Shared by Sentry beforeSend redaction
+  /// of `event.extra`, `breadcrumb.data`, `event.context`, and
+  /// `exception.mechanism.data`.
+  public static func redactDict(_ input: [String: Any]) -> [String: Any] {
+    var output: [String: Any] = [:]
+    for (key, value) in input {
+      output[key] = redactValue(value)
+    }
+    return output
+  }
+
+  public static func redactValue(_ value: Any) -> Any {
+    if let str = value as? String {
+      return redactString(str)
+    }
+    if let dict = value as? [String: Any] {
+      return redactDict(dict)
+    }
+    if let array = value as? [Any] {
+      return array.map(redactValue)
+    }
+    return value
+  }
+
+  /// Redacts a string if it matches known PII patterns:
+  /// - Long strings (> 100 chars) that are not URLs (likely transcript content)
+  /// - API key patterns: sk-*, phc_*, sntrys_*, key_*, or >= 32 contiguous hex chars
+  /// - Email-like patterns
+  /// Returns the original string if it matches no pattern, or `[REDACTED]` if it does.
+  /// Never throws — any regex failure is silently ignored and the original value returned.
+  public static func redactString(_ input: String) -> String {
+    // Long non-URL strings (transcript content heuristic)
+    if input.count > 100 {
+      let lower = input.lowercased()
+      if !lower.hasPrefix("http://") && !lower.hasPrefix("https://") {
+        return "[REDACTED]"
+      }
+    }
+
+    // API key patterns
+    let apiKeyPrefixes = ["sk-", "phc_", "sntrys_", "key_"]
+    for prefix in apiKeyPrefixes {
+      if input.lowercased().hasPrefix(prefix) && input.count >= 20 {
+        return "[REDACTED]"
+      }
+    }
+
+    // 32+ contiguous hex characters (generic secret/token heuristic)
+    if let hexRange = input.range(of: "[0-9a-fA-F]{32,}", options: .regularExpression),
+      hexRange == input.startIndex..<input.endIndex || input.count <= input[hexRange].count + 8
+    {
+      return "[REDACTED]"
+    }
+
+    // Email pattern: something@something.something
+    if input.range(
+      of: #"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"#,
+      options: .regularExpression) != nil
+    {
+      return "[REDACTED]"
+    }
+
+    return input
+  }
+}

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -1,3 +1,4 @@
+import EnviousWisprObservabilityCore
 import Foundation
 import PostHog
 import Sentry
@@ -26,7 +27,9 @@ public enum ObservabilityBootstrap {
   // MARK: - Private
 
   private static func initializePostHog() {
-    guard let apiKey = resolveKey(plistKey: "PostHogAPIKey", fileName: "posthog-api-key") else {
+    guard
+      let apiKey = KeyResolver.resolveKey(plistKey: "PostHogAPIKey", fileName: "posthog-api-key")
+    else {
       print(
         "[ObservabilityBootstrap] Warning: PostHog API key not found — skipping PostHog initialization"
       )
@@ -55,7 +58,7 @@ public enum ObservabilityBootstrap {
   }
 
   private static func initializeSentry() {
-    guard let dsn = resolveKey(plistKey: "SentryDSN", fileName: "sentry-dsn") else {
+    guard let dsn = KeyResolver.resolveKey(plistKey: "SentryDSN", fileName: "sentry-dsn") else {
       print(
         "[ObservabilityBootstrap] Warning: Sentry DSN not found — skipping Sentry initialization")
       return
@@ -102,223 +105,39 @@ public enum ObservabilityBootstrap {
     }
   }
 
-  /// Sanitize a Sentry event in place and return it. This is the EXACT body the
-  /// SDK `beforeSend` runs — the FINAL payload seam (#1095). Extracted so the
-  /// redaction tripwire test can assert on the same output the SDK transmits.
-  /// Pure, idempotent, and never throws (a limb — heart path is unaffected).
+  // MARK: - Privacy seam (single source of truth in EnviousWisprObservabilityCore)
+  //
+  // The sanitizer + redaction primitives + key resolver moved to
+  // `EnviousWisprObservabilityCore` (#1174) so the app AND both XPC helper
+  // processes run the IDENTICAL redactor — one source of truth, no copy to
+  // drift. These thin forwarders keep the `ObservabilityBootstrap.*` symbols the
+  // redaction tripwire (#1095) and the app's `beforeSend` wiring already call,
+  // so their output stays byte-identical.
+
+  /// Forwarder to the shared sanitizer — the `beforeSend` body + tripwire seam.
   static func sanitizeSentryEvent(_ event: Event) -> Event {
-    // Redact event message (SentryMessage wraps formatted + raw strings)
-    if let sentryMsg = event.message {
-      let redacted = redactString(sentryMsg.formatted)
-      if redacted != sentryMsg.formatted {
-        event.message = SentryMessage(formatted: redacted)
-      }
-    }
-
-    // Redact extra context values
-    if let extra = event.extra {
-      event.extra = redactDict(extra)
-    }
-
-    // Redact breadcrumb messages and data
-    if let crumbs = event.breadcrumbs {
-      for crumb in crumbs {
-        if let msg = crumb.message {
-          crumb.message = redactString(msg)
-        }
-        if let data = crumb.data {
-          crumb.data = redactDict(data)
-        }
-      }
-    }
-
-    // Redact exception value + mechanism data. Sentry's native crash
-    // handler captures the formatted exception message into
-    // `event.exceptions[].value`; without this pass, a future
-    // `fatalError("transcript=\(text)")` would leak. Verified during V3
-    // audit (#566): no current call sites interpolate transcript-typed
-    // values into fatal traps, but defense-in-depth — a regression
-    // would be invisible until users started crashing.
-    if let exceptions = event.exceptions {
-      for exception in exceptions {
-        if let value = exception.value {
-          exception.value = redactString(value)
-        }
-        if let mechData = exception.mechanism?.data {
-          exception.mechanism?.data = redactDict(mechData)
-        }
-      }
-    }
-
-    // Redact context dictionaries (arbitrary nested string values).
-    // Current contexts are diagnostic counts/statuses, but context is
-    // the natural place where future diagnostic strings would land —
-    // protect it now so a future change doesn't bypass redaction.
-    if let context = event.context {
-      var redactedContext: [String: [String: Any]] = [:]
-      for (key, inner) in context {
-        redactedContext[key] = redactDict(inner)
-      }
-      event.context = redactedContext
-    }
-
-    // Redact tag values. Current tags are low-cardinality strings
-    // (build_type, app_version), but cheap defense-in-depth against
-    // a future tag whose value bleeds transcript-shaped data.
-    if let tags = event.tags {
-      var redactedTags: [String: String] = [:]
-      for (key, value) in tags {
-        redactedTags[key] = redactString(value)
-      }
-      event.tags = redactedTags
-    }
-
-    // #1095 Layer C — native-crash surfaces. Hard crashes (segfault /
-    // NSException) are written to disk and replayed through `beforeSend` on
-    // next launch carrying stack frames + `debugMeta` (and no `message`). These
-    // fields hold image/source paths, not dictation, but a release build's
-    // paths can embed the developer/user home directory (`/Users/<name>/…`).
-    // Clear the host identifier and scrub the username segment from every
-    // stack-frame and debug-image path so a crash report carries no identity.
-    // Frames live in three serialized surfaces — `event.stacktrace`, each
-    // `thread.stacktrace`, and each `exception.stacktrace` (the SDK sets the
-    // crashed thread's stacktrace directly on the exception for native crashes)
-    // — so cover all three, not just `threads`.
-    event.serverName = nil
-    redactUserPaths(in: event.stacktrace)
-    for thread in event.threads ?? [] {
-      redactUserPaths(in: thread.stacktrace)
-    }
-    for exception in event.exceptions ?? [] {
-      redactUserPaths(in: exception.stacktrace)
-    }
-    for meta in event.debugMeta ?? [] {
-      if let codeFile = meta.codeFile { meta.codeFile = redactUserPath(codeFile) }
-    }
-
-    return event
-  }
-
-  /// Scrub `/Users/<name>/` usernames from every frame's path fields in a
-  /// stacktrace, in place. No-op for a nil stacktrace. (#1095 Layer C helper.)
-  private static func redactUserPaths(in stacktrace: SentryStacktrace?) {
-    guard let frames = stacktrace?.frames else { return }
-    for frame in frames {
-      if let package = frame.package { frame.package = redactUserPath(package) }
-      if let fileName = frame.fileName { frame.fileName = redactUserPath(fileName) }
-    }
+    SentryEventSanitizer.sanitize(event)
   }
 
   /// Redact every value in a PostHog event's property bag (the EXACT body the
-  /// PostHog `beforeSend` runs). Shares the same value redactor as Sentry, so
-  /// the tripwire test (#1095) covers both pipelines through one seam.
+  /// PostHog `beforeSend` runs). PostHog is app-only, so this stays in Services,
+  /// but it shares the one value redactor so the tripwire (#1095) covers both
+  /// pipelines through a single seam.
   static func sanitizePostHogProperties(_ properties: [String: Any]) -> [String: Any] {
     var redacted: [String: Any] = [:]
     for (key, value) in properties {
-      redacted[key] = redactValue(value)
+      redacted[key] = SentryEventSanitizer.redactValue(value)
     }
     return redacted
   }
 
-  /// Replace the username segment of a macOS home path (`/Users/<name>/…`)
-  /// with a placeholder, leaving the rest of the path intact for triage.
-  /// No-op when the string contains no such segment. Idempotent; never throws.
-  /// Mirrors the server-side "Usernames in filepaths" scrubbing rule (#1095).
+  /// Forwarder to the shared username-path scrubber (#1095 tripwire seam).
   static func redactUserPath(_ input: String) -> String {
-    input.replacingOccurrences(
-      of: #"/Users/[^/]+"#,
-      with: "/Users/[REDACTED]",
-      options: .regularExpression
-    )
+    SentryEventSanitizer.redactUserPath(input)
   }
 
-  /// Redact every String value in a `[String: Any]` dictionary recursively,
-  /// leaving non-string scalar values untouched. Shared by Sentry beforeSend redaction
-  /// of `event.extra`, `breadcrumb.data`, `event.context`, and
-  /// `exception.mechanism.data`.
+  /// Forwarder to the shared recursive dictionary redactor (#1095 tripwire seam).
   static func redactDict(_ input: [String: Any]) -> [String: Any] {
-    var output: [String: Any] = [:]
-    for (key, value) in input {
-      output[key] = redactValue(value)
-    }
-    return output
-  }
-
-  static func redactValue(_ value: Any) -> Any {
-    if let str = value as? String {
-      return redactString(str)
-    }
-    if let dict = value as? [String: Any] {
-      return redactDict(dict)
-    }
-    if let array = value as? [Any] {
-      return array.map(redactValue)
-    }
-    return value
-  }
-
-  /// Redacts a string if it matches known PII patterns:
-  /// - Long strings (> 100 chars) that are not URLs (likely transcript content)
-  /// - API key patterns: sk-*, phc_*, sntrys_*, key_*, or >= 32 contiguous hex chars
-  /// - Email-like patterns
-  /// Returns the original string if it matches no pattern, or `[REDACTED]` if it does.
-  /// Never throws — any regex failure is silently ignored and the original value returned.
-  static func redactString(_ input: String) -> String {
-    // Long non-URL strings (transcript content heuristic)
-    if input.count > 100 {
-      let lower = input.lowercased()
-      if !lower.hasPrefix("http://") && !lower.hasPrefix("https://") {
-        return "[REDACTED]"
-      }
-    }
-
-    // API key patterns
-    let apiKeyPrefixes = ["sk-", "phc_", "sntrys_", "key_"]
-    for prefix in apiKeyPrefixes {
-      if input.lowercased().hasPrefix(prefix) && input.count >= 20 {
-        return "[REDACTED]"
-      }
-    }
-
-    // 32+ contiguous hex characters (generic secret/token heuristic)
-    if let hexRange = input.range(of: "[0-9a-fA-F]{32,}", options: .regularExpression),
-      hexRange == input.startIndex..<input.endIndex || input.count <= input[hexRange].count + 8
-    {
-      return "[REDACTED]"
-    }
-
-    // Email pattern: something@something.something
-    if input.range(
-      of: #"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"#,
-      options: .regularExpression) != nil
-    {
-      return "[REDACTED]"
-    }
-
-    return input
-  }
-
-  /// Resolves a key by checking Info.plist first, then falling back to the file system.
-  /// File system path: `~/.enviouswispr-keys/<fileName>`
-  private static func resolveKey(plistKey: String, fileName: String) -> String? {
-    // Try Info.plist first (stamped at build time for release builds)
-    if let plistValue = Bundle.main.object(forInfoDictionaryKey: plistKey) as? String,
-      !plistValue.isEmpty
-    {
-      return plistValue
-    }
-
-    // Fall back to file system (dev builds)
-    let keysDir = FileManager.default.homeDirectoryForCurrentUser
-      .appendingPathComponent(".enviouswispr-keys")
-    let keyFile = keysDir.appendingPathComponent(fileName)
-    if let value = try? String(contentsOf: keyFile, encoding: .utf8).trimmingCharacters(
-      in: .whitespacesAndNewlines),
-      !value.isEmpty
-    {
-      return value
-    }
-
-    return nil
+    SentryEventSanitizer.redactDict(input)
   }
 }

--- a/Tests/EnviousWisprTests/Services/HelperObservabilityConfigTests.swift
+++ b/Tests/EnviousWisprTests/Services/HelperObservabilityConfigTests.swift
@@ -1,0 +1,136 @@
+import EnviousWisprObservabilityCore
+import Foundation
+import Sentry
+import Testing
+
+/// #1174 — helper crash-reporting bootstrap config. Asserts the PURE seams
+/// (`makeConfig` / `apply`) and the skip-on-missing-DSN behavior of `start`
+/// WITHOUT launching a real XPC process or initializing the Sentry SDK (the SDK
+/// start + scope are injected). This is the local proof that the two helper
+/// processes report under one release identity, never inflate session counts,
+/// and run the same privacy sanitizer the app does.
+@Suite("Helper observability config (#1174)")
+struct HelperObservabilityConfigTests {
+
+  /// A transcript-shaped sentinel (>100 chars) for the beforeSend redaction proof.
+  private static let marker = "PURPLE ELEPHANT SEVENTEEN"
+  private static let transcript =
+    "Reminder to self, please email the whole team about the schedule change "
+    + "for next week and mention that the code phrase is \(marker) before the call."
+
+  // MARK: - makeConfig (scope tags)
+
+  @Test("audio role + release bundle builds the expected scope tags")
+  func audioRoleBuildsExpectedScopeTags() {
+    let config = HelperObservability.makeConfig(
+      role: .audioXPC, bundleID: "com.enviouswispr.audioservice", version: "1.2.3")
+    #expect(config.role.rawValue == "audio_xpc")
+    #expect(config.bundleId == "com.enviouswispr.audioservice")
+    #expect(config.environment == "production")
+    #expect(config.buildType == "release")
+  }
+
+  @Test("asr role + dev bundle builds the expected scope tags")
+  func asrRoleBuildsExpectedScopeTags() {
+    let config = HelperObservability.makeConfig(
+      role: .asrXPC, bundleID: "com.enviouswispr.asrservice.dev", version: "1.2.3")
+    #expect(config.role.rawValue == "asr_xpc")
+    #expect(config.bundleId == "com.enviouswispr.asrservice.dev")
+    // The `.dev` suffix routes to the development environment + debug build type.
+    #expect(config.environment == "development")
+    #expect(config.buildType == "debug")
+  }
+
+  @Test("release name uses the app project prefix + the helper bundle version")
+  func releaseNameUsesAppProjectPrefixAndHelperBundleVersion() {
+    let config = HelperObservability.makeConfig(
+      role: .audioXPC, bundleID: "com.enviouswispr.audioservice", version: "9.9.9")
+    // All three processes report under ONE release identity: the app's exact
+    // string — NOT a helper-bundle-derived `com.enviouswispr.audioservice@…`.
+    #expect(config.releaseName == "com.enviouswispr.app@9.9.9")
+    #expect(config.releaseName.contains("audioservice") == false)
+  }
+
+  // MARK: - apply (Sentry.Options surface)
+
+  @Test("helper options disable auto session tracking")
+  func helperOptionsDisableAutoSessionTracking() {
+    let options = appliedOptions()
+    // The single guarantee against 3-process release-health session inflation.
+    #expect(options.enableAutoSessionTracking == false)
+  }
+
+  @Test("helper options disable all auto-collection + PII")
+  func helperOptionsDisableAutoCollectionAndPii() {
+    let options = appliedOptions()
+    #expect(options.sendDefaultPii == false)
+    #expect(options.enableAutoBreadcrumbTracking == false)
+    #expect(options.enableNetworkBreadcrumbs == false)
+    #expect(options.enableCaptureFailedRequests == false)
+    #expect(options.enableSwizzling == false)
+    #expect(options.enableFileIOTracing == false)
+    #expect(options.enableCoreDataTracing == false)
+    #expect(options.enableAppHangTracking == false)
+    #expect(options.tracesSampleRate?.doubleValue == 0)
+    // Identity rides along, sourced from the config.
+    #expect(options.releaseName == "com.enviouswispr.app@1.2.3")
+    #expect(options.environment == "production")
+  }
+
+  @Test("helper options wire beforeSend to the shared sanitizer")
+  func helperOptionsWireBeforeSendToSharedSanitizer() {
+    let options = appliedOptions()
+    #expect(options.beforeSend != nil)
+
+    // Run a transcript-shaped sentinel through the wired beforeSend — it must be
+    // scrubbed, proving it routes to the one shared SentryEventSanitizer.
+    let event = Event(level: .error)
+    event.extra = ["leak": Self.transcript]
+    let processed = options.beforeSend?(event)
+    #expect(processed?.extra?["leak"] as? String == "[REDACTED]")
+  }
+
+  // MARK: - start (skip-on-missing-DSN)
+
+  @Test("empty DSN skips SDK start + scope config; a real DSN runs both")
+  func emptyDSNSkipsSDKStart() {
+    // Empty string is treated as MISSING (the release script stamps it empty
+    // when the secret is unset) — start must skip, never call the SDK.
+    let skipped = StartProbe()
+    HelperObservability.start(
+      role: .audioXPC,
+      dsnResolver: { "" },
+      startSDK: { _ in skipped.startCalled = true },
+      configureScope: { _ in skipped.scopeCalled = true })
+    #expect(skipped.startCalled == false)
+    #expect(skipped.scopeCalled == false)
+
+    // A real DSN runs both limbs.
+    let ran = StartProbe()
+    HelperObservability.start(
+      role: .audioXPC,
+      dsnResolver: { "https://key@o0.ingest.sentry.io/1" },
+      startSDK: { _ in ran.startCalled = true },
+      configureScope: { _ in ran.scopeCalled = true })
+    #expect(ran.startCalled == true)
+    #expect(ran.scopeCalled == true)
+  }
+
+  // MARK: - Helpers
+
+  /// A fresh `Options` configured via the pure `apply` seam (release-bundle config).
+  private func appliedOptions() -> Options {
+    let options = Options()
+    let config = HelperObservability.makeConfig(
+      role: .audioXPC, bundleID: "com.enviouswispr.audioservice", version: "1.2.3")
+    HelperObservability.apply(
+      config: config, dsn: "https://key@o0.ingest.sentry.io/1", to: options)
+    return options
+  }
+
+  /// Mutable observation box for the injected `start` seams.
+  private final class StartProbe {
+    var startCalled = false
+    var scopeCalled = false
+  }
+}

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -123,6 +123,11 @@ plutil -replace CFBundleShortVersionString -string "$VERSION" "$BUNDLE/Contents/
 plutil -replace CFBundleVersion -string "$VERSION" "$BUNDLE/Contents/Info.plist"
 for XPC_SVC in "$BUNDLE/Contents/XPCServices"/*.xpc; do
     [[ -d "$XPC_SVC" ]] || continue
+    # SentryDSN: helper crash reporting (#1174). Stamped UNCONDITIONALLY (empty
+    # when the secret is unset), same pattern as the app stamp above, so the
+    # archive-time placeholder never survives. HelperObservability treats an
+    # empty value as "no DSN, skip" — never a real DSN.
+    plutil -replace SentryDSN -string "${SENTRY_DSN:-}" "$XPC_SVC/Contents/Info.plist"
     plutil -replace CFBundleShortVersionString -string "$VERSION" "$XPC_SVC/Contents/Info.plist"
     plutil -replace CFBundleVersion -string "$VERSION" "$XPC_SVC/Contents/Info.plist"
 done
@@ -141,6 +146,16 @@ if [[ -n "${SENTRY_DSN:-}" ]]; then
     test "$SENTRY_VALUE" = "$SENTRY_DSN"
     [[ "$SENTRY_VALUE" != *'$('* ]]
     unset SENTRY_VALUE
+    # #1174: helper crash reporting requires the DSN to reach BOTH XPC plists.
+    # REQUIRED verify (not optional) — a missing helper DSN silently loses helper
+    # crash visibility in release. Same plutil-stamp guard as the app above.
+    for XPC_PLIST in "$BUNDLE/Contents/XPCServices"/*.xpc/Contents/Info.plist; do
+        [[ -f "$XPC_PLIST" ]] || continue
+        XPC_SENTRY_VALUE="$(/usr/libexec/PlistBuddy -c 'Print :SentryDSN' "$XPC_PLIST")"
+        test "$XPC_SENTRY_VALUE" = "$SENTRY_DSN"
+        [[ "$XPC_SENTRY_VALUE" != *'$('* ]]
+        unset XPC_SENTRY_VALUE
+    done
 fi
 FEED_VALUE="$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$APP_PLIST")"
 test "$FEED_VALUE" = "$FEED_URL"

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -7,15 +7,16 @@
 # Bible if the new edge represents an architectural decision):
 #   EnviousWispr           -> AppKit (thin launchable shell; #919). Imports ONLY the kit.
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
-#   EnviousWisprAudioService -> Core, Audio (XPC executable)
-#   EnviousWisprASRService -> Core, ASR, Audio (XPC executable)
+#   EnviousWisprAudioService -> Core, Audio, ObservabilityCore (XPC executable)
+#   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
 #   EnviousWisprASR        -> Core, Audio
-#   EnviousWisprServices   -> Core
+#   EnviousWisprServices   -> Core, ObservabilityCore
 #   EnviousWisprLLM        -> Core
 #   EnviousWisprAudio      -> Core
 #   EnviousWisprPostProcessing -> Core
 #   EnviousWisprContacts   -> Core (Contacts-framework shim; #636, App-layer-scoped leaf)
+#   EnviousWisprObservabilityCore -> (no app deps; Sentry-only privacy/crash leaf; #1174)
 #   EnviousWisprStorage    -> Core
 #   EnviousWisprCore       -> (no app deps)
 #
@@ -28,16 +29,17 @@ set -euo pipefail
 permitted_imports_for() {
   case "$1" in
     EnviousWisprCore)              echo "" ;;
+    EnviousWisprObservabilityCore) echo "" ;;
     EnviousWisprAudio)             echo "EnviousWisprCore" ;;
     EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio" ;;
     EnviousWisprPostProcessing)    echo "EnviousWisprCore" ;;
     EnviousWisprContacts)          echo "EnviousWisprCore" ;;
     EnviousWisprStorage)           echo "EnviousWisprCore" ;;
     EnviousWisprLLM)               echo "EnviousWisprCore" ;;
-    EnviousWisprServices)          echo "EnviousWisprCore" ;;
+    EnviousWisprServices)          echo "EnviousWisprCore EnviousWisprObservabilityCore" ;;
     EnviousWisprPipeline)          echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprLLM EnviousWisprPostProcessing EnviousWisprServices EnviousWisprStorage" ;;
-    EnviousWisprAudioService)      echo "EnviousWisprCore EnviousWisprAudio" ;;
-    EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio" ;;
+    EnviousWisprAudioService)      echo "EnviousWisprCore EnviousWisprAudio EnviousWisprObservabilityCore" ;;
+    EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprObservabilityCore" ;;
     EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprPipeline EnviousWisprContacts" ;;
     EnviousWispr)                  echo "EnviousWisprAppKit" ;;
     *)                             return 1 ;;


### PR DESCRIPTION
Part of #1174 (Telemetry Bible Phase 5). This is **PR-5a (A1: XPC helper crash visibility)**. A2 (model-load watchdog) + A3 (audio-interrupt capture) ship as sibling PR-5b.

## Problem
The two crash-prone background processes — the audio-capture XPC helper and the ASR-inference XPC helper — linked no crash reporter and ran no init, so a native helper crash reached us only as a generic host-side `.xpcServiceError` with no helper stack. We were blind to the crashiest code in the product (live audio engine; CoreML/Parakeet inference).

## Change
New Sentry-only low-level module `EnviousWisprObservabilityCore` (deps: Sentry only) holding:
- the **one** privacy sanitizer + redaction primitives (moved verbatim from `ObservabilityBootstrap`), so the app + both helpers run the identical redactor — one source of truth, no copy to drift;
- the generic `KeyResolver` (Info.plist → `~/.enviouswispr-keys/<file>` fallback);
- `HelperObservability` — a Sentry-only bootstrap that bakes `enableAutoSessionTracking=false` in **by construction** (three processes can't inflate release-health session counts), with a pure/injectable seam (`makeConfig` / `apply` / `start`) so the config is unit-testable without launching XPC.

Both helper mains call `HelperObservability.start(role:)` before `listener.resume()` — a **limb** (never throws; a missing/empty DSN just skips reporting; heart path unaffected). The release script stamps the DSN into the helper plists in the loop that already stamps their version (+ a required verify); dev resolves the existing key-file fallback.

`ObservabilityBootstrap` keeps thin forwarders (`sanitizeSentryEvent`, `sanitizePostHogProperties`, `redactUserPath`, `redactDict`) so all three redaction tripwire tests stay byte-identical.

## Single-seam design (Phase 4 lesson)
The privacy/edge-case class disappears because there is exactly one owner: one sanitizer, one key resolver, one bootstrap, three readers. Helper `releaseName` is locked to the app's exact `com.enviouswispr.app@<version>` so all three processes report under one release identity; symbolication is UUID-bound (helper dSYMs already build + upload). The pre-existing app-vs-CI `v<version>` grouping mismatch affects only release-health grouping (not symbolication) and is out of scope.

## Build graph
New target + 3 production edges mirrored in BOTH `Project.swift` and `Package.swift` (+ the test-target edge for the new config tests); `check-dependency-direction.sh` allowlist updated (14 modules clean).

## Validation
- **Full logic suite: 2060 tests green** — incl. the 3 redaction tripwires via the forwarders + 7 new `HelperObservabilityConfigTests`.
- **Local `codex review`: clean** (no actionable correctness issues).
- **Release-config build: green.**
- **Live UAT (dev build, both helpers):**
  - Heart path intact (record→transcribe→paste) with the new init.
  - Heart path **recovers** from a crash in each helper (both recovery recordings pass; helpers relaunch and transcribe).
  - `kill -ABRT` each helper → cached crash replays on relaunch → Sentry event tagged `process.role=audio_xpc` / `asr_xpc`, correct `xpc.service_bundle_id`, `serverName` cleared, **zero** real usernames, username segments scrubbed to `/Users/[REDACTED]` (client marker — proves the helper's own `beforeSend` ran, not just the server backstop), `environment=development`. Local `.ips` confirms the SIGABRT cause.

## Not in scope
A2 + A3 → PR-5b. No new alert rules (the existing "XPC Service Crash >1/hr" metric alert simply becomes meaningful once helpers report). Dual-signal dedup + a host↔helper correlation id → Phase 10.