### PR TITLE
feat(telemetry): capture audio-engine-interrupt lost dictations (#1174 PR-5b)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -159,9 +159,15 @@ public actor WhisperKitBackend: ASRBackend {
       computeOptions: dictationComputeOptions,
       download: false
     )
-    // TODO(#827): watchdog needs CoreML/WhisperKit model-load progress or a
-    // service process-liveness signal owned upstream. Do not wrap this in a
-    // wall-clock timeout.
+    // Load-duration timing + the hang signal for this in-process WhisperKit load
+    // already exist: `ensureEngineWarm` emits `coldstart.warmup_started` /
+    // `_completed {duration_ms}` / `_failed` (and `launch.model_preload_completed`)
+    // for the launch / engine-swap paths where the model actually cold-loads, so
+    // a hang shows up as `warmup_started` with no terminal. What is still missing
+    // is a FINE-GRAINED progress callback: upstream `WhisperKit(config)` exposes
+    // no per-step load progress, so an automatic hang WATCHDOG stays deferred for
+    // lack of a defended-timeout distribution — NOT for lack of timing data. Do
+    // not wrap this in a wall-clock timeout (timeout-numbers-need-distribution-evidence).
     let kit = try await WhisperKit(config)
     self.whisperKit = kit
     isReady = true

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -71,9 +71,12 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
           self.parakeetBackend = backend
         case "whisperKit":
           let backend = WhisperKitBackend()
-          // TODO(#827): watchdog needs WhisperKit/CoreML model-load progress
-          // written to ProgressFile or XPCOperationSignalFile. Current upstream
-          // load has no progress callback.
+          // NOTE: this branch is unreachable on current main — the XPC ASR
+          // service is Parakeet-only (architecture.md FACT:
+          // xpc-asr-service-is-parakeet-only). WhisperKit loads IN-PROCESS via
+          // `WhisperKitEngineAdapter` → `WhisperKitBackend`, never here. The real
+          // in-process load duration + hang signal are already observed by the
+          // `coldstart.warmup_*` telemetry (`TelemetryService` / `ensureEngineWarm`).
           try await backend.prepare()
           self.whisperKitBackend = backend
         default:
@@ -187,8 +190,7 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     language: String,
     enableTimestamps: Bool,
     reply: @escaping (NSError?) -> Void
-  )
-  {
+  ) {
     let signal = XPCOperationSignalFile.asr.makeEmitter(operationID: operationID)
     signal.emit(stage: "asr.start_streaming.received")
     guard let parakeet = parakeetBackend else {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/AudioEventRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/AudioEventRouter.swift
@@ -54,7 +54,7 @@ final class AudioEventRouter {
       }
     }
 
-    audioCapture.onEngineInterrupted = { [weak self] in
+    audioCapture.onEngineInterrupted = { [weak self] cause in
       guard let self else { return }
       let pState = self.kernelDriver.state
       let wkState = self.whisperKitKernelDriver.state
@@ -72,9 +72,9 @@ final class AudioEventRouter {
         ])
       switch self.resolveActiveCaptureBackend() {
       case .parakeet:
-        self.kernelDriver.handleEngineInterruption()
+        self.kernelDriver.handleEngineInterruption(cause)
       case .whisperKit:
-        self.whisperKitKernelDriver.handleEngineInterruption()
+        self.whisperKitKernelDriver.handleEngineInterruption(cause)
       case nil:
         break
       }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -15,7 +15,11 @@ public protocol AudioCaptureInterface: AnyObject {
 
   // Callback properties (read-write)
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
-  var onEngineInterrupted: (() -> Void)? { get set }
+  /// Fires when a live recording is lost to an audio-engine interruption. The
+  /// `EngineInterruptionCause` lets the consumer route the lost-dictation
+  /// capture for `.engineLost` only, suppressing the three already-owned causes
+  /// (issue #1174 A3).
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)? { get set }
   var onVADAutoStop: (() -> Void)? { get set }
 
   // Telemetry callbacks (round-4 additions for #285 heart-path Sentry coverage).

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -31,7 +31,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Called on the main actor when the audio engine is interrupted (e.g., device disconnect).
   /// The pipeline should transition to an error state when this fires.
-  public var onEngineInterrupted: (() -> Void)?
+  public var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
 
   /// Called when service-side VAD detects sustained silence after speech.
   /// No-op for in-process capture — VAD runs in the pipeline's monitorVAD() loop instead.
@@ -209,18 +209,27 @@ public final class AudioCaptureManager: AudioCaptureInterface {
           )
           self.isCapturing = false
           self.audioLevel = 0.0
-          self.onEngineInterrupted?()
+          // Direct-mode 60-min cap — a normal auto-stop, never captured as a loss.
+          self.onEngineInterrupted?(.maxDurationReached)
         }
       }
     }
     source.onBufferCaptured = onBufferCaptured
+    // Direct mode: an AVCaptureSession interruption is already captured by
+    // `onCaptureSessionInterruption` (→ `.audioCaptureFailed`), so tag it
+    // `.captureSessionLost` (suppress). An AVAudioEngine device disconnect has
+    // no other owner → `.engineLost` (capture). Resolve the discriminator to a
+    // value at bind time so the closure captures only the `Bool` (no strong
+    // `source` capture / retain cycle — matches the `sourceID`-only pattern).
+    let interruptionCause: EngineInterruptionCause =
+      source is AVCaptureSessionSource ? .captureSessionLost : .engineLost
     source.onInterrupted = { [weak self] in
       guard let self,
         self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
       else { return }
       self.isCapturing = false
       self.audioLevel = 0.0
-      self.onEngineInterrupted?()
+      self.onEngineInterrupted?(interruptionCause)
     }
 
     // Forward heart-path telemetry callbacks (issue #285) — direct capture

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -28,7 +28,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   // MARK: - Callbacks
 
   public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  public var onEngineInterrupted: (() -> Void)?
+  public var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   public var onVADAutoStop: (() -> Void)?
 
   // MARK: - Round-4 telemetry callbacks (issue #285)
@@ -608,7 +608,9 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           proxy.captureGeneration &+= 1
           proxy.bufferContinuation?.finish()
           proxy.bufferContinuation = nil
-          proxy.onEngineInterrupted?()
+          // XPC connection break — `onXPCServiceError` (below) is the sole owner
+          // of this capture, so tag `.xpcConnectionLost` (A3 suppresses it).
+          proxy.onEngineInterrupted?(.xpcConnectionLost)
           // Fire telemetry callback — idle interruptions stay silent (§3.4 row 2).
           proxy.onXPCServiceError?(
             XPCErrorContext(
@@ -652,7 +654,9 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
           proxy.captureGeneration &+= 1
           proxy.bufferContinuation?.finish()
           proxy.bufferContinuation = nil
-          proxy.onEngineInterrupted?()
+          // XPC connection break — `onXPCServiceError` (below) is the sole owner
+          // of this capture, so tag `.xpcConnectionLost` (A3 suppresses it).
+          proxy.onEngineInterrupted?(.xpcConnectionLost)
         }
         proxy.needsReinit = true
         // Invalidation is always a telemetry signal — connection is gone.
@@ -844,10 +848,12 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
     }
   }
 
-  /// Service's audio engine was interrupted (device disconnect, emergency teardown).
-  /// Matches interruptionHandler contract: only fires onEngineInterrupted during active capture.
-  /// Idle interruptions are transient — just set needsReinit.
-  nonisolated public func engineInterrupted() {
+  /// Service's audio engine was interrupted (device disconnect, emergency
+  /// teardown, max-duration cap). Matches interruptionHandler contract: only
+  /// fires onEngineInterrupted during active capture. Idle interruptions are
+  /// transient — just set needsReinit. `cause` is the relayed
+  /// `EngineInterruptionCause` raw value (issue #1174 A3).
+  nonisolated public func engineInterrupted(cause: String) {
     Task { @MainActor [weak self] in
       guard let self else { return }
       if self.isCapturing {
@@ -859,7 +865,13 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         self.captureGeneration &+= 1
         self.bufferContinuation?.finish()
         self.bufferContinuation = nil
-        self.onEngineInterrupted?()
+        // The service relays ALL its interruptions through this one channel.
+        // Every loss cause collapses to `.engineLost` (no other owner across the
+        // XPC boundary — there is no capture-session relay, so an XPC-mode
+        // AVCaptureSession interruption must be captured here too); only the hard
+        // max-duration cap is preserved so it stays suppressed exactly as in
+        // direct mode (issue #1174 A3).
+        self.onEngineInterrupted?(EngineInterruptionCause.hostCause(forRelayedRawValue: cause))
       }
       self.needsReinit = true
     }

--- a/Sources/EnviousWisprAudio/EngineInterruptionCause.swift
+++ b/Sources/EnviousWisprAudio/EngineInterruptionCause.swift
@@ -1,0 +1,43 @@
+/// Classifies why the audio-capture `onEngineInterrupted` callback fired, so a
+/// downstream telemetry consumer can route the lost-dictation capture without
+/// double-counting causes that already have an owner.
+///
+/// This is a CLASSIFICATION value, not heart-path control flow: the kernel still
+/// resets / stops identically for every case. Only the telemetry capture gate
+/// reads it (issue #1174 A3). The cause's job is to SUPPRESS the three causes
+/// already accounted for elsewhere and CAPTURE everything else — every other
+/// recording-losing interruption is a genuine lost dictation with no other owner.
+public enum EngineInterruptionCause: String, Sendable, Equatable, CaseIterable {
+  /// A recording-losing audio interruption with no other owner — the gap A3
+  /// closes. Set by `AVAudioEngineSource` device disconnects (direct mode) and
+  /// by the XPC service relay (`AudioCaptureProxy.engineInterrupted(cause:)`),
+  /// which funnels ALL service-side interruptions through one channel because the
+  /// XPC client protocol has no capture-session callback. CAPTURED.
+  case engineLost = "engine_lost"
+
+  /// A DIRECT-mode `AVCaptureSession` interruption. Already captured by
+  /// `captureSessionInterrupted` → `.audioCaptureFailed`, so A3 does NOT
+  /// re-capture. (In XPC mode this path does not exist — see `.engineLost`.)
+  case captureSessionLost = "capture_session_lost"
+
+  /// An audio XPC connection break (interrupt / invalidate handler). Already
+  /// captured by `onXPCServiceError` → `.xpcServiceError`. NOT re-captured.
+  case xpcConnectionLost = "xpc_connection_lost"
+
+  /// Direct-mode 60-minute max-duration cap (a normal auto-stop, not a loss).
+  /// NOT captured.
+  case maxDurationReached = "max_duration_reached"
+}
+
+extension EngineInterruptionCause {
+  /// Maps a cause RELAYED across the XPC boundary (its raw value) to the cause the
+  /// host should fire. Across XPC there is no capture-session relay, so every loss
+  /// cause collapses to `.engineLost` — on the host side it has no other owner, so
+  /// it must be captured. Only the non-loss `.maxDurationReached` cap is preserved
+  /// so the host suppresses it exactly as direct mode does. Unknown / legacy raw
+  /// values default to `.engineLost` (fail toward visibility). Issue #1174 A3.
+  public static func hostCause(forRelayedRawValue raw: String) -> EngineInterruptionCause {
+    let relayed = EngineInterruptionCause(rawValue: raw) ?? .engineLost
+    return relayed == .maxDurationReached ? .maxDurationReached : .engineLost
+  }
+}

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -90,10 +90,17 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       }
     }
 
-    // Engine interruption callback: fires on @MainActor.
-    manager.onEngineInterrupted = { [weak self] in
+    // Engine interruption callback: fires on @MainActor. Relay the cause's raw
+    // value across XPC so the host can suppress the non-loss max-duration cap
+    // while still capturing genuine losses. The host collapses every loss cause
+    // to `.engineLost` (AVCaptureSession interruptions have no separate relay
+    // across the boundary, so they have no other owner there) and suppresses
+    // only `.maxDurationReached`. See `AudioCaptureProxy.engineInterrupted(cause:)`
+    // (issue #1174 A3).
+    manager.onEngineInterrupted = { [weak self] cause in
+      let raw = cause.rawValue
       self?.xpcSendQueue.async { [weak self] in
-        self?.clientProxy?.engineInterrupted()
+        self?.clientProxy?.engineInterrupted(cause: raw)
       }
     }
   }

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -91,8 +91,12 @@ import Foundation
   func audioBufferCaptured(_ data: Data, frameCount: Int, audioLevel: Float)
 
   /// The audio engine was interrupted (device disconnect, emergency teardown, max-duration cap).
-  /// The proxy should transition pipelines to error state.
-  func engineInterrupted()
+  /// The proxy should transition pipelines to error state. `cause` is the
+  /// `EngineInterruptionCause` raw value so the host can suppress the telemetry
+  /// capture for the non-loss `max_duration_reached` cap while still capturing
+  /// genuine losses (issue #1174 A3). Unknown / legacy values map to
+  /// `engine_lost` at the host.
+  func engineInterrupted(cause: String)
 
   /// Service-side VAD detected sustained silence after speech — auto-stop should trigger.
   func vadAutoStopTriggered()

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
@@ -485,10 +486,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// was state-agnostic: emit Sentry+PostHog state change, cancel cleanup,
   /// flip UI to the mic-disconnect error. Bridge matrix #4 ports the old
   /// behavior for those states via `setExternalError`.
-  public func handleEngineInterruption() {
+  public func handleEngineInterruption(_ cause: EngineInterruptionCause) {
     switch kernel.state {
     case .recording:
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(cause)
     case .preparing, .warmingUp, .stopping, .transcribing, .finalizing:
       // Direct PostHog state update — the kernel won't reach
       // `.audioInterrupted` from here, so the lifecycle sink's

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -47,8 +47,11 @@ enum KernelLifecycleEvent: Equatable, Sendable {
   /// The session reached a `failed` terminal — a per-reason `captureError`.
   /// `model.load_wedged` is the `.modelWedged` case.
   case failed(RecordingFailureReason)
-  /// The session reached `audioInterrupted` — a microphone-disconnect event.
-  case audioInterrupted
+  /// The session reached `audioInterrupted` — a microphone / audio-engine
+  /// interruption mid-recording. Carries the `EngineInterruptionCause` so the
+  /// sink captures the lost dictation for `.engineLost` only, suppressing the
+  /// three already-owned causes (issue #1174 A3).
+  case audioInterrupted(cause: EngineInterruptionCause)
   /// The session reached `asrInterrupted` — the `captureError(xpcServiceError)`.
   /// Carries the `was_recording` flag the old TP:1145 captureError extra
   /// carried: `true` when entered from `.recording`, `false` when entered
@@ -182,6 +185,7 @@ final class KernelHeartPathTelemetryObserver {
         discardReason: kernel.discardReason,
         didLoadModelThisSession: kernel.didLoadModelThisSession,
         lastNoSpeechSource: kernel.lastNoSpeechSource,
+        lastAudioInterruptionCause: kernel.lastAudioInterruptionCause,
         isStreamingSession: kernel.isStreamingSession
       )
     else { return }
@@ -210,6 +214,7 @@ final class KernelHeartPathTelemetryObserver {
     discardReason: DiscardReason?,
     didLoadModelThisSession: Bool,
     lastNoSpeechSource: NoSpeechSource?,
+    lastAudioInterruptionCause: EngineInterruptionCause?,
     isStreamingSession: Bool
   ) -> KernelLifecycleEvent? {
     switch state {
@@ -222,7 +227,12 @@ final class KernelHeartPathTelemetryObserver {
     case .failed(let reason):
       return .failed(reason)
     case .audioInterrupted:
-      return .audioInterrupted
+      // The cause is a sibling observable stamped by `externalEngineInterrupted`
+      // before the `→ .audioInterrupted` transition (the terminal's only path),
+      // mirroring `discardReason` / `lastNoSpeechSource`. Default defensively to
+      // `.engineLost` (capture) if somehow absent — a lost recording at this
+      // terminal with no cause is still an unowned loss.
+      return .audioInterrupted(cause: lastAudioInterruptionCause ?? .engineLost)
     case .asrInterrupted:
       // Bridge matrix #3 — old TP:1145 reported `was_recording == state == .recording`
       // at crash time. The kernel reaches `.asrInterrupted` from either

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -238,7 +238,28 @@ final class KernelLifecycleTelemetrySink {
     case .failed(let reason):
       emitFailed(reason)
 
-    case .audioInterrupted:
+    case .audioInterrupted(let cause):
+      // Capture the lost dictation ONLY for `.engineLost` — a recording-losing
+      // audio interruption with no other owner (issue #1174 A3). The three other
+      // causes are already accounted for: `.captureSessionLost` by
+      // `captureSessionInterrupted`, `.xpcConnectionLost` by `onXPCServiceError`,
+      // and `.maxDurationReached` is a normal auto-stop, not a loss. Category is
+      // `.audioCaptureFailed` (matching the `captureSessionInterrupted` sibling),
+      // never `.xpcServiceError` — a benign device disconnect must not page the
+      // "XPC Service Crash >1/hr" alert.
+      switch cause {
+      case .engineLost:
+        let snapshot = recordingSnapshot()
+        emitCaptureError(
+          HeartPathError.audioEngineInterrupted(
+            route: snapshot?.audioRoute ?? audioCapture.currentAudioRoute,
+            durationMs: snapshot?.durationMs ?? 0),
+          .audioCaptureFailed, "audio",
+          ["was_recording": true, "backend": backend.rawValue],
+          snapshot: snapshot)
+      case .captureSessionLost, .xpcConnectionLost, .maxDurationReached:
+        break
+      }
       updateRecordingState(false, nil, nil)
 
     case .asrInterrupted(let wasRecording):

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -237,6 +237,14 @@ final class RecordingSessionKernel {
   /// time to choose `.vadGate` or `.asrEmptyNoSpeech`. Reset on session start.
   private(set) var lastNoSpeechSource: NoSpeechSource?
 
+  /// Why the audio engine was interrupted for this session, or `nil` if the
+  /// session did not reach `.audioInterrupted`. Stamped immediately BEFORE the
+  /// `→ .audioInterrupted` transition in `externalEngineInterrupted(_:)` (the
+  /// terminal's only path). The observer reads it at lifecycle-event mapping
+  /// time so the sink captures the lost dictation for `.engineLost` only
+  /// (issue #1174 A3). Reset on session start.
+  private(set) var lastAudioInterruptionCause: EngineInterruptionCause?
+
   /// `true` if the kernel started this session in streaming mode. Set
   /// immediately BEFORE `adapter.beginSession(..., streaming:)`. The observer
   /// reads this at `.recording` lifecycle mapping time so the
@@ -1683,8 +1691,24 @@ final class RecordingSessionKernel {
   /// into the FSM. Replaces the removed direct subscription to
   /// `audioCapture.onEngineInterrupted`. Idempotent: a second call after a
   /// terminal short-circuits via `!state.isTerminal`.
-  func externalEngineInterrupted() {
+  func externalEngineInterrupted(_ cause: EngineInterruptionCause) {
     guard !state.isTerminal else { return }
+    // Stamp the cause + freeze the recording snapshot ONLY on the interruption
+    // that actually latches the exit (first-wins), BEFORE delivering it so the
+    // observer reads the right cause at the `→ .audioInterrupted` transition
+    // (the exit resolves the recording-loop continuation, which then calls
+    // `finishTerminal(.audioInterrupted)`). A later callback in the post-latch /
+    // pre-transition window — `state` still `.recording` but `recordingExitLatched`
+    // already true — has its exit ignored by `deliverRecordingExit`, so it must
+    // NOT overwrite the cause/snapshot the terminal will use (cloud review #1207:
+    // an already-owned `.xpcConnectionLost` / `.maxDurationReached` could otherwise
+    // be replaced by a stale `.engineLost` and get falsely captured). The guard
+    // mirrors `deliverRecordingExitIfCurrent`'s accept condition. The freeze
+    // reports real duration / route / backend (mirrors `routeASRInterruption`).
+    if state == .recording, !recordingExitLatched {
+      lastAudioInterruptionCause = cause
+      freezeRecordingSnapshot()
+    }
     deliverRecordingExitIfCurrent(.audioInterruption, sid: currentSessionID)
   }
 
@@ -2108,6 +2132,7 @@ final class RecordingSessionKernel {
     discardReason = nil
     didLoadModelThisSession = false
     lastNoSpeechSource = nil
+    lastAudioInterruptionCause = nil
     isStreamingSession = false
     pasteCount = 0
     forbiddenTransitionRejected = false

--- a/Sources/EnviousWisprServices/HeartPathError.swift
+++ b/Sources/EnviousWisprServices/HeartPathError.swift
@@ -25,6 +25,11 @@ public enum HeartPathError: LocalizedError, Sendable {
   case xpcServerClientProxyNil(sessionID: UInt64?, consecutiveDrops: Int)
   case emptyAfterProcessing(route: String, wasPolishEnabled: Bool)
   case zombieEngineZeroPeak(sessionID: UInt64, durationMs: Int, route: String, sampleCount: Int)
+  // APPEND-ONLY: handled Sentry errors are fingerprinted on the bridged NSError
+  // `domain#code`, and a Swift enum's `_code` is its declaration ordinal — so
+  // inserting a case mid-enum shifts every later case's code and SPLITS existing
+  // Sentry issues. New cases go at the END (Codex #1174 PR-5b r1).
+  case audioEngineInterrupted(route: String, durationMs: Int)
 
   public var errorDescription: String? {
     switch self {
@@ -52,6 +57,8 @@ public enum HeartPathError: LocalizedError, Sendable {
     case .zombieEngineZeroPeak(let sessionID, let durationMs, let route, let sampleCount):
       return
         "Zombie engine: zero-peak \(sampleCount) samples over \(durationMs)ms (session \(sessionID), route=\(route))"
+    case .audioEngineInterrupted(let route, let durationMs):
+      return "Audio engine interrupted: recording lost after \(durationMs)ms (route=\(route))"
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
@@ -3,8 +3,8 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprLLM
 @testable import EnviousWisprPipeline
@@ -227,7 +227,7 @@ struct AudioEventRouterTests {
       }
     )
 
-    audio.onEngineInterrupted?()
+    audio.onEngineInterrupted?(.engineLost)
 
     #expect(resolverCallCount == 1)
     withExtendedLifetime(router) {}

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -21,7 +21,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -6,8 +6,8 @@ import Foundation
 import Observation
 import Testing
 
-@testable import EnviousWisprAppKit
 @testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage
@@ -148,7 +148,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
@@ -198,7 +198,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
@@ -59,7 +59,7 @@ import Testing
     driver.onStateChange = { _ in }
     driver.onOverlayIntentChange = { _ in }  // #930 — App-consumed overlay channel
     driver.setExternalError("probe")
-    driver.handleEngineInterruption()
+    driver.handleEngineInterruption(.engineLost)
     driver.handleASRServiceInterruption()
     driver.reset()
     #expect(true, "reaching this line means the public surface compiled")

--- a/Tests/EnviousWisprTests/Audio/EngineInterruptionCauseTests.swift
+++ b/Tests/EnviousWisprTests/Audio/EngineInterruptionCauseTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1174 A3 — locks the XPC-boundary host-cause remap (Codex PR-5b r1 finding 2).
+// In XPC mode the audio service relays interruptions through one no-cause-typed
+// channel; the host collapses every LOSS cause to `.engineLost` (none has another
+// owner across the boundary) and preserves ONLY the non-loss max-duration cap so
+// it stays suppressed exactly as direct mode does. Unknown / legacy raw values
+// fail toward visibility (`.engineLost`).
+@Suite("EngineInterruptionCause XPC host remap")
+struct EngineInterruptionCauseTests {
+
+  @Test("max-duration is the only relayed cause the host preserves (suppress)")
+  func maxDurationPreserved() {
+    #expect(
+      EngineInterruptionCause.hostCause(forRelayedRawValue: "max_duration_reached")
+        == .maxDurationReached)
+  }
+
+  @Test("every loss cause collapses to .engineLost across XPC (capture)")
+  func lossesCollapseToEngineLost() {
+    #expect(
+      EngineInterruptionCause.hostCause(forRelayedRawValue: "engine_lost") == .engineLost)
+    // An XPC-mode AVCaptureSession interruption has no capture-session relay, so
+    // it must be captured here — not suppressed as it would be in direct mode.
+    #expect(
+      EngineInterruptionCause.hostCause(forRelayedRawValue: "capture_session_lost") == .engineLost)
+    #expect(
+      EngineInterruptionCause.hostCause(forRelayedRawValue: "xpc_connection_lost") == .engineLost)
+  }
+
+  @Test("unknown / legacy raw values default to .engineLost (fail toward visibility)")
+  func unknownDefaultsToEngineLost() {
+    #expect(EngineInterruptionCause.hostCause(forRelayedRawValue: "") == .engineLost)
+    #expect(EngineInterruptionCause.hostCause(forRelayedRawValue: "garbage") == .engineLost)
+  }
+
+  @Test("every raw value round-trips through its rawValue (relay contract)")
+  func rawValuesRoundTrip() {
+    for cause in EngineInterruptionCause.allCases {
+      #expect(EngineInterruptionCause(rawValue: cause.rawValue) == cause)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -62,7 +62,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -442,7 +442,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "synthetic-fixture"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -304,7 +304,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -216,7 +216,7 @@ import Testing
       ] {
         let fx = makeFixture()
         await forceState(fx.kernel, to: state)
-        fx.driver.handleEngineInterruption()
+        fx.driver.handleEngineInterruption(.engineLost)
         await drain()
         // Driver public state must surface the mic-disconnect error.
         assertDriverIsError(fx.driver, contains: "Microphone disconnected")
@@ -229,7 +229,7 @@ import Testing
         let fx = makeFixture()
         await forceState(fx.kernel, to: state)
         let priorPipelineState = fx.driver.state
-        fx.driver.handleEngineInterruption()
+        fx.driver.handleEngineInterruption(.engineLost)
         await drain()
         #expect(fx.driver.state == priorPipelineState)
       }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
@@ -86,7 +86,7 @@ import Testing
       // The external entry is idempotent at idle (terminal guard). Calling it
       // here proves the wire reaches the kernel — no exception thrown is the
       // signal; deeper FSM coverage lives in the kernel external-entry tests.
-      driver.handleEngineInterruption()
+      driver.handleEngineInterruption(.engineLost)
     }
 
     // MARK: 5. handleASRServiceInterruption routes to kernel.externalASRInterrupted

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -32,7 +32,12 @@ import Testing
       #expect(event(.completed) == .pipelineCompleted)
       #expect(event(.cancelled) == .cancelled)
       #expect(event(.noSpeech) == .noSpeech(.vadGate))
-      #expect(event(.audioInterrupted) == .audioInterrupted)
+      // #1174 A3 — absent cause defaults defensively to `.engineLost` (capture).
+      #expect(event(.audioInterrupted) == .audioInterrupted(cause: .engineLost))
+      // The stamped cause threads through unchanged (here an already-owned one).
+      #expect(
+        event(.audioInterrupted, lastAudioInterruptionCause: .xpcConnectionLost)
+          == .audioInterrupted(cause: .xpcConnectionLost))
       // Default priorState `.idle` → wasRecording == false (the non-recording
       // path); the routing test below covers the `.recording` → true case
       // and the `.transcribing` → false case.
@@ -220,6 +225,7 @@ import Testing
       discardReason: DiscardReason? = nil,
       didLoadModelThisSession: Bool = false,
       lastNoSpeechSource: NoSpeechSource? = nil,
+      lastAudioInterruptionCause: EngineInterruptionCause? = nil,
       isStreamingSession: Bool = false
     ) -> KernelLifecycleEvent? {
       KernelHeartPathTelemetryObserver.lifecycleEvent(
@@ -228,6 +234,7 @@ import Testing
         discardReason: discardReason,
         didLoadModelThisSession: didLoadModelThisSession,
         lastNoSpeechSource: lastNoSpeechSource,
+        lastAudioInterruptionCause: lastAudioInterruptionCause,
         isStreamingSession: isStreamingSession)
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -358,16 +358,61 @@ import Testing
       ])
   }
 
-  @Test(".audioInterrupted emits updateRecordingState(false) and no captureError")
-  func audioInterruptedEmission() {
+  // #1174 A3 — matcher-set-adversarial: the `.audioInterrupted` capture gate
+  // flips on the cause. Only `.engineLost` (a lost dictation with no other owner)
+  // captures `.audioCaptureFailed`; the three already-owned causes
+  // (`.captureSessionLost`, `.xpcConnectionLost`, `.maxDurationReached`) must
+  // emit NO captureError, so A3 never double-counts a loss already owned by
+  // `captureSessionInterrupted` / `onXPCServiceError`, and never counts a normal
+  // max-duration auto-stop as a loss. Every case resets recording state.
+
+  @Test(".audioInterrupted(.engineLost) captures .audioCaptureFailed + resets state")
+  func audioInterruptedEngineLostCaptures() {
     let recorder = Recorder()
-    let sink = makeSink(recorder: recorder)
-    sink.emit(.audioInterrupted)
+    let sink = makeSink(recorder: recorder, backend: .whisperKit)
+    sink.emit(.audioInterrupted(cause: .engineLost))
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.category == .audioCaptureFailed)
+    #expect(recorder.captureErrors.first?.stage == "audio")
+    #expect(
+      recorder.captureErrors.first?.errorDescription.contains("Audio engine interrupted") == true)
     #expect(
       recorder.recordingStates == [
         .init(active: false, backend: nil, isStreaming: nil)
       ])
-    #expect(recorder.captureErrors.isEmpty)
+  }
+
+  @Test(".audioInterrupted suppresses the three already-owned causes (no double-count)")
+  func audioInterruptedSuppressesOwnedCauses() {
+    for cause: EngineInterruptionCause in [
+      .captureSessionLost, .xpcConnectionLost, .maxDurationReached,
+    ] {
+      let recorder = Recorder()
+      let sink = makeSink(recorder: recorder)
+      sink.emit(.audioInterrupted(cause: cause))
+      #expect(
+        recorder.captureErrors.isEmpty,
+        "cause \(cause) must NOT emit a captureError (already owned / not a loss)")
+      #expect(
+        recorder.recordingStates == [
+          .init(active: false, backend: nil, isStreaming: nil)
+        ],
+        "cause \(cause) must still reset recording state")
+    }
+  }
+
+  @Test("exactly one EngineInterruptionCause captures at the .audioInterrupted terminal")
+  func audioInterruptedExactlyOneCauseCaptures() {
+    // CaseIterable guard — if a future cause is added, this forces an explicit
+    // capture/suppress decision rather than silently inheriting either branch.
+    var capturingCauses: [EngineInterruptionCause] = []
+    for cause in EngineInterruptionCause.allCases {
+      let recorder = Recorder()
+      let sink = makeSink(recorder: recorder)
+      sink.emit(.audioInterrupted(cause: cause))
+      if !recorder.captureErrors.isEmpty { capturingCauses.append(cause) }
+    }
+    #expect(capturingCauses == [.engineLost])
   }
 
   @Test(".asrInterrupted(wasRecording: true) emits captureError + state(false)")

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
 import Testing
@@ -60,7 +61,7 @@ import Testing
       await startToRecording(wrapper)
       #expect(kernel.state == .recording)
 
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       await wrapper.drainReadyWork()
 
       #expect(kernel.state == .audioInterrupted)
@@ -102,12 +103,12 @@ import Testing
       let kernel = wrapper.testKernel
 
       await startToRecording(wrapper)
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       await wrapper.drainReadyWork()
       let firstTerminal = kernel.state
       #expect(firstTerminal == .audioInterrupted)
 
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       await wrapper.drainReadyWork()
       #expect(kernel.state == firstTerminal)
     }
@@ -152,7 +153,7 @@ import Testing
       let kernel = wrapper.testKernel
       #expect(kernel.state == .idle)
 
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       kernel.externalASRInterrupted()
       kernel.externalCaptureStalled(context.capture.makeStallContext())
       await wrapper.drainReadyWork()
@@ -172,7 +173,7 @@ import Testing
       await wrapper.drainReadyWork()
       #expect(kernel.state == .cancelled)
 
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       kernel.externalASRInterrupted()
       kernel.externalCaptureStalled(context.capture.makeStallContext())
       await wrapper.drainReadyWork()
@@ -188,7 +189,7 @@ import Testing
       let kernel = wrapper.testKernel
 
       await startToRecording(wrapper)
-      kernel.externalEngineInterrupted()
+      kernel.externalEngineInterrupted(.engineLost)
       // Second call lands BEFORE the first has settled — the FSM is still in
       // `.recording` so the guard does not bite yet. The forward path picks
       // up one exit signal; the second is overwritten in `pendingRecordingExit`
@@ -201,6 +202,33 @@ import Testing
       #expect(
         kernel.state == .audioInterrupted || kernel.state == .asrInterrupted,
         "exactly one of the two interruption terminals must win")
+    }
+
+    @Test("a second engine interruption in the post-latch window preserves the FIRST cause")
+    func doubleEngineFirstCauseWins() async {
+      // #1207 cloud review: the exit is first-wins via `recordingExitLatched`, so
+      // the stamped `lastAudioInterruptionCause` must be first-wins too. A second
+      // callback arriving after the first latched the exit (state still
+      // `.recording`) must NOT overwrite the cause the `.audioInterrupted` terminal
+      // will use — else an already-owned `.xpcConnectionLost` could be replaced by
+      // a stale `.engineLost` and falsely captured (or vice-versa).
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await startToRecording(wrapper)
+      // First (latching) interruption: an already-owned XPC break → must be the
+      // cause the terminal carries (so the sink suppresses it).
+      kernel.externalEngineInterrupted(.xpcConnectionLost)
+      // Second, in the post-latch / pre-transition window: a genuine engine loss.
+      // Its exit is ignored; it must NOT overwrite the stamped cause.
+      kernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(kernel.state == .audioInterrupted)
+      #expect(
+        kernel.lastAudioInterruptionCause == .xpcConnectionLost,
+        "the FIRST (latching) cause must survive; got \(String(describing: kernel.lastAudioInterruptionCause))"
+      )
     }
 
     // MARK: 6. Capture-stall cross-domain sessionID

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -72,7 +72,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
   // MARK: AudioCaptureInterface — callbacks
 
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   // XPC-only telemetry callbacks — a direct (non-XPC) source leaves these nil.
@@ -188,9 +188,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
   }
 
   /// Raise an engine interruption (mic disconnect / route change mid-session) —
-  /// the audio-interruption path.
-  func raiseEngineInterruption() {
-    onEngineInterrupted?()
+  /// the audio-interruption path. Defaults to `.engineLost` (the captured case)
+  /// so existing callers keep their behavior; pass a cause to exercise the
+  /// suppress paths.
+  func raiseEngineInterruption(cause: EngineInterruptionCause = .engineLost) {
+    onEngineInterrupted?(cause)
   }
 
   /// Fire the VAD auto-stop callback.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
@@ -76,7 +76,7 @@ struct FakeAudioCaptureTests {
   func interruptionFiresCallback() {
     let capture = FakeAudioCapture()
     var interrupted = false
-    capture.onEngineInterrupted = { interrupted = true }
+    capture.onEngineInterrupted = { _ in interrupted = true }
     capture.raiseEngineInterruption()
     #expect(interrupted == true)
   }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import Foundation
 
 @testable import EnviousWisprPipeline
@@ -158,8 +159,8 @@ struct ScenarioRunner {
       // match the production path PR-4b.4 wires (App router → driver → kernel).
       kernel?.externalCaptureStalled(context.capture.makeStallContext())
     case .interrupt, .routeChange:
-      // The audio-interruption channel (C5).
-      kernel?.externalEngineInterrupted()
+      // The audio-interruption channel (C5). A genuine engine loss → captured.
+      kernel?.externalEngineInterrupted(.engineLost)
     case .permissionDenied:
       context.capture.permissionDenied = true
     case .startFailure:

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -137,7 +137,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "synthetic-fixture"
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onEngineInterrupted: (() -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?

--- a/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
+++ b/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
@@ -43,6 +43,7 @@ struct HeartPathErrorTests {
       .xpcServerClientProxyNil(sessionID: 1, consecutiveDrops: 5),
       .emptyAfterProcessing(route: "built_in_mic", wasPolishEnabled: true),
       .zombieEngineZeroPeak(sessionID: 7, durationMs: 9000, route: "bt", sampleCount: 145360),
+      .audioEngineInterrupted(route: "built_in_mic", durationMs: 3200),
     ]
 
     for heart in cases {


### PR DESCRIPTION
## What & why

Phase 5 (Telemetry Bible #1168) part 2 — the two remaining blind spots after PR-5a (#1205).

**A3 — capture audio-engine-interrupt lost dictations.** When a live recording is lost to a genuine `AVAudioEngine` device disconnect (AirPods drop, headphone unplug mid-sentence), the kernel previously reset silently with no Sentry capture — unlike its `.asrInterrupted` sibling. This adds a typed 4-case `EngineInterruptionCause` that threads from the audio callback to the kernel's `.audioInterrupted` terminal, where the lifecycle sink captures one `.audioCaptureFailed` handled-error **for `.engineLost` only**, never double-counting the three already-owned causes:

| Cause | Owner | A3 |
|---|---|---|
| `.engineLost` (AVAudioEngine disconnect; XPC-relayed losses) | none — the gap | **capture** |
| `.captureSessionLost` (direct-mode AVCaptureSession) | `captureSessionInterrupted` | suppress |
| `.xpcConnectionLost` (audio XPC break) | `onXPCServiceError` → `.xpcServiceError` | suppress |
| `.maxDurationReached` (hard 60-min cap) | n/a — not a loss | suppress |

Category is `.audioCaptureFailed` (matching the `captureSessionInterrupted` sibling), **never** `.xpcServiceError`, so a benign disconnect can't page the "XPC Service Crash >1/hr" alert.

**A2 — comment-only.** Grounding discovered the cold-load duration distribution + hang signal already exist as `coldstart.warmup_*` / `launch.model_preload_completed` (emitted by `ensureEngineWarm` for the launch/engine-swap cold-load paths). A new event triad would have duplicated them. So A2 is reduced to correcting two misleading comments (`ASRServiceHandler` dead-code branch; `WhisperKitBackend` TODO) to point at the existing telemetry.

## Design notes

- **Cause threaded across XPC** (`engineInterrupted(cause:)`): the host collapses every genuine loss to `.engineLost` (XPC-mode AVCaptureSession interruptions have no separate relay, so they have no other owner there) and preserves only the non-loss max-duration cap — so the hard cap is suppressed in XPC mode exactly as in direct mode. `EngineInterruptionCause.hostCause(forRelayedRawValue:)` owns that remap (unit-tested).
- **Cause stamped on the kernel** as a sibling observable (mirrors `discardReason` / `lastNoSpeechSource`), read by the observer at lifecycle-event mapping.
- **`externalEngineInterrupted` freezes the recording snapshot** while still `.recording` (mirrors `routeASRInterruption`) so the event reports real duration / route / backend.
- **`HeartPathError.audioEngineInterrupted` appended at the enum end** so the bridged NSError codes (Sentry fingerprints) of existing cases don't shift.
- Capture is the kernel terminal only (one-shot, `was_recording` true by construction); the non-recording driver fallback is deliberately not used (avoids false-loss on a user-stop racing a disconnect).

## Review + validation

- Council (GPT + Gemini) on the plan; **3 Codex grounded/code-diff rounds** (r1: enum-code stability + XPC cause threading; r2: snapshot freeze; r3 clean).
- Logic tests green via `scripts/xcode-test.sh` on final code (incl. the adversarial 4-case sink test + the XPC-remap test).
- **Live UAT:** heart-path recording PASS; audio-XPC-kill mid-recording threads the cause end-to-end (`onEngineInterrupted — recording` → kernel `terminal audioInterrupted`) and the app recovers/records again (no wedge). The Sentry-event level isn't observable in the local dev build (no bundled DSN → SDK off) — covered by the adversarial unit test. The genuine hardware mic-disconnect (`.engineLost` capture) is a Lane B founder-driven hardware test per `docs/LANE_B_AUDIO_TESTS.md` (OS-level interruption can't be honestly simulated in-process), release-gated.

## Follow-up (separate scope)

An interrupted recording is currently discarded, not salvaged. Whether to transcribe audio captured before the disconnect is a heart-path recovery feature — exactly what this telemetry should justify first. Filing a follow-up issue, not in this PR.

Closes #1174.